### PR TITLE
Call inner disable buffering feature

### DIFF
--- a/src/Http/Http/src/StreamResponseBodyFeature.cs
+++ b/src/Http/Http/src/StreamResponseBodyFeature.cs
@@ -75,6 +75,7 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         public virtual void DisableBuffering()
         {
+            PriorFeature?.DisableBuffering();
         }
 
         /// <summary>

--- a/src/Http/Http/src/StreamResponseBodyFeature.cs
+++ b/src/Http/Http/src/StreamResponseBodyFeature.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Http
         }
 
         /// <summary>
-        /// Not supported.
+        /// Opts out of write buffering for the response.
         /// </summary>
         public virtual void DisableBuffering()
         {

--- a/src/Http/Http/test/Features/StreamResponseBodyFeatureTests.cs
+++ b/src/Http/Http/test/Features/StreamResponseBodyFeatureTests.cs
@@ -41,6 +41,22 @@ namespace Microsoft.AspNetCore.Http.Features
             //Assert
             Assert.Equal(1, streamResponseBodyFeature.StartCalled);
         }
+
+        [Fact]
+        public void DisableBufferingCallsInnerFeature()
+        {
+            // Arrange
+            var stream = new MemoryStream();
+
+            var innerFeature = new InnerDisableBufferingFeature(stream, null);
+            var streamResponseBodyFeature = new StreamResponseBodyFeature(stream, innerFeature);
+
+            // Act
+            streamResponseBodyFeature.DisableBuffering();
+
+            //Assert
+            Assert.True(innerFeature.DisableBufferingCalled);
+        }
     }
 
     public class TestStreamResponseBodyFeature : StreamResponseBodyFeature
@@ -58,5 +74,20 @@ namespace Microsoft.AspNetCore.Http.Features
         }
 
         public int StartCalled { get; private set; }
+    }
+
+    public class InnerDisableBufferingFeature : StreamResponseBodyFeature
+    {
+        public InnerDisableBufferingFeature(Stream stream, IHttpResponseBodyFeature priorFeature)
+            : base(stream, priorFeature)
+        {
+        }
+
+        public override void DisableBuffering()
+        {
+            DisableBufferingCalled = true;
+        }
+
+        public bool DisableBufferingCalled { get; set; }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/20498

The issue was that SignalR for SSE calls DisableBuffering, which should call into IIS and disable buffering there. However, because the default StreamResponseBodyFeature noops in DisableBuffering rather than calling the inner feature, DisableBuffer is never called.