### PR TITLE
Add option to specify hostname in BrowserRefreshServer

### DIFF
--- a/src/Tools/dotnet-watch/src/BrowserRefreshServer.cs
+++ b/src/Tools/dotnet-watch/src/BrowserRefreshServer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<string> StartAsync(CancellationToken cancellationToken)
         {
-            var hostName = Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_HOSTNAME") ?? "127.0.0.1";
+            var hostName = Environment.GetEnvironmentVariable("DOTNET_WATCH_AUTO_RELOAD_WS_HOSTNAME") ?? "127.0.0.1";
 
             _refreshServer = new HostBuilder()
                 .ConfigureWebHost(builder =>

--- a/src/Tools/dotnet-watch/src/BrowserRefreshServer.cs
+++ b/src/Tools/dotnet-watch/src/BrowserRefreshServer.cs
@@ -33,11 +33,13 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         public async ValueTask<string> StartAsync(CancellationToken cancellationToken)
         {
+            var hostName = Environment.GetEnvironmentVariable("ASPNETCORE_AUTO_RELOAD_WS_HOSTNAME") ?? "127.0.0.1";
+
             _refreshServer = new HostBuilder()
                 .ConfigureWebHost(builder =>
                 {
                     builder.UseKestrel();
-                    builder.UseUrls("http://127.0.0.1:0");
+                    builder.UseUrls($"http://{hostName}:0");
 
                     builder.Configure(app =>
                     {
@@ -100,7 +102,7 @@ namespace Microsoft.DotNet.Watcher.Tools
             {
                 _refreshServer.Dispose();
             }
-            
+
             _taskCompletionSource.TrySetResult();
         }
     }


### PR DESCRIPTION
Summary of the changes
 - Looks for an environment variable specifying the hostname for the dotnet-watch browser refresh server.

Addresses #25570
