### PR TITLE
Fix ClearsResponseBuffer_BeforeRequestIsReexecuted

### DIFF
--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -145,15 +145,14 @@ namespace Microsoft.AspNetCore.Diagnostics
                             try
                             {
                                 await next();
-
-                                response.Body = originalResponseBody;
-                                bufferingStream.Seek(0, SeekOrigin.Begin);
-                                await bufferingStream.CopyToAsync(response.Body);
                             }
                             finally
                             {
                                 response.Body = originalResponseBody;
                             }
+
+                            bufferingStream.Seek(0, SeekOrigin.Begin);
+                            await bufferingStream.CopyToAsync(response.Body);
                         });
 
                         app.UseExceptionHandler("/handle-errors");


### PR DESCRIPTION
Fixes #24146 Test only fix. We're still taking test fixes into release/5.0 right?

The `response.Body` was being restored twice, causing an extra StreamResponseBodyFeature to be created and not be properly disposed. The automatic disposal kicked in at the end of the request, tried to flush the body, and threw because the body was already completed.
https://github.com/dotnet/aspnetcore/blob/4e01bbe4cfeb8d63cf5ac40fcf1a6a7c77c7e911/src/Http/Http/src/Internal/DefaultHttpResponse.cs#L67-L89