### PR TITLE
Update HtmlDirectoryFormatter.cs

### DIFF
--- a/src/Middleware/StaticFiles/src/HtmlDirectoryFormatter.cs
+++ b/src/Middleware/StaticFiles/src/HtmlDirectoryFormatter.cs
@@ -108,9 +108,9 @@ namespace Microsoft.AspNetCore.StaticFiles
 <body>
   <section id=""main"">");
             builder.AppendFormat(@"
-    <header><h1>{0} <a href=""/"">/</a>", HtmlEncode(Resources.HtmlDir_IndexOf));
+    <header><h1>{0} <a href=""./"">/</a>", HtmlEncode(Resources.HtmlDir_IndexOf));
 
-            string cumulativePath = "/";
+            string cumulativePath = "./";
             foreach (var segment in requestPath.Value.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries))
             {
                 cumulativePath = cumulativePath + segment + "/";


### PR DESCRIPTION
I noticed DirectoryBrowser header links are not consistent with the table links.

This would generate links relative to current path rather than an absolute path (just like in the directory listing.)

Note: this only correctly works if there's a trailing slash in the original route. (RedirectToAppendTrailingSlash=true)