### PR TITLE
Add async ServerOptionsSelectionCallback UseHttps overload

### DIFF
--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -235,7 +234,37 @@ namespace Microsoft.AspNetCore.Hosting
         /// </summary>
         /// <param name="listenOptions">The <see cref="ListenOptions"/> to configure.</param>
         /// <param name="httpsOptionsCallback">Callback to configure HTTPS options.</param>
-        /// <param name="state">State for the <see cref="ServerOptionsSelectionCallback" />.</param>
+        /// <param name="state">State for the <paramref name="httpsOptionsCallback"/>.</param>
+        /// <returns>The <see cref="ListenOptions"/>.</returns>
+        public static ListenOptions UseHttps(this ListenOptions listenOptions, ServerOptionsSelectionCallback httpsOptionsCallback, object state)
+        {
+            return listenOptions.UseHttps(httpsOptionsCallback, state, HttpsConnectionAdapterOptions.DefaultHandshakeTimeout);
+        }
+
+        /// <summary>
+        /// Configure Kestrel to use HTTPS.
+        /// </summary>
+        /// <param name="listenOptions">The <see cref="ListenOptions"/> to configure.</param>
+        /// <param name="httpsOptionsCallback">Callback to configure HTTPS options.</param>
+        /// <param name="state">State for the <paramref name="httpsOptionsCallback"/>.</param>
+        /// <param name="handshakeTimeout">Specifies the maximum amount of time allowed for the TLS/SSL handshake. This must be positive and finite.</param>
+        /// <returns>The <see cref="ListenOptions"/>.</returns>
+        public static ListenOptions UseHttps(this ListenOptions listenOptions, ServerOptionsSelectionCallback httpsOptionsCallback, object state, TimeSpan handshakeTimeout)
+        {
+            // HttpsOptionsCallback is an internal delegate that is just the ServerOptionsSelectionCallback + a ConnectionContext parameter.
+            // Given that ConnectionContext will eventually be replaced by System.Net.Connections, it doesn't make much sense to make the HttpsOptionsCallback delegate public.
+            HttpsOptionsCallback adaptedCallback = (connection, stream, clientHelloInfo, state, cancellationToken) =>
+                httpsOptionsCallback(stream, clientHelloInfo, state, cancellationToken);
+
+            return listenOptions.UseHttps(adaptedCallback, state, handshakeTimeout);
+        }
+
+        /// <summary>
+        /// Configure Kestrel to use HTTPS.
+        /// </summary>
+        /// <param name="listenOptions">The <see cref="ListenOptions"/> to configure.</param>
+        /// <param name="httpsOptionsCallback">Callback to configure HTTPS options.</param>
+        /// <param name="state">State for the <paramref name="httpsOptionsCallback"/>.</param>
         /// <param name="handshakeTimeout">Specifies the maximum amount of time allowed for the TLS/SSL handshake. This must be positive and finite.</param>
         /// <returns>The <see cref="ListenOptions"/>.</returns>
         internal static ListenOptions UseHttps(this ListenOptions listenOptions, HttpsOptionsCallback httpsOptionsCallback, object state, TimeSpan handshakeTimeout)

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -208,7 +208,8 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
-        /// Configure Kestrel to use HTTPS.
+        /// Configure Kestrel to use HTTPS. This does not use default certificates or other defaults specified via config or
+        /// <see cref="KestrelServerOptions.ConfigureHttpsDefaults(Action{HttpsConnectionAdapterOptions})"/>.
         /// </summary>
         /// <param name="listenOptions">The <see cref="ListenOptions"/> to configure.</param>
         /// <param name="httpsOptions">Options to configure HTTPS.</param>
@@ -230,31 +231,33 @@ namespace Microsoft.AspNetCore.Hosting
         }
 
         /// <summary>
-        /// Configure Kestrel to use HTTPS.
+        /// Configure Kestrel to use HTTPS. This does not use default certificates or other defaults specified via config or
+        /// <see cref="KestrelServerOptions.ConfigureHttpsDefaults(Action{HttpsConnectionAdapterOptions})"/>.
         /// </summary>
         /// <param name="listenOptions">The <see cref="ListenOptions"/> to configure.</param>
-        /// <param name="httpsOptionsCallback">Callback to configure HTTPS options.</param>
-        /// <param name="state">State for the <paramref name="httpsOptionsCallback"/>.</param>
+        /// <param name="serverOptionsSelectionCallback">Callback to configure HTTPS options.</param>
+        /// <param name="state">State for the <paramref name="serverOptionsSelectionCallback"/>.</param>
         /// <returns>The <see cref="ListenOptions"/>.</returns>
-        public static ListenOptions UseHttps(this ListenOptions listenOptions, ServerOptionsSelectionCallback httpsOptionsCallback, object state)
+        public static ListenOptions UseHttps(this ListenOptions listenOptions, ServerOptionsSelectionCallback serverOptionsSelectionCallback, object state)
         {
-            return listenOptions.UseHttps(httpsOptionsCallback, state, HttpsConnectionAdapterOptions.DefaultHandshakeTimeout);
+            return listenOptions.UseHttps(serverOptionsSelectionCallback, state, HttpsConnectionAdapterOptions.DefaultHandshakeTimeout);
         }
 
         /// <summary>
-        /// Configure Kestrel to use HTTPS.
+        /// Configure Kestrel to use HTTPS. This does not use default certificates or other defaults specified via config or
+        /// <see cref="KestrelServerOptions.ConfigureHttpsDefaults(Action{HttpsConnectionAdapterOptions})"/>.
         /// </summary>
         /// <param name="listenOptions">The <see cref="ListenOptions"/> to configure.</param>
-        /// <param name="httpsOptionsCallback">Callback to configure HTTPS options.</param>
-        /// <param name="state">State for the <paramref name="httpsOptionsCallback"/>.</param>
+        /// <param name="serverOptionsSelectionCallback">Callback to configure HTTPS options.</param>
+        /// <param name="state">State for the <paramref name="serverOptionsSelectionCallback"/>.</param>
         /// <param name="handshakeTimeout">Specifies the maximum amount of time allowed for the TLS/SSL handshake. This must be positive and finite.</param>
         /// <returns>The <see cref="ListenOptions"/>.</returns>
-        public static ListenOptions UseHttps(this ListenOptions listenOptions, ServerOptionsSelectionCallback httpsOptionsCallback, object state, TimeSpan handshakeTimeout)
+        public static ListenOptions UseHttps(this ListenOptions listenOptions, ServerOptionsSelectionCallback serverOptionsSelectionCallback, object state, TimeSpan handshakeTimeout)
         {
             // HttpsOptionsCallback is an internal delegate that is just the ServerOptionsSelectionCallback + a ConnectionContext parameter.
             // Given that ConnectionContext will eventually be replaced by System.Net.Connections, it doesn't make much sense to make the HttpsOptionsCallback delegate public.
             HttpsOptionsCallback adaptedCallback = (connection, stream, clientHelloInfo, state, cancellationToken) =>
-                httpsOptionsCallback(stream, clientHelloInfo, state, cancellationToken);
+                serverOptionsSelectionCallback(stream, clientHelloInfo, state, cancellationToken);
 
             return listenOptions.UseHttps(adaptedCallback, state, handshakeTimeout);
         }


### PR DESCRIPTION
The changes to HttpsConnectionMiddleware to support this UseHttps overload were made in #24286. I didn't want to slow down that PR with public API considerations, but now is the time to review the API.

This not only allows async SNI configuration, but allows configuring nearly any part of SslServerAuthenticationOptions asynchronously after getting the ClientHello.

Initially, I was a little concerned that this doesn't respect configuration made via ConfigureHttpsDefaults or EndpointDefaults in config, but then I noticed that this not unique to this UseHttps overload. `UseHttps(HttpsConnectionAdapterOptions)` has this same limitation, because unlike `UseHttps(Action<HttpsConnectionAdapterOptions>)` and like this new overload, there are no incoming options to pre-populate with defaults.

Addresses #20981

@davidfowl @Tratcher 
