### PR TITLE
stop using RuntimeInformation.IsOSPlatform(OSPlatform.Browser) (removed in upcoming builds)

### DIFF
--- a/src/Components/Components/src/PlatformInfo.cs
+++ b/src/Components/Components/src/PlatformInfo.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Components
 
         static PlatformInfo()
         {
-            IsWebAssembly = RuntimeInformation.IsOSPlatform(OSPlatform.Browser);
+            IsWebAssembly = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
         }
     }
 }

--- a/src/Components/Web.Extensions/src/ProtectedBrowserStorage/ProtectedBrowserStorage.cs
+++ b/src/Components/Web.Extensions/src/ProtectedBrowserStorage/ProtectedBrowserStorage.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Components.Web.Extensions
         protected ProtectedBrowserStorage(string storeName, IJSRuntime jsRuntime, IDataProtectionProvider dataProtectionProvider)
         {
             // Performing data protection on the client would give users a false sense of security, so we'll prevent this.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Browser))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
             {
                 throw new PlatformNotSupportedException($"{GetType()} cannot be used when running in a browser.");
             }

--- a/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Services
         /// <returns>A list of the loaded <see cref="Assembly"/></returns>
         public async Task<IEnumerable<Assembly>> LoadAssembliesAsync(IEnumerable<string> assembliesToLoad)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Browser))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
             {
                 return await LoadAssembliesInClientAsync(assembliesToLoad);
             }


### PR DESCRIPTION
and switch back to RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"))

TL;DR: we have removed `OSPlatform.Browser` and added `OperatingSystem.IsBrowser()`

https://github.com/dotnet/runtime/pull/40373
https://github.com/dotnet/runtime/pull/40457

