### PR TITLE
Double timeout for MacOS test job

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -573,6 +573,7 @@ stages:
         jobName: MacOS_Test
         jobDisplayName: "Test: macOS 10.14"
         agentOs: macOS
+        timeoutInMinutes: 120
         isTestingJob: true
         buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
         beforeBuild:


### PR DESCRIPTION
This job has been timing out more since we moved to in-house OSX agents. Increasing the timeout to 120 should help mitigate (CC @MattGal)

@Pilchie good for RC2 tell mode?