### PR TITLE
Log for SameSite=None without Secure

### DIFF
--- a/src/Http/Http/src/Features/ResponseCookiesFeature.cs
+++ b/src/Http/Http/src/Features/ResponseCookiesFeature.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Http.Features
         // Lambda hoisted to static readonly field to improve inlining https://github.com/dotnet/roslyn/issues/13624
         private readonly static Func<IFeatureCollection, IHttpResponseFeature?> _nullResponseFeature = f => null;
 
-        private FeatureReferences<IHttpResponseFeature> _features;
+        private readonly IFeatureCollection _features;
         private IResponseCookies? _cookiesCollection;
 
         /// <summary>
@@ -27,12 +27,7 @@ namespace Microsoft.AspNetCore.Http.Features
         /// </param>
         public ResponseCookiesFeature(IFeatureCollection features)
         {
-            if (features == null)
-            {
-                throw new ArgumentNullException(nameof(features));
-            }
-
-            _features.Initalize(features);
+            _features = features ?? throw new ArgumentNullException(nameof(features));
         }
 
         /// <summary>
@@ -46,15 +41,8 @@ namespace Microsoft.AspNetCore.Http.Features
         [Obsolete("This constructor is obsolete and will be removed in a future version.")]
         public ResponseCookiesFeature(IFeatureCollection features, ObjectPool<StringBuilder>? builderPool)
         {
-            if (features == null)
-            {
-                throw new ArgumentNullException(nameof(features));
-            }
-
-            _features.Initalize(features);
+            _features = features ?? throw new ArgumentNullException(nameof(features));
         }
-
-        private IHttpResponseFeature HttpResponseFeature => _features.Fetch(ref _features.Cache, _nullResponseFeature)!;
 
         /// <inheritdoc />
         public IResponseCookies Cookies
@@ -63,8 +51,7 @@ namespace Microsoft.AspNetCore.Http.Features
             {
                 if (_cookiesCollection == null)
                 {
-                    var headers = HttpResponseFeature.Headers;
-                    _cookiesCollection = new ResponseCookies(headers);
+                    _cookiesCollection = new ResponseCookies(_features);
                 }
 
                 return _cookiesCollection;

--- a/src/Http/Http/src/Internal/EventIds.cs
+++ b/src/Http/Http/src/Internal/EventIds.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Http
 {
-    internal class EventIds
+    internal static class EventIds
     {
         public static readonly EventId SameSiteNotSecure = new EventId(1, "SameSiteNotSecure");
     }

--- a/src/Http/Http/src/Internal/EventIds.cs
+++ b/src/Http/Http/src/Internal/EventIds.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Http
+{
+    internal class EventIds
+    {
+        public static readonly EventId SameSiteNotSecure = new EventId(1, "SameSiteNotSecure");
+    }
+}


### PR DESCRIPTION
Fixes #19939 Setting `SameSite=None` on a cookie without also setting `secure` will cause the cookie to be blocked by Chrome. This PR adds a warning log for this condition on all cookies.

We don't want to modify the cookie because we don't know that our modifications will work any better. E.g. if we add `secure` but the request wasn't https then it's not going to work anyways.

cc: @brockallen