### PR TITLE
Minimal changes to support certificate chain-preloading at startup

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -68,6 +68,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                     }
                 }
 
+                if (sslOptions.ServerCertificate != null)
+                {
+                    // This might be do blocking IO but it'll resolve the certificate chain up front before any connections are
+                    // made to the server
+                    sslOptions.ServerCertificateContext = SslStreamCertificateContext.Create((X509Certificate2)sslOptions.ServerCertificate, additionalCertificates: null);
+                }
+
                 if (!certifcateConfigLoader.IsTestMock && sslOptions.ServerCertificate is X509Certificate2 cert2)
                 {
                     HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(cert2);

--- a/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
+++ b/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
@@ -385,10 +385,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 { "www.example.org", new SniConfig() }
             };
-
             var fallbackOptions = new HttpsConnectionAdapterOptions
             {
-                ServerCertificate = new X509Certificate2()
+                ServerCertificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword")
             };
 
             var sniOptionsSelector = new SniOptionsSelector(
@@ -761,7 +760,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     return null;
                 }
 
-                var cert = new X509Certificate2();
+                var cert = TestResources.GetTestCertificate();
                 CertToPathDictionary.Add(cert, certInfo.Path);
                 return cert;
             }


### PR DESCRIPTION
This is a pre-cursor to supporting preloaded certificate chains in configuration. We resolve the certificate context outside of the connection establishment phase.

Contributes to #21512