### PR TITLE
Include the DebugProxy binaries in DevServer

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -34,7 +34,6 @@
 
   <ItemGroup>
     <NuspecProperty Include="publishDir=$(PublishDir)" />
-    <NuspecProperty Include="componentsrootdir=..\..\..\" />
     <NuspecProperty Include="PackageThirdPartyNoticesFile=$(PackageThirdPartyNoticesFile)" />
   </ItemGroup>
 

--- a/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
+++ b/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
@@ -33,7 +33,7 @@
   <!-- Emit debug proxy binaries to output directory. This lets us launch it as a separate process while keeping the build output self-contained.  -->
   <Target Name="IncludeDebugProxyBinariesAsContent" BeforeTargets="AssignTargetPaths">
     <ItemGroup>
-      <DebugProxyBinaries Include="..\..\DebugProxy\src\bin\$(Configuration)\$(DefaultNetCoreTargetFramework)\**" />
+      <DebugProxyBinaries Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Components.WebAssembly.DebugProxy\$(Configuration)\$(DefaultNetCoreTargetFramework)\**" />
 
       <!--
         For when we're building a package, we use Pack and PackagePath to bundle the debug proxy binaries into 'tools'.
@@ -50,6 +50,10 @@
         Link="BlazorDebugProxy\%(RecursiveDir)%(FileName)%(Extension)"
         CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
+
+    <Error
+      Text="Debugger proxy files were not found in $(ArtifactsBinDir)Microsoft.AspNetCore.Components.WebAssembly.DebugProxy\$(Configuration)\$(DefaultNetCoreTargetFramework)"
+      Condition="'@(DebugProxyBinaries->Count())' == '0'" />
   </Target>
 
 </Project>


### PR DESCRIPTION
* Remove unused nuspec property that relied on relative path

### Description

DebugProxy binaries required to enable debugging for Blazor WebAssembly applications are missing from our packages. This was caught as part of local testing

### Customer impact

This prevents debugging Blazor WebAssembly applications

### Regression

Yes. This was functioning in preview7 and was regressed due to some infrastructure changes.

### Risk

Low. This is a primarily a change to the packaging to include the missing files.