### PR TITLE
Disable failing/hanging tests due to Chrome/Selenium issue

### DIFF
--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -14,6 +14,9 @@
     <SkipTests Condition="'$(SeleniumE2ETestsSupported)' != 'true'">true</SkipTests>
     <SkipTests Condition="'$(SeleniumE2ETestsSupported)' == 'true'">false</SkipTests>
 
+    <!-- Tests are disabled due to https://github.com/dotnet/aspnetcore/issues/25322 -->
+    <SkipTests>true</SkipTests>
+
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
     <BaseOutputPath />
 

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
@@ -10,6 +10,10 @@
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''" >true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
+
+    <!-- Tests are disabled due to https://github.com/dotnet/aspnetcore/issues/25322 -->
+    <SkipTests>true</SkipTests>
+
     <!--Do not run this test project on Helix.-->
     <BuildHelixPayload>false</BuildHelixPayload>
     <SkipHelixArm>true</SkipHelixArm>


### PR DESCRIPTION
Disabling tests to unblock CI. Issue tracking re-enabling tests at https://github.com/dotnet/aspnetcore/issues/25322