### PR TITLE
Backport fix on IAsyncEnumerable from 5.0 to 3.1 (PR 24926)

### DIFF
--- a/src/SignalR/common/Shared/ReflectionHelper.cs
+++ b/src/SignalR/common/Shared/ReflectionHelper.cs
@@ -37,7 +37,10 @@ namespace Microsoft.AspNetCore.SignalR
         {
             if (type.IsGenericType)
             {
-                return type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>);
+                if (type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>))
+                {
+                    return true;
+                }
             }
 
             return type.GetInterfaces().Any(t =>

--- a/src/SignalR/server/SignalR/test/Internal/ReflectionHelperTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/ReflectionHelperTests.cs
@@ -57,9 +57,23 @@ namespace Microsoft.AspNetCore.SignalR.Tests.Internal
                 typeof(CustomAsyncEnumerable),
                 true
             };
+
+            yield return new object[]
+            {
+                typeof(CustomAsyncEnumerableOfT<object>),
+                true
+            };
         }
 
         private class CustomAsyncEnumerable : IAsyncEnumerable<object>
+        {
+            public IAsyncEnumerator<object> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class CustomAsyncEnumerableOfT<T> : IAsyncEnumerable<object>
         {
             public IAsyncEnumerator<object> GetAsyncEnumerator(CancellationToken cancellationToken = default)
             {


### PR DESCRIPTION
fixes #25164

#### Description
> Found from a stackoverflow question.
> System.Linq.Async has a ToAsyncEnumerable method which returns a generic class that implements IAsyncEnumerable<T> which didn't work with our reflection logic.
> https://github.com/dotnet/reactive/blob/7ad606b3dcd4bb2c6ae9622f8a59db7f8f52aa85/Ix.NET/Source/System.Linq.Async/System/Linq/Operators/ToAsyncEnumerable.cs#L34

This is a backport of #24926

#### Regression?
no

#### Risk
same as #24926
I see no obvious Risk

## More:

As @BrennanConroy explained:
> I mean it's possible, it's just the servicing bar is unlikely to be met. https://github.com/dotnet/aspnetcore/blob/master/docs/Servicing.md#servicing-bar

This might be rejected, but at least the PR is ready as the bug was discussed about on Gitter
This is also on `LTS` (since 5.0 will NOT be LTS)
eg: 
The team responsible for `AuthN / AuthZ Handler` usually refuse to work on non-LTS, so no `net5.0` for us :(


> Before we were assuming if the type was generic then it must be an IAsyncEnumerable<> or some non-streaming type which is what that check was doing. But that was a wrong assumption since you can have a generic type that implements IAsyncEnumerable<> instead of being an IAsyncEnumerable directly. We then fallback to the logic below that statement that checks all interface types for IAsyncEnumerable<>. If you take a look at the added test case then you can see the structure of a type that failed the check before.


