### PR TITLE
Get Helix ready for servicing

### DIFF
--- a/eng/helix/content/RunTests/RunTestsOptions.cs
+++ b/eng/helix/content/RunTests/RunTestsOptions.cs
@@ -22,13 +22,8 @@ namespace RunTests
                     { Argument = new Argument<string>(), Required = true },
 
                 new Option(
-                    aliases: new string[] { "--sdk" },
-                    description: "The version of the sdk being used")
-                { Argument = new Argument<string>(), Required = true },
-
-                new Option(
                     aliases: new string[] { "--runtime" },
-                    description: "The version of the runtime being used")
+                    description: "The version of the ASP.NET runtime being installed and used")
                 { Argument = new Argument<string>(), Required = true },
 
                 new Option(
@@ -70,7 +65,6 @@ namespace RunTests
             var parseResult = command.Parse(args);
             var options = new RunTestsOptions();
             options.Target = parseResult.ValueForOption<string>("--target");
-            options.SdkVersion = parseResult.ValueForOption<string>("--sdk");
             options.RuntimeVersion = parseResult.ValueForOption<string>("--runtime");
             options.HelixQueue = parseResult.ValueForOption<string>("--queue");
             options.Architecture = parseResult.ValueForOption<string>("--arch");

--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -6,13 +6,15 @@ REM Use '$' as a variable name prefix to avoid MSBuild variable collisions with 
 set $target=%1
 set $sdkVersion=%2
 set $runtimeVersion=%3
-set $queue=%4
-set $arch=%5
-set $quarantined=%6
-set $ef=%7
-set $aspnetruntime=%8
-set $aspnetref=%9
+set $aspRuntimeVersion=%4
+set $queue=%5
+set $arch=%6
+set $quarantined=%7
+set $ef=%8
+set $aspnetruntime=%9
 REM Batch only supports up to 9 arguments using the %# syntax, need to shift to get more
+shift
+set $aspnetref=%9
 shift
 set $helixTimeout=%9
 
@@ -31,8 +33,8 @@ set exit_code=0
 echo "Restore: dotnet restore RunTests\RunTests.csproj --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json --source https://api.nuget.org/v3/index.json --ignore-failed-sources..."
 dotnet restore RunTests\RunTests.csproj --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json --source https://api.nuget.org/v3/index.json --ignore-failed-sources
 
-echo "Running tests: dotnet run --project RunTests\RunTests.csproj -- --target %$target% --sdk %$sdkVersion% --runtime %$runtimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%..."
-dotnet run --project RunTests\RunTests.csproj -- --target %$target% --sdk %$sdkVersion% --runtime %$runtimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%
+echo "Running tests: dotnet run --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%..."
+dotnet run --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%
 if errorlevel neq 0 (
     set exit_code=%errorlevel%
 )

--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -88,8 +88,8 @@ sync
 exit_code=0
 echo "Restore: $DOTNET_ROOT/dotnet restore RunTests/RunTests.csproj --source https://api.nuget.org/v3/index.json --ignore-failed-sources..."
 $DOTNET_ROOT/dotnet restore RunTests/RunTests.csproj --source https://api.nuget.org/v3/index.json --ignore-failed-sources
-echo "Running tests: $DOTNET_ROOT/dotnet run --project RunTests/RunTests.csproj -- --target $1 --sdk $2 --runtime $3 --queue $4 --arch $5 --quarantined $6 --ef $7 --aspnetruntime $8 --aspnetref $9 --helixTimeout ${10}..."
-$DOTNET_ROOT/dotnet run --project RunTests/RunTests.csproj -- --target $1 --sdk $2 --runtime $3 --queue $4 --arch $5 --quarantined $6 --ef $7 --aspnetruntime $8 --aspnetref $9 --helixTimeout ${10}
+echo "Running tests: $DOTNET_ROOT/dotnet run --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --aspnetruntime $9 --aspnetref ${10} --helixTimeout ${11}"
+$DOTNET_ROOT/dotnet run --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --aspnetruntime $9 --aspnetref ${10} --helixTimeout ${11}
 exit_code=$?
 echo "Finished tests...exit_code=$exit_code"
 

--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -22,7 +22,6 @@
     <HelixUseArchive>false</HelixUseArchive>
     <LoggingTestingDisableFileLogging Condition="'$(IsHelixJob)' == 'true'">false</LoggingTestingDisableFileLogging>
     <NodeVersion>10.15.3</NodeVersion>
-    <AppRuntimeVersion>5.0.0-ci</AppRuntimeVersion>
     <TestDependsOnAspNetRuntime>false</TestDependsOnAspNetRuntime>
   </PropertyGroup>
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -16,10 +16,6 @@
     <HelixPreCommand Include="call RunPowershell.cmd InstallNode.ps1 $(NodeVersion) %25HELIX_CORRELATION_PAYLOAD%25\node\bin || exit /b 1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsHelixJob)' == 'true' AND '$(TestDependsOnAspNetRef)' == 'true' AND '$(IsTargetingPackBuilding)' == 'true'">
-    <HelixContent Include="$(RepoRoot)artifacts\packages\Release\Shipping\Microsoft.AspNetCore.App.Ref.$(AppRuntimeVersion).nupkg" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(IsHelixJob)' == 'true' AND '$(TestDependsOnAspNetRuntime)' == 'true'">
     <HelixContent Include="$(RepoRoot)artifacts\packages\Release\Shipping\*-ci.nupkg" />
   </ItemGroup>
@@ -91,11 +87,23 @@ Usage: dotnet msbuild /t:Helix src/MyTestProject.csproj
   </Target>
 
   <Target Name="_CreateHelixWorkItem" Condition="$(BuildHelixPayload)">
-
     <ItemGroup>
       <HelixContent Include="$(OutputPath)/Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestAdapter.dll" />
       <HelixContent Include="$(OutputPath)/Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger.dll" />
-      <HelixContent Condition="'$(TestDependsOnAspNetRuntime)' == 'true'" Include="$(RepoRoot)artifacts\packages\Release\Shipping\Microsoft.AspNetCore.App.Runtime.win-x64.$(AppRuntimeVersion).nupkg" />
+    </ItemGroup>
+
+    <!--
+      Could use _GetPackageVersionInfo target (defined in eng/targets/Packaging.targets and included in every C#
+      and F# project) instead of the $(SharedFxVersion) property but the property works everywhere except in site
+      extensions projects. Could also use $(TargetingPackVersion) but that has slightly more complicated semantics
+      and doesn't keep up when in servicing.
+    -->
+    <ItemGroup Condition=" '$(TestDependsOnAspNetRef)' == 'true' AND '$(IsTargetingPackBuilding)' == 'true' ">
+      <HelixContent Include="$(RepoRoot)artifacts\packages\Release\Shipping\Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TestDependsOnAspNetRuntime)' == 'true' ">
+      <HelixContent Include="$(RepoRoot)artifacts\packages\Release\Shipping\Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -117,8 +125,8 @@ Usage: dotnet msbuild /t:Helix src/MyTestProject.csproj
         <TestAssembly>$(TargetFileName)</TestAssembly>
         <PreCommands>@(HelixPreCommand)</PreCommands>
         <PostCommands>@(HelixPostCommand)</PostCommands>
-        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(AppRuntimeVersion).nupkg Microsoft.AspNetCore.App.Ref.$(AppRuntimeVersion).nupkg $(HelixTimeout)</Command>
-        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(AppRuntimeVersion).nupkg Microsoft.AspNetCore.App.Ref.$(AppRuntimeVersion).nupkg $(HelixTimeout)</Command>
+        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg $(HelixTimeout)</Command>
+        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg $(HelixTimeout)</Command>
         <Command Condition="$(HelixCommand) != ''">$(HelixCommand)</Command>
         <Timeout>$(HelixTimeout)</Timeout>
       </HelixWorkItem>


### PR DESCRIPTION
Do not use `$(AppRuntimeVersion)` or NETCore version for shared Fx in Helix runs
- remove hard-coded `$(AppRuntimeVersion)` property entirely
  - use `$(SharedFxVersion)` instead

nits:
- make `RunTests` help more clear about how `--runtime` option is used
- remove unused `--sdk` option on `RunTests` command line
- add Microsoft.AspNetCore.App.Ref package to Helix content later, ensuring it exists