### PR TITLE
Quarantine falky test ServerEventTest.EventDuringBatchRendering_CanTriggerDOMEvents

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BasicTestApp;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.Components.E2ETest.Tests;
+using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
+{
+    public class ServerEventTest : EventTest
+    {
+        public ServerEventTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
+            : base(browserFixture, serverFixture.WithServerExecution(), output)
+        {
+        }
+
+        [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24688")]
+        public override void EventDuringBatchRendering_CanTriggerDOMEvents()
+        {
+            base.EventDuringBatchRendering_CanTriggerDOMEvents();
+        }
+    }
+}

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerGlobalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerGlobalizationTest.cs
@@ -6,6 +6,7 @@ using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.Components.E2ETests.Tests;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using TestServer;
@@ -31,6 +32,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Navigate(ServerPathBase);
             Browser.MountTestComponent<CulturePicker>();
             Browser.Exists(By.Id("culture-selector"));
+        }
+
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24692")]
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("fr-FR")]
+        public override void CanSetCultureAndParseCultureSensitiveNumbersAndDates(string culture)
+        {
+            base.CanSetCultureAndParseCultureSensitiveNumbersAndDates(culture);
         }
 
         protected override void SetCulture(string culture)

--- a/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
@@ -25,14 +25,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
     }
 
-    public class ServerEventTest : EventTest
-    {
-        public ServerEventTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
-            : base(browserFixture, serverFixture.WithServerExecution(), output)
-        {
-        }
-    }
-
     public class ServerInteropTest : InteropTest
     {
         public ServerInteropTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        public void EventDuringBatchRendering_CanTriggerDOMEvents()
+        public virtual void EventDuringBatchRendering_CanTriggerDOMEvents()
         {
             Browser.MountTestComponent<EventDuringBatchRendering>();
 

--- a/src/Components/test/E2ETest/Tests/GlobalizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/GlobalizationTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
         [Theory]
         [InlineData("en-US")]
         [InlineData("fr-FR")]
-        public void CanSetCultureAndParseCultureSensitiveNumbersAndDates(string culture)
+        public virtual void CanSetCultureAndParseCultureSensitiveNumbersAndDates(string culture)
         {
             var cultureInfo = CultureInfo.GetCultureInfo(culture);
             SetCulture(culture);

--- a/src/Shared/E2ETesting/E2ETestOptions.cs
+++ b/src/Shared/E2ETesting/E2ETestOptions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.E2ETesting
 
         public string ScreenShotsPath { get; set; }
 
-        public double DefaultAfterFailureWaitTimeoutInSeconds { get; set; } = 3;
+        public double DefaultAfterFailureWaitTimeoutInSeconds { get; set; } = 10;
 
         public bool SauceTest { get; set; }
 


### PR DESCRIPTION
Blazor's E2E testing uses a much shorter timeout after a test failure. This test run had several test failures, but most of these appear to be the result of
an incredibly short timeot. This PR quarantines the one test that appears to be a genuine failure and also increases the timeout duration for after test failure.
