### PR TITLE
Remove requirements for VS 16.7

### DIFF
--- a/.azure/pipelines/jobs/codesign-xplat.yml
+++ b/.azure/pipelines/jobs/codesign-xplat.yml
@@ -31,6 +31,7 @@ jobs:
     - powershell: .\eng\common\build.ps1
         -ci
         -nobl
+        -msbuildEngine dotnet
         -restore
         -sign
         -publish

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -115,7 +115,7 @@ jobs:
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCoreInternal-Pool
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+          queue: BuildPool.Server.Amd64.VS2019
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
     variables:

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -31,12 +31,14 @@
   </ItemGroup>
 
   <Target Name="_PublishInstallersAndChecksums">
-    <!-- 
-      This target is defined in eng/targets/Packaging.targets and included in every C# and F# project.
-      We use Microsoft.AspNetCore.DeveloperCertificates.XPlat because it is a nonshipping package, and we need a non-stable version string to use as our publish location.
-      If Microsoft.AspNetCore.DeveloperCertificates.XPlat ever becomes a shipping package, this logic will break, so be careful
+    <!--
+      This target is defined in eng/targets/Packaging.targets and Npm.Common.targets and included in every C#, F#,
+      and npm project. We use SignalR.Npm.FunctionalTests.npmproj because it is non-shipping (we need a non-stable
+      version string to use as our publish location), non-packed (won't be shipped in the future), and it is _not_ a
+      C# or F# project. For now at least, C# and F# projects should not be referenced when using desktop msbuild.
     -->
-    <MSBuild Projects="$(RepoRoot)src\Tools\FirstRunCertGenerator\src\Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj"
+    <MSBuild Projects="$(RepoRoot)src\SignalR\clients\ts\FunctionalTests\SignalR.Npm.FunctionalTests.npmproj"
+        Properties="DisableYarnCheck=true"
         Targets="_GetPackageVersionInfo"
         SkipNonexistentProjects="false">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -29,7 +29,7 @@
     <BuildOutputFiles Include="dist\**\*.js" />
   </ItemGroup>
 
-  <Target Name="_CheckForInvalidConfiguration">
+  <Target Name="_CheckForInvalidConfiguration" Condition=" '$(DisableYarnCheck)' != 'true' ">
     <Error Text="Missing expected property: PackageId" Condition="'$(IsPackable)' != 'false' and '$(PackageId)' == ''" />
 
     <Exec ContinueOnError="true" Command="node -v" StandardOutputImportance="Low">
@@ -114,6 +114,19 @@
   </Target>
 
   <Target Name="Pack" Condition="'$(IsPackable)' == 'true'" DependsOnTargets="$(PackDependsOn)" />
+
+  <!-- This target is used to get the package versions of projects. A variant also exists in Packaging.targets. -->
+  <Target Name="_GetPackageVersionInfo" Returns="@(_ProjectPathWithVersion)">
+    <ItemGroup>
+      <_ProjectPathWithVersion Include="$(MSBuildProjectFullPath)">
+        <PackageId>$(PackageId)</PackageId>
+        <PackageVersion>$(PackageVersionForPackageVersionInfo)</PackageVersion>
+        <VersionSuffix>$(VersionSuffix)</VersionSuffix>
+        <!-- Fill in the item though variable names like "@microsoft/signalrPackageVersion" are likely invalid. -->
+        <VersionVariableName>$(PackageId.Replace('.',''))PackageVersion</VersionVariableName>
+      </_ProjectPathWithVersion>
+    </ItemGroup>
+  </Target>
 
   <Target Name="_RestoreBackupPackageJsonFile">
     <Move SourceFiles="$(_BackupPackageJson)" DestinationFiles="$(PackageJson)" />

--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -7,7 +7,7 @@
                  See $(RepoRoot)eng\tools\BaselineGenerator\README.md for instructions on updating this baseline." />
   </Target>
 
-  <!-- This target is used to get the package versions of projects -->
+  <!-- This target is used to get the package versions of projects. A variant also exists in Npm.Common.targets. -->
   <Target Name="_GetPackageVersionInfo" DependsOnTargets="$(GetPackageVersionDependsOn)"
           Returns="@(_ProjectPathWithVersion)">
     <ItemGroup>


### PR DESCRIPTION
- use signalr.npmproj (not Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj) to get non-stable version
    - add `_GetPackageVersionInfo` target to all `*.npmproj` projects
    - make `_GetPackageVersionInfo` target work when `yarn` is not installed
- switch codesign-xplat.yml to use `dotnet msbuild`
    - above change also fixes Code-sign jobs but they're slightly faster using `dotnet msbuild`
- revert "Use preview queues (#24683)"
    - go back to main VS2019 queues
    - this reverts commit 407b623

Test internal builds were both successful:
- https://dev.azure.com/dnceng/internal/_build/results?buildId=762755
    - Code-sign jobs took average 8m 11s without codesign-xplay.yml change
- https://dev.azure.com/dnceng/internal/_build/results?buildId=762771
    - Code-sign jobs took average 7m 59s with codesign-xplat.yml change