### PR TITLE
Support pseudoelements in CSS scoping

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 // of the W3C spec. Our CSS parser sees them as pseudoselectors rather than pseudoelements, so
                 // we have to special-case them. The single-colon option doesn't exist for other more modern
                 // pseudoelements.
-                switch (selector.Text)
+                switch (selector.Text?.ToLowerInvariant())
                 {
                     case ":after":
                     case ":before":

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
@@ -221,12 +221,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
                         case PseudoElementSelector:
                         case PseudoElementFunctionSelector:
                         case PseudoClassSelector s when IsSingleColonPseudoElement(s):
-                            if (i > 0)
-                            {
-                                var insertAfterChild = children[i - 1];
-                                return insertAfterChild.AfterEnd;
-                            }
-                            break;
+                            // Insert after the previous token if there is one, otherwise before the whole thing
+                            return i > 0 ? children[i - 1].AfterEnd : lastSimpleSelector.Start;
                     }
                 }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
@@ -239,16 +239,11 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 // of the W3C spec. Our CSS parser sees them as pseudoselectors rather than pseudoelements, so
                 // we have to special-case them. The single-colon option doesn't exist for other more modern
                 // pseudoelements.
-                switch (selector.Text?.ToLowerInvariant())
-                {
-                    case ":after":
-                    case ":before":
-                    case ":first-letter":
-                    case ":first-line":
-                        return true;
-                    default:
-                        return false;
-                }
+                var selectorText = selector.Text;
+                return string.Equals(selectorText, ":after", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(selectorText, ":before", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(selectorText, ":first-letter", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(selectorText, ":first-line", StringComparison.OrdinalIgnoreCase);
             }
 
             private static bool IsTrailingCombinator(CssTokenType tokenType)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/RewriteCssCommand.cs
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 var lastSimpleSelector = allSimpleSelectors.TakeWhile(s => s != firstDeepCombinator).LastOrDefault();
                 if (lastSimpleSelector != null)
                 {
-                    Edits.Add(new InsertSelectorScopeEdit { Position = FindPositionBeforeTrailingCombinator(lastSimpleSelector) });
+                    Edits.Add(new InsertSelectorScopeEdit { Position = FindPositionToInsertInSelector(lastSimpleSelector) });
                 }
                 else if (firstDeepCombinator != null)
                 {
@@ -203,28 +203,69 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 }
             }
 
-            private int FindPositionBeforeTrailingCombinator(SimpleSelector lastSimpleSelector)
+            private int FindPositionToInsertInSelector(SimpleSelector lastSimpleSelector)
             {
-                // For a selector like "a > ::deep b", the parser splits it as "a >", "::deep", "b".
-                // The place we want to insert the scope is right after "a", hence we need to detect
-                // if the simple selector ends with " >" or similar, and if so, insert before that.
-                var text = lastSimpleSelector.Text;
-                var lastChar = text.Length > 0 ? text[^1] : default;
-                switch (lastChar)
+                var children = lastSimpleSelector.Children;
+                for (var i  = 0; i < children.Count; i++)
                 {
-                    case '>':
-                    case '+':
-                    case '~':
-                        var trailingCombinatorMatch = _trailingCombinatorRegex.Match(text);
-                        if (trailingCombinatorMatch.Success)
-                        {
-                            var trailingCombinatorLength = trailingCombinatorMatch.Length;
-                            return lastSimpleSelector.AfterEnd - trailingCombinatorLength;
-                        }
-                        break;
+                    switch (children[i])
+                    {
+                        // Selectors like "a > ::deep b" get parsed as [[a][>]][::deep][b], and we want to
+                        // insert right after the "a". So if we're processing a SimpleSelector like [[a][>]],
+                        // consider the ">" to signal the "insert before" position.
+                        case TokenItem t when IsTrailingCombinator(t.TokenType):
+
+                        // Similarly selectors like "a::before" get parsed as [[a][::before]], and we want to
+                        // insert right after the "a".  So if we're processing a SimpleSelector like [[a][::before]],
+                        // consider the pseudoelement to signal the "insert before" position.
+                        case PseudoElementSelector:
+                        case PseudoElementFunctionSelector:
+                        case PseudoClassSelector s when IsSingleColonPseudoElement(s):
+                            if (i > 0)
+                            {
+                                var insertAfterChild = children[i - 1];
+                                return insertAfterChild.AfterEnd;
+                            }
+                            break;
+                    }
                 }
 
+                // Since we didn't find any children that signal the insert-before position,
+                // insert after the whole thing
                 return lastSimpleSelector.AfterEnd;
+            }
+
+            private static bool IsSingleColonPseudoElement(PseudoClassSelector selector)
+            {
+                // See https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements
+                // Normally, pseudoelements require a double-colon prefix. However the following "original set"
+                // of pseudoelements also support single-colon prefixes for back-compatibility with older versions
+                // of the W3C spec. Our CSS parser sees them as pseudoselectors rather than pseudoelements, so
+                // we have to special-case them. The single-colon option doesn't exist for other more modern
+                // pseudoelements.
+                switch (selector.Text)
+                {
+                    case ":after":
+                    case ":before":
+                    case ":first-letter":
+                    case ":first-line":
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+
+            private static bool IsTrailingCombinator(CssTokenType tokenType)
+            {
+                switch (tokenType)
+                {
+                    case CssTokenType.Plus:
+                    case CssTokenType.Tilde:
+                    case CssTokenType.Greater:
+                        return true;
+                    default:
+                        return false;
+                }
             }
 
             protected override void VisitAtDirective(AtDirective item)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
@@ -41,6 +41,9 @@ namespace Microsoft.AspNetCore.Razor.Tools
             var result = RewriteCssCommand.AddScopeToSelectors("file.css", @"
     .first, .second { color: red; }
     .third { color: blue; }
+    :root { color: green; }
+    * { color: white; }
+    #some-id { color: yellow; }
 ", "TestScope", out var diagnostics);
 
             // Assert
@@ -48,6 +51,9 @@ namespace Microsoft.AspNetCore.Razor.Tools
             Assert.Equal(@"
     .first[TestScope], .second[TestScope] { color: red; }
     .third[TestScope] { color: blue; }
+    :root[TestScope] { color: green; }
+    *[TestScope] { color: white; }
+    #some-id[TestScope] { color: yellow; }
 ", result);
         }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
     a::after::placeholder { content: ""🐯""; }
     custom-element::part(foo) { content: ""🤷‍""; }
     a::before > ::deep another { content: ""👞""; }
-    a::fake-pseudo-element { content: ""🐔""; }
+    a::fake-PsEuDo-element { content: ""🐔""; }
     ::selection { content: ""😾""; }
     other, ::selection { content: ""👂""; }
 ", "TestScope", out var diagnostics);
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
     a[TestScope]::after::placeholder { content: ""🐯""; }
     custom-element[TestScope]::part(foo) { content: ""🤷‍""; }
     a[TestScope]::before >  another { content: ""👞""; }
-    a[TestScope]::fake-pseudo-element { content: ""🐔""; }
+    a[TestScope]::fake-PsEuDo-element { content: ""🐔""; }
     [TestScope]::selection { content: ""😾""; }
     other[TestScope], [TestScope]::selection { content: ""👂""; }
 ", result);
@@ -148,6 +148,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
     a:before { content: ""x""; }
     a:first-letter { content: ""x""; }
     a:first-line { content: ""x""; }
+    a:AFTER { content: ""x""; }
     a:not(something):before { content: ""x""; }
 ", "TestScope", out var diagnostics);
 
@@ -158,6 +159,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
     a[TestScope]:before { content: ""x""; }
     a[TestScope]:first-letter { content: ""x""; }
     a[TestScope]:first-line { content: ""x""; }
+    a[TestScope]:AFTER { content: ""x""; }
     a:not(something)[TestScope]:before { content: ""x""; }
 ", result);
         }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/RewriteCssCommandTest.cs
@@ -122,6 +122,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
     custom-element::part(foo) { content: ""🤷‍""; }
     a::before > ::deep another { content: ""👞""; }
     a::fake-pseudo-element { content: ""🐔""; }
+    ::selection { content: ""😾""; }
+    other, ::selection { content: ""👂""; }
 ", "TestScope", out var diagnostics);
 
             // Assert
@@ -132,6 +134,8 @@ namespace Microsoft.AspNetCore.Razor.Tools
     custom-element[TestScope]::part(foo) { content: ""🤷‍""; }
     a[TestScope]::before >  another { content: ""👞""; }
     a[TestScope]::fake-pseudo-element { content: ""🐔""; }
+    [TestScope]::selection { content: ""😾""; }
+    other[TestScope], [TestScope]::selection { content: ""👂""; }
 ", result);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/25268

Without this, the new test cases `HandlesPseudoElements` and `HandlesSingleColonPseudoElements` (added in this PR) would fail.

Note that the new test case `HandlesPseudoClasses` (also added in this PR) would pass even without the implementation change, but it's good to have more test cases explicitly about pseudoclasses to make sure the pseudoelement support doesn't trip them up.

## Ask-mode template

#### Description

The new CSS scoping feature, first shipped in 5.0-preview8, contains a bug whereby a particular kind of CSS rule doesn't get scoped properly.

#### Customer Impact

This was reported by a customer: https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-5-preview-8/#comment-2540

The impact is that CSS pseudoelements don't work with CSS scoping, so the application UI doesn't render with the intended styling.

The only workaround would be for the developer to change their CSS to avoid having this combination of features, which probably means not using scoping.

It's very desirable to include the fix in RC1 because we want to be sure the CSS scoping feature is totally robust by the time it ships. If we don't include the fix, then customers won't get a ship-ready-candidate version of the feature until RC2, and then there will be very little time left for remaining feedback.

#### Regression?

No, this is a new feature

#### Risk

In the worst case, this might theoretically introduce some other new bug into the CSS scoping feature. However, test coverage is pretty good, and it doesn't have interactions with other features.