### PR TITLE
Do not specify TaskCreationOptions \ TaskContinuationOptions in JSRuntime

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -110,7 +110,7 @@ namespace Microsoft.JSInterop
             object?[]? args)
         {
             var taskId = Interlocked.Increment(ref _nextPendingTaskId);
-            var tcs = new TaskCompletionSource<TValue>(TaskContinuationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource<TValue>();
             if (cancellationToken != default)
             {
                 _cancellationRegistrations[taskId] = cancellationToken.Register(() =>


### PR DESCRIPTION
Using TaskContinuationOptions is incorrect. Changing this to correctly use TaskCreationOptions causes an additional StateHasChanged to be triggered for JS operations which is undesirable. Removing this option entirely.

Fixes https://github.com/dotnet/aspnetcore/issues/25213