### PR TITLE
Improving logs from hostfxr

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -268,7 +268,9 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
         auto startupReturnCode = context->m_hostFxr.InitializeForApp(context->m_argc, context->m_argv.get(), m_dotnetExeKnownLocation);
         if (startupReturnCode != 0)
         {
-            throw InvalidOperationException(format(L"Error occurred when initializing in-process application, Return code: 0x%x", startupReturnCode));
+            auto content = m_stringRedirectionOutput->GetOutput();
+
+            throw InvalidOperationException(format(L"Error occurred when initializing in-process application, Return code: 0x%x, Error logs: %ls", startupReturnCode, content));
         }
 
         if (m_pConfig->QueryCallStartupHook())

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -270,7 +270,7 @@ IN_PROCESS_APPLICATION::ExecuteApplication()
         {
             auto content = m_stringRedirectionOutput->GetOutput();
 
-            throw InvalidOperationException(format(L"Error occurred when initializing in-process application, Return code: 0x%x, Error logs: %ls", startupReturnCode, content));
+            throw InvalidOperationException(format(L"Error occurred when initializing in-process application, Return code: 0x%x, Error logs: %ls", startupReturnCode, content.c_str()));
         }
 
         if (m_pConfig->QueryCallStartupHook())


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/24358

Example error message:
```
[aspnetcorev2_inprocess.dll] Event Log: 'Application '/LM/W3SVC/1/ROOT' with physical root 'C:\inetpub\wwwroot\' failed to load coreclr. Exception message:
Error occurred when initializing in-process application, Return code: 0x80008083, Error logs: A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'C:\Program Files\dotnet'.
Failed to run as a self-contained app.
  - The application was run as a self-contained app because 'C:\inetpub\wwwroot\SelfContainedIssueRepro.runtimeconfig.json' did not specify a framework.
  - If this should be a framework-dependent app, specify the appropriate framework in 'C:\inetpub\wwwroot\SelfContainedIssueRepro.runtimeconfig.json'.
A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'C:\Program Files\dotnet'.
Failed to run as a self-contained app.
  - The application was run as a self-contained app because 'C:\inetpub\wwwroot\SelfContainedIssueRepro.runtimeconfig.json' did not specify a framework.
  - If this should be a framework-dependent app, specify the appropriate framework in 'C:\inetpub\wwwroot\SelfContainedIssueRepro.runtimeconfig.json'.
' 
End Event Log 
```