### PR TITLE
Fix MaxRequestBodySize in IIS

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
@@ -19,6 +19,6 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
         public bool fAnonymousAuthEnable;
         [MarshalAs(UnmanagedType.BStr)]
         public string pwzBindings;
-        public int maxRequestBodySize;
+        public uint maxRequestBodySize;
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Servers/IIS/IIS/src/IISServerOptions.cs
+++ b/src/Servers/IIS/IIS/src/IISServerOptions.cs
@@ -38,17 +38,21 @@ namespace Microsoft.AspNetCore.Builder
 
         internal string[] ServerAddresses { get; set; }
 
+        // Matches the default maxAllowedContentLength in IIS (~28.6 MB)
+        // https://www.iis.net/configreference/system.webserver/security/requestfiltering/requestlimits#005
+        private long? _maxRequestBodySize = 30000000;
+
         internal long IisMaxRequestSizeLimit; // Used for verifying if limit set in managed exceeds native 
-        private long? _maxRequestBodySize;
 
         /// <summary>
         /// Gets or sets the maximum allowed size of any request body in bytes.
-        /// When set to null, the maximum request body size is unlimited.
+        /// When set to null, the maximum request length will not be restricted in ASP.NET Core.
+        /// However, the IIS maxAllowedContentLength will still restrict content length requests (30,000,000 by default).
         /// This limit has no effect on upgraded connections which are always unlimited.
         /// This can be overridden per-request via <see cref="IHttpMaxRequestBodySizeFeature"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to null (unlimited).
+        /// Defaults to 30,000,000 bytes (~28.6 MB).
         /// </remarks>
         public long? MaxRequestBodySize
         {

--- a/src/Servers/IIS/IIS/src/IISServerOptions.cs
+++ b/src/Servers/IIS/IIS/src/IISServerOptions.cs
@@ -38,11 +38,8 @@ namespace Microsoft.AspNetCore.Builder
 
         internal string[] ServerAddresses { get; set; }
 
-        // Matches the default maxAllowedContentLength in IIS (~28.6 MB)
-        // https://www.iis.net/configreference/system.webserver/security/requestfiltering/requestlimits#005
-        private long? _maxRequestBodySize = 30000000;
-
-        internal long IisMaxRequestSizeLimit;
+        internal long IisMaxRequestSizeLimit; // Used for verifying if limit set in managed exceeds native 
+        private long? _maxRequestBodySize;
 
         /// <summary>
         /// Gets or sets the maximum allowed size of any request body in bytes.

--- a/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
+++ b/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Hosting
                             options => {
                                 options.ServerAddresses = iisConfigData.pwzBindings.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                                 options.ForwardWindowsAuthentication = iisConfigData.fWindowsAuthEnabled || iisConfigData.fBasicAuthEnabled;
+                                options.MaxRequestBodySize = iisConfigData.maxRequestBodySize;
                                 options.IisMaxRequestSizeLimit = iisConfigData.maxRequestBodySize;
                             }
                         );

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
                 });
             var deploymentResult = await DeployAsync(deploymentParameters);
 
-            var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 10)));
+            var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 100000000)));
 
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
@@ -96,26 +96,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
         [ConditionalFact]
         [RequiresNewHandler]
-        public async Task SetIISLimitMaxRequestBodySizeE2EWorksNoLimit()
-        {
-            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
-            deploymentParameters.ServerConfigActionList.Add(
-                (config, _) => {
-                    config
-                        .RequiredElement("system.webServer")
-                        .GetOrAdd("security")
-                        .GetOrAdd("requestFiltering")
-                        .Remove();
-                });
-            var deploymentResult = await DeployAsync(deploymentParameters);
-
-            var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 100000000)));
-
-            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-        }
-
-        [ConditionalFact]
-        [RequiresNewHandler]
         public async Task IISRejectsContentLengthTooLargeByDefault()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters();

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
@@ -71,8 +71,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 100000000)));
 
-            // IIS either returns a 404 or a 413 based on versions of IIS.
-            // Check for both as we don't know which specific patch version.
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
 
@@ -93,8 +91,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 10000)));
 
-            // IIS either returns a 404 or a 413 based on versions of IIS.
-            // Check for both as we don't know which specific patch version.
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
 
@@ -115,8 +111,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
             var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 10)));
 
-            // IIS either returns a 404 or a 413 based on versions of IIS.
-            // Check for both as we don't know which specific patch version.
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
                 });
             var deploymentResult = await DeployAsync(deploymentParameters);
 
-            var result = await deploymentResult.HttpClient.PostAsync("/DecreaseRequestLimit", new StringContent("1"));
+            var result = await deploymentResult.HttpClient.PostAsync("/IncreaseRequestLimit", new StringContent("1"));
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
             StopServer();

--- a/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
@@ -329,8 +329,8 @@ namespace IIS.Tests
                     await connection.Send(
                         "POST / HTTP/1.1",
                         "Host: localhost",
-                        "Content-Length: " + (new IISServerOptions().MaxRequestBodySize + 1),
                         "",
+                        "Content-Length: " + (new IISServerOptions().MaxRequestBodySize + 1),
                         "");
                     await connection.Receive(
                         "HTTP/1.1 413 Payload Too Large");

--- a/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
@@ -329,8 +329,8 @@ namespace IIS.Tests
                     await connection.Send(
                         "POST / HTTP/1.1",
                         "Host: localhost",
-                        "",
                         "Content-Length: " + (new IISServerOptions().MaxRequestBodySize + 1),
+                        "",
                         "");
                     await connection.Receive(
                         "HTTP/1.1 413 Payload Too Large");

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -478,6 +478,16 @@ namespace TestSite
             }
         }
 
+        private async Task ReadRequestBodyLarger(HttpContext ctx)
+        {
+            var readBuffer = new byte[4096];
+            var result = await ctx.Request.Body.ReadAsync(readBuffer, 0, 4096);
+            while (result != 0)
+            {
+                result = await ctx.Request.Body.ReadAsync(readBuffer, 0, 4096);
+            }
+        }
+
         private int _requestsInFlight = 0;
         private async Task ReadAndCountRequestBody(HttpContext ctx)
         {

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1454,6 +1454,13 @@ namespace TestSite
             await Assert.ThrowsAsync<IOException>(() => readTask);
         }
 
+        public Task IncreaseRequestLimit(HttpContext httpContext)
+        {
+            var maxRequestBodySizeFeature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
+            maxRequestBodySizeFeature.MaxRequestBodySize = 2;
+            return Task.CompletedTask;
+        }
+
         internal static readonly HashSet<(string, StringValues, StringValues)> NullTrailers = new HashSet<(string, StringValues, StringValues)>()
         {
             ("NullString", (string)null, (string)null),


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/24555
Fixes https://github.com/dotnet/aspnetcore/issues/22950
Fixes https://github.com/dotnet/aspnetcore/issues/22834

- When checking the MaxRequestBodySize, we never updated it with the value from IIS.
- Change int to uint to allow uint.MaxValue
- Remove 30MB constant in managed code as the value already defaults to 30MB from native and we always set the value in managed from native.

# Description
There is two bug in the IIS MaxRequestBodySize feature which made it so it wouldn't read the value from IIS correctly and couldn't accept a value larger than Int.MaxValue. This made the middleware too restrictive, causing people difficulties who were trying to increase the limit.

# Customer Impact

Fixes the feature by reading the correct value from native as well as accepting UInt.MaxValue, matching the max limit in IIS.

# Regression?

No

# Risk

Low. This fixes an already existing feature and people who were working around it today wouldn't be affected.