### PR TITLE
Add a regression test for web.config transform

### DIFF
--- a/src/Components/WebAssembly/Sdk/integrationtests/Microsoft.NET.Sdk.BlazorWebAssembly.IntegrationTests.csproj
+++ b/src/Components/WebAssembly/Sdk/integrationtests/Microsoft.NET.Sdk.BlazorWebAssembly.IntegrationTests.csproj
@@ -36,6 +36,8 @@
     <Compile Include="..\src\BootJsonData.cs" LinkBase="Wasm" />
     <Compile Include="..\src\AssetsManifestFile.cs" LinkBase="Wasm" />
     <Compile Include="$(SharedSourceRoot)CommandLineUtils\**\*.cs" />
+
+    <EmbeddedResource Include="..\src\targets\BlazorWasm.web.config" />
   </ItemGroup>
 
   <Target Name="GenerateTestData" BeforeTargets="GetAssemblyAttributes">

--- a/src/Components/WebAssembly/Sdk/integrationtests/WasmPublishIntegrationTest.cs
+++ b/src/Components/WebAssembly/Sdk/integrationtests/WasmPublishIntegrationTest.cs
@@ -41,6 +41,8 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
 
             // Verify web.config
             Assert.FileExists(result, publishDirectory, "web.config");
+            var webConfigContent = new StreamReader(GetType().Assembly.GetManifestResourceStream("Microsoft.NET.Sdk.BlazorWebAssembly.IntegrationTests.BlazorWasm.web.config")).ReadToEnd();
+            Assert.FileContentEquals(result, Path.Combine(publishDirectory, "web.config"), webConfigContent);
             Assert.FileCountEquals(result, 1, publishDirectory, "*", SearchOption.TopDirectoryOnly);
 
             VerifyBootManifestHashes(result, blazorPublishDirectory);


### PR DESCRIPTION
This was resolved as part of moving to the WebAssembly SDK.
A test that would have helped us catch this sooner. This change addresses the test gap.

Resolves https://github.com/dotnet/aspnetcore/issues/24568

