### PR TITLE
Change hosting tests to use TCS instead of manual reset events

### DIFF
--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -73,14 +73,14 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
                 {
                     await deployer.DeployAsync();
 
-                    var started = new ManualResetEventSlim();
-                    var completed = new ManualResetEventSlim();
+                    var startedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var completedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     var output = string.Empty;
                     deployer.HostProcess.OutputDataReceived += (sender, args) =>
                     {
                         if (!string.IsNullOrEmpty(args.Data) && args.Data.StartsWith(StartedMessage))
                         {
-                            started.Set();
+                            startedTcs.TrySetResult();
                             output += args.Data.Substring(StartedMessage.Length) + '\n';
                         }
                         else
@@ -90,26 +90,30 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
 
                         if (output.Contains(CompletionMessage))
                         {
-                            completed.Set();
+                            completedTcs.TrySetResult();
                         }
                     };
 
-                    started.Wait(50000);
-
-                    if (!started.IsSet)
+                    try
                     {
-                        throw new InvalidOperationException("Application did not start successfully");
+                        await startedTcs.Task.TimeoutAfter(TimeSpan.FromMinutes(1));
+                    }
+                    catch (TimeoutException ex)
+                    {
+                        throw new InvalidOperationException("Timeout while waiting for host process to output started message.", ex);
                     }
 
                     SendSIGINT(deployer.HostProcess.Id);
 
                     WaitForExitOrKill(deployer.HostProcess);
 
-                    completed.Wait(50000);
-
-                    if (!started.IsSet)
+                    try
                     {
-                        throw new InvalidOperationException($"Application did not write the expected output. The received output is: {output}");
+                        await completedTcs.Task.TimeoutAfter(TimeSpan.FromMinutes(1));
+                    }
+                    catch (TimeoutException ex)
+                    {
+                        throw new InvalidOperationException($"Timeout while waiting for host process to output completion message. The received output is: {output}", ex);
                     }
 
                     output = output.Trim('\n');

--- a/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
+++ b/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
                     await deployer.DeployAsync();
 
                     string output = string.Empty;
-                    var mre = new ManualResetEventSlim();
+                    var mre = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     deployer.HostProcess.OutputDataReceived += (sender, args) =>
                     {
                         if (!string.IsNullOrWhiteSpace(args.Data))

--- a/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
+++ b/src/Hosting/test/FunctionalTests/WebHostBuilderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
             {
                 var logger = loggerFactory.CreateLogger(nameof(InjectedStartup_DefaultApplicationNameIsEntryAssembly));
 
-// https://github.com/dotnet/aspnetcore/issues/8247
+                // https://github.com/dotnet/aspnetcore/issues/8247
 #pragma warning disable 0618
                 var applicationPath = Path.Combine(TestPathUtilities.GetSolutionRootDirectory("Hosting"), "test", "testassets", "IStartupInjectionAssemblyName");
 #pragma warning restore 0618
@@ -44,17 +45,24 @@ namespace Microsoft.AspNetCore.Hosting.FunctionalTests
                     await deployer.DeployAsync();
 
                     string output = string.Empty;
-                    var mre = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                     deployer.HostProcess.OutputDataReceived += (sender, args) =>
                     {
                         if (!string.IsNullOrWhiteSpace(args.Data))
                         {
                             output += args.Data + '\n';
-                            mre.Set();
+                            tcs.TrySetResult();
                         }
                     };
 
-                    mre.Wait(50000);
+                    try
+                    {
+                        await tcs.Task.TimeoutAfter(TimeSpan.FromMinutes(1));
+                    }
+                    catch (TimeoutException ex)
+                    {
+                        throw new InvalidOperationException("Timeout while waiting for output from host process.", ex);
+                    }
 
                     output = output.Trim('\n');
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/22921. This doesn't do anything to fix the tests, it just improves the error message.

I put the failing test in a for loop and ran it 1000 times. I couldn't recreate the test failure. Also there are no failures in the last 30 days in the CI build.

All the hosting tests in functional tests project are quarantined. I wonder if we just accept that these tests can be prone to transient failures, and place them in a retry loop, i.e. the test fails if the hosting logic fails twice.