### PR TITLE
Update RCL template to use 5.0 features

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
@@ -13,24 +13,27 @@ namespace Company.RazorClassLibrary1
 
     public class ExampleJsInterop : IAsyncDisposable
     {
-        private readonly Task<IJSObjectReference> moduleTask;
+        private readonly Lazy<Task<IJSObjectReference>> moduleTask;
 
         public ExampleJsInterop(IJSRuntime jsRuntime)
         {
-            moduleTask = jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", "./_content/Company.RazorClassLibrary1/exampleJsInterop.js").AsTask();
+            moduleTask = new (async () => await jsRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/Company.RazorClassLibrary1/exampleJsInterop.js"));
         }
 
         public async ValueTask<string> Prompt(string message)
         {
-            var module = await moduleTask;
+            var module = await moduleTask.Value;
             return await module.InvokeAsync<string>("showPrompt", message);
         }
 
         public async ValueTask DisposeAsync()
         {
-            var module = await moduleTask;
-            await module.DisposeAsync();
+            if (moduleTask.IsValueCreated)
+            {
+                var module = await moduleTask.Value;
+                await module.DisposeAsync();
+            }
         }
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
@@ -17,8 +17,8 @@ namespace Company.RazorClassLibrary1
 
         public ExampleJsInterop(IJSRuntime jsRuntime)
         {
-            moduleTask = new (async () => await jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", "./_content/Company.RazorClassLibrary1/exampleJsInterop.js"));
+            moduleTask = new (() => jsRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/Company.RazorClassLibrary1/exampleJsInterop.js").AsTask());
         }
 
         public async ValueTask<string> Prompt(string message)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
@@ -6,7 +6,7 @@ namespace Company.RazorClassLibrary1
 {
     // This class provides an example of how JavaScript functionality can be wrapped
     // in a .NET class for easy consumption. The associated JavaScript module is
-    // loaded on demand when the class is instantiated.
+    // loaded on demand when first needed.
     //
     // This class can be registered as scoped DI service and then injected into Blazor
     // components for use.

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
@@ -1,16 +1,36 @@
-using Microsoft.JSInterop;
+using System;
 using System.Threading.Tasks;
+using Microsoft.JSInterop;
 
 namespace Company.RazorClassLibrary1
 {
-    public class ExampleJsInterop
+    // This class provides an example of how JavaScript functionality can be wrapped
+    // in a .NET class for easy consumption. The associated JavaScript module is
+    // loaded on demand when the class is instantiated.
+    //
+    // This class can be registered as scoped DI service and then injected into Blazor
+    // components for use.
+
+    public class ExampleJsInterop : IAsyncDisposable
     {
-        public static ValueTask<string> Prompt(IJSRuntime jsRuntime, string message)
+        private readonly Task<IJSObjectReference> moduleTask;
+
+        public ExampleJsInterop(IJSRuntime jsRuntime)
         {
-            // Implemented in exampleJsInterop.js
-            return jsRuntime.InvokeAsync<string>(
-                "exampleJsFunctions.showPrompt",
-                message);
+            moduleTask = jsRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/Company.RazorClassLibrary1/exampleJsInterop.js").AsTask();
+        }
+
+        public async ValueTask<string> Prompt(string message)
+        {
+            var module = await moduleTask;
+            return await module.InvokeAsync<string>("showPrompt", message);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            var module = await moduleTask;
+            await module.DisposeAsync();
         }
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/wwwroot/exampleJsInterop.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/wwwroot/exampleJsInterop.js
@@ -1,8 +1,6 @@
-// This file is to show how a library package may provide JavaScript interop features
-// wrapped in a .NET API
+// This is a JavaScript module that is loaded on demand. It can export any number of
+// functions, and may import other JavaScript modules if required.
 
-window.exampleJsFunctions = {
-  showPrompt: function (message) {
-    return prompt(message, 'Type anything here');
-  }
-};
+export function showPrompt(message) {
+  return prompt(message, 'Type anything here');
+}

--- a/src/ProjectTemplates/test/template-baselines.json
+++ b/src/ProjectTemplates/test/template-baselines.json
@@ -877,9 +877,9 @@
       "Files": [
         "wwwroot/background.png",
         "wwwroot/exampleJsInterop.js",
-        "wwwroot/styles.css",
         "_Imports.razor",
         "Component1.razor",
+        "Component1.razor.css",
         "ExampleJsInterop.cs"
       ]
     },


### PR DESCRIPTION
**Note** This PR is based on `javiercn/css-isolation-follow-ups`, not because I actually want to merge into that branch, but because it builds on functionality added in https://github.com/dotnet/aspnetcore/pull/25565 and can't be merged until that one is.

### Description

This PR improves the Razor Class Library template to use 5.0 features:

 * CSS isolation, so that (1) styles are scoped, and (2) consumers of the library no longer have to add any `<link>` tag for the library's styles - it's auto-bundled.
 * JS isolation, so that (1) it doesn't pollute the global namespace, and (2) consumers of the library no longer have to add any `<script>` tag for the library's JS - it's auto-loaded on demand.

### Customer Impact

Makes clear how the 5.0 features are meant to be used in RCLs, and avoids the weirdness of shipping an RCL template that inexplicably fails to use the features that are obviously designed for this scenario.

### Regression

No

### Risk

As long as we actually do some verification on this, very low chance of causing any bugs.

### Design note

It does make the `ExampleJsInterop.cs` code quite a bit longer and involves more concepts.

Previously it was just a few-lines-long `static` function you could invoke and pass in an `IJSRuntime` instance, and it relied on the associated `.js` file already being loaded in the global namespace. The new version is set up to be used as a DI service (not a `static`) and contains code to lazy-load the associated `.js` file.

I've made it an `IAsyncDisposable` because you could think of it as a good practice to remind people that `IJSObjectReference` instances are `IAsyncDisposable`. In practice, as long as `ExampleJsInterop` is consumed as a scoped or singleton instance, there would be no need ever to dispose the lazy-loaded JS module so it's kind of redundant, but I think we should do it like I have here in order to be more risk averse and not set a bad example that disposability can be ignored.

On balance I think the new version of `ExampleJsInterop.cs` is more useful than the previous one and guides people to be more successful, so it's worth the extra 20 lines of code there.

### Design note 2

Most of the lines of code in `ExampleJsInterop.cs` could be factored out into an abstract base class, e.g., `JSModuleBase`. This could contain methods like `InvokeAsync(...)` etc. that pass through the call to `(await ModuleTask).InvokeAsync(...)` so you wouldn't even have to think about awaiting the module load. This base class constructor would take care of calling `import`, and obviously it could deal with `IAsyncDisposable` too. Then the developer's own code could be reduced to something like:

```cs
public class ExampleJsInterop : JSModuleBase
{
    public ExampleJsInterop(IJSRuntime jsRuntime)
        : base(jsRuntime, "./_content/Company.RazorClassLibrary1/exampleJsInterop.js")
    {
    }

    public ValueTask<string> Prompt(string message)
        => InvokeAsync<string>("showPrompt", message);
}
```

Not suggesting we do that right now, but if customers start using JS modules a lot, it might be worth thinking as a feature for 6.0.