### PR TITLE
Fast path for validating static table HTTP/2 headers

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -1208,20 +1208,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Allow, key))
-                    {
-                        if ((_bits & 0x800L) != 0)
-                        {
-                            value = _headers._Allow;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
                         if ((_bits & 0x400000L) != 0)
                         {
                             value = _headers._Path;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Allow, key))
+                    {
+                        if ((_bits & 0x800L) != 0)
+                        {
+                            value = _headers._Allow;
                             return true;
                         }
                         return false;
@@ -1236,20 +1236,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
-                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800L) != 0)
-                        {
-                            value = _headers._Allow;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000L) != 0)
                         {
                             value = _headers._Path;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800L) != 0)
+                        {
+                            value = _headers._Allow;
                             return true;
                         }
                         return false;
@@ -1362,6 +1362,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
+                    if (ReferenceEquals(HeaderNames.Method, key))
+                    {
+                        if ((_bits & 0x200000L) != 0)
+                        {
+                            value = _headers._Method;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Scheme, key))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            value = _headers._Scheme;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.Trailer, key))
                     {
                         if ((_bits & 0x40L) != 0)
@@ -1398,24 +1416,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Method, key))
-                    {
-                        if ((_bits & 0x200000L) != 0)
-                        {
-                            value = _headers._Method;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Scheme, key))
-                    {
-                        if ((_bits & 0x800000L) != 0)
-                        {
-                            value = _headers._Scheme;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
                         if ((_bits & 0x40000000000L) != 0)
@@ -1426,6 +1426,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
+                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000L) != 0)
+                        {
+                            value = _headers._Method;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            value = _headers._Scheme;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x40L) != 0)
@@ -1458,24 +1476,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if ((_bits & 0x40000L) != 0)
                         {
                             value = _headers._Expires;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x200000L) != 0)
-                        {
-                            value = _headers._Method;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000L) != 0)
-                        {
-                            value = _headers._Scheme;
                             return true;
                         }
                         return false;
@@ -1566,6 +1566,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.Authority, key))
+                    {
+                        if ((_bits & 0x100000L) != 0)
+                        {
+                            value = _headers._Authority;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
                         if ((_bits & 0x400000000000L) != 0)
@@ -1580,15 +1589,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if ((_bits & 0x10L) != 0)
                         {
                             value = _headers._KeepAlive;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authority, key))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            value = _headers._Authority;
                             return true;
                         }
                         return false;
@@ -1621,6 +1621,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x100000L) != 0)
+                        {
+                            value = _headers._Authority;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000000000L) != 0)
@@ -1635,15 +1644,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if ((_bits & 0x10L) != 0)
                         {
                             value = _headers._KeepAlive;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            value = _headers._Authority;
                             return true;
                         }
                         return false;
@@ -2312,16 +2312,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Allow, key))
-                    {
-                        _bits |= 0x800L;
-                        _headers._Allow = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
                         _bits |= 0x400000L;
                         _headers._Path = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Allow, key))
+                    {
+                        _bits |= 0x800L;
+                        _headers._Allow = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
@@ -2331,16 +2331,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return;
                     }
 
-                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x800L;
-                        _headers._Allow = value;
-                        return;
-                    }
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         _bits |= 0x400000L;
                         _headers._Path = value;
+                        return;
+                    }
+                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x800L;
+                        _headers._Allow = value;
                         return;
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
@@ -2418,6 +2418,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
+                    if (ReferenceEquals(HeaderNames.Method, key))
+                    {
+                        _bits |= 0x200000L;
+                        _headers._Method = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Scheme, key))
+                    {
+                        _bits |= 0x800000L;
+                        _headers._Scheme = value;
+                        return;
+                    }
                     if (ReferenceEquals(HeaderNames.Trailer, key))
                     {
                         _bits |= 0x40L;
@@ -2442,18 +2454,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Expires = value;
                         return;
                     }
-                    if (ReferenceEquals(HeaderNames.Method, key))
-                    {
-                        _bits |= 0x200000L;
-                        _headers._Method = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Scheme, key))
-                    {
-                        _bits |= 0x800000L;
-                        _headers._Scheme = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
                         _bits |= 0x40000000000L;
@@ -2461,6 +2461,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return;
                     }
 
+                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x200000L;
+                        _headers._Method = value;
+                        return;
+                    }
+                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x800000L;
+                        _headers._Scheme = value;
+                        return;
+                    }
                     if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         _bits |= 0x40L;
@@ -2483,18 +2495,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         _bits |= 0x40000L;
                         _headers._Expires = value;
-                        return;
-                    }
-                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x200000L;
-                        _headers._Method = value;
-                        return;
-                    }
-                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x800000L;
-                        _headers._Scheme = value;
                         return;
                     }
                     if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
@@ -2559,6 +2559,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Connection = value;
                         return;
                     }
+                    if (ReferenceEquals(HeaderNames.Authority, key))
+                    {
+                        _bits |= 0x100000L;
+                        _headers._Authority = value;
+                        return;
+                    }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
                         _bits |= 0x400000000000L;
@@ -2569,12 +2575,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         _bits |= 0x10L;
                         _headers._KeepAlive = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authority, key))
-                    {
-                        _bits |= 0x100000L;
-                        _headers._Authority = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
@@ -2596,6 +2596,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Connection = value;
                         return;
                     }
+                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x100000L;
+                        _headers._Authority = value;
+                        return;
+                    }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         _bits |= 0x400000000000L;
@@ -2606,12 +2612,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         _bits |= 0x10L;
                         _headers._KeepAlive = value;
-                        return;
-                    }
-                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x100000L;
-                        _headers._Authority = value;
                         return;
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
@@ -3156,22 +3156,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Allow, key))
-                    {
-                        if ((_bits & 0x800L) == 0)
-                        {
-                            _bits |= 0x800L;
-                            _headers._Allow = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
                         if ((_bits & 0x400000L) == 0)
                         {
                             _bits |= 0x400000L;
                             _headers._Path = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Allow, key))
+                    {
+                        if ((_bits & 0x800L) == 0)
+                        {
+                            _bits |= 0x800L;
+                            _headers._Allow = value;
                             return true;
                         }
                         return false;
@@ -3187,22 +3187,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
     
-                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800L) == 0)
-                        {
-                            _bits |= 0x800L;
-                            _headers._Allow = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000L) == 0)
                         {
                             _bits |= 0x400000L;
                             _headers._Path = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800L) == 0)
+                        {
+                            _bits |= 0x800L;
+                            _headers._Allow = value;
                             return true;
                         }
                         return false;
@@ -3326,6 +3326,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
+                    if (ReferenceEquals(HeaderNames.Method, key))
+                    {
+                        if ((_bits & 0x200000L) == 0)
+                        {
+                            _bits |= 0x200000L;
+                            _headers._Method = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Scheme, key))
+                    {
+                        if ((_bits & 0x800000L) == 0)
+                        {
+                            _bits |= 0x800000L;
+                            _headers._Scheme = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.Trailer, key))
                     {
                         if ((_bits & 0x40L) == 0)
@@ -3366,26 +3386,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Method, key))
-                    {
-                        if ((_bits & 0x200000L) == 0)
-                        {
-                            _bits |= 0x200000L;
-                            _headers._Method = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Scheme, key))
-                    {
-                        if ((_bits & 0x800000L) == 0)
-                        {
-                            _bits |= 0x800000L;
-                            _headers._Scheme = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
                         if ((_bits & 0x40000000000L) == 0)
@@ -3397,6 +3397,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
     
+                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000L) == 0)
+                        {
+                            _bits |= 0x200000L;
+                            _headers._Method = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800000L) == 0)
+                        {
+                            _bits |= 0x800000L;
+                            _headers._Scheme = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x40L) == 0)
@@ -3433,26 +3453,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits |= 0x40000L;
                             _headers._Expires = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x200000L) == 0)
-                        {
-                            _bits |= 0x200000L;
-                            _headers._Method = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000L) == 0)
-                        {
-                            _bits |= 0x800000L;
-                            _headers._Scheme = value;
                             return true;
                         }
                         return false;
@@ -3551,6 +3551,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.Authority, key))
+                    {
+                        if ((_bits & 0x100000L) == 0)
+                        {
+                            _bits |= 0x100000L;
+                            _headers._Authority = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
                         if ((_bits & 0x400000000000L) == 0)
@@ -3567,16 +3577,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits |= 0x10L;
                             _headers._KeepAlive = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authority, key))
-                    {
-                        if ((_bits & 0x100000L) == 0)
-                        {
-                            _bits |= 0x100000L;
-                            _headers._Authority = value;
                             return true;
                         }
                         return false;
@@ -3612,6 +3612,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x100000L) == 0)
+                        {
+                            _bits |= 0x100000L;
+                            _headers._Authority = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000000000L) == 0)
@@ -3628,16 +3638,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits |= 0x10L;
                             _headers._KeepAlive = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) == 0)
-                        {
-                            _bits |= 0x100000L;
-                            _headers._Authority = value;
                             return true;
                         }
                         return false;
@@ -4408,22 +4408,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Allow, key))
-                    {
-                        if ((_bits & 0x800L) != 0)
-                        {
-                            _bits &= ~0x800L;
-                            _headers._Allow = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
                         if ((_bits & 0x400000L) != 0)
                         {
                             _bits &= ~0x400000L;
                             _headers._Path = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Allow, key))
+                    {
+                        if ((_bits & 0x800L) != 0)
+                        {
+                            _bits &= ~0x800L;
+                            _headers._Allow = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4439,22 +4439,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
     
-                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800L) != 0)
-                        {
-                            _bits &= ~0x800L;
-                            _headers._Allow = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000L) != 0)
                         {
                             _bits &= ~0x400000L;
                             _headers._Path = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800L) != 0)
+                        {
+                            _bits &= ~0x800L;
+                            _headers._Allow = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4578,6 +4578,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
+                    if (ReferenceEquals(HeaderNames.Method, key))
+                    {
+                        if ((_bits & 0x200000L) != 0)
+                        {
+                            _bits &= ~0x200000L;
+                            _headers._Method = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Scheme, key))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            _bits &= ~0x800000L;
+                            _headers._Scheme = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.Trailer, key))
                     {
                         if ((_bits & 0x40L) != 0)
@@ -4618,26 +4638,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Method, key))
-                    {
-                        if ((_bits & 0x200000L) != 0)
-                        {
-                            _bits &= ~0x200000L;
-                            _headers._Method = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Scheme, key))
-                    {
-                        if ((_bits & 0x800000L) != 0)
-                        {
-                            _bits &= ~0x800000L;
-                            _headers._Scheme = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
                         if ((_bits & 0x40000000000L) != 0)
@@ -4649,6 +4649,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
     
+                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000L) != 0)
+                        {
+                            _bits &= ~0x200000L;
+                            _headers._Method = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            _bits &= ~0x800000L;
+                            _headers._Scheme = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x40L) != 0)
@@ -4685,26 +4705,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits &= ~0x40000L;
                             _headers._Expires = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x200000L) != 0)
-                        {
-                            _bits &= ~0x200000L;
-                            _headers._Method = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000L) != 0)
-                        {
-                            _bits &= ~0x800000L;
-                            _headers._Scheme = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4803,6 +4803,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.Authority, key))
+                    {
+                        if ((_bits & 0x100000L) != 0)
+                        {
+                            _bits &= ~0x100000L;
+                            _headers._Authority = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
                         if ((_bits & 0x400000000000L) != 0)
@@ -4819,16 +4829,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits &= ~0x10L;
                             _headers._KeepAlive = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authority, key))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            _bits &= ~0x100000L;
-                            _headers._Authority = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4864,6 +4864,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x100000L) != 0)
+                        {
+                            _bits &= ~0x100000L;
+                            _headers._Authority = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000000000L) != 0)
@@ -4880,16 +4890,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits &= ~0x10L;
                             _headers._KeepAlive = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            _bits &= ~0x100000L;
-                            _headers._Authority = default(StringValues);
                             return true;
                         }
                         return false;
@@ -5532,6 +5532,46 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x2L;
             }
             
+            if ((tempBits & 0x100000L) != 0)
+            {
+                _headers._Authority = default;
+                if((tempBits & ~0x100000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x100000L;
+            }
+            
+            if ((tempBits & 0x200000L) != 0)
+            {
+                _headers._Method = default;
+                if((tempBits & ~0x200000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x200000L;
+            }
+            
+            if ((tempBits & 0x400000L) != 0)
+            {
+                _headers._Path = default;
+                if((tempBits & ~0x400000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x400000L;
+            }
+            
+            if ((tempBits & 0x800000L) != 0)
+            {
+                _headers._Scheme = default;
+                if((tempBits & ~0x800000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x800000L;
+            }
+            
             if ((tempBits & 0x1000000L) != 0)
             {
                 _headers._Accept = default;
@@ -5750,46 +5790,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     return;
                 }
                 tempBits &= ~0x80000L;
-            }
-            
-            if ((tempBits & 0x100000L) != 0)
-            {
-                _headers._Authority = default;
-                if((tempBits & ~0x100000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x100000L;
-            }
-            
-            if ((tempBits & 0x200000L) != 0)
-            {
-                _headers._Method = default;
-                if((tempBits & ~0x200000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x200000L;
-            }
-            
-            if ((tempBits & 0x400000L) != 0)
-            {
-                _headers._Path = default;
-                if((tempBits & ~0x400000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x400000L;
-            }
-            
-            if ((tempBits & 0x800000L) != 0)
-            {
-                _headers._Scheme = default;
-                if((tempBits & ~0x800000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x800000L;
             }
             
             if ((tempBits & 0x2000000L) != 0)
@@ -6785,7 +6785,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     break;
                 case 10:
-                    if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x495443454e4e4f43uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4e4fu))
+                    if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfffuL) == 0x49524f485455413auL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x5954u))
+                    {
+                        flag = 0x100000L;
+                        values = ref _headers._Authority;
+                        nameStr = HeaderNames.Authority;
+                    }
+                    else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x495443454e4e4f43uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4e4fu))
                     {
                         flag = 0x2L;
                         values = ref _headers._Connection;
@@ -6796,12 +6802,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         flag = 0x400000000000L;
                         values = ref _headers._UserAgent;
                         nameStr = HeaderNames.UserAgent;
-                    }
-                    else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfffuL) == 0x49524f485455413auL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x5954u))
-                    {
-                        flag = 0x100000L;
-                        values = ref _headers._Authority;
-                        nameStr = HeaderNames.Authority;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x494c412d5045454buL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4556u))
                     {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -1208,20 +1208,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Path, key))
-                    {
-                        if ((_bits & 0x400000L) != 0)
-                        {
-                            value = _headers._Path;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
                         if ((_bits & 0x800L) != 0)
                         {
                             value = _headers._Allow;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Path, key))
+                    {
+                        if ((_bits & 0x400000L) != 0)
+                        {
+                            value = _headers._Path;
                             return true;
                         }
                         return false;
@@ -1236,20 +1236,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
-                    if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x400000L) != 0)
-                        {
-                            value = _headers._Path;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x800L) != 0)
                         {
                             value = _headers._Allow;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000L) != 0)
+                        {
+                            value = _headers._Path;
                             return true;
                         }
                         return false;
@@ -1362,24 +1362,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Method, key))
-                    {
-                        if ((_bits & 0x200000L) != 0)
-                        {
-                            value = _headers._Method;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Scheme, key))
-                    {
-                        if ((_bits & 0x800000L) != 0)
-                        {
-                            value = _headers._Scheme;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Trailer, key))
                     {
                         if ((_bits & 0x40L) != 0)
@@ -1416,6 +1398,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.Method, key))
+                    {
+                        if ((_bits & 0x200000L) != 0)
+                        {
+                            value = _headers._Method;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Scheme, key))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            value = _headers._Scheme;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
                         if ((_bits & 0x40000000000L) != 0)
@@ -1426,24 +1426,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
-                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x200000L) != 0)
-                        {
-                            value = _headers._Method;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000L) != 0)
-                        {
-                            value = _headers._Scheme;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x40L) != 0)
@@ -1476,6 +1458,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if ((_bits & 0x40000L) != 0)
                         {
                             value = _headers._Expires;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000L) != 0)
+                        {
+                            value = _headers._Method;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            value = _headers._Scheme;
                             return true;
                         }
                         return false;
@@ -1566,15 +1566,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Authority, key))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            value = _headers._Authority;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
                         if ((_bits & 0x400000000000L) != 0)
@@ -1589,6 +1580,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if ((_bits & 0x10L) != 0)
                         {
                             value = _headers._KeepAlive;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Authority, key))
+                    {
+                        if ((_bits & 0x100000L) != 0)
+                        {
+                            value = _headers._Authority;
                             return true;
                         }
                         return false;
@@ -1621,15 +1621,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            value = _headers._Authority;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000000000L) != 0)
@@ -1644,6 +1635,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         if ((_bits & 0x10L) != 0)
                         {
                             value = _headers._KeepAlive;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x100000L) != 0)
+                        {
+                            value = _headers._Authority;
                             return true;
                         }
                         return false;
@@ -2312,16 +2312,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Path, key))
-                    {
-                        _bits |= 0x400000L;
-                        _headers._Path = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
                         _bits |= 0x800L;
                         _headers._Allow = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Path, key))
+                    {
+                        _bits |= 0x400000L;
+                        _headers._Path = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
@@ -2331,16 +2331,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return;
                     }
 
-                    if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x400000L;
-                        _headers._Path = value;
-                        return;
-                    }
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         _bits |= 0x800L;
                         _headers._Allow = value;
+                        return;
+                    }
+                    if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x400000L;
+                        _headers._Path = value;
                         return;
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
@@ -2418,18 +2418,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Method, key))
-                    {
-                        _bits |= 0x200000L;
-                        _headers._Method = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Scheme, key))
-                    {
-                        _bits |= 0x800000L;
-                        _headers._Scheme = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Trailer, key))
                     {
                         _bits |= 0x40L;
@@ -2454,6 +2442,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Expires = value;
                         return;
                     }
+                    if (ReferenceEquals(HeaderNames.Method, key))
+                    {
+                        _bits |= 0x200000L;
+                        _headers._Method = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Scheme, key))
+                    {
+                        _bits |= 0x800000L;
+                        _headers._Scheme = value;
+                        return;
+                    }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
                         _bits |= 0x40000000000L;
@@ -2461,18 +2461,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return;
                     }
 
-                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x200000L;
-                        _headers._Method = value;
-                        return;
-                    }
-                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x800000L;
-                        _headers._Scheme = value;
-                        return;
-                    }
                     if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         _bits |= 0x40L;
@@ -2495,6 +2483,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         _bits |= 0x40000L;
                         _headers._Expires = value;
+                        return;
+                    }
+                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x200000L;
+                        _headers._Method = value;
+                        return;
+                    }
+                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x800000L;
+                        _headers._Scheme = value;
                         return;
                     }
                     if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
@@ -2559,12 +2559,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Connection = value;
                         return;
                     }
-                    if (ReferenceEquals(HeaderNames.Authority, key))
-                    {
-                        _bits |= 0x100000L;
-                        _headers._Authority = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
                         _bits |= 0x400000000000L;
@@ -2575,6 +2569,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         _bits |= 0x10L;
                         _headers._KeepAlive = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Authority, key))
+                    {
+                        _bits |= 0x100000L;
+                        _headers._Authority = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
@@ -2596,12 +2596,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Connection = value;
                         return;
                     }
-                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x100000L;
-                        _headers._Authority = value;
-                        return;
-                    }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         _bits |= 0x400000000000L;
@@ -2612,6 +2606,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         _bits |= 0x10L;
                         _headers._KeepAlive = value;
+                        return;
+                    }
+                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x100000L;
+                        _headers._Authority = value;
                         return;
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
@@ -3156,22 +3156,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Path, key))
-                    {
-                        if ((_bits & 0x400000L) == 0)
-                        {
-                            _bits |= 0x400000L;
-                            _headers._Path = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
                         if ((_bits & 0x800L) == 0)
                         {
                             _bits |= 0x800L;
                             _headers._Allow = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Path, key))
+                    {
+                        if ((_bits & 0x400000L) == 0)
+                        {
+                            _bits |= 0x400000L;
+                            _headers._Path = value;
                             return true;
                         }
                         return false;
@@ -3187,22 +3187,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
     
-                    if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x400000L) == 0)
-                        {
-                            _bits |= 0x400000L;
-                            _headers._Path = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x800L) == 0)
                         {
                             _bits |= 0x800L;
                             _headers._Allow = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000L) == 0)
+                        {
+                            _bits |= 0x400000L;
+                            _headers._Path = value;
                             return true;
                         }
                         return false;
@@ -3326,26 +3326,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Method, key))
-                    {
-                        if ((_bits & 0x200000L) == 0)
-                        {
-                            _bits |= 0x200000L;
-                            _headers._Method = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Scheme, key))
-                    {
-                        if ((_bits & 0x800000L) == 0)
-                        {
-                            _bits |= 0x800000L;
-                            _headers._Scheme = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Trailer, key))
                     {
                         if ((_bits & 0x40L) == 0)
@@ -3386,6 +3366,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.Method, key))
+                    {
+                        if ((_bits & 0x200000L) == 0)
+                        {
+                            _bits |= 0x200000L;
+                            _headers._Method = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Scheme, key))
+                    {
+                        if ((_bits & 0x800000L) == 0)
+                        {
+                            _bits |= 0x800000L;
+                            _headers._Scheme = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
                         if ((_bits & 0x40000000000L) == 0)
@@ -3397,26 +3397,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
     
-                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x200000L) == 0)
-                        {
-                            _bits |= 0x200000L;
-                            _headers._Method = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000L) == 0)
-                        {
-                            _bits |= 0x800000L;
-                            _headers._Scheme = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x40L) == 0)
@@ -3453,6 +3433,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits |= 0x40000L;
                             _headers._Expires = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000L) == 0)
+                        {
+                            _bits |= 0x200000L;
+                            _headers._Method = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800000L) == 0)
+                        {
+                            _bits |= 0x800000L;
+                            _headers._Scheme = value;
                             return true;
                         }
                         return false;
@@ -3551,16 +3551,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Authority, key))
-                    {
-                        if ((_bits & 0x100000L) == 0)
-                        {
-                            _bits |= 0x100000L;
-                            _headers._Authority = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
                         if ((_bits & 0x400000000000L) == 0)
@@ -3577,6 +3567,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits |= 0x10L;
                             _headers._KeepAlive = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Authority, key))
+                    {
+                        if ((_bits & 0x100000L) == 0)
+                        {
+                            _bits |= 0x100000L;
+                            _headers._Authority = value;
                             return true;
                         }
                         return false;
@@ -3612,16 +3612,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) == 0)
-                        {
-                            _bits |= 0x100000L;
-                            _headers._Authority = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000000000L) == 0)
@@ -3638,6 +3628,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits |= 0x10L;
                             _headers._KeepAlive = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x100000L) == 0)
+                        {
+                            _bits |= 0x100000L;
+                            _headers._Authority = value;
                             return true;
                         }
                         return false;
@@ -4408,22 +4408,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Path, key))
-                    {
-                        if ((_bits & 0x400000L) != 0)
-                        {
-                            _bits &= ~0x400000L;
-                            _headers._Path = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
                         if ((_bits & 0x800L) != 0)
                         {
                             _bits &= ~0x800L;
                             _headers._Allow = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Path, key))
+                    {
+                        if ((_bits & 0x400000L) != 0)
+                        {
+                            _bits &= ~0x400000L;
+                            _headers._Path = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4439,22 +4439,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
     
-                    if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x400000L) != 0)
-                        {
-                            _bits &= ~0x400000L;
-                            _headers._Path = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x800L) != 0)
                         {
                             _bits &= ~0x800L;
                             _headers._Allow = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000L) != 0)
+                        {
+                            _bits &= ~0x400000L;
+                            _headers._Path = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4578,26 +4578,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Method, key))
-                    {
-                        if ((_bits & 0x200000L) != 0)
-                        {
-                            _bits &= ~0x200000L;
-                            _headers._Method = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Scheme, key))
-                    {
-                        if ((_bits & 0x800000L) != 0)
-                        {
-                            _bits &= ~0x800000L;
-                            _headers._Scheme = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Trailer, key))
                     {
                         if ((_bits & 0x40L) != 0)
@@ -4638,6 +4618,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.Method, key))
+                    {
+                        if ((_bits & 0x200000L) != 0)
+                        {
+                            _bits &= ~0x200000L;
+                            _headers._Method = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Scheme, key))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            _bits &= ~0x800000L;
+                            _headers._Scheme = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
                         if ((_bits & 0x40000000000L) != 0)
@@ -4649,26 +4649,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
     
-                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x200000L) != 0)
-                        {
-                            _bits &= ~0x200000L;
-                            _headers._Method = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000L) != 0)
-                        {
-                            _bits &= ~0x800000L;
-                            _headers._Scheme = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x40L) != 0)
@@ -4705,6 +4685,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits &= ~0x40000L;
                             _headers._Expires = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000L) != 0)
+                        {
+                            _bits &= ~0x200000L;
+                            _headers._Method = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            _bits &= ~0x800000L;
+                            _headers._Scheme = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4803,16 +4803,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Authority, key))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            _bits &= ~0x100000L;
-                            _headers._Authority = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
                         if ((_bits & 0x400000000000L) != 0)
@@ -4829,6 +4819,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits &= ~0x10L;
                             _headers._KeepAlive = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Authority, key))
+                    {
+                        if ((_bits & 0x100000L) != 0)
+                        {
+                            _bits &= ~0x100000L;
+                            _headers._Authority = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4864,16 +4864,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            _bits &= ~0x100000L;
-                            _headers._Authority = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x400000000000L) != 0)
@@ -4890,6 +4880,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits &= ~0x10L;
                             _headers._KeepAlive = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x100000L) != 0)
+                        {
+                            _bits &= ~0x100000L;
+                            _headers._Authority = default(StringValues);
                             return true;
                         }
                         return false;
@@ -5532,46 +5532,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x2L;
             }
             
-            if ((tempBits & 0x100000L) != 0)
-            {
-                _headers._Authority = default;
-                if((tempBits & ~0x100000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x100000L;
-            }
-            
-            if ((tempBits & 0x200000L) != 0)
-            {
-                _headers._Method = default;
-                if((tempBits & ~0x200000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x200000L;
-            }
-            
-            if ((tempBits & 0x400000L) != 0)
-            {
-                _headers._Path = default;
-                if((tempBits & ~0x400000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x400000L;
-            }
-            
-            if ((tempBits & 0x800000L) != 0)
-            {
-                _headers._Scheme = default;
-                if((tempBits & ~0x800000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x800000L;
-            }
-            
             if ((tempBits & 0x1000000L) != 0)
             {
                 _headers._Accept = default;
@@ -5790,6 +5750,46 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     return;
                 }
                 tempBits &= ~0x80000L;
+            }
+            
+            if ((tempBits & 0x100000L) != 0)
+            {
+                _headers._Authority = default;
+                if((tempBits & ~0x100000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x100000L;
+            }
+            
+            if ((tempBits & 0x200000L) != 0)
+            {
+                _headers._Method = default;
+                if((tempBits & ~0x200000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x200000L;
+            }
+            
+            if ((tempBits & 0x400000L) != 0)
+            {
+                _headers._Path = default;
+                if((tempBits & ~0x400000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x400000L;
+            }
+            
+            if ((tempBits & 0x800000L) != 0)
+            {
+                _headers._Scheme = default;
+                if((tempBits & ~0x800000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x800000L;
             }
             
             if ((tempBits & 0x2000000L) != 0)
@@ -6617,7 +6617,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
             var flag = 0L;
 
-            // Does the name matched any "known" headers
+            // Does the name match any "known" headers
             switch (name.Length)
             {
                 case 2:
@@ -6785,13 +6785,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     break;
                 case 10:
-                    if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfffuL) == 0x49524f485455413auL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x5954u))
-                    {
-                        flag = 0x100000L;
-                        values = ref _headers._Authority;
-                        nameStr = HeaderNames.Authority;
-                    }
-                    else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x495443454e4e4f43uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4e4fu))
+                    if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x495443454e4e4f43uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4e4fu))
                     {
                         flag = 0x2L;
                         values = ref _headers._Connection;
@@ -6802,6 +6796,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         flag = 0x400000000000L;
                         values = ref _headers._UserAgent;
                         nameStr = HeaderNames.UserAgent;
+                    }
+                    else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfffuL) == 0x49524f485455413auL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x5954u))
+                    {
+                        flag = 0x100000L;
+                        values = ref _headers._Authority;
+                        nameStr = HeaderNames.Authority;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x494c412d5045454buL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4556u))
                     {
@@ -7067,6 +7067,251 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 nameStr = name.GetHeaderName();
                 var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector);
                 AppendUnknownHeaders(nameStr, valueStr);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value)
+        {
+            ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
+            var nameStr = string.Empty;
+            var flag = 0L;
+
+            // Does the HPack static index match any "known" headers
+            switch (index)
+            {
+                case 1:
+                    flag = 0x100000L;
+                    values = ref _headers._Authority;
+                    nameStr = HeaderNames.Authority;
+                    break;
+                case 2:
+                case 3:
+                    flag = 0x200000L;
+                    values = ref _headers._Method;
+                    nameStr = HeaderNames.Method;
+                    break;
+                case 4:
+                case 5:
+                    flag = 0x400000L;
+                    values = ref _headers._Path;
+                    nameStr = HeaderNames.Path;
+                    break;
+                case 6:
+                case 7:
+                    flag = 0x800000L;
+                    values = ref _headers._Scheme;
+                    nameStr = HeaderNames.Scheme;
+                    break;
+                case 15:
+                    flag = 0x2000000L;
+                    values = ref _headers._AcceptCharset;
+                    nameStr = HeaderNames.AcceptCharset;
+                    break;
+                case 16:
+                    flag = 0x4000000L;
+                    values = ref _headers._AcceptEncoding;
+                    nameStr = HeaderNames.AcceptEncoding;
+                    break;
+                case 17:
+                    flag = 0x8000000L;
+                    values = ref _headers._AcceptLanguage;
+                    nameStr = HeaderNames.AcceptLanguage;
+                    break;
+                case 19:
+                    flag = 0x1000000L;
+                    values = ref _headers._Accept;
+                    nameStr = HeaderNames.Accept;
+                    break;
+                case 22:
+                    flag = 0x800L;
+                    values = ref _headers._Allow;
+                    nameStr = HeaderNames.Allow;
+                    break;
+                case 23:
+                    flag = 0x10000000L;
+                    values = ref _headers._Authorization;
+                    nameStr = HeaderNames.Authorization;
+                    break;
+                case 24:
+                    flag = 0x1L;
+                    values = ref _headers._CacheControl;
+                    nameStr = HeaderNames.CacheControl;
+                    break;
+                case 26:
+                    flag = 0x2000L;
+                    values = ref _headers._ContentEncoding;
+                    nameStr = HeaderNames.ContentEncoding;
+                    break;
+                case 27:
+                    flag = 0x4000L;
+                    values = ref _headers._ContentLanguage;
+                    nameStr = HeaderNames.ContentLanguage;
+                    break;
+                case 28:
+                    if (ReferenceEquals(EncodingSelector, KestrelServerOptions.DefaultRequestHeaderEncodingSelector))
+                    {
+                        AppendContentLength(value);
+                    }
+                    else
+                    {
+                        AppendContentLengthCustomEncoding(value, EncodingSelector(HeaderNames.ContentLength));
+                    }
+                    return true;
+                case 29:
+                    flag = 0x8000L;
+                    values = ref _headers._ContentLocation;
+                    nameStr = HeaderNames.ContentLocation;
+                    break;
+                case 30:
+                    flag = 0x20000L;
+                    values = ref _headers._ContentRange;
+                    nameStr = HeaderNames.ContentRange;
+                    break;
+                case 31:
+                    flag = 0x1000L;
+                    values = ref _headers._ContentType;
+                    nameStr = HeaderNames.ContentType;
+                    break;
+                case 32:
+                    flag = 0x20000000L;
+                    values = ref _headers._Cookie;
+                    nameStr = HeaderNames.Cookie;
+                    break;
+                case 33:
+                    flag = 0x4L;
+                    values = ref _headers._Date;
+                    nameStr = HeaderNames.Date;
+                    break;
+                case 35:
+                    flag = 0x40000000L;
+                    values = ref _headers._Expect;
+                    nameStr = HeaderNames.Expect;
+                    break;
+                case 36:
+                    flag = 0x40000L;
+                    values = ref _headers._Expires;
+                    nameStr = HeaderNames.Expires;
+                    break;
+                case 37:
+                    flag = 0x80000000L;
+                    values = ref _headers._From;
+                    nameStr = HeaderNames.From;
+                    break;
+                case 38:
+                    flag = 0x400000000L;
+                    values = ref _headers._Host;
+                    nameStr = HeaderNames.Host;
+                    break;
+                case 39:
+                    flag = 0x800000000L;
+                    values = ref _headers._IfMatch;
+                    nameStr = HeaderNames.IfMatch;
+                    break;
+                case 40:
+                    flag = 0x1000000000L;
+                    values = ref _headers._IfModifiedSince;
+                    nameStr = HeaderNames.IfModifiedSince;
+                    break;
+                case 41:
+                    flag = 0x2000000000L;
+                    values = ref _headers._IfNoneMatch;
+                    nameStr = HeaderNames.IfNoneMatch;
+                    break;
+                case 42:
+                    flag = 0x4000000000L;
+                    values = ref _headers._IfRange;
+                    nameStr = HeaderNames.IfRange;
+                    break;
+                case 43:
+                    flag = 0x8000000000L;
+                    values = ref _headers._IfUnmodifiedSince;
+                    nameStr = HeaderNames.IfUnmodifiedSince;
+                    break;
+                case 44:
+                    flag = 0x80000L;
+                    values = ref _headers._LastModified;
+                    nameStr = HeaderNames.LastModified;
+                    break;
+                case 47:
+                    flag = 0x10000000000L;
+                    values = ref _headers._MaxForwards;
+                    nameStr = HeaderNames.MaxForwards;
+                    break;
+                case 49:
+                    flag = 0x20000000000L;
+                    values = ref _headers._ProxyAuthorization;
+                    nameStr = HeaderNames.ProxyAuthorization;
+                    break;
+                case 50:
+                    flag = 0x80000000000L;
+                    values = ref _headers._Range;
+                    nameStr = HeaderNames.Range;
+                    break;
+                case 51:
+                    flag = 0x40000000000L;
+                    values = ref _headers._Referer;
+                    nameStr = HeaderNames.Referer;
+                    break;
+                case 57:
+                    flag = 0x80L;
+                    values = ref _headers._TransferEncoding;
+                    nameStr = HeaderNames.TransferEncoding;
+                    break;
+                case 58:
+                    flag = 0x400000000000L;
+                    values = ref _headers._UserAgent;
+                    nameStr = HeaderNames.UserAgent;
+                    break;
+                case 60:
+                    flag = 0x200L;
+                    values = ref _headers._Via;
+                    nameStr = HeaderNames.Via;
+                    break;
+            }
+
+            if (flag != 0)
+            {
+                // Matched a known header
+                if ((_previousBits & flag) != 0)
+                {
+                    // Had a previous string for this header, mark it as used so we don't clear it OnHeadersComplete or consider it if we get a second header
+                    _previousBits ^= flag;
+
+                    // We will only reuse this header if there was only one previous header
+                    if (values.Count == 1)
+                    {
+                        var previousValue = values.ToString();
+                        // Check lengths are the same, then if the bytes were converted to an ascii string if they would be the same.
+                        // We do not consider Utf8 headers for reuse.
+                        if (previousValue.Length == value.Length &&
+                            StringUtilities.BytesOrdinalEqualsStringAndAscii(previousValue, value))
+                        {
+                            // The previous string matches what the bytes would convert to, so we will just use that one.
+                            _bits |= flag;
+                            return true;
+                        }
+                    }
+                }
+
+                // We didn't have a previous matching header value, or have already added a header, so get the string for this value.
+                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector);
+                if ((_bits & flag) == 0)
+                {
+                    // We didn't already have a header set, so add a new one.
+                    _bits |= flag;
+                    values = new StringValues(valueStr);
+                }
+                else
+                {
+                    // We already had a header set, so concatenate the new one.
+                    values = AppendValue(values, valueStr);
+                }
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1259,10 +1259,116 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
+        public void OnStaticIndexedHeader(int index)
+        {
+            Debug.Assert(index <= H2StaticTable.Count);
+
+            ref readonly var entry = ref H2StaticTable.Get(index - 1);
+            OnStaticIndexedHeaderCore(index, entry.Name, entry.Value);
+        }
+
+        public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+        {
+            Debug.Assert(index <= H2StaticTable.Count);
+
+            OnStaticIndexedHeaderCore(index, H2StaticTable.Get(index - 1).Name, value);
+        }
+
+        // We can't throw a Http2StreamErrorException here, it interrupts the header decompression state and may corrupt subsequent header frames on other streams.
+        // For now these either need to be connection errors or BadRequests. If we want to downgrade any of them to stream errors later then we need to
+        // rework the flow so that the remaining headers are drained and the decompression state is maintained.
+        public void OnStaticIndexedHeaderCore(int index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        {
+            // https://tools.ietf.org/html/rfc7540#section-6.5.2
+            // "The value is based on the uncompressed size of header fields, including the length of the name and value in octets plus an overhead of 32 octets for each header field.";
+            _totalParsedHeaderSize += HeaderField.RfcOverhead + name.Length + value.Length;
+            if (_totalParsedHeaderSize > _context.ServiceContext.ServerOptions.Limits.MaxRequestHeadersTotalSize)
+            {
+                throw new Http2ConnectionErrorException(CoreStrings.BadRequest_HeadersExceedMaxTotalSize, Http2ErrorCode.PROTOCOL_ERROR);
+            }
+
+            ValidateHeader(index, value);
+            try
+            {
+                if (_requestHeaderParsingState == RequestHeaderParsingState.Trailers)
+                {
+                    _currentHeadersStream.OnTrailer(name, value);
+                }
+                else
+                {
+                    // Throws BadRequest for header count limit breaches.
+                    // Throws InvalidOperation for bad encoding.
+                    _currentHeadersStream.OnHeader(index, name, value);
+                }
+            }
+            catch (Microsoft.AspNetCore.Http.BadHttpRequestException bre)
+            {
+                throw new Http2ConnectionErrorException(bre.Message, Http2ErrorCode.PROTOCOL_ERROR);
+            }
+            catch (InvalidOperationException)
+            {
+                throw new Http2ConnectionErrorException(CoreStrings.BadRequest_MalformedRequestInvalidHeaders, Http2ErrorCode.PROTOCOL_ERROR);
+            }
+        }
+
         public void OnHeadersComplete(bool endStream)
             => _currentHeadersStream.OnHeadersComplete();
 
         private void ValidateHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        {
+            UpdateHeaderParsingState(value, GetPseudoHeaderField(name));
+
+            if (IsConnectionSpecificHeaderField(name, value))
+            {
+                throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorConnectionSpecificHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
+            }
+
+            // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
+            // A request or response containing uppercase header field names MUST be treated as malformed (Section 8.1.2.6).
+            for (var i = 0; i < name.Length; i++)
+            {
+                if (((uint)name[i] - 65) <= (90 - 65))
+                {
+                    if (_requestHeaderParsingState == RequestHeaderParsingState.Trailers)
+                    {
+                        throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorTrailerNameUppercase, Http2ErrorCode.PROTOCOL_ERROR);
+                    }
+                    else
+                    {
+                        throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorHeaderNameUppercase, Http2ErrorCode.PROTOCOL_ERROR);
+                    }
+                }
+            }
+        }
+
+        private void ValidateHeader(int index, ReadOnlySpan<byte> value)
+        {
+            var headerField = index switch
+            {
+                1 => PseudoHeaderFields.Authority,
+                2 => PseudoHeaderFields.Method,
+                3 => PseudoHeaderFields.Method,
+                4 => PseudoHeaderFields.Path,
+                5 => PseudoHeaderFields.Path,
+                6 => PseudoHeaderFields.Scheme,
+                7 => PseudoHeaderFields.Scheme,
+                8 => PseudoHeaderFields.Status,
+                9 => PseudoHeaderFields.Status,
+                10 => PseudoHeaderFields.Status,
+                11 => PseudoHeaderFields.Status,
+                12 => PseudoHeaderFields.Status,
+                13 => PseudoHeaderFields.Status,
+                14 => PseudoHeaderFields.Status,
+                _ => PseudoHeaderFields.None
+            };
+
+            UpdateHeaderParsingState(value, headerField);
+
+            // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
+            // No need to validate if header name if it is specified using a static index.
+        }
+
+        private void UpdateHeaderParsingState(ReadOnlySpan<byte> value, PseudoHeaderFields headerField)
         {
             // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.1
             /*
@@ -1278,7 +1384,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                against several types of common attacks against HTTP; they are
                deliberately strict because being permissive can expose
                implementations to these vulnerabilities.*/
-            if (IsPseudoHeaderField(name, out var headerField))
+            if (headerField != PseudoHeaderFields.None)
             {
                 if (_requestHeaderParsingState == RequestHeaderParsingState.Headers)
                 {
@@ -1328,65 +1434,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             {
                 _requestHeaderParsingState = RequestHeaderParsingState.Headers;
             }
-
-            if (IsConnectionSpecificHeaderField(name, value))
-            {
-                throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorConnectionSpecificHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
-            }
-
-            // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
-            // A request or response containing uppercase header field names MUST be treated as malformed (Section 8.1.2.6).
-            for (var i = 0; i < name.Length; i++)
-            {
-                if (name[i] >= 65 && name[i] <= 90)
-                {
-                    if (_requestHeaderParsingState == RequestHeaderParsingState.Trailers)
-                    {
-                        throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorTrailerNameUppercase, Http2ErrorCode.PROTOCOL_ERROR);
-                    }
-                    else
-                    {
-                        throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorHeaderNameUppercase, Http2ErrorCode.PROTOCOL_ERROR);
-                    }
-                }
-            }
         }
 
-        private bool IsPseudoHeaderField(ReadOnlySpan<byte> name, out PseudoHeaderFields headerField)
+        private PseudoHeaderFields GetPseudoHeaderField(ReadOnlySpan<byte> name)
         {
-            headerField = PseudoHeaderFields.None;
-
             if (name.IsEmpty || name[0] != (byte)':')
             {
-                return false;
+                return PseudoHeaderFields.None;
             }
-
-            if (name.SequenceEqual(PathBytes))
+            else if (name.SequenceEqual(PathBytes))
             {
-                headerField = PseudoHeaderFields.Path;
+                return PseudoHeaderFields.Path;
             }
             else if (name.SequenceEqual(MethodBytes))
             {
-                headerField = PseudoHeaderFields.Method;
+                return PseudoHeaderFields.Method;
             }
             else if (name.SequenceEqual(SchemeBytes))
             {
-                headerField = PseudoHeaderFields.Scheme;
+                return PseudoHeaderFields.Scheme;
             }
             else if (name.SequenceEqual(StatusBytes))
             {
-                headerField = PseudoHeaderFields.Status;
+                return PseudoHeaderFields.Status;
             }
             else if (name.SequenceEqual(AuthorityBytes))
             {
-                headerField = PseudoHeaderFields.Authority;
+                return PseudoHeaderFields.Authority;
             }
             else
             {
-                headerField = PseudoHeaderFields.Unknown;
+                return PseudoHeaderFields.Unknown;
             }
-
-            return true;
         }
 
         private static bool IsConnectionSpecificHeaderField(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
@@ -1462,16 +1541,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 await _context.Transport.Input.CompleteAsync();
                 _input.Writer.Complete(error);
             }
-        }
-
-        public void OnStaticIndexedHeader(int index)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
-        {
-            throw new NotImplementedException();
         }
 
         private class StreamCloseAwaitable : ICriticalNotifyCompletion

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Core components of ASP.NET Core Kestrel cross-platform web server.</Description>

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Http2ConnectionBenchmarkBase.cs
@@ -50,10 +50,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
             _connectionPair = DuplexPipe.CreateConnectionPair(options, options);
 
             _httpRequestHeaders = new HttpRequestHeaders();
-            _httpRequestHeaders.Append(HeaderNames.Method, new StringValues("GET"));
-            _httpRequestHeaders.Append(HeaderNames.Path, new StringValues("/"));
-            _httpRequestHeaders.Append(HeaderNames.Scheme, new StringValues("http"));
-            _httpRequestHeaders.Append(HeaderNames.Authority, new StringValues("localhost:80"));
+            _httpRequestHeaders.HeaderMethod = new StringValues("GET");
+            _httpRequestHeaders.HeaderPath = new StringValues("/");
+            _httpRequestHeaders.HeaderScheme = new StringValues("http");
+            _httpRequestHeaders.HeaderAuthority = new StringValues("localhost:80");
 
             _headersBuffer = new byte[1024 * 16];
             _hpackEncoder = new HPackEncoder();

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -21,10 +21,14 @@ namespace CodeGenerator
         {
             var requestPrimaryHeaders = new[]
             {
+                ":authority",
+                ":method",
+                ":path",
+                ":scheme",
                 "Accept",
                 "Connection",
                 "Host",
-                "User-Agent",
+                "User-Agent"
             };
             var responsePrimaryHeaders = new[]
             {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2042,12 +2042,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             public void OnStaticIndexedHeader(int index)
             {
-                throw new NotImplementedException();
+                ref readonly var entry = ref H2StaticTable.Get(index - 1);
+                OnHeader(entry.Name, entry.Value);
             }
 
             public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
             {
-                throw new NotImplementedException();
+                OnHeader(H2StaticTable.Get(index - 1).Name, value);
             }
         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.IO.Pipelines;
@@ -408,6 +409,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var nameStr = name.GetHeaderName();
             _decodedHeaders[nameStr] = value.GetRequestHeaderString(nameStr, _serviceContext.ServerOptions.RequestHeaderEncodingSelector);
+        }
+
+        public void OnStaticIndexedHeader(int index)
+        {
+            Debug.Assert(index <= H2StaticTable.Count);
+
+            ref readonly var entry = ref H2StaticTable.Get(index - 1);
+            ((IHttpHeadersHandler)this).OnHeader(entry.Name, entry.Value);
+        }
+
+        public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+        {
+            Debug.Assert(index <= H2StaticTable.Count);
+
+            ((IHttpHeadersHandler)this).OnHeader(H2StaticTable.Get(index - 1).Name, value);
         }
 
         void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }
@@ -1269,16 +1285,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             // null means that we have no back pressure
             return bufferSize ?? 0;
-        }
-
-        public void OnStaticIndexedHeader(int index)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
-        {
-            throw new NotImplementedException();
         }
 
         internal class Http2FrameWithPayload : Http2Frame

--- a/src/Servers/Kestrel/tools/CodeGenerator/CodeGenerator.csproj
+++ b/src/Servers/Kestrel/tools/CodeGenerator/CodeGenerator.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <Compile Include="$(KestrelSharedSourceRoot)KnownHeaders.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http2\Hpack\H2StaticTable.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http2\Hpack\HeaderField.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/tools/CodeGenerator/Program.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/Program.cs
@@ -75,12 +75,11 @@ namespace CodeGenerator
             if (!string.Equals(content, existingContent))
             {
                 File.WriteAllText(path, content);
+                Console.WriteLine($"{path} updated.");
             }
-
-            var existingHttp2Connection = File.Exists(path) ? File.ReadAllText(path) : "";
-            if (!string.Equals(content, existingHttp2Connection))
+            else
             {
-                File.WriteAllText(path, content);
+                Console.WriteLine($"{path} already up to date.");
             }
         }
     }

--- a/src/Shared/Http2cat/Http2Utilities.cs
+++ b/src/Shared/Http2cat/Http2Utilities.cs
@@ -1022,12 +1022,13 @@ namespace Microsoft.AspNetCore.Http2Cat
 
         public void OnStaticIndexedHeader(int index)
         {
-            throw new NotImplementedException();
+            ref readonly var entry = ref H2StaticTable.Get(index - 1);
+            ((IHttpHeadersHandler)this).OnHeader(entry.Name, entry.Value);
         }
 
         public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
         {
-            throw new NotImplementedException();
+            ((IHttpHeadersHandler)this).OnHeader(H2StaticTable.Get(index - 1).Name, value);
         }
 
         internal class Http2FrameWithPayload : Http2Frame

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -92,6 +92,7 @@ namespace System.Net.Http.HPack
 
         private State _state = State.Ready;
         private byte[]? _headerName;
+        private int _headerStaticIndex;
         private int _stringIndex;
         private int _stringLength;
         private int _headerNameLength;
@@ -492,23 +493,36 @@ namespace System.Net.Http.HPack
 
         private void ProcessHeaderValue(ReadOnlySpan<byte> data, IHttpHeadersHandler handler)
         {
-            ReadOnlySpan<byte> headerNameSpan = _headerNameRange == null
-                ? new Span<byte>(_headerName, 0, _headerNameLength)
-                : data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
-
             ReadOnlySpan<byte> headerValueSpan = _headerValueRange == null
-                ? new Span<byte>(_headerValueOctets, 0, _headerValueLength)
+                ? _headerValueOctets.AsSpan(0, _headerValueLength)
                 : data.Slice(_headerValueRange.GetValueOrDefault().start, _headerValueRange.GetValueOrDefault().length);
 
-            handler.OnHeader(headerNameSpan, headerValueSpan);
+            if (_headerStaticIndex > 0)
+            {
+                handler.OnStaticIndexedHeader(_headerStaticIndex, headerValueSpan);
 
+                if (_index)
+                {
+                    _dynamicTable.Insert(H2StaticTable.Get(_headerStaticIndex - 1).Name, headerValueSpan);
+                }
+            }
+            else
+            {
+                ReadOnlySpan<byte> headerNameSpan = _headerNameRange == null
+                    ? _headerName.AsSpan(0, _headerNameLength)
+                    : data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
+
+                handler.OnHeader(headerNameSpan, headerValueSpan);
+
+                if (_index)
+                {
+                    _dynamicTable.Insert(headerNameSpan, headerValueSpan);
+                }
+            }
+
+            _headerStaticIndex = 0;
             _headerNameRange = null;
             _headerValueRange = null;
-
-            if (_index)
-            {
-                _dynamicTable.Insert(headerNameSpan, headerValueSpan);
-            }
         }
 
         public void CompleteDecode()
@@ -522,15 +536,30 @@ namespace System.Net.Http.HPack
 
         private void OnIndexedHeaderField(int index, IHttpHeadersHandler handler)
         {
-            ref readonly HeaderField header = ref GetHeader(index);
-            handler.OnHeader(header.Name, header.Value);
+            if (index <= H2StaticTable.Count)
+            {
+                handler.OnStaticIndexedHeader(index);
+            }
+            else
+            {
+                ref readonly HeaderField header = ref GetDynamicHeader(index);
+                handler.OnHeader(header.Name, header.Value);
+            }
+
             _state = State.Ready;
         }
 
         private void OnIndexedHeaderName(int index)
         {
-            _headerName = GetHeader(index).Name;
-            _headerNameLength = _headerName.Length;
+            if (index <= H2StaticTable.Count)
+            {
+                _headerStaticIndex = index;
+            }
+            else
+            {
+                _headerName = GetDynamicHeader(index).Name;
+                _headerNameLength = _headerName.Length;
+            }
             _state = State.HeaderValueLength;
         }
 
@@ -615,13 +644,11 @@ namespace System.Net.Http.HPack
             return (b & HuffmanMask) != 0;
         }
 
-        private ref readonly HeaderField GetHeader(int index)
+        private ref readonly HeaderField GetDynamicHeader(int index)
         {
             try
             {
-                return ref index <= H2StaticTable.Count
-                    ? ref H2StaticTable.Get(index - 1)
-                    : ref _dynamicTable[index - H2StaticTable.Count - 1];
+                return ref _dynamicTable[index - H2StaticTable.Count - 1];
             }
             catch (IndexOutOfRangeException)
             {


### PR DESCRIPTION
Incoming request headers are currently identified during validation by comparing header bytes. This can be made faster for headers with a static table index. Static table headers can also skip validation that names are all lower case.

This change will speed up validation of request headers. Once it is merged I think the next step is to add a method on `HttpRequestHeaders` collection that sets headers using the index instead of name. **Update:** Now also in this PR.

Note: There will probably need to be a reaction in dotnet/runtime to the `IHttpHeadersHandler.OnStaticIndexedHeader` overloads being used. If runtime doesn't want to use the static index then it is pretty easy to implement the methods like so:

```cs
public void OnStaticIndexedHeader(int index)
{
    ref readonly var entry = ref H2StaticTable.Get(index - 1);
    OnHeader(entry.Name, entry.Value);
}

public void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
{
    OnHeader(H2StaticTable.Get(index - 1).Name, value);
}

public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
{
    // ...
}
```

@geoffkizer I don't know if you are still looking at HttpClient perf but you might be able to get some perf gains in the client by comparing the index instead of bytes/strings.