### PR TITLE
Add support for loading certificate chains from configuration.

### DIFF
--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -40,6 +40,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         public X509Certificate2 ServerCertificate { get; set; }
 
         /// <summary>
+        /// Specifies the intermediate certificates in the chain.
+        /// </summary>
+        public X509Certificate2Collection ServerCertificateIntermediates { get; set; }
+
+        /// <summary>
         /// <para>
         /// A callback that will be invoked to dynamically select a server certificate. This is higher priority than ServerCertificate.
         /// If SNI is not available then the name parameter will be null.

--- a/src/Servers/Kestrel/Core/src/Internal/Certificates/CertificateConfigLoader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Certificates/CertificateConfigLoader.cs
@@ -24,13 +24,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Certificates
         public IHostEnvironment HostEnvironment { get; }
         public ILogger<KestrelServer> Logger { get; }
 
-        public bool IsTestMock => false;
-
-        public X509Certificate2 LoadCertificate(CertificateConfig certInfo, string endpointName)
+        public (X509Certificate2, X509Certificate2Collection) LoadCertificate(CertificateConfig certInfo, string endpointName)
         {
             if (certInfo is null)
             {
-                return null;
+                return (null, null);
             }
 
             if (certInfo.IsFileCert && certInfo.IsStoreCert)
@@ -40,9 +38,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Certificates
             else if (certInfo.IsFileCert)
             {
                 var certificatePath = Path.Combine(HostEnvironment.ContentRootPath, certInfo.Path);
+
+                X509Certificate2Collection intermediates = null;
+
+                if (certInfo.ChainPath != null)
+                {
+                    var certificateChainPath = Path.Combine(HostEnvironment.ContentRootPath, certInfo.ChainPath);
+
+                    intermediates = new X509Certificate2Collection();
+                    intermediates.ImportFromPemFile(certificateChainPath);
+                }
+
                 if (certInfo.KeyPath != null)
                 {
                     var certificateKeyPath = Path.Combine(HostEnvironment.ContentRootPath, certInfo.KeyPath);
+
                     var certificate = GetCertificate(certificatePath);
 
                     if (certificate != null)
@@ -58,10 +68,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Certificates
                     {
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                         {
-                            return PersistKey(certificate);
+                            return (PersistKey(certificate), intermediates);
                         }
 
-                        return certificate;
+                        return (certificate, intermediates);
                     }
                     else
                     {
@@ -71,14 +81,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Certificates
                     throw new InvalidOperationException(CoreStrings.InvalidPemKey);
                 }
 
-                return new X509Certificate2(Path.Combine(HostEnvironment.ContentRootPath, certInfo.Path), certInfo.Password);
+                return (new X509Certificate2(Path.Combine(HostEnvironment.ContentRootPath, certInfo.Path), certInfo.Password), intermediates);
             }
             else if (certInfo.IsStoreCert)
             {
-                return LoadFromStoreCert(certInfo);
+                return (LoadFromStoreCert(certInfo), null);
             }
 
-            return null;
+            return (null, null);
         }
 
         private static X509Certificate2 PersistKey(X509Certificate2 fullCertificate)

--- a/src/Servers/Kestrel/Core/src/Internal/Certificates/ICertificateConfigLoader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Certificates/ICertificateConfigLoader.cs
@@ -7,8 +7,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Certificates
 {
     internal interface ICertificateConfigLoader
     {
-        bool IsTestMock { get; }
-
-        X509Certificate2 LoadCertificate(CertificateConfig certInfo, string endpointName);
+        (X509Certificate2, X509Certificate2Collection) LoadCertificate(CertificateConfig certInfo, string endpointName);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -345,9 +345,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     }
 
     // "CertificateName": {
-    //     "Path": "testCert.pfx",
-    //     "KeyPath": "",
-    //     "ChainPath": "",
+    //     "Path": "testCert.pem/pfx",
+    //     "KeyPath": "key.pem",
+    //     "ChainPath": "chain.pem",
     //     "Password": "testPassword"
     // }
     internal class CertificateConfig
@@ -359,6 +359,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             // Bind explictly to preserve linkability
             Path = configSection[nameof(Path)];
             KeyPath = configSection[nameof(KeyPath)];
+            ChainPath = configSection[nameof(ChainPath)];
             Password = configSection[nameof(Password)];
             Subject = configSection[nameof(Subject)];
             Store = configSection[nameof(Store)];

--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -346,6 +346,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
     // "CertificateName": {
     //     "Path": "testCert.pfx",
+    //     "KeyPath": "",
+    //     "ChainPath": "",
     //     "Password": "testPassword"
     // }
     internal class CertificateConfig
@@ -379,6 +381,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         public bool IsFileCert => !string.IsNullOrEmpty(Path);
 
         public string Path { get; set; }
+
+        public string ChainPath { get; set; }
 
         public string KeyPath { get; set; }
 

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -355,8 +355,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     }
 
                     // A cert specified directly on the endpoint overrides any defaults.
-                    httpsOptions.ServerCertificate = CertificateConfigLoader.LoadCertificate(endpoint.Certificate, endpoint.Name)
-                        ?? httpsOptions.ServerCertificate;
+                    var (serverCert, intermediates) = CertificateConfigLoader.LoadCertificate(endpoint.Certificate, endpoint.Name);
+
+                    httpsOptions.ServerCertificate = serverCert ?? httpsOptions.ServerCertificate;
+                    httpsOptions.ServerCertificateIntermediates = intermediates ?? httpsOptions.ServerCertificateIntermediates;
 
                     if (httpsOptions.ServerCertificate == null && httpsOptions.ServerCertificateSelector == null)
                     {
@@ -417,7 +419,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel
         {
             if (ConfigurationReader.Certificates.TryGetValue("Default", out var defaultCertConfig))
             {
-                var defaultCert = CertificateConfigLoader.LoadCertificate(defaultCertConfig, "Default");
+                var (defaultCert, intermediates) = CertificateConfigLoader.LoadCertificate(defaultCertConfig, "Default");
                 if (defaultCert != null)
                 {
                     DefaultCertificateConfig = defaultCertConfig;

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
 
                 // This might be do blocking IO but it'll resolve the certificate chain up front before any connections are
                 // made to the server
-                _serverCertificateContext = SslStreamCertificateContext.Create(certificate, additionalCertificates: null);
+                _serverCertificateContext = SslStreamCertificateContext.Create(certificate, additionalCertificates: options.ServerCertificateIntermediates);
             }
 
             var remoteCertificateValidationCallback = _options.ClientCertificateMode == ClientCertificateMode.NoCertificate ?

--- a/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
+++ b/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
@@ -751,18 +751,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             public Dictionary<object, string> CertToPathDictionary { get; } = new Dictionary<object, string>(ReferenceEqualityComparer.Instance);
 
-            public bool IsTestMock => true;
-
-            public X509Certificate2 LoadCertificate(CertificateConfig certInfo, string endpointName)
+            public (X509Certificate2, X509Certificate2Collection) LoadCertificate(CertificateConfig certInfo, string endpointName)
             {
                 if (certInfo is null)
                 {
-                    return null;
+                    return (null, null);
                 }
 
                 var cert = TestResources.GetTestCertificate();
                 CertToPathDictionary.Add(cert, certInfo.Path);
-                return cert;
+                return (cert, null);
             }
         }
 


### PR DESCRIPTION
- Adds a ServerCertificateIntermediates property to HttpsConnectionAdapterOptions
- Adds a Chain property to configuration. This only supports PEM certificates.

TODO: Add tests

Fixes #21513
Contributes to #21512