### PR TITLE
Support more IAsyncEnumerable types in SignalR

### DIFF
--- a/src/SignalR/common/Shared/ReflectionHelper.cs
+++ b/src/SignalR/common/Shared/ReflectionHelper.cs
@@ -1,5 +1,5 @@
 // Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #nullable disable
 
@@ -39,7 +39,10 @@ namespace Microsoft.AspNetCore.SignalR
         {
             if (type.IsGenericType)
             {
-                return type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>);
+                if (type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+                {
+                    return true;
+                }
             }
 
             return type.GetInterfaces().Any(t =>

--- a/src/SignalR/server/SignalR/test/Internal/ReflectionHelperTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/ReflectionHelperTests.cs
@@ -57,9 +57,23 @@ namespace Microsoft.AspNetCore.SignalR.Tests.Internal
                 typeof(CustomAsyncEnumerable),
                 true
             };
+
+            yield return new object[]
+            {
+                typeof(CustomAsyncEnumerableOfT<object>),
+                true
+            };
         }
 
         private class CustomAsyncEnumerable : IAsyncEnumerable<object>
+        {
+            public IAsyncEnumerator<object> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class CustomAsyncEnumerableOfT<T> : IAsyncEnumerable<object>
         {
             public IAsyncEnumerator<object> GetAsyncEnumerator(CancellationToken cancellationToken = default)
             {


### PR DESCRIPTION
Found from a stackoverflow question.
System.Linq.Async has a `ToAsyncEnumerable` method which returns a generic class that implements `IAsyncEnumerable<T>` which didn't work with our reflection logic.

https://github.com/dotnet/reactive/blob/7ad606b3dcd4bb2c6ae9622f8a59db7f8f52aa85/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToAsyncEnumerable.cs#L34