### PR TITLE
Clarification of API remark on ParameterView

### DIFF
--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -200,9 +200,8 @@ namespace Microsoft.AspNetCore.Components
         /// <returns>A <see cref="Task"/> that completes when the component has finished updating and rendering itself.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="SetParametersAsync(ParameterView)"/> method is passed a set of parameter values each
-        /// time <see cref="SetParametersAsync(ParameterView)"/> is called. It is not required that the caller supply a parameter
-        /// value for all of the parameters that are logically understood by the component.
+        /// Parameters are passed when <see cref="SetParametersAsync(ParameterView)"/> is called. It is not required that 
+        /// the caller supply a parameter value for all of the parameters that are logically understood by the component.
         /// </para>
         /// <para>
         /// The default implementation of <see cref="SetParametersAsync(ParameterView)"/> will set the value of each property

--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -200,9 +200,9 @@ namespace Microsoft.AspNetCore.Components
         /// <returns>A <see cref="Task"/> that completes when the component has finished updating and rendering itself.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="SetParametersAsync(ParameterView)"/> method should be passed the entire set of parameter values each
-        /// time <see cref="SetParametersAsync(ParameterView)"/> is called. It not required that the caller supply a parameter
-        /// value for all parameters that are logically understood by the component.
+        /// The <see cref="SetParametersAsync(ParameterView)"/> method is passed a set of parameter values each
+        /// time <see cref="SetParametersAsync(ParameterView)"/> is called. It is not required that the caller supply a parameter
+        /// value for all of the parameters that are logically understood by the component.
         /// </para>
         /// <para>
         /// The default implementation of <see cref="SetParametersAsync(ParameterView)"/> will set the value of each property


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

@pstricks-fans asked on https://github.com/dotnet/AspNetCore.Docs/issues/19597 ...

> The first paragraph said that `ParameterView` contains the entire set of `[Parameter]` properties , but the second paragraph said that `[Parameter]` properties may have no corresponding values in `ParameterView`.
>
> It sounds contradictory to me.
>
> How can `[Parameter]` properties have no corresponding values in `ParameterView` while `ParameterView` is said to contain the entire set of `[Parameter]` properties?

I created doc PR https://github.com/dotnet/AspNetCore.Docs/pull/19598 to address it in the Blazor *Lifecycle* topic.

Should the API remark be updated along the lines of what's on this PR?

* **A set** of params is passed to the method ... either via the parent component or dev code.
* The set **doesn't need to be the entire set** given that unmatched params are left alone.
