### PR TITLE
Add MigrationsEndPoint when DatabaseDeveloperPageExceptionFilter is used

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Startup.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/samples/ApiAuthSample/Startup.cs
@@ -50,6 +50,7 @@ namespace ApiAuthSample
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseMigrationsEndPoint();
             }
             else
             {

--- a/src/Identity/samples/IdentitySample.DefaultUI/Startup.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Startup.cs
@@ -60,6 +60,7 @@ namespace IdentitySample.DefaultUI
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseMigrationsEndPoint();
             }
             else
             {

--- a/src/Identity/samples/IdentitySample.Mvc/Startup.cs
+++ b/src/Identity/samples/IdentitySample.Mvc/Startup.cs
@@ -63,6 +63,7 @@ namespace IdentitySample
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseMigrationsEndPoint();
             }
             else
             {

--- a/src/Identity/testassets/Identity.DefaultUI.WebSite/NoIdentityStartup.cs
+++ b/src/Identity/testassets/Identity.DefaultUI.WebSite/NoIdentityStartup.cs
@@ -49,6 +49,7 @@ namespace Identity.DefaultUI.WebSite
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseMigrationsEndPoint();
             }
             else
             {

--- a/src/Identity/testassets/Identity.DefaultUI.WebSite/StartupBase.cs
+++ b/src/Identity/testassets/Identity.DefaultUI.WebSite/StartupBase.cs
@@ -65,6 +65,7 @@ namespace Identity.DefaultUI.WebSite
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseMigrationsEndPoint();
             }
             else
             {

--- a/src/Identity/testassets/Identity.DefaultUI.WebSite/StartupWithoutEndpointRouting.cs
+++ b/src/Identity/testassets/Identity.DefaultUI.WebSite/StartupWithoutEndpointRouting.cs
@@ -34,6 +34,7 @@ namespace Identity.DefaultUI.WebSite
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseMigrationsEndPoint();
             }
             else
             {

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/StartupOpenIdConnectTesting.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/StartupOpenIdConnectTesting.cs
@@ -125,6 +125,8 @@ namespace MusicStore
             // During development use the ErrorPage middleware to display error information in the browser
             app.UseDeveloperExceptionPage();
 
+            app.UseMigrationsEndPoint();
+
             // Configure Session.
             app.UseSession();
 

--- a/src/MusicStore/samples/MusicStore/ForTesting/Mocks/StartupSocialTesting.cs
+++ b/src/MusicStore/samples/MusicStore/ForTesting/Mocks/StartupSocialTesting.cs
@@ -161,6 +161,8 @@ namespace MusicStore
             // Note: Not recommended for production.
             app.UseDeveloperExceptionPage();
 
+            app.UseMigrationsEndPoint();
+
             // Configure Session.
             app.UseSession();
 

--- a/src/MusicStore/samples/MusicStore/Startup.cs
+++ b/src/MusicStore/samples/MusicStore/Startup.cs
@@ -134,6 +134,8 @@ namespace MusicStore
             // During development use the ErrorPage middleware to display error information in the browser
             app.UseDeveloperExceptionPage();
 
+            app.UseMigrationsEndPoint();
+
             Configure(app);
         }
 

--- a/src/MusicStore/samples/MusicStore/StartupNtlmAuthentication.cs
+++ b/src/MusicStore/samples/MusicStore/StartupNtlmAuthentication.cs
@@ -117,6 +117,8 @@ namespace MusicStore
             // Note: Not recommended for production.
             app.UseDeveloperExceptionPage();
 
+            app.UseMigrationsEndPoint();
+
             app.Use((context, next) =>
             {
                 context.Response.Headers["Arch"] = RuntimeInformation.ProcessArchitecture.ToString();

--- a/src/MusicStore/samples/MusicStore/StartupOpenIdConnect.cs
+++ b/src/MusicStore/samples/MusicStore/StartupOpenIdConnect.cs
@@ -124,6 +124,8 @@ namespace MusicStore
             // During development use the ErrorPage middleware to display error information in the browser
             app.UseDeveloperExceptionPage();
 
+            app.UseMigrationsEndPoint();
+
             // Configure Session.
             app.UseSession();
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Startup.cs
@@ -136,6 +136,9 @@ namespace BlazorServerWeb_CSharp
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+#if (IndividualLocalAuth)
+                app.UseMigrationsEndPoint();
+#endif
             }
             else
             {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Startup.cs
@@ -99,6 +99,9 @@ namespace ComponentsWebAssembly_CSharp.Server
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+#if (IndividualLocalAuth)
+                app.UseMigrationsEndPoint();
+#endif
                 app.UseWebAssemblyDebugging();
             }
             else

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Startup.cs
@@ -119,6 +119,9 @@ namespace Company.WebApplication1
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+#if (IndividualLocalAuth)
+                app.UseMigrationsEndPoint();
+#endif
             }
             else
             {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs
@@ -120,6 +120,9 @@ namespace Company.WebApplication1
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+#if (IndividualLocalAuth)
+                app.UseMigrationsEndPoint();
+#endif
             }
             else
             {

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Startup.cs
@@ -72,6 +72,9 @@ namespace Company.WebApplication1
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+#if (IndividualLocalAuth)
+                app.UseMigrationsEndPoint();
+#endif
             }
             else
             {

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/Startup.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/Startup.cs
@@ -74,6 +74,9 @@ namespace Company.WebApplication1
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+#if (IndividualLocalAuth)
+                app.UseMigrationsEndPoint();
+#endif
             }
             else
             {

--- a/src/Security/samples/Identity.ExternalClaims/Startup.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Startup.cs
@@ -74,6 +74,7 @@ namespace Identity.ExternalClaims
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseMigrationsEndPoint();
             }
             else
             {


### PR DESCRIPTION
Following up to https://github.com/dotnet/aspnetcore/pull/24588. I noticed that the removed UseDatabaseErrorPage calls also adds a migrations endpoint middleware. This function was lost when I made the original changes in https://github.com/dotnet/aspnetcore/pull/24588. This PR adds the migrations endpoint middleware back. Once this is fixed, I'll update the breaking changes announcement to include this step.