### PR TITLE
Avoid build race between x64 and x86

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/AspNetCore.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/AspNetCore.vcxproj
@@ -303,8 +303,9 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <Target Name="AfterBuild">
+  <Target Name="AfterBuild" Condition="'$(Platform)' == 'x64'">
     <!-- Drop a file in the artifacts directory containing the ANCM version number -->
+    <!-- Only write on x64 build to avoid both x64 and x86 writing to same place. -->
     <ItemGroup>
       <VersionFileContents Include="$(AspNetCoreModuleVersionMajor).$(AspNetCoreMinorVersion).$(AssemblyBuild).$(AspNetCorePatchVersion)" />
       <VersionFileContents Include="$(SourceRevisionId)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/25394

@Pilchie This is a build only fix to avoid two builds trying to write the same file at the same time. It isn't required for 5.0, but I'd like it to be in the 5.0 branch if possible.

