### PR TITLE
Enable PlatformCompatibilityAnalyzer for RCL projects

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/RazorClassLibrary-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/RazorClassLibrary-CSharp.csproj.in
@@ -9,6 +9,10 @@
   <ItemGroup Condition="'$(SupportPagesAndViews)' == 'True'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(SupportPagesAndViews)' == 'False'">
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(SupportPagesAndViews)' != 'True'">
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="${MicrosoftAspNetCoreComponentsWebPackageVersion}" />


### PR DESCRIPTION
## Description
For the PlatformCompaotibilityAnalyzer to highlight issues it needs to know the target platform.
We've made a change to include that in the Blazor WebAssembly Shared project, but missed this one.

## Customer Impact
Customers won't be flagged by the analyzer without this setting.

## Regression
No

## Risk
Low

Addresses #25337