### PR TITLE
Backport [Java] Observe error to avoid crash (#22016)

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -4,6 +4,7 @@
 package com.microsoft.signalr;
 
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +27,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
     private WebSocketOnClosedCallback onClose;
     private CompletableSubject startSubject = CompletableSubject.create();
     private CompletableSubject closeSubject = CompletableSubject.create();
+    private final ReentrantLock closeLock = new ReentrantLock();
 
     private final Logger logger = LoggerFactory.getLogger(OkHttpWebSocketWrapper.class);
 
@@ -87,14 +89,29 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
         @Override
         public void onClosing(WebSocket webSocket, int code, String reason) {
             onClose.invoke(code, reason);
-            closeSubject.onComplete();
+            try {
+                closeLock.lock();
+                closeSubject.onComplete();
+            }
+            finally {
+                closeLock.unlock();
+            }
             checkStartFailure();
         }
 
         @Override
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
             logger.error("WebSocket closed from an error: {}.", t.getMessage());
-            closeSubject.onError(new RuntimeException(t));
+
+            try {
+                closeLock.lock();
+                if (!closeSubject.hasComplete()) {
+                    closeSubject.onError(new RuntimeException(t));
+                }
+            }
+            finally {
+                closeLock.unlock();
+            }
             onClose.invoke(null, t.getMessage());
             checkStartFailure();
         }


### PR DESCRIPTION
#### Description

Ungraceful disconnects can cause the Java application to crash. The cause is similar to how UnobservedTaskException's would crash the process in .NET. In the Java client there was a case where there was an exception and we would not observe it which crashes the process. The fix is to avoid causing the exception in the first place so there isn't an unobserved error.

#### Customer Impact

The bug was reported by a customer in issue https://github.com/dotnet/aspnetcore/issues/20187 and also by an internal customer recently who is asking us to backport the fix.

The bug can cause occasional crashes for ungraceful disconnects, these can be caused by things like going through a tunnel, etc.

#### Regression?

No

#### Risk

Low, fix is small and unlikely to cause issues.