### PR TITLE
if isNewSessionKey, No need to refresh

### DIFF
--- a/src/Middleware/Session/src/DistributedSession.cs
+++ b/src/Middleware/Session/src/DistributedSession.cs
@@ -289,7 +289,9 @@ namespace Microsoft.AspNetCore.Session
                 {
                     try
                     {
+                       if(!_isNewSessionKey){
                         await _cache.RefreshAsync(_sessionKey, cts.Token);
+                       }
                     }
                     catch (OperationCanceledException oex)
                     {


### PR DESCRIPTION
It will cause a lot of waste of resources
for example:
    Some interfaces that do not require a session,It takes up a lot of connection in redis and cache key missing.

Summary of the changes (Less than 80 chars)
 - Detail 1
 - Detail 2

Addresses #bugnumber (in this specific format)
