### PR TITLE
Remove \r\n for \n when writing to ostream

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RedirectionOutput.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/RedirectionOutput.cpp
@@ -77,7 +77,18 @@ void FileRedirectionOutput::Append(const std::wstring& text)
 {
     if (m_file.is_open())
     {
-        const auto multiByte = to_multi_byte_string(text, CP_UTF8);
+        auto multiByte = to_multi_byte_string(text, CP_UTF8);
+
+        // Writing \r\n to an ostream will cause two new lines to be written rather
+        // than one. Change all \r\n to \n.
+        std::string slashRslashN = "\r\n";
+        std::string slashN = "\n";
+        size_t start_pos = 0;
+        while ((start_pos = multiByte.find(slashRslashN, start_pos)) != std::string::npos) {
+            multiByte.replace(start_pos, slashRslashN.length(), slashN);
+            start_pos += slashN.length();
+        }
+
         m_file << multiByte;
     }
 }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, _logFolderPath), Logger);
 
             Assert.Contains("TEST MESSAGE", contents);
+            Assert.DoesNotContain("\r\n\r\n", contents);
         }
 
         // Move to separate file

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LogFileTests.cs
@@ -54,6 +54,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
             Assert.Contains("TEST MESSAGE", contents);
             Assert.DoesNotContain("\r\n\r\n", contents);
+            Assert.Contains("\r\n", contents);
         }
 
         // Move to separate file


### PR DESCRIPTION
When writing to the stdout file with ANCM, for some reason, \r\n get interpreted as two new lines when writing to an ostream. This change replaces \r\n with \n before writing to the file.