### PR TITLE
Add inline scheduler option for Sockets transport

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
@@ -63,7 +63,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 _trace,
                 _options.MaxReadBufferSize,
                 _options.MaxWriteBufferSize,
-                _options.WaitForDataBeforeAllocatingBuffer);
+                _options.WaitForDataBeforeAllocatingBuffer,
+                _options.UnsafeInlineScheduling);
 
             socketConnection.Start();
             return socketConnection;

--- a/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Client/SocketConnectionFactory.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 _options.MaxReadBufferSize,
                 _options.MaxWriteBufferSize,
                 _options.WaitForDataBeforeAllocatingBuffer,
-                _options.UnsafeInlineScheduling);
+                _options.UnsafePreferInlineScheduling);
 
             socketConnection.Start();
             return socketConnection;

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -124,7 +124,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                     }
 
                     var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers[_schedulerIndex], _trace,
-                        _options.MaxReadBufferSize, _options.MaxWriteBufferSize, _options.WaitForDataBeforeAllocatingBuffer);
+                        _options.MaxReadBufferSize, _options.MaxWriteBufferSize, _options.WaitForDataBeforeAllocatingBuffer,
+                        _options.UnsafeInlineScheduling);
 
                     connection.Start();
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
                     var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers[_schedulerIndex], _trace,
                         _options.MaxReadBufferSize, _options.MaxWriteBufferSize, _options.WaitForDataBeforeAllocatingBuffer,
-                        _options.UnsafeInlineScheduling);
+                        _options.UnsafePreferInlineScheduling);
 
                     connection.Start();
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -49,10 +49,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// </summary>
         /// <remarks>
         /// This will run application code on the IO thread which is why this is unsafe.
-        /// We recommend setting the DOTNET_SYSTEM_NET_SOCKETS_INLINE_COMPLETIONS environment variable to '1' when using this setting to also inline the completions
+        /// It is recommended to set the DOTNET_SYSTEM_NET_SOCKETS_INLINE_COMPLETIONS environment variable to '1' when using this setting to also inline the completions
         /// at the runtime layer as well.
-        /// This setting can make make perf worse if you have expensive work that will end up holding onto the IO thread for longer than needed. As always, test your
-        /// scenarios to make sure this setting helps you.
+        /// This setting can make performance worse if there is expensive work that will end up holding onto the IO thread for longer than needed.
+        /// Test to make sure this setting helps performance.
         /// </remarks>
         public bool UnsafePreferInlineScheduling { get; set; }
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -49,8 +49,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// </summary>
         /// <remarks>
         /// This will run application code on the IO thread which is why this is unsafe.
+        /// We recommend setting the DOTNET_SYSTEM_NET_SOCKETS_INLINE_COMPLETIONS environment variable to '1' when using this setting to also inline the completions
+        /// at the runtime layer as well.
+        /// This setting can make make perf worse if you have expensive work that will end up holding onto the IO thread for longer than needed. As always, test your
+        /// scenarios to make sure this setting helps you.
         /// </remarks>
-        public bool UnsafeInlineScheduling { get; set; }
+        public bool UnsafePreferInlineScheduling { get; set; }
 
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.SlabMemoryPoolFactory.Create;
     }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -44,6 +44,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
         public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
 
+        public bool UnsafeInlineScheduling { get; set; }
+
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.SlabMemoryPoolFactory.Create;
     }
 }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -44,6 +44,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
         public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
 
+        /// <summary>
+        /// Inline application and transport continuations instead of dispatching to the threadpool.
+        /// </summary>
+        /// <remarks>
+        /// This will run application code on the IO thread which is why this is unsafe.
+        /// </remarks>
         public bool UnsafeInlineScheduling { get; set; }
 
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.SlabMemoryPoolFactory.Create;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/20952

```
Sockets Default + Kestrel Default : 1,187,598 RPS
Sockets Inline + Kestrel Inline: 1,242,924 RPS
Sockets Inline + Kestrel Default: 1,072,542 RPS
Sockets Default + Kestrel Inline: 1,153,500 RPS
```