### PR TITLE
Make IdentityServer.Configuration.KeyDefinition linker friendly

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureSigningCredentials.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureSigningCredentials.cs
@@ -52,8 +52,21 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
                 return null;
             }
 
-            var key = new KeyDefinition();
-            _configuration.Bind(key);
+            var key = new KeyDefinition()
+            {
+                Type = _configuration[nameof(KeyDefinition.Type)],
+                FilePath = _configuration[nameof(KeyDefinition.FilePath)],
+                Password = _configuration[nameof(KeyDefinition.Password)],
+                Name = _configuration[nameof(KeyDefinition.Name)],
+                StoreLocation = _configuration[nameof(KeyDefinition.StoreLocation)],
+                StoreName = _configuration[nameof(KeyDefinition.StoreName)],
+                StorageFlags = _configuration[nameof(KeyDefinition.StorageFlags)]
+            };
+
+            if (bool.TryParse(_configuration[nameof(KeyDefinition.Persisted)], out var value))
+            {
+                key.Persisted = value;
+            }
 
             switch (key.Type)
             {


### PR DESCRIPTION
Merged  #25487 but retargeted for release/5.0-rc2 (that was merged to master thought it was approved for 5.0-rc2)

/cc @javiercn @Pilchie 