### PR TITLE
Align scope used by client and server in blazor wasm template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
@@ -38,7 +38,7 @@ namespace ComponentsWebAssembly_CSharp.Server.Controllers
         private readonly ILogger<WeatherForecastController> _logger;
 
         // The Web API will only accept tokens 1) for users, and 2) having the access_as_user scope for this API
-        static readonly string[] scopeRequiredByApi = new string[] { "access_as_user" };
+        static readonly string[] scopeRequiredByApi = new string[] { "api-scope" };
 
 #if (GenerateApi)
         private readonly IDownstreamWebApi _downstreamWebApi;


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/149.

#### Description

The scope used during validation in the WeatherForecast controller is hard coded to `access_as_user`. This is an issue for the blazor-wasm template since if IndividualB2C auth is configured, the scope specified by the `default-scope` option will could lead to a mismatch between the client's configuration and the validation logic in the controller of the server. This change removes the hardcoding and aligns the scopes so that the same scope is used in the client and the server.

#### Customer Impact

If the customer creates a hosted blazor wasm template (aka ComponentsWebAssembly) and selectes to use IndividualB2C auth and sets the `default-scope` option to anything other than `access_as_user`. The validation check in the WeatherForecast controller will fail.

#### Regression?

Yes, this is a regression that was introduced in 5.0 preview8

#### Risk

Very low, this template change affects a very narrow scenario (hosted blazor wasm with IndividualB2C enabled) and has been verified locally.