### PR TITLE
Throw original exception if exception handler is not found

### DIFF
--- a/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -18,6 +18,9 @@ namespace Microsoft.AspNetCore.Diagnostics
 
         private static readonly Action<ILogger, Exception> _errorHandlerException =
             LoggerMessage.Define(LogLevel.Error, new EventId(3, "Exception"), "An exception was thrown attempting to execute the error handler.");
+
+        private static readonly Action<ILogger, Exception> _errorHandlerNotFound =
+            LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), "No exception handler was found, rethrowing original exception.");
 
         // DeveloperExceptionPageMiddleware
         private static readonly Action<ILogger, Exception> _responseStartedErrorPageMiddleware =
@@ -39,6 +42,11 @@ namespace Microsoft.AspNetCore.Diagnostics
         public static void ErrorHandlerException(this ILogger logger, Exception exception)
         {
             _errorHandlerException(logger, exception);
+        }
+
+        public static void ErrorHandlerNotFound(this ILogger logger)
+        {
+            _errorHandlerNotFound(logger, null);
         }
 
         public static void ResponseStartedErrorPageMiddleware(this ILogger logger)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/21510.

In the event where the exception handler could not be resolved (i.e. 404) I've taken the third approach as suggested in https://github.com/dotnet/aspnetcore/issues/21510#issuecomment-626377899 which is to re-throw the original error.

The problem would also be logged:
```
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/2 GET https://localhost:5001/throw - -fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.Exception: Application Exception
         at ExceptionHandlerSample.Startup.<>c.<Configure>b__0_3(HttpContext context) in C:\gh\aspnetcore\src\Middleware\Diagnostics\test\testassets\ExceptionHandlerSample\Startup.cs:line 27
         at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context) in C:\gh\aspnetcore\src\Http\Http.Abstractions\src\Extensions\MapMiddleware.cs:line 70
         at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware.<Invoke>g__Awaited|6_0(ExceptionHandlerMiddleware middleware, HttpContext context, Task task) in C:\gh\aspnetcore\src\Middleware\Diagnostics\src\ExceptionHandler\ExceptionHandlerMiddleware.cs:line 75
warn: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[4]
      No exception handler was found, rethrowing original exception.
fail: Microsoft.AspNetCore.Server.Kestrel[13]
      Connection id "0HM24OM464IUL", Request id "0HM24OM464IUL:00000003": An unhandled exception was thrown by the application.
      System.Exception: Application Exception
         at ExceptionHandlerSample.Startup.<>c.<Configure>b__0_3(HttpContext context) in C:\gh\aspnetcore\src\Middleware\Diagnostics\test\testassets\ExceptionHandlerSample\Startup.cs:line 27
         at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context) in C:\gh\aspnetcore\src\Http\Http.Abstractions\src\Extensions\MapMiddleware.cs:line 70
         at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware.<Invoke>g__Awaited|6_0(ExceptionHandlerMiddleware middleware, HttpContext context, Task task) in C:\gh\aspnetcore\src\Middleware\Diagnostics\src\ExceptionHandler\ExceptionHandlerMiddleware.cs:line 75
         at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware.HandleException(HttpContext context, ExceptionDispatchInfo edi) in C:\gh\aspnetcore\src\Middleware\Diagnostics\src\ExceptionHandler\ExceptionHandlerMiddleware.cs:line 143
         at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware.<Invoke>g__Awaited|6_0(ExceptionHandlerMiddleware middleware, HttpContext context, Task task) in C:\gh\aspnetcore\src\Middleware\Diagnostics\src\ExceptionHandler\ExceptionHandlerMiddleware.cs:line 85
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application) in C:\gh\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\HttpProtocol.cs:line 651
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/2 GET https://localhost:5001/throw - - - 500 0 - 49.1896ms
```