### PR TITLE
Upgrade Gradle used for the SignalR Java client from 6.1 to 6.5

### DIFF
--- a/src/SignalR/clients/java/signalr/gradle/wrapper/gradle-wrapper.properties
+++ b/src/SignalR/clients/java/signalr/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=d0c43d14e1c70a48b82442f435d06186351a2d290d72afd5b8866f15e6d7038a
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
+distributionSha256Sum=23e7d37e9bb4f8dabb8a3ea7fdee9dd0428b9b1a71d298aefd65b11dccea220f
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This way I don't run into https://github.com/gradle/gradle/issues/10248 when running `.\gradlew.bat`.
