### PR TITLE
Quick infrastructure fix-ups

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -573,6 +573,7 @@ stages:
         jobName: MacOS_Test
         jobDisplayName: "Test: macOS 10.14"
         agentOs: macOS
+        timeoutInMinutes: 240
         isTestingJob: true
         buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
         beforeBuild:

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -86,7 +86,7 @@ jobs:
     jobName: MacOS_Quarantined_Test
     jobDisplayName: "Tests: macOS 10.14"
     agentOs: macOS
-    timeoutInMinutes: 60
+    timeoutInMinutes: 120
     isTestingJob: true
     steps:
     - bash: ./build.sh --all --pack --ci --nobl --no-build-java

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -329,9 +329,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4be47e467013f8a07a1ed7b6e49e39c8150bde54</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-2.20407.3">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="3.8.0-2.20403.2" Pinned="true">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>dba2fa57432b4bd9cc7880e2c6fe3acdd01bba3c</Sha>
+      <Sha>b6a07e61473ed8a804de465f7c1cb5c17f80732d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
   -->
   <PropertyGroup Label="Automated">
     <!-- Packages from dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>3.8.0-2.20407.3</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>3.8.0-2.20403.2</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- Packages from dotnet/runtime -->
     <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-rc.2.20451.27</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreAppInternalPackageVersion>5.0.0-rc.2.20451.27</MicrosoftNETCoreAppInternalPackageVersion>


### PR DESCRIPTION
- pin Microsoft.Net.Compilers.Toolset version to isolate us from Arcade
  - the version now matches dotnet/runtime
  - will move the pin to previous version if anything breaks
- double the macOS job max. length in our quarantined PR runs
  - have been seeing this timeout too often