### PR TITLE
Fix Linux installer dependency versioning

### DIFF
--- a/src/Installers/Debian/Runtime/Debian.Runtime.debproj
+++ b/src/Installers/Debian/Runtime/Debian.Runtime.debproj
@@ -13,10 +13,12 @@
     <!-- Needed some creativity to convert the PackageVersion M.N.P-PreReleaseVersionLabel-Build to the installer version M.N.P~PreReleaseVersionLabel-Build, The conditional handles stabilized builds -->
     <DotnetRuntimeDependencyVersion>$(MicrosoftNETCoreAppRuntimeVersion)</DotnetRuntimeDependencyVersion>
     <DotnetRuntimeDependencyVersion Condition="$(DotnetRuntimeDependencyVersion.Contains('-'))">$(DotnetRuntimeDependencyVersion.Substring(0, $(DotnetRuntimeDependencyVersion.IndexOf('-'))))~$(DotnetRuntimeDependencyVersion.Substring($([MSBuild]::Add($(DotnetRuntimeDependencyVersion.IndexOf('-')), 1))))</DotnetRuntimeDependencyVersion>
+    <DotnetRuntimeDependencyMajorMinorVersion>$(MicrosoftNETCoreAppRuntimeVersion.Split('.')[0]).$(MicrosoftNETCoreAppRuntimeVersion.Split('.')[1])</DotnetRuntimeDependencyMajorMinorVersion>
 
     <PackageSummary>$(SharedFxProductName)</PackageSummary>
     <PackageDescription>$(SharedFxDescription)</PackageDescription>
     <DebianConfigProperties>
+      DotnetRuntimeDependencyMajorMinorVersion=$(DotnetRuntimeDependencyMajorMinorVersion);
       DotnetRuntimeDependencyVersion=$(DotnetRuntimeDependencyVersion);
     </DebianConfigProperties>
   </PropertyGroup>

--- a/src/Installers/Debian/Runtime/debian_config.json.in
+++ b/src/Installers/Debian/Runtime/debian_config.json.in
@@ -29,7 +29,7 @@
   },
 
   "debian_dependencies": {
-    "dotnet-runtime-${AspNetCoreMajorVersion}.${AspNetCoreMinorVersion}": {
+    "dotnet-runtime-${DotnetRuntimeDependencyMajorMinorVersion}": {
       "package_version": "${DotnetRuntimeDependencyVersion}"
     }
   }

--- a/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
+++ b/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
@@ -16,10 +16,12 @@
     <!-- Needed some creativity to convert the PackageVersion M.N.P-PreReleaseVersionLabel-Build to the installer version M.N.P~PreReleaseVersionLabel-Build, The conditional handles stabilized builds -->
     <DotnetTargetingPackDependencyVersion>$(MicrosoftNETCoreAppRefPackageVersion)</DotnetTargetingPackDependencyVersion>
     <DotnetTargetingPackDependencyVersion Condition="$(DotnetTargetingPackDependencyVersion.Contains('-'))">$(DotnetTargetingPackDependencyVersion.Substring(0, $(DotnetTargetingPackDependencyVersion.IndexOf('-'))))~$(DotnetTargetingPackDependencyVersion.Substring($([MSBuild]::Add($(DotnetTargetingPackDependencyVersion.IndexOf('-')), 1))))</DotnetTargetingPackDependencyVersion>
+    <DotnetTargetingPackDependencyMajorMinorVersion>$(MicrosoftNETCoreAppRefPackageVersion.Split('.')[0]).$(MicrosoftNETCoreAppRefPackageVersion.Split('.')[1])</DotnetTargetingPackDependencyMajorMinorVersion>
 
     <PackageSummary>$(SharedFxProductName)</PackageSummary>
     <PackageDescription>$(SharedFxDescription)</PackageDescription>
     <DebianConfigProperties>
+      DotnetTargetingPackDependencyMajorMinorVersion=$(DotnetTargetingPackDependencyMajorMinorVersion);
       DotnetTargetingPackDependencyVersion=$(DotnetTargetingPackDependencyVersion);
     </DebianConfigProperties>
 

--- a/src/Installers/Debian/TargetingPack/debian_config.json.in
+++ b/src/Installers/Debian/TargetingPack/debian_config.json.in
@@ -29,7 +29,7 @@
   },
 
   "debian_dependencies": {
-    "dotnet-targeting-pack-${AspNetCoreMajorVersion}.${AspNetCoreMinorVersion}": {
+    "dotnet-targeting-pack-${DotnetTargetingPackDependencyMajorMinorVersion}": {
       "package_version": "${DotnetTargetingPackDependencyVersion}"
     }
   }

--- a/src/Installers/Rpm/Rpm.Runtime.Common.targets
+++ b/src/Installers/Rpm/Rpm.Runtime.Common.targets
@@ -15,6 +15,8 @@
     <PackageDescription>$(SharedFxDescription)</PackageDescription>
 
     <PackageContentRoot>$(SharedFrameworkLayoutRoot)</PackageContentRoot>
+
+    <MicrosoftNETCoreAppRuntimeMajorMinorVersion>$(MicrosoftNETCoreAppRuntimeVersion.Split('.')[0]).$(MicrosoftNETCoreAppRuntimeVersion.Split('.')[1])</MicrosoftNETCoreAppRuntimeMajorMinorVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +26,6 @@
     </ProjectReference>
 
     <InstallerOwnedDirectory Include="$(RpmPackageInstallRoot)shared/Microsoft.AspNetCore.App" />
-    <RpmDependency Include="dotnet-runtime-$(AspNetCoreMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRuntimeVersion.Split('-')[0])" />
+    <RpmDependency Include="dotnet-runtime-$(MicrosoftNETCoreAppRuntimeMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRuntimeVersion.Split('-')[0])" />
   </ItemGroup>
 </Project>

--- a/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
+++ b/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
@@ -12,6 +12,8 @@
 
     <PackageSummary>ASP.NET Core Targeting Pack</PackageSummary>
     <PackageDescription>Provides a default set of APIs for building an ASP.NET Core $(AspNetCoreMajorMinorVersion) application. Contains reference assemblies, documentation, and other design-time assets.</PackageDescription>
+
+    <MicrosoftNETCoreAppRefMajorMinorVersion>$(MicrosoftNETCoreAppRefPackageVersion.Split('.')[0]).$(MicrosoftNETCoreAppRefPackageVersion.Split('.')[1])</MicrosoftNETCoreAppRefMajorMinorVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +23,7 @@
     </ProjectReference>
 
     <InstallerOwnedDirectory Include="$(RpmPackageInstallRoot)packs/$(TargetingPackName)/" />
-    <RpmDependency Include="dotnet-targeting-pack-$(AspNetCoreMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRefPackageVersion.Split('-')[0])" />
+    <RpmDependency Include="dotnet-targeting-pack-$(MicrosoftNETCoreAppRefMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRefPackageVersion.Split('-')[0])" />
   </ItemGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />


### PR DESCRIPTION
Fixes ingestion issue in https://github.com/dotnet/installer/pull/8235

The error there was:
```
  dpkg: dependency problems prevent configuration of aspnetcore-targeting-pack-5.0:
   aspnetcore-targeting-pack-5.0 depends on dotnet-targeting-pack-5.0 (>= 6.0.0~alpha.1.20428.2); however:
    Package dotnet-targeting-pack-5.0 is not installed.
```

This is because we assume that the major.minor between aspnetcore and dotnet-targeting-pack or dotnet-runtime-pack are always aligned. This is not the case in the master branch at the moment since our branding update PR is still in progress. Nevertheless, we should never make that assumption and calculate the major.minor version of the runtime dependencies instead.