### PR TITLE
Increase main Helix job timeout

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -604,7 +604,7 @@ stages:
         jobName: Helix_x64
         jobDisplayName: 'Tests: Helix x64'
         agentOs: Windows
-        timeoutInMinutes: 180
+        timeoutInMinutes: 240
         steps:
         # Build the shared framework
         - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log


### PR DESCRIPTION
- now matches timeout in quarantined-pr.yml which uses the same queues
- internal PRs may otherwise time out