### PR TITLE
Fix fetch of package version in eng/Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -38,7 +38,7 @@
       C# or F# project. For now at least, C# and F# projects should not be referenced when using desktop msbuild.
     -->
     <MSBuild Projects="$(RepoRoot)src\SignalR\clients\ts\FunctionalTests\SignalR.Npm.FunctionalTests.npmproj"
-        Properties="DisableYarnCheck=true"
+        Properties="DisableYarnCheck=true;ExcludeFromBuild=false"
         Targets="_GetPackageVersionInfo"
         SkipNonexistentProjects="false">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />

--- a/src/Tools/FirstRunCertGenerator/src/Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj
+++ b/src/Tools/FirstRunCertGenerator/src/Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj
@@ -8,9 +8,6 @@
 
     <!-- This package contains API for the .NET CLI to generate the aspnet HTTPs dev cert during CLI first-run initialization. -->
 
-    <!-- Our publishing logic depends on this particular package being NonShipping - if this ever becomes a Shipping project, we will incorrectly calculate the repo's version string,
-         which will cause us to publish installers & checksums to the wrong place. If this ever becomes a Shipping project, we also need to update the following line to reference a different NonShipping project:
-         https://github.com/dotnet/aspnetcore/blob/6301eefbc346b9ef00ede83ce223d8240b71942a/eng/Publishing.props#L39 -->
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>


### PR DESCRIPTION
- target project is a test project; need to undo `$(SkipTestBuild)` impact in these jobs

nit: remove a comment from DeveloperCertificates project that's irrelevant now