### PR TITLE
Declare AddScheme's displayName parameter as nullable

### DIFF
--- a/src/Http/Authentication.Abstractions/src/AuthenticationOptions.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationOptions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <typeparam name="THandler">The <see cref="IAuthenticationHandler"/> responsible for the scheme.</typeparam>
         /// <param name="name">The name of the scheme being added.</param>
         /// <param name="displayName">The display name for the scheme.</param>
-        public void AddScheme<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(string name, string displayName) where THandler : IAuthenticationHandler
+        public void AddScheme<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]THandler>(string name, string? displayName) where THandler : IAuthenticationHandler
             => AddScheme(name, b =>
             {
                 b.DisplayName = displayName;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/25422.