### PR TITLE
Fix invalid path in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,6 @@
 /global.json                    @aspnet/build
 /.azure/                        @aspnet/build
 /.config/                       @aspnet/build
-/*build.*                       @aspnet/build
 /eng/                           @aspnet/build
 /eng/common/                    @dotnet-maestro-bot
 /eng/Versions.props             @dotnet-maestro-bot @dougbu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /global.json                    @aspnet/build
 /.azure/                        @aspnet/build
 /.config/                       @aspnet/build
-/build/                         @aspnet/build
+/*build.*                       @aspnet/build
 /eng/                           @aspnet/build
 /eng/common/                    @dotnet-maestro-bot
 /eng/Versions.props             @dotnet-maestro-bot @dougbu


### PR DESCRIPTION
There doesn't appear to be a folder called build in the root. There are build files (build.cmd, build.ps, etc).

I'm not 100% sure that the asterisk will work as expected. I'll need to test that.