### PR TITLE
Record type follow ups:

### DIFF
--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -501,7 +501,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return;
             }
 
-            _recordTypeConstructorDetailsCalculated = true;
 
             var boundParameters = BoundConstructor!.BoundConstructorParameters!;
             var parameterMapping = new Dictionary<ModelMetadata, ModelMetadata>();

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.Extensions.Internal;
@@ -26,11 +28,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// </summary>
         public static readonly int DefaultOrder = 10000;
 
-        private static readonly IReadOnlyDictionary<ModelMetadata, ModelMetadata> EmptyParameterMapping = new Dictionary<ModelMetadata, ModelMetadata>(0);
-
         private int? _hashCode;
         private IReadOnlyList<ModelMetadata>? _boundProperties;
         private IReadOnlyDictionary<ModelMetadata, ModelMetadata>? _parameterMapping;
+        private Exception? _recordTypeValidatorsOnPropertiesError;
+        private bool _recordTypeConstructorDetailsCalculated;
 
         /// <summary>
         /// Creates a new <see cref="ModelMetadata"/>.
@@ -137,37 +139,16 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
         }
 
+        /// <summary>
+        /// A mapping from parameters to their corresponding properties on a record type.
+        /// </summary>
         internal IReadOnlyDictionary<ModelMetadata, ModelMetadata> BoundConstructorParameterMapping
         {
             get
             {
-                if (_parameterMapping != null)
-                {
-                    return _parameterMapping;
-                }
+                Debug.Assert(BoundConstructor != null, "This API can be only called for types with bound constructors.");
+                CalculateRecordTypeConstructorDetails();
 
-                if (BoundConstructor is null)
-                {
-                    _parameterMapping = EmptyParameterMapping;
-                    return _parameterMapping;
-                }
-
-                var boundParameters = BoundConstructor.BoundConstructorParameters!;
-                var parameterMapping = new Dictionary<ModelMetadata, ModelMetadata>();
-
-                foreach (var parameter in boundParameters)
-                {
-                    var property = Properties.FirstOrDefault(p =>
-                        string.Equals(p.Name, parameter.ParameterName, StringComparison.Ordinal) &&
-                        p.ModelType == parameter.ModelType);
-
-                    if (property != null)
-                    {
-                        parameterMapping[parameter] = property;
-                    }
-                }
-
-                _parameterMapping = parameterMapping;
                 return _parameterMapping;
             }
         }
@@ -493,6 +474,62 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
         /// Gets a delegate that invokes the bound constructor <see cref="BoundConstructor" /> if non-<see langword="null" />.
         /// </summary>
         public virtual Func<object[], object>? BoundConstructorInvoker => null;
+
+        /// <summary>
+        /// Gets a value that determines if validators can be constructed using metadata exclusively defined on the property.
+        /// </summary>
+        internal virtual bool PropertyHasValidators => false;
+
+        /// <summary>
+        /// Throws if the ModelMetadata is for a record type with validation on properties.
+        /// </summary>
+        internal void ThrowIfRecordTypeHasValidationOnProperties()
+        {
+            CalculateRecordTypeConstructorDetails();
+            if (_recordTypeValidatorsOnPropertiesError != null)
+            {
+                throw _recordTypeValidatorsOnPropertiesError;
+            }
+        }
+
+        [MemberNotNull(nameof(_parameterMapping))]
+        private void CalculateRecordTypeConstructorDetails()
+        {
+            if (_recordTypeConstructorDetailsCalculated)
+            {
+                Debug.Assert(_parameterMapping != null);
+                return;
+            }
+
+            _recordTypeConstructorDetailsCalculated = true;
+
+            var boundParameters = BoundConstructor!.BoundConstructorParameters!;
+            var parameterMapping = new Dictionary<ModelMetadata, ModelMetadata>();
+
+            foreach (var parameter in boundParameters)
+            {
+                var property = Properties.FirstOrDefault(p =>
+                    string.Equals(p.Name, parameter.ParameterName, StringComparison.Ordinal) &&
+                    p.ModelType == parameter.ModelType);
+
+                if (property != null)
+                {
+                    parameterMapping[parameter] = property;
+
+                    if (property.PropertyHasValidators)
+                    {
+                        // When constructing the mapping of paramets -> properties, also determine
+                        // if the property has any validators (without looking at metadata on the type).
+                        // This will help us throw during validation if a user defines validation attributes
+                        // on the property of a record type.
+                        _recordTypeValidatorsOnPropertiesError = new InvalidOperationException(
+                            Resources.FormatRecordTypeHasValidationOnProperties(ModelType, property.Name));
+                    }
+                }
+            }
+
+            _parameterMapping = parameterMapping;
+        }
 
         /// <summary>
         /// Gets a display name for the model.

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -527,6 +527,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 }
             }
 
+             _recordTypeConstructorDetailsCalculated = true;
             _parameterMapping = parameterMapping;
         }
 

--- a/src/Mvc/Mvc.Abstractions/src/Resources.resx
+++ b/src/Mvc/Mvc.Abstractions/src/Resources.resx
@@ -177,4 +177,7 @@
   <data name="BinderType_MustBeIModelBinder" xml:space="preserve">
     <value>The type '{0}' must implement '{1}' to be used as a model binder.</value>
   </data>
+  <data name="RecordTypeHasValidationOnProperties" xml:space="preserve">
+    <value>Record type '{0}' has validation metadata defined on property '{1}' that will be ignored. Consider specifying these on the constructor parameter '{1}' instead.</value>
+  </data>
 </root>

--- a/src/Mvc/Mvc.Abstractions/src/Resources.resx
+++ b/src/Mvc/Mvc.Abstractions/src/Resources.resx
@@ -178,6 +178,6 @@
     <value>The type '{0}' must implement '{1}' to be used as a model binder.</value>
   </data>
   <data name="RecordTypeHasValidationOnProperties" xml:space="preserve">
-    <value>Record type '{0}' has validation metadata defined on property '{1}' that will be ignored. Consider specifying these on the constructor parameter '{1}' instead.</value>
+    <value>Record type '{0}' has validation metadata defined on property '{1}' that will be ignored. '{1}' is a parameter in the record primary constructor and validation metadata must specified against the constructor parameter.</value>
   </data>
 </root>

--- a/src/Mvc/Mvc.Abstractions/src/Resources.resx
+++ b/src/Mvc/Mvc.Abstractions/src/Resources.resx
@@ -178,6 +178,6 @@
     <value>The type '{0}' must implement '{1}' to be used as a model binder.</value>
   </data>
   <data name="RecordTypeHasValidationOnProperties" xml:space="preserve">
-    <value>Record type '{0}' has validation metadata defined on property '{1}' that will be ignored. '{1}' is a parameter in the record primary constructor and validation metadata must be specified against the constructor parameter.</value>
+    <value>Record type '{0}' has validation metadata defined on property '{1}' that will be ignored. '{1}' is a parameter in the record primary constructor and validation metadata must be associated with the constructor parameter.</value>
   </data>
 </root>

--- a/src/Mvc/Mvc.Abstractions/src/Resources.resx
+++ b/src/Mvc/Mvc.Abstractions/src/Resources.resx
@@ -178,6 +178,6 @@
     <value>The type '{0}' must implement '{1}' to be used as a model binder.</value>
   </data>
   <data name="RecordTypeHasValidationOnProperties" xml:space="preserve">
-    <value>Record type '{0}' has validation metadata defined on property '{1}' that will be ignored. '{1}' is a parameter in the record primary constructor and validation metadata must specified against the constructor parameter.</value>
+    <value>Record type '{0}' has validation metadata defined on property '{1}' that will be ignored. '{1}' is a parameter in the record primary constructor and validation metadata must be specified against the constructor parameter.</value>
   </data>
 </root>

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
@@ -79,8 +79,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             if (boundConstructor != null)
             {
-                // To bind record we need to instantiate the type. This means we'll ignore a previously
-                // assigned bindingContext.Model value.
+                // Only record types are allowed to have a BoundConstructor. Binding a record type requires
+                // instantiating the type. This means we'll ignore a previously assigned bindingContext.Model value.
                 // This behaior is identical to input formatting with S.T.Json and Json.NET.
  
                 var values = new object[boundConstructor.BoundConstructorParameters.Count];

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
@@ -75,31 +75,32 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             var bindingSucceeded = false;
 
             var modelMetadata = bindingContext.ModelMetadata;
+            var boundConstructor = modelMetadata.BoundConstructor;
 
-            if (bindingContext.Model == null)
+            if (boundConstructor != null)
             {
-                var boundConstructor = modelMetadata.BoundConstructor;
-                if (boundConstructor != null)
-                {
-                    var values = new object[boundConstructor.BoundConstructorParameters.Count];
-                    var (attemptedParameterBinding, parameterBindingSucceeded) = await BindParametersAsync(
-                        bindingContext,
-                        propertyData,
-                        boundConstructor.BoundConstructorParameters,
-                        values);
+                // To bind record we need to instantiate the type. This means we'll ignore a previously
+                // assigned bindingContext.Model value.
+                // This behaior is identical to input formatting with S.T.Json and Json.NET.
+ 
+                var values = new object[boundConstructor.BoundConstructorParameters.Count];
+                var (attemptedParameterBinding, parameterBindingSucceeded) = await BindParametersAsync(
+                    bindingContext,
+                    propertyData,
+                    boundConstructor.BoundConstructorParameters,
+                    values);
 
-                    attemptedBinding |= attemptedParameterBinding;
-                    bindingSucceeded |= parameterBindingSucceeded;
+                attemptedBinding |= attemptedParameterBinding;
+                bindingSucceeded |= parameterBindingSucceeded;
 
-                    if (!CreateModel(bindingContext, boundConstructor, values))
-                    {
-                        return;
-                    }
-                }
-                else
+                if (!CreateModel(bindingContext, boundConstructor, values))
                 {
-                    CreateModel(bindingContext);
+                    return;
                 }
+            }
+            else if (bindingContext.Model == null)
+            {
+                CreateModel(bindingContext);
             }
 
             var (attemptedPropertyBinding, propertyBindingSucceeded) = await BindPropertiesAsync(

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultBindingMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultBindingMetadataProvider.cs
@@ -143,8 +143,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             static bool IsRecordType(Type type)
             {
                 // Based on the state of the art as described in https://github.com/dotnet/roslyn/issues/45777
-                var cloneMethod = type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance) ??
-                    type.GetMethod("<>Clone", BindingFlags.Public | BindingFlags.Instance);
+                var cloneMethod = type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance);
                 return cloneMethod != null && cloneMethod.ReturnType == type;
             }
         }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultModelMetadata.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultModelMetadata.cs
@@ -468,6 +468,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             }
         }
 
+        internal override bool PropertyHasValidators => ValidationMetadata.PropertyHasValidators;
+
         internal static bool CalculateHasValidators(HashSet<DefaultModelMetadata> visited, ModelMetadata metadata)
         {
             RuntimeHelpers.EnsureSufficientExecutionStack();

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/HasValidatorsValidationMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/HasValidatorsValidationMetadataProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -40,7 +40,23 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
                 if (provider.HasValidators(context.Key.ModelType, context.ValidationMetadata.ValidatorMetadata))
                 {
                     context.ValidationMetadata.HasValidators = true;
-                    return;
+
+                    if (context.Key.MetadataKind == ModelMetadataKind.Property)
+                    {
+                        // For properties, additionally determine that if there's validators defined exclusively
+                        // from property attributes. This is later used to produce a error for record types
+                        // where a record type property that is bound as a parameter defines validation attributes.
+
+                        if (!(context.PropertyAttributes is IList<object> propertyAttributes))
+                        {
+                            propertyAttributes = context.PropertyAttributes.ToList();
+                        }
+
+                        if (provider.HasValidators(typeof(object), propertyAttributes))
+                        {
+                            context.ValidationMetadata.PropertyHasValidators = true;
+                        }
+                    }
                 }
             }
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ValidationMetadata.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ValidationMetadata.cs
@@ -46,5 +46,10 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
         /// Gets a value that indicates if the model has validators .
         /// </summary>
         public bool? HasValidators { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that determines if validators can be constructed using metadata on properties.
+        /// </summary>
+        internal bool PropertyHasValidators { get; set; }
     }
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/ModelBindingHelper.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/ModelBindingHelper.cs
@@ -268,6 +268,12 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             var modelMetadata = metadataProvider.GetMetadataForType(modelType);
+
+            if (modelMetadata.BoundConstructor != null)
+            {
+                throw new NotSupportedException(Resources.FormatTryUpdateModel_RecordTypeNotSupported(nameof(TryUpdateModelAsync), modelType));
+            }
+
             var modelState = actionContext.ModelState;
 
             var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Validation/DefaultComplexObjectValidationStrategy.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Validation/DefaultComplexObjectValidationStrategy.cs
@@ -58,6 +58,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
                 }
                 else
                 {
+                    _modelMetadata.ThrowIfRecordTypeHasValidationOnProperties();
                     _parameters = _modelMetadata.BoundConstructor.BoundConstructorParameters;
                 }
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Validation/ValidationVisitor.cs
@@ -304,6 +304,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation
             else if (metadata.HasValidators == false &&
                 ModelState.GetFieldValidationState(key) != ModelValidationState.Invalid)
             {
+                if (metadata.BoundConstructor != null)
+                {
+                    metadata.ThrowIfRecordTypeHasValidationOnProperties();
+                }
+
                 // No validators will be created for this graph of objects. Mark it as valid if it wasn't previously validated.
                 var entries = ModelState.FindKeysWithPrefix(key);
                 foreach (var item in entries)

--- a/src/Mvc/Mvc.Core/src/Resources.resx
+++ b/src/Mvc/Mvc.Core/src/Resources.resx
@@ -535,6 +535,6 @@
     <value>No property found that maps to constructor parameter '{0}' for type '{1}'. Validation requires that each bound parameter of a record type's primary constructor must have a property to read the value.</value>
   </data>
   <data name="TryUpdateModel_RecordTypeNotSupported" xml:space="preserve">
-    <value>{0} is not supported on record type model '{1}'.</value>
+    <value>{0} cannot update a record type model. If a '{1}' must be updated, include it in an object type.</value>
   </data>
 </root>

--- a/src/Mvc/Mvc.Core/src/Resources.resx
+++ b/src/Mvc/Mvc.Core/src/Resources.resx
@@ -534,4 +534,7 @@
   <data name="ValidationStrategy_MappedPropertyNotFound" xml:space="preserve">
     <value>No property found that maps to constructor parameter '{0}' for type '{1}'. Validation requires that each bound parameter of a record type's primary constructor must have a property to read the value.</value>
   </data>
+  <data name="TryUpdateModel_RecordTypeNotSupported" xml:space="preserve">
+    <value>{0} is not supported on record type model '{1}'.</value>
+  </data>
 </root>

--- a/src/Mvc/test/Mvc.FunctionalTests/SystemTextJsonInputFormatterTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/SystemTextJsonInputFormatterTest.cs
@@ -17,11 +17,11 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         public override Task JsonInputFormatter_RoundtripsRecordType()
             => base.JsonInputFormatter_RoundtripsRecordType();
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/38539")]
+        [Fact]
         public override Task JsonInputFormatter_ValidationWithRecordTypes_NoValidationErrors()
             => base.JsonInputFormatter_ValidationWithRecordTypes_NoValidationErrors();
 
-        [Fact(Skip = "https://github.com/dotnet/runtime/issues/38539")]
+        [Fact]
         public override Task JsonInputFormatter_ValidationWithRecordTypes_ValidationErrors()
             => base.JsonInputFormatter_ValidationWithRecordTypes_ValidationErrors();
     }

--- a/src/Mvc/test/Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/TryUpdateModelIntegrationTest.cs
@@ -1163,7 +1163,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
             // Act & Assert
             var ex = await Assert.ThrowsAsync<NotSupportedException>(() => TryUpdateModelAsync(model, string.Empty, testContext));
-            Assert.Equal($"TryUpdateModelAsync is not supported on record type model '{model.GetType()}'.", ex.Message);
+            Assert.Equal($"TryUpdateModelAsync cannot update a record type model. If a '{model.GetType()}' must be updated, include it in an object type." , ex.Message);
 
         }
 

--- a/src/Mvc/test/Mvc.IntegrationTests/ValidationWithRecordIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ValidationWithRecordIntegrationTests.cs
@@ -2313,7 +2313,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var modelMetadata = modelMetadataProvider.GetMetadataForType(modelType);
             var parameterBinder = ModelBindingTestHelper.GetParameterBinder(modelMetadataProvider);
             var expected = $"Record type '{modelType}' has validation metadata defined on property 'Property1' that will be ignored. " +
-                "'Property1' is a parameter in the record primary constructor and validation metadata must be specified against the constructor parameter.";
+                "'Property1' is a parameter in the record primary constructor and validation metadata must be associated with the constructor parameter.";
 
             var parameter = new ParameterDescriptor()
             {
@@ -2350,7 +2350,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var modelMetadata = modelMetadataProvider.GetMetadataForType(modelType);
             var parameterBinder = ModelBindingTestHelper.GetParameterBinder(modelMetadataProvider);
             var expected = $"Record type '{modelType}' has validation metadata defined on property 'Property1' that will be ignored. " +
-                "'Property1' is a parameter in the record primary constructor and validation metadata must be specified against the constructor parameter.";
+                "'Property1' is a parameter in the record primary constructor and validation metadata must be associated with the constructor parameter.";
 
             var parameter = new ParameterDescriptor()
             {
@@ -2389,7 +2389,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             var modelMetadata = modelMetadataProvider.GetMetadataForType(modelType);
             var parameterBinder = ModelBindingTestHelper.GetParameterBinder(modelMetadataProvider);
             var expected = $"Record type '{modelType}' has validation metadata defined on property 'Property2' that will be ignored. " +
-                "'Property2' is a parameter in the record primary constructor and validation metadata must be specified against the constructor parameter.";
+                "'Property2' is a parameter in the record primary constructor and validation metadata must be associated with the constructor parameter.";
 
             var parameter = new ParameterDescriptor()
             {

--- a/src/Mvc/test/Mvc.IntegrationTests/ValidationWithRecordIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ValidationWithRecordIntegrationTests.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             Assert.Equal("The value '-123' is not valid.", error.ErrorMessage);
         }
 
-        private record NeverValid(string NeverValidProperty)  : IValidatableObject
+        private record NeverValid(string NeverValidProperty) : IValidatableObject
         {
             public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
             {
@@ -2297,6 +2297,119 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
         }
 
         private static void Validation_InifnitelyRecursiveModel_ValidationOnTopLevelParameterMethod([Required] RecursiveModel model) { }
+
+        [Fact]
+        public async Task Validation_ValidatorsDefinedOnRecordTypeProperties()
+        {
+            // Arrange
+            var modelType = typeof(RecordTypeWithValidatorsOnProperties);
+            var modelMetadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var modelMetadata = modelMetadataProvider.GetMetadataForType(modelType);
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder(modelMetadataProvider);
+            var expected = $"Record type '{modelType}' has validation metadata defined on property 'Property1' that will be ignored. " +
+                "Consider specifying these on the constructor parameter 'Property1' instead.";
+
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = modelType,
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(request =>
+            {
+                request.QueryString = new QueryString("?Property1=8");
+            });
+
+            var modelState = testContext.ModelState;
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                parameterBinder.BindModelAsync(parameter, testContext, modelMetadataProvider, modelMetadata));
+
+            Assert.Equal(expected, ex.Message);
+        }
+
+        private record RecordTypeWithValidatorsOnProperties(string Property1)
+        {
+            [Required]
+            public string Property1 { get; init; }
+        }
+
+        [Fact]
+        public async Task Validation_ValidatorsDefinedOnRecordTypePropertiesAndParameters()
+        {
+            // Arrange
+            var modelType = typeof(RecordTypeWithValidatorsOnPropertiesAndParameters);
+            var modelMetadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var modelMetadata = modelMetadataProvider.GetMetadataForType(modelType);
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder(modelMetadataProvider);
+            var expected = $"Record type '{modelType}' has validation metadata defined on property 'Property1' that will be ignored. " +
+                "Consider specifying these on the constructor parameter 'Property1' instead.";
+
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = modelType,
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(request =>
+            {
+                request.QueryString = new QueryString("?Property1=8");
+            });
+
+            var modelState = testContext.ModelState;
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                parameterBinder.BindModelAsync(parameter, testContext, modelMetadataProvider, modelMetadata));
+
+            Assert.Equal(expected, ex.Message);
+        }
+
+        private record RecordTypeWithValidatorsOnPropertiesAndParameters([Required] string Property1)
+        {
+            [Required]
+            public string Property1 { get; init; }
+        }
+
+        [Fact]
+        public async Task Validation_ValidatorsDefinedOnMixOfRecordTypePropertiesAndParameters()
+        {
+            // Variation of Validation_ValidatorsDefinedOnRecordTypePropertiesAndParameters, but validators
+            // appear on a mix of properties and parameters.
+            // Arrange
+            var modelType = typeof(RecordTypeWithValidatorsOnMixOfPropertiesAndParameters);
+            var modelMetadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var modelMetadata = modelMetadataProvider.GetMetadataForType(modelType);
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder(modelMetadataProvider);
+            var expected = $"Record type '{modelType}' has validation metadata defined on property 'Property2' that will be ignored. " +
+                "Consider specifying these on the constructor parameter 'Property2' instead.";
+
+            var parameter = new ParameterDescriptor()
+            {
+                Name = "parameter",
+                ParameterType = modelType,
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(request =>
+            {
+                request.QueryString = new QueryString("?Property1=8");
+            });
+
+            var modelState = testContext.ModelState;
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                parameterBinder.BindModelAsync(parameter, testContext, modelMetadataProvider, modelMetadata));
+
+            Assert.Equal(expected, ex.Message);
+        }
+
+        private record RecordTypeWithValidatorsOnMixOfPropertiesAndParameters([Required] string Property1, string Property2)
+        {
+            [Required]
+            public string Property2 { get; init; }
+        }
 
         private static void AssertRequiredError(string key, ModelError error)
         {


### PR DESCRIPTION
* Throw an error if a record type property has validation metadata
* Disallow TryUpdateModel on a top-level record type
* Ignore previously specified model value when binding a record type
* Unskip record type tests
* Clean up record type detection

Fixes https://github.com/dotnet/aspnetcore/issues/24265