### PR TITLE
Support custom validation class names

### DIFF
--- a/src/Components/Forms/src/EditContext.cs
+++ b/src/Components/Forms/src/EditContext.cs
@@ -31,6 +31,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             // really don't, you can pass an empty object then ignore it. Ensuring it's nonnull
             // simplifies things for all consumers of EditContext.
             Model = model ?? throw new ArgumentNullException(nameof(model));
+            Properties = new EditContextProperties();
         }
 
         /// <summary>
@@ -61,6 +62,11 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// Gets the model object for this <see cref="EditContext"/>.
         /// </summary>
         public object Model { get; }
+
+        /// <summary>
+        /// Gets a collection of arbitrary properties associated with this instance.
+        /// </summary>
+        public EditContextProperties Properties { get; }
 
         /// <summary>
         /// Signals that the value for the specified field has changed.

--- a/src/Components/Forms/src/EditContextProperties.cs
+++ b/src/Components/Forms/src/EditContextProperties.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    /// <summary>
+    /// Holds arbitrary key/value pairs associated with an <see cref="EditContext"/>.
+    /// This can be used to track additional metadata for application-specific purposes.
+    /// </summary>
+    public sealed class EditContextProperties
+    {
+        // We don't want to expose any way of enumerating the underlying dictionary, because that would
+        // prevent its usage to store private information. So we only expose an indexer and TryGetValue.
+        private Dictionary<object, object>? _contents;
+
+        /// <summary>
+        /// Gets or sets a value in the collection.
+        /// </summary>
+        /// <param name="key">The key under which the value is stored.</param>
+        /// <returns>The stored value.</returns>
+        public object this[object key]
+        {
+            get => _contents is null ? throw new KeyNotFoundException() : _contents[key];
+            set
+            {
+                _contents ??= new Dictionary<object, object>();
+                _contents[key] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the value associated with the specified key, if any.
+        /// </summary>
+        /// <param name="key">The key under which the value is stored.</param>
+        /// <param name="value">The value, if present.</param>
+        /// <returns>True if the value was present, otherwise false.</returns>
+        public bool TryGetValue(object key, [NotNullWhen(true)] out object? value)
+        {
+            if (_contents is null)
+            {
+                value = default;
+                return false;
+            }
+            else
+            {
+                return _contents.TryGetValue(key, out value);
+            }
+        }
+
+        /// <summary>
+        /// Removes the specified entry from the collection.
+        /// </summary>
+        /// <param name="key">The key of the entry to be removed.</param>
+        /// <returns>True if the value was present, otherwise false.</returns>
+        public bool Remove(object key)
+        {
+            return _contents?.Remove(key) ?? false;
+        }
+    }
+}

--- a/src/Components/Forms/test/EditContextTest.cs
+++ b/src/Components/Forms/test/EditContextTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -250,6 +251,76 @@ namespace Microsoft.AspNetCore.Components.Forms
             model.Property = "new value";
 
             Assert.True(editContext.IsModified(editContext.Field(nameof(EquatableModel.Property))));
+        }
+
+        [Fact]
+        public void Properties_CanRetrieveViaIndexer()
+        {
+            // Arrange
+            var editContext = new EditContext(new object());
+            var key1 = new object();
+            var key2 = new object();
+            var key3 = new object();
+            var value1 = new object();
+            var value2 = new object();
+
+            // Initially, the values are not present
+            Assert.Throws<KeyNotFoundException>(() => editContext.Properties[key1]);
+
+            // Can store and retrieve values
+            editContext.Properties[key1] = value1;
+            editContext.Properties[key2] = value2;
+            Assert.Same(value1, editContext.Properties[key1]);
+            Assert.Same(value2, editContext.Properties[key2]);
+
+            // Unrelated keys are still not found
+            Assert.Throws<KeyNotFoundException>(() => editContext.Properties[key3]);
+        }
+
+        [Fact]
+        public void Properties_CanRetrieveViaTryGetValue()
+        {
+            // Arrange
+            var editContext = new EditContext(new object());
+            var key1 = new object();
+            var key2 = new object();
+            var key3 = new object();
+            var value1 = new object();
+            var value2 = new object();
+
+            // Initially, the values are not present
+            Assert.False(editContext.Properties.TryGetValue(key1, out _));
+
+            // Can store and retrieve values
+            editContext.Properties[key1] = value1;
+            editContext.Properties[key2] = value2;
+            Assert.True(editContext.Properties.TryGetValue(key1, out var retrievedValue1));
+            Assert.True(editContext.Properties.TryGetValue(key2, out var retrievedValue2));
+            Assert.Same(value1, retrievedValue1);
+            Assert.Same(value2, retrievedValue2);
+
+            // Unrelated keys are still not found
+            Assert.False(editContext.Properties.TryGetValue(key3, out _));
+        }
+
+        [Fact]
+        public void Properties_CanRemove()
+        {
+            // Arrange
+            var editContext = new EditContext(new object());
+            var key = new object();
+            var value = new object();
+            editContext.Properties[key] = value;
+
+            // Act
+            var resultForExistingKey = editContext.Properties.Remove(key);
+            var resultForNonExistingKey = editContext.Properties.Remove(new object());
+
+            // Assert
+            Assert.True(resultForExistingKey);
+            Assert.False(resultForNonExistingKey);
+            Assert.False(editContext.Properties.TryGetValue(key, out _));
+            Assert.Throws<KeyNotFoundException>(() => editContext.Properties[key]);
         }
 
         class EquatableModel : IEquatable<EquatableModel>

--- a/src/Components/Web/src/Forms/EditContextFieldClassExtensions.cs
+++ b/src/Components/Web/src/Forms/EditContextFieldClassExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Microsoft.AspNetCore.Components.Forms
@@ -13,6 +12,8 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// </summary>
     public static class EditContextFieldClassExtensions
     {
+        private readonly static object FieldCssClassProviderKey = new object();
+
         /// <summary>
         /// Gets a string that indicates the status of the specified field as a CSS class. This will include
         /// some combination of "modified", "valid", or "invalid", depending on the status of the field.
@@ -24,23 +25,34 @@ namespace Microsoft.AspNetCore.Components.Forms
             => FieldCssClass(editContext, FieldIdentifier.Create(accessor));
 
         /// <summary>
-        /// Gets a string that indicates the status of the specified field as a CSS class. This will include
-        /// some combination of "modified", "valid", or "invalid", depending on the status of the field.
+        /// Gets a string that indicates the status of the specified field as a CSS class.
         /// </summary>
         /// <param name="editContext">The <see cref="EditContext"/>.</param>
         /// <param name="fieldIdentifier">An identifier for the field.</param>
         /// <returns>A string that indicates the status of the field.</returns>
         public static string FieldCssClass(this EditContext editContext, in FieldIdentifier fieldIdentifier)
         {
-            var isValid = !editContext.GetValidationMessages(fieldIdentifier).Any();
-            if (editContext.IsModified(fieldIdentifier))
+            var provider = editContext.Properties.TryGetValue(FieldCssClassProviderKey, out var customProvider)
+                ? (FieldCssClassProvider)customProvider
+                : FieldCssClassProvider.Instance;
+
+            return provider.GetFieldCssClass(editContext, fieldIdentifier);
+        }
+
+        /// <summary>
+        /// Associates the supplied <see cref="FieldCssClassProvider"/> with the supplied <see cref="EditContext"/>.
+        /// This customizes the field CSS class names used within the <see cref="EditContext"/>.
+        /// </summary>
+        /// <param name="editContext">The <see cref="EditContext"/>.</param>
+        /// <param name="fieldCssClassProvider">The <see cref="FieldCssClassProvider"/>.</param>
+        public static void SetFieldCssClassProvider(this EditContext editContext, FieldCssClassProvider fieldCssClassProvider)
+        {
+            if (fieldCssClassProvider is null)
             {
-                return isValid ? "modified valid" : "modified invalid";
+                throw new ArgumentNullException(nameof(fieldCssClassProvider));
             }
-            else
-            {
-                return isValid ? "valid" : "invalid";
-            }
+
+            editContext.Properties[FieldCssClassProviderKey] = fieldCssClassProvider;
         }
     }
 }

--- a/src/Components/Web/src/Forms/FieldCssClassProvider.cs
+++ b/src/Components/Web/src/Forms/FieldCssClassProvider.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Components.Forms
+{
+    /// <summary>
+    /// Supplies CSS class names for form fields to represent their validation state or other
+    /// state information from an <see cref="EditContext"/>.
+    /// </summary>
+    public class FieldCssClassProvider
+    {
+        internal readonly static FieldCssClassProvider Instance = new FieldCssClassProvider();
+
+        /// <summary>
+        /// Gets a string that indicates the status of the specified field as a CSS class.
+        /// </summary>
+        /// <param name="editContext">The <see cref="EditContext"/>.</param>
+        /// <param name="fieldIdentifier">The <see cref="FieldIdentifier"/>.</param>
+        /// <returns>A CSS class name string.</returns>
+        public virtual string GetFieldCssClass(EditContext editContext, in FieldIdentifier fieldIdentifier)
+        {
+            var isValid = !editContext.GetValidationMessages(fieldIdentifier).Any();
+            if (editContext.IsModified(fieldIdentifier))
+            {
+                return isValid ? "modified valid" : "modified invalid";
+            }
+            else
+            {
+                return isValid ? "valid" : "invalid";
+            }
+        }
+    }
+}

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -561,6 +561,23 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        public void RespectsCustomFieldCssClassProvider()
+        {
+            var appElement = MountTypicalValidationComponent();
+            var socksInput = appElement.FindElement(By.ClassName("socks")).FindElement(By.TagName("input"));
+            var messagesAccessor = CreateValidationMessagesAccessor(appElement);
+
+            // Validates on edit
+            Browser.Equal("valid-socks", () => socksInput.GetAttribute("class"));
+            socksInput.SendKeys("Purple\t");
+            Browser.Equal("modified valid-socks", () => socksInput.GetAttribute("class"));
+
+            // Can become invalid
+            socksInput.SendKeys(" with yellow spots\t");
+            Browser.Equal("modified invalid-socks", () => socksInput.GetAttribute("class"));
+        }
+
+        [Fact]
         public void NavigateOnSubmitWorks()
         {
             var app = Browser.MountTestComponent<NavigateOnSubmit>();

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/CustomFieldCssClassProvider.cs
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/CustomFieldCssClassProvider.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace BasicTestApp.FormsTest
+{
+    // For E2E testing, this is a rough example of a field CSS class provider that looks for
+    // a custom attribute defining CSS class names. It isn't very efficient (it does reflection
+    // and allocates on every invocation) but is sufficient for testing purposes.
+    public class CustomFieldCssClassProvider : FieldCssClassProvider
+    {
+        public override string GetFieldCssClass(EditContext editContext, in FieldIdentifier fieldIdentifier)
+        {
+            var cssClassName = base.GetFieldCssClass(editContext, fieldIdentifier);
+
+            // If we can find a [CustomValidationClassName], use it
+            var propertyInfo = fieldIdentifier.Model.GetType().GetProperty(fieldIdentifier.FieldName);
+            if (propertyInfo != null)
+            {
+                var customValidationClassName = (CustomValidationClassNameAttribute)propertyInfo
+                    .GetCustomAttributes(typeof(CustomValidationClassNameAttribute), true)
+                    .FirstOrDefault();
+                if (customValidationClassName != null)
+                {
+                    cssClassName = string.Join(' ', cssClassName.Split(' ').Select(token => token switch
+                    {
+                        "valid" => customValidationClassName.Valid ?? token,
+                        "invalid" => customValidationClassName.Invalid ?? token,
+                        _ => token,
+                    }));
+                }
+            }
+
+            return cssClassName;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    public class CustomValidationClassNameAttribute : Attribute
+    {
+        public string Valid { get; set; }
+        public string Invalid { get; set; }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
@@ -66,6 +66,9 @@
             </InputRadioGroup>
         </InputRadioGroup>
     </p>
+    <p class="socks">
+        Socks color: <InputText @bind-Value="person.SocksColor" />
+    </p>
     <p class="accepts-terms">
         Accepts terms: <InputCheckbox @bind-Value="person.AcceptsTerms" title="You have to check this" />
     </p>
@@ -98,6 +101,7 @@
     protected override void OnInitialized()
     {
         editContext = new EditContext(person);
+        editContext.SetFieldCssClassProvider(new CustomFieldCssClassProvider());
         customValidationMessageStore = new ValidationMessageStore(editContext);
     }
 
@@ -144,6 +148,9 @@
 
         [Required, EnumDataType(typeof(Country))]
         public Country? Country { get; set; } = null;
+
+        [Required, StringLength(10), CustomValidationClassName(Valid = "valid-socks", Invalid = "invalid-socks")]
+        public string SocksColor { get; set; }
 
         public string Username { get; set; }
     }


### PR DESCRIPTION
Fixes #8695

I'm pretty ambivalent about the design here. However there are some constraints that limit our options:

 * For back-compat, we need the CSS class names to continue being supplied by [a public extension method](https://github.com/dotnet/aspnetcore/blob/master/src/Components/Web/src/Forms/EditContextFieldClassExtensions.cs#L33). This takes the EditContext/FieldIdentifier pair and returns the computed class name string. We want this to live in the Web project because CSS is a web concept - that's why it's an extension method in the first place.
    * In turn, this means the CSS class name rules are only a function of that EditContext/FieldIdentifier pair, and don't (for example) vary between different inputs within the same form, or between different forms that are both attached to the same editcontext. So we can't implement the customization on `InputBase` or `EditForm`.
 * People may want to have different class names in different parts of their app. That rules out a `static` field to hold the custom names, and rules out using a DI service that provides it, as both these would be global to the app.
    * Although it might seem like a `<CascadingValue>` would give a way to customize it in different parts of the app, that's not an applicable choice either because `EditContext` isn't a component and hence can't receive cascaded parameters. It doesn't make sense to receive the value on `EditForm` either for many reasons (CSS is a web-specific concept, it would be noisy in the markup, and would make no sense if the same edit context was used by multiple forms that want different validation messages).

Given these constraints, the solution here:

 * Extends `EditContext` to have an arbitrary property bag that can be used for anything. I know this is a bit meh but there's lots of prior art for it in MVC APIs. It has to be public because of the cross-assembly dependency here and we don't have IVT.
 * Has the extension method look in the property bag for an `FieldCssClassProvider` instance under a particular private key. If it finds one, it uses it, otherwise it uses a private singleton instance.
 * The new `FieldCssClassProvider` type is something you can subclass to implement arbitrary logic for deciding a CSS class name string as a function of the EditContext/FieldIdentifier pair. You're not limited to just the validation state of the one field - you could use field metadata to look up arbitrary other info from the editcontext and factor that into the result too.

So if a developer wants to customize things, they do something like this:

```cs
var editContext = new EditContext(model);
editContext.SetFieldCssClassProvider(new MyFieldClassProvider());

...

class MyFieldClassProvider : FieldCssClassProvider
{
    public override string GetFieldCssClass(EditContext editContext, in FieldIdentifier fieldIdentifier)
    {
        var isValid = !editContext.GetValidationMessages(fieldIdentifier).Any();
        return isValid ? "legit" : "totally-bogus";
    }
}

```

There isn't a way to configure a global default field class provider. We could add that in the future if we wanted (e.g., a DI service - the `EditForm` could look for it and if found, associate it with the editcontext). However I still hope this is a niche use case and we don't have to go too far with this extensibility. For now, developers who want their own default could make their own factory method that returns a preconfigured `EditContext` and use that everywhere that an `EditContext` needs to be supplied.

Alternate design ideas are welcome. If you didn't already read the info about design constraints above, please do so before making up a design :)

~~I haven't yet added all the tests we'd want for this because I'm still open to design changes.~~ **Update:** Added tests now.

## Risks

1. Developers customizing this might be confused and think the way to implement custom validation itself is just to have custom `FieldCssClassProvider` logic that returns an "invalid"-type CSS class if a field value is bad, independently of the actual validation state in the editcontext. Making this mistake this would produce weird behaviors where the UI may imply a field is invalid but the EditContext believes it is valid so allows form submission.

If we wanted, we could prevent the use of custom logic altogether and change `FieldCssClassProvider` just to be something like:

```cs
public class FieldCssClassProvider
{
    public virtual string Modified => "modified";
    public virtual string Valid => "valid";
    public virtual string Invalid => "invalid";
}
```

Then developers would only be able to customize the strings, and not the logic used for determining which string to use. The drawback of this is that it prevents other useful customizations. For example, maybe they want to omit the valid/invalid class entirely for unmodified fields, or they need the class names to vary according to the *type* of the field as well (e.g., `valid-date` vs `valid-number`), or maybe they want to figure out some more advanced cases like having a `validation-pending` state depending on other info like an async process.

2. Developers might be confused by `editContext.Properties` and think it refers to the properties of the model object being edited, whereas in fact it refers to an arbitrary set of extra metadata on the `EditContext` itself.

---

## API review info:

**M.A.C.Forms package:**

```diff
namespace Microsoft.AspNetCore.Components.Forms
{
    public sealed class EditContext
    {
+        /// <summary>
+        /// Gets a collection of arbitrary properties associated with this instance.
+        /// </summary>
+        public EditContextProperties Properties { get; }
    }
}

+    /// <summary>
+    /// Holds arbitrary key/value pairs associated with an <see cref="EditContext"/>.
+    /// This can be used to track additional metadata for application-specific purposes.
+    /// </summary>
+    public sealed class EditContextProperties
+    {
+        /// <summary>
+        /// Gets or sets a value in the collection.
+        /// </summary>
+        /// <param name="key">The key under which the value is stored.</param>
+        /// <returns>The stored value.</returns>
+        public object this[object key] { get; set; }
+
+        /// <summary>
+        /// Gets the value associated with the specified key, if any.
+        /// </summary>
+        /// <param name="key">The key under which the value is stored.</param>
+        /// <param name="value">The value, if present.</param>
+        /// <returns>True if the value was present, otherwise false.</returns>
+        public bool TryGetValue(object key, [NotNullWhen(true)] out object? value);
+
+        /// <summary>
+        /// Removes the specified entry from the collection.
+        /// </summary>
+        /// <param name="key">The key of the entry to be removed.</param>
+        /// <returns>True if the value was present, otherwise false.</returns>
+        public bool Remove(object key);
+    }
}
```

**M.A.C.Web package:**

```diff
namespace Microsoft.AspNetCore.Components.Forms
{
    public static class EditContextFieldClassExtensions
    {
+        /// <summary>
+        /// Associates the supplied <see cref="FieldCssClassProvider"/> with the supplied <see cref="EditContext"/>.
+        /// This customizes the field CSS class names used within the <see cref="EditContext"/>.
+        /// </summary>
+        /// <param name="editContext">The <see cref="EditContext"/>.</param>
+        /// <param name="fieldCssClassProvider">The <see cref="FieldCssClassProvider"/>.</param>
+        public static void SetFieldCssClassProvider(this EditContext editContext, FieldCssClassProvider fieldCssClassProvider);
    }

+    /// <summary>
+    /// Supplies CSS class names for form fields to represent their validation state or other
+    /// state information from an <see cref="EditContext"/>.
+    /// </summary>
+    public class FieldCssClassProvider
+    {
+        /// <summary>
+        /// Gets a string that indicates the status of the specified field as a CSS class.
+        /// </summary>
+        /// <param name="editContext">The <see cref="EditContext"/>.</param>
+        /// <param name="fieldIdentifier">The <see cref="FieldIdentifier"/>.</param>
+        /// <returns>A CSS class name string.</returns>
+        public virtual string GetFieldCssClass(EditContext editContext, FieldIdentifier fieldIdentifier);
+    }
}
```