### PR TITLE
Correct the site extensions builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -88,7 +88,10 @@
 
     <IncludeSymbols>true</IncludeSymbols>
 
-    <!-- Also update the DefaultNetCoreTargetFramework defined at src/Razor/test/testassets/Directory.Build.props -->
+    <!--
+      Also update the DefaultNetCoreTargetFramework defined at src/Razor/test/testassets/Directory.Build.props and
+      the packages referenced in Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj when this changes.
+    -->
     <DefaultNetCoreTargetFramework>net5.0</DefaultNetCoreTargetFramework>
     <DefaultNetFxTargetFramework>net461</DefaultNetFxTargetFramework>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -237,10 +237,10 @@
     <MicrosoftWebAdministrationPackageVersion>11.1.0</MicrosoftWebAdministrationPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
     <SystemIdentityModelTokensJwtPackageVersion>6.7.1</SystemIdentityModelTokensJwtPackageVersion>
-    <!-- Packages from 2.1/2.2 branches used for site extension build -->
+    <!-- Packages from 2.1, 2.2, and 3.1 branches used for site extension build. -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>2.2.0</MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>
-    <MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>3.1.3-servicing-20163-14</MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>
+    <MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>3.1.7-servicing-20372-13</MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension31x64PackageVersion>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion)</MicrosoftAspNetCoreAzureAppServicesSiteExtension31x64PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension31x86PackageVersion>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension31PackageVersion)</MicrosoftAspNetCoreAzureAppServicesSiteExtension31x86PackageVersion>
     <!-- 3rd party dependencies -->

--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -24,13 +24,27 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--
+      Bundle in most down-level versions of the runtime-specific site extension packages. When updating
+      $(DefaultNetCoreTargetFramework), add previous SiteExtension packages to the list below. Remove
+      entries when packages aren't needed in the bundle anymore.
+      -->
     <Reference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.2.1" PrivateAssets="All" />
     <Reference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.2.2" PrivateAssets="All" />
     <Reference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.1.x64" PrivateAssets="All" />
     <Reference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.1.x86" PrivateAssets="All" />
-    <!-- When updating this add the previous SiteExtension(s) to the list above -->
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.5.0.x86" Version="$(PackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.5.0.x64" Version="$(PackageVersion)" PrivateAssets="All" />
+    <!--
+      Bundle the just-built LB.csproj package content into this one the easy way. See
+      UpdateLatestPackageReferences for the hard way.
+    -->
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64"
+        Condition=" '$(IsShipping)' == 'false' "
+        PrivateAssets="All"
+        Version="$(PackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86"
+        Condition=" '$(IsShipping)' == 'false' "
+        PrivateAssets="All"
+        Version="$(PackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -43,8 +57,13 @@
     <Reference Include="Microsoft.Web.Xdt.Extensions" PrivateAssets="All" />
   </ItemGroup>
 
-  <Target Name="AddContent" BeforeTargets="_GetPackageFiles">
-    <!-- Cannot assume this project and LB.csproj have the same package version. -->
+  <!--
+    Cannot assume this project and LB.csproj have the same package version because this creates a shipping
+    package in non-preview builds and LB.csproj never creates a shipping package.
+  -->
+  <Target Name="UpdateLatestPackageReferences"
+      BeforeTargets="CollectPackageReferences;ResolveAssemblyReferencesDesignTime;ResolveAssemblyReferences"
+      Condition=" '$(IsShipping)' == 'true' ">
     <!-- This target is defined in eng/targets/Packaging.targets and included in every C# and F# project. -->
     <MSBuild Projects="$(RepoRoot)src\SiteExtensions\LoggingBranch\LB.csproj"
         Targets="_GetPackageVersionInfo"
@@ -53,17 +72,21 @@
     </MSBuild>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.1.x86"
-          Version="%(_ResolvedPackageVersionInfo.PackageVersion)"
-          PrivateAssets="All" />
-      <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.3.1.x64"
-          Version="%(_ResolvedPackageVersionInfo.PackageVersion)"
-          PrivateAssets="All" />
+      <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64"
+          PrivateAssets="All"
+          Version="%(_ResolvedPackageVersionInfo.PackageVersion)" />
+      <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86"
+          PrivateAssets="All"
+          Version="%(_ResolvedPackageVersionInfo.PackageVersion)" />
     </ItemGroup>
+  </Target>
 
+  <Target Name="AddContent" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
-      <!-- LB.csproj package content is bundled into this one. -->
-      <!-- The x64 & x86 SiteExtension packages have identical deps.json files - we only include the x64 files to avoid build warnings -->
+      <!--
+        The x64 & x86 SiteExtension packages have identical deps.json files. We include only the x64 files to
+        avoid build warnings.
+      -->
       <ContentFilesToPack
           Include="$(NugetPackageRoot)\%(PackageReference.Identity)\%(PackageReference.Version)\content\**\*.*"
           Exclude="$(NugetPackageRoot)\Microsoft.AspNetCore.AzureAppServices.SiteExtension.*.x86\**\Microsoft.AspNetCore.AzureAppServices.HostingStartup.deps.json"/>

--- a/src/SiteExtensions/Sdk/SiteExtension.targets
+++ b/src/SiteExtensions/Sdk/SiteExtension.targets
@@ -9,11 +9,11 @@
 
     <PropertyGroup>
       <_TemplatesDirectory>$(MSBuildThisFileDirectory)..\content\</_TemplatesDirectory>
-      <_DepsOutputDirectory>$(IntermediateOutputPath)\se\</_DepsOutputDirectory>
-      <_WorkingDirectory>$(_DepsOutputDirectory)\depswork</_WorkingDirectory>
+      <_DepsOutputDirectory>$(IntermediateOutputPath)se\</_DepsOutputDirectory>
+      <_WorkingDirectory>$(_DepsOutputDirectory)depswork</_WorkingDirectory>
       <_BasePackagePath>content\additionaldeps\</_BasePackagePath>
-      <_RuntimeStoreManifestFile>$(_DepsOutputDirectory)\rs.csproj</_RuntimeStoreManifestFile>
-      <_RuntimeStoreOutput>$(_DepsOutputDirectory)\rs\</_RuntimeStoreOutput>
+      <_RuntimeStoreManifestFile>$(_DepsOutputDirectory)rs.csproj</_RuntimeStoreManifestFile>
+      <_RuntimeStoreOutput>$(_DepsOutputDirectory)rs\</_RuntimeStoreOutput>
       <_RsRestoreSources>
         $(RestoreAdditionalProjectSources);
         $(ArtifactsShippingPackagesDir);
@@ -55,7 +55,7 @@
         Project="$(_DepsOutputDirectory)%(HostingStartupPackageReference.Identity)\HostingStartup.csproj"
         DepsFile="$(_DepsOutputDirectory)%(HostingStartupPackageReference.Identity)\p\HostingStartup.deps.json"
         TrimmedDepsFile="$(_DepsOutputDirectory)%(HostingStartupPackageReference.Identity)\%(HostingStartupPackageReference.Identity).deps.json"
-        PackagePath="$(_BasePackagePath)\shared\Microsoft.AspNetCore.App\$(AspNetCoreMajorMinorVersion).0\"
+        PackagePath="$(_BasePackagePath)shared\Microsoft.AspNetCore.App\$(AspNetCoreMajorMinorVersion).0\"
          />
     </ItemGroup>
     <MakeDir Directories="$(_DepsOutputDirectory)" />

--- a/src/SiteExtensions/build.cmd
+++ b/src/SiteExtensions/build.cmd
@@ -3,7 +3,7 @@ SET RepoRoot=%~dp0..\..
 
 ECHO Building x64 Microsoft.AspNetCore.Runtime.SiteExtension
 CALL "%RepoRoot%\build.cmd" -arch x64 -projects "%~dp0Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj" ^
-    "/bl:%RepoRoot%/artifacts/log/SiteExtensions-Runtime-x86.binlog" %*
+    "/bl:%RepoRoot%/artifacts/log/SiteExtensions-Runtime-x64.binlog" %*
 IF %ERRORLEVEL% NEQ 0 (
    EXIT /b %ErrorLevel%
 )


### PR DESCRIPTION
- handle differing SiteExtensions package versions
  - the arch-specific packages don't stabilize when final package does
- remove 2.2 package from the site extensions bundle
- update 3.1 packages in bundle to 3.1.7 version
- remove useless empty folder from LoggingBranch (arch-specific) package
  - double slashes help nobody but add an empty-named level in the package

nit: fix a binary log filename