### PR TITLE
Reset failed access count on successful login with remembered TFA

### DIFF
--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -378,8 +378,8 @@ namespace Microsoft.AspNetCore.Identity
             if (await UserManager.CheckPasswordAsync(user, password))
             {
                 var alwaysLockout = AppContext.TryGetSwitch("Microsoft.AspNetCore.Identity.CheckPasswordSignInAlwaysResetLockoutOnSuccess", out var enabled) && enabled;
-                // Only reset the lockout when TFA is not enabled when not in quirks mode
-                if (alwaysLockout || !await IsTfaEnabled(user))
+                // Only reset the lockout when not in quirks mode if either TFA is not enabled or the client is remembered for TFA.
+                if (alwaysLockout || !await IsTfaEnabled(user) || await IsTwoFactorClientRememberedAsync(user))
                 {
                     await ResetLockout(user);
                 }

--- a/src/Identity/Identity.slnf
+++ b/src/Identity/Identity.slnf
@@ -82,7 +82,10 @@
       "src\\Security\\Authentication\\OAuth\\src\\Microsoft.AspNetCore.Authentication.OAuth.csproj",
       "src\\Mvc\\Mvc.NewtonsoftJson\\src\\Microsoft.AspNetCore.Mvc.NewtonsoftJson.csproj",
       "src\\Features\\JsonPatch\\src\\Microsoft.AspNetCore.JsonPatch.csproj",
-      "src\\Mvc\\Mvc.Testing\\src\\Microsoft.AspNetCore.Mvc.Testing.csproj"
+      "src\\Mvc\\Mvc.Testing\\src\\Microsoft.AspNetCore.Mvc.Testing.csproj",
+      "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj",
+      "src\\Http\\Metadata\\src\\Microsoft.AspNetCore.Metadata.csproj",
+      "src\\Localization\\Abstractions\\src\\Microsoft.Extensions.Localization.Abstractions.csproj"
     ]
   }
 }


### PR DESCRIPTION
Reset failed access count on successful login with remembered TFA

 - Updates SignInManager.CheckPasswordSignInAsync with the above logic
 - Updates the tests to cover these scenario (does not include a test in which TFA is disabled but remembered, since that scenario can't/shouldn't happen).

Addresses #24441 (in this specific format)
