### PR TITLE
Make startup timeout recycle worker process

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ConfigurationSection.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ConfigurationSection.h
@@ -30,6 +30,7 @@
 #define CS_ENABLED                                       L"enabled"
 #define CS_ASPNETCORE_HANDLER_CALL_STARTUP_HOOK          L"callStartupHook"
 #define CS_ASPNETCORE_HANDLER_STACK_SIZE                 L"stackSize"
+#define CS_ASPNETCORE_DISABLE_RECYCLE_ON_STARTUP_TIMEOUT L"disableRecycleOnStartupTimeout"
 #define CS_ASPNETCORE_DETAILEDERRORS                     L"ASPNETCORE_DETAILEDERRORS"
 #define CS_ASPNETCORE_ENVIRONMENT                        L"ASPNETCORE_ENVIRONMENT"
 #define CS_DOTNET_ENVIRONMENT                            L"DOTNET_ENVIRONMENT"

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ConfigurationSection.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/ConfigurationSection.h
@@ -30,7 +30,7 @@
 #define CS_ENABLED                                       L"enabled"
 #define CS_ASPNETCORE_HANDLER_CALL_STARTUP_HOOK          L"callStartupHook"
 #define CS_ASPNETCORE_HANDLER_STACK_SIZE                 L"stackSize"
-#define CS_ASPNETCORE_DISABLE_RECYCLE_ON_STARTUP_TIMEOUT L"disableRecycleOnStartupTimeout"
+#define CS_ASPNETCORE_SUPPRESS_RECYCLE_ON_STARTUP_TIMEOUT L"suppressRecycleOnStartupTimeout"
 #define CS_ASPNETCORE_DETAILEDERRORS                     L"ASPNETCORE_DETAILEDERRORS"
 #define CS_ASPNETCORE_ENVIRONMENT                        L"ASPNETCORE_ENVIRONMENT"
 #define CS_DOTNET_ENVIRONMENT                            L"DOTNET_ENVIRONMENT"

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.cpp
@@ -66,7 +66,7 @@ InProcessOptions::InProcessOptions(const ConfigurationSource &configurationSourc
     m_fSetCurrentDirectory = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_HANDLER_SET_CURRENT_DIRECTORY).value_or(L"true"), L"true");
     m_fCallStartupHook = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_HANDLER_CALL_STARTUP_HOOK).value_or(L"true"), L"true");
     m_strStackSize = find_element(handlerSettings, CS_ASPNETCORE_HANDLER_STACK_SIZE).value_or(L"1048576");
-    m_fDisableRecycleOnStartupTimeout = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_DISABLE_RECYCLE_ON_STARTUP_TIMEOUT).value_or(L"false"), L"true");
+    m_fSuppressRecycleOnStartupTimeout = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_SUPPRESS_RECYCLE_ON_STARTUP_TIMEOUT).value_or(L"false"), L"true");
 
     m_dwStartupTimeLimitInMS = aspNetCoreSection->GetRequiredLong(CS_ASPNETCORE_PROCESS_STARTUP_TIME_LIMIT) * 1000;
     m_dwShutdownTimeLimitInMS = aspNetCoreSection->GetRequiredLong(CS_ASPNETCORE_PROCESS_SHUTDOWN_TIME_LIMIT) * 1000;

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.cpp
@@ -66,6 +66,7 @@ InProcessOptions::InProcessOptions(const ConfigurationSource &configurationSourc
     m_fSetCurrentDirectory = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_HANDLER_SET_CURRENT_DIRECTORY).value_or(L"true"), L"true");
     m_fCallStartupHook = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_HANDLER_CALL_STARTUP_HOOK).value_or(L"true"), L"true");
     m_strStackSize = find_element(handlerSettings, CS_ASPNETCORE_HANDLER_STACK_SIZE).value_or(L"1048576");
+    m_fDisableRecycleOnStartupTimeout = equals_ignore_case(find_element(handlerSettings, CS_ASPNETCORE_DISABLE_RECYCLE_ON_STARTUP_TIMEOUT).value_or(L"false"), L"true");
 
     m_dwStartupTimeLimitInMS = aspNetCoreSection->GetRequiredLong(CS_ASPNETCORE_PROCESS_STARTUP_TIME_LIMIT) * 1000;
     m_dwShutdownTimeLimitInMS = aspNetCoreSection->GetRequiredLong(CS_ASPNETCORE_PROCESS_SHUTDOWN_TIME_LIMIT) * 1000;

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
@@ -75,10 +75,10 @@ public:
     DWORD
     QueryStartupTimeLimitInMS() const
     {
-        //if (IsDebuggerPresent())
-        //{
-        //    return INFINITE;
-        //}
+        if (IsDebuggerPresent())
+        {
+            return INFINITE;
+        }
 
         return m_dwStartupTimeLimitInMS;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
@@ -75,10 +75,10 @@ public:
     DWORD
     QueryStartupTimeLimitInMS() const
     {
-        if (IsDebuggerPresent())
-        {
-            return INFINITE;
-        }
+        //if (IsDebuggerPresent())
+        //{
+        //    return INFINITE;
+        //}
 
         return m_dwStartupTimeLimitInMS;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
@@ -118,6 +118,12 @@ public:
         return m_strStackSize;
     }
 
+    bool
+    QueryDisableRecycleOnStartupTimeout() const
+    {
+        return m_fDisableRecycleOnStartupTimeout;
+    }
+
     InProcessOptions(const ConfigurationSource &configurationSource, IHttpSite* pSite);
 
     static
@@ -139,6 +145,7 @@ private:
     bool                           m_fWindowsAuthEnabled;
     bool                           m_fBasicAuthEnabled;
     bool                           m_fAnonymousAuthEnabled;
+    bool                           m_fDisableRecycleOnStartupTimeout;
     DWORD                          m_dwStartupTimeLimitInMS;
     DWORD                          m_dwShutdownTimeLimitInMS;
     DWORD                          m_dwMaxRequestBodySize;

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessOptions.h
@@ -119,9 +119,9 @@ public:
     }
 
     bool
-    QueryDisableRecycleOnStartupTimeout() const
+    QuerySuppressRecycleOnStartupTimeout() const
     {
-        return m_fDisableRecycleOnStartupTimeout;
+        return m_fSuppressRecycleOnStartupTimeout;
     }
 
     InProcessOptions(const ConfigurationSource &configurationSource, IHttpSite* pSite);
@@ -145,7 +145,7 @@ private:
     bool                           m_fWindowsAuthEnabled;
     bool                           m_fBasicAuthEnabled;
     bool                           m_fAnonymousAuthEnabled;
-    bool                           m_fDisableRecycleOnStartupTimeout;
+    bool                           m_fSuppressRecycleOnStartupTimeout;
     DWORD                          m_dwStartupTimeLimitInMS;
     DWORD                          m_dwShutdownTimeLimitInMS;
     DWORD                          m_dwMaxRequestBodySize;

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -169,7 +169,7 @@ IN_PROCESS_APPLICATION::LoadManagedApplication(ErrorContext& errorContext)
         errorContext.errorReason = format("ASP.NET Core app failed to start after %d milliseconds", m_pConfig->QueryStartupTimeLimitInMS());
 
         m_waitForShutdown = false;
-        StopClr();
+        Stop(/* fServerInitiated */false);
         throw InvalidOperationException(format(L"Managed server didn't initialize after %u ms.", m_pConfig->QueryStartupTimeLimitInMS()));
     }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -169,7 +169,14 @@ IN_PROCESS_APPLICATION::LoadManagedApplication(ErrorContext& errorContext)
         errorContext.errorReason = format("ASP.NET Core app failed to start after %d milliseconds", m_pConfig->QueryStartupTimeLimitInMS());
 
         m_waitForShutdown = false;
-        Stop(/* fServerInitiated */false);
+        if (m_pConfig->QueryDisableRecycleOnStartupTimeout())
+        {
+            StopClr();
+        }
+        else
+        {
+            Stop(/* fServerInitiated */false);
+        }
         throw InvalidOperationException(format(L"Managed server didn't initialize after %u ms.", m_pConfig->QueryStartupTimeLimitInMS()));
     }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -169,7 +169,7 @@ IN_PROCESS_APPLICATION::LoadManagedApplication(ErrorContext& errorContext)
         errorContext.errorReason = format("ASP.NET Core app failed to start after %d milliseconds", m_pConfig->QueryStartupTimeLimitInMS());
 
         m_waitForShutdown = false;
-        if (m_pConfig->QueryDisableRecycleOnStartupTimeout())
+        if (m_pConfig->QuerySuppressRecycleOnStartupTimeout())
         {
             StopClr();
         }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -497,7 +497,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
                 deploymentParameters.TransformArguments((a, _) => $"{a} Hang");
                 deploymentParameters.WebConfigActionList.Add(
                     WebConfigHelpers.AddOrModifyAspNetCoreSection("startupTimeLimit", "1"));
-                deploymentParameters.HandlerSettings["disableRecycleOnStartupTimeout"] = "true";
+                deploymentParameters.HandlerSettings["suppressRecycleOnStartupTimeout"] = "true";
                 var deploymentResult = await DeployAsync(deploymentParameters);
 
                 var response = await deploymentResult.HttpClient.GetAsync("/");

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -453,6 +453,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
         }
 
         [ConditionalFact]
+        [RequiresNewHandler]
         public async Task StartupTimeoutIsApplied()
         {
             // From what we can tell, this failure is due to ungraceful shutdown.
@@ -486,6 +487,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
         }
 
         [ConditionalFact]
+        [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H1, SkipReason = "Shutdown hangs https://github.com/dotnet/aspnetcore/issues/25107")]
         public async Task StartupTimeoutIsApplied_DisableRecycleOnStartupTimeout()
         {
             // From what we can tell, this failure is due to ungraceful shutdown.

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/StartupTests.cs
@@ -455,7 +455,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
         [ConditionalFact]
         public async Task StartupTimeoutIsApplied()
         {
-            // From what I can tell, this failure is due to ungraceful shutdown.
+            // From what we can tell, this failure is due to ungraceful shutdown.
             // The error could be the same as https://github.com/dotnet/core-setup/issues/4646
             // But can't be certain without another repro.
             using (AppVerifier.Disable(DeployerSelector.ServerType, 0x300))
@@ -470,11 +470,12 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
                 var response = await deploymentResult.HttpClient.GetAsync("/");
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-                StopServer(gracefulShutdown: false);
+                deploymentResult.AssertWorkerProcessStop();
+                //StopServer(gracefulShutdown: false);
 
-                EventLogHelpers.VerifyEventLogEvents(deploymentResult,
-                    EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms.")
-                    );
+                EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+                    EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
+                    Logger);
 
                 if (DeployerSelector.HasNewHandler)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/24485

Today, IIS will get into an unrecoverable state if the startup timeout limit is hit, until someone redeploys the site. This usually isn't a concern, however many people have multiple w3wp sites starting up at the same time, which occasionally causes w3wp process to timeout on the startup time limit, especially if there is a lot going on before startup.

This change makes it so instead of being in an unrecoverable state, ANCM will queue to recycle the worker process instead.

There are some drawbacks that should be noted with this change. By now restarting the process, more resources will be consumed by IIS. I think this drawback is fine for normal scenarios where the app just failed to start, restarting the app is preferable here as a restart most likely will fix the timeout hit.

Let's think of the worst case scenario. Let's say Program.Main has a Thread.Sleep, causing the process to always fail to start. If the process fails to start, we recycle the worker process. From what I can tell, the rapidFailureProtectionModule will not trigger as we are enqueuing for recycling the worker process rather than the worker process crashing (need to confirm this, but https://github.com/dotnet/aspnetcore/issues/25163 is blocking validation). So, if the startup time limit is set to 1 second, I'm concerned about IIS constantly needing to recycle the process. I'll chat with some IIS folk about that as well.

Other options besides this are to either increase the startup timeout, which requires a schema update (which are hard to deploy) and/or shim changes, or disabling the limit with in-process, which is concerning because people may want to use the limit itself.