### PR TITLE
Update ReferenceEqualityComparer.cs

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/ReferenceEqualityComparer.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/ReferenceEqualityComparer.cs
@@ -9,8 +9,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 {
     internal class ReferenceEqualityComparer : IEqualityComparer<object>
     {
-        private static readonly bool IsMono = Type.GetType("Mono.Runtime") != null;
-
         public static ReferenceEqualityComparer Instance { get; } = new ReferenceEqualityComparer();
 
         public new bool Equals(object x, object y)
@@ -20,14 +18,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
         public int GetHashCode(object obj)
         {
-            // RuntimeHelpers.GetHashCode sometimes crashes the runtime on Mono 4.0.4
-            // See: https://github.com/aspnet/External/issues/45
-            // The workaround here is to just not hash anything, and fall back to an equality check.
-            if (IsMono)
-            {
-                return 0;
-            }
-
             return RuntimeHelpers.GetHashCode(obj);
         }
     }


### PR DESCRIPTION
We don't support running on mono 4.x anymore
