### PR TITLE
Fix:ControllerLinkGeneratorExtensions.GetAmbientValues throws NullReferenceException

### DIFF
--- a/src/Mvc/Mvc.Core/src/Routing/ControllerLinkGeneratorExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerLinkGeneratorExtensions.cs
@@ -256,7 +256,7 @@ namespace Microsoft.AspNetCore.Routing
 
         private static RouteValueDictionary GetAmbientValues(HttpContext httpContext)
         {
-            return httpContext?.Features.Get<IRouteValuesFeature>()?.RouteValues;
+            return httpContext?.Features?.Get<IRouteValuesFeature>()?.RouteValues;
         }
     }
 }


### PR DESCRIPTION


Summary of the changes (Less than 80 chars)
- add null check on GetAmbientValues(HttpContext)

Related issue #24412
