### PR TITLE
Include project file in F# Worker Service template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
@@ -59,6 +59,7 @@
     <GeneratedContent Include="WebApi-CSharp.csproj.in" OutputPath="content/WebApi-CSharp/Company.WebApplication1.csproj" />
     <GeneratedContent Include="WebApi-FSharp.fsproj.in" OutputPath="content/WebApi-FSharp/Company.WebApplication1.fsproj" />
     <GeneratedContent Include="Worker-CSharp.csproj.in" OutputPath="content/Worker-CSharp/Company.Application1.csproj" />
+    <GeneratedContent Include="Worker-FSharp.fsproj.in" OutputPath="content/Worker-FSharp/Company.Application1.fsproj" />
     <GeneratedContent Include="ComponentsWebAssembly-CSharp.Client.csproj.in" OutputPath="content/ComponentsWebAssembly-CSharp/Client/ComponentsWebAssembly-CSharp.Client.csproj" />
     <GeneratedContent Include="ComponentsWebAssembly-CSharp.Shared.csproj.in" OutputPath="content/ComponentsWebAssembly-CSharp/Shared/ComponentsWebAssembly-CSharp.Shared.csproj" />
     <GeneratedContent Include="ComponentsWebAssembly-CSharp.Server.csproj.in" OutputPath="content/ComponentsWebAssembly-CSharp/Server/ComponentsWebAssembly-CSharp.Server.csproj" />

--- a/src/ProjectTemplates/test/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/WorkerTemplateTest.cs
@@ -21,13 +21,17 @@ namespace Templates.Test
         public ProjectFactoryFixture ProjectFactory { get; }
         public ITestOutputHelper Output { get; }
 
-        [ConditionalFact]
+        [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Linux, SkipReason = "https://github.com/dotnet/sdk/issues/12831")]
-        public async Task WorkerTemplateAsync()
+        [InlineData("C#")]
+        [InlineData("F#")]
+        public async Task WorkerTemplateAsync(string language)
         {
-            Project = await ProjectFactory.GetOrCreateProject("worker", Output);
+            Project = await ProjectFactory.GetOrCreateProject(
+                $"worker-{ language.ToLowerInvariant()[0] }sharp",
+                Output);
 
-            var createResult = await Project.RunDotNetNewAsync("worker");
+            var createResult = await Project.RunDotNetNewAsync("worker", language: language);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", Project, createResult));
 
             var publishResult = await Project.RunDotNetPublishAsync();


### PR DESCRIPTION
- add test of this project template

# Description

We discovered the Worker Service template for F# lacks a `*.fsproj` file in the Microsoft.DotNet.Web.ProjectTemplates package. The file existed in this repo since a722c4cd7a3a1ed7ea8f10727d1cf802753b0e2d but was not included when building our project templates.

Though this was discovered internally, a customer noticed the problem a couple of days ago and reported it in #25158.

# Customer Impact

As-is, created "projects" are not complete. Customers wishing to use the F# Worker Service template must craft the `*.fsproj` file themselves.

# Regression?

No. Appears the problem existed since the template was added in early July.

# Risk

Very very low. The fix is a one-liner to add the missing `*.fsproj.in` template file to the Microsoft.DotNet.Web.ProjectTemplates.csproj. That results in the creating and packing the `*.fsproj` file into the package.

Also added a test confirming the project works as expected.

# Examples
``` text
> dotnet new --list
Templates                                         Short Name               Language          Tags
--------------------------------------------      -------------------      ------------      ----------------------
Console Application                               console                  [C#], F#, VB      Common/Console
Class library                                     classlib                 [C#], F#, VB      Common/Library
WPF Application                                   wpf                      [C#], VB          Common/WPF
WPF Class library                                 wpflib                   [C#], VB          Common/WPF
WPF Custom Control Library                        wpfcustomcontrollib      [C#], VB          Common/WPF
WPF User Control Library                          wpfusercontrollib        [C#], VB          Common/WPF
Windows Forms (WinForms) Application              winforms                 [C#], VB          Common/WinForms
Windows Forms (WinForms) Class library            winformslib              [C#], VB          Common/WinForms
Worker Service                                    worker                   [C#], F#          Common/Worker/Web
...
```

``` text
> dotnet new worker --language f#
The template "Worker Service" was created successfully.

Processing post-creation actions...
Running 'dotnet restore' on C:\dd\dnx\aspnetcore\Company.Application1.fsproj...
MSBUILD : error MSB1009: Project file does not exist.
Switch: C:\dd\dnx\aspnetcore\Company.Application1.fsproj
Restore failed.
Post action failed.
Description: Restore NuGet packages required by this project.
Manual instructions: Run 'dotnet restore'
```