### PR TITLE
Add TypeReference class to signalr java client

### DIFF
--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -718,6 +718,7 @@ public class HubConnection implements AutoCloseable {
 
     /**
      * Invokes a hub method on the server using the specified method name and arguments.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param returnType The expected return type.
      * @param method The name of the server method to invoke.
@@ -1097,6 +1098,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1113,6 +1115,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1133,6 +1136,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1157,6 +1161,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1183,6 +1188,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1212,6 +1218,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1243,6 +1250,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1277,6 +1285,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
+     * A Type can be retrieved from a Class by using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -718,7 +718,7 @@ public class HubConnection implements AutoCloseable {
 
     /**
      * Invokes a hub method on the server using the specified method name and arguments.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param returnType The expected return type.
      * @param method The name of the server method to invoke.
@@ -1098,7 +1098,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1115,7 +1115,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1136,7 +1136,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1161,7 +1161,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1188,7 +1188,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1218,7 +1218,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1250,7 +1250,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.
@@ -1285,7 +1285,7 @@ public class HubConnection implements AutoCloseable {
     /**
      * Registers a handler that will be invoked when the hub method with the specified method name is invoked.
      * Should be used for generic classes and Parameterized Collections, like List or Map.
-     * A Type can be retrieved from a Class by using {@link TypeReference}
+     * A Type can be retrieved using {@link TypeReference}
      *
      * @param target   The name of the hub method to define.
      * @param callback The handler that will be raised when the hub method is invoked.

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/TypeReference.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/TypeReference.java
@@ -7,7 +7,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.ParameterizedType;
 
 /**
- * A utility for getting a Java Type from a literal Class
+ * A utility for getting a Java Type from a literal Class.
  */
 public class TypeReference<T> {
 

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/TypeReference.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/TypeReference.java
@@ -16,7 +16,7 @@ public class TypeReference<T> {
      * To get the Type of Class Foo, use the following syntax:
      * <pre>{@code
      * Type fooType = (new TypeReference<Foo>() { }).getType();
-     * </pre>
+     * }</pre>
      */
     public TypeReference() {
         Type superclass = getClass().getGenericSuperclass();

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/TypeReference.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/TypeReference.java
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.ParameterizedType;
+
+public class TypeReference<T> {
+
+    private final Type type;
+
+    /**
+     * Creates a new instance of {@link TypeReference}.
+     *
+     * To get the Type of Class Foo, use the following syntax:
+     * <pre>{@code
+     * Type fooType = (new TypeReference<Foo>() { }).getType();
+     * </pre>
+     */
+    public TypeReference() {
+        Type superclass = getClass().getGenericSuperclass();
+        if (superclass instanceof Class) {
+            throw new RuntimeException("Missing type parameter.");
+        }
+        this.type = ((ParameterizedType) superclass).getActualTypeArguments()[0];
+    }
+
+    /**
+     * Gets the referenced type.
+     */ 
+    public Type getType() {
+        return this.type;
+    }
+}

--- a/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/TypeReference.java
+++ b/src/SignalR/clients/java/signalr/src/main/java/com/microsoft/signalr/TypeReference.java
@@ -6,6 +6,9 @@ package com.microsoft.signalr;
 import java.lang.reflect.Type;
 import java.lang.reflect.ParameterizedType;
 
+/**
+ * A utility for getting a Java Type from a literal Class
+ */
 public class TypeReference<T> {
 
     private final Type type;

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/HubConnectionTest.java
@@ -18,8 +18,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
 import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/JsonHubProtocolTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/JsonHubProtocolTest.java
@@ -13,8 +13,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
 class JsonHubProtocolTest {
     private JsonHubProtocol jsonHubProtocol = new JsonHubProtocol();
 

--- a/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/MessagePackHubProtocolTest.java
+++ b/src/SignalR/clients/java/signalr/src/test/java/com/microsoft/signalr/MessagePackHubProtocolTest.java
@@ -19,8 +19,6 @@ import java.util.TreeMap;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
 class MessagePackHubProtocolTest {
     private MessagePackHubProtocol messagePackHubProtocol = new MessagePackHubProtocol();
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspnetcore/issues/25086

Provide a way for users of MessagePackHubProtocol to get a Type from a Class, rather than forcing them to figure out how to do it themselves.