### PR TITLE
HTTP2: Track at least 100 closed streams

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -59,10 +59,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private int _clientActiveStreamCount = 0;
         private int _serverActiveStreamCount = 0;
 
-        // Default MaxConcurrentStreams is 100. If a small MaxConcurrentStreams is configured still track up
-        // to 100 streams to support clients that send a burst of streams while the connection was being established.
-        private uint MaxTrackedStreams => Math.Max(_serverSettings.MaxConcurrentStreams * 2, 100);
-
         // The following are the only fields that can be modified outside of the ProcessRequestsAsync loop.
         private readonly ConcurrentQueue<Http2Stream> _completedStreams = new ConcurrentQueue<Http2Stream>();
         private readonly StreamCloseAwaitable _streamCompletionAwaitable = new StreamCloseAwaitable();
@@ -73,6 +69,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         internal readonly Http2KeepAlive _keepAlive;
         internal readonly Dictionary<int, Http2Stream> _streams = new Dictionary<int, Http2Stream>();
         internal Http2StreamStack StreamPool;
+        // Max tracked streams is double max concurrent streams.
+        // If a small MaxConcurrentStreams value is configured then still track at least to 100 streams
+        // to support clients that send a burst of streams while the connection is being established.
+        internal uint MaxTrackedStreams => Math.Max(_serverSettings.MaxConcurrentStreams * 2, 100);
 
         internal const int InitialStreamPoolSize = 5;
         internal const int MaxStreamPoolSize = 100;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1484,6 +1484,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task MaxTrackedStreams_LargeMaxConcurrentStreams_DoubleLimit()
+        {
+            _serviceContext.ServerOptions.Limits.Http2.MaxStreamsPerConnection = int.MaxValue;
+
+            await InitializeConnectionAsync(_noopApplication);
+
+            Assert.Equal((uint)int.MaxValue * 2, _connection.MaxTrackedStreams);
+
+            await StopConnectionAsync(0, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
         public Task Frame_MultipleStreams_RequestsNotFinished_LowMaxStreamsPerConnection_EnhanceYourCalmAfter100()
         {
             // Kestrel always tracks at least 100 streams


### PR DESCRIPTION
If Kestrel is configured with a very small MaxConcurrentStreams value, e.g. 1, then it will only track up to 2 closed streams (MaxConcurrentStreams * 2). If a client sends a burst of requests during the connection handshake it is very easy for incoming DATA frames to be received for a stream that has been refused and forgotten about. When that happens the connection will close with an error.

Demonstrated here: https://github.com/dotnet/runtime/issues/40249#issuecomment-669875305

A very aggressive client could still overwhelm this limit, but always tracking at least 100 streams is a simple change to make Kestrel much more likely to gracefully handle this situation.