### PR TITLE
Increase HTTP/2 stream pool max size to 100

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         internal Http2StreamStack StreamPool;
 
         internal const int InitialStreamPoolSize = 5;
-        internal const int MaxStreamPoolSize = 40;
+        internal const int MaxStreamPoolSize = 100;
 
         public Http2Connection(HttpConnectionContext context)
         {


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/13750

A benchmark with 100 concurrent requests on a connection uses all 100 streams. The previous lower value resulted in streams not being reused because the pool was at capacity. They are garbage collected and new streams have to be created.

Before:

![image](https://user-images.githubusercontent.com/303201/89728878-9cd58a80-da84-11ea-9ad4-5eef3e3671c1.png)

After:

![image](https://user-images.githubusercontent.com/303201/89728669-271cef00-da83-11ea-98ed-ef4346112a88.png)