### PR TITLE
Make certificate config linker friendly

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -353,7 +353,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         public CertificateConfig(IConfigurationSection configSection)
         {
             ConfigSection = configSection;
-            ConfigSection.Bind(this);
+            
+            // Bind explictly to preserve linkability
+            Path = configSection[nameof(Path)];
+            KeyPath = configSection[nameof(KeyPath)];
+            Password = configSection[nameof(Password)];
+            Subject = configSection[nameof(Subject)];
+            Store = configSection[nameof(Store)];
+            Location = configSection[nameof(Location)];
+
+            if (bool.TryParse(configSection[nameof(AllowInvalid)], out var value))
+            {
+                AllowInvalid = value;
+            }
         }
 
         // For testing


### PR DESCRIPTION
#25485 targeting 5.0-rc2

Currently can't use Certificates from config files if you link ASP.NET as all the setters for the config section are removed.

This directly references the properties rather than nebulously reflecting them via `object` so the linker will preserve them as they are directly used.

Resolves https://github.com/dotnet/aspnetcore/issues/25482

/cc @Tratcher 