### PR TITLE
Make OnNavigateAsync EventCallback and cancel previous navigation

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Components.Routing
         /// <summary>
         /// Gets or sets a handler that should be called before navigating to a new page.
         /// </summary>
-        [Parameter] public Func<NavigationContext, Task>? OnNavigateAsync { get; set; }
+        [Parameter] public EventCallback<NavigationContext> OnNavigateAsync { get; set; }
 
         private RouteTable Routes { get; set; }
 
@@ -115,8 +115,7 @@ namespace Microsoft.AspNetCore.Components.Routing
             if (!_onNavigateCalled)
             {
                 _onNavigateCalled = true;
-                await RunOnNavigateWithRefreshAsync(NavigationManager.ToBaseRelativePath(_locationAbsolute), isNavigationIntercepted: false);
-                return;
+                await RunOnNavigateAsync(NavigationManager.ToBaseRelativePath(_locationAbsolute), isNavigationIntercepted: false);
             }
 
             Refresh(isNavigationIntercepted: false);
@@ -206,9 +205,8 @@ namespace Microsoft.AspNetCore.Components.Routing
             }
         }
 
-        private async ValueTask<bool> RunOnNavigateAsync(string path, Task previousOnNavigate)
+        internal async ValueTask RunOnNavigateAsync(string path, bool isNavigationIntercepted)
         {
-
             // Cancel the CTS instead of disposing it, since disposing does not
             // actually cancel and can cause unintended Object Disposed Exceptions.
             // This effectivelly cancels the previously running task and completes it.
@@ -217,59 +215,35 @@ namespace Microsoft.AspNetCore.Components.Routing
             // before starting the next one. This avoid race conditions where the cancellation
             // for the previous task was set but not fully completed by the time we get to this
             // invocation.
-            await previousOnNavigate;
+            await _previousOnNavigateTask;
 
-            if (OnNavigateAsync == null)
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _previousOnNavigateTask = tcs.Task;
+
+            if (!OnNavigateAsync.HasDelegate)
             {
-                return true;
+                Refresh(isNavigationIntercepted);
             }
 
             _onNavigateCts = new CancellationTokenSource();
             var navigateContext = new NavigationContext(path, _onNavigateCts.Token);
 
+            var cancellationTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            navigateContext.CancellationToken.Register(state =>
+                ((TaskCompletionSource)state).SetResult(), cancellationTcs);
+
             try
             {
-                if (Navigating != null)
-                {
-                    _renderHandle.Render(Navigating);
-                }
-                await OnNavigateAsync(navigateContext);
-                return true;
-            }
-            catch (OperationCanceledException e)
-            {
-                if (e.CancellationToken != navigateContext.CancellationToken)
-                {
-                    var rethrownException = new InvalidOperationException("OnNavigateAsync can only be cancelled via NavigateContext.CancellationToken.", e);
-                    _renderHandle.Render(builder => ExceptionDispatchInfo.Throw(rethrownException));
-                }
+                // Task.WhenAny returns a Task<Task> so we need to await twice to unwrap the exception
+                var task = await Task.WhenAny(OnNavigateAsync.InvokeAsync(navigateContext), cancellationTcs.Task);
+                await task;
+                tcs.SetResult();
+                Refresh(isNavigationIntercepted);
             }
             catch (Exception e)
             {
                 _renderHandle.Render(builder => ExceptionDispatchInfo.Throw(e));
             }
-
-            return false;
-        }
-
-        internal async Task RunOnNavigateWithRefreshAsync(string path, bool isNavigationIntercepted)
-        {
-            // We cache the Task representing the previously invoked RunOnNavigateWithRefreshAsync
-            // that is stored. Then we create a new one that represents our current invocation and store it
-            // globally for the next invocation. This allows us to check inside `RunOnNavigateAsync` if the
-            // previous OnNavigateAsync task has fully completed before starting the next one.
-            var previousTask = _previousOnNavigateTask;
-            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            _previousOnNavigateTask = tcs.Task;
-
-            // And pass an indicator for the previous task to the currently running one.
-            var shouldRefresh = await RunOnNavigateAsync(path, previousTask);
-            tcs.SetResult();
-            if (shouldRefresh)
-            {
-                Refresh(isNavigationIntercepted);
-            }
-
         }
 
         private void OnLocationChanged(object sender, LocationChangedEventArgs args)
@@ -277,7 +251,7 @@ namespace Microsoft.AspNetCore.Components.Routing
             _locationAbsolute = args.Location;
             if (_renderHandle.IsInitialized && Routes != null)
             {
-                _ = RunOnNavigateWithRefreshAsync(NavigationManager.ToBaseRelativePath(_locationAbsolute), args.IsNavigationIntercepted);
+                _ = RunOnNavigateAsync(NavigationManager.ToBaseRelativePath(_locationAbsolute), args.IsNavigationIntercepted);
             }
         }
 

--- a/src/Components/Components/test/Routing/RouterTest.cs
+++ b/src/Components/Components/test/Routing/RouterTest.cs
@@ -10,9 +10,7 @@ using Microsoft.AspNetCore.Components.Test.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using Xunit;
-using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.AspNetCore.Components.Test.Routing
 {
@@ -70,6 +68,12 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
                     throw new Exception("This is an uncaught exception.");
                 }
             };
+            var refreshCalled = 0;
+            _renderer.OnUpdateDisplay = (renderBatch) =>
+            {
+                refreshCalled += 1;
+                return;
+            };
             _router.OnNavigateAsync = new EventCallback<NavigationContext>(null, OnNavigateAsync);
 
             // Act
@@ -82,6 +86,7 @@ namespace Microsoft.AspNetCore.Components.Test.Routing
             // Assert that we render the second route component and don't throw an exception
             Assert.Empty(_renderer.HandledExceptions);
             Assert.Equal(2, onNavigateInvoked);
+            Assert.Equal(2, refreshCalled);
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -570,9 +570,19 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             var app = Browser.MountTestComponent<TestRouterWithOnNavigate>();
 
-            // Navigating from one page to another should
-            // cancel the previous OnNavigate Task
             SetUrlViaPushState("/Other");
+
+            var errorUiElem = Browser.Exists(By.Id("blazor-error-ui"), TimeSpan.FromSeconds(10));
+            Assert.NotNull(errorUiElem);
+        }
+
+        [Fact]
+        public void OnNavigate_CanRenderUIForSyncExceptions()
+        {
+            var app = Browser.MountTestComponent<TestRouterWithOnNavigate>();
+
+            // Should capture exception from synchronously thrown
+            SetUrlViaPushState("/WithLazyAssembly");
 
             var errorUiElem = Browser.Exists(By.Id("blazor-error-ui"), TimeSpan.FromSeconds(10));
             Assert.NotNull(errorUiElem);

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
@@ -26,8 +26,14 @@
         { "LongPage1", new Func<NavigationContext, Task>(TestLoadingPageShows) },
         { "LongPage2", new Func<NavigationContext, Task>(TestOnNavCancel) },
         { "Other", new Func<NavigationContext, Task>(TestOnNavException) },
-        {"WithParameters/name/Abc", new Func<NavigationContext, Task>(TestRefreshHandling)}
+        { "WithLazyAssembly", new Func<NavigationContext, Task>(TestOnNavException) },
+        { "WithParameters/name/Abc", new Func<NavigationContext, Task>(TestRefreshHandling) }
     };
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        Console.WriteLine("Render triggered...");
+    }
 
     private async Task OnNavigateAsync(NavigationContext args)
     {
@@ -53,6 +59,11 @@
     public static async Task TestOnNavException(NavigationContext args)
     {
         await Task.CompletedTask;
+        throw new Exception("This is an uncaught exception.");
+    }
+
+    public static Task TestOnNavSyncException(NavigationContext args)
+    {
         throw new Exception("This is an uncaught exception.");
     }
 


### PR DESCRIPTION
* Change `OnNavigateAsync` type to `EventCallback`
* Remove conditional rendering logic in `RunOnNavigateAsyncWithRefresh`
* Remove check for OperationCancelledException (CallStateHasChangedWhenAsyncTaskFinished ignores this)

Addresses https://github.com/dotnet/aspnetcore/issues/24215