### PR TITLE
[Routing] Update DfaMatcherBuilder to use the correct behavior by default

### DIFF
--- a/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             }
             else
             {
-                UseCorrectCatchAllBehavior = false; // default to bugged behavior
+                UseCorrectCatchAllBehavior = true; // default to correct behavior
             }
 
             var (nodeBuilderPolicies, endpointComparerPolicies, endpointSelectorPolicies) = ExtractPolicies(policies.OrderBy(p => p.Order));

--- a/src/Http/Routing/test/UnitTests/Matching/DfaMatcherBuilderTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DfaMatcherBuilderTest.cs
@@ -543,7 +543,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         public void BuildDfaTree_MultipleEndpoint_ParameterAndCatchAll_OnSameNode_Order2_DefaultBehavior()
         {
             var builder = CreateDfaMatcherBuilder();
-            BuildDfaTree_MultipleEndpoint_ParameterAndCatchAll_OnSameNode_Order2_LegacyBehavior_Core(builder);
+            BuildDfaTree_MultipleEndpoint_ParameterAndCatchAll_OnSameNode_Order2_CorrectBehavior_Core(builder);
         }
 
         [Fact]
@@ -636,7 +636,11 @@ namespace Microsoft.AspNetCore.Routing.Matching
             // Arrange
             var builder = CreateDfaMatcherBuilder();
             builder.UseCorrectCatchAllBehavior = true;
+            BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order1_CorrectBehavior_Core(builder);
+        }
 
+        private void BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order1_CorrectBehavior_Core(DfaMatcherBuilder builder)
+        {
             var endpoint1 = CreateEndpoint("{a}/{b}", order: 0);
             builder.AddEndpoint(endpoint1);
 
@@ -688,10 +692,14 @@ namespace Microsoft.AspNetCore.Routing.Matching
         [Fact]
         public void BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order2_CorrectBehavior()
         {
-            // Arrange
             var builder = CreateDfaMatcherBuilder();
             builder.UseCorrectCatchAllBehavior = true;
+            BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order2_CorrectBehavior_Core(builder);
+        }
 
+        private void BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order2_CorrectBehavior_Core(DfaMatcherBuilder builder)
+        {
+            // Arrange
             var endpoint1 = CreateEndpoint("a/{*b}", order: 0);
             builder.AddEndpoint(endpoint1);
 
@@ -744,7 +752,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         public void BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order1_DefaultBehavior()
         {
             var builder = CreateDfaMatcherBuilder();
-            BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order1_Legacy30Behavior_Core(builder);
+            BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order1_CorrectBehavior_Core(builder);
         }
 
         // Regression test for https://github.com/dotnet/aspnetcore/issues/18677
@@ -803,7 +811,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         public void BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order2_DefaultBehavior()
         {
             var builder = CreateDfaMatcherBuilder();
-            BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order2_Legacy30Behavior_Core(builder);
+            BuildDfaTree_MultipleEndpoint_CatchAllWithHigherPrecedenceThanParameter_Order2_CorrectBehavior_Core(builder);
         }
 
         // Regression test for https://github.com/dotnet/aspnetcore/issues/18677

--- a/src/Http/Routing/test/UnitTests/Matching/DfaMatcherConformanceTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DfaMatcherConformanceTest.cs
@@ -60,8 +60,8 @@ namespace Microsoft.AspNetCore.Routing.Matching
         //
         [Theory]
         [InlineData("/middleware", 1)]
-        [InlineData("/middleware/test", 0)]
-        [InlineData("/middleware/test1/test2", -1)]
+        [InlineData("/middleware/test", 1)]
+        [InlineData("/middleware/test1/test2", 1)]
         [InlineData("/bill/boga", 0)]
         public async Task Match_Regression_1867_DefaultBehavior(string path, int endpointIndex)
         {


### PR DESCRIPTION
# Description

Routing in 5.0 still defaults to the wrong behavior in #18677.

We want to turn this on by default to avoid people being caught up by surprise by the old behavior and relying or inadvertently taking a dependency on it. We will get rid of the legacy behavior all together in 6.0. 

People wanting to retain the old behavior (because they took a dependency on it, can still switch the flag explicitly to false).

We will also be patching the 3.1 templates to make this behavior enabled by default in the templates in a future patch (we didn't did that when we fixed the issue).

# Customer Impact
* Route precedence doesn't behave in the way we describe in the docs and it is hard for users to determine why without going to the docs.
* People can rely on this behavior without noticing and we want to avoid that as it would make a change in the future more painful.

# Regression?

No. It's re-establishing the legitimate behavior that routing had before 3.1.

# Risk

Low. We might get bugs from people upgrading where their routes change, but the changes are well understood and there is an explicit opt-out through the feature switch.

## Fixes
https://github.com/dotnet/aspnetcore/issues/25617