### PR TITLE
Fixed flaky test 'CanInfluenceHeadDuringPrerender'.

### DIFF
--- a/src/Components/test/testassets/BasicTestApp/PrerenderedHeadComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/PrerenderedHeadComponent.razor
@@ -23,7 +23,23 @@
 
 <Meta id="meta-no-bindings" content="Immutable meta content" />
 
+@if (isInteractive)
+{
+    <span id="interactive-indicator">Interactive mode enabled.</span>
+}
+
 @code {
     private string title = "Initial title";
     private string metaContent = "Initial meta content";
+
+    private bool isInteractive;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            isInteractive = true;
+            StateHasChanged();
+        }
+    }
 }


### PR DESCRIPTION
Failures were caused by references to stale elements. I've resolved this by removing `WaitForNewElement` and by not caching references to web elements. To wait until prerendering has completed before continuing with assertions for interactivity, I've added an element to the test component that does not get rendered during prerendering. The test uses it as an indicator to proceed.

Addresses #24602
