### PR TITLE
Increase memory buffering threshold for input formatter

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/src/MvcNewtonsoftJsonOptions.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/MvcNewtonsoftJsonOptions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// </para>
         /// </summary>
         /// <value>Defaults to 30Kb.</value>
-        public int InputFormatterMemoryBufferThreshold { get; set; } = 1024 * 30;
+        public int InputFormatterMemoryBufferThreshold { get; set; } = 1024 * 1024;
 
         IEnumerator<ICompatibilitySwitch> IEnumerable<ICompatibilitySwitch>.GetEnumerator() => _switches.GetEnumerator();
 


### PR DESCRIPTION
This PR increases the amount of data buffered to memory before switching to buffering on disk from 30kb to 1mb. The table below highlights (requests per second, mean latency) across different combinations of input size and threshold size for this scenario.

|                 | 2kb input        | 60kb input       | 2mb input        |
|-----------------|------------------|------------------|------------------|
| 30kb threshold  | (7,253.09, 37.08) | (535.68, 475.59) | (109.69, 1320.0) |
| 512kb threshold | (7,424.88, 36.28) | (537.14, 474.95) | (107.7, 1350.0)  |
| 1mb threshold   | (52,428.87, 7.92) | (528.1, 482.06) | (109.37, 1240.0) |
| 2mb threshold   | (51,887.11, 7.95) | (518.05, 496.92) | (107.43, 1320.0) |
| 30mb threshold | (7,228.17, 37.29) | (549.05, 459.4) | (112.85, 1340.0) |

|      | 2kb          | 60kb         | 2mb          |
|------|--------------|--------------|--------------|
| 32kb | 66,687, 4.21 | 4,401, 61.32 | 122.4, 1770  |
| 1mb  | 66,525, 4.12 | 4,458, 58.89 | 123, 1740    |
| 2mb  | 66,630, 4.19 | 4,548, 56.85 | 119.18, 1800 |
| 30mb | 65,046, 4.33 | 4,444, 58.8  | 119.27, 1770 |



