### PR TITLE
Updating titles in project templates 

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Empty",
+    "name": "ASP.NET Core Empty",
     "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Empty",
+    "text": "ASP.NET Core Empty",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1011"
   },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Empty",
+    "name": "ASP.NET Core Empty",
     "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Empty",
+    "text": "ASP.NET Core Empty",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1011"
   },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "gRPC Service",
+    "name": "ASP.NET Core gRPC Service",
     "description": "A project template for creating a gRPC ASP.NET Core service."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "gRPC Service",
+    "text": "ASP.NET Core gRPC Service",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1027"
   },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Web Application",
+    "name": "ASP.NET Core Web App",
     "description": "A project template for creating an ASP.NET Core application with example ASP.NET Razor Pages content."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Web Application",
+    "text": "ASP.NET Core Web App",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1017"
   },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Web Application (Model-View-Controller)",
+    "name": "ASP.NET Core Web App (Model-View-Controller)",
     "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Web Application (Model-View-Controller)",
+    "text": "ASP.NET Core Web App (Model-View-Controller)",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1015"
   },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "API",
+    "name": "ASP.NET Core Web API",
     "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "API",
+    "text": "ASP.NET Core Web API",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1013"
   },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "API",
+    "name": "ASP.NET Core Web API",
     "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "API",
+    "text": "ASP.NET Core Web API",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1013"
   },

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "Angular",
+    "name": "ASP.NET Core with Angular",
     "description": "A project template for creating an ASP.NET Core application with Angular"
   }
 }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Angular",
+    "text": "ASP.NET Core with Angular",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1100"
   },

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "React.js",
+    "name": "ASP.NET Core with React.js",
     "description": "A project template for creating an ASP.NET Core application with React.js"
   }
 }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "React.js",
+    "text": "ASP.NET Core with React.js",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1500"
   },

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/en/strings.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/en/strings.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0.0",
   "strings": {
-    "name": "React.js and Redux",
+    "name": "ASP.NET Core with React.js and Redux",
     "description": "A project template for creating an ASP.NET Core application with React.js and Redux"
   }
 }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "React.js and Redux",
+    "text": "ASP.NET Core with React.js and Redux",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1400"
   },


### PR DESCRIPTION
Replaces #25581

Updating titles in project templates because in Visual Studio the templates will be showing the templates directly in the New Project Dialog instead in the One ASP.NET dialog.

In this PR I have updated the English titles. For localized strings we will need to get those from the localization team. I believe we are not setup for that to be automated here.

I think we should merge the English strings because they are the most used, and for other locales we will show the old localized names for now. If it's difficult to get those localized, I can work with @phenning to see if we can localize those files this time.

I will send another PR once I have the updated icons.

@mkArtakMSFT @Pilchie @timheuer @KathleenDollard 