### PR TITLE
Enable the compatibility analyzer for Blazor WebAssembly

### DIFF
--- a/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -69,6 +69,12 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Configuration for the platform compatibility analyzer. See https://github.com/dotnet/designs/blob/master/accepted/2020/platform-exclusion/platform-exclusion.md#build-configuration-for-platforms -->
+    <SupportedPlatform Remove="@(SupportedPlatform)" />
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
   <Import Project="Microsoft.NET.Sdk.BlazorWebAssembly.ServiceWorkerAssetsManifest.targets" Condition="'$(ServiceWorkerAssetsManifest)' != ''" />
 
   <Target Name="_ScrambleDotnetJsFileName" AfterTargets="ResolveRuntimePackAssets">


### PR DESCRIPTION
See https://github.com/dotnet/sdk/pull/12872#issuecomment-673783153

There's an inflight PR which makes it difficult to test this end-to-end with this change without editing SDK files. But with those in-flight changes, the analyzer works and provides warnings.

Fixes #24891 