### PR TITLE
Add support for views + SingleFileExe

### DIFF
--- a/src/ProjectTemplates/BlazorTemplates.Tests/Infrastructure/GenerateTestProps.targets
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/Infrastructure/GenerateTestProps.targets
@@ -35,7 +35,7 @@
         MicrosoftNETSdkRazorPackageVersion=$(MicrosoftNETSdkRazorPackageVersion);
         MicrosoftAspNetCoreAppRefPackageVersion=$(MicrosoftAspNetCoreAppRefPackageVersion);
         MicrosoftAspNetCoreAppRuntimePackageVersion=@(_RuntimePackageVersionInfo->'%(PackageVersion)');
-        SupportedRuntimeIdentifiers=$(SupportedRuntimeIdentifiers);
+        SupportedRuntimeIdentifiers=$(SupportedRuntimeIdentifiers.Trim());
         DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
         RepoRoot=$(RepoRoot);
         Configuration=$(Configuration);

--- a/src/ProjectTemplates/Shared/AspNetProcess.cs
+++ b/src/ProjectTemplates/Shared/AspNetProcess.cs
@@ -42,6 +42,7 @@ namespace Templates.Test.Helpers
             IDictionary<string, string> environmentVariables,
             bool published,
             bool hasListeningUri = true,
+            bool usePublishedAppHost = false,
             ILogger logger = null)
         {
             _developmentCertificate = DevelopmentCertificate.Create(workingDirectory);
@@ -64,9 +65,17 @@ namespace Templates.Test.Helpers
             string arguments;
             if (published)
             {
-                // When publishingu used the app host to run the app. This makes it easy to consistently run for regular and single-file publish
-                process = OperatingSystem.IsWindows() ? dllPath + ".exe" : dllPath;
-                arguments = null;
+                if (usePublishedAppHost)
+                {
+                    // When publishingu used the app host to run the app. This makes it easy to consistently run for regular and single-file publish
+                    process = Path.ChangeExtension(dllPath, OperatingSystem.IsWindows() ? ".exe" : null);
+                    arguments = null;
+                }
+                else
+                {
+                    process = DotNetMuxer.MuxerPathOrDefault();
+                    arguments = $"exec {dllPath}";
+                }
             }
             else
             {

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -179,7 +179,7 @@ namespace Templates.Test.Helpers
             return new AspNetProcess(Output, TemplateOutputDir, projectDll, environment, published: false, hasListeningUri: hasListeningUri, logger: logger);
         }
 
-        internal AspNetProcess StartPublishedProjectAsync(bool hasListeningUri = true)
+        internal AspNetProcess StartPublishedProjectAsync(bool hasListeningUri = true, bool usePublishedAppHost = false)
         {
             var environment = new Dictionary<string, string>
             {
@@ -190,8 +190,8 @@ namespace Templates.Test.Helpers
                 ["ASPNETCORE_Logging__Console__FormatterOptions__IncludeScopes"] = "true",
             };
 
-            var projectDll = Path.Combine(TemplatePublishDir, ProjectName);
-            return new AspNetProcess(Output, TemplatePublishDir, projectDll, environment, published: true, hasListeningUri: hasListeningUri);
+            var projectDll = Path.Combine(TemplatePublishDir, $"{ProjectName}.dll");
+            return new AspNetProcess(Output, TemplatePublishDir, projectDll, environment, published: true, hasListeningUri: hasListeningUri, usePublishedAppHost: usePublishedAppHost);
         }
 
         internal async Task<ProcessResult> RunDotNetEfCreateMigrationAsync(string migrationName)

--- a/src/ProjectTemplates/test/Infrastructure/GenerateTestProps.targets
+++ b/src/ProjectTemplates/test/Infrastructure/GenerateTestProps.targets
@@ -35,7 +35,7 @@
         MicrosoftNETSdkRazorPackageVersion=$(MicrosoftNETSdkRazorPackageVersion);
         MicrosoftAspNetCoreAppRefPackageVersion=$(MicrosoftAspNetCoreAppRefPackageVersion);
         MicrosoftAspNetCoreAppRuntimePackageVersion=@(_RuntimePackageVersionInfo->'%(PackageVersion)');
-        SupportedRuntimeIdentifiers=$(SupportedRuntimeIdentifiers);
+        SupportedRuntimeIdentifiers=$(SupportedRuntimeIdentifiers.Trim());
         DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
         RepoRoot=$(RepoRoot);
         Configuration=$(Configuration);

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -223,7 +223,7 @@ namespace Templates.Test
             }
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "https://github.com/dotnet/aspnetcore/issues/25103")]
         [SkipOnHelix("cert failure", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
         public async Task MvcTemplate_SingleFileExe()
         {

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -243,7 +243,7 @@ namespace Templates.Test
                 return;
             }
 
-            Project = await ProjectFactory.GetOrCreateProject("mvcindividualuld", Output);
+            Project = await ProjectFactory.GetOrCreateProject("mvcsinglefileexe", Output);
             Project.RuntimeIdentifier = runtimeIdentifer;
 
             var createResult = await Project.RunDotNetNewAsync("mvc", auth: "Individual", useLocalDB: true);
@@ -286,7 +286,7 @@ namespace Templates.Test
                 },
             };
 
-            using var aspNetProcess = Project.StartPublishedProjectAsync();
+            using var aspNetProcess = Project.StartPublishedProjectAsync(usePublishedAppHost: true);
             Assert.False(
                 aspNetProcess.Process.HasExited,
                 ErrorMessages.GetFailedProcessMessageOrEmpty("Run published project", Project, aspNetProcess.Process));

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -720,10 +720,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AllPublishItemsFullPathWithTargetPath Include="@(RazorIntermediateAssembly->'%(FullPath)')">
         <TargetPath>%(Filename)%(Extension)</TargetPath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       </AllPublishItemsFullPathWithTargetPath>
       <AllPublishItemsFullPathWithTargetPath Include="@(_RazorDebugSymbolsIntermediatePath->'%(FullPath)')">
         <TargetPath>%(Filename)%(Extension)</TargetPath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       </AllPublishItemsFullPathWithTargetPath>
     </ItemGroup>
 


### PR DESCRIPTION
* Exclude views dll \ pdb from single file archive
* When loading related parts, check if the Assembly is already loaded. 

~~I tried writing a template test for this, but we don't build rid specific M.A.A before the template tests are available. I'll add a CTI item for this.~~