### PR TITLE
[Blazor] Add docker support for the Blazor WebAssembly template in Visual Studio

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/vs-2017.3.host.json
@@ -50,6 +50,7 @@
   ],
   "excludeLaunchSettings": false,
   "disableHttpsSymbol": "NoHttps",
+  "supportsDocker": true,
   "symbolInfo": [
     {
       "id": "Hosted",


### PR DESCRIPTION
* Lights up the UI that lets you pick whether or not to enable docker support in Blazor WebAssembly

Fixes https://github.com/dotnet/aspnetcore/issues/22964