### PR TITLE
Suppress baseline reference of Microsoft.AspNetCore.SpaServices

### DIFF
--- a/src/Middleware/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
+++ b/src/Middleware/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
@@ -15,4 +15,11 @@
     <InternalsVisibleTo Include="Microsoft.AspNetCode.SpaServices.Extensions.Tests" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(AspNetCoreMajorMinorVersion)' == '5.0' ">
+    <!--
+      Dependency (now in shared Fx and a transitive ref for netstandard2.x) was removed in 5.0. Suppression can be
+      removed after 5.0 RTM is released.
+    -->
+    <SuppressBaselineReference Include="Microsoft.AspNetCore.SpaServices" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This fixes the error:

```
error BUILD001: Reference to 'Microsoft.AspNetCore.SpaServices' was removed since the last stable release of this package. This could be a breaking change. See docs/ReferenceResolution.md for instructions on how to update changes to references or suppress this warning if the error was intentional.
```

The build break was caused by the concurrent merging of #25290 and https://github.com/dotnet/aspnetcore/pull/25227. The baseline checks were fixed which flagged the missing baseline reference that was removed in #25290. This is an unfortunate timing issue and both PRs by themselves would have passed all CI checks. The combination of the two broke the build. 

This is an FYI only, I'm merging immediately to fix build.