### PR TITLE
Partially-complete support for "import" with JSObjectReference.

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/tsconfig.json
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/tsconfig.json
@@ -8,7 +8,8 @@
         "lib": ["es2015", "dom", "es2015.promise"],
         "strict": true,
         "declaration": true,
-        "outDir": "dist"
+        "outDir": "dist",
+        "module": "ESNext",
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
I'm looking into what's needed to make JSObjectReference sufficient for our JS encapsulation needs.

It's not quite as trivial as I hoped - it's taken quite a while to figure out the magic combination of things needed. Also it's still not 100% working here, but the remaining changes are more to do with the JSObjectReference implementation so this is something to discuss with @MackinnonBuck.

## Goal

Developers should be able to add an ES6 module, for example creating `myfile.js` inside their `wwwroot` containing:

```js
export function doAlert(myVal) {
    alert('From the module: ' + myVal);
}
```

... and then consume it from a Blazor component:

```razor
@using Microsoft.JSInterop
@inject IJSRuntime JS

@code {
    async Task HandleSomeEvent()
    {
        var myModule = await JS.InvokeAsync<JSObjectReference>("import", "./myfile.js");
        await myModule.InvokeVoidAsync("doAlert", "My prompt here");
    }
}
```

Of course, they can also store the `myModule` instance and reuse it over time.