### PR TITLE
Make authentication linker friendly

### DIFF
--- a/src/Http/Authentication.Abstractions/src/AuthenticationOptions.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 
@@ -54,7 +55,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <typeparam name="THandler">The <see cref="IAuthenticationHandler"/> responsible for the scheme.</typeparam>
         /// <param name="name">The name of the scheme being added.</param>
         /// <param name="displayName">The display name for the scheme.</param>
-        public void AddScheme<THandler>(string name, string displayName) where THandler : IAuthenticationHandler
+        public void AddScheme<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(string name, string displayName) where THandler : IAuthenticationHandler
             => AddScheme(name, b =>
             {
                 b.DisplayName = displayName;

--- a/src/Http/Authentication.Abstractions/src/AuthenticationScheme.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationScheme.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Authentication
 {
@@ -17,7 +18,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="name">The name for the authentication scheme.</param>
         /// <param name="displayName">The display name for the authentication scheme.</param>
         /// <param name="handlerType">The <see cref="IAuthenticationHandler"/> type that handles this scheme.</param>
-        public AuthenticationScheme(string name, string? displayName, Type handlerType)
+        public AuthenticationScheme(string name, string? displayName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type handlerType)
         {
             if (name == null)
             {
@@ -50,6 +51,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// The <see cref="IAuthenticationHandler"/> type that handles this scheme.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type HandlerType { get; }
     }
 }

--- a/src/Http/Authentication.Abstractions/src/AuthenticationSchemeBuilder.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationSchemeBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Authentication
 {
@@ -32,6 +33,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// The <see cref="IAuthenticationHandler"/> type responsible for this scheme.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? HandlerType { get; set; }
 
         /// <summary>

--- a/src/Security/Authentication/Core/src/AuthenticationBuilder.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -25,7 +26,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         public virtual IServiceCollection Services { get; }
 
-        private AuthenticationBuilder AddSchemeHelper<TOptions, THandler>(string authenticationScheme, string? displayName, Action<TOptions>? configureOptions)
+        private AuthenticationBuilder AddSchemeHelper<TOptions, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(string authenticationScheme, string? displayName, Action<TOptions>? configureOptions)
             where TOptions : AuthenticationSchemeOptions, new()
             where THandler : class, IAuthenticationHandler
         {
@@ -57,7 +58,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="displayName">The display name of this scheme.</param>
         /// <param name="configureOptions">Used to configure the scheme options.</param>
         /// <returns>The builder.</returns>
-        public virtual AuthenticationBuilder AddScheme<TOptions, THandler>(string authenticationScheme, string? displayName, Action<TOptions>? configureOptions)
+        public virtual AuthenticationBuilder AddScheme<TOptions, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(string authenticationScheme, string? displayName, Action<TOptions>? configureOptions)
             where TOptions : AuthenticationSchemeOptions, new()
             where THandler : AuthenticationHandler<TOptions>
             => AddSchemeHelper<TOptions, THandler>(authenticationScheme, displayName, configureOptions);
@@ -70,7 +71,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="authenticationScheme">The name of this scheme.</param>
         /// <param name="configureOptions">Used to configure the scheme options.</param>
         /// <returns>The builder.</returns>
-        public virtual AuthenticationBuilder AddScheme<TOptions, THandler>(string authenticationScheme, Action<TOptions>? configureOptions)
+        public virtual AuthenticationBuilder AddScheme<TOptions, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(string authenticationScheme, Action<TOptions>? configureOptions)
             where TOptions : AuthenticationSchemeOptions, new()
             where THandler : AuthenticationHandler<TOptions>
             => AddScheme<TOptions, THandler>(authenticationScheme, displayName: null, configureOptions: configureOptions);
@@ -85,7 +86,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="displayName">The display name of this scheme.</param>
         /// <param name="configureOptions">Used to configure the scheme options.</param>
         /// <returns>The builder.</returns>
-        public virtual AuthenticationBuilder AddRemoteScheme<TOptions, THandler>(string authenticationScheme, string? displayName, Action<TOptions>? configureOptions)
+        public virtual AuthenticationBuilder AddRemoteScheme<TOptions, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(string authenticationScheme, string? displayName, Action<TOptions>? configureOptions)
             where TOptions : RemoteAuthenticationOptions, new()
             where THandler : RemoteAuthenticationHandler<TOptions>
         {

--- a/src/Security/Authentication/Core/src/AuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationHandler.cs
@@ -17,8 +17,6 @@ namespace Microsoft.AspNetCore.Authentication
         private Task<AuthenticateResult>? _authenticateTask;
 
         public AuthenticationScheme Scheme { get; private set; } = default!;
-
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
         public TOptions Options { get; private set; } = default!;
         protected HttpContext Context { get; private set; } = default!;
 

--- a/src/Security/Authentication/Core/src/AuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -16,6 +17,8 @@ namespace Microsoft.AspNetCore.Authentication
         private Task<AuthenticateResult>? _authenticateTask;
 
         public AuthenticationScheme Scheme { get; private set; } = default!;
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
         public TOptions Options { get; private set; } = default!;
         protected HttpContext Context { get; private set; } = default!;
 

--- a/src/Security/Authentication/Core/src/AuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;

--- a/src/Security/Authentication/OAuth/src/OAuthExtensions.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -17,12 +18,12 @@ namespace Microsoft.Extensions.DependencyInjection
         public static AuthenticationBuilder AddOAuth(this AuthenticationBuilder builder, string authenticationScheme, string displayName, Action<OAuthOptions> configureOptions)
             => builder.AddOAuth<OAuthOptions, OAuthHandler<OAuthOptions>>(authenticationScheme, displayName, configureOptions);
 
-        public static AuthenticationBuilder AddOAuth<TOptions, THandler>(this AuthenticationBuilder builder, string authenticationScheme, Action<TOptions> configureOptions)
+        public static AuthenticationBuilder AddOAuth<TOptions, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(this AuthenticationBuilder builder, string authenticationScheme, Action<TOptions> configureOptions)
             where TOptions : OAuthOptions, new()
             where THandler : OAuthHandler<TOptions>
             => builder.AddOAuth<TOptions, THandler>(authenticationScheme, OAuthDefaults.DisplayName, configureOptions);
 
-        public static AuthenticationBuilder AddOAuth<TOptions, THandler>(this AuthenticationBuilder builder, string authenticationScheme, string displayName, Action<TOptions> configureOptions)
+        public static AuthenticationBuilder AddOAuth<TOptions, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(this AuthenticationBuilder builder, string authenticationScheme, string displayName, Action<TOptions> configureOptions)
             where TOptions : OAuthOptions, new()
             where THandler : OAuthHandler<TOptions>
         {


### PR DESCRIPTION
- Preserve constructors wherever open generics or type arguments exist
- Unfortunately this doesn't make the auth stack *just work* because of DataProtection (see #24705)

Remaining warnings:

```
C:\dev\git\aspnetcore\src\Security\Authentication\OAuth\src\OAuthHandler.cs(38,15): Trim analysis warning IL2006: Microsoft.AspNetCore.Authentication.OAuth.OAuthHandler<TOptions>.OAuthHandler`1(IOptionsMonitor<OAuthHandler<TOptions>.TOptions>,ILoggerFactory,UrlEncoder,ISystemClock): The generic parameter 'TOptions' from 'Microsoft.AspNetCore.Authentication.OAuth.OAuthHandler<TOptions>' with dynamically accessed member kinds 'None' is passed into the generic parameter 'TOptions' from 'Microsoft.Extensions.Options.IOptionsMonitor<TOptions>' which requires dynamically accessed member kinds 'PublicParameterlessConstructor'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicParameterlessConstructor'. [C:\Users\davifowl\source\repos\WebApplication60\WebApplication60\WebApplication60.csproj]
C:\dev\git\aspnetcore\src\Security\Authentication\Core\src\RemoteAuthenticationHandler.cs(35,15): Trim analysis warning IL2006: Microsoft.AspNetCore.Authentication.RemoteAuthenticationHandler<TOptions>.RemoteAuthenticationHandler`1(IOptionsMonitor<RemoteAuthenticationHandler<TOptions>.TOptions>,ILoggerFactory,UrlEncoder,ISystemClock): The generic parameter 'TOptions' from 'Microsoft.AspNetCore.Authentication.RemoteAuthenticationHandler<TOptions>' with dynamically accessed member kinds 'None' is passed into the generic parameter 'TOptions' from 'Microsoft.Extensions.Options.IOptionsMonitor<TOptions>' which requires dynamically accessed member kinds 'PublicParameterlessConstructor'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicParameterlessConstructor'. [C:\Users\davifowl\source\repos\WebApplication60\WebApplication60\WebApplication60.csproj]
C:\dev\git\aspnetcore\src\Security\Authentication\Core\src\AuthenticationHandler.cs(19,68): Trim analysis warning IL2006: Microsoft.AspNetCore.Authentication.AuthenticationHandler<TOptions>.AuthenticationHandler`1(IOptionsMonitor<AuthenticationHandler<TOptions>.TOptions>,ILoggerFactory,UrlEncoder,ISystemClock): The generic parameter 'TOptions' from 'Microsoft.AspNetCore.Authentication.AuthenticationHandler<TOptions>' with dynamically accessed member kinds 'None' is passed into the generic parameter 'TOptions' from 'Microsoft.Extensions.Options.IOptionsMonitor<TOptions>' which requires dynamically accessed member kinds 'PublicParameterlessConstructor'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicParameterlessConstructor'. [C:\Users\davifowl\source\repos\WebApplication60\WebApplication60\WebApplication60.csproj]
```

https://github.com/mono/linker/issues/1416 - - Compiler generated generic parameters

```
C:\dev\git\aspnetcore\src\Security\Authentication\Core\src\AuthenticationBuilder.cs(36,21): Trim analysis warning IL2006: Microsoft.AspNetCore.Authentication.AuthenticationBuilder.<>c__DisplayClass4_0<TOptions,THandler>.<AddSchemeHelper>b__2(AuthenticationSchemeBuilder): The generic parameter 'THandler' from 'Microsoft.AspNetCore.Authentication.AuthenticationBuilder.<>c__DisplayClass4_0<TOptions,THandler>' with dynamically accessed member kinds 'None' is passed into the parameter 'value' of method 'Microsoft.AspNetCore.Authentication.AuthenticationSchemeBuilder.set_HandlerType(Type)' which requires dynamically accessed member kinds 'PublicConstructors'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicConstructors'. [C:\Users\davifowl\source\repos\WebApplication60\WebApplication60\WebApplication60.csproj]
```

https://github.com/mono/linker/issues/1403 - Compiler generated backing fields

```
ILLink : Trim analysis warning IL2006: Microsoft.Extensions.Options.IOptionsMonitor`1<TOptions> Microsoft.AspNetCore.Authentication.AuthenticationHandler`1::<OptionsMonitor>k__BackingField: The generic parameter 'TOptions' from 'Microsoft.AspNetCore.Authentication.AuthenticationHandler<TOptions>' with dynamically accessed member kinds 'None' is passed into the generic parameter 'TOptions' from 'Microsoft.Extensions.Options.IOptionsMonitor<TOptions>' which requires dynamically accessed member kinds 'PublicParameterlessConstructor'. To fix this add DynamicallyAccessedMembersAttribute to it and specify at least these member kinds 'PublicParameterlessConstructor'. [C:\Users\davifowl\source\repos\WebApplication60\WebApplication60\WebApplication60.csproj]
```

Mostly constructors and compiler generated code.