### PR TITLE
Restore legacy behavior for certs without private keys

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -641,4 +641,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="FailedToLocateCertificateFromStore" xml:space="preserve">
     <value>Failure to locate certificate from store.</value>
   </data>
+  <data name="FailedToOpenCertStore" xml:space="preserve">
+    <value>Failed to open certificate store {StoreName}.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -632,4 +632,13 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="EndpointHasUnusedHttpsConfig" xml:space="preserve">
     <value>The non-HTTPS endpoint {endpointName} includes HTTPS-only configuration for {keyName}.</value>
   </data>
+  <data name="FoundCertWithPrivateKey" xml:space="preserve">
+    <value>Found certificate with private key and thumbprint {Thumbprint} in certificate store {StoreName}.</value>
+  </data>
+  <data name="LocatingCertWithPrivateKey" xml:space="preserve">
+    <value>Searching for certificate with private key and thumbprint {Thumbprint} in the certificate store.</value>
+  </data>
+  <data name="FailedToLocateCertificateFromStore" xml:space="preserve">
+    <value>Failure to locate certificate from store.</value>
+  </data>
 </root>


### PR DESCRIPTION
- When trying to use an SSL certificate without a private key, SslStream would try to find another certificate in the cert store matching the thumbprint. Now that we're using the SslStreamCertificateContext, that behavior is no longer included so we need to restore it in Kestrel.

See https://github.com/dotnet/runtime/issues/41246 for more details.