### PR TITLE
Use IgnoreStandardErrorWarningFormat more extensively in Npm.Common.targets

### DIFF
--- a/eng/targets/Npm.Common.props
+++ b/eng/targets/Npm.Common.props
@@ -5,4 +5,10 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <PackOnBuild>false</PackOnBuild>
   </PropertyGroup>
+
+  <!-- Properties to control how we handle warnings when using the tasks provided by the Yarn MSBuild SDK -->
+  <PropertyGroup>
+    <IgnoreYarnWarnings>false</IgnoreYarnWarnings>
+    <IgnoreYarnWarnings Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</IgnoreYarnWarnings>
+  </PropertyGroup>
 </Project>

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -76,7 +76,7 @@
     DependsOnTargets="GetBuildInputCacheFile"
     Inputs="@(TSFiles);$(BaseIntermediateOutputPath)tsfiles.cache"
     Outputs="@(BuildOutputFiles)">
-    <Yarn Command="$(NpmBuildArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
+    <Yarn Command="$(NpmBuildArgs)" StandardOutputImportance="High" StandardErrorImportance="High" IgnoreStandardErrorWarningFormat="$(IgnoreYarnWarnings)" />
     <WriteLinesToFile Overwrite="true" File="$(BaseIntermediateOutputPath)build-sentinel" />
   </Target>
 
@@ -102,9 +102,9 @@
 
     <Copy SourceFiles="$(PackageJson)" DestinationFiles="$(_BackupPackageJson)" />
 
-    <Yarn Command="version --no-git-tag-version --new-version $(PackageVersion)" />
+    <Yarn Command="version --no-git-tag-version --new-version $(PackageVersion)" IgnoreStandardErrorWarningFormat="$(IgnoreYarnWarnings)" />
     <Exec Command="node &quot;$(MSBuildThisFileDirectory)..\scripts\update-packagejson-links.js&quot; &quot;$(PackageJson)&quot; $(PackageVersion)" />
-    <Yarn Command="pack --filename $(PackageFileName)" />
+    <Yarn Command="pack --filename $(PackageFileName)" IgnoreStandardErrorWarningFormat="$(IgnoreYarnWarnings)" />
 
     <Move SourceFiles="$(_PackageTargetPath)" DestinationFolder="$(PackageOutputPath)" />
     <Message Importance="High" Text="$(MSBuildProjectName) -> $(_PackageTargetPath)" />
@@ -122,7 +122,7 @@
   <Target Name="Test" Condition="'$(IsTestProject)' == 'true' AND '$(SkipTests)' != 'true'">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Test" />
     <Message Importance="High" Text="Running npm tests for $(MSBuildProjectName)" />
-    <Yarn Command="$(NpmTestArgs)" StandardOutputImportance="High" StandardErrorImportance="High" />
+    <Yarn Command="$(NpmTestArgs)" StandardOutputImportance="High" StandardErrorImportance="High" IgnoreStandardErrorWarningFormat="$(IgnoreYarnWarnings)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This is a possible fix for the 'Waiting for the other yarn instance to finish' error that appears during our CI builds

This property is configured in [CSharp.Common.props](https://github.com/dotnet/aspnetcore/blob/master/eng/targets/CSharp.Common.props#L57-L61) but not the NPM one. However it is used in it's targets: 