### PR TITLE
Move the code sync action to the release branch

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -21,12 +21,14 @@ jobs:
         # Test this script using changes in a fork 
         repository: 'dotnet/aspnetcore'
         path: aspnetcore
+        ref: release/5.0
     - name: Checkout runtime
       uses: actions/checkout@v2.0.0
       with:
         # Test this script using changes in a fork 
         repository: 'dotnet/runtime'
         path: runtime
+        ref: release/5.0-rc1
     - name: Copy
       shell: cmd
       working-directory: .\runtime\src\libraries\Common\src\System\Net\Http\aspnetcore\
@@ -65,5 +67,6 @@ jobs:
         title: 'Sync shared code from runtime'
         body: 'This PR was automatically generated to sync shared code changes from runtime. Fixes #18943'
         labels: area-servers
+        base: release/5.0
         branch: github-action/sync-runtime
         branch-suffix: timestamp


### PR DESCRIPTION
This updates the code sync bot to specify the release branches to keep them in sync for 5.0.
