### PR TITLE
Fixing some failing IIS tests

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalTheory]
         [MemberData(nameof(TestVariants))]
-        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8)]
         public Task HttpsClientCert_GetCertInformation(TestVariant variant)
         {
             return ClientCertTest(variant, sendClientCert: true);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalTheory]
         [MemberData(nameof(TestVariants))]
-        [RequiresIIS(IISCapability.ClientCertificate)]
         [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8)]
         public Task HttpsClientCert_GetCertInformation(TestVariant variant)
         {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         public static TestMatrix TestVariants
             => TestMatrix.ForServers(DeployerSelector.ServerType)
                 .WithTfms(Tfm.Net50)
-                .WithAllApplicationTypes()
+                .WithApplicationTypes(ApplicationType.Portable)
                 .WithAllHostingModels();
 
         [ConditionalTheory]
@@ -42,8 +42,8 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         }
 
         [ConditionalTheory]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/22319")]
         [MemberData(nameof(TestVariants))]
+        [RequiresIIS(IISCapability.ClientCertificate)]
         [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8)]
         public Task HttpsClientCert_GetCertInformation(TestVariant variant)
         {
@@ -61,6 +61,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             {
                 ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
                 ClientCertificateOptions = ClientCertificateOption.Manual,
+                SslProtocols = System.Security.Authentication.SslProtocols.Tls12
             };
 
             X509Certificate2 cert = null;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
@@ -59,8 +59,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             var handler = new HttpClientHandler
             {
                 ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
-                ClientCertificateOptions = ClientCertificateOption.Manual,
-                SslProtocols = System.Security.Authentication.SslProtocols.Tls12
+                ClientCertificateOptions = ClientCertificateOption.Manual
             };
 
             X509Certificate2 cert = null;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         [RequiresNewShim]
         public async Task ServerAddressesIncludesBaseAddress()
         {
-            var appName = "TEST";
+            var appName = "test";
 
             var port = TestPortHelper.GetNextSSLPort();
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.InProcess);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         [RequiresNewShim]
         public async Task ServerAddressesIncludesBaseAddress()
         {
-            var appName = "\u041C\u043E\u0451\u041F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u0435";
+            var appName = "TEST";
 
             var port = TestPortHelper.GetNextSSLPort();
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.InProcess);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22319
Fixes https://github.com/dotnet/aspnetcore/issues/25107 (except timeouts due to my supposed guess of HTTP.SYS issues).

@Tratcher I had to force TLS 1.2 to fix this test, do you think this is the same issue we were seeing with TLS 1.3 and nuget?