### PR TITLE
Run 1 browser at a time in SignalR javascript functional tests

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/scripts/karma.base.conf.js
+++ b/src/SignalR/clients/ts/FunctionalTests/scripts/karma.base.conf.js
@@ -26,7 +26,7 @@ try {
                 logLevel: config.LOG_INFO,
                 autoWatch: false,
                 singleRun: false,
-                concurrency: Infinity,
+                concurrency: 1,
 
                 // Log browser messages to a file, not the terminal.
                 browserConsoleLogOptions: {


### PR DESCRIPTION
We've started seeing some timeouts on Mac: https://github.com/dotnet/aspnetcore/issues/24969

This will limit the concurrency a bit to hopefully make the tests more reliable on slower machines, it also makes the logs file a bit cleaner now that browser logs wont be intermingled.