### PR TITLE
Increase timeout of Windows test job

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -517,6 +517,7 @@ stages:
         jobDisplayName: "Test: Windows Server 2016 x64"
         agentOs: Windows
         isTestingJob: true
+        timeoutInMinutes: 240
         buildArgs: -all -pack -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
                    /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
                    $(_InternalRuntimeDownloadArgs)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -517,7 +517,8 @@ stages:
         jobDisplayName: "Test: Windows Server 2016 x64"
         agentOs: Windows
         isTestingJob: true
-        timeoutInMinutes: 240
+        # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
+        cancelTimeoutInMinutes: 30
         buildArgs: -all -pack -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
                    /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
                    $(_InternalRuntimeDownloadArgs)


### PR DESCRIPTION
- no consistency in failures, maybe we have more tests now?
  - both of the runs below involved test failures but results were not uploaded
- https://dev.azure.com/dnceng/public/_build/results?buildId=768850
- https://dev.azure.com/dnceng/public/_build/results?buildId=768703
