### PR TITLE
Update gRPC version in template to 2.32.0-pre1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -251,11 +251,11 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
-    <GoogleProtobufPackageVersion>3.10.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>2.27.0</GrpcAspNetCorePackageVersion>
-    <GrpcAuthPackageVersion>2.27.0</GrpcAuthPackageVersion>
-    <GrpcNetClientPackageVersion>2.27.0</GrpcNetClientPackageVersion>
-    <GrpcToolsPackageVersion>2.27.0</GrpcToolsPackageVersion>
+    <GoogleProtobufPackageVersion>3.13.0</GoogleProtobufPackageVersion>
+    <GrpcAspNetCorePackageVersion>2.32.0-pre1</GrpcAspNetCorePackageVersion>
+    <GrpcAuthPackageVersion>2.32.0-pre1</GrpcAuthPackageVersion>
+    <GrpcNetClientPackageVersion>2.32.0-pre1</GrpcNetClientPackageVersion>
+    <GrpcToolsPackageVersion>2.32.0-pre1</GrpcToolsPackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>4.0.4</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>4.0.4</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>4.0.4</IdentityServer4PackageVersion>

--- a/src/Grpc/test/InteropTests/InteropTests.cs
+++ b/src/Grpc/test/InteropTests/InteropTests.cs
@@ -90,7 +90,22 @@ namespace InteropTests
         {
             using (var serverProcess = new WebsiteProcess(_serverPath, _output))
             {
-                await serverProcess.WaitForReady().TimeoutAfter(DefaultTimeout);
+                try
+                {
+                    await serverProcess.WaitForReady().TimeoutAfter(DefaultTimeout);
+                }
+                catch (Exception ex)
+                {
+                    var errorMessage = $@"Error while running server process.
+
+Server ready: {serverProcess.IsReady}
+
+Server process output:
+======================================
+{serverProcess.GetOutput()}
+======================================";
+                    throw new InvalidOperationException(errorMessage, ex);
+                }
 
                 using (var clientProcess = new ClientProcess(_output, _clientPath, serverProcess.ServerPort, name))
                 {

--- a/src/Grpc/test/InteropTests/InteropTests.csproj
+++ b/src/Grpc/test/InteropTests/InteropTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <ContainsFunctionalTestAssets>true</ContainsFunctionalTestAssets>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc/test/InteropTests/InteropTests.csproj
+++ b/src/Grpc/test/InteropTests/InteropTests.csproj
@@ -4,6 +4,7 @@
     <ContainsFunctionalTestAssets>true</ContainsFunctionalTestAssets>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
+    <IsWindowsOnlyTest>true</IsWindowsOnlyTest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc/test/testassets/InteropClient/InteropClient.cs
+++ b/src/Grpc/test/testassets/InteropClient/InteropClient.cs
@@ -168,7 +168,7 @@ namespace InteropTestsClient
                 httpClientHandler.ClientCertificates.Add(cert);
             }
 
-            var httpClient = new HttpClient(new VersionPolicyHandler(httpClientHandler));
+            var httpClient = new HttpClient(httpClientHandler);
 
             var channel = GrpcChannel.ForAddress($"{scheme}://{options.ServerHost}:{options.ServerPort}", new GrpcChannelOptions
             {
@@ -178,21 +178,6 @@ namespace InteropTestsClient
             });
 
             return new GrpcChannelWrapper(channel);
-        }
-
-        // TODO(JamesNK): This type can be removed in the future when Grpc.Net.Client sets VersionPolicy automatically.
-        // https://github.com/grpc/grpc-dotnet/pull/987
-        private class VersionPolicyHandler : DelegatingHandler
-        {
-            public VersionPolicyHandler(HttpMessageHandler innerHandler) : base(innerHandler)
-            {
-            }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                request.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
-                return base.SendAsync(request, cancellationToken);
-            }
         }
 
         private async Task<ChannelCredentials> CreateCredentialsAsync(bool? useTestCaOverride = null)
@@ -875,7 +860,7 @@ namespace InteropTestsClient
             string keyFile = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS")!;
             Assert.IsNotNull(keyFile);
             var jobject = JObject.Parse(File.ReadAllText(keyFile));
-            string email = jobject.GetValue("client_email").Value<string>();
+            string email = jobject.GetValue("client_email")!.Value<string>()!;
             Assert.IsTrue(email.Length > 0);  // spec requires nonempty client email.
             return email;
         }

--- a/src/Grpc/test/testassets/InteropWebsite/Startup.cs
+++ b/src/Grpc/test/testassets/InteropWebsite/Startup.cs
@@ -22,6 +22,7 @@ using Grpc.Testing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Net.Http.Headers;
 
 namespace InteropTestsWebsite
 {
@@ -44,6 +45,8 @@ namespace InteropTestsWebsite
 
                 var runtimeVersion = typeof(object).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
                 Console.WriteLine($"NetCoreAppVersion: {runtimeVersion}");
+                var aspNetCoreVersion = typeof(HeaderNames).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
+                Console.WriteLine($"AspNetCoreAppVersion: {aspNetCoreVersion}");
             });
 
             app.UseRouting();


### PR DESCRIPTION
This PR updates the gRPC template and interop tests to use 2.32.0-pre1 of Grpc.AspNetCore/Grpc.Net.Client.

2.32.0-pre1 is being published to NuGet.org non-publicly because it uses RC1 APIs. When RC1 is released then it will be made public.

2.32.0 (non-preview) should be released on NuGet.org in two weeks. .NET 5 GA will be updated to use it in the template.