### PR TITLE
Remove ANCM shim and outofprocess handler from Runtime SiteExtension

### DIFF
--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -33,15 +33,11 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
     </ProjectReference>
-
-    <NativeProjectReference Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" Platform="$(TargetArchitecture)" />
-    <NativeProjectReference Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" HandlerPath="2.0.0" Platform="$(TargetArchitecture)" />
   </ItemGroup>
 
   <Target Name="ResolveReferenceItemsForPackage" DependsOnTargets="ResolveReferences" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <Content Include="$(DotNetUnpackFolder)\**\*.*" Exclude="$(DotNetUnpackFolder)\**\.*" Condition="$(DotNetAssetRootUrl) != ''" PackagePath="content\%(RecursiveDir)" />
-      <Content Include="%(NativeContent.Identity)" PackagePath="content\ancm\%(NativeContent.HandlerPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/SiteExtensions/Runtime/applicationHost.xdt
+++ b/src/SiteExtensions/Runtime/applicationHost.xdt
@@ -12,10 +12,6 @@
           <add name="DOTNET_ROOT" value="%XDT_EXTENSIONPATH%" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"  />
         </environmentVariables>
       </runtime>
-
-      <globalModules>
-        <add name="AspNetCoreModuleV2" image="%XDT_EXTENSIONPATH%\ancm\aspnetcorev2.dll" xdt:Locator="Match(name)" xdt:Transform="Replace" />
-      </globalModules>
     </system.webServer>
 
     <location>


### PR DESCRIPTION
The site extension is currently broken because it no longer includes the /ancm folder with the shim and outofprocess handler but still sets the module path to the non-existent shim location.

We don't think it's interesting to keep the shim and outofprocess handler in the extension as we don't do any significant changes to them. And the current shipped versions are already on Antares so nothing breaks.