### PR TITLE
Mark some projects as non-packable or non-shippable

### DIFF
--- a/src/Components/WebAssembly/Sdk/src/Microsoft.NET.Sdk.BlazorWebAssembly.csproj
+++ b/src/Components/WebAssembly/Sdk/src/Microsoft.NET.Sdk.BlazorWebAssembly.csproj
@@ -12,6 +12,8 @@
     <NoWarn>$(NoWarn);NU5100</NoWarn>
     <!-- Need to build this project in source build -->
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/Microsoft.NET.Sdk.Razor.csproj
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/Microsoft.NET.Sdk.Razor.csproj
@@ -15,6 +15,8 @@
     <NoWarn>$(NoWarn);NU5129</NoWarn>
     <!-- Need to build this project in source build -->
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+
+    <IsShipping>false</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Directory.Build.props
+++ b/src/Razor/test/Directory.Build.props
@@ -2,7 +2,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <!-- Projects in this folder don't follow the usual naming conventions for tests. -->
-    <IsUnitTestProject>false</IsUnitTestProject>
+    <!--
+      Projects in this folder don't follow the usual naming conventions for test assets. Marking as such
+      though the projects directly w/in this folder are more like test infrastructure.
+    -->
+    <IsTestAssetProject>false</IsTestAssetProject>
   </PropertyGroup>
 </Project>

--- a/src/Razor/test/Directory.Build.props
+++ b/src/Razor/test/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup>
+    <!-- Projects in this folder don't follow the usual naming conventions for tests. -->
+    <IsUnitTestProject>false</IsUnitTestProject>
+  </PropertyGroup>
+</Project>

--- a/src/Razor/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
+++ b/src/Razor/tools/RazorSyntaxGenerator/RazorSyntaxGenerator.csproj
@@ -7,6 +7,7 @@
     <PackageId>RazorSyntaxGenerator</PackageId>
     <OutputType>Exe</OutputType>
     <EnableApiCheck>false</EnableApiCheck>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- used `$(IsUnitTestProject)` in src/Razor/test; slightly more correct
