### PR TITLE
React to runtime release branch rename

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -28,7 +28,7 @@ jobs:
         # Test this script using changes in a fork 
         repository: 'dotnet/runtime'
         path: runtime
-        ref: release/5.0-rc1
+        ref: release/5.0
     - name: Copy
       shell: cmd
       working-directory: .\runtime\src\libraries\Common\src\System\Net\Http\aspnetcore\


### PR DESCRIPTION
The prior change to use release branches worked, but runtime just renamed the branch from release/5.0-rc1 to release/5.0.