### PR TITLE
Set PrivateAssets on transport package

### DIFF
--- a/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
+++ b/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
-    <Reference Include="Microsoft.NETCore.BrowserDebugHost.Transport" GeneratePathProperty="true" />
+    <Reference Include="Microsoft.NETCore.BrowserDebugHost.Transport" GeneratePathProperty="true" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The transport package does not ship and we do not want it to appear in WebAssembly.Server's nuspec.

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/176