### PR TITLE
Set SameSiteMode for cookies in authentication tests

### DIFF
--- a/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Startup.cs
+++ b/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Startup.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -56,6 +57,11 @@ namespace Wasm.Authentication.Server
                 app.UseDeveloperExceptionPage();
                 app.UseWebAssemblyDebugging();
             }
+
+            app.UseCookiePolicy(new CookiePolicyOptions
+            {
+                MinimumSameSitePolicy = SameSiteMode.Lax
+            });
 
             app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();

--- a/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Wasm.Authentication.Server.csproj
+++ b/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Wasm.Authentication.Server.csproj
@@ -10,10 +10,12 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.CookiePolicy" />
     <Reference Include="Microsoft.AspNetCore.Diagnostics" />
     <Reference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <Reference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.EntityFrameworkCore.Design" />
     <Reference Include="Microsoft.AspNetCore.Identity.UI" />
     <Reference Include="Microsoft.EntityFrameworkCore.Relational" />


### PR DESCRIPTION
Chrome (as of v80) enforces a strict check on cookie settings. Cookies set with SameSiteMode=None must be marked as secure.

The Identity.Server sets the SameSiteMode to None by default. This PR sets the SameSiteMode to `Lax` by default since the WASM auth tests do not run on an HTTPS server.

I verified this by confirming that a Register -> Log in -> visit preferences flow works on the Authentication app.