### PR TITLE
Blazor: Display value in property setter exception

### DIFF
--- a/src/Components/Components/src/Reflection/ComponentProperties.cs
+++ b/src/Components/Components/src/Reflection/ComponentProperties.cs
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Components.Reflection
                 catch (Exception ex)
                 {
                     throw new InvalidOperationException(
-                        $"Unable to set property '{parameterName}' on object of " +
+                        $"Unable to set property '{parameterName}' to value '{value}' on object of " +
                         $"type '{target.GetType().FullName}'. The error was: {ex.Message}", ex);
                 }
             }

--- a/src/Components/Components/test/ParameterViewTest.Assignment.cs
+++ b/src/Components/Components/test/ParameterViewTest.Assignment.cs
@@ -462,8 +462,7 @@ namespace Microsoft.AspNetCore.Components
                 () => parameters.SetParameterProperties(target));
 
             // Assert
-            Assert.Equal(
-                $"Unable to set property '{nameof(HasInstanceProperties.IntProp)}' on object of " +
+            Assert.Equal($"Unable to set property '{nameof(HasInstanceProperties.IntProp)}' to value 'string value' on object of " +
                 $"type '{typeof(HasInstanceProperties).FullName}'. The error was: {ex.InnerException.Message}",
                 ex.Message);
         }
@@ -484,7 +483,7 @@ namespace Microsoft.AspNetCore.Components
 
             // Assert
             Assert.Equal(
-                $"Unable to set property '{nameof(HasPropertyWhoseSetterThrows.StringProp)}' on object of " +
+                $"Unable to set property '{nameof(HasPropertyWhoseSetterThrows.StringProp)}' to value 'anything' on object of " +
                 $"type '{typeof(HasPropertyWhoseSetterThrows).FullName}'. The error was: {ex.InnerException.Message}",
                 ex.Message);
         }


### PR DESCRIPTION
Summary of the changes
 - Adds a value to the exception message displayed when the PropertySetter throws an exception.

This is something that just popped up for me.  I'm finagling with types and have this error popping up that offers few clues to where it might be going wrong.  I may not be thinking of adverse effects of this, but given that this bombs the renderer, it seems like adding this to the message shouldn't be any worse than that.

Addresses #25625.
