### PR TITLE
Add missing configuration for blazor daily tests

### DIFF
--- a/.azure/pipelines/blazor-daily-tests.yml
+++ b/.azure/pipelines/blazor-daily-tests.yml
@@ -1,0 +1,59 @@
+# Uses Scheduled Triggers, which aren't supported in YAML yet.
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=vsts&tabs=yaml#scheduled
+
+# Daily Tests for Blazor
+# These use Sauce Labs resources, hence they run daily rather than per-commit.
+
+# We just need one Windows machine because all it does is trigger SauceLabs.
+variables:
+  SAUCE_CONNECT_DOWNLOAD_ON_INSTALL: true
+  E2ETESTS_SauceTest: true
+  E2ETESTS_Sauce__TunnelIdentifier: 'blazor-e2e-sc-proxy-tunnel'
+  E2ETESTS_Sauce__HostName: 'sauce.local'
+jobs:
+- template: jobs/default-build.yml
+  parameters:
+    buildDirectory: src/Components
+    isTestingJob: true
+    agentOs: Windows
+    jobName: BlazorDailyTests
+    jobDisplayName: "Blazor Daily Tests"
+    afterBuild:
+
+    # macOS/Safari
+    - script: 'dotnet test --filter "StandaloneAppTest"'
+      workingDirectory: 'src/Components/test/E2ETest'
+      displayName: 'Run Blazor tests - macOS/Safari'
+      condition: succeededOrFailed()
+      env:
+        # Secrets need to be explicitly mapped to env variables.
+        E2ETESTS_Sauce__Username: '$(asplab-sauce-labs-username)'
+        E2ETESTS_Sauce__AccessKey: '$(asplab-sauce-labs-access-key)'
+        # Set platform/browser configuration.
+        E2ETESTS_Sauce__TestName: 'Blazor Daily Tests - macOS/Safari'
+        E2ETESTS_Sauce__PlatformName: 'macOS 10.14'
+        E2ETESTS_Sauce__BrowserName: 'Safari'
+        # Need to explicitly set version here because some older versions don't support timeouts in Safari.
+        E2ETESTS_Sauce__SeleniumVersion: '3.4.0'
+
+    # Android/Chrome
+    - script: 'dotnet test --filter "StandaloneAppTest"'
+      workingDirectory: 'src/Components/test/E2ETest'
+      displayName: 'Run Blazor tests - Android/Chrome'
+      condition: succeededOrFailed()
+      env:
+        # Secrets need to be explicitly mapped to env variables.
+        E2ETESTS_Sauce__Username: '$(asplab-sauce-labs-username)'
+        E2ETESTS_Sauce__AccessKey: '$(asplab-sauce-labs-access-key)'
+        # Set platform/browser configuration.
+        E2ETESTS_Sauce__TestName: 'Blazor Daily Tests - Android/Chrome'
+        E2ETESTS_Sauce__PlatformName: 'Android'
+        E2ETESTS_Sauce__PlatformVersion: '10.0'
+        E2ETESTS_Sauce__BrowserName: 'Chrome'
+        E2ETESTS_Sauce__DeviceName: 'Android GoogleAPI Emulator'
+        E2ETESTS_Sauce__DeviceOrientation: 'portrait'
+        E2ETESTS_Sauce__AppiumVersion: '1.9.1'
+    artifacts:
+    - name: Windows_Logs
+      path: ../../artifacts/log/
+      publishOnError: true


### PR DESCRIPTION
@pranavkm why was this file removed in https://github.com/dotnet/aspnetcore/pull/22790. This meant that the blazor daily tests haven't been running since May it turns out.

cc @ajaybhargavb 