### PR TITLE
Indicate if the request has a body

### DIFF
--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -66,32 +66,35 @@ namespace Microsoft.AspNetCore.TestHost
 
             var contextBuilder = new HttpContextBuilder(_application, AllowSynchronousIO, PreserveExecutionContext);
 
-            var requestContent = request.Content ?? new StreamContent(Stream.Null);
+            var requestContent = request.Content;
 
-            // Read content from the request HttpContent into a pipe in a background task. This will allow the request
-            // delegate to start before the request HttpContent is complete. A background task allows duplex streaming scenarios.
-            contextBuilder.SendRequestStream(async writer =>
+            if (requestContent != null)
             {
-                if (requestContent is StreamContent)
+                // Read content from the request HttpContent into a pipe in a background task. This will allow the request
+                // delegate to start before the request HttpContent is complete. A background task allows duplex streaming scenarios.
+                contextBuilder.SendRequestStream(async writer =>
                 {
+                    if (requestContent is StreamContent)
+                    {
                     // This is odd but required for backwards compat. If StreamContent is passed in then seek to beginning.
                     // This is safe because StreamContent.ReadAsStreamAsync doesn't block. It will return the inner stream.
                     var body = await requestContent.ReadAsStreamAsync();
-                    if (body.CanSeek)
-                    {
+                        if (body.CanSeek)
+                        {
                         // This body may have been consumed before, rewind it.
                         body.Seek(0, SeekOrigin.Begin);
+                        }
+
+                        await body.CopyToAsync(writer);
+                    }
+                    else
+                    {
+                        await requestContent.CopyToAsync(writer.AsStream());
                     }
 
-                    await body.CopyToAsync(writer);
-                }
-                else
-                {
-                    await requestContent.CopyToAsync(writer.AsStream());
-                }
-
-                await writer.CompleteAsync();
-            });
+                    await writer.CompleteAsync();
+                });
+            }
 
             contextBuilder.Configure((context, reader) =>
             {
@@ -109,6 +112,39 @@ namespace Microsoft.AspNetCore.TestHost
                 req.Method = request.Method.ToString();
 
                 req.Scheme = request.RequestUri.Scheme;
+
+                var canHaveBody = false;
+                if (requestContent != null)
+                {
+                    canHaveBody = true;
+                    // Chunked takes precedence over Content-Length, don't create a request with both Content-Length and chunked.
+                    if (request.Headers.TransferEncodingChunked != true)
+                    {
+                        // Reading the ContentLength will add it to the Headers‼
+                        // https://github.com/dotnet/runtime/blob/874399ab15e47c2b4b7c6533cc37d27d47cb5242/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs#L68-L87
+                        var contentLength = requestContent.Headers.ContentLength;
+                        if (!contentLength.HasValue && request.Version == HttpVersion.Version11)
+                        {
+                            // HTTP/1.1 requests with a body require either Content-Length or Transfer-Encoding: chunked.
+                            request.Headers.TransferEncodingChunked = true;
+                        }
+                        else if (contentLength == 0)
+                        {
+                            canHaveBody = false;
+                        }
+                    }
+
+                    foreach (var header in requestContent.Headers)
+                    {
+                        req.Headers.Append(header.Key, header.Value.ToArray());
+                    }
+
+                    if (canHaveBody)
+                    {
+                        req.Body = new AsyncStreamWrapper(reader.AsStream(), () => contextBuilder.AllowSynchronousIO);
+                    }
+                }
+                context.Features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(canHaveBody));
 
                 foreach (var header in request.Headers)
                 {
@@ -141,17 +177,6 @@ namespace Microsoft.AspNetCore.TestHost
                     req.PathBase = _pathBase;
                 }
                 req.QueryString = QueryString.FromUriComponent(request.RequestUri);
-
-                // Reading the ContentLength will add it to the Headers‼
-                // https://github.com/dotnet/runtime/blob/874399ab15e47c2b4b7c6533cc37d27d47cb5242/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs#L68-L87
-                _ = requestContent.Headers.ContentLength;
-
-                foreach (var header in requestContent.Headers)
-                {
-                    req.Headers.Append(header.Key, header.Value.ToArray());
-                }
-
-                req.Body = new AsyncStreamWrapper(reader.AsStream(), () => contextBuilder.AllowSynchronousIO);
             });
 
             var response = new HttpResponseMessage();

--- a/src/Hosting/TestHost/src/RequestBodyDetectionFeature.cs
+++ b/src/Hosting/TestHost/src/RequestBodyDetectionFeature.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    internal class RequestBodyDetectionFeature : IHttpRequestBodyDetectionFeature
+    {
+        public RequestBodyDetectionFeature(bool canHaveBody)
+        {
+            CanHaveBody = canHaveBody;
+        }
+
+        public bool CanHaveBody { get; }
+    }
+}

--- a/src/Hosting/TestHost/test/HttpContextBuilderTests.cs
+++ b/src/Hosting/TestHost/test/HttpContextBuilderTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal("/A/Path", context.Request.PathBase.Value);
             Assert.Equal("/and/file.txt", context.Request.Path.Value);
             Assert.Equal("?and=query", context.Request.QueryString.Value);
+            Assert.Null(context.Request.CanHaveBody());
             Assert.NotNull(context.Request.Body);
             Assert.NotNull(context.Request.Headers);
             Assert.NotNull(context.Response.Headers);

--- a/src/Hosting/TestHost/test/TestServerTests.cs
+++ b/src/Hosting/TestHost/test/TestServerTests.cs
@@ -228,6 +228,7 @@ namespace Microsoft.AspNetCore.TestHost
 
             var stream = new ThrowOnDisposeStream();
             stream.Write(Encoding.ASCII.GetBytes("Hello World"));
+            stream.Seek(0, SeekOrigin.Begin);
             var response = await server.CreateClient().PostAsync("/", new StreamContent(stream));
             Assert.True(response.IsSuccessStatusCode);
             Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());

--- a/src/Hosting/TestHost/test/Utilities.cs
+++ b/src/Hosting/TestHost/test/Utilities.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.TestHost
@@ -14,5 +16,10 @@ namespace Microsoft.AspNetCore.TestHost
         internal static Task<T> WithTimeout<T>(this Task<T> task) => task.TimeoutAfter(DefaultTimeout);
 
         internal static Task WithTimeout(this Task task) => task.TimeoutAfter(DefaultTimeout);
+
+        internal static bool? CanHaveBody(this HttpRequest request)
+        {
+            return request.HttpContext.Features.Get<IHttpRequestBodyDetectionFeature>()?.CanHaveBody;
+        }
     }
 }

--- a/src/Http/Http.Features/src/IHttpRequestBodyDetectionFeature.cs
+++ b/src/Http/Http.Features/src/IHttpRequestBodyDetectionFeature.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Http.Features
+{
+    /// <summary>
+    /// Used to indicate if the request can have a body.
+    /// </summary>
+    public interface IHttpRequestBodyDetectionFeature
+    {
+        /// <summary>
+        /// Indicates if the request can have a body.
+        /// </summary>
+        /// <remarks>
+        /// This returns true when:
+        /// - It's an HTTP/1.x request with a non-zero Content-Length or a 'Transfer-Encoding: chunked' header.
+        /// - It's an HTTP/2 request that did not set the END_STREAM flag on the initial headers frame.
+        /// The final request body length may still be zero for the chunked or HTTP/2 scenarios.
+        ///
+        /// This returns false when:
+        /// - It's an HTTP/1.x request with no Content-Length or 'Transfer-Encoding: chunked' header, or the Content-Length is 0.
+        /// - It's an HTTP/1.x request with Connection: Upgrade (e.g. WebSockets). There is no HTTP request body for these requests and
+        ///   no data should be received until after the upgrade.
+        /// - It's an HTTP/2 request that set END_STREAM on the initial headers frame.
+        /// When false, the request body should never return data.
+        /// </remarks>
+        bool CanHaveBody { get; }
+    }
+}

--- a/src/Servers/HttpSys/src/FeatureContext.cs
+++ b/src/Servers/HttpSys/src/FeatureContext.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 {
     internal class FeatureContext :
         IHttpRequestFeature,
+        IHttpRequestBodyDetectionFeature,
         IHttpConnectionFeature,
         IHttpResponseFeature,
         IHttpResponseBodyFeature,
@@ -211,6 +212,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             get { return _scheme; }
             set { _scheme = value; }
         }
+
+        bool IHttpRequestBodyDetectionFeature.CanHaveBody => Request.HasEntityBody;
 
         IPAddress IHttpConnectionFeature.LocalIpAddress
         {

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -135,6 +135,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 if (_contentBoundaryType == BoundaryType.None)
                 {
+                    // Note Http.Sys adds the Transfer-Encoding: chunked header to HTTP/2 requests with bodies for back compat.
                     string transferEncoding = Headers[HttpKnownHeaderNames.TransferEncoding];
                     if (string.Equals("chunked", transferEncoding?.Trim(), StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/Servers/HttpSys/src/StandardFeatureCollection.cs
+++ b/src/Servers/HttpSys/src/StandardFeatureCollection.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private static readonly Dictionary<Type, Func<FeatureContext, object>> _featureFuncLookup = new Dictionary<Type, Func<FeatureContext, object>>()
         {
             { typeof(IHttpRequestFeature), _identityFunc },
+            { typeof(IHttpRequestBodyDetectionFeature), _identityFunc },
             { typeof(IHttpConnectionFeature), _identityFunc },
             { typeof(IHttpResponseFeature), _identityFunc },
             { typeof(IHttpResponseBodyFeature), _identityFunc },

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestBodyLimitTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestBodyLimitTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 var feature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
                 Assert.NotNull(feature);
                 Assert.False(feature.IsReadOnly);
+                Assert.True(httpContext.Request.CanHaveBody());
                 Assert.Equal(11, httpContext.Request.ContentLength);
                 byte[] input = new byte[100];
                 int read = await httpContext.Request.Body.ReadAsync(input, 0, input.Length);
@@ -114,6 +115,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 var feature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
                 Assert.NotNull(feature);
                 Assert.False(feature.IsReadOnly);
+                Assert.True(httpContext.Request.CanHaveBody());
                 Assert.Null(httpContext.Request.ContentLength);
                 byte[] input = new byte[100];
                 int read = await httpContext.Request.Body.ReadAsync(input, 0, input.Length);

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
@@ -9,6 +9,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
@@ -23,6 +24,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, httpContext =>
             {
+                Assert.True(httpContext.Request.CanHaveBody());
                 byte[] input = new byte[100];
                 httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
                 int read = httpContext.Request.Body.Read(input, 0, input.Length);
@@ -42,6 +44,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string address;
             using (Utilities.CreateHttpServer(out address, async httpContext =>
             {
+                Assert.True(httpContext.Request.CanHaveBody());
                 byte[] input = new byte[100];
                 int read = await httpContext.Request.Body.ReadAsync(input, 0, input.Length);
                 httpContext.Response.ContentLength = read;

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     Assert.Equal("/basepath/SomePath?SomeQuery", requestInfo.RawTarget);
                     Assert.Equal("HTTP/1.1", requestInfo.Protocol);
 
+                    Assert.False(httpContext.Request.CanHaveBody());
                     var connectionInfo = httpContext.Features.Get<IHttpConnectionFeature>();
                     Assert.Equal("::1", connectionInfo.RemoteIpAddress.ToString());
                     Assert.NotEqual(0, connectionInfo.RemotePort);

--- a/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Utilities.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -170,5 +171,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         internal static Task WithTimeout(this Task task) => task.TimeoutAfter(DefaultTimeout);
 
         internal static Task<T> WithTimeout<T>(this Task<T> task) => task.TimeoutAfter(DefaultTimeout);
+
+        internal static bool? CanHaveBody(this HttpRequest request)
+        {
+            return request.HttpContext.Features.Get<IHttpRequestBodyDetectionFeature>()?.CanHaveBody;
+        }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -18,6 +18,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal partial class HttpProtocol : IHttpRequestFeature,
+                                          IHttpRequestBodyDetectionFeature,
                                           IHttpResponseFeature,
                                           IHttpResponseBodyFeature,
                                           IRequestBodyPipeFeature,
@@ -120,6 +121,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return RequestBodyPipeReader;
             }
         }
+
+        bool IHttpRequestBodyDetectionFeature.CanHaveBody => _bodyControl.CanHaveBody;
 
         bool IHttpRequestTrailersFeature.Available => RequestTrailersAvailable;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     internal partial class HttpProtocol : IFeatureCollection
     {
         private object _currentIHttpRequestFeature;
+        private object _currentIHttpRequestBodyDetectionFeature;
         private object _currentIHttpResponseFeature;
         private object _currentIHttpResponseBodyFeature;
         private object _currentIRequestBodyPipeFeature;
@@ -48,6 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private void FastReset()
         {
             _currentIHttpRequestFeature = this;
+            _currentIHttpRequestBodyDetectionFeature = this;
             _currentIHttpResponseFeature = this;
             _currentIHttpResponseBodyFeature = this;
             _currentIRequestBodyPipeFeature = this;
@@ -132,6 +134,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (key == typeof(IHttpRequestFeature))
                 {
                     feature = _currentIHttpRequestFeature;
+                }
+                else if (key == typeof(IHttpRequestBodyDetectionFeature))
+                {
+                    feature = _currentIHttpRequestBodyDetectionFeature;
                 }
                 else if (key == typeof(IHttpResponseFeature))
                 {
@@ -253,6 +259,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIHttpRequestFeature = value;
                 }
+                else if (key == typeof(IHttpRequestBodyDetectionFeature))
+                {
+                    _currentIHttpRequestBodyDetectionFeature = value;
+                }
                 else if (key == typeof(IHttpResponseFeature))
                 {
                     _currentIHttpResponseFeature = value;
@@ -370,6 +380,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (typeof(TFeature) == typeof(IHttpRequestFeature))
             {
                 feature = (TFeature)_currentIHttpRequestFeature;
+            }
+            else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
+            {
+                feature = (TFeature)_currentIHttpRequestBodyDetectionFeature;
             }
             else if (typeof(TFeature) == typeof(IHttpResponseFeature))
             {
@@ -495,6 +509,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIHttpRequestFeature = feature;
             }
+            else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
+            {
+                _currentIHttpRequestBodyDetectionFeature = feature;
+            }
             else if (typeof(TFeature) == typeof(IHttpResponseFeature))
             {
                 _currentIHttpResponseFeature = feature;
@@ -610,6 +628,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_currentIHttpRequestFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IHttpRequestFeature), _currentIHttpRequestFeature);
+            }
+            if (_currentIHttpRequestBodyDetectionFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestBodyDetectionFeature), _currentIHttpRequestBodyDetectionFeature);
             }
             if (_currentIHttpResponseFeature != null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
@@ -36,6 +36,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             _upgradeStream = new HttpUpgradeStream(_request, _response);
         }
 
+        public bool CanHaveBody { get; private set; }
+
         public Stream Upgrade()
         {
             // causes writes to context.Response.Body to throw
@@ -46,6 +48,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         public (Stream request, Stream response, PipeReader reader, PipeWriter writer) Start(MessageBody body)
         {
+            CanHaveBody = !body.IsEmpty;
             _requestReader.StartAcceptingReads(body);
             _emptyRequestReader.StartAcceptingReads(MessageBody.ZeroContentLengthClose);
             _responseWriter.StartAcceptingWrites();

--- a/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpProtocolFeatureCollectionTests.cs
@@ -116,6 +116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void FeaturesSetByTypeSameAsGeneric()
         {
             _collection[typeof(IHttpRequestFeature)] = CreateHttp1Connection();
+            _collection[typeof(IHttpRequestBodyDetectionFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpResponseFeature)] = CreateHttp1Connection();
             _collection[typeof(IHttpResponseBodyFeature)] = CreateHttp1Connection();
             _collection[typeof(IRequestBodyPipeFeature)] = CreateHttp1Connection();
@@ -139,6 +140,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void FeaturesSetByGenericSameAsByType()
         {
             _collection.Set<IHttpRequestFeature>(CreateHttp1Connection());
+            _collection.Set<IHttpRequestBodyDetectionFeature>(CreateHttp1Connection());
             _collection.Set<IHttpResponseFeature>(CreateHttp1Connection());
             _collection.Set<IHttpResponseBodyFeature>(CreateHttp1Connection());
             _collection.Set<IRequestBodyPipeFeature>(CreateHttp1Connection());
@@ -194,6 +196,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         private void CompareGenericGetterToIndexer()
         {
             Assert.Same(_collection.Get<IHttpRequestFeature>(), _collection[typeof(IHttpRequestFeature)]);
+            Assert.Same(_collection.Get<IHttpRequestBodyDetectionFeature>(), _collection[typeof(IHttpRequestBodyDetectionFeature)]);
             Assert.Same(_collection.Get<IHttpResponseFeature>(), _collection[typeof(IHttpResponseFeature)]);
             Assert.Same(_collection.Get<IHttpResponseBodyFeature>(), _collection[typeof(IHttpResponseBodyFeature)]);
             Assert.Same(_collection.Get<IRequestBodyPipeFeature>(), _collection[typeof(IRequestBodyPipeFeature)]);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedRequestTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             var request = httpContext.Request;
             var response = httpContext.Response;
+            Assert.True(request.CanHaveBody());
             while (true)
             {
                 var buffer = new byte[8192];
@@ -40,6 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             var request = httpContext.Request;
             var response = httpContext.Response;
+            Assert.True(request.CanHaveBody());
             while (true)
             {
                 var readResult = await request.BodyReader.ReadAsync();
@@ -58,6 +60,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         {
             var request = httpContext.Request;
             var response = httpContext.Response;
+            Assert.True(request.CanHaveBody());
             var data = new MemoryStream();
             await request.Body.CopyToAsync(data);
             var bytes = data.ToArray();
@@ -174,6 +177,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
                 var request = httpContext.Request;
+                Assert.True(request.CanHaveBody());
 
                 Assert.Equal("POST", request.Method);
 
@@ -229,6 +233,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
                 var request = httpContext.Request;
+                Assert.True(request.CanHaveBody());
 
                 var buffer = new byte[200];
 
@@ -356,6 +361,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
                 var request = httpContext.Request;
+                Assert.True(request.CanHaveBody());
 
                 // The first request is chunked with no trailers.
                 if (requestsReceived == 0)
@@ -652,6 +658,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
                 var request = httpContext.Request;
+                Assert.True(request.CanHaveBody());
 
                 var buffer = new byte[200];
 
@@ -695,6 +702,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             {
                 var response = httpContext.Response;
                 var request = httpContext.Request;
+                Assert.True(request.CanHaveBody());
 
                 var buffer = new byte[200];
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -64,22 +64,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
-        [Fact]
-        public async Task HEADERS_Received_CustomMethod_Accepted()
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        [InlineData("PATCH")]
+        [InlineData("DELETE")]
+        [InlineData("CUSTOM")]
+        public async Task HEADERS_Received_KnownOrCustomMethods_Accepted(string method)
         {
             var headers = new[]
             {
-                new KeyValuePair<string, string>(HeaderNames.Method, "Custom"),
+                new KeyValuePair<string, string>(HeaderNames.Method, method),
                 new KeyValuePair<string, string>(HeaderNames.Path, "/"),
                 new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
                 new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
             };
-            await InitializeConnectionAsync(_echoMethod);
+            await InitializeConnectionAsync(_echoMethodNoBody);
 
             await StartStreamAsync(1, headers, endStream: true);
 
             var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
-                withLength: 51,
+                withLength: 45 + method.Length,
                 withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
                 withStreamId: 1);
 
@@ -90,14 +96,146 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(4, _decodedHeaders.Count);
             Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
             Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
-            Assert.Equal("Custom", _decodedHeaders["Method"]);
-            Assert.Equal("0", _decodedHeaders["content-length"]);
+            Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
+            Assert.Equal(method, _decodedHeaders["Method"]);
+        }
+
+        [Fact]
+        public async Task HEADERS_Received_HEADMethod_Accepted()
+        {
+            await InitializeConnectionAsync(_echoMethodNoBody);
+
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "HEAD"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+            await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, headers);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 45,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("HEAD", _decodedHeaders["Method"]);
+        }
+
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        [InlineData("PATCH")]
+        [InlineData("DELETE")]
+        [InlineData("CUSTOM")]
+        public async Task HEADERS_Received_MethodsWithContentLength_Accepted(string method)
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, method),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+                new KeyValuePair<string, string>(HeaderNames.ContentLength, "11"),
+            };
+            await InitializeConnectionAsync(context =>
+            {
+                Assert.True(HttpMethods.Equals(method, context.Request.Method));
+                Assert.True(context.Request.CanHaveBody());
+                Assert.Equal(11, context.Request.ContentLength);
+                Assert.False(context.Request.Headers.ContainsKey(HeaderNames.TransferEncoding));
+                return context.Request.BodyReader.CopyToAsync(context.Response.BodyWriter);
+            });
+
+            await StartStreamAsync(1, headers, endStream: false);
+            await SendDataAsync(1, Encoding.UTF8.GetBytes("Hello World"), endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 32,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var dataFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 0,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(dataFrame.Payload.Span));
+        }
+
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        [InlineData("PATCH")]
+        [InlineData("DELETE")]
+        [InlineData("CUSTOM")]
+        public async Task HEADERS_Received_MethodsWithoutContentLength_Accepted(string method)
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, method),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+            await InitializeConnectionAsync(context =>
+            {
+                Assert.True(HttpMethods.Equals(method, context.Request.Method));
+                Assert.True(context.Request.CanHaveBody());
+                Assert.Null(context.Request.ContentLength);
+                Assert.False(context.Request.Headers.ContainsKey(HeaderNames.TransferEncoding));
+                return context.Request.BodyReader.CopyToAsync(context.Response.BodyWriter);
+            });
+
+            await StartStreamAsync(1, headers, endStream: false);
+            await SendDataAsync(1, Encoding.UTF8.GetBytes("Hello World"), endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 32,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+                withStreamId: 1);
+            var dataFrame = await ExpectAsync(Http2FrameType.DATA,
+                withLength: 11,
+                withFlags: (byte)(Http2HeadersFrameFlags.NONE),
+                withStreamId: 1);
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 0,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+            Assert.Equal(2, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("Hello World", Encoding.UTF8.GetString(dataFrame.Payload.Span));
         }
 
         [Fact]
         public async Task HEADERS_Received_CONNECTMethod_Accepted()
         {
-            await InitializeConnectionAsync(_echoMethod);
+            await InitializeConnectionAsync(_echoMethodNoBody);
 
             // :path and :scheme are not allowed, :authority is optional
             var headers = new[] { new KeyValuePair<string, string>(HeaderNames.Method, "CONNECT") };

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected readonly RequestDelegate _waitForAbortApplication;
         protected readonly RequestDelegate _waitForAbortFlushingApplication;
         protected readonly RequestDelegate _readRateApplication;
-        protected readonly RequestDelegate _echoMethod;
+        protected readonly RequestDelegate _echoMethodNoBody;
         protected readonly RequestDelegate _echoHost;
         protected readonly RequestDelegate _echoPath;
         protected readonly RequestDelegate _appAbort;
@@ -346,8 +346,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 await stalledReadTask;
             };
 
-            _echoMethod = context =>
+            _echoMethodNoBody = context =>
             {
+                Assert.False(context.Request.CanHaveBody());
                 context.Response.Headers["Method"] = context.Request.Method;
 
                 return Task.CompletedTask;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             await using (var server = new TestServer(async context =>
             {
+                Assert.True(context.Request.CanHaveBody());
                 var buffer = new byte[1];
 #pragma warning disable CS0618 // Type or member is obsolete
                 requestRejectedEx = await Assert.ThrowsAsync<BadHttpRequestException>(

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -1933,7 +1933,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 var request = httpContext.Request;
 
                 Assert.Equal("POST", request.Method);
-
+                Assert.True(request.CanHaveBody());
                 var readResult = await request.BodyReader.ReadAsync();
                 request.BodyReader.AdvanceTo(readResult.Buffer.End);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/RequestExtensions.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/RequestExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Http
+{
+    internal static class RequestExtensions
+    {
+        internal static bool? CanHaveBody(this HttpRequest request)
+        {
+            return request.HttpContext.Features.Get<IHttpRequestBodyDetectionFeature>()?.CanHaveBody;
+        }
+    }
+}

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -12,6 +12,7 @@ namespace CodeGenerator
             var alwaysFeatures = new[]
             {
                 "IHttpRequestFeature",
+                "IHttpRequestBodyDetectionFeature",
                 "IHttpResponseFeature",
                 "IHttpResponseBodyFeature",
                 "IRequestBodyPipeFeature",
@@ -58,6 +59,7 @@ namespace CodeGenerator
             var implementedFeatures = new[]
             {
                 "IHttpRequestFeature",
+                "IHttpRequestBodyDetectionFeature",
                 "IHttpResponseFeature",
                 "IHttpResponseBodyFeature",
                 "IRequestBodyPipeFeature",


### PR DESCRIPTION
#24175 In HTTP/2 and later the app can't tell from examining request headers if there's a request body. Content-Length is optional and `Transfer-Encoding: chunked` is prohibited. The only way for the app to know if there's a body is to try to read it. That's not great for scenarios like YARP that need to act differently if there's a request body, but want to avoid reading it as long as possible.

For back-compat Http.Sys/IIS adds a fake `Transfer-Encoding: chunked` header to HTTP/2 requests that have bodies and no Content-Length.

Edit: I've reworked this as a first class feature and property `bool? HttpRequest.CanHaveBody`. Returns null for not implemented, false if the server is sure there's no body, or true if there might be a body. I say might because with HTTP/2 or chunked the body could still end up being empty, you just don't know that up front.

Done:
- Kestrel
- HttpSys
- TestServer - Note TestServer has two modes:
  - HttpClient/HttpRequestMessage - I implemented CanHaveBody for this one, it maps directly to having an HttpContent.
  - Direct HttpContext - Not implemented. In this mode TestServer isn't involved in the request body processing, that's handled directly by the calling test (e.g. they directly set HttpRequest.Body with their own stream). The test would also set CanHaveBody if it cared.
  - I also implemented #21677, automatically including the chunked header for HTTP/1.1 bodies.

TODO:
- IIS - Having issues running tests. https://github.com/dotnet/aspnetcore/issues/25107

The API:
```c#
         /// <summary>
        /// Indicates if the request may have a body.
        /// </summary>
        /// <remarks>
        /// This returns true when:
        /// - It's an HTTP/1.x request with a non-zero Content-Length or a 'Transfer-Encoding: chunked' header.
        /// - It's an HTTP/2 request that did not set the END_STREAM flag on the initial headers frame.
        /// The final request body length may still be zero for the chunked or HTTP/2 scenarios.
        ///
        /// This returns false when:
        /// - It's an HTTP/1.x request with no Content-Length or 'Transfer-Encoding: chunked' header, or the Content-Length is 0.
        /// - It's an HTTP/2 request that set END_STREAM on the initial headers frame.
        /// When false, the request body should never return data.
        ///
        /// This returns null if the underlying server has not implemented the feature.
        /// </remarks>
        bool IHttpRequestBodyDetectionFeature?.CanHaveBody { get; }
```