### PR TITLE
Add edition option into BuildFromSource.md

### DIFF
--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -32,11 +32,12 @@ Building ASP.NET Core on Windows requires:
   * To install the exact required components, run [eng/scripts/InstallVisualStudio.ps1](/eng/scripts/InstallVisualStudio.ps1).
 
     ```ps1
-    PS> ./eng/scripts/InstallVisualStudio.ps1
+    PS> ./eng/scripts/InstallVisualStudio.ps1  [-Edition {Enterprise|Community|Professional}]
     ```
 
     However, any Visual Studio 2019 instance that meets the requirements should be fine. See [global.json](/global.json)
     and [eng/scripts/vs.json](/eng/scripts/vs.json) for those requirements. By default, the script will install Visual Studio Enterprise Edition, however you can use a different edition by passing the `-Edition` flag.
+    Even if you have installed Visual Studio, still recommend you should use this script to install again to avoid errors due to missing components just in case.
 * Git. <https://git-scm.org>
 * NodeJS. LTS version of 10.14.2 or newer <https://nodejs.org>.
 * Install yarn globally (`npm install -g yarn`)


### PR DESCRIPTION
I added the option of the edition when installing Visual Studio. Because some people carry out "InstallVisualStudio.ps1" without reading the description bellow. Therefore, I believe that adding the option and the supplementary explanation are more kind to everyone who try to build from the source. Also I referred to the issue(#23919).
