### PR TITLE
Add support for model binding DateTime as UTC

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
@@ -63,6 +63,7 @@ namespace Microsoft.AspNetCore.Mvc
             options.ModelBinderProviders.Add(new HeaderModelBinderProvider());
             options.ModelBinderProviders.Add(new FloatingPointTypeModelBinderProvider());
             options.ModelBinderProviders.Add(new EnumTypeModelBinderProvider(options));
+            options.ModelBinderProviders.Add(new DateTimeModelBinderProvider());
             options.ModelBinderProviders.Add(new SimpleTypeModelBinderProvider());
             options.ModelBinderProviders.Add(new CancellationTokenModelBinderProvider());
             options.ModelBinderProviders.Add(new ByteArrayModelBinderProvider());

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -18,9 +17,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         private readonly ILogger _logger;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="DecimalModelBinder"/>.
+        /// Initializes a new instance of <see cref="DateTimeModelBinder"/>.
         /// </summary>
-        /// <param name="supportedStyles">The <see cref="NumberStyles"/>.</param>
+        /// <param name="supportedStyles">The <see cref="DateTimeStyles"/>.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
         public DateTimeModelBinder(DateTimeStyles supportedStyles, ILoggerFactory loggerFactory)
         {
@@ -61,8 +60,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var type = metadata.UnderlyingOrModelType;
             try
             {
+
                 var value = valueProviderResult.FirstValue;
-                var culture = valueProviderResult.Culture;
 
                 object model;
                 if (string.IsNullOrWhiteSpace(value))
@@ -72,7 +71,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 }
                 else if (type == typeof(DateTime))
                 {
-                    model = DateTime.Parse(value, culture, _supportedStyles);
+                    model = DateTime.Parse(value, valueProviderResult.Culture, _supportedStyles);
                 }
                 else
                 {
@@ -97,17 +96,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             }
             catch (Exception exception)
             {
-                var isFormatException = exception is FormatException;
-                if (!isFormatException && exception.InnerException != null)
-                {
-                    // Unlike TypeConverters, floating point types do not seem to wrap FormatExceptions. Preserve
-                    // this code in case a cursory review of the CoreFx code missed something.
-                    exception = ExceptionDispatchInfo.Capture(exception.InnerException).SourceException;
-                }
-
-                modelState.TryAddModelError(modelName, exception, metadata);
-
                 // Conversion failed.
+                modelState.TryAddModelError(modelName, exception, metadata);
             }
 
             _logger.DoneAttemptingToBindModel(bindingContext);

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs
@@ -60,7 +60,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var type = metadata.UnderlyingOrModelType;
             try
             {
-
                 var value = valueProviderResult.FirstValue;
 
                 object model;
@@ -75,7 +74,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 }
                 else
                 {
-                    // unreachable
                     throw new NotSupportedException();
                 }
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs
@@ -1,0 +1,117 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// An <see cref="IModelBinder"/> for <see cref="DateTime"/> and nullable <see cref="DateTime"/> models.
+    /// </summary>
+    public class DateTimeModelBinder : IModelBinder
+    {
+        private readonly DateTimeStyles _supportedStyles;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DecimalModelBinder"/>.
+        /// </summary>
+        /// <param name="supportedStyles">The <see cref="NumberStyles"/>.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+        public DateTimeModelBinder(DateTimeStyles supportedStyles, ILoggerFactory loggerFactory)
+        {
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _supportedStyles = supportedStyles;
+            _logger = loggerFactory.CreateLogger<DateTimeModelBinder>();
+        }
+
+        /// <inheritdoc />
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext == null)
+            {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
+            _logger.AttemptingToBindModel(bindingContext);
+
+            var modelName = bindingContext.ModelName;
+            var valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+            if (valueProviderResult == ValueProviderResult.None)
+            {
+                _logger.FoundNoValueInRequest(bindingContext);
+
+                // no entry
+                _logger.DoneAttemptingToBindModel(bindingContext);
+                return Task.CompletedTask;
+            }
+
+            var modelState = bindingContext.ModelState;
+            modelState.SetModelValue(modelName, valueProviderResult);
+
+            var metadata = bindingContext.ModelMetadata;
+            var type = metadata.UnderlyingOrModelType;
+            try
+            {
+                var value = valueProviderResult.FirstValue;
+                var culture = valueProviderResult.Culture;
+
+                object model;
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    // Parse() method trims the value (with common DateTimeSyles) then throws if the result is empty.
+                    model = null;
+                }
+                else if (type == typeof(DateTime))
+                {
+                    model = DateTime.Parse(value, culture, _supportedStyles);
+                }
+                else
+                {
+                    // unreachable
+                    throw new NotSupportedException();
+                }
+
+                // When converting value, a null model may indicate a failed conversion for an otherwise required
+                // model (can't set a ValueType to null). This detects if a null model value is acceptable given the
+                // current bindingContext. If not, an error is logged.
+                if (model == null && !metadata.IsReferenceOrNullableType)
+                {
+                    modelState.TryAddModelError(
+                        modelName,
+                        metadata.ModelBindingMessageProvider.ValueMustNotBeNullAccessor(
+                            valueProviderResult.ToString()));
+                }
+                else
+                {
+                    bindingContext.Result = ModelBindingResult.Success(model);
+                }
+            }
+            catch (Exception exception)
+            {
+                var isFormatException = exception is FormatException;
+                if (!isFormatException && exception.InnerException != null)
+                {
+                    // Unlike TypeConverters, floating point types do not seem to wrap FormatExceptions. Preserve
+                    // this code in case a cursory review of the CoreFx code missed something.
+                    exception = ExceptionDispatchInfo.Capture(exception.InnerException).SourceException;
+                }
+
+                modelState.TryAddModelError(modelName, exception, metadata);
+
+                // Conversion failed.
+            }
+
+            _logger.DoneAttemptingToBindModel(bindingContext);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinderProvider.cs
@@ -24,9 +24,9 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             }
 
             var modelType = context.Metadata.UnderlyingOrModelType;
-            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
             if (modelType == typeof(DateTime))
             {
+                var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
                 return new DateTimeModelBinder(SupportedStyles, loggerFactory);
             }
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinderProvider.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    /// <summary>
+    /// An <see cref="IModelBinderProvider"/> for binding <see cref="DateTime" /> and nullable <see cref="DateTime"/> models.
+    /// </summary>
+    public class DateTimeModelBinderProvider : IModelBinderProvider
+    {
+        internal static readonly DateTimeStyles SupportedStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces;
+
+        /// <inheritdoc />
+        public IModelBinder GetBinder(ModelBinderProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var modelType = context.Metadata.UnderlyingOrModelType;
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            if (modelType == typeof(DateTime))
+            {
+                return new DateTimeModelBinder(SupportedStyles, loggerFactory);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DecimalModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DecimalModelBinder.cs
@@ -63,7 +63,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             try
             {
                 var value = valueProviderResult.FirstValue;
-                var culture = valueProviderResult.Culture;
 
                 object model;
                 if (string.IsNullOrWhiteSpace(value))
@@ -73,7 +72,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 }
                 else if (type == typeof(decimal))
                 {
-                    model = decimal.Parse(value, _supportedStyles, culture);
+                    model = decimal.Parse(value, _supportedStyles, valueProviderResult.Culture);
                 }
                 else
                 {

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DoubleModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DoubleModelBinder.cs
@@ -63,7 +63,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             try
             {
                 var value = valueProviderResult.FirstValue;
-                var culture = valueProviderResult.Culture;
 
                 object model;
                 if (string.IsNullOrWhiteSpace(value))
@@ -73,7 +72,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 }
                 else if (type == typeof(double))
                 {
-                    model = double.Parse(value, _supportedStyles, culture);
+                    model = double.Parse(value, _supportedStyles, valueProviderResult.Culture);
                 }
                 else
                 {

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FloatModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FloatModelBinder.cs
@@ -63,7 +63,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             try
             {
                 var value = valueProviderResult.FirstValue;
-                var culture = valueProviderResult.Culture;
 
                 object model;
                 if (string.IsNullOrWhiteSpace(value))
@@ -73,7 +72,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 }
                 else if (type == typeof(float))
                 {
-                    model = float.Parse(value, _supportedStyles, culture);
+                    model = float.Parse(value, _supportedStyles, valueProviderResult.Culture);
                 }
                 else
                 {

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
@@ -46,6 +46,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 throw new ArgumentNullException(nameof(bindingContext));
             }
 
+            _logger.AttemptingToBindModel(bindingContext);
+
             var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
             if (valueProviderResult == ValueProviderResult.None)
             {
@@ -55,8 +57,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 _logger.DoneAttemptingToBindModel(bindingContext);
                 return Task.CompletedTask;
             }
-
-            _logger.AttemptingToBindModel(bindingContext);
 
             bindingContext.ModelState.SetModelValue(bindingContext.ModelName, valueProviderResult);
 

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -463,6 +463,9 @@ Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexObjectModelBinderProvider.C
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinder
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinderProvider
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinderProvider.ComplexTypeModelBinderProvider() -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider.DateTimeModelBinderProvider() -> void
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DecimalModelBinder
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DictionaryModelBinder<TKey, TValue>
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DictionaryModelBinderProvider
@@ -1464,6 +1467,9 @@ virtual Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.Visit
 ~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinder.ComplexTypeModelBinder(System.Collections.Generic.IDictionary<Microsoft.AspNetCore.Mvc.ModelBinding.ModelMetadata, Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder> propertyBinders, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) -> void
 ~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinder.ComplexTypeModelBinder(System.Collections.Generic.IDictionary<Microsoft.AspNetCore.Mvc.ModelBinding.ModelMetadata, Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder> propertyBinders, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, bool allowValidatingTopLevelNodes) -> void
 ~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder
+~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext bindingContext) -> System.Threading.Tasks.Task
+~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder.DateTimeModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) -> void
+~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder
 ~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DecimalModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext bindingContext) -> System.Threading.Tasks.Task
 ~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DecimalModelBinder.DecimalModelBinder(System.Globalization.NumberStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) -> void
 ~Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DictionaryModelBinder<TKey, TValue>.DictionaryModelBinder(Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder keyBinder, Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder valueBinder, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) -> void

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateTimeModelBinderProviderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateTimeModelBinderProviderTest.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    public class DateTimeModelBinderProviderTest
+    {
+        private readonly DateTimeModelBinderProvider _provider = new DateTimeModelBinderProvider();
+
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(DateTimeOffset))]
+        [InlineData(typeof(DateTimeOffset?))]
+        [InlineData(typeof(TimeSpan))]
+        public void Create_ForNonDateTime_ReturnsNull(Type modelType)
+        {
+            // Arrange
+            var context = new TestModelBinderProviderContext(modelType);
+
+            // Act
+            var result = _provider.GetBinder(context);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Create_ForDateTime_ReturnsBinder()
+        {
+            // Arrange
+            var context = new TestModelBinderProviderContext(typeof(DateTime));
+
+            // Act
+            var result = _provider.GetBinder(context);
+
+            // Assert
+            Assert.IsType<DateTimeModelBinder>(result);
+        }
+
+        [Fact]
+        public void Create_ForNullableDateTime_ReturnsBinder()
+        {
+            // Arrange
+            var context = new TestModelBinderProviderContext(typeof(DateTime?));
+
+            // Act
+            var result = _provider.GetBinder(context);
+
+            // Assert
+            Assert.IsType<DateTimeModelBinder>(result);
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateTimeModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateTimeModelBinderTest.cs
@@ -1,0 +1,226 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
+{
+    public class DateTimeModelBinderTest
+    {
+        [Fact]
+        public async Task BindModel_ReturnsFailure_IfAttemptedValueCannotBeParsed()
+        {
+            // Arrange
+            var bindingContext = GetBindingContext();
+            bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", "some-value" }
+            };
+            var binder = GetBinder();
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.False(bindingContext.Result.IsModelSet);
+        }
+
+        [Fact]
+        public async Task BindModel_CreatesError_IfAttemptedValueCannotBeParsed()
+        {
+            // Arrange
+            var message = "The value 'not a number' is not valid.";
+            var bindingContext = GetBindingContext();
+            bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", "not a number" },
+            };
+            var binder = GetBinder();
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.False(bindingContext.Result.IsModelSet);
+            Assert.Null(bindingContext.Result.Model);
+            Assert.False(bindingContext.ModelState.IsValid);
+
+            var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+            Assert.Equal(message, error.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task BindModel_CreatesError_IfAttemptedValueCannotBeCompletelyParsed()
+        {
+            // Arrange
+            var bindingContext = GetBindingContext();
+            bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("en-GB"))
+            {
+                { "theModelName", "2020-08-not-a-date" }
+            };
+            var binder = GetBinder();
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.False(bindingContext.Result.IsModelSet);
+            Assert.Null(bindingContext.Result.Model);
+
+            var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+            Assert.Equal("The value '2020-08-not-a-date' is not valid.", error.ErrorMessage, StringComparer.Ordinal);
+            Assert.Null(error.Exception);
+        }
+
+        [Fact]
+        public async Task BindModel_ReturnsFailed_IfValueProviderEmpty()
+        {
+            // Arrange
+            var bindingContext = GetBindingContext(typeof(DateTime));
+            var binder = GetBinder();
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.Equal(ModelBindingResult.Failed(), bindingContext.Result);
+            Assert.Empty(bindingContext.ModelState);
+        }
+
+        [Fact]
+        public async Task BindModel_NullableDatetime_ReturnsFailed_IfValueProviderEmpty()
+        {
+            // Arrange
+            var bindingContext = GetBindingContext(typeof(DateTime?));
+            var binder = GetBinder();
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.Equal(ModelBindingResult.Failed(), bindingContext.Result);
+            Assert.Empty(bindingContext.ModelState);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" \t \r\n ")]
+        public async Task BindModel_CreatesError_IfTrimmedAttemptedValueIsEmpty_NonNullableDestination(string value)
+        {
+            // Arrange
+            var message = $"The value '{value}' is invalid.";
+            var bindingContext = GetBindingContext();
+            bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", value },
+            };
+            var binder = GetBinder();
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.False(bindingContext.Result.IsModelSet);
+            Assert.Null(bindingContext.Result.Model);
+
+            var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+            Assert.Equal(message, error.ErrorMessage, StringComparer.Ordinal);
+            Assert.Null(error.Exception);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" \t \r\n ")]
+        public async Task BindModel_ReturnsNull_IfTrimmedAttemptedValueIsEmpty_NullableDestination(string value)
+        {
+            // Arrange
+            var bindingContext = GetBindingContext(typeof(DateTime?));
+            bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", value }
+            };
+            var binder = GetBinder();
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.Null(bindingContext.Result.Model);
+            var entry = Assert.Single(bindingContext.ModelState);
+            Assert.Equal("theModelName", entry.Key);
+        }
+
+        [Theory]
+        [InlineData(typeof(DateTime))]
+        [InlineData(typeof(DateTime?))]
+        public async Task BindModel_ReturnsModel_IfAttemptedValueIsValid(Type type)
+        {
+            // Arrange
+            var expected = new DateTime(2019, 06, 14, 2, 30, 4, 0, DateTimeKind.Utc);
+            var bindingContext = GetBindingContext(type);
+            bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
+            {
+                { "theModelName", "2019-06-14T02:30:04.0Z" }
+            };
+            var binder = GetBinder();
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.True(bindingContext.Result.IsModelSet);
+            var model = Assert.IsType<DateTime>(bindingContext.Result.Model);
+            Assert.Equal(expected, model);
+            Assert.Equal(DateTimeKind.Utc, model.Kind);
+            Assert.True(bindingContext.ModelState.ContainsKey("theModelName"));
+        }
+
+        [Fact]
+        public async Task UsesSpecifiedStyleToParseModel()
+        {
+            // Arrange
+            var bindingContext = GetBindingContext();
+            var expected = new DateTime(2019, 06, 13, 19, 30, 4, 0, DateTimeKind.Local);
+            bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
+            {
+                { "theModelName", "2019-06-14T02:30:04.0Z" }
+            };
+            var binder = GetBinder(DateTimeStyles.AssumeLocal);
+
+            // Act
+            await binder.BindModelAsync(bindingContext);
+
+            // Assert
+            Assert.True(bindingContext.Result.IsModelSet);
+            var model = Assert.IsType<DateTime>(bindingContext.Result.Model);
+            Assert.Equal(expected, model);
+            Assert.Equal(DateTimeKind.Local, model.Kind);
+            Assert.True(bindingContext.ModelState.ContainsKey("theModelName"));
+        }
+
+        private IModelBinder GetBinder(DateTimeStyles? dateTimeStyles = null)
+        {
+            return new DateTimeModelBinder(dateTimeStyles ?? DateTimeModelBinderProvider.SupportedStyles, NullLoggerFactory.Instance);
+        }
+
+        private static DefaultModelBindingContext GetBindingContext(Type modelType = null)
+        {
+            modelType ??= typeof(DateTime);
+            return new DefaultModelBindingContext
+            {
+                ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(modelType),
+                ModelName = "theModelName",
+                ModelState = new ModelStateDictionary(),
+                ValueProvider = new SimpleValueProvider() // empty
+            };
+        }
+
+        private sealed class TestClass
+        {
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateTimeModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateTimeModelBinderTest.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             // Arrange
             var bindingContext = GetBindingContext();
-            var expected = new DateTime(2019, 06, 13, 19, 30, 4, 0, DateTimeKind.Local);
+            var expected = DateTime.Parse("2019-06-14T02:30:04.0Z");
             bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
             {
                 { "theModelName", "2019-06-14T02:30:04.0Z" }

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateTimeModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateTimeModelBinderTest.cs
@@ -33,11 +33,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         public async Task BindModel_CreatesError_IfAttemptedValueCannotBeParsed()
         {
             // Arrange
-            var message = "The value 'not a number' is not valid.";
+            var message = "The value 'not a date' is not valid.";
             var bindingContext = GetBindingContext();
             bindingContext.ValueProvider = new SimpleValueProvider
             {
-                { "theModelName", "not a number" },
+                { "theModelName", "not a date" },
             };
             var binder = GetBinder();
 
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var bindingContext = GetBindingContext(type);
             bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
             {
-                { "theModelName", "2019-06-14T02:30:04.0Z" }
+                { "theModelName", "2019-06-14T02:30:04.0000000Z" }
             };
             var binder = GetBinder();
 
@@ -184,10 +184,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             // Arrange
             var bindingContext = GetBindingContext();
-            var expected = DateTime.Parse("2019-06-14T02:30:04.0Z");
+            var expected = DateTime.Parse("2019-06-14T02:30:04.0000000Z");
             bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
             {
-                { "theModelName", "2019-06-14T02:30:04.0Z" }
+                { "theModelName", "2019-06-14T02:30:04.0000000Z" }
             };
             var binder = GetBinder(DateTimeStyles.AssumeLocal);
 
@@ -217,10 +217,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 ModelState = new ModelStateDictionary(),
                 ValueProvider = new SimpleValueProvider() // empty
             };
-        }
-
-        private sealed class TestClass
-        {
         }
     }
 }

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/SimpleTypeModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/SimpleTypeModelBinderTest.cs
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             // Assert
             Assert.Equal(ModelBindingResult.Failed(), bindingContext.Result);
             Assert.Empty(bindingContext.ModelState);
-            Assert.Equal(2, sink.Writes.Count());
+            Assert.Equal(3, sink.Writes.Count());
         }
 
         [Theory]

--- a/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
+++ b/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
@@ -58,6 +58,7 @@ namespace Microsoft.AspNetCore.Mvc
                 binder => Assert.IsType<HeaderModelBinderProvider>(binder),
                 binder => Assert.IsType<FloatingPointTypeModelBinderProvider>(binder),
                 binder => Assert.IsType<EnumTypeModelBinderProvider>(binder),
+                binder => Assert.IsType<DateTimeModelBinderProvider>(binder),
                 binder => Assert.IsType<SimpleTypeModelBinderProvider>(binder),
                 binder => Assert.IsType<CancellationTokenModelBinderProvider>(binder),
                 binder => Assert.IsType<ByteArrayModelBinderProvider>(binder),


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/11584

This change adds a model binder that produces UTC DateTime values by default. Prior to this change, model bound DateTime values used local times. However, this was inconsistent with JSON formatted values which produces DateTime of UTC kinds. 

I'll add a migration note as a follow up with a code sample to revert to the previous behavior.