### PR TITLE
Tiny optimization

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/TaskExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/TaskExtensions.cs
@@ -21,6 +21,6 @@ namespace System.Threading.Tasks
         // Observe exception
         public void GetResult() { _ = _task.Exception; }
         public void OnCompleted(Action continuation) => _task.GetAwaiter().OnCompleted(continuation);
-        public void UnsafeOnCompleted(Action continuation) =>_task.GetAwaiter().UnsafeOnCompleted(continuation);
+        public void UnsafeOnCompleted(Action continuation) => _task.GetAwaiter().UnsafeOnCompleted(continuation);
     }
 }

--- a/src/SignalR/common/Http.Connections/src/Internal/TaskExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/TaskExtensions.cs
@@ -21,6 +21,6 @@ namespace System.Threading.Tasks
         // Observe exception
         public void GetResult() { _ = _task.Exception; }
         public void OnCompleted(Action continuation) => _task.GetAwaiter().OnCompleted(continuation);
-        public void UnsafeOnCompleted(Action continuation) => OnCompleted(continuation);
+        public void UnsafeOnCompleted(Action continuation) =>_task.GetAwaiter().UnsafeOnCompleted(continuation);
     }
 }


### PR DESCRIPTION
- Don't capture the execution context when using UnsafeOnCompleted
