### PR TITLE
Simplify storing certificates in the keychain on macOS

### DIFF
--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -17,20 +17,12 @@ namespace Microsoft.AspNetCore.Certificates.Generation
 
         public override bool IsTrusted(X509Certificate2 certificate) => false;
 
-        protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate)
+        protected override X509Certificate2 CertificateForStore(X509Certificate2 certificate)
         {
             var export = certificate.Export(X509ContentType.Pkcs12, "");
             certificate.Dispose();
             certificate = new X509Certificate2(export, "", X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             Array.Clear(export, 0, export.Length);
-
-            using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
-            {
-                store.Open(OpenFlags.ReadWrite);
-                store.Add(certificate);
-                store.Close();
-            };
-
             return certificate;
         }
 

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             // Do nothing since we don't have anything to check here.
         }
 
-        protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate)
+        protected override X509Certificate2 CertificateForStore(X509Certificate2 certificate)
         {
             // On non OSX systems we need to export the certificate and import it so that the transient
             // key that we generated gets persisted.
@@ -53,15 +53,8 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             certificate.Dispose();
             certificate = new X509Certificate2(export, "", X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             Array.Clear(export, 0, export.Length);
+            // Setting a friendly name is only supported on Windows
             certificate.FriendlyName = AspNetHttpsOidFriendlyName;
-
-            using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
-            {
-                store.Open(OpenFlags.ReadWrite);
-                store.Add(certificate);
-                store.Close();
-            };
-
             return certificate;
         }
 


### PR DESCRIPTION
The X509Store class knows how to save a certificate in the user keychain on macOS so there is no need to go through the `security` command line tool.

/cc @javiercn