### PR TITLE
Require a newer version of Visual Studio

### DIFF
--- a/.azure/pipelines/jobs/codesign-xplat.yml
+++ b/.azure/pipelines/jobs/codesign-xplat.yml
@@ -31,6 +31,7 @@ jobs:
     - powershell: .\eng\common\build.ps1
         -ci
         -nobl
+        -msbuildEngine dotnet
         -restore
         -sign
         -publish

--- a/global.json
+++ b/global.json
@@ -19,14 +19,14 @@
     "Git": "2.22.0",
     "jdk": "11.0.3",
     "vs": {
-      "version": "16.5",
+      "version": "16.7",
       "components": [
         "Microsoft.VisualStudio.Component.VC.ATL",
         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
         "Microsoft.VisualStudio.Component.Windows10SDK.17134"
       ]
     },
-    "xcopy-msbuild": "16.5.0-alpha"
+    "xcopy-msbuild": "16.8.0-preview2"
   },
   "msbuild-sdks": {
     "Yarn.MSBuild": "1.15.2",


### PR DESCRIPTION
- 16.7 may be new enough to run our codesign-xplat.yml and to sign our installers
- until agents are updated, should fall back to an `xcopy` (16.8) version of `msbuild`