### PR TITLE
Adds an analyzer and code fix for closure over a loop variable

### DIFF
--- a/src/Components/Analyzers/src/ComponentClosureOverLoopVariablesCodeFixProvider.cs
+++ b/src/Components/Analyzers/src/ComponentClosureOverLoopVariablesCodeFixProvider.cs
@@ -1,0 +1,130 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.AspNetCore.Components.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ComponentClosureOverLoopVariablesCodeFixProvider)), Shared]
+    public class ComponentClosureOverLoopVariablesCodeFixProvider : CodeFixProvider
+    {
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.ComponentClosureOverLoopVariables_FixTitle), Resources.ResourceManager, typeof(Resources));
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(DiagnosticDescriptors.ClosureOverLoopVariables.Id);
+
+        public sealed override FixAllProvider GetFixAllProvider()
+            => null;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Find the identifier declaration identified by the diagnostic.
+            var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<IdentifierNameSyntax>().First();
+
+            // Register a code action that will invoke the fix.
+            var title = Title.ToString();
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: title,
+                    createChangedDocument: c => GetTransformedDocumentAsync(context.Document, root, declaration),
+                    equivalenceKey: title),
+                diagnostic);
+        }
+
+        private Task<Document> GetTransformedDocumentAsync(
+            Document document,
+            SyntaxNode root,
+            IdentifierNameSyntax declarationNode)
+        {
+
+            var loopVariableName = declarationNode.Identifier.Text;
+
+            var loopStatement = declarationNode
+                .Parent
+                .AncestorsAndSelf()
+                .Where(node => node.IsKind(SyntaxKind.ForStatement))
+                .First() as ForStatementSyntax;
+
+            var existingVariable = loopStatement
+                .Statement
+                .ChildNodes()
+                .OfType<LocalDeclarationStatementSyntax>()
+                .Where(node
+                    => node
+                        .DescendantNodes()
+                        .OfType<EqualsValueClauseSyntax>()
+                        .Any(dcnode => (dcnode.Value as IdentifierNameSyntax)?.Identifier.Text == loopVariableName)
+                    )
+                .FirstOrDefault();
+
+            var existingName = existingVariable?.Declaration?.Variables.FirstOrDefault()?.Identifier.Text;
+
+            var localIdentifier = SyntaxFactory
+            .IdentifierName(existingName ?? $"lcl_{loopVariableName.ToUpper()}")
+            .WithTriviaFrom(declarationNode);
+
+            // Track the nodes we are modifying
+            var tracker = root.TrackNodes(declarationNode, loopStatement);
+
+            // Replace the loop variable with the identifier of the local variable
+            declarationNode = tracker.GetCurrentNode(declarationNode);
+            tracker = tracker.ReplaceNode(declarationNode, localIdentifier);
+
+            if (existingName is null)
+            {
+                loopStatement = tracker.GetCurrentNode(loopStatement);
+
+                var localVariableDeclaration = $"var {localIdentifier.Identifier.Text}";
+
+                // Introduce a new locally scoped variable
+                if (loopStatement.Statement.Kind() != SyntaxKind.Block)
+                {
+                    var newStatement = SyntaxFactory
+                        .ParseStatement($"{localVariableDeclaration} = {loopVariableName};")
+                        .WithTriviaFrom(loopStatement.Statement);
+
+                    var blockContent = SyntaxFactory.Block(loopStatement.Statement)
+                        .WithTriviaFrom(loopStatement);
+
+                    blockContent = blockContent
+                        .InsertNodesBefore(blockContent.Statements.First(), new SyntaxNode[] { newStatement });
+
+                    var newLoopStatement = loopStatement.ReplaceNode(loopStatement.Statement, blockContent);
+
+                    tracker = tracker.ReplaceNode(loopStatement, newLoopStatement);
+                }
+                else
+                {
+                    SyntaxList<StatementSyntax> blockStatements = ((BlockSyntax)loopStatement.Statement).Statements;
+
+                    var newStatement = SyntaxFactory
+                        .ParseStatement($"{localVariableDeclaration} = {loopVariableName};")
+                        .WithTriviaFrom(blockStatements.First());
+
+                    var blockContent = SyntaxFactory.Block(blockStatements)
+                        .WithTriviaFrom(loopStatement.Statement);
+
+                    blockContent = blockContent
+                        .InsertNodesBefore(blockContent.Statements.First(), new SyntaxNode[] { newStatement });
+
+                    var newLoopStatement = loopStatement.ReplaceNode(loopStatement.Statement, blockContent);
+
+                    tracker = tracker.ReplaceNode(loopStatement, newLoopStatement);
+                }
+            }
+            return Task.FromResult(document.WithSyntaxRoot(tracker));
+        }
+    }
+}

--- a/src/Components/Analyzers/src/ComponentClosureOverLoopVariablesDiagnosticAnalzyer.cs
+++ b/src/Components/Analyzers/src/ComponentClosureOverLoopVariablesDiagnosticAnalzyer.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection.Metadata;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.AspNetCore.Components.Analyzers
+{
+    /// <summary>
+    /// This API supports infrastructure and is not intended to be used
+    /// directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ComponentClosureOverLoopVariablesDiagnosticAnalzyer : DiagnosticAnalyzer
+    {
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.ClosureOverLoopVariables);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.RegisterCompilationStartAction(context =>
+            {
+                context.RegisterSyntaxNodeAction(AnalyzeForLoop, SyntaxKind.ForStatement);
+            });
+        }
+
+        private void AnalyzeForLoop(SyntaxNodeAnalysisContext context)
+        {
+            SyntaxNode syntaxNode = context.Node;
+
+            if (syntaxNode is ForStatementSyntax forSyntax)
+            { 
+                var variableIdentifier = forSyntax
+                    .DescendantTokens()
+                    .Where(token => token.IsKind(SyntaxKind.IdentifierToken))
+                    .FirstOrDefault()
+                    .Text;
+                
+                if (String.IsNullOrWhiteSpace(variableIdentifier))
+                {
+                    return;
+                }
+
+                var lambdaExpressions = forSyntax
+                    .DescendantNodes()
+                    .OfType<LambdaExpressionSyntax>();
+
+                foreach (var expression in lambdaExpressions)
+                {
+                    var indentifiers = expression
+                        .DescendantNodes()
+                        .OfType<IdentifierNameSyntax>();
+
+                    foreach (var identifierName in indentifiers)
+                    {
+                        if (identifierName.Identifier.Text == variableIdentifier)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                        DiagnosticDescriptors.ClosureOverLoopVariables,
+                                        identifierName.GetLocation(),
+                                        expression.GetText().ToString()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Components/Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Components/Analyzers/src/DiagnosticDescriptors.cs
@@ -65,5 +65,15 @@ namespace Microsoft.AspNetCore.Components.Analyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: new LocalizableResourceString(nameof(Resources.DoNotUseRenderTreeTypes_Description), Resources.ResourceManager, typeof(Resources)));
+
+        public static DiagnosticDescriptor ClosureOverLoopVariables = new DiagnosticDescriptor(
+            "BL0007",
+            new LocalizableResourceString(nameof(Resources.ComponentClosureOverLoopVariables_Title), Resources.ResourceManager, typeof(Resources)),
+            new LocalizableResourceString(nameof(Resources.ComponentClosureOverLoopVariables_Description), Resources.ResourceManager, typeof(Resources)),
+            "Usage",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: new LocalizableResourceString(nameof(Resources.ComponentClosureOverLoopVariables_Description), Resources.ResourceManager, typeof(Resources)));
+
     }
 }

--- a/src/Components/Analyzers/src/Resources.resx
+++ b/src/Components/Analyzers/src/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -173,5 +173,14 @@
   </data>
   <data name="DoNotUseRenderTreeTypes_Title" xml:space="preserve">
     <value>Do not use RenderTree types</value>
+  </data>
+  <data name="ComponentClosureOverLoopVariables_Description" xml:space="preserve">
+    <value>The lambda in this loop forms a closure over the loop variable. Use a local copy of the loop variable instead.</value>
+  </data>
+  <data name="ComponentClosureOverLoopVariables_Title" xml:space="preserve">
+    <value>Closure over loop variable.</value>
+  </data>
+  <data name="ComponentClosureOverLoopVariables_FixTitle" xml:space="preserve">
+    <value>Introduce locally scoped variable.</value>
   </data>
 </root>

--- a/src/Components/Analyzers/test/ComponentClosureOverLoopVariableAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/ComponentClosureOverLoopVariableAnalyzerTest.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using TestHelper;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Analyzers.Test
+{
+    public class ComponentClosureOverLoopVariableAnalyzerTest : DiagnosticVerifier
+    {
+        public ComponentClosureOverLoopVariableAnalyzerTest()
+        {
+            Analyzer = new ComponentClosureOverLoopVariablesDiagnosticAnalzyer();
+            Runner = new ComponentAnalyzerDiagnosticAnalyzerRunner(Analyzer);
+        }
+
+        private ComponentClosureOverLoopVariablesDiagnosticAnalzyer Analyzer { get; }
+        private ComponentAnalyzerDiagnosticAnalyzerRunner Runner { get; }
+
+        [Fact]
+        public void FindsUseOfClosureOverLoopVariable()
+        {
+            var test = @"namespace Test1
+{
+    class Test1
+    {
+        private void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+				Action DoSomething = () => { var x = i; Console.WriteLine($""Loopvars:{x},{i}""); };
+            }
+        }
+    }
+}
+";
+
+            VerifyCSharpDiagnostic(test,
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 9, 42)
+                    }
+                },
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 9, 79)
+                    }
+                }
+            );
+        }
+
+        [Fact]
+        public void FindsNoUseOfClosureOverLoopVariable()
+        {
+            var test = @"namespace Test1
+{
+    class Test1
+    {
+        private void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var lcl_I = i;
+				Action DoSomething = () => { var x = lcl_I; Console.WriteLine($""Loopvars:{x},{lcl_I}""); };
+            }
+        }
+    }
+}
+";
+
+            VerifyCSharpDiagnostic(test);
+        }
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+            => new ComponentClosureOverLoopVariablesDiagnosticAnalzyer();
+    }
+}

--- a/src/Components/Analyzers/test/ComponentClosureOverLoopVariableCodeFixProviderTest.cs
+++ b/src/Components/Analyzers/test/ComponentClosureOverLoopVariableCodeFixProviderTest.cs
@@ -1,0 +1,346 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using TestHelper;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Analyzers.Test
+{
+    public class ComponentClosureOverLoopVariableCodeFixProviderTest : CodeFixVerifier
+    {
+
+        [Fact]
+        public void AddsLocalVariableForLoopClosure_WhenNeeded()
+        {
+            var test = @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                SomeAction( () => { var x = i; } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}";
+            VerifyCSharpDiagnostic(test,
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 11, 45)
+                    }
+                }
+            );
+
+            VerifyCSharpFix(test, @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var lcl_I = i;
+                SomeAction( () => { var x = lcl_I; } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}");
+        }
+
+        [Fact]
+        public void AddsLocalVariableForLoopClosure_WhenMultipleInstances()
+        {
+            var test = @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                SomeAction( () => { var x = i; Console.WriteLine($""Loop var: {i}""); } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}";
+            VerifyCSharpDiagnostic(test,
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 11, 45)
+                    }
+                },
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 11, 79)
+                    }
+                }
+            );
+
+            VerifyCSharpFix(test, @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var lcl_I = i;
+                SomeAction( () => { var x = lcl_I; Console.WriteLine($""Loop var: {lcl_I}""); } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}");
+        }
+
+        [Fact]
+        public void UsesExistingLocalVariableForLoopClosure_WhenExists()
+        {
+            var test = @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                int loopVar =   i;
+                SomeAction( () => { var x = i; } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}";
+            VerifyCSharpDiagnostic(test,
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 12, 45)
+                    }
+                }
+            );
+
+            VerifyCSharpFix(test, @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                int loopVar =   i;
+                SomeAction( () => { var x = loopVar; } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}");
+        }
+
+        [Fact]
+        public void AddsLocalVariableForLoopClosure_WhenExistingIsNotUseful()
+        {
+            var test = @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                int loopVar =  2 * i;
+                SomeAction( () => { var x = i; } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}";
+            VerifyCSharpDiagnostic(test,
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 12, 45)
+                    }
+                }
+            );
+
+            VerifyCSharpFix(test, @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var lcl_I = i;
+                int loopVar =  2 * i;
+                SomeAction( () => { var x = lcl_I; } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}");
+        }
+
+        [Fact]
+        public void AddsLocalVariableForSingleLineLoopClosure_WhenNeeded()
+        {
+            var test = @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+                SomeAction( () => { var x = i; } );
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}";
+            VerifyCSharpDiagnostic(test,
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 10, 45)
+                    }
+                }
+            );
+
+            VerifyCSharpFix(test, @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var lcl_I = i;
+                SomeAction( () => { var x = lcl_I; } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}");
+        }
+
+        [Fact]
+        public void AddsLocalVariableForSingleLineLoopClosure_WhenMultipleInstances()
+        {
+            var test = @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+                SomeAction( () => { var x = i;  Console.WriteLine($""Loop var: {i}""); } );
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}";
+            VerifyCSharpDiagnostic(test,
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 10, 45)
+                    }
+                },
+                new DiagnosticResult
+                {
+                    Id = DiagnosticDescriptors.ClosureOverLoopVariables.Id,
+                    Message = DiagnosticDescriptors.ClosureOverLoopVariables.Description.ToString(),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations = new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 10, 80)
+                    }
+                }
+            );
+
+            VerifyCSharpFix(test, @"
+namespace LoopTesting
+{
+    using System;
+    class UsesClosureOverForLoopVariable
+    {
+        void Test()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var lcl_I = i;
+                SomeAction( () => { var x = lcl_I;  Console.WriteLine($""Loop var: {lcl_I}""); } );
+            }
+        }
+        void SomeAction(Action action) => action.Invoke();
+    }
+}");
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+            => new ComponentClosureOverLoopVariablesCodeFixProvider();
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+            => new ComponentClosureOverLoopVariablesDiagnosticAnalzyer();
+    }
+}


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Adds a Roslyn analyzer to detect use of a for loop variable in a lambda
 - Adds a Roslyn code fix to introduce a local variable and replace it in the lambda

Addresses #10476 
