### PR TITLE
 Add more assembly version testing for SharedFx/Targeting pack

### DIFF
--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -168,8 +168,6 @@ namespace Microsoft.AspNetCore
 
             Assert.All(dlls, path =>
             {
-                var fileName = Path.GetFileNameWithoutExtension(path);
-                var assemblyName = AssemblyName.GetAssemblyName(path);
                 using var fileStream = File.OpenRead(path);
                 using var peReader = new PEReader(fileStream, PEStreamOptions.Default);
                 var reader = peReader.GetMetadataReader(MetadataReaderOptions.Default);
@@ -184,7 +182,7 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void SharedFrameworkAssemblyReferencesHaveExpectedAssemblyVersions()
         {
-            IEnumerable<string> dlls = Directory.GetFiles(_sharedFxRoot, "*.dll", SearchOption.AllDirectories).Where(i => !i.Contains("aspnetcorev2_inprocess"));
+            IEnumerable<string> dlls = Directory.GetFiles(_sharedFxRoot, "*.dll", SearchOption.AllDirectories).Where(i => !i.Contains("aspnetcorev2_inprocess") && !i.Contains("System.Security.Cryptography.Xml", StringComparison.OrdinalIgnoreCase));
             Assert.NotEmpty(dlls);
 
             Assert.All(dlls, path =>

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -182,6 +182,26 @@ namespace Microsoft.AspNetCore
         }
 
         [Fact]
+        public void SharedFrameworkAssemblyReferencesHaveExpectedAssemblyVersions()
+        {
+            IEnumerable<string> dlls = Directory.GetFiles(_sharedFxRoot, "*.dll", SearchOption.AllDirectories).Where(i => !i.Contains("aspnetcorev2_inprocess"));
+            Assert.NotEmpty(dlls);
+
+            Assert.All(dlls, path =>
+            {
+                using var fileStream = File.OpenRead(path);
+                using var peReader = new PEReader(fileStream, PEStreamOptions.Default);
+                var reader = peReader.GetMetadataReader(MetadataReaderOptions.Default);
+                
+                Assert.All(reader.AssemblyReferences, handle =>
+                {
+                    var reference = reader.GetAssemblyReference(handle);
+                    Assert.Equal(0, reference.Version.Revision);
+                });
+            });
+        }
+
+        [Fact]
         public void ItContainsVersionFile()
         {
             var versionFile = Path.Combine(_sharedFxRoot, _expectedVersionFileName);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/24541

Adds tests to confirm that assemblies contained in the SharedFx/Targeting pack have versions ending in `0.0`, and only reference things with versions ending in `.0`

One of these tests currently fails - today, the `System.Security.Cryptography.Xml` that we have in the SharedFx (which is versioned `5.0.0.0`) references `System.Security.Cryptography.Pkcs` at `4.0.3.2`, and `System.Memory` at `4.0.1.1`. I believe those are both 3.1 versions. @ericstj @safern @Anipik @joperezr is that expected?