### PR TITLE
[dotnet-dev-certs] Report logs from CertificateManager on stdout/stderr

### DIFF
--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
         // We don't have a good way of checking on the underlying implementation if ti is exportable, so just return true.
         protected override bool IsExportable(X509Certificate2 c) => true;
 
-        protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate)
+        protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate, StoreName storeName, StoreLocation storeLocation)
         {
             // security import https.pfx -k $loginKeyChain -t cert -f pkcs12 -P password -A;
             var passwordBytes = new byte[48];

--- a/src/Shared/CertificateGeneration/UnixCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/UnixCertificateManager.cs
@@ -17,14 +17,14 @@ namespace Microsoft.AspNetCore.Certificates.Generation
 
         public override bool IsTrusted(X509Certificate2 certificate) => false;
 
-        protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate)
+        protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate, StoreName storeName, StoreLocation storeLocation)
         {
             var export = certificate.Export(X509ContentType.Pkcs12, "");
             certificate.Dispose();
             certificate = new X509Certificate2(export, "", X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             Array.Clear(export, 0, export.Length);
 
-            using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (var store = new X509Store(storeName, storeLocation))
             {
                 store.Open(OpenFlags.ReadWrite);
                 store.Add(certificate);

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             // Do nothing since we don't have anything to check here.
         }
 
-        protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate)
+        protected override X509Certificate2 SaveCertificateCore(X509Certificate2 certificate, StoreName storeName, StoreLocation storeLocation)
         {
             // On non OSX systems we need to export the certificate and import it so that the transient
             // key that we generated gets persisted.
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             Array.Clear(export, 0, export.Length);
             certificate.FriendlyName = AspNetHttpsOidFriendlyName;
 
-            using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (var store = new X509Store(storeName, storeLocation))
             {
                 store.Open(OpenFlags.ReadWrite);
                 store.Add(certificate);

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -116,6 +116,12 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                     {
                         var reporter = new ConsoleReporter(PhysicalConsole.Singleton, verbose.HasValue(), quiet.HasValue());
 
+                        if (verbose.HasValue())
+                        {
+                            var listener = new ReporterEventListener(reporter);
+                            listener.EnableEvents(CertificateManager.Log, System.Diagnostics.Tracing.EventLevel.Verbose);
+                        }
+
                         if (clean.HasValue())
                         {
                             if (exportPath.HasValue() || trust?.HasValue() == true || format.HasValue() || noPassword.HasValue() || check.HasValue() ||

--- a/src/Tools/dotnet-dev-certs/src/ReporterEventListener.cs
+++ b/src/Tools/dotnet-dev-certs/src/ReporterEventListener.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.Tools.Internal;
+
+namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
+{
+    internal class ReporterEventListener : EventListener
+    {
+        private readonly IReporter _reporter;
+
+        public ReporterEventListener(IReporter reporter)
+        {
+            _reporter = reporter ?? throw new ArgumentNullException(nameof(reporter));
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            Action<string> report = eventData.Level switch
+            {
+                EventLevel.LogAlways => _reporter.Output,
+                EventLevel.Critical => _reporter.Error,
+                EventLevel.Error => _reporter.Error,
+                EventLevel.Warning => _reporter.Warn,
+                EventLevel.Informational => _reporter.Output,
+                EventLevel.Verbose => _reporter.Verbose,
+                _ => throw new ArgumentOutOfRangeException(nameof(eventData.Level), eventData.Level, $"The value of argument '{nameof(eventData.Level)}' ({eventData.Level}) is invalid for Enum type '{nameof(EventLevel)}'.")
+            };
+            var message = string.Format(CultureInfo.InvariantCulture, eventData.Message ?? "", eventData.Payload?.ToArray() ?? Array.Empty<object>());
+            report($"[{eventData.EventId}] " + message);
+        }
+    }
+}


### PR DESCRIPTION
In commit 8e1e81ae78e876eecad1b816093f0519682e205d it was mentioned:
>  We can decide to write an EventListener in `dotnet-dev-certs` to write the results to the console output.

This is what is achieved with the new `ReporterEventListener` in order to bring back ASP.NET Core v3 feature parity where the --verbose option prints debug messages to help diagnose potential certificate issues. 

Also, all the methods from the CertificateManagerEventSource have been appropriately adapted as per the [EventAttribute][1] documentation.

[1]: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventattribute

/cc @javiercn