### PR TITLE
Use preview queues for internal build

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -115,7 +115,7 @@ jobs:
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCoreInternal-Pool
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Server.Amd64.VS2019
+          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
     variables:


### PR DESCRIPTION
The preview queue has VS 16.7 p5 which allows builds in master to run successfully.