### PR TITLE
Optimize writing single segment sequences

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -438,21 +438,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        private void Copy(in ReadOnlySequence<byte> readableBuffer, PipeWriter writableBuffer)
-        {
-            if (readableBuffer.IsSingleSegment)
-            {
-                writableBuffer.Write(readableBuffer.FirstSpan);
-            }
-            else
-            {
-                foreach (var memory in readableBuffer)
-                {
-                    writableBuffer.Write(memory.Span);
-                }
-            }
-        }
-
         private void ParseChunkedSuffix(in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
         {
             consumed = buffer.Start;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -438,6 +438,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
+        private void Copy(in ReadOnlySequence<byte> readableBuffer, PipeWriter writableBuffer)
+        {
+            if (readableBuffer.IsSingleSegment)
+            {
+                writableBuffer.Write(readableBuffer.FirstSpan);
+            }
+            else
+            {
+                foreach (var memory in readableBuffer)
+                {
+                    writableBuffer.Write(memory.Span);
+                }
+            }
+        }
+
         private void ParseChunkedSuffix(in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
         {
             consumed = buffer.Start;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -218,21 +218,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _requestBodyPipe.Reset();
         }
 
-        private void Copy(in ReadOnlySequence<byte> readableBuffer, PipeWriter writableBuffer)
-        {
-            if (readableBuffer.IsSingleSegment)
-            {
-                writableBuffer.Write(readableBuffer.FirstSpan);
-            }
-            else
-            {
-                foreach (var memory in readableBuffer)
-                {
-                    writableBuffer.Write(memory.Span);
-                }
-            }
-        }
-
         protected override void OnReadStarted()
         {
             _pumpTask = PumpAsync();
@@ -442,7 +427,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             consumed = buffer.GetPosition(actual);
             examined = consumed;
 
-            Copy(buffer.Slice(0, actual), writableBuffer);
+            buffer.Slice(0, actual).CopyTo(writableBuffer);
 
             _inputLength -= actual;
             AddAndCheckObservedBytes(actual);

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -317,10 +317,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
             WriteHeaderUnsynchronized();
 
-            foreach (var buffer in data)
-            {
-                _outputWriter.Write(buffer.Span);
-            }
+            data.CopyTo(_outputWriter);
 
             // Plus padding
             return;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -435,10 +435,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     // Ignore data frames for aborted streams, but only after counting them for purposes of connection level flow control.
                     if (!IsAborted)
                     {
-                        foreach (var segment in dataPayload)
-                        {
-                            RequestBodyPipe.Writer.Write(segment.Span);
-                        }
+                        dataPayload.CopyTo(RequestBodyPipe.Writer);
 
                         // If the stream is completed go ahead and call RequestBodyPipe.Writer.Complete().
                         // Data will still be available to the reader.

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -32,10 +32,11 @@ namespace System.Buffers
             if (buffer.IsSingleSegment)
             {
                 pipeWriter.Write(buffer.FirstSpan);
-                return;
             }
-
-            CopyToMultiSegment(buffer, pipeWriter);
+            else
+            {
+                CopyToMultiSegment(buffer, pipeWriter);
+            }
         }
 
         private static void CopyToMultiSegment(in ReadOnlySequence<byte> buffer, PipeWriter pipeWriter)

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -26,6 +26,25 @@ namespace System.Buffers
             return buffer.ToArray();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyTo(in this ReadOnlySequence<byte> buffer, PipeWriter pipeWriter)
+        {
+            if (buffer.IsSingleSegment)
+            {
+                pipeWriter.Write(buffer.FirstSpan);
+            }
+
+            CopyToMultiSegment(buffer, pipeWriter);
+        }
+
+        private static void CopyToMultiSegment(in ReadOnlySequence<byte> buffer, PipeWriter pipeWriter)
+        {
+            foreach (var item in buffer)
+            {
+                pipeWriter.Write(item.Span);
+            }
+        }
+
         public static ArraySegment<byte> GetArray(this Memory<byte> buffer)
         {
             return ((ReadOnlyMemory<byte>)buffer).GetArray();

--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -32,6 +32,7 @@ namespace System.Buffers
             if (buffer.IsSingleSegment)
             {
                 pipeWriter.Write(buffer.FirstSpan);
+                return;
             }
 
             CopyToMultiSegment(buffer, pipeWriter);


### PR DESCRIPTION
Avoid foreach over `ReadOnlySequence<byte>` when it is a single segment.
