### PR TITLE
[Mvc] Add support for order in dynamic controller routes

### DIFF
--- a/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -506,18 +506,10 @@ namespace Microsoft.AspNetCore.Builder
             EnsureControllerServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
-
-            endpoints.Map(
-                pattern, 
-                context =>
-                {
-                    throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
-                })
-                .Add(b =>
-                {
-                    b.Metadata.Add(new DynamicControllerRouteValueTransformerMetadata(typeof(TTransformer), state));
-                });
+            var controllerDataSource = GetOrCreateDataSource(endpoints);
+            
+            // The data source is just used to share the common order with conventionally routed actions.
+            controllerDataSource.AddDynamicControllerEndpoint(endpoints, pattern, typeof(TTransformer), state);
         }
 
         private static DynamicControllerMetadata CreateDynamicControllerMetadata(string action, string controller, string area)

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -269,6 +269,7 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             // Endpoint Routing / Endpoints
             //
+            services.TryAddSingleton<OrderedEndpointsSequenceProvider>();
             services.TryAddSingleton<ControllerActionEndpointDataSource>();
             services.TryAddSingleton<ActionEndpointFactory>();
             services.TryAddSingleton<DynamicControllerEndpointSelector>();

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/OrderedEndpointsSequenceProvider.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/OrderedEndpointsSequenceProvider.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
+{
+    internal class OrderedEndpointsSequenceProvider
+    {
+        private object Lock = new object();
+
+        // In traditional conventional routing setup, the routes defined by a user have a order
+        // defined by how they are added into the list. We would like to maintain the same order when building
+        // up the endpoints too.
+        //
+        // Start with an order of '1' for conventional routes as attribute routes have a default order of '0'.
+        // This is for scenarios dealing with migrating existing Router based code to Endpoint Routing world.
+        private int _current = 1;
+
+        public int GetNext()
+        {
+            lock (Lock)
+            {
+                return _current++;
+            }
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSource.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -107,6 +107,24 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             }
 
             return endpoints;
+        }
+
+        internal void AddDynamicControllerEndpoint(IEndpointRouteBuilder endpoints, string pattern, Type transformerType, object state)
+        {
+            CreateInertEndpoints = true;
+            var order = _order++;
+
+            endpoints.Map(
+                pattern,
+                context =>
+                {
+                    throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
+                })
+                .Add(b =>
+                {
+                    ((RouteEndpointBuilder)b).Order = order;
+                    b.Metadata.Add(new DynamicControllerRouteValueTransformerMetadata(transformerType, state));
+                });
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSource.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSource.cs
@@ -15,26 +15,18 @@ namespace Microsoft.AspNetCore.Mvc.Routing
     internal class ControllerActionEndpointDataSource : ActionEndpointDataSourceBase
     {
         private readonly ActionEndpointFactory _endpointFactory;
+        private readonly OrderedEndpointsSequenceProvider _orderSequence;
         private readonly List<ConventionalRouteEntry> _routes;
-
-        private int _order;
 
         public ControllerActionEndpointDataSource(
             IActionDescriptorCollectionProvider actions,
-            ActionEndpointFactory endpointFactory)
+            ActionEndpointFactory endpointFactory,
+            OrderedEndpointsSequenceProvider orderSequence)
             : base(actions)
         {
             _endpointFactory = endpointFactory;
-
+            _orderSequence = orderSequence;
             _routes = new List<ConventionalRouteEntry>();
-
-            // In traditional conventional routing setup, the routes defined by a user have a order
-            // defined by how they are added into the list. We would like to maintain the same order when building
-            // up the endpoints too.
-            //
-            // Start with an order of '1' for conventional routes as attribute routes have a default order of '0'.
-            // This is for scenarios dealing with migrating existing Router based code to Endpoint Routing world.
-            _order = 1;
 
             DefaultBuilder = new ControllerActionEndpointConventionBuilder(Lock, Conventions);
 
@@ -59,7 +51,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             lock (Lock)
             {
                 var conventions = new List<Action<EndpointBuilder>>();
-                _routes.Add(new ConventionalRouteEntry(routeName, pattern, defaults, constraints, dataTokens, _order++, conventions));
+                _routes.Add(new ConventionalRouteEntry(routeName, pattern, defaults, constraints, dataTokens, _orderSequence.GetNext(), conventions));
                 return new ControllerActionEndpointConventionBuilder(Lock, conventions);
             }
         }
@@ -112,19 +104,22 @@ namespace Microsoft.AspNetCore.Mvc.Routing
         internal void AddDynamicControllerEndpoint(IEndpointRouteBuilder endpoints, string pattern, Type transformerType, object state)
         {
             CreateInertEndpoints = true;
-            var order = _order++;
+            lock (Lock)
+            {
+                var order = _orderSequence.GetNext();
 
-            endpoints.Map(
-                pattern,
-                context =>
-                {
-                    throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
-                })
-                .Add(b =>
-                {
-                    ((RouteEndpointBuilder)b).Order = order;
-                    b.Metadata.Add(new DynamicControllerRouteValueTransformerMetadata(transformerType, state));
-                });
+                endpoints.Map(
+                    pattern,
+                    context =>
+                    {
+                        throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
+                    })
+                    .Add(b =>
+                    {
+                        ((RouteEndpointBuilder)b).Order = order;
+                        b.Metadata.Add(new DynamicControllerRouteValueTransformerMetadata(transformerType, state));
+                    });
+            }
         }
     }
 }

--- a/src/Mvc/Mvc.Core/test/Routing/ControllerActionEndpointDataSourceTest.cs
+++ b/src/Mvc/Mvc.Core/test/Routing/ControllerActionEndpointDataSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -385,7 +385,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
         private protected override ActionEndpointDataSourceBase CreateDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
         {
-            return new ControllerActionEndpointDataSource(actions, endpointFactory);
+            return new ControllerActionEndpointDataSource(actions, endpointFactory, new OrderedEndpointsSequenceProvider());
         }
 
         protected override ActionDescriptor CreateActionDescriptor(

--- a/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
@@ -337,18 +337,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureRazorPagesServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var dataSource = GetOrCreateDataSource(endpoints);
 
-            endpoints.Map(
-                pattern,
-                context =>
-                {
-                    throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
-                })
-                .Add(b =>
-                {
-                    b.Metadata.Add(new DynamicPageRouteValueTransformerMetadata(typeof(TTransformer), state));
-                });
+            dataSource.AddDynamicPageEndpoint(endpoints, pattern, typeof(TTransformer), state);
         }
 
         private static DynamicPageMetadata CreateDynamicPageMetadata(string page, string area)

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSource.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,18 +8,23 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 {
     internal class PageActionEndpointDataSource : ActionEndpointDataSourceBase
     {
         private readonly ActionEndpointFactory _endpointFactory;
+        private readonly OrderedEndpointsSequenceProvider _orderSequence;
 
-        public PageActionEndpointDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
+        public PageActionEndpointDataSource(
+            IActionDescriptorCollectionProvider actions,
+            ActionEndpointFactory endpointFactory,
+            OrderedEndpointsSequenceProvider orderedEndpoints)
             : base(actions)
         {
             _endpointFactory = endpointFactory;
-
+            _orderSequence = orderedEndpoints;
             DefaultBuilder = new PageActionEndpointConventionBuilder(Lock, Conventions);
 
             // IMPORTANT: this needs to be the last thing we do in the constructor.
@@ -46,6 +51,27 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             }
 
             return endpoints;
+        }
+
+        internal void AddDynamicPageEndpoint(IEndpointRouteBuilder endpoints, string pattern, Type transformerType, object state)
+        {
+            CreateInertEndpoints = true;
+            lock (Lock)
+            {
+                var order = _orderSequence.GetNext();
+
+                endpoints.Map(
+                    pattern,
+                    context =>
+                    {
+                        throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
+                    })
+                    .Add(b =>
+                    {
+                        ((RouteEndpointBuilder)b).Order = order;
+                        b.Metadata.Add(new DynamicPageRouteValueTransformerMetadata(transformerType, state));
+                    });
+            }
         }
     }
 }

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionEndpointDataSourceTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionEndpointDataSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
         private protected override ActionEndpointDataSourceBase CreateDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
         {
-            return new PageActionEndpointDataSource(actions, endpointFactory);
+            return new PageActionEndpointDataSource(actions, endpointFactory, new OrderedEndpointsSequenceProvider());
         }
 
         protected override ActionDescriptor CreateActionDescriptor(

--- a/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance/ControllerActionEndpointDatasourceBenchmark.cs
+++ b/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance/ControllerActionEndpointDatasourceBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -110,7 +110,8 @@ namespace Microsoft.AspNetCore.Mvc.Performance
         {
             var dataSource = new ControllerActionEndpointDataSource(
                 actionDescriptorCollectionProvider,
-                new ActionEndpointFactory(new MockRoutePatternTransformer()));
+                new ActionEndpointFactory(new MockRoutePatternTransformer()),
+                new OrderedEndpointsSequenceProvider());
 
             return dataSource;
         }

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingDynamicOrderTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingDynamicOrderTest.cs
@@ -1,0 +1,121 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using RoutingWebSite;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests
+{
+    public class RoutingDynamicOrderTest : IClassFixture<MvcTestFixture<RoutingWebSite.StartupForDynamic>>
+    {
+        public RoutingDynamicOrderTest(MvcTestFixture<RoutingWebSite.StartupForDynamic> fixture)
+        {
+            Factory = fixture.Factories.FirstOrDefault() ?? fixture.WithWebHostBuilder(ConfigureWebHostBuilder);
+        }
+
+        private static void ConfigureWebHostBuilder(IWebHostBuilder builder) => builder.UseStartup<RoutingWebSite.StartupForDynamicOrder>();
+
+        public WebApplicationFactory<StartupForDynamic> Factory { get; }
+
+        [Fact]
+        public async Task PrefersAttributeRoutesOverDynamicRoutes()
+        {
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.AttributeRouteDynamicRoute));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/attribute-dynamic-order/Controller=Home,Action=Index";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("AttributeRouteSlug", content.RouteName);
+        }
+
+        [Fact]
+        public async Task DynamicRoutesAreMatchedInDefinitionOrderOverPrecedence()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", isEnabled: true);
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.MultipleDynamicRoute));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/dynamic-order/specific/Controller=Home,Action=Index";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(content.RouteValues.TryGetValue("version", out var version));
+            Assert.Equal("slug", version);
+        }
+
+        [Fact]
+        public async Task ConventionalRoutesDefinedEarlierWinOverDynamicControllerRoutes()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", isEnabled: true);
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.ConventionalRouteDynamicRoute));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/conventional-dynamic-order-before";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.False(content.RouteValues.TryGetValue("version", out var version));
+        }
+
+        [Fact]
+        public async Task ConventionalRoutesDefinedLaterLooseToDynamicControllerRoutes()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", isEnabled: true);
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.ConventionalRouteDynamicRoute));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/conventional-dynamic-order-after";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(content.RouteValues.TryGetValue("version", out var version));
+            Assert.Equal("slug", version);
+        }
+
+        private record RouteInfo(string RouteName, IDictionary<string,string> RouteValues);
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/Controllers/DynamicOrderController.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Controllers/DynamicOrderController.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mvc.RoutingWebSite.Controllers
+{
+    public class DynamicOrderController : Controller
+    {
+        private readonly TestResponseGenerator _generator;
+
+        public DynamicOrderController(TestResponseGenerator generator)
+        {
+            _generator = generator;
+        }
+
+        [HttpGet("attribute-dynamic-order/{**slug}", Name = "AttributeRouteSlug")]
+        public IActionResult Get(string slug)
+        {
+            return _generator.Generate(Url.RouteUrl("AttributeRouteSlug", new { slug }));
+        }
+
+        [HttpGet]
+        public IActionResult Index()
+        {
+            return _generator.Generate(Url.RouteUrl(null, new { controller = "DynamicOrder", action = "Index" }));
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/Pages/DynamicPage.cshtml
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Pages/DynamicPage.cshtml
@@ -1,3 +1,3 @@
 ﻿@page
 @model RoutingWebSite.Pages.DynamicPageModel
-Hello from dynamic page: @Url.Page("")
+Hello from dynamic page: @Url.Page("")@RouteData.Values["identifier"]

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamicOrder.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamicOrder.cs
@@ -1,0 +1,112 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RoutingWebSite
+{
+    // For by tests for dynamic routing to pages/controllers
+    public class StartupForDynamicOrder
+    {
+        public static class DynamicOrderScenarios
+        {
+            public const string AttributeRouteDynamicRoute = nameof(AttributeRouteDynamicRoute);
+            public const string MultipleDynamicRoute = nameof(MultipleDynamicRoute);
+            public const string ConventionalRouteDynamicRoute = nameof(ConventionalRouteDynamicRoute);
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public StartupForDynamicOrder(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services
+                .AddMvc()
+                .AddNewtonsoftJson()
+                .SetCompatibilityVersion(CompatibilityVersion.Latest);
+
+            services.AddTransient<Transformer>();
+            services.AddScoped<TestResponseGenerator>();
+            services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
+
+            // Used by some controllers defined in this project.
+            services.Configure<RouteOptions>(options => options.ConstraintMap["slugify"] = typeof(SlugifyParameterTransformer));
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            var scenario = Configuration.GetValue<string>("Scenario");
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                // Route order definition is important for all these routes:
+                switch (scenario)
+                {
+                    case DynamicOrderScenarios.AttributeRouteDynamicRoute:
+                        endpoints.MapDynamicControllerRoute<Transformer>("attribute-dynamic-order/{**slug}", new DynamicVersion() { Version = "slug" });
+                        endpoints.MapControllers();
+                        break;
+                    case DynamicOrderScenarios.ConventionalRouteDynamicRoute:
+                        endpoints.MapControllerRoute(null, "conventional-dynamic-order-before", new { controller = "DynamicOrder", action = "Index" });
+                        endpoints.MapDynamicControllerRoute<Transformer>("{conventional-dynamic-order}", new DynamicVersion() { Version = "slug" });
+                        endpoints.MapControllerRoute(null, "conventional-dynamic-order-after", new { controller = "DynamicOrder", action = "Index" });
+                        break;
+                    case DynamicOrderScenarios.MultipleDynamicRoute:
+                        endpoints.MapDynamicControllerRoute<Transformer>("dynamic-order/{**slug}", new DynamicVersion() { Version = "slug" });
+                        endpoints.MapDynamicControllerRoute<Transformer>("dynamic-order/specific/{**slug}", new DynamicVersion() { Version = "specific" });
+                        break;
+                    default:
+                        throw new InvalidOperationException("Invalid scenario configuration.");
+                }
+            });
+
+            app.Map("/afterrouting", b => b.Run(c =>
+            {
+                return c.Response.WriteAsync("Hello from middleware after routing");
+            }));
+        }
+
+        private class Transformer : DynamicRouteValueTransformer
+        {
+            // Turns a format like `controller=Home,action=Index` into an RVD
+            public override ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
+            {
+                var kvps = ((string)values?["slug"])?.Split("/")?.LastOrDefault()?.Split(",") ?? Array.Empty<string>();
+
+                // Go to index by default if the route doesn't follow the slug pattern, we want to make sure always match to
+                // test the order is applied
+                var results = new RouteValueDictionary();
+                results["controller"] = "Home";
+                results["action"] = "Index";
+
+                foreach (var kvp in kvps)
+                {
+                    var split = kvp.Split("=");
+                    if (split.Length == 2)
+                    {
+                        results[split[0]] = split[1];
+                    }
+                }
+
+                results["version"] = ((DynamicVersion)State).Version;
+
+                return new ValueTask<RouteValueDictionary>(results);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
We want to support order with dynamic endpoints in the same way it is supported for conventionally routed actions.

## Motivation
Conventional routes have an order concept that is tied up with the order they are defined in code. That means that a route that is defined earlier during the execution will have
precendence over a route that was defined later. Dynamic routes don't support this functionality and that discrepance is the source of to big problems:
* It is confusing and surprising for customers since they expect these routes to have a similar behavior as conventional routes.
* It makes it hard to use more than one dynamic route in the same application, since these tend to be very generic routes, its easy for them to catch many incoming requests.

## Goals
* Make using multiple dynamic routes in the same app easier.
* Make using dynamic routes in conjunction with conventional and attribute routes easier.

## Non-goals
* Link generation
* Order is global now for all registered MVC/Pages, we don't plan to change that as part of this PR.

## Scenarios
* Mapping dynamic routes and attribute routes.
* Mapping multiple dynamic routes.
* Mapping multiple dynamic routes and conventional routes.
* Mapping dynamic controller routes and dynamic page routes.

## Risks
* Existing applications might experience changes in the matched actions for a given pattern:
  * An attribute route with a lower routing precedence might match a request that was previously matched by a dynamic action.
  * Conflicting routing configurations can be resolved in favor of attribute routed actions by default.

* We can make this opt-in and enabled in the template by default, with the behavior becomming the default in 6.0.

## Interaction with other parts of the framework
* These routes will now have a lower order than endpoints registered by other frameworks like SignalR.

## Detailed design

We want dynamic routes to behave more like conventional routes and participate in the ordering these routes have:

* Dynamic controller routes have the same order as conventional routes by default.
  * All attribute routed controller routes have lower order than dynamic controller routes, which means if they match, they win.
```csharp
builder.UseEndpoints(endpoints => {
  endpoints.MapControllers();
  endpoints.MapDynamicController<DbTransformer>(...);
});

```

* Dynamic controller routes order is based on the definion order
  * Routes that get defined first have a lower order, which means they win even if they are less specific than routes after them/
  * This behavior is inline with conventional mvc routing behavior.
```csharp
builder.UseEndpoints(endpoints => {
  endpoints.MapDynamicController<DbTransformer>(...);
  endpoints.MapDynamicController<CoolBeansTransformer>(...);
});
```

* Dynamic controllers routes order and conventional controller routes share order
  * Routes that get defined first have a lower order, which means that a dynamic route that is less specific than a conventional route wins when both match.
  
```csharp
builder.UseEndpoints(endpoints => {
  endpoints.MapDynamicController<DbTransformer>(...);
  endpoints.MapControllerRoute(...);
});
```

* Dynamic page routes order and dynamic controller routes share order
  * Routes that get defined first have a lower order, which means that a dynamic route that is less specific than a dynamic page route wins when both match.
  
```csharp
builder.UseEndpoints(endpoints => {
  endpoints.MapDynamicController<DbTransformer>(...);
  endpoints.MapDynamicPage<DocumentTransformer>(...);
});
```

## Drawbacks
* You need to order your routes from most specific to less specific since they now behave in the same way as conventional routes.

## Considered alternatives
The alternative is to keep the current behavior, which has the problems we indicated above.