### PR TITLE
Fix SignalR typescript tests with Chrome SameSite reaction

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -163,12 +163,21 @@ namespace FunctionalTests
             {
                 if (context.Request.Path.Value.Contains("/negotiate"))
                 {
-                    context.Response.Cookies.Append("testCookie", "testValue",
-                        new CookieOptions() { SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None, Secure = true });
-                    context.Response.Cookies.Append("testCookie2", "testValue2",
-                        new CookieOptions() { SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None, Secure = true });
-                    context.Response.Cookies.Append("expiredCookie", "doesntmatter",
-                        new CookieOptions() { SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None, Secure = true, Expires = DateTimeOffset.Now.AddHours(-1) });
+                    var cookieOptions = new CookieOptions();
+                    var expiredCookieOptions = new CookieOptions() { Expires = DateTimeOffset.Now.AddHours(-1) };
+                    if (context.Request.IsHttps)
+                    {
+                        cookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
+                        cookieOptions.Secure = true;
+
+                        expiredCookieOptions.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None;
+                        expiredCookieOptions.Secure = true;
+                    }
+                    context.Response.Cookies.Append("testCookie", "testValue", cookieOptions);
+                    context.Response.Cookies.Append("testCookie2", "testValue2", cookieOptions);
+
+                    cookieOptions.Expires = DateTimeOffset.Now.AddHours(-1);
+                    context.Response.Cookies.Append("expiredCookie", "doesntmatter", expiredCookieOptions);
                 }
 
                 await next.Invoke();

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -163,9 +163,12 @@ namespace FunctionalTests
             {
                 if (context.Request.Path.Value.Contains("/negotiate"))
                 {
-                    context.Response.Cookies.Append("testCookie", "testValue");
-                    context.Response.Cookies.Append("testCookie2", "testValue2");
-                    context.Response.Cookies.Append("expiredCookie", "doesntmatter", new CookieOptions() { Expires = DateTimeOffset.Now.AddHours(-1) });
+                    context.Response.Cookies.Append("testCookie", "testValue",
+                        new CookieOptions() { SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None, Secure = true });
+                    context.Response.Cookies.Append("testCookie2", "testValue2",
+                        new CookieOptions() { SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None, Secure = true });
+                    context.Response.Cookies.Append("expiredCookie", "doesntmatter",
+                        new CookieOptions() { SameSite = Microsoft.AspNetCore.Http.SameSiteMode.None, Secure = true, Expires = DateTimeOffset.Now.AddHours(-1) });
                 }
 
                 await next.Invoke();

--- a/src/SignalR/clients/ts/FunctionalTests/ts/Common.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/Common.ts
@@ -60,6 +60,7 @@ console.log(`Using SignalR HTTPS Server: '${ENDPOINT_BASE_HTTPS_URL}'`);
 console.log(`Jasmine DEFAULT_TIMEOUT_INTERVAL: ${jasmine.DEFAULT_TIMEOUT_INTERVAL}`);
 
 export const ECHOENDPOINT_URL = ENDPOINT_BASE_URL + "/echo";
+export const HTTPS_ECHOENDPOINT_URL = ENDPOINT_BASE_HTTPS_URL + "/echo";
 
 export function getHttpTransportTypes(): HttpTransportType[] {
     const transportTypes = [];
@@ -131,3 +132,14 @@ export function eachHttpClient(action: (transport: HttpClient) => void) {
         return action(t);
     });
 }
+
+// Run test in Node or Chrome, but not on macOS
+export const shouldRunHttpsTests =
+    // Need to have an HTTPS URL
+    !!ENDPOINT_BASE_HTTPS_URL &&
+
+    // Run on Node, unless macOS
+    (process && process.platform !== "darwin") &&
+
+    // Only run under Chrome browser
+    (typeof navigator === "undefined" || navigator.userAgent.search("Chrome") !== -1);

--- a/src/SignalR/clients/ts/FunctionalTests/ts/ConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/ConnectionTests.ts
@@ -5,7 +5,7 @@
 // tslint:disable:no-floating-promises
 
 import { HttpTransportType, IHttpConnectionOptions, TransferFormat } from "@microsoft/signalr";
-import { DEFAULT_TIMEOUT_INTERVAL, eachHttpClient, eachTransport, ECHOENDPOINT_URL } from "./Common";
+import { DEFAULT_TIMEOUT_INTERVAL, eachHttpClient, eachTransport, ECHOENDPOINT_URL, HTTPS_ECHOENDPOINT_URL, shouldRunHttpsTests } from "./Common";
 import { TestLogger } from "./TestLogger";
 
 // We want to continue testing HttpConnection, but we don't export it anymore. So just pull it in directly from the source file.
@@ -15,6 +15,8 @@ import "./LogBannerReporter";
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = DEFAULT_TIMEOUT_INTERVAL;
 
+const USED_ECHOENDPOINT_URL = shouldRunHttpsTests ? HTTPS_ECHOENDPOINT_URL : ECHOENDPOINT_URL;
+
 const commonOptions: IHttpConnectionOptions = {
     logMessageContent: true,
     logger: TestLogger.instance,
@@ -23,7 +25,7 @@ const commonOptions: IHttpConnectionOptions = {
 describe("connection", () => {
     it("can connect to the server without specifying transport explicitly", (done) => {
         const message = "Hello World!";
-        const connection = new HttpConnection(ECHOENDPOINT_URL, {
+        const connection = new HttpConnection(USED_ECHOENDPOINT_URL, {
             ...commonOptions,
         });
 
@@ -53,7 +55,7 @@ describe("connection", () => {
                     const message = "Hello World!";
                     // the url should be resolved relative to the document.location.host
                     // and the leading '/' should be automatically added to the url
-                    const connection = new HttpConnection(ECHOENDPOINT_URL, {
+                    const connection = new HttpConnection(USED_ECHOENDPOINT_URL, {
                         ...commonOptions,
                         httpClient,
                         transport: transportType,
@@ -83,7 +85,7 @@ describe("connection", () => {
                     const message = "Hello World!";
 
                     // DON'T use commonOptions because we want to specifically test the scenario where logMessageContent is not set.
-                    const connection = new HttpConnection(ECHOENDPOINT_URL, {
+                    const connection = new HttpConnection(USED_ECHOENDPOINT_URL, {
                         httpClient,
                         logger: TestLogger.instance,
                         transport: transportType,
@@ -119,7 +121,7 @@ describe("connection", () => {
                     const message = "Hello World!";
 
                     // DON'T use commonOptions because we want to specifically test the scenario where logMessageContent is set to true (even if commonOptions changes).
-                    const connection = new HttpConnection(ECHOENDPOINT_URL, {
+                    const connection = new HttpConnection(USED_ECHOENDPOINT_URL, {
                         httpClient,
                         logMessageContent: true,
                         logger: TestLogger.instance,
@@ -167,7 +169,7 @@ describe("connection", () => {
                         const message = "Hello World!";
 
                         // The server will set some response headers for the '/negotiate' endpoint
-                        const connection = new HttpConnection(ECHOENDPOINT_URL, {
+                        const connection = new HttpConnection(USED_ECHOENDPOINT_URL, {
                             ...commonOptions,
                             httpClient,
                             transport: transportType,


### PR DESCRIPTION
Chrome released its SameSite cookie support on 8/25 which broke some tests that used cookies cross-domain. This fixes the tests.