### PR TITLE
Throw if a component produces an invalid render tree. Fixes #24579

### DIFF
--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -69,6 +69,8 @@ namespace Microsoft.AspNetCore.Components.Rendering
             CurrentRenderTree.Clear();
             renderFragment(CurrentRenderTree);
 
+            CurrentRenderTree.AssertTreeIsValid(Component);
+
             var diff = RenderTreeDiffBuilder.ComputeDiff(
                 _renderer,
                 batchBuilder,

--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -685,6 +685,17 @@ namespace Microsoft.AspNetCore.Components.Rendering
         public ArrayRange<RenderTreeFrame> GetFrames() =>
             _entries.ToRange();
 
+        internal void AssertTreeIsValid(IComponent component)
+        {
+            if (_openElementIndices.Count > 0)
+            {
+                // It's never valid to leave an element/component/region unclosed. Doing so
+                // could cause undefined behavior in diffing.
+                ref var invalidFrame = ref _entries.Buffer[_openElementIndices.Peek()];
+                throw new InvalidOperationException($"Render output is invalid for component of type '{component.GetType().FullName}'. A frame of type '{invalidFrame.FrameType}' was left unclosed. Do not use try/catch inside rendering logic, because partial output cannot be undone.");
+            }
+        }
+
         // Internal for testing
         internal void ProcessDuplicateAttributes(int first)
         {

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -4001,6 +4001,22 @@ namespace Microsoft.AspNetCore.Components.Test
                 requestedType => Assert.Equal(typeof(TestComponent), requestedType));
         }
 
+        [Fact]
+        public async Task ThrowsIfComponentProducesInvalidRenderTree()
+        {
+            // Arrange
+            var renderer = new TestRenderer();
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenElement(0, "myElem");
+            });
+            var rootComponentId = renderer.AssignRootComponentId(component);
+
+            // Act/Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => renderer.RenderRootComponentAsync(rootComponentId));
+            Assert.StartsWith($"Render output is invalid for component of type '{typeof(TestComponent).FullName}'. A frame of type 'Element' was left unclosed.", ex.Message);
+        }
+
         private class TestComponentActivator<TResult> : IComponentActivator where TResult : IComponent, new()
         {
             public List<Type> RequestedComponentTypes { get; } = new List<Type>();

--- a/src/Components/Components/test/Rendering/RenderTreeBuilderTest.cs
+++ b/src/Components/Components/test/Rendering/RenderTreeBuilderTest.cs
@@ -1831,12 +1831,79 @@ namespace Microsoft.AspNetCore.Components.Rendering
                 f => AssertFrame.Attribute(f, "3", "see ya"));
         }
 
+        [Fact]
+        public void AcceptsClosedFramesAsValid()
+        {
+            // Arrange
+            var builder = new RenderTreeBuilder();
+            var component = new TestComponent();
+            builder.OpenElement(0, "myElem");
+            builder.OpenRegion(1);
+            builder.OpenComponent<OtherComponent>(2);
+            builder.CloseComponent();
+            builder.CloseRegion();
+            builder.CloseElement();
+
+            // Act/Assert
+            // Lack of exception is success
+            builder.AssertTreeIsValid(component);
+        }
+
+        [Fact]
+        public void ReportsUnclosedElementAsInvalid()
+        {
+            // Arrange
+            var builder = new RenderTreeBuilder();
+            var component = new TestComponent();
+            builder.OpenElement(0, "outerElem");
+            builder.OpenElement(1, "innerElem");
+            builder.CloseElement();
+
+            // Act/Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => builder.AssertTreeIsValid(component));
+            Assert.StartsWith($"Render output is invalid for component of type '{typeof(TestComponent).FullName}'. A frame of type 'Element' was left unclosed.", ex.Message);
+        }
+
+        [Fact]
+        public void ReportsUnclosedComponentAsInvalid()
+        {
+            // Arrange
+            var builder = new RenderTreeBuilder();
+            var component = new TestComponent();
+            builder.OpenComponent<OtherComponent>(0);
+            builder.OpenComponent<OtherComponent>(1);
+            builder.CloseComponent();
+
+            // Act/Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => builder.AssertTreeIsValid(component));
+            Assert.StartsWith($"Render output is invalid for component of type '{typeof(TestComponent).FullName}'. A frame of type 'Component' was left unclosed.", ex.Message);
+        }
+
+        [Fact]
+        public void ReportsUnclosedRegionAsInvalid()
+        {
+            // Arrange
+            var builder = new RenderTreeBuilder();
+            var component = new TestComponent();
+            builder.OpenRegion(0);
+            builder.OpenRegion(1);
+            builder.CloseRegion();
+
+            // Act/Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => builder.AssertTreeIsValid(component));
+            Assert.StartsWith($"Render output is invalid for component of type '{typeof(TestComponent).FullName}'. A frame of type 'Region' was left unclosed.", ex.Message);
+        }
+
         private class TestComponent : IComponent
         {
             public void Attach(RenderHandle renderHandle) { }
 
             public Task SetParametersAsync(ParameterView parameters)
                 => throw new NotImplementedException();
+        }
+
+        private class OtherComponent : TestComponent
+        {
         }
 
         private class TestRenderer : Renderer


### PR DESCRIPTION
The cause of #24579 was what I thought. Components aren't allowed to produce invalid trees - this has always been an unsupported situation. However it's unfortunate that developers can produce invalid trees using something as reasonable-seeming as a `try`/`catch` block, so we need to do something to prevent this class of problems.

Previously we didn't detect this scenario, so the diffing logic could just get stuck on it. With this PR we check whether there were any unclosed tree entries left behind, and if so, fails the entire rendering process with an exception, so the behavior is properly defined.

Longer term we might want to prevent the `try`/`catch` block at compile time in the Razor compiler, but this runtime check is still desirable, and is sufficient to block the situation.