### PR TITLE
Fix test that fails on machine using en-GB

### DIFF
--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTestsBase.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTestsBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -310,7 +311,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
                 IntProp = 43,
                 DoubleProp = 3.14159,
                 StringProp = "test",
-                DateTimeProp = DateTime.Parse("6/3/2019 10:00:00 PM")
+                DateTimeProp = DateTime.Parse("6/3/2019 10:00:00 PM", CultureInfo.InvariantCulture)
             }, streamItemMessage.Item);
         }
 


### PR DESCRIPTION
Fix test that fails due to the month and date being swapped when run on a machine configured to use UK English.

```
Test Name:	Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol.NewtonsoftJsonHubProtocolTests.ReadCaseInsensitivePropertiesByDefault
Test FullName:	Microsoft.AspNetCore.SignalR.Common.Tests.Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol.NewtonsoftJsonHubProtocolTests.Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol.NewtonsoftJsonHubProtocolTests.ReadCaseInsensitivePropertiesByDefault
Test Source:	C:\Coding\dotnet\aspnetcore\src\SignalR\common\SignalR.Common\test\Internal\Protocol\JsonHubProtocolTestsBase.cs : line 299
Test Outcome:	Failed
Test Duration:	0:00:00

Test Name:	Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol.NewtonsoftJsonHubProtocolTests.ReadCaseInsensitivePropertiesByDefault
Test Outcome:	Failed
Result StackTrace:	at Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol.JsonHubProtocolTestsBase.ReadCaseInsensitivePropertiesByDefault() in C:\Coding\dotnet\aspnetcore\src\SignalR\common\SignalR.Common\test\Internal\Protocol\JsonHubProtocolTestsBase.cs:line 308
Result Message:	
Assert.Equal() Failure
Expected: CustomObject { ByteArrProp = [2, 4, 6], DateTimeProp = 2019-03-06T22:00:00.0000000, DoubleProp = 3.14159, IntProp = 43, NullProp = null, ... }
Actual:   CustomObject { ByteArrProp = [2, 4, 6], DateTimeProp = 2019-06-03T22:00:00.0000000, DoubleProp = 3.14159, IntProp = 43, NullProp = null, ... }

```