### PR TITLE
Add reset support for IIS

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
@@ -589,4 +589,16 @@ http_response_set_trailer(
     IHttpResponse4* pHttpResponse = (IHttpResponse4*)pInProcessHandler->QueryHttpContext()->GetResponse();
     return pHttpResponse->SetTrailer(pszHeaderName, pszHeaderValue, usHeaderValueLength, fReplace);
 }
+
+EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+VOID
+http_reset_stream(
+    _In_ IN_PROCESS_HANDLER* pInProcessHandler,
+    ULONG errorCode
+)
+{
+    IHttpResponse4* pHttpResponse = (IHttpResponse4*)pInProcessHandler->QueryHttpContext()->GetResponse();
+    pHttpResponse->ResetStream(errorCode);
+}
+
 // End of export

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -408,6 +408,11 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
         void IHttpResetFeature.Reset(int errorCode)
         {
+            if (errorCode < 0)
+            {
+                throw new ArgumentOutOfRangeException("'errorCode' cannot be negative");
+            }
+
             SetResetCode(errorCode);
             AbortIO(clientDisconnect: false);
         }

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -409,19 +409,12 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
         void IHttpResetFeature.Reset(int errorCode)
         {
             SetResetCode(errorCode);
-            Abort(new Exception());
+            AbortIO(clientDisconnect: false);
         }
 
         internal unsafe void SetResetCode(int errorCode)
         {
-            try
-            {
-                NativeMethods.HttpResetStream(_pInProcessHandler, (ulong)errorCode);
-            }
-            catch (ObjectDisposedException)
-            {
-                // RequestQueueHandle may have been closed
-            }
+            NativeMethods.HttpResetStream(_pInProcessHandler, (ulong)errorCode);
         }
 
         void IHttpResponseBodyFeature.DisableBuffering()

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.Features.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.Features.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
         private static readonly Type IServerVariablesFeature = typeof(global::Microsoft.AspNetCore.Http.Features.IServerVariablesFeature);
         private static readonly Type IHttpMaxRequestBodySizeFeature = typeof(global::Microsoft.AspNetCore.Http.Features.IHttpMaxRequestBodySizeFeature);
         private static readonly Type IHttpResponseTrailersFeature = typeof(global::Microsoft.AspNetCore.Http.Features.IHttpResponseTrailersFeature);
+        private static readonly Type IHttpResetFeature = typeof(global::Microsoft.AspNetCore.Http.Features.IHttpResetFeature);
 
         private object _currentIHttpRequestFeature;
         private object _currentIHttpResponseFeature;
@@ -50,6 +51,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
         private object _currentIServerVariablesFeature;
         private object _currentIHttpMaxRequestBodySizeFeature;
         private object _currentIHttpResponseTrailersFeature;
+        private object _currentIHttpResetFeature;
 
         private void Initialize()
         {
@@ -66,6 +68,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             _currentIHttpMaxRequestBodySizeFeature = this;
             _currentITlsConnectionFeature = this;
             _currentIHttpResponseTrailersFeature = GetResponseTrailersFeature();
+            _currentIHttpResetFeature = GetResetFeature();
         }
 
         internal object FastFeatureGet(Type key)
@@ -153,6 +156,10 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             if (key == IHttpResponseTrailersFeature)
             {
                 return _currentIHttpResponseTrailersFeature;
+            }
+            if (key == IHttpResetFeature)
+            {
+                return _currentIHttpResetFeature;
             }
 
             return ExtraFeatureGet(key);
@@ -260,6 +267,10 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             {
                 _currentIHttpResponseTrailersFeature = feature;
             }
+            if (key == IHttpResetFeature)
+            {
+                _currentIHttpResetFeature = feature;
+            }
             if (key == IISHttpContextType)
             {
                 throw new InvalidOperationException("Cannot set IISHttpContext in feature collection");
@@ -348,6 +359,10 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             if (_currentIHttpResponseTrailersFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(IHttpResponseTrailersFeature, _currentIHttpResponseTrailersFeature as global::Microsoft.AspNetCore.Http.Features.IHttpResponseTrailersFeature);
+            }
+            if (_currentIHttpResetFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(IHttpResponseTrailersFeature, _currentIHttpResetFeature as global::Microsoft.AspNetCore.Http.Features.IHttpResetFeature);
             }
 
             if (MaybeExtra != null)

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
@@ -59,6 +59,13 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                     // Dispose
                 }
 
+                if (!success && HasResponseStarted)
+                {
+                    // HTTP/2 INTERNAL_ERROR = 0x2 https://tools.ietf.org/html/rfc7540#section-7
+                    // Otherwise the default is Cancel = 0x8.
+                    SetResetCode(2);
+                }
+
                 if (_onCompleted != null)
                 {
                     await FireOnCompleted();

--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -202,9 +202,9 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             {
                 server = (IISHttpServer)GCHandle.FromIntPtr(serverContext).Target;
 
-                server._nativeApplication.StopCallsIntoManaged();
-                server._shutdownSignal.TrySetResult(null);
-                server._cancellationTokenRegistration.Dispose();
+                server?._nativeApplication.StopCallsIntoManaged();
+                server?._shutdownSignal.TrySetResult(null);
+                server?._cancellationTokenRegistration.Dispose();
             }
             catch (Exception ex)
             {

--- a/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpServer.cs
@@ -202,9 +202,9 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             {
                 server = (IISHttpServer)GCHandle.FromIntPtr(serverContext).Target;
 
-                server?._nativeApplication.StopCallsIntoManaged();
-                server?._shutdownSignal.TrySetResult(null);
-                server?._cancellationTokenRegistration.Dispose();
+                server._nativeApplication.StopCallsIntoManaged();
+                server._shutdownSignal.TrySetResult(null);
+                server._cancellationTokenRegistration.Dispose();
             }
             catch (Exception ex)
             {

--- a/src/Servers/IIS/IIS/src/NativeMethods.cs
+++ b/src/Servers/IIS/IIS/src/NativeMethods.cs
@@ -147,6 +147,9 @@ namespace Microsoft.AspNetCore.Server.IIS
         private static extern unsafe int http_response_set_trailer(IntPtr pInProcessHandler, byte* pszHeaderName, byte* pszHeaderValue, ushort usHeaderValueLength, bool replace);
 
         [DllImport(AspNetCoreModuleDll)]
+        private static extern unsafe int http_reset_stream(IntPtr pInProcessHandler, ulong errorCode);
+
+        [DllImport(AspNetCoreModuleDll)]
         private static extern unsafe int http_response_set_known_header(IntPtr pInProcessHandler, int headerId, byte* pHeaderValue, ushort length, bool fReplace);
 
         [DllImport(AspNetCoreModuleDll)]
@@ -316,6 +319,11 @@ namespace Microsoft.AspNetCore.Server.IIS
         internal static unsafe void HttpResponseSetTrailer(IntPtr pInProcessHandler, byte* pHeaderName, byte* pHeaderValue, ushort length, bool replace)
         {
             Validate(http_response_set_trailer(pInProcessHandler, pHeaderName, pHeaderValue, length, false));
+        }
+
+        internal static unsafe void HttpResetStream(IntPtr pInProcessHandler, ulong errorCode)
+        {
+            Validate(http_reset_stream(pInProcessHandler, errorCode));
         }
 
         internal static unsafe bool HttpSupportTrailer(IntPtr pInProcessHandler)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResetTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResetTests.cs
@@ -1,0 +1,372 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http2Cat;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
+using Microsoft.AspNetCore.Server.IntegrationTesting.Common;
+using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+{
+    [Collection(PublishedSitesCollection.Name)]
+    public class ResetTests : IISFunctionalTestBase
+    {
+        public ResetTests(PublishedSitesFixture fixture) : base(fixture)
+        {
+        }
+
+        private static readonly Version Win10_Regressed_DataFrame = new Version(10, 0, 20145, 0);
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
+        public async Task AppException_BeforeResponseHeaders_500()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri + "AppException_BeforeResponseHeaders_500", async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+
+                    await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
+                    {
+                        Assert.Equal("500", decodedHeaders[HeaderNames.Status]);
+                    });
+
+                    var dataFrame = await h2Connection.ReceiveFrameAsync();
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
+
+                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                    }
+                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: true, length: 0);
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
+        [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H1, SkipReason = "This is last version without custom Reset support")]
+        public async Task AppException_AfterHeaders_PriorOSVersions_ResetCancel()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri + "AppException_AfterHeaders_PriorOSVersions_ResetCancel", async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+
+                    await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
+                    {
+                        Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
+                    });
+
+                    var resetFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, Http2ErrorCode.CANCEL);
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Custom Reset support was added in Win10_20H2.")]
+        public async Task AppException_AfterHeaders_ResetInternalError()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri, async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+
+                    await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
+                    {
+                        Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
+                    });
+
+                    var frame = await h2Connection.ReceiveFrameAsync();
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(frame, 1, endOfStream: false, length: 0);
+
+                        frame = await h2Connection.ReceiveFrameAsync();
+                    }
+                    Http2Utilities.VerifyResetFrame(frame, expectedStreamId: 1, Http2ErrorCode.INTERNAL_ERROR);
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        [ConditionalFact]
+        public async Task Reset_Http1_NotSupported()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var handler = new HttpClientHandler();
+            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            using HttpClient client = new HttpClient(handler);
+            client.DefaultRequestVersion = HttpVersion.Version11;
+            var response = await client.GetStringAsync(deploymentResult.ApplicationBaseUri);
+            Assert.Equal("Hello World", response);
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
+        [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H1, SkipReason = "This is last version without Reset support")]
+        public async Task Reset_PriorOSVersions_NotSupported()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var handler = new HttpClientHandler();
+            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            using HttpClient client = new HttpClient(handler);
+            client.DefaultRequestVersion = HttpVersion.Version20;
+            var response = await client.GetStringAsync(deploymentResult.ApplicationBaseUri);
+            Assert.Equal("Hello World", response);
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
+        public async Task Reset_BeforeResponse_Resets()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri, async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+
+                    var resetFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+
+                    // Any app errors?
+
+                    //Assert.True(deploymentResult.HttpClient.SendAsync(""))
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
+        public async Task Reset_AfterResponseHeaders_Resets()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri, async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+
+                    // Any app errors?
+                    //Assert.Equal(0, await appResult.Task.DefaultTimeout());
+
+                    await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
+                    {
+                        Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
+                    });
+
+                    var dataFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyDataFrame(dataFrame, expectedStreamId: 1, endOfStream: false, length: 0);
+
+                    var resetFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
+        public async Task Reset_DurringResponseBody_Resets()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri, async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+
+                    // Any app errors?
+                    //Assert.Equal(0, await appResult.Task.DefaultTimeout());
+
+                    await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
+                    {
+                        Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
+                    });
+
+                    var dataFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 11);
+
+                    var resetFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
+        public async Task Reset_BeforeRequestBody_Resets()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri, async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.PostRequestHeaders, endStream: false);
+
+                    // Any app errors?
+                    //Assert.Equal(0, await appResult.Task.DefaultTimeout());
+
+                    var resetFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
+        public async Task Reset_DurringRequestBody_Resets()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri, async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.PostRequestHeaders, endStream: false);
+                    await h2Connection.SendDataAsync(1, new byte[10], endStream: false);
+
+                    // Any app errors?
+                    //Assert.Equal(0, await appResult.Task.DefaultTimeout());
+
+                    var resetFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
+        public async Task Reset_CompleteAsyncDurringRequestBody_Resets()
+        {
+            var deploymentParameters = GetHttpsDeploymentParameters();
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await new HostBuilder()
+                .UseHttp2Cat(deploymentResult.ApplicationBaseUri, async h2Connection =>
+                {
+                    await h2Connection.InitializeConnectionAsync();
+
+                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
+
+                    await h2Connection.StartStreamAsync(1, Http2Utilities.PostRequestHeaders, endStream: false);
+                    await h2Connection.SendDataAsync(1, new byte[10], endStream: false);
+
+                    // Any app errors?
+                    //Assert.Equal(0, await appResult.Task.DefaultTimeout());
+
+                    await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
+                    {
+                        Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
+                    });
+
+                    var dataFrame = await h2Connection.ReceiveFrameAsync();
+                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
+                    {
+                        // TODO: Remove when the regression is fixed.
+                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
+                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
+
+                        dataFrame = await h2Connection.ReceiveFrameAsync();
+                    }
+                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: true, length: 0);
+
+                    var resetFrame = await h2Connection.ReceiveFrameAsync();
+                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: Http2ErrorCode.NO_ERROR);
+
+                    h2Connection.Logger.LogInformation("Connection stopped.");
+                })
+                .Build().RunAsync();
+        }
+
+        private IISDeploymentParameters GetHttpsDeploymentParameters()
+        {
+            var port = TestPortHelper.GetNextSSLPort();
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+            deploymentParameters.ApplicationBaseUriHint = $"https://localhost:{port}/";
+            deploymentParameters.AddHttpsToServerConfig();
+            return deploymentParameters;
+        }
+    }
+}

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResetTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/ResetTests.cs
@@ -42,6 +42,13 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             new KeyValuePair<string, string>("upgrade-insecure-requests", "1"),
         };
 
+        public static readonly IEnumerable<KeyValuePair<string, string>> PostRequestHeaders = new[]
+{
+            new KeyValuePair<string, string>(HeaderNames.Method, "POST"),
+            new KeyValuePair<string, string>(HeaderNames.Scheme, "https"),
+            new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+        };
+
         [ConditionalFact]
         [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
         public async Task AppException_BeforeResponseHeaders_500()
@@ -156,7 +163,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
             using HttpClient client = new HttpClient(handler);
             client.DefaultRequestVersion = HttpVersion.Version11;
-            var response = await client.GetStringAsync(deploymentResult.ApplicationBaseUri);
+            var response = await client.GetStringAsync(deploymentResult.ApplicationBaseUri + "Reset_Http1_NotSupported");
             Assert.Equal("Hello World", response);
         }
 
@@ -190,14 +197,15 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
                     h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
 
-                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+                    await h2Connection.StartStreamAsync(1, GetHeaders("/Reset_BeforeResponse_Resets"), endStream: true);
 
                     var resetFrame = await h2Connection.ReceiveFrameAsync();
                     Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
 
                     // Any app errors?
-
-                    //Assert.True(deploymentResult.HttpClient.SendAsync(""))
+                    var client = CreateClient();
+                    var response = await client.GetAsync(deploymentResult.ApplicationBaseUri + "/Reset_BeforeResponse_Resets_Complete");
+                    Assert.True(response.IsSuccessStatusCode);
 
                     h2Connection.Logger.LogInformation("Connection stopped.");
                 })
@@ -218,10 +226,12 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
                     h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
 
-                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+                    await h2Connection.StartStreamAsync(1, GetHeaders("/Reset_AfterResponseHeaders_Resets"), endStream: true);
 
                     // Any app errors?
-                    //Assert.Equal(0, await appResult.Task.DefaultTimeout());
+                    var client = CreateClient();
+                    var response = await client.GetAsync(deploymentResult.ApplicationBaseUri + "/Reset_AfterResponseHeaders_Resets_Complete");
+                    Assert.True(response.IsSuccessStatusCode);
 
                     await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
                     {
@@ -241,7 +251,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalFact]
         [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
-        public async Task Reset_DurringResponseBody_Resets()
+        public async Task Reset_DuringResponseBody_Resets()
         {
             var deploymentParameters = GetHttpsDeploymentParameters();
             var deploymentResult = await DeployAsync(deploymentParameters);
@@ -253,21 +263,24 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
                     h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
 
-                    await h2Connection.StartStreamAsync(1, Http2Utilities.BrowserRequestHeaders, endStream: true);
+                    await h2Connection.StartStreamAsync(1, GetHeaders("/Reset_DuringResponseBody_Resets"), endStream: true);
 
-                    // Any app errors?
-                    //Assert.Equal(0, await appResult.Task.DefaultTimeout());
+                    // This is currently flaky, can either receive header or reset at this point
+                    var headerOrResetFrame = await h2Connection.ReceiveFrameAsync();
+                    Assert.True(headerOrResetFrame.Type == Http2FrameType.HEADERS || headerOrResetFrame.Type == Http2FrameType.RST_STREAM);
 
-                    await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
+                    if (headerOrResetFrame.Type == Http2FrameType.HEADERS)
                     {
-                        Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
-                    });
+                        var dataFrame = await h2Connection.ReceiveFrameAsync();
+                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 11);
 
-                    var dataFrame = await h2Connection.ReceiveFrameAsync();
-                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 11);
-
-                    var resetFrame = await h2Connection.ReceiveFrameAsync();
-                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+                        var resetFrame = await h2Connection.ReceiveFrameAsync();
+                        Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+                    }
+                    else
+                    {
+                        Http2Utilities.VerifyResetFrame(headerOrResetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
+                    }
 
                     h2Connection.Logger.LogInformation("Connection stopped.");
                 })
@@ -289,7 +302,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
                     h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
 
-                    await h2Connection.StartStreamAsync(1, Http2Utilities.PostRequestHeaders, endStream: false);
+                    await h2Connection.StartStreamAsync(1, GetPostHeaders("/Reset_BeforeRequestBody_Resets"), endStream: false);
 
                     // Any app errors?
                     //Assert.Equal(0, await appResult.Task.DefaultTimeout());
@@ -304,7 +317,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalFact]
         [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
-        public async Task Reset_DurringRequestBody_Resets()
+        public async Task Reset_DuringRequestBody_Resets()
         {
             var deploymentParameters = GetHttpsDeploymentParameters();
             var deploymentResult = await DeployAsync(deploymentParameters);
@@ -316,7 +329,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
                     h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
 
-                    await h2Connection.StartStreamAsync(1, Http2Utilities.PostRequestHeaders, endStream: false);
+                    await h2Connection.StartStreamAsync(1, GetPostHeaders("/Reset_DuringRequestBody_Resets"), endStream: false);
                     await h2Connection.SendDataAsync(1, new byte[10], endStream: false);
 
                     // Any app errors?
@@ -324,50 +337,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
                     var resetFrame = await h2Connection.ReceiveFrameAsync();
                     Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: (Http2ErrorCode)1111);
-
-                    h2Connection.Logger.LogInformation("Connection stopped.");
-                })
-                .Build().RunAsync();
-        }
-
-        [ConditionalFact]
-        [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Reset support was added in Win10_20H2.")]
-        public async Task Reset_CompleteAsyncDurringRequestBody_Resets()
-        {
-            var deploymentParameters = GetHttpsDeploymentParameters();
-            var deploymentResult = await DeployAsync(deploymentParameters);
-
-            await new HostBuilder()
-                .UseHttp2Cat(deploymentResult.ApplicationBaseUri, async h2Connection =>
-                {
-                    await h2Connection.InitializeConnectionAsync();
-
-                    h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
-
-                    await h2Connection.StartStreamAsync(1, Http2Utilities.PostRequestHeaders, endStream: false);
-                    await h2Connection.SendDataAsync(1, new byte[10], endStream: false);
-
-                    // Any app errors?
-                    //Assert.Equal(0, await appResult.Task.DefaultTimeout());
-
-                    await h2Connection.ReceiveHeadersAsync(1, decodedHeaders =>
-                    {
-                        Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
-                    });
-
-                    var dataFrame = await h2Connection.ReceiveFrameAsync();
-                    if (Environment.OSVersion.Version >= Win10_Regressed_DataFrame)
-                    {
-                        // TODO: Remove when the regression is fixed.
-                        // https://github.com/dotnet/aspnetcore/issues/23164#issuecomment-652646163
-                        Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: false, length: 0);
-
-                        dataFrame = await h2Connection.ReceiveFrameAsync();
-                    }
-                    Http2Utilities.VerifyDataFrame(dataFrame, 1, endOfStream: true, length: 0);
-
-                    var resetFrame = await h2Connection.ReceiveFrameAsync();
-                    Http2Utilities.VerifyResetFrame(resetFrame, expectedStreamId: 1, expectedErrorCode: Http2ErrorCode.NO_ERROR);
 
                     h2Connection.Logger.LogInformation("Connection stopped.");
                 })
@@ -383,6 +352,16 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             return headers;
         }
 
+        private static List<KeyValuePair<string, string>> GetPostHeaders(string path)
+        {
+            var headers = PostRequestHeaders.ToList();
+
+            var kvp = new KeyValuePair<string, string>(HeaderNames.Path, path);
+            headers.Add(kvp);
+            return headers;
+        }
+
+
         private IISDeploymentParameters GetHttpsDeploymentParameters()
         {
             var port = TestPortHelper.GetNextSSLPort();
@@ -391,5 +370,15 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             deploymentParameters.AddHttpsToServerConfig();
             return deploymentParameters;
         }
+
+        private static HttpClient CreateClient()
+        {
+            var handler = new HttpClientHandler();
+            handler.MaxResponseHeadersLength = 128;
+            handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            var client = new HttpClient(handler);
+            return client;
+        }
+
     }
 }

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
@@ -5,6 +5,7 @@
     <TestGroupName>IIS.FunctionalTests</TestGroupName>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <SkipTests Condition=" '$(SkipIISTests)' == 'true' ">true</SkipTests>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <Import Project="../FunctionalTest.props" />
@@ -19,13 +20,30 @@
   <ItemGroup>
     <Compile Include="..\Common.FunctionalTests\**\*.cs" />
     <Compile Include="..\IIS.Shared.FunctionalTests\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
+    <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
     <Reference Include="System.Net.Http.WinHttpHandler" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="$(SharedSourceRoot)ServerInfrastructure\SharedStrings.resx" Link="Shared\SharedStrings.resx">
+      <ManifestResourceName>Microsoft.AspNetCore.Server.SharedStrings</ManifestResourceName>
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(SharedSourceRoot)runtime\SR.resx" Link="Shared\runtime\SR.resx">
+      <ManifestResourceName>System.Net.Http.SR</ManifestResourceName>
+      <Generator></Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
@@ -5,6 +5,7 @@
     <TestGroupName>IISNewHandler.FunctionalTests</TestGroupName>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <SkipTests Condition=" '$(SkipIISNewHandlerTests)' == 'true' ">true</SkipTests>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <Import Project="../FunctionalTest.props" />
@@ -12,6 +13,12 @@
   <ItemGroup>
     <Compile Include="..\Common.FunctionalTests\**\*.cs" />
     <Compile Include="..\IIS.Shared.FunctionalTests\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
+    <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,10 +37,22 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
     <Reference Include="System.Net.WebSockets.WebSocketProtocol" />
     <Reference Include="System.Net.Http.WinHttpHandler" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="$(SharedSourceRoot)ServerInfrastructure\SharedStrings.resx" Link="Shared\SharedStrings.resx">
+      <ManifestResourceName>Microsoft.AspNetCore.Server.SharedStrings</ManifestResourceName>
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(SharedSourceRoot)runtime\SR.resx" Link="Shared\runtime\SR.resx">
+      <ManifestResourceName>System.Net.Http.SR</ManifestResourceName>
+      <Generator></Generator>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
@@ -5,6 +5,7 @@
     <TestGroupName>IISNewShim.FunctionalTests</TestGroupName>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <SkipTests Condition=" '$(SkipIISNewShimTests)' == 'true' ">true</SkipTests>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <Import Project="../FunctionalTest.props" />
@@ -21,13 +22,30 @@
   <ItemGroup>
     <Compile Include="..\Common.FunctionalTests\**\*.cs" />
     <Compile Include="..\IIS.Shared.FunctionalTests\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
+    <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
     <Reference Include="System.Net.Http.WinHttpHandler" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="$(SharedSourceRoot)ServerInfrastructure\SharedStrings.resx" Link="Shared\SharedStrings.resx">
+      <ManifestResourceName>Microsoft.AspNetCore.Server.SharedStrings</ManifestResourceName>
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(SharedSourceRoot)runtime\SR.resx" Link="Shared\runtime\SR.resx">
+      <ManifestResourceName>System.Net.Http.SR</ManifestResourceName>
+      <Generator></Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
@@ -7,6 +7,7 @@
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <TestGroupName>IISExpress.FunctionalTests</TestGroupName>
     <SkipTests Condition=" '$(SkipIISExpressTests)' == 'true' ">true</SkipTests>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 
@@ -23,13 +24,31 @@
 
   <ItemGroup>
     <Compile Include="..\Common.FunctionalTests\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
+    <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="System.Diagnostics.EventLog" />
     <Reference Include="System.Net.Http.WinHttpHandler" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="$(SharedSourceRoot)ServerInfrastructure\SharedStrings.resx" Link="Shared\SharedStrings.resx">
+      <ManifestResourceName>Microsoft.AspNetCore.Server.SharedStrings</ManifestResourceName>
+      <Generator></Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(SharedSourceRoot)runtime\SR.resx" Link="Shared\runtime\SR.resx">
+      <ManifestResourceName>System.Net.Http.SR</ManifestResourceName>
+      <Generator></Generator>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1214,9 +1214,9 @@ namespace TestSite
             await _Reset_AfterResponseHeaders_ResetsCt.Task;
         }
 
-        private TaskCompletionSource<object> _Reset_DurringResponseBody_ResetsCt = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _Reset_DuringResponseBody_ResetsCt = new TaskCompletionSource<object>();
 
-        public async Task Reset_DurringResponseBody_Resets(HttpContext httpContext)
+        public async Task Reset_DuringResponseBody_Resets(HttpContext httpContext)
         {
             try
             {
@@ -1224,18 +1224,19 @@ namespace TestSite
                 var feature = httpContext.Features.Get<IHttpResetFeature>();
                 Assert.NotNull(feature);
                 await httpContext.Response.WriteAsync("Hello World");
+                await httpContext.Response.Body.FlushAsync();
                 feature.Reset(1111); // Custom
-                _Reset_DurringResponseBody_ResetsCt.SetResult(0);
+                _Reset_DuringResponseBody_ResetsCt.SetResult(0);
             }
             catch (Exception ex)
             {
-                _Reset_DurringResponseBody_ResetsCt.SetException(ex);
+                _Reset_DuringResponseBody_ResetsCt.SetException(ex);
             }
         }
 
-        public async Task Reset_DurringResponseBody_Resets_Complete(HttpContext httpContext)
+        public async Task Reset_DuringResponseBody_Resets_Complete(HttpContext httpContext)
         {
-            await _Reset_DurringResponseBody_ResetsCt.Task;
+            await _Reset_DuringResponseBody_ResetsCt.Task;
         }
 
         private TaskCompletionSource<object> _Reset_BeforeRequestBody_ResetsCt = new TaskCompletionSource<object>();
@@ -1266,9 +1267,9 @@ namespace TestSite
             await _Reset_BeforeRequestBody_ResetsCt.Task;
         }
 
-        private TaskCompletionSource<object> _Reset_DurringRequestBody_ResetsCt = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _Reset_DuringRequestBody_ResetsCt = new TaskCompletionSource<object>();
 
-        public async Task Reset_DurringRequestBody_Resets(HttpContext httpContext)
+        public async Task Reset_DuringRequestBody_Resets(HttpContext httpContext)
         {
             try
             {
@@ -1283,17 +1284,17 @@ namespace TestSite
                 feature.Reset(1111);
                 await Assert.ThrowsAsync<IOException>(() => readTask);
 
-                _Reset_DurringRequestBody_ResetsCt.SetResult(0);
+                _Reset_DuringRequestBody_ResetsCt.SetResult(0);
             }
             catch (Exception ex)
             {
-                _Reset_DurringRequestBody_ResetsCt.SetException(ex);
+                _Reset_DuringRequestBody_ResetsCt.SetException(ex);
             }
         }
 
-        public async Task Reset_DurringRequestBody_Resets_Complete(HttpContext httpContext)
+        public async Task Reset_DuringRequestBody_Resets_Complete(HttpContext httpContext)
         {
-            await _Reset_DurringRequestBody_ResetsCt.Task;
+            await _Reset_DuringRequestBody_ResetsCt.Task;
         }
 
         internal static readonly HashSet<(string, StringValues, StringValues)> NullTrailers = new HashSet<(string, StringValues, StringValues)>()

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1168,7 +1168,7 @@ namespace TestSite
             return httpContext.Response.WriteAsync("Hello World");
         }
 
-        private TaskCompletionSource<object> _Reset_BeforeResponse_ResetsCt = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _resetBeforeResponseResetsCts = new TaskCompletionSource<object>();
         public Task Reset_BeforeResponse_Resets(HttpContext httpContext)
         {
             try
@@ -1177,21 +1177,21 @@ namespace TestSite
                 var feature = httpContext.Features.Get<IHttpResetFeature>();
                 Assert.NotNull(feature);
                 feature.Reset(1111); // Custom
-                _Reset_BeforeResponse_ResetsCt.SetResult(0);
+                _resetBeforeResponseResetsCts.SetResult(0);
             }
             catch (Exception ex)
             {
-                _Reset_BeforeResponse_ResetsCt.SetException(ex);
+                _resetBeforeResponseResetsCts.SetException(ex);
             }
             return Task.FromResult(0);
         }
 
         public async Task Reset_BeforeResponse_Resets_Complete(HttpContext httpContext)
         {
-            await _Reset_BeforeResponse_Zero_ResetsCt.Task;
+            await _resetBeforeResponseResetsCts.Task;
         }
 
-        private TaskCompletionSource<object> _Reset_BeforeResponse_Zero_ResetsCt = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _resetBeforeResponseZeroResetsCts = new TaskCompletionSource<object>();
         public Task Reset_BeforeResponse_Zero_Resets(HttpContext httpContext)
         {
             try
@@ -1200,21 +1200,21 @@ namespace TestSite
                 var feature = httpContext.Features.Get<IHttpResetFeature>();
                 Assert.NotNull(feature);
                 feature.Reset(0); // Zero should be an allowed errorCode
-                _Reset_BeforeResponse_Zero_ResetsCt.SetResult(0);
+                _resetBeforeResponseZeroResetsCts.SetResult(0);
             }
             catch (Exception ex)
             {
-                _Reset_BeforeResponse_Zero_ResetsCt.SetException(ex);
+                _resetBeforeResponseZeroResetsCts.SetException(ex);
             }
             return Task.FromResult(0);
         }
 
         public async Task Reset_BeforeResponse_Resets_Zero_Complete(HttpContext httpContext)
         {
-            await _Reset_BeforeResponse_Zero_ResetsCt.Task;
+            await _resetBeforeResponseZeroResetsCts.Task;
         }
 
-        private TaskCompletionSource<object> _Reset_AfterResponseHeaders_ResetsCt = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _resetAfterResponseHeadersResetsCts = new TaskCompletionSource<object>();
 
         public async Task Reset_AfterResponseHeaders_Resets(HttpContext httpContext)
         {
@@ -1225,19 +1225,19 @@ namespace TestSite
                 Assert.NotNull(feature);
                 await httpContext.Response.Body.FlushAsync();
                 feature.Reset(1111); // Custom
-                _Reset_AfterResponseHeaders_ResetsCt.SetResult(0);
+                _resetAfterResponseHeadersResetsCts.SetResult(0);
             }
             catch (Exception ex)
             {
-                _Reset_AfterResponseHeaders_ResetsCt.SetException(ex);
+                _resetAfterResponseHeadersResetsCts.SetException(ex);
             }
         }
         public async Task Reset_AfterResponseHeaders_Resets_Complete(HttpContext httpContext)
         {
-            await _Reset_AfterResponseHeaders_ResetsCt.Task;
+            await _resetAfterResponseHeadersResetsCts.Task;
         }
 
-        private TaskCompletionSource<object> _Reset_DuringResponseBody_ResetsCt = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _resetDuringResponseBodyResetsCts = new TaskCompletionSource<object>();
 
         public async Task Reset_DuringResponseBody_Resets(HttpContext httpContext)
         {
@@ -1249,20 +1249,20 @@ namespace TestSite
                 await httpContext.Response.WriteAsync("Hello World");
                 await httpContext.Response.Body.FlushAsync();
                 feature.Reset(1111); // Custom
-                _Reset_DuringResponseBody_ResetsCt.SetResult(0);
+                _resetDuringResponseBodyResetsCts.SetResult(0);
             }
             catch (Exception ex)
             {
-                _Reset_DuringResponseBody_ResetsCt.SetException(ex);
+                _resetDuringResponseBodyResetsCts.SetException(ex);
             }
         }
 
         public async Task Reset_DuringResponseBody_Resets_Complete(HttpContext httpContext)
         {
-            await _Reset_DuringResponseBody_ResetsCt.Task;
+            await _resetDuringResponseBodyResetsCts.Task;
         }
 
-        private TaskCompletionSource<object> _Reset_BeforeRequestBody_ResetsCt = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _resetBeforeRequestBodyResetsCts = new TaskCompletionSource<object>();
 
         public async Task Reset_BeforeRequestBody_Resets(HttpContext httpContext)
         {
@@ -1277,20 +1277,20 @@ namespace TestSite
 
                 await Assert.ThrowsAsync<IOException>(() => readTask);
 
-                _Reset_BeforeRequestBody_ResetsCt.SetResult(0);
+                _resetBeforeRequestBodyResetsCts.SetResult(0);
             }
             catch (Exception ex)
             {
-                _Reset_BeforeRequestBody_ResetsCt.SetException(ex);
+                _resetBeforeRequestBodyResetsCts.SetException(ex);
             }
         }
 
         public async Task Reset_BeforeRequestBody_Resets_Complete(HttpContext httpContext)
         {
-            await _Reset_BeforeRequestBody_ResetsCt.Task;
+            await _resetBeforeRequestBodyResetsCts.Task;
         }
 
-        private TaskCompletionSource<object> _Reset_DuringRequestBody_ResetsCt = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _resetDuringRequestBodyResetsCts = new TaskCompletionSource<object>();
 
         public async Task Reset_DuringRequestBody_Resets(HttpContext httpContext)
         {
@@ -1307,17 +1307,17 @@ namespace TestSite
                 feature.Reset(1111);
                 await Assert.ThrowsAsync<IOException>(() => readTask);
 
-                _Reset_DuringRequestBody_ResetsCt.SetResult(0);
+                _resetDuringRequestBodyResetsCts.SetResult(0);
             }
             catch (Exception ex)
             {
-                _Reset_DuringRequestBody_ResetsCt.SetException(ex);
+                _resetDuringRequestBodyResetsCts.SetException(ex);
             }
         }
 
         public async Task Reset_DuringRequestBody_Resets_Complete(HttpContext httpContext)
         {
-            await _Reset_DuringRequestBody_ResetsCt.Task;
+            await _resetDuringRequestBodyResetsCts.Task;
         }
 
         internal static readonly HashSet<(string, StringValues, StringValues)> NullTrailers = new HashSet<(string, StringValues, StringValues)>()

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1188,7 +1188,30 @@ namespace TestSite
 
         public async Task Reset_BeforeResponse_Resets_Complete(HttpContext httpContext)
         {
-            await _Reset_BeforeResponse_ResetsCt.Task;
+            await _Reset_BeforeResponse_Zero_ResetsCt.Task;
+        }
+
+        private TaskCompletionSource<object> _Reset_BeforeResponse_Zero_ResetsCt = new TaskCompletionSource<object>();
+        public Task Reset_BeforeResponse_Zero_Resets(HttpContext httpContext)
+        {
+            try
+            {
+                Assert.Equal("HTTP/2", httpContext.Request.Protocol);
+                var feature = httpContext.Features.Get<IHttpResetFeature>();
+                Assert.NotNull(feature);
+                feature.Reset(0); // Zero should be an allowed errorCode
+                _Reset_BeforeResponse_Zero_ResetsCt.SetResult(0);
+            }
+            catch (Exception ex)
+            {
+                _Reset_BeforeResponse_Zero_ResetsCt.SetException(ex);
+            }
+            return Task.FromResult(0);
+        }
+
+        public async Task Reset_BeforeResponse_Resets_Zero_Complete(HttpContext httpContext)
+        {
+            await _Reset_BeforeResponse_Zero_ResetsCt.Task;
         }
 
         private TaskCompletionSource<object> _Reset_AfterResponseHeaders_ResetsCt = new TaskCompletionSource<object>();

--- a/src/Servers/IIS/IISIntegration.slnf
+++ b/src/Servers/IIS/IISIntegration.slnf
@@ -1,30 +1,29 @@
-﻿{
+{
   "solution": {
     "path": "..\\..\\..\\AspNetCore.sln",
-    "projects" : [
-      "src\\Servers\\IIS\\IISIntegration\\src\\Microsoft.AspNetCore.Server.IISIntegration.csproj",
-      "src\\Servers\\IIS\\IIS\\test\\IISExpress.FunctionalTests\\IISExpress.FunctionalTests.csproj",
-      "src\\Servers\\IIS\\IIS\\samples\\NativeIISSample\\NativeIISSample.csproj",
-      "src\\Servers\\IIS\\IIS\\src\\Microsoft.AspNetCore.Server.IIS.csproj",
+    "projects": [
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\AspNetCore\\AspNetCore.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\CommonLibTests\\CommonLibTests.vcxproj",
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\CommonLib\\CommonLib.vcxproj",
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\IISLib\\IISLib.vcxproj",
-      "src\\Servers\\IIS\\IIS\\benchmarks\\IIS.Performance\\IIS.Performance.csproj",
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\InProcessRequestHandler\\InProcessRequestHandler.vcxproj",
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\OutOfProcessRequestHandler\\OutOfProcessRequestHandler.vcxproj",
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\RequestHandlerLib\\RequestHandlerLib.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\Symbols\\Microsoft.AspNetCore.ANCMSymbols.csproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\gtest\\gtest.vcxproj",
+      "src\\Servers\\IIS\\IISIntegration\\samples\\IISSample\\IISSample.csproj",
+      "src\\Servers\\IIS\\IISIntegration\\src\\Microsoft.AspNetCore.Server.IISIntegration.csproj",
+      "src\\Servers\\IIS\\IISIntegration\\test\\Tests\\Microsoft.AspNetCore.Server.IISIntegration.Tests.csproj",
+      "src\\Servers\\IIS\\IIS\\benchmarks\\IIS.Performance\\IIS.Performance.csproj",
+      "src\\Servers\\IIS\\IIS\\samples\\NativeIISSample\\NativeIISSample.csproj",
+      "src\\Servers\\IIS\\IIS\\src\\Microsoft.AspNetCore.Server.IIS.csproj",
       "src\\Servers\\IIS\\IIS\\test\\IIS.FunctionalTests\\IIS.FunctionalTests.csproj",
-      "src\\Servers\\IIS\\IIS\\test\\IIS.Tests\\IIS.Tests.csproj",
-      "src\\Servers\\IIS\\IIS\\test\\testassets\\IIS.Common.TestLib\\IIS.Common.TestLib.csproj",
       "src\\Servers\\IIS\\IIS\\test\\IIS.NewHandler.FunctionalTests\\IIS.NewHandler.FunctionalTests.csproj",
       "src\\Servers\\IIS\\IIS\\test\\IIS.NewShim.FunctionalTests\\IIS.NewShim.FunctionalTests.csproj",
-      "src\\Servers\\IIS\\IIS\\test\\testassets\\TestTasks\\TestTasks.csproj",
+      "src\\Servers\\IIS\\IIS\\test\\IIS.Tests\\IIS.Tests.csproj",
+      "src\\Servers\\IIS\\IIS\\test\\IISExpress.FunctionalTests\\IISExpress.FunctionalTests.csproj",
       "src\\Servers\\IIS\\IIS\\test\\testassets\\InProcessWebSite\\InProcessWebSite.csproj",
-      "src\\Servers\\IIS\\IISIntegration\\test\\Tests\\Microsoft.AspNetCore.Server.IISIntegration.Tests.csproj",
-      "src\\Servers\\IIS\\IntegrationTesting.IIS\\src\\Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj",
-      "src\\Servers\\IIS\\AspNetCoreModuleV2\\CommonLibTests\\CommonLibTests.vcxproj",
-      "src\\Servers\\IIS\\IISIntegration\\samples\\IISSample\\IISSample.csproj",
-      "src\\Servers\\IIS\\AspNetCoreModuleV2\\gtest\\gtest.vcxproj"
+      "src\\Servers\\IIS\\IntegrationTesting.IIS\\src\\Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj"
     ]
   }
 }


### PR DESCRIPTION
Part of support gRPC in IIS.

This currently is targeting the Trailers PR for now.

@JamesNK this may be relevant, but from what I can tell, if you call WriteAsync and then call Reset(), it isn't guaranteed that the data written in WriteAsync is sent to the client. Is this a large concern?