### PR TITLE
[Https] Various improvements to the dev-certs tool

### DIFF
--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -454,6 +454,10 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                 else
                 {
                     bytes = certificate.Export(X509ContentType.Cert);
+                    if (format == CertificateKeyExportFormat.Pem)
+                    {
+                        bytes = Encoding.ASCII.GetBytes(PemEncoding.Write("CERTIFICATE", certificate.Export(X509ContentType.Cert)));
+                    }
                 }
             }
             catch (Exception e)

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -453,10 +453,13 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                 }
                 else
                 {
-                    bytes = certificate.Export(X509ContentType.Cert);
                     if (format == CertificateKeyExportFormat.Pem)
                     {
                         bytes = Encoding.ASCII.GetBytes(PemEncoding.Write("CERTIFICATE", certificate.Export(X509ContentType.Cert)));
+                    }
+                    else
+                    {
+                        bytes = certificate.Export(X509ContentType.Cert);
                     }
                 }
             }

--- a/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
+++ b/src/Tools/FirstRunCertGenerator/test/CertificateManagerTests.cs
@@ -351,6 +351,44 @@ namespace Microsoft.AspNetCore.Certificates.Generation.Tests
             var httpsCertificateList = _manager.ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true);
             Assert.NotEmpty(httpsCertificateList);
         }
+
+        [ConditionalFact]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/6720", Queues = "OSX.1014.Amd64;OSX.1014.Amd64.Open")]
+        public void ListCertificates_AlwaysReturnsTheCertificate_WithHighestVersion()
+        {
+            _fixture.CleanupCertificates();
+
+            var now = DateTimeOffset.UtcNow;
+            now = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second, 0, now.Offset);
+            _manager.AspNetHttpsCertificateVersion = 1;
+            var creation = _manager.EnsureAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1), path: null, trust: false, isInteractive: false);
+            Output.WriteLine(creation.ToString());
+            ListCertificates();
+
+            _manager.AspNetHttpsCertificateVersion = 2;
+            creation = _manager.EnsureAspNetCoreHttpsDevelopmentCertificate(now, now.AddYears(1), path: null, trust: false, isInteractive: false);
+            Output.WriteLine(creation.ToString());
+            ListCertificates();
+
+            _manager.AspNetHttpsCertificateVersion = 1;
+            var httpsCertificateList = _manager.ListCertificates(StoreName.My, StoreLocation.CurrentUser, isValid: true);
+            Assert.Equal(2, httpsCertificateList.Count);
+
+            var firstCertificate = httpsCertificateList[0];
+            var secondCertificate = httpsCertificateList[1];
+
+            Assert.Contains(
+                firstCertificate.Extensions.OfType<X509Extension>(),
+                e => e.Critical == false &&
+                    e.Oid.Value == "1.3.6.1.4.1.311.84.1.1" &&
+                    e.RawData[0] == 2);
+
+            Assert.Contains(
+                secondCertificate.Extensions.OfType<X509Extension>(),
+                e => e.Critical == false &&
+                    e.Oid.Value == "1.3.6.1.4.1.311.84.1.1" &&
+                    e.RawData[0] == 1);
+        }
     }
 
     public class CertFixture : IDisposable

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -356,7 +356,6 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    reporter.Warn("Trusting the HTTPS development certificate was requested. We don't support trusting the certificate on Linux distributions automatically. " +
                     reporter.Warn("Trusting the HTTPS development certificate was requested. Trusting the certificate on Linux distributions automatically is not supported. " +
                         "For instructions on how to manually trust the certificate on your Linux distribution, go to https://aka.ms/dev-certs-trust");
                 }

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -314,7 +314,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
             return Success;
         }
 
-        private static int EnsureHttpsCertificate(CommandOption exportPath, CommandOption password, CommandOption noPassword, CommandOption trust, CommandOption keyFormat, IReporter reporter)
+        private static int EnsureHttpsCertificate(CommandOption exportPath, CommandOption password, CommandOption noPassword, CommandOption trust, CommandOption exportFormat, IReporter reporter)
         {
             var now = DateTimeOffset.Now;
             var manager = CertificateManager.Instance;
@@ -362,9 +362,9 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
             }
 
             var format = CertificateKeyExportFormat.Pfx;
-            if (keyFormat.HasValue() && !Enum.TryParse(keyFormat.Value(), ignoreCase: true, out format))
+            if (exportFormat.HasValue() && !Enum.TryParse(exportFormat.Value(), ignoreCase: true, out format))
             {
-                reporter.Error($"Unknown key format '{keyFormat.Value()}'.");
+                reporter.Error($"Unknown key format '{exportFormat.Value()}'.");
                 return InvalidKeyExportFormat;
             }
 
@@ -375,7 +375,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 trust == null ? false : trust.HasValue() && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
                 password.HasValue() || (noPassword.HasValue() && format == CertificateKeyExportFormat.Pem),
                 password.Value(),
-                keyFormat.HasValue() ? format : CertificateKeyExportFormat.Pfx);
+                exportFormat.HasValue() ? format : CertificateKeyExportFormat.Pfx);
 
             switch (result)
             {

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -98,12 +98,9 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                         CommandOptionType.SingleValue);
 
                     CommandOption trust = null;
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                    {
-                        trust = c.Option("-t|--trust",
-                            "Trust the certificate on the current platform",
-                            CommandOptionType.NoValue);
-                    }
+                    trust = c.Option("-t|--trust",
+                        "Trust the certificate on the current platform",
+                        CommandOptionType.NoValue);
 
                     var verbose = c.Option("-v|--verbose",
                         "Display more debug information.",
@@ -292,17 +289,25 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
 
             if (trust != null && trust.HasValue())
             {
-                var store = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? StoreName.My : StoreName.Root;
-                var trustedCertificates = certificateManager.ListCertificates(store, StoreLocation.CurrentUser, isValid: true);
-                if (!certificates.Any(c => certificateManager.IsTrusted(c)))
+                if(!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    reporter.Output($@"The following certificates were found, but none of them is trusted:
-{string.Join(Environment.NewLine, certificates.Select(c => $"{c.Subject} - {c.Thumbprint}"))}");
-                    return ErrorCertificateNotTrusted;
+                    var store = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? StoreName.My : StoreName.Root;
+                    var trustedCertificates = certificateManager.ListCertificates(store, StoreLocation.CurrentUser, isValid: true);
+                    if (!certificates.Any(c => certificateManager.IsTrusted(c)))
+                    {
+                        reporter.Output($@"The following certificates were found, but none of them is trusted:
+    {string.Join(Environment.NewLine, certificates.Select(c => $"{c.Subject} - {c.Thumbprint}"))}");
+                        return ErrorCertificateNotTrusted;
+                    }
+                    else
+                    {
+                        reporter.Output("A trusted certificate was found.");
+                    }
                 }
                 else
                 {
-                    reporter.Output("A trusted certificate was found.");
+                    reporter.Warn("Checking the HTTPS development certificate trust status was requested. We don't support checking whether the certificate is trusted or not on Linux distributions automatically. " +
+                        "For instructions on how to manually validate the certificate is trusted on your Linux distribution, go to <<placeholder>>.");
                 }
             }
 
@@ -332,19 +337,28 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 }
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && trust?.HasValue() == true)
+            if (trust?.HasValue() == true)
             {
-                reporter.Warn("Trusting the HTTPS development certificate was requested. If the certificate is not " +
-                    "already trusted we will run the following command:" + Environment.NewLine +
-                    "'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <<certificate>>'" +
-                    Environment.NewLine + "This command might prompt you for your password to install the certificate " +
-                    "on the system keychain.");
-            }
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    reporter.Warn("Trusting the HTTPS development certificate was requested. If the certificate is not " +
+                        "already trusted we will run the following command:" + Environment.NewLine +
+                        "'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <<certificate>>'" +
+                        Environment.NewLine + "This command might prompt you for your password to install the certificate " +
+                        "on the system keychain.");
+                }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && trust?.HasValue() == true)
-            {
-                reporter.Warn("Trusting the HTTPS development certificate was requested. A confirmation prompt will be displayed " +
-                    "if the certificate was not previously trusted. Click yes on the prompt to trust the certificate.");
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    reporter.Warn("Trusting the HTTPS development certificate was requested. A confirmation prompt will be displayed " +
+                        "if the certificate was not previously trusted. Click yes on the prompt to trust the certificate.");
+                }
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    reporter.Warn("Trusting the HTTPS development certificate was requested. We don't support trusting the certificate on Linux distributions automatically. " +
+                        "For instructions on how to manually trust the certificate on your Linux distribution, go to <<placeholder>>.");
+                }
             }
 
             var format = CertificateKeyExportFormat.Pfx;
@@ -358,7 +372,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 now,
                 now.Add(HttpsCertificateValidity),
                 exportPath.Value(),
-                trust == null ? false : trust.HasValue(),
+                trust == null ? false : trust.HasValue() && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
                 password.HasValue() || (noPassword.HasValue() && format == CertificateKeyExportFormat.Pem),
                 password.Value(),
                 keyFormat.HasValue() ? format : CertificateKeyExportFormat.Pfx);

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -307,7 +307,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 else
                 {
                     reporter.Warn("Checking the HTTPS development certificate trust status was requested. We don't support checking whether the certificate is trusted or not on Linux distributions automatically. " +
-                        "For instructions on how to manually validate the certificate is trusted on your Linux distribution, go to <<placeholder>>.");
+                        "For instructions on how to manually validate the certificate is trusted on your Linux distribution, go to https://aka.ms/dev-certs-trust");
                 }
             }
 
@@ -357,7 +357,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     reporter.Warn("Trusting the HTTPS development certificate was requested. We don't support trusting the certificate on Linux distributions automatically. " +
-                        "For instructions on how to manually trust the certificate on your Linux distribution, go to <<placeholder>>.");
+                        "For instructions on how to manually trust the certificate on your Linux distribution, go to https://aka.ms/dev-certs-trust");
                 }
             }
 

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 }
                 else
                 {
-                    reporter.Warn("Checking the HTTPS development certificate trust status was requested. We don't support checking whether the certificate is trusted or not on Linux distributions automatically. " +
+                    reporter.Warn("Checking the HTTPS development certificate trust status was requested. Checking whether the certificate is trusted or not is not supported on Linux distributions." +
                         "For instructions on how to manually validate the certificate is trusted on your Linux distribution, go to https://aka.ms/dev-certs-trust");
                 }
             }
@@ -357,6 +357,7 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     reporter.Warn("Trusting the HTTPS development certificate was requested. We don't support trusting the certificate on Linux distributions automatically. " +
+                    reporter.Warn("Trusting the HTTPS development certificate was requested. Trusting the certificate on Linux distributions automatically is not supported. " +
                         "For instructions on how to manually trust the certificate on your Linux distribution, go to https://aka.ms/dev-certs-trust");
                 }
             }


### PR DESCRIPTION
* Support exporting the certificate in PEM format without a key.
* Bump the certificate version number to `2` and ensure the certificate with the highest version is picked moving forward.
* Add support for the `--trust` option in the command-line on Linux and emit a message pointing to the documentation page with instructions on how to trust the certificate on different Linux distributions manually.

Fixes https://github.com/dotnet/aspnetcore/issues/21266 https://github.com/dotnet/aspnetcore/issues/23776