### PR TITLE
Fix some linker warnings, report others

### DIFF
--- a/src/Hosting/Abstractions/src/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
         /// <param name="startupAssemblyName">The name of the assembly containing the startup type.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-        [RequiresUnreferencedCode("Types and members the loaded assembly depends on might be removed")]
+        [RequiresUnreferencedCode("Types and members the loaded assembly depends on might be removed.")]
         public static IWebHostBuilder UseStartup(this IWebHostBuilder hostBuilder, string startupAssemblyName)
         {
             if (startupAssemblyName == null)

--- a/src/Hosting/Abstractions/src/HostingAbstractionsWebHostBuilderExtensions.cs
+++ b/src/Hosting/Abstractions/src/HostingAbstractionsWebHostBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -47,13 +48,13 @@ namespace Microsoft.AspNetCore.Hosting
         /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
         /// <param name="startupAssemblyName">The name of the assembly containing the startup type.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        [RequiresUnreferencedCode("Types and members the loaded assembly depends on might be removed")]
         public static IWebHostBuilder UseStartup(this IWebHostBuilder hostBuilder, string startupAssemblyName)
         {
             if (startupAssemblyName == null)
             {
                 throw new ArgumentNullException(nameof(startupAssemblyName));
             }
-
 
             return hostBuilder
                 .UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName)

--- a/src/Hosting/Abstractions/src/HostingStartupAttribute.cs
+++ b/src/Hosting/Abstractions/src/HostingStartupAttribute.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Microsoft.AspNetCore.Hosting
@@ -16,7 +17,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// Constructs the <see cref="HostingStartupAttribute"/> with the specified type.
         /// </summary>
         /// <param name="hostingStartupType">A type that implements <see cref="IHostingStartup"/>.</param>
-        public HostingStartupAttribute(Type hostingStartupType)
+        public HostingStartupAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type hostingStartupType)
         {
             if (hostingStartupType == null)
             {
@@ -35,6 +36,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// The implementation of <see cref="IHostingStartup"/> that should be loaded when 
         /// starting an application.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
         public Type HostingStartupType { get; }
     }
 }

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -234,6 +234,7 @@ namespace Microsoft.AspNetCore.Hosting
             return this;
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern", Justification = "We need to call a generic method on IHostBuilder")]
         private void UseStartup([DynamicallyAccessedMembers(StartupLinkerOptions.Accessibility)] Type startupType, HostBuilderContext context, IServiceCollection services, object instance = null)
         {
             var webHostBuilderContext = GetWebHostBuilderContext(context);
@@ -275,12 +276,12 @@ namespace Microsoft.AspNetCore.Hosting
                     var actionType = typeof(Action<,>).MakeGenericType(typeof(HostBuilderContext), containerType);
 
                     // Get the private ConfigureContainer method on this type then close over the container type
-                    var configureCallback = GetType().GetMethod(nameof(ConfigureContainer), BindingFlags.NonPublic | BindingFlags.Instance)
+                    var configureCallback = typeof(GenericWebHostBuilder).GetMethod(nameof(ConfigureContainerImpl), BindingFlags.NonPublic | BindingFlags.Instance)
                                                      .MakeGenericMethod(containerType)
                                                      .CreateDelegate(actionType, this);
 
                     // _builder.ConfigureContainer<T>(ConfigureContainer);
-                    typeof(IHostBuilder).GetMethods().First(m => m.Name == nameof(IHostBuilder.ConfigureContainer))
+                    typeof(IHostBuilder).GetMethod(nameof(IHostBuilder.ConfigureContainer))
                         .MakeGenericMethod(containerType)
                         .InvokeWithoutWrappingExceptions(_builder, new object[] { configureCallback });
                 }
@@ -310,7 +311,7 @@ namespace Microsoft.AspNetCore.Hosting
             });
         }
 
-        private void ConfigureContainer<TContainer>(HostBuilderContext context, TContainer container)
+        private void ConfigureContainerImpl<TContainer>(HostBuilderContext context, TContainer container)
         {
             var instance = context.Properties[_startupKey];
             var builder = (ConfigureContainerBuilder)context.Properties[typeof(ConfigureContainerBuilder)];

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -234,7 +234,7 @@ namespace Microsoft.AspNetCore.Hosting
             return this;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern", Justification = "We need to call a generic method on IHostBuilder")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern", Justification = "We need to call a generic method on IHostBuilder.")]
         private void UseStartup([DynamicallyAccessedMembers(StartupLinkerOptions.Accessibility)] Type startupType, HostBuilderContext context, IServiceCollection services, object instance = null)
         {
             var webHostBuilderContext = GetWebHostBuilderContext(context);

--- a/src/Hosting/Hosting/src/Internal/StartupLoader.cs
+++ b/src/Hosting/Hosting/src/Internal/StartupLoader.cs
@@ -222,6 +222,7 @@ namespace Microsoft.AspNetCore.Hosting
             }
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "We're warning at the entry point. This is an implementation detail.")]
         public static Type FindStartupType(string startupAssemblyName, string environmentName)
         {
             if (string.IsNullOrEmpty(startupAssemblyName))

--- a/src/Hosting/Server.IntegrationTesting/src/ApplicationPublisher.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/ApplicationPublisher.cs
@@ -79,8 +79,9 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 //    https://stackoverflow.com/a/37983587/102052
                 //
                 // 2. If "dotnet publish" does hang indefinitely for some reason, tests should fail fast with an error message.
-                const int timeoutMinutes = 5;
-                if (hostProcess.WaitForExit(milliseconds: timeoutMinutes * 60 * 1000))
+                var timeout = deploymentParameters.PublishTimeout ?? TimeSpan.FromMinutes(5);
+
+                if (hostProcess.WaitForExit(milliseconds: (int)timeout.TotalMilliseconds))
                 {
                     if (hostProcess.ExitCode != 0)
                     {
@@ -91,7 +92,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
                 }
                 else
                 {
-                    var message = $"{DotnetCommandName} publish failed to exit after {timeoutMinutes} minutes";
+                    var message = $"{DotnetCommandName} publish failed to exit after {timeout.TotalMinutes} minutes";
                     logger.LogError(message);
                     throw new Exception(message);
                 }

--- a/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentParameters.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentParameters.cs
@@ -179,6 +179,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         /// </summary>
         public Action<DeploymentParameters> UserAdditionalCleanup { get; set; }
 
+        /// <summary>
+        /// Timeout for publish
+        /// </summary>
+        public TimeSpan? PublishTimeout { get; set; }
+
         public override string ToString()
         {
             return string.Format(

--- a/src/Hosting/test/FunctionalTests/LinkedApplicationTests.cs
+++ b/src/Hosting/test/FunctionalTests/LinkedApplicationTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
                     ApplicationType = ApplicationType.Standalone,
                     PublishApplicationBeforeDeployment = true,
                     RestoreDependencies = true,
+                    PublishTimeout = TimeSpan.FromMinutes(10), // Machines are slow (these tests restore)
                     StatusMessagesEnabled = false
                 };
 


### PR DESCRIPTION
Follow up to #24458 

- Added RequiresUnreferencedCode to UseStartup that takes a string
- Added some suppressions
- Fixed ConfigureContainer calls
- Fixed HostingStartupAttribute

The other warnings require refactoring to put attributes on code that today exists as lambdas 😢. @agocke @jaredpar I need attributes on local functions so I can put linker attributes on them.