### PR TITLE
Update path after dupe fix

### DIFF
--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -9,4 +9,4 @@
 -TsaCodebaseName AspNetCore
 -TsaOnboard $True
 -TsaPublish $True
--PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/aspnetcore/eng/PoliCheckExclusions.xml")
+-PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/s/eng/PoliCheckExclusions.xml")


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
TSA bugs were being opened even though they already existed. We found that the reason was the path where the code was cloned. After that change we need to update the Policheck exclusion file path as well

Addresses #bugnumber (in this specific format)