### PR TITLE
Improve various messages for the dotnet-dev-certs https command

### DIFF
--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -263,7 +263,6 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
 
         private static int CheckHttpsCertificate(CommandOption trust, IReporter reporter)
         {
-            var now = DateTimeOffset.Now;
             var certificateManager = CertificateManager.Instance;
             var certificates = certificateManager.ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true);
             if (certificates.Count == 0)
@@ -292,8 +291,6 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
             {
                 if(!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    var store = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? StoreName.My : StoreName.Root;
-                    var trustedCertificates = certificateManager.ListCertificates(store, StoreLocation.CurrentUser, isValid: true);
                     if (!certificates.Any(c => certificateManager.IsTrusted(c)))
                     {
                         reporter.Output($@"The following certificates were found, but none of them is trusted:

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -223,8 +223,9 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                         break;
                 }
             }
-            catch (Exception)
+            catch (Exception exception)
             {
+                reporter.Error($"An unexpected error occurred: {exception}");
                 return ErrorImportingCertificate;
             }
 

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -284,7 +284,6 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                         return InvalidCertificateState;
                     }
                 }
-                reporter.Verbose("A valid certificate was found.");
             }
 
             if (trust != null && trust.HasValue())
@@ -306,6 +305,14 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 {
                     reporter.Warn("Checking the HTTPS development certificate trust status was requested. Checking whether the certificate is trusted or not is not supported on Linux distributions." +
                         "For instructions on how to manually validate the certificate is trusted on your Linux distribution, go to https://aka.ms/dev-certs-trust");
+                }
+            }
+            else
+            {
+                reporter.Output("A valid certificate was found.");
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    reporter.Output("Run the command with both --check and --trust options to ensure that the certificate is not only valid but also trusted.");
                 }
             }
 

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
 
                     CommandOption trust = null;
                     trust = c.Option("-t|--trust",
-                        "Trust the certificate on the current platform",
+                        "Trust the certificate on the current platform. When combined with the --check option, validates that the certificate is trusted.",
                         CommandOptionType.NoValue);
 
                     var verbose = c.Option("-v|--verbose",


### PR DESCRIPTION
* Show an error if importing a certificate fails because of an exception
* Improve the output message when running dotnet-dev-certs https --check
* Improve the --trust option documentation (when combined with --check)
* Show _which_ certificates are valid or trusted

/cc @javiercn