### PR TITLE
HTTP2: Fix known header type not reset for multi-value headers

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2HeaderEnumerator.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2HeaderEnumerator.cs
@@ -90,19 +90,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         private bool SetCurrent(string name, StringValues value, KnownHeaderType knownHeaderType)
         {
+            _knownHeaderType = knownHeaderType;
+
             if (value.Count == 1)
             {
                 Current = new KeyValuePair<string, string>(name, value.ToString());
-                _knownHeaderType = knownHeaderType;
                 _hasMultipleValues = false;
                 return true;
             }
             else
             {
                 _stringValuesEnumerator = value.GetEnumerator();
-                _knownHeaderType = knownHeaderType;
                 _hasMultipleValues = true;
-
                 return MoveNextOnStringEnumerator(name);
             }
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2HeaderEnumerator.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2HeaderEnumerator.cs
@@ -100,6 +100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             else
             {
                 _stringValuesEnumerator = value.GetEnumerator();
+                _knownHeaderType = knownHeaderType;
                 _hasMultipleValues = true;
 
                 return MoveNextOnStringEnumerator(name);

--- a/src/Servers/Kestrel/Core/test/Http2HeadersEnumeratorTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http2HeadersEnumeratorTests.cs
@@ -137,9 +137,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.False(e.MoveNext());
         }
 
-        private (int HPackStaticTableId, string name, string value)[] GetNormalizedHeaders(Http2HeadersEnumerator enumerator)
+        private (int HPackStaticTableId, string Name, string Value)[] GetNormalizedHeaders(Http2HeadersEnumerator enumerator)
         {
-            var headers = new List<(int HPackStaticTableId, string name, string value)>();
+            var headers = new List<(int HPackStaticTableId, string Name, string Value)>();
             while (enumerator.MoveNext())
             {
                 headers.Add(CreateHeaderResult(enumerator.HPackStaticTableId, enumerator.Current.Key, enumerator.Current.Value));

--- a/src/Servers/Kestrel/Core/test/Http2HeadersEnumeratorTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http2HeadersEnumeratorTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Http;


### PR DESCRIPTION
Fix HTTP/2 headers with multiple values being sent back with the wrong name.

@Tratcher 