### PR TITLE
Change OIDC default to Code + PKCE

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -113,8 +113,8 @@ namespace OpenIdConnectSample
                 o.ClientId = "interactive.public";
                 o.ClientSecret = "secret";
                 o.Authority = "https://demo.identityserver.io/";
-                o.NonceCookie.SameSite = SameSiteMode.Unspecified;
-                o.CorrelationCookie.SameSite = SameSiteMode.Unspecified;
+                // o.NonceCookie.SameSite = SameSiteMode.Unspecified;
+                // o.CorrelationCookie.SameSite = SameSiteMode.Unspecified;
                 /*
                 o.ClientId = "hybrid";
                 o.ResponseType = OpenIdConnectResponseType.CodeIdToken;

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -110,8 +110,8 @@ namespace OpenIdConnectSample
                 o.Authority = Configuration["oidc:authority"];
                 */
                 // https://github.com/IdentityServer/IdentityServer4.Demo/blob/master/src/IdentityServer4Demo/Config.cs
-                o.ClientId = "server.hybrid";
-                o.ClientSecret = "secret"; // for code flow
+                o.ClientId = "hybrid";
+                o.ClientSecret = "secret";
                 o.Authority = "https://demo.identityserver.io/";
 
                 o.ResponseType = OpenIdConnectResponseType.CodeIdToken;

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -110,11 +110,21 @@ namespace OpenIdConnectSample
                 o.Authority = Configuration["oidc:authority"];
                 */
                 // https://github.com/IdentityServer/IdentityServer4.Demo/blob/master/src/IdentityServer4Demo/Config.cs
-                o.ClientId = "hybrid";
+                o.ClientId = "interactive.public";
                 o.ClientSecret = "secret";
                 o.Authority = "https://demo.identityserver.io/";
-
+                o.NonceCookie.SameSite = SameSiteMode.Unspecified;
+                o.CorrelationCookie.SameSite = SameSiteMode.Unspecified;
+                /*
+                o.ClientId = "hybrid";
                 o.ResponseType = OpenIdConnectResponseType.CodeIdToken;
+                o.ResponseMode = OpenIdConnectResponseMode.FormPost;
+                o.NonceCookie.SameSite = SameSiteMode.None;
+                o.CorrelationCookie.SameSite = SameSiteMode.None;
+                */
+                // o.NonceCookie.SameSite = SameSiteMode.Unspecified;
+                // o.CorrelationCookie.SameSite = SameSiteMode.Unspecified;
+
                 o.SaveTokens = true;
                 o.GetClaimsFromUserInfoEndpoint = true;
                 o.AccessDeniedPath = "/access-denied-from-remote";
@@ -329,7 +339,7 @@ namespace OpenIdConnectSample
 
         private static async Task WriteHtmlAsync(HttpResponse response, Func<HttpResponse, Task> writeContent)
         {
-            var bootstrap = "<link rel=\"stylesheet\" href=\"https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css\" integrity=\"sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu\" crossorigin=\"anonymous\">";
+            var bootstrap = "<link rel=\"stylesheet\" href=\"https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css\" integrity=\"sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu\" crossorigin=\"anonymous\"><link rel=\"icon\" href=\"data:; base64,iVBORw0KGgo = \">";
 
             response.ContentType = "text/html";
             await response.WriteAsync($"<html><head>{bootstrap}</head><body><div class=\"container\">");

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
@@ -214,12 +214,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         /// <summary>
         /// Gets or sets the 'response_mode'.
         /// </summary>
-        public string ResponseMode { get; set; } = OpenIdConnectResponseMode.FormPost;
+        public string ResponseMode { get; set; } = OpenIdConnectResponseMode.Query;
 
         /// <summary>
         /// Gets or sets the 'response_type'.
         /// </summary>
-        public string ResponseType { get; set; } = OpenIdConnectResponseType.IdToken;
+        public string ResponseType { get; set; } = OpenIdConnectResponseType.Code;
 
         /// <summary>
         /// Gets or sets the 'prompt'.

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
@@ -212,12 +212,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public string Resource { get; set; }
 
         /// <summary>
-        /// Gets or sets the 'response_mode'.
+        /// Gets or sets the 'response_mode'. The default is 'query'.
         /// </summary>
         public string ResponseMode { get; set; } = OpenIdConnectResponseMode.Query;
 
         /// <summary>
-        /// Gets or sets the 'response_type'.
+        /// Gets or sets the 'response_type'. The default is 'code'.
         /// </summary>
         public string ResponseType { get; set; } = OpenIdConnectResponseType.Code;
 

--- a/src/Security/Authentication/samples/SocialSample/Startup.cs
+++ b/src/Security/Authentication/samples/SocialSample/Startup.cs
@@ -173,7 +173,7 @@ namespace SocialSample
                 // https://demo.identityserver.io/
                 .AddOAuth("IdentityServer", "Identity Server", o =>
                 {
-                    o.ClientId = "server.code";
+                    o.ClientId = "interactive.confidential";
                     o.ClientSecret = "secret";
                     o.CallbackPath = new PathString("/signin-identityserver");
                     o.AuthorizationEndpoint = "https://demo.identityserver.io/connect/authorize";


### PR DESCRIPTION
#18932

Update: I was finally able to test chrome by downloading Chromium. I enabled every current and future restriction available and the SameSite=none cookies continued to work. That makes this change safer because we can leave the cookies as is, but it also makes this change less necessary.

We also need to figure out what the impact is on the AzureAd.UI, Identity.Web, templates, etc.. @jmprieur 

The biggest difference is that the code flow requires a client secret.

Edit: I've split out the new cookie warning log into #24970.