### PR TITLE
 Increase SignalR Java client test timeouts to 30 seconds

### DIFF
--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -38,7 +38,7 @@ class HubConnectionTest {
     @Test
     public void checkHubConnectionState() {
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com");
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
         hubConnection.stop();
@@ -49,7 +49,7 @@ class HubConnectionTest {
     public void transportCloseTriggersStopInHubConnection() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         mockTransport.stop();
 
@@ -67,7 +67,7 @@ class HubConnectionTest {
             message.set(error.getMessage());
         });
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         mockTransport.stopWithError(errorMessage);
         assertEquals(errorMessage, message.get());
@@ -82,7 +82,7 @@ class HubConnectionTest {
                 .shouldSkipNegotiate(true)
                 .withHandshakeResponseTimeout(100)
                 .build();
-        Throwable exception = assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+        Throwable exception = assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
         assertEquals(TimeoutException.class, exception.getCause().getClass());
         assertEquals("Timed out waiting for the server to respond to the handshake message.", exception.getCause().getMessage());
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
@@ -93,7 +93,7 @@ class HubConnectionTest {
         Transport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
         hubConnection.stop();
@@ -105,7 +105,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
@@ -119,21 +119,21 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("http://example.com", hubConnection.getBaseUrl());
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
 
         hubConnection.setBaseUrl("http://newurl.com");
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals("http://newurl.com", hubConnection.getBaseUrl());
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
     }
 
     @Test
@@ -141,7 +141,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("http://example.com", hubConnection.getBaseUrl());
@@ -150,15 +150,15 @@ class HubConnectionTest {
             hubConnection.setBaseUrl("http://newurl.com");
         });
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals("http://newurl.com", hubConnection.getBaseUrl());
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
     }
 
     @Test
@@ -166,7 +166,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("http://example.com", hubConnection.getBaseUrl());
@@ -180,7 +180,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("http://example.com", hubConnection.getBaseUrl());
@@ -195,7 +195,7 @@ class HubConnectionTest {
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
         hubConnection.start();
-        mockTransport.getStartTask().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        mockTransport.getStartTask().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         Throwable exception = assertThrows(RuntimeException.class, () -> mockTransport.receiveMessage("{" + RECORD_SEPARATOR));
         assertEquals("An invalid handshake response was received from the server.", exception.getMessage());
@@ -208,8 +208,8 @@ class HubConnectionTest {
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
         hubConnection.start();
-        mockTransport.getStartTask().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        Throwable exception = assertThrows(RuntimeException.class, () -> 
+        mockTransport.getStartTask().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        Throwable exception = assertThrows(RuntimeException.class, () ->
             mockTransport.receiveMessage("{\"error\":\"Requested protocol 'messagepack' is not available.\"}" + RECORD_SEPARATOR));
         assertEquals("Error in handshake Requested protocol 'messagepack' is not available.", exception.getMessage());
     }
@@ -226,7 +226,7 @@ class HubConnectionTest {
 
         assertEquals(Double.valueOf(0), value.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         String message = TestUtils.byteBufferToString(mockTransport.getSentMessages()[0]);
         String expectedHanshakeRequest = "{\"protocol\":\"json\",\"version\":1}" + RECORD_SEPARATOR;
@@ -250,7 +250,7 @@ class HubConnectionTest {
 
         assertEquals(Double.valueOf(0), value.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         String message = TestUtils.byteBufferToString(mockTransport.getSentMessages()[0]);
         String expectedHanshakeRequest = "{\"protocol\":\"json\",\"version\":1}" + RECORD_SEPARATOR;
 
@@ -277,7 +277,7 @@ class HubConnectionTest {
 
         assertEquals(Double.valueOf(0), value.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         String message = TestUtils.byteBufferToString(mockTransport.getSentMessages()[0]);
         String expectedHanshakeRequest = "{\"protocol\":\"json\",\"version\":1}" + RECORD_SEPARATOR;
 
@@ -302,7 +302,7 @@ class HubConnectionTest {
 
         assertEquals(Double.valueOf(0), value.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         String message = TestUtils.byteBufferToString(mockTransport.getSentMessages()[0]);
         String expectedHanshakeRequest = "{\"protocol\":\"json\",\"version\":1}" + RECORD_SEPARATOR;
 
@@ -331,7 +331,7 @@ class HubConnectionTest {
 
         assertEquals(Double.valueOf(0), value.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         String message = TestUtils.byteBufferToString(mockTransport.getSentMessages()[0]);
         String expectedHanshakeRequest = "{\"protocol\":\"json\",\"version\":1}" + RECORD_SEPARATOR;
 
@@ -363,7 +363,7 @@ class HubConnectionTest {
 
         assertEquals(Double.valueOf(0), value.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         String message = TestUtils.byteBufferToString(mockTransport.getSentMessages()[0]);
         String expectedHanshakeRequest = "{\"protocol\":\"json\",\"version\":1}" + RECORD_SEPARATOR;
 
@@ -398,7 +398,7 @@ class HubConnectionTest {
 
         assertEquals(Double.valueOf(0), value.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         String message = TestUtils.byteBufferToString(mockTransport.getSentMessages()[0]);
         String expectedHanshakeRequest = "{\"protocol\":\"json\",\"version\":1}" + RECORD_SEPARATOR;
 
@@ -426,7 +426,7 @@ class HubConnectionTest {
 
         assertEquals(Double.valueOf(0), value.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         try {
             mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[]}" + RECORD_SEPARATOR);
@@ -450,7 +450,7 @@ class HubConnectionTest {
         hubConnection.on("add", action, Double.class);
 
         assertEquals(Double.valueOf(0), value.get());
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"add\",\"arguments\":[12]}" + RECORD_SEPARATOR);
 
         // Confirming that our handler was called and the correct message was passed in.
@@ -462,7 +462,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream);
@@ -481,7 +481,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> firstStream = ReplaySubject.create();
         ReplaySubject<String> secondStream = ReplaySubject.create();
@@ -508,7 +508,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream, 12);
@@ -528,7 +528,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream, 12);
@@ -542,7 +542,7 @@ class HubConnectionTest {
         messages = mockTransport.getSentMessages();
         assertEquals("{\"type\":3,\"invocationId\":\"1\"}\u001E", TestUtils.byteBufferToString(messages[3]));
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertTrue(hubConnection.getStreamMap().isEmpty());
     }
@@ -552,7 +552,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream, 12);
@@ -587,7 +587,7 @@ class HubConnectionTest {
         assertEquals("{\"type\":3,\"invocationId\":\"1\"}\u001E", TestUtils.byteBufferToString(messages[5]));
         assertEquals("{\"type\":3,\"invocationId\":\"2\",\"error\":\"java.lang.Exception: Exception\"}\u001E", TestUtils.byteBufferToString(messages[6]));
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(hubConnection.getStreamMap().isEmpty());
     }
 
@@ -596,7 +596,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream, stream);
@@ -620,7 +620,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.invoke(String.class, "UploadStream", stream);
@@ -631,7 +631,7 @@ class HubConnectionTest {
             System.out.println(TestUtils.byteBufferToString(bb));
         }
         assertEquals(3, messages.length);
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"2\"]}\u001E", 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"2\"]}\u001E",
                 TestUtils.byteBufferToString(messages[1]));
         assertEquals("{\"type\":2,\"invocationId\":\"2\",\"item\":\"FirstItem\"}\u001E", TestUtils.byteBufferToString(messages[2]));
 
@@ -639,13 +639,13 @@ class HubConnectionTest {
         messages = mockTransport.getSentMessages();
         assertEquals("{\"type\":3,\"invocationId\":\"2\"}\u001E", TestUtils.byteBufferToString(messages[3]));
     }
-    
+
     @Test
     public void checkStreamUploadSingleItemThroughInvokeWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.<String>invoke(stringType, "UploadStream", stream);
@@ -656,18 +656,18 @@ class HubConnectionTest {
             System.out.println(TestUtils.byteBufferToString(bb));
         }
         assertEquals(3, messages.length);
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F,
             0x61, 0x64, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6D, (byte) 0x90, (byte) 0x91, (byte) 0xA1, 0x32 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(messages[1]));
-        
-        byte[] secondMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 
+
+        byte[] secondMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73,
             0x74, 0x49, 0x74, 0x65, 0x6D };
         assertEquals(ByteString.of(secondMessageExpectedBytes), ByteString.of(messages[2]));
 
         stream.onComplete();
         messages = mockTransport.getSentMessages();
-        
+
         byte[] thirdMessageExpectedBytes = new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x32, 0x02 };
         assertEquals(ByteString.of(thirdMessageExpectedBytes), ByteString.of(messages[3]));
     }
@@ -677,7 +677,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.stream(String.class, "UploadStream", stream);
@@ -686,7 +686,7 @@ class HubConnectionTest {
 
         ByteBuffer[] messages = mockTransport.getSentMessages();
         assertEquals(3, messages.length);
-        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"2\"]}\u001E", 
+        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"2\"]}\u001E",
                 TestUtils.byteBufferToString(messages[1]));
         assertEquals("{\"type\":2,\"invocationId\":\"2\",\"item\":\"FirstItem\"}\u001E", TestUtils.byteBufferToString(messages[2]));
 
@@ -695,13 +695,13 @@ class HubConnectionTest {
         assertEquals(4, messages.length);
         assertEquals("{\"type\":3,\"invocationId\":\"2\"}\u001E", TestUtils.byteBufferToString(messages[3]));
     }
-    
+
     @Test
     public void checkStreamUploadSingleItemThroughStreamWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.<String>stream(stringType, "UploadStream", stream);
@@ -710,19 +710,19 @@ class HubConnectionTest {
 
         ByteBuffer[] messages = mockTransport.getSentMessages();
         assertEquals(3, messages.length);
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F,
             0x61, 0x64, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6D, (byte) 0x90, (byte) 0x91, (byte) 0xA1, 0x32 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(messages[1]));
-        
-        byte[] secondMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 
+
+        byte[] secondMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73,
             0x74, 0x49, 0x74, 0x65, 0x6D };
         assertEquals(ByteString.of(secondMessageExpectedBytes), ByteString.of(messages[2]));
 
         stream.onComplete();
         messages = mockTransport.getSentMessages();
         assertEquals(4, messages.length);
-        
+
         byte[] thirdMessageExpectedBytes = new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x32, 0x02 };
         assertEquals(ByteString.of(thirdMessageExpectedBytes), ByteString.of(messages[3]));
     }
@@ -732,7 +732,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream);
@@ -742,9 +742,9 @@ class HubConnectionTest {
         ByteBuffer[] messages = mockTransport.getSentMessages();
         assertEquals(4, messages.length);
         assertEquals("{\"type\":1,\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"1\"]}\u001E", TestUtils.byteBufferToString(messages[1]));
-        assertEquals("{\"type\":1,\"invocationId\":\"2\",\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"3\"]}\u001E", 
+        assertEquals("{\"type\":1,\"invocationId\":\"2\",\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"3\"]}\u001E",
                 TestUtils.byteBufferToString(messages[2]));
-        assertEquals("{\"type\":4,\"invocationId\":\"4\",\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"5\"]}\u001E", 
+        assertEquals("{\"type\":4,\"invocationId\":\"4\",\"target\":\"UploadStream\",\"arguments\":[],\"streamIds\":[\"5\"]}\u001E",
                 TestUtils.byteBufferToString(messages[3]));
 
         stream.onNext("FirstItem");
@@ -762,13 +762,13 @@ class HubConnectionTest {
         assertEquals("{\"type\":3,\"invocationId\":\"3\"}\u001E", TestUtils.byteBufferToString(messages[8]));
         assertEquals("{\"type\":3,\"invocationId\":\"5\"}\u001E", TestUtils.byteBufferToString(messages[9]));
     }
-    
+
     @Test
     public void useSameSubjectInMutlipleStreamsFromDifferentMethodsWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream);
@@ -777,16 +777,16 @@ class HubConnectionTest {
 
         ByteBuffer[] messages = mockTransport.getSentMessages();
         assertEquals(4, messages.length);
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x15, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F, 0x61, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x15, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F, 0x61,
             0x64, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6D, (byte) 0x90, (byte) 0x91, (byte) 0xA1, 0x31 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(messages[1]));
-        
-        byte[] secondMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F, 
+
+        byte[] secondMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F,
             0x61, 0x64, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6D, (byte) 0x90, (byte) 0x91, (byte) 0xA1, 0x33 };
         assertEquals(ByteString.of(secondMessageExpectedBytes), ByteString.of(messages[2]));
 
-        byte[] thirdMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x34, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F, 
+        byte[] thirdMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x34, (byte) 0xAC, 0x55, 0x70, 0x6C, 0x6F,
             0x61, 0x64, 0x53, 0x74, 0x72, 0x65, 0x61, 0x6D, (byte) 0x90, (byte) 0x91, (byte) 0xA1, 0x35 };
         assertEquals(ByteString.of(thirdMessageExpectedBytes), ByteString.of(messages[3]));
 
@@ -794,29 +794,29 @@ class HubConnectionTest {
 
         messages = mockTransport.getSentMessages();
         assertEquals(7, messages.length);
-        
-        byte[] fourthMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 0x74, 
+
+        byte[] fourthMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 0x74,
             0x49, 0x74, 0x65, 0x6D };
         assertEquals(ByteString.of(fourthMessageExpectedBytes), ByteString.of(messages[4]));
-        
-        byte[] fifthMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x33, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 0x74, 
+
+        byte[] fifthMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x33, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 0x74,
                 0x49, 0x74, 0x65, 0x6D };
         assertEquals(ByteString.of(fifthMessageExpectedBytes), ByteString.of(messages[5]));
-        
-        byte[] sixthMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x35, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 0x74, 
+
+        byte[] sixthMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x35, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 0x74,
                 0x49, 0x74, 0x65, 0x6D };
         assertEquals(ByteString.of(sixthMessageExpectedBytes), ByteString.of(messages[6]));
 
         stream.onComplete();
         messages = mockTransport.getSentMessages();
         assertEquals(10, messages.length);
-        
+
         byte[] seventhMessageExpectedBytes = new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x02 };
         assertEquals(ByteString.of(seventhMessageExpectedBytes), ByteString.of(messages[7]));
-        
+
         byte[] eighthMessageExpectedBytes = new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x33, 0x02 };
         assertEquals(ByteString.of(eighthMessageExpectedBytes), ByteString.of(messages[8]));
-        
+
         byte[] ninthMessageExpectedBytes = new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x35, 0x02 };
         assertEquals(ByteString.of(ninthMessageExpectedBytes), ByteString.of(messages[9]));
     }
@@ -826,7 +826,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream);
@@ -836,7 +836,7 @@ class HubConnectionTest {
         ByteBuffer[] messages = mockTransport.getSentMessages();
         assertEquals(4, messages.length);
         assertEquals("{\"type\":2,\"invocationId\":\"1\",\"item\":\"FirstItem\"}\u001E", TestUtils.byteBufferToString(messages[2]));
-        assertEquals("{\"type\":3,\"invocationId\":\"1\",\"error\":\"java.lang.RuntimeException: onError called\"}\u001E", 
+        assertEquals("{\"type\":3,\"invocationId\":\"1\",\"error\":\"java.lang.RuntimeException: onError called\"}\u001E",
                 TestUtils.byteBufferToString(messages[3]));
 
         // onComplete doesn't send a completion message after onError.
@@ -850,7 +850,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.send("UploadStream", stream);
@@ -876,7 +876,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.invoke(String.class, "UploadStream", stream);
@@ -894,13 +894,13 @@ class HubConnectionTest {
         assertEquals(5, messages.length);
         assertEquals("{\"type\":3,\"invocationId\":\"2\"}\u001E", TestUtils.byteBufferToString(messages[4]));
     }
-    
+
     @Test
     public void checkStreamUploadMultipleItemsThroughInvokeWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ReplaySubject<String> stream = ReplaySubject.create();
         hubConnection.<String>invoke(stringType, "UploadStream", stream);
@@ -910,19 +910,19 @@ class HubConnectionTest {
 
         ByteBuffer[] messages = mockTransport.getSentMessages();
         assertEquals(4, messages.length);
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 0x74, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x0F, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xA9, 0x46, 0x69, 0x72, 0x73, 0x74,
             0x49, 0x74, 0x65, 0x6D };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(messages[2]));
-        
-        byte[] secondMessageExpectedBytes = new byte[] { 0x10, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xAA, 0x53, 0x65, 0x63, 0x6F, 0x6E, 
+
+        byte[] secondMessageExpectedBytes = new byte[] { 0x10, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xAA, 0x53, 0x65, 0x63, 0x6F, 0x6E,
             0x64, 0x49, 0x74, 0x65, 0x6D };
         assertEquals(ByteString.of(secondMessageExpectedBytes), ByteString.of(messages[3]));
 
         stream.onComplete();
         messages = mockTransport.getSentMessages();
         assertEquals(5, messages.length);
-        
+
         byte[] thirdMessageExpectedBytes = new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x32, 0x02 };
         assertEquals(ByteString.of(thirdMessageExpectedBytes), ByteString.of(messages[4]));
     }
@@ -932,7 +932,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         PublishSubject<String> streamOne = PublishSubject.create();
         PublishSubject<String> streamTwo = PublishSubject.create();
@@ -964,7 +964,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         AtomicBoolean onNextCalled = new AtomicBoolean();
@@ -973,7 +973,7 @@ class HubConnectionTest {
                 (error) -> {},
                 () -> completed.set(true));
 
-        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
         assertFalse(onNextCalled.get());
@@ -985,15 +985,15 @@ class HubConnectionTest {
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":\"hello\"}" + RECORD_SEPARATOR);
         assertTrue(completed.get());
 
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingFirst());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingFirst());
     }
-    
+
     @Test
     public void checkStreamSingleItemWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         AtomicBoolean onNextCalled = new AtomicBoolean();
@@ -1002,7 +1002,7 @@ class HubConnectionTest {
                 (error) -> {},
                 () -> completed.set(true));
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
@@ -1017,15 +1017,15 @@ class HubConnectionTest {
         mockTransport.receiveMessage(ByteBuffer.wrap(thirdMessageExpectedBytes));
         assertTrue(completed.get());
 
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingFirst());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingFirst());
     }
-    
+
     @Test
     public void checkStreamCompletionResult() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         AtomicBoolean onNextCalled = new AtomicBoolean();
@@ -1034,7 +1034,7 @@ class HubConnectionTest {
                 (error) -> {},
                 () -> completed.set(true));
 
-        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
         assertFalse(onNextCalled.get());
@@ -1046,16 +1046,16 @@ class HubConnectionTest {
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":\"COMPLETED\"}" + RECORD_SEPARATOR);
         assertTrue(completed.get());
 
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingFirst());
-        assertEquals("COMPLETED", result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingFirst());
+        assertEquals("COMPLETED", result.timeout(30, TimeUnit.SECONDS).blockingLast());
     }
-    
+
     @Test
     public void checkStreamCompletionResultWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         AtomicBoolean onNextCalled = new AtomicBoolean();
@@ -1064,7 +1064,7 @@ class HubConnectionTest {
                 (error) -> {},
                 () -> completed.set(true));
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
@@ -1075,13 +1075,13 @@ class HubConnectionTest {
 
         assertTrue(onNextCalled.get());
 
-        byte[] thirdMessageExpectedBytes = new byte[] { 0x10, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, (byte) 0xA9, 0x43, 0x4F, 0x4D, 0x50, 
+        byte[] thirdMessageExpectedBytes = new byte[] { 0x10, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, (byte) 0xA9, 0x43, 0x4F, 0x4D, 0x50,
             0x4C, 0x45, 0x54, 0x45, 0x44 };
         mockTransport.receiveMessage(ByteBuffer.wrap(thirdMessageExpectedBytes));
         assertTrue(completed.get());
 
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingFirst());
-        assertEquals("COMPLETED", result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingFirst());
+        assertEquals("COMPLETED", result.timeout(30, TimeUnit.SECONDS).blockingLast());
     }
 
     @Test
@@ -1089,7 +1089,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean onErrorCalled = new AtomicBoolean();
         AtomicBoolean onNextCalled = new AtomicBoolean();
@@ -1098,7 +1098,7 @@ class HubConnectionTest {
                 (error) -> onErrorCalled.set(true),
                 () -> {});
 
-        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(onErrorCalled.get());
         assertFalse(onNextCalled.get());
@@ -1110,17 +1110,17 @@ class HubConnectionTest {
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"error\":\"There was an error\"}" + RECORD_SEPARATOR);
         assertTrue(onErrorCalled.get());
 
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingFirst());
-        Throwable exception = assertThrows(HubException.class, () -> result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingFirst());
+        Throwable exception = assertThrows(HubException.class, () -> result.timeout(30, TimeUnit.SECONDS).blockingLast());
         assertEquals("There was an error", exception.getMessage());
     }
-    
+
     @Test
     public void checkStreamCompletionErrorWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean onErrorCalled = new AtomicBoolean();
         AtomicBoolean onNextCalled = new AtomicBoolean();
@@ -1129,7 +1129,7 @@ class HubConnectionTest {
                 (error) -> onErrorCalled.set(true),
                 () -> {});
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(onErrorCalled.get());
@@ -1144,8 +1144,8 @@ class HubConnectionTest {
         mockTransport.receiveMessage(ByteBuffer.wrap(thirdMessageExpectedBytes));
         assertTrue(onErrorCalled.get());
 
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingFirst());
-        Throwable exception = assertThrows(HubException.class, () -> result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingFirst());
+        Throwable exception = assertThrows(HubException.class, () -> result.timeout(30, TimeUnit.SECONDS).blockingLast());
         assertEquals("Error", exception.getMessage());
     }
 
@@ -1154,7 +1154,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         Observable<String> result = hubConnection.stream(String.class, "echo", "message");
@@ -1162,7 +1162,7 @@ class HubConnectionTest {
                 (error) -> {/*OnError*/},
                 () -> {/*OnCompleted*/completed.set(true);});
 
-        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
 
@@ -1170,18 +1170,18 @@ class HubConnectionTest {
         mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"Second\"}" + RECORD_SEPARATOR);
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":\"null\"}" + RECORD_SEPARATOR);
 
-        Iterator<String> resultIterator = result.timeout(1000, TimeUnit.MILLISECONDS).blockingIterable().iterator();
+        Iterator<String> resultIterator = result.timeout(30, TimeUnit.SECONDS).blockingIterable().iterator();
         assertEquals("First", resultIterator.next());
         assertEquals("Second", resultIterator.next());
         assertTrue(completed.get());
     }
-    
+
     @Test
     public void checkStreamMultipleItemsWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         Observable<String> result = hubConnection.<String>stream(stringType, "echo", "message");
@@ -1189,21 +1189,21 @@ class HubConnectionTest {
                 (error) -> {/*OnError*/},
                 () -> {/*OnCompleted*/completed.set(true);});
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
 
         byte[] secondMessageExpectedBytes = new byte[] { 0x0B, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA5, 0x46, 0x69, 0x72, 0x73, 0x74 };
         mockTransport.receiveMessage(ByteBuffer.wrap(secondMessageExpectedBytes));
-        
+
         byte[] thirdMessageExpectedBytes = new byte[] { 0x0C, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA6, 0x53, 0x65, 0x63, 0x6F, 0x6E, 0x64 };
         mockTransport.receiveMessage(ByteBuffer.wrap(thirdMessageExpectedBytes));
-        
+
         byte[] fourthMessageExpectedBytes = new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x02 };
         mockTransport.receiveMessage(ByteBuffer.wrap(fourthMessageExpectedBytes));
 
-        Iterator<String> resultIterator = result.timeout(1000, TimeUnit.MILLISECONDS).blockingIterable().iterator();
+        Iterator<String> resultIterator = result.timeout(30, TimeUnit.SECONDS).blockingIterable().iterator();
         assertEquals("First", resultIterator.next());
         assertEquals("Second", resultIterator.next());
         assertTrue(completed.get());
@@ -1214,7 +1214,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         Observable<String> result = hubConnection.stream(String.class, "echo", "message");
@@ -1222,20 +1222,20 @@ class HubConnectionTest {
                 (error) -> {/*OnError*/},
                 () -> {/*OnCompleted*/completed.set(true);});
 
-        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
 
         subscription.dispose();
         assertEquals("{\"type\":5,\"invocationId\":\"1\"}" + RECORD_SEPARATOR, TestUtils.byteBufferToString(mockTransport.getSentMessages()[2]));
     }
-    
+
     @Test
     public void checkCancelIsSentAfterDisposeWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         Observable<String> result = hubConnection.<String>stream(stringType, "echo", "message");
@@ -1243,7 +1243,7 @@ class HubConnectionTest {
                 (error) -> {/*OnError*/},
                 () -> {/*OnCompleted*/completed.set(true);});
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
@@ -1258,7 +1258,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         Observable<String> result = hubConnection.stream(String.class, "echo", "message");
         Disposable subscription = result.subscribe((item) -> {/*OnNext*/ },
@@ -1279,13 +1279,13 @@ class HubConnectionTest {
         assertEquals("{\"type\":5,\"invocationId\":\"1\"}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[mockTransport.getSentMessages().length - 1]));
     }
-    
+
     @Test
     public void checkCancelIsSentAfterAllSubscriptionsAreDisposedWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         Observable<String> result = hubConnection.<String>stream(stringType, "echo", "message");
         Disposable subscription = result.subscribe((item) -> {/*OnNext*/ },
@@ -1298,8 +1298,8 @@ class HubConnectionTest {
 
         subscription.dispose();
         assertEquals(2, mockTransport.getSentMessages().length);
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[mockTransport.getSentMessages().length - 1]));
 
@@ -1314,14 +1314,14 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         Observable<String> result = hubConnection.stream(String.class, "echo", "message");
         Disposable subscription = result.subscribe((item) -> {/*OnNext*/},
                 (error) -> {/*OnError*/},
                 () -> {/*OnCompleted*/});
 
-        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
 
         mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"First\"}" + RECORD_SEPARATOR);
@@ -1329,33 +1329,33 @@ class HubConnectionTest {
         subscription.dispose();
         mockTransport.receiveMessage("{\"type\":2,\"invocationId\":\"1\",\"item\":\"Second\"}" + RECORD_SEPARATOR);
 
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingLast());
     }
-    
+
     @Test
     public void checkStreamWithDisposeWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         Observable<String> result = hubConnection.<String>stream(stringType, "echo", "message");
         Disposable subscription = result.subscribe((item) -> {/*OnNext*/},
                 (error) -> {/*OnError*/},
                 () -> {/*OnCompleted*/});
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
-        
+
         byte[] secondMessageExpectedBytes = new byte[] { 0x0B, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA5, 0x46, 0x69, 0x72, 0x73, 0x74 };
         mockTransport.receiveMessage(ByteBuffer.wrap(secondMessageExpectedBytes));
-        
+
         subscription.dispose();
         byte[] thirdMessageExpectedBytes = new byte[] { 0x0C, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA6, 0x53, 0x65, 0x63, 0x6F, 0x6E, 0x64 };
         mockTransport.receiveMessage(ByteBuffer.wrap(thirdMessageExpectedBytes));
 
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingLast());
     }
 
     @Test
@@ -1363,7 +1363,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         Observable<String> result = hubConnection.stream(String.class, "echo", "message");
@@ -1375,7 +1375,7 @@ class HubConnectionTest {
                 (error) -> {/*OnError*/},
                 () -> {/*OnCompleted*/completed.set(true);});
 
-        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":4,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
 
@@ -1386,18 +1386,18 @@ class HubConnectionTest {
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\"}" + RECORD_SEPARATOR);
         assertTrue(completed.get());
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingFirst());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingFirst());
 
         subscription2.dispose();
-        assertEquals("Second", result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
+        assertEquals("Second", result.timeout(30, TimeUnit.SECONDS).blockingLast());
     }
-    
+
     @Test
     public void checkStreamWithDisposeWithMultipleSubscriptionsWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean completed = new AtomicBoolean();
         Observable<String> result = hubConnection.<String>stream(stringType, "echo", "message");
@@ -1409,26 +1409,26 @@ class HubConnectionTest {
                 (error) -> {/*OnError*/},
                 () -> {/*OnCompleted*/completed.set(true);});
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x04, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(completed.get());
-        
+
         byte[] secondMessageExpectedBytes = new byte[] { 0x0B, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA5, 0x46, 0x69, 0x72, 0x73, 0x74 };
         mockTransport.receiveMessage(ByteBuffer.wrap(secondMessageExpectedBytes));
-        
+
         subscription.dispose();
         byte[] thirdMessageExpectedBytes = new byte[] { 0x0C, (byte) 0x94, 0x02, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA6, 0x53, 0x65, 0x63, 0x6F, 0x6E, 0x64 };
         mockTransport.receiveMessage(ByteBuffer.wrap(thirdMessageExpectedBytes));
-        
+
         byte[] fourthMessageExpectedBytes = new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x02 };
         mockTransport.receiveMessage(ByteBuffer.wrap(fourthMessageExpectedBytes));
 
         assertTrue(completed.get());
-        assertEquals("First", result.timeout(1000, TimeUnit.MILLISECONDS).blockingFirst());
+        assertEquals("First", result.timeout(30, TimeUnit.SECONDS).blockingFirst());
 
         subscription2.dispose();
-        assertEquals("Second", result.timeout(1000, TimeUnit.MILLISECONDS).blockingLast());
+        assertEquals("Second", result.timeout(30, TimeUnit.SECONDS).blockingLast());
     }
 
     @Test
@@ -1436,40 +1436,40 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<Integer> result = hubConnection.invoke(Integer.class, "echo", "message");
         result.doOnSuccess(value -> done.set(true)).subscribe();
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":42}" + RECORD_SEPARATOR);
 
-        assertEquals(Integer.valueOf(42), result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals(Integer.valueOf(42), result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
-    
+
     @Test
     public void invokeWaitsForCompletionMessageWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<Integer> result = hubConnection.<Integer>invoke(integerType, "echo", "message");
         result.doOnSuccess(value -> done.set(true)).subscribe();
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage(ByteBuffer.wrap(new byte[] { 0x07, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, 0x2A }));
 
-        assertEquals(Integer.valueOf(42), result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals(Integer.valueOf(42), result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
 
@@ -1478,41 +1478,41 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Completable result = hubConnection.invoke("test", "message");
         result.doOnComplete(() -> done.set(true)).subscribe();
 
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"test\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"test\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\"}" + RECORD_SEPARATOR);
 
-        assertNull(result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertNull(result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
-    
+
     @Test
     public void invokeNoReturnValueWaitsForCompletionWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Completable result = hubConnection.invoke("test", "message");
         result.doOnComplete(() -> done.set(true)).subscribe();
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x74, 0x65, 0x73, 0x74, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x74, 0x65, 0x73, 0x74,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage(ByteBuffer.wrap(new byte[] { 0x06, (byte) 0x94, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x02 }));
 
-        assertNull(result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertNull(result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
 
@@ -1521,19 +1521,19 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Completable result = hubConnection.invoke("test", "message");
         result.doOnComplete(() -> done.set(true)).subscribe();
 
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"test\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"test\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":42}" + RECORD_SEPARATOR);
 
-        assertNull(result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertNull(result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
 
@@ -1542,20 +1542,20 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Completable result = hubConnection.invoke("test", "message");
         result.doOnComplete(() -> done.set(true)).subscribe();
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x74, 0x65, 0x73, 0x74, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x74, 0x65, 0x73, 0x74,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage(ByteBuffer.wrap(new byte[] { 0x07, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, 0x2A }));
 
-        assertNull(result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertNull(result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
 
@@ -1564,17 +1564,17 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Completable result = hubConnection.invoke("test", "message");
         result.doOnComplete(() -> done.set(true)).subscribe(() -> {}, (error) -> {});
 
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"test\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"test\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
-        Throwable exception = assertThrows(IllegalArgumentException.class, () -> 
+        Throwable exception = assertThrows(IllegalArgumentException.class, () ->
             mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":42,\"error\":\"There was an error\"}" + RECORD_SEPARATOR));
         assertEquals("Expected either 'error' or 'result' to be provided, but not both.", exception.getMessage());
     }
@@ -1584,19 +1584,19 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Completable result = hubConnection.invoke("test", "message");
         result.doOnComplete(() -> done.set(true)).subscribe(() -> {}, (error) -> {});
 
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"test\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"test\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"error\":\"There was an error\"}" + RECORD_SEPARATOR);
 
-        result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet();
+        result.timeout(30, TimeUnit.SECONDS).blockingGet();
 
         AtomicReference<String> errorMessage = new AtomicReference<>();
         result.doOnError(error -> {
@@ -1605,28 +1605,28 @@ class HubConnectionTest {
 
         assertEquals("There was an error", errorMessage.get());
     }
-    
+
     @Test
     public void invokeNoReturnValueHandlesErrorWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Completable result = hubConnection.invoke("test", "message");
         result.doOnComplete(() -> done.set(true)).subscribe(() -> {}, (error) -> {});
 
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x74, 0x65, 0x73, 0x74, 
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x74, 0x65, 0x73, 0x74,
                 (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
             assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
-        byte[] completionMessageErrorBytes = new byte[] { 0x19, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x01, (byte) 0xB2, 0x54, 0x68, 0x65, 
+        byte[] completionMessageErrorBytes = new byte[] { 0x19, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x01, (byte) 0xB2, 0x54, 0x68, 0x65,
                 0x72, 0x65, 0x20, 0x77, 0x61, 0x73, 0x20, 0x61, 0x6E, 0x20, 0x65, 0x72, 0x72, 0x6F, 0x72 };
         mockTransport.receiveMessage(ByteBuffer.wrap(completionMessageErrorBytes));
 
-        result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet();
+        result.timeout(30, TimeUnit.SECONDS).blockingGet();
 
         AtomicReference<String> errorMessage = new AtomicReference<>();
         result.doOnError(error -> {
@@ -1641,42 +1641,42 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<String> result = hubConnection.invoke(String.class, "fixedMessage", (Object)null);
         result.doOnSuccess(value -> done.set(true)).subscribe();
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"fixedMessage\",\"arguments\":[null]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"fixedMessage\",\"arguments\":[null]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":\"Hello World\"}" + RECORD_SEPARATOR);
 
-        assertEquals("Hello World", result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals("Hello World", result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
-    
+
     @Test
     public void canSendNullArgInInvocationWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<String> result = hubConnection.<String>invoke(stringType, "fixedMessage", (Object)null);
         result.doOnSuccess(value -> done.set(true)).subscribe();
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x15, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xAC, 0x66, 0x69, 0x78, 0x65, 0x64, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x15, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xAC, 0x66, 0x69, 0x78, 0x65, 0x64,
             0x4D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x91, (byte) 0xC0, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
-        byte[] completionMessageBytes = new byte[] { 0x12, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, (byte) 0xAB, 0x48, 0x65, 0x6C, 0x6C, 
+        byte[] completionMessageBytes = new byte[] { 0x12, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, (byte) 0xAB, 0x48, 0x65, 0x6C, 0x6C,
             0x6F, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64 };
         mockTransport.receiveMessage(ByteBuffer.wrap(completionMessageBytes));
 
-        assertEquals("Hello World", result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals("Hello World", result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
 
@@ -1685,42 +1685,42 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<String> result = hubConnection.invoke(String.class, "fixedMessage", null, null);
         result.doOnSuccess(value -> done.set(true)).subscribe();
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"fixedMessage\",\"arguments\":[null,null]}"+ RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"fixedMessage\",\"arguments\":[null,null]}"+ RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":\"Hello World\"}" + RECORD_SEPARATOR);
 
-        assertEquals("Hello World", result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals("Hello World", result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
-    
+
     @Test
     public void canSendMultipleNullArgsInInvocationWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<String> result = hubConnection.invoke(String.class, "fixedMessage", null, null);
         result.doOnSuccess(value -> done.set(true)).subscribe();
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xAC, 0x66, 0x69, 0x78, 0x65, 0x64, 0x4D, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x16, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xAC, 0x66, 0x69, 0x78, 0x65, 0x64, 0x4D,
             0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x92, (byte) 0xC0, (byte) 0xC0, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
         assertFalse(done.get());
 
-        byte[] completionMessageBytes = new byte[] { 0x12, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, (byte) 0xAB, 0x48, 0x65, 0x6C, 0x6C, 
+        byte[] completionMessageBytes = new byte[] { 0x12, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, (byte) 0xAB, 0x48, 0x65, 0x6C, 0x6C,
             0x6F, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64 };
         mockTransport.receiveMessage(ByteBuffer.wrap(completionMessageBytes));
 
-        assertEquals("Hello World", result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals("Hello World", result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
 
@@ -1729,7 +1729,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean doneFirst = new AtomicBoolean();
         AtomicBoolean doneSecond = new AtomicBoolean();
@@ -1737,29 +1737,29 @@ class HubConnectionTest {
         Single<String> result2 = hubConnection.invoke(String.class, "echo", "message");
         result.doOnSuccess(value -> doneFirst.set(true)).subscribe();
         result2.doOnSuccess(value -> doneSecond.set(true)).subscribe();
-        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"1\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[1]));
-        assertEquals("{\"type\":1,\"invocationId\":\"2\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR, 
+        assertEquals("{\"type\":1,\"invocationId\":\"2\",\"target\":\"echo\",\"arguments\":[\"message\"]}" + RECORD_SEPARATOR,
                 TestUtils.byteBufferToString(mockTransport.getSentMessages()[2]));
         assertFalse(doneFirst.get());
         assertFalse(doneSecond.get());
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"2\",\"result\":\"message\"}" + RECORD_SEPARATOR);
-        assertEquals("message", result2.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals("message", result2.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertFalse(doneFirst.get());
         assertTrue(doneSecond.get());
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":42}" + RECORD_SEPARATOR);
-        assertEquals(Integer.valueOf(42), result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals(Integer.valueOf(42), result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(doneFirst.get());
     }
-    
+
     @Test
     public void multipleInvokesWaitForOwnCompletionMessageWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean doneFirst = new AtomicBoolean();
         AtomicBoolean doneSecond = new AtomicBoolean();
@@ -1767,27 +1767,27 @@ class HubConnectionTest {
         Single<String> result2 = hubConnection.<String>invoke(stringType, "echo", "message");
         result.doOnSuccess(value -> doneFirst.set(true)).subscribe();
         result2.doOnSuccess(value -> doneSecond.set(true)).subscribe();
-        
-        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+
+        byte[] firstMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x31, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
             (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(firstMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[1]));
-        
-        byte[] secondMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F, 
+
+        byte[] secondMessageExpectedBytes = new byte[] { 0x14, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xA1, 0x32, (byte) 0xA4, 0x65, 0x63, 0x68, 0x6F,
                 (byte) 0x91, (byte) 0xA7, 0x6D, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, (byte) 0x90 };
         assertEquals(ByteString.of(secondMessageExpectedBytes), ByteString.of(mockTransport.getSentMessages()[2]));
         assertFalse(doneFirst.get());
         assertFalse(doneSecond.get());
 
-        byte[] firstCompletionMessageBytes = new byte[] { 0x0E, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x32, 0x03, (byte) 0xA7, 0x6D, 0x65, 0x73, 
+        byte[] firstCompletionMessageBytes = new byte[] { 0x0E, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x32, 0x03, (byte) 0xA7, 0x6D, 0x65, 0x73,
             0x73, 0x61, 0x67, 0x65 };
         mockTransport.receiveMessage(ByteBuffer.wrap(firstCompletionMessageBytes));
-        assertEquals("message", result2.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals("message", result2.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertFalse(doneFirst.get());
         assertTrue(doneSecond.get());
 
         byte[] secondCompletionMessageBytes = new byte[] { 0x07, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, 0x2A };
         mockTransport.receiveMessage(ByteBuffer.wrap(secondCompletionMessageBytes));
-        assertEquals(Integer.valueOf(42), result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals(Integer.valueOf(42), result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(doneFirst.get());
     }
 
@@ -1796,7 +1796,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         // int.class is a primitive type and since we use Class.cast to cast an Object to the expected return type
@@ -1807,16 +1807,16 @@ class HubConnectionTest {
 
         mockTransport.receiveMessage("{\"type\":3,\"invocationId\":\"1\",\"result\":42}" + RECORD_SEPARATOR);
 
-        assertEquals(Integer.valueOf(42), result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals(Integer.valueOf(42), result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
-    
+
     @Test
     public void invokeWorksForPrimitiveTypesWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         // int.class is a primitive type and since we use Class.cast to cast an Object to the expected return type
@@ -1827,7 +1827,7 @@ class HubConnectionTest {
 
         mockTransport.receiveMessage(ByteBuffer.wrap(new byte[] { 0x07, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x03, 0x2A }));
 
-        assertEquals(Integer.valueOf(42), result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet());
+        assertEquals(Integer.valueOf(42), result.timeout(30, TimeUnit.SECONDS).blockingGet());
         assertTrue(done.get());
     }
 
@@ -1836,7 +1836,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<Integer> result = hubConnection.invoke(int.class, "echo", "message");
@@ -1847,7 +1847,7 @@ class HubConnectionTest {
 
         String exceptionMessage = null;
         try {
-            result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet();
+            result.timeout(30, TimeUnit.SECONDS).blockingGet();
             assertFalse(true);
         } catch (HubException ex) {
             exceptionMessage = ex.getMessage();
@@ -1855,26 +1855,26 @@ class HubConnectionTest {
 
         assertEquals("There was an error", exceptionMessage);
     }
-    
+
     @Test
     public void completionMessageCanHaveErrorWithMessagePack() {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport, true);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<Integer> result = hubConnection.invoke(int.class, "echo", "message");
         result.doOnSuccess(value -> done.set(true));
         assertFalse(done.get());
 
-        byte[] completionMessageErrorBytes = new byte[] { 0x19, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x01, (byte) 0xB2, 0x54, 0x68, 0x65, 
+        byte[] completionMessageErrorBytes = new byte[] { 0x19, (byte) 0x95, 0x03, (byte) 0x80, (byte) 0xA1, 0x31, 0x01, (byte) 0xB2, 0x54, 0x68, 0x65,
             0x72, 0x65, 0x20, 0x77, 0x61, 0x73, 0x20, 0x61, 0x6E, 0x20, 0x65, 0x72, 0x72, 0x6F, 0x72 };
         mockTransport.receiveMessage(ByteBuffer.wrap(completionMessageErrorBytes));
 
         String exceptionMessage = null;
         try {
-            result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet();
+            result.timeout(30, TimeUnit.SECONDS).blockingGet();
             assertFalse(true);
         } catch (HubException ex) {
             exceptionMessage = ex.getMessage();
@@ -1888,7 +1888,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         AtomicBoolean done = new AtomicBoolean();
         Single<Integer> result = hubConnection.invoke(int.class, "echo", "message");
@@ -1899,7 +1899,7 @@ class HubConnectionTest {
 
         RuntimeException hasException = null;
         try {
-            result.timeout(1000, TimeUnit.MILLISECONDS).blockingGet();
+            result.timeout(30, TimeUnit.SECONDS).blockingGet();
             assertFalse(true);
         } catch (CancellationException ex) {
             hasException = ex;
@@ -1919,7 +1919,7 @@ class HubConnectionTest {
             value.getAndUpdate((val) -> val + 1);
         });
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[]}" + RECORD_SEPARATOR);
 
         // Confirming that our handler was called and that the counter property was incremented.
@@ -1937,7 +1937,7 @@ class HubConnectionTest {
             value.set(param);
         }, String.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"Hello World\"]}" + RECORD_SEPARATOR);
         hubConnection.send("inc", "Hello World");
 
@@ -1961,7 +1961,7 @@ class HubConnectionTest {
             value2.set(param2);
         }, String.class, Double.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"Hello World\", 12]}" + RECORD_SEPARATOR);
         hubConnection.send("inc", "Hello World", 12);
 
@@ -1989,7 +1989,7 @@ class HubConnectionTest {
             value3.set(param3);
         }, String.class, String.class, String.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"A\", \"B\", \"C\"]}" + RECORD_SEPARATOR);
         hubConnection.send("inc", "A", "B", "C");
 
@@ -2021,7 +2021,7 @@ class HubConnectionTest {
             value4.set(param4);
         }, String.class, String.class, String.class, String.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"A\", \"B\", \"C\", \"D\"]}" + RECORD_SEPARATOR);
 
         // Confirming that our handler was called and the correct message was passed in.
@@ -2056,7 +2056,7 @@ class HubConnectionTest {
             value5.set(param5);
         }, String.class, String.class, String.class, Boolean.class, Double.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"A\", \"B\", \"C\",true,12 ]}" + RECORD_SEPARATOR);
 
         // Confirming that our handler was called and the correct message was passed in.
@@ -2095,7 +2095,7 @@ class HubConnectionTest {
             value6.set(param6);
         }, String.class, String.class, String.class, Boolean.class, Double.class, String.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"A\", \"B\", \"C\",true,12,\"D\"]}" + RECORD_SEPARATOR);
 
         // Confirming that our handler was called and the correct message was passed in.
@@ -2138,7 +2138,7 @@ class HubConnectionTest {
             value7.set(param7);
         }, String.class, String.class, String.class, Boolean.class, Double.class, String.class, String.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"A\", \"B\", \"C\",true,12,\"D\",\"E\"]}" + RECORD_SEPARATOR);
 
         // Confirming that our handler was called and the correct message was passed in.
@@ -2185,7 +2185,7 @@ class HubConnectionTest {
             value8.set(param8);
         }, String.class, String.class, String.class, Boolean.class, Double.class, String.class, String.class, String.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[\"A\", \"B\", \"C\",true,12,\"D\",\"E\",\"F\"]}" + RECORD_SEPARATOR);
         // Confirming that our handler was called and the correct message was passed in.
         assertEquals("A", value1.get());
@@ -2197,7 +2197,7 @@ class HubConnectionTest {
         assertEquals("E", value7.get());
         assertEquals("F", value8.get());
     }
-    
+
     @Test
     public void sendWithNoParamsTriggersOnHandlerWithMessagePack() {
         AtomicReference<Integer> value = new AtomicReference<>(0);
@@ -2209,7 +2209,7 @@ class HubConnectionTest {
             value.getAndUpdate((val) -> val + 1);
         });
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         byte[] messageBytes = new byte[] { 0x0A, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x90, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
 
@@ -2228,8 +2228,8 @@ class HubConnectionTest {
             value.set(param);
         }, stringType);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x0C, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x91, (byte) 0xA1, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x0C, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x91, (byte) 0xA1,
             0x41, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
         hubConnection.send("inc", "A");
@@ -2254,8 +2254,8 @@ class HubConnectionTest {
             value2.set(param2);
         }, stringType, doubleType);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x15, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x92, (byte) 0xA1, 0x41, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x15, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x92, (byte) 0xA1, 0x41,
             (byte) 0xCB, 0x40, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
         hubConnection.send("inc", "A", 12);
@@ -2284,8 +2284,8 @@ class HubConnectionTest {
             value3.set(param3);
         }, stringType, stringType, stringType);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x10, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x93, (byte) 0xA1, 0x41, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x10, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x93, (byte) 0xA1, 0x41,
             (byte) 0xA1, 0x42, (byte) 0xA1, 0x43, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
         hubConnection.send("inc", "A", "B", "C");
@@ -2318,8 +2318,8 @@ class HubConnectionTest {
             value4.set(param4);
         }, stringType, stringType, stringType, stringType);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x12, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x94, (byte) 0xA1, 0x41, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x12, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x94, (byte) 0xA1, 0x41,
                 (byte) 0xA1, 0x42, (byte) 0xA1, 0x43, (byte) 0xA1, 0x44, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
 
@@ -2355,8 +2355,8 @@ class HubConnectionTest {
             value5.set(param5);
         }, stringType, stringType, stringType, booleanType, doubleType);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x1A, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x95, (byte) 0xA1, 0x41, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x1A, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x95, (byte) 0xA1, 0x41,
             (byte) 0xA1, 0x42, (byte) 0xA1, 0x43, (byte) 0xC3, (byte) 0xCB, 0x40, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
 
@@ -2396,8 +2396,8 @@ class HubConnectionTest {
             value6.set(param6);
         }, stringType, stringType, stringType, booleanType, doubleType, stringType);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x1C, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x96, (byte) 0xA1, 0x41, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x1C, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x96, (byte) 0xA1, 0x41,
             (byte) 0xA1, 0x42, (byte) 0xA1, 0x43, (byte) 0xC3, (byte) 0xCB, 0x40, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xA1, 0x44, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
 
@@ -2441,9 +2441,9 @@ class HubConnectionTest {
             value7.set(param7);
         }, stringType, stringType, stringType, booleanType, doubleType, stringType, stringType);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x1E, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x97, (byte) 0xA1, 0x41, 
-            (byte) 0xA1, 0x42, (byte) 0xA1, 0x43, (byte) 0xC3, (byte) 0xCB, 0x40, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xA1, 0x44, (byte) 0xA1, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x1E, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x97, (byte) 0xA1, 0x41,
+            (byte) 0xA1, 0x42, (byte) 0xA1, 0x43, (byte) 0xC3, (byte) 0xCB, 0x40, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xA1, 0x44, (byte) 0xA1,
             0x45, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
 
@@ -2491,9 +2491,9 @@ class HubConnectionTest {
             value8.set(param8);
         }, stringType, stringType, stringType, booleanType, doubleType, stringType, stringType, stringType);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x20, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x98, (byte) 0xA1, 0x41, 
-            (byte) 0xA1, 0x42, (byte) 0xA1, 0x43, (byte) 0xC3, (byte) 0xCB, 0x40, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xA1, 0x44, (byte) 0xA1, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x20, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x98, (byte) 0xA1, 0x41,
+            (byte) 0xA1, 0x42, (byte) 0xA1, 0x43, (byte) 0xC3, (byte) 0xCB, 0x40, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xA1, 0x44, (byte) 0xA1,
             0x45, (byte) 0xA1, 0x46, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
         // Confirming that our handler was called and the correct message was passed in.
@@ -2526,7 +2526,7 @@ class HubConnectionTest {
             value1.set(param1);
         }, Custom.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"inc\",\"arguments\":[{\"number\":1,\"str\":\"A\",\"bools\":[true,false]}]}" + RECORD_SEPARATOR);
 
         // Confirming that our handler was called and the correct message was passed in.
@@ -2537,7 +2537,7 @@ class HubConnectionTest {
         assertEquals(true, custom.bools[0]);
         assertEquals(false, custom.bools[1]);
     }
-    
+
     @Test
     public void sendWithCustomObjectTriggersOnHandlerWithMessagePack()  {
         AtomicReference<PersonPojo<Short>> value1 = new AtomicReference<>();
@@ -2551,9 +2551,9 @@ class HubConnectionTest {
             value1.set(param1);
         }, (new TypeReference<PersonPojo<Short>>() { }).getType());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
-        byte[] messageBytes = new byte[] { 0x2F, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x91, (byte) 0x84, 
-            (byte) 0xA9, 0x66, 0x69, 0x72, 0x73, 0x74, 0x4E, 0x61, 0x6D, 0x65, (byte) 0xA4, 0x4A, 0x6F, 0x68, 0x6E, (byte) 0xA8, 0x6C, 0x61, 0x73, 0x74, 
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        byte[] messageBytes = new byte[] { 0x2F, (byte) 0x96, 0x01, (byte) 0x80, (byte) 0xC0, (byte) 0xA3, 0x69, 0x6E, 0x63, (byte) 0x91, (byte) 0x84,
+            (byte) 0xA9, 0x66, 0x69, 0x72, 0x73, 0x74, 0x4E, 0x61, 0x6D, 0x65, (byte) 0xA4, 0x4A, 0x6F, 0x68, 0x6E, (byte) 0xA8, 0x6C, 0x61, 0x73, 0x74,
             0x4E, 0x61, 0x6D, 0x65, (byte) 0xA3, 0x44, 0x6F, 0x65, (byte) 0xA3, 0x61, 0x67, 0x65, 0x1E, (byte) 0xA1, 0x74, 0x05, (byte) 0x90 };
         mockTransport.receiveMessage(ByteBuffer.wrap(messageBytes));
 
@@ -2579,7 +2579,7 @@ class HubConnectionTest {
         SingleSubject<ByteBuffer> handshakeMessageTask = mockTransport.getNextSentMessage();
         // On start we're going to receive the handshake response and also an invocation in the same payload.
         hubConnection.start();
-        ByteBuffer sentMessage = handshakeMessageTask.timeout(1, TimeUnit.SECONDS).blockingGet();
+        ByteBuffer sentMessage = handshakeMessageTask.timeout(30, TimeUnit.SECONDS).blockingGet();
         String expectedSentMessage  = "{\"protocol\":\"json\",\"version\":1}" + RECORD_SEPARATOR;
         assertEquals(expectedSentMessage, TestUtils.byteBufferToString(mockTransport.getSentMessages()[0]));
 
@@ -2593,7 +2593,7 @@ class HubConnectionTest {
     public void onClosedCallbackRunsWhenStopIsCalled()  {
         AtomicReference<String> value1 = new AtomicReference<>();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com");
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         hubConnection.onClosed((ex) -> {
             assertNull(value1.get());
             value1.set("Closed callback ran.");
@@ -2609,7 +2609,7 @@ class HubConnectionTest {
         AtomicReference<String> value1 = new AtomicReference<>();
         AtomicReference<String> value2 = new AtomicReference<>();
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com");
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         hubConnection.onClosed((ex) -> {
             assertNull(value1.get());
@@ -2637,7 +2637,7 @@ class HubConnectionTest {
         hubConnection.onClosed((ex) -> {
             assertEquals(ex.getMessage(), "There was an error");
         });
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
@@ -2649,13 +2649,13 @@ class HubConnectionTest {
     @Test
     public void callingStartOnStartedHubConnectionNoops()  {
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com");
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
@@ -2668,22 +2668,22 @@ class HubConnectionTest {
                 .withHttpClient(new TestHttpClient())
                 .withAccessTokenProvider(Single.defer(() -> {
                     startedAccessToken.onComplete();
-                    continueAccessToken.timeout(1, TimeUnit.SECONDS).blockingAwait();
+                    continueAccessToken.timeout(30, TimeUnit.SECONDS).blockingAwait();
                     return Single.just("test");
                 }).subscribeOn(Schedulers.newThread()))
                 .shouldSkipNegotiate(true)
                 .build();
         Completable start = hubConnection.start();
-        startedAccessToken.timeout(1, TimeUnit.SECONDS).blockingAwait();
+        startedAccessToken.timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTING, hubConnection.getConnectionState());
 
         Completable start2 = hubConnection.start();
         continueAccessToken.onComplete();
-        start.timeout(1, TimeUnit.SECONDS).blockingAwait();
-        start2.timeout(1, TimeUnit.SECONDS).blockingAwait();
+        start.timeout(30, TimeUnit.SECONDS).blockingAwait();
+        start2.timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
@@ -2722,7 +2722,7 @@ class HubConnectionTest {
             assertTrue(false);
         }, String.class);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         mockTransport.receiveMessage("{\"type\":1,\"target\":\"Send\",\"arguments\":[]}" + RECORD_SEPARATOR);
         hubConnection.stop();
@@ -2738,7 +2738,7 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        Exception exception = assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+        Exception exception = assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
         assertEquals("Unexpected status code returned from negotiate: 404 .", exception.getMessage());
 
         List<HttpRequest> sentRequests = client.getSentRequests();
@@ -2757,7 +2757,7 @@ class HubConnectionTest {
             .build();
 
         RuntimeException exception = assertThrows(RuntimeException.class,
-            () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+            () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
         assertEquals("Negotiate redirection limit exceeded.", exception.getMessage());
     }
 
@@ -2771,10 +2771,10 @@ class HubConnectionTest {
                 .build();
 
         assertNull(hubConnection.getConnectionId());
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
     }
@@ -2795,11 +2795,11 @@ class HubConnectionTest {
 
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
     }
@@ -2822,11 +2822,11 @@ class HubConnectionTest {
 
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
         assertEquals("http://example.com?id=connection-token-value", transport.getUrl());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
     }
@@ -2848,11 +2848,11 @@ class HubConnectionTest {
 
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
         assertEquals("http://example.com?id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
     }
@@ -2874,11 +2874,11 @@ class HubConnectionTest {
 
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("bVOiRPG8-6YiJ6d7ZcTOVQ", hubConnection.getConnectionId());
         assertEquals("http://example.com?negotiateVersion=42&id=bVOiRPG8-6YiJ6d7ZcTOVQ", transport.getUrl());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
         assertNull(hubConnection.getConnectionId());
     }
@@ -2897,7 +2897,7 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ByteBuffer[] sentMessages = transport.getSentMessages();
         assertEquals(1, sentMessages.length);
@@ -2918,7 +2918,7 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         ByteBuffer[] sentMessages = transport.getSentMessages();
         assertEquals(1, sentMessages.length);
@@ -2950,10 +2950,10 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(hubConnection.getTransport() instanceof LongPollingTransport);
         close.onComplete();
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
     }
 
     @Test
@@ -2974,7 +2974,7 @@ class HubConnectionTest {
 
         assertEquals(TransportEnum.WEBSOCKETS, hubConnection.getTransportEnum());
         RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+                () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
 
         assertEquals(exception.getMessage(), "There were no compatible transports on the server.");
     }
@@ -2993,7 +2993,7 @@ class HubConnectionTest {
 
         assertEquals(TransportEnum.LONG_POLLING, hubConnection.getTransportEnum());
         RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+                () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
 
         assertEquals(exception.getMessage(), "There were no compatible transports on the server.");
     }
@@ -3026,7 +3026,7 @@ class HubConnectionTest {
                 .build();
 
         try {
-            hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
             assertTrue(false);
         } catch (RuntimeException ex) {
             assertEquals("Error from accessTokenProvider", ex.getMessage());
@@ -3070,10 +3070,10 @@ class HubConnectionTest {
             closed.onComplete();
         });
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         blockGet.onComplete();
-        
-        closed.timeout(1, TimeUnit.SECONDS).blockingAwait();
+
+        closed.timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
@@ -3114,16 +3114,16 @@ class HubConnectionTest {
             closed.onComplete();
         });
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
         try {
-            hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
             assertTrue(false);
         } catch (Exception ex) {
             assertEquals("Error from accessTokenProvider", ex.getMessage());
         }
         blockGet.onComplete();
-        closed.timeout(1, TimeUnit.SECONDS).blockingAwait();
+        closed.timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
@@ -3142,7 +3142,7 @@ class HubConnectionTest {
                 .build();
 
         RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+                () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
 
         assertEquals(exception.getMessage(), "There were no compatible transports on the server.");
     }
@@ -3160,7 +3160,7 @@ class HubConnectionTest {
                 .build();
 
         RuntimeException exception = assertThrows(RuntimeException.class,
-            () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+            () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
         assertEquals("Test error.", exception.getMessage());
     }
 
@@ -3185,7 +3185,7 @@ class HubConnectionTest {
                 .build();
 
         RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+                () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
         assertEquals("Detected an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.",
                 exception.getMessage());
     }
@@ -3205,7 +3205,7 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
     }
@@ -3234,9 +3234,9 @@ class HubConnectionTest {
                 .withAccessTokenProvider(Single.just("User Registered Token"))
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals("Bearer User Registered Token", beforeRedirectToken.get());
         assertEquals("Bearer newToken", token.get());
 
@@ -3245,7 +3245,7 @@ class HubConnectionTest {
         token.set("");
 
         // Restart the connection to make sure that the original accessTokenProvider that we registered is still registered before the redirect.
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertEquals("Bearer User Registered Token", beforeRedirectToken.get());
@@ -3271,7 +3271,7 @@ class HubConnectionTest {
                 .withAccessTokenProvider(Single.just("secretToken"))
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertEquals("Bearer secretToken", token.get());
@@ -3297,14 +3297,14 @@ class HubConnectionTest {
                 .withAccessTokenProvider(Single.defer(() -> Single.just("secret" + i.getAndIncrement())))
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals("Bearer secret0", token.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals("Bearer secret1", token.get());
     }
 
@@ -3312,7 +3312,7 @@ class HubConnectionTest {
     public void accessTokenProviderIsOverriddenFromRedirectNegotiate() {
         AtomicReference<String> token = new AtomicReference<>();
         TestHttpClient client = new TestHttpClient()
-            .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", 
+            .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "",
             		TestUtils.stringToByteBuffer("{\"url\":\"http://testexample.com/\",\"accessToken\":\"newToken\"}"))))
             .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> {
                 token.set(req.getHeaders().get("Authorization"));
@@ -3330,7 +3330,7 @@ class HubConnectionTest {
                 .withAccessTokenProvider(Single.just("secretToken"))
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("http://testexample.com/?id=connection-token-value", transport.getUrl());
         hubConnection.stop();
@@ -3360,9 +3360,9 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals("Bearer newToken", token.get());
 
         // Clear the tokens to see if they get reset to the proper values
@@ -3370,7 +3370,7 @@ class HubConnectionTest {
         token.set("");
 
         // Restart the connection to make sure that the original accessTokenProvider that we registered is still registered before the redirect.
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertNull(beforeRedirectToken.get());
@@ -3407,16 +3407,16 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals("Bearer firstRedirectToken", token.get());
 
         // Clear the tokens to see if they get reset to the proper values
         redirectToken.set("");
         token.set("");
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertNull(redirectToken.get());
@@ -3431,7 +3431,7 @@ class HubConnectionTest {
                 .build();
 
         try {
-            hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
             assertTrue(false);
         } catch (RuntimeException ex) {
             assertEquals("Error from accessTokenProvider", ex.getMessage());
@@ -3448,9 +3448,9 @@ class HubConnectionTest {
             closedSubject.onSuccess(e);
         });
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
-        assertEquals("Server timeout elapsed without receiving a message from the server.", closedSubject.timeout(1, TimeUnit.SECONDS).blockingGet().getMessage());
+        assertEquals("Server timeout elapsed without receiving a message from the server.", closedSubject.timeout(30, TimeUnit.SECONDS).blockingGet().getMessage());
     }
 
     @Test
@@ -3460,14 +3460,14 @@ class HubConnectionTest {
         hubConnection.setKeepAliveInterval(1);
         hubConnection.setTickRate(1);
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
 
-        String message = TestUtils.byteBufferToString(mockTransport.getNextSentMessage().timeout(1, TimeUnit.SECONDS).blockingGet());
+        String message = TestUtils.byteBufferToString(mockTransport.getNextSentMessage().timeout(30, TimeUnit.SECONDS).blockingGet());
         assertEquals("{\"type\":6}" + RECORD_SEPARATOR, message);
-        message = TestUtils.byteBufferToString(mockTransport.getNextSentMessage().timeout(1, TimeUnit.SECONDS).blockingGet());
+        message = TestUtils.byteBufferToString(mockTransport.getNextSentMessage().timeout(30, TimeUnit.SECONDS).blockingGet());
         assertEquals("{\"type\":6}" + RECORD_SEPARATOR, message);
 
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
     }
 
     @Test
@@ -3487,7 +3487,7 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
 
@@ -3512,7 +3512,7 @@ class HubConnectionTest {
                 .withHeader("User-Agent", "Updated Value")
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertEquals("Updated Value", header.get());
@@ -3536,7 +3536,7 @@ class HubConnectionTest {
                 .withHeader("User-Agent", "")
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertEquals("", header.get());
@@ -3560,7 +3560,7 @@ class HubConnectionTest {
                 .withHeader("ExampleHeader", "ExampleValue")
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertEquals("ExampleValue", header.get());
@@ -3584,12 +3584,12 @@ class HubConnectionTest {
                 .withHeader("Authorization", "ExampleValue")
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertEquals("ExampleValue", header.get());
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         assertEquals("ExampleValue", header.get());
     }
@@ -3619,14 +3619,14 @@ class HubConnectionTest {
                 .withHeader("Authorization", "ExampleValue")
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop().blockingAwait();
         assertEquals("ExampleValue", beforeRedirectHeader.get());
         assertEquals("Bearer redirectToken", afterRedirectHeader.get());
 
         // Making sure you can do this after restarting the HubConnection.
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop().blockingAwait();
         assertEquals("ExampleValue", beforeRedirectHeader.get());
@@ -3653,7 +3653,7 @@ class HubConnectionTest {
                 .withHeader("ExampleHeader", "New Value")
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         hubConnection.stop();
         assertEquals("New Value", header.get());
@@ -3668,13 +3668,13 @@ class HubConnectionTest {
                 .shouldSkipNegotiate(true)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
@@ -3683,7 +3683,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         TestHttpClient client = new TestHttpClient()
                 .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", TestUtils.stringToByteBuffer("{\"url\":\"http://testexample.com/\"}"))))
-                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", 
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "",
                 		TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
 
         HubConnection hubConnection = HubConnectionBuilder
@@ -3692,13 +3692,13 @@ class HubConnectionTest {
                 .withHttpClient(client)
                 .build();
 
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
-        hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
-        hubConnection.stop().timeout(1, TimeUnit.SECONDS).blockingAwait();
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
@@ -3716,7 +3716,7 @@ class HubConnectionTest {
                 .build();
 
         RuntimeException exception = assertThrows(RuntimeException.class,
-            () -> hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait());
+            () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
         assertEquals("Unexpected status code returned from negotiate: 500 Internal server error.", exception.getMessage());
     }
 
@@ -3725,7 +3725,7 @@ class HubConnectionTest {
         MockTransport mockTransport = new MockTransport();
         TestHttpClient client = new TestHttpClient()
                 .on("POST", "http://example.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", TestUtils.stringToByteBuffer("{\"url\":\"http://testexample.com/\"}"))))
-                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "", 
+                .on("POST", "http://testexample.com/negotiate?negotiateVersion=1", (req) -> Single.just(new HttpResponse(200, "",
                 		TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
 
         CompletableSubject close = CompletableSubject.create();
@@ -3739,10 +3739,10 @@ class HubConnectionTest {
             hubConnection.onClosed(e -> {
                 close.onComplete();
             });
-            hubConnection.start().timeout(1, TimeUnit.SECONDS).blockingAwait();
+            hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
             assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
         }
 
-        close.timeout(1, TimeUnit.SECONDS).blockingGet();
+        close.timeout(30, TimeUnit.SECONDS).blockingGet();
     }
 }

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -27,7 +27,7 @@ public class LongPollingTransportTest {
 
         Map<String, String> headers = new HashMap<>();
         LongPollingTransport transport = new LongPollingTransport(headers, client, Single.just(""));
-        Throwable exception = assertThrows(RuntimeException.class, () -> transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait());
+        Throwable exception = assertThrows(RuntimeException.class, () -> transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait());
         assertEquals(Exception.class, exception.getCause().getClass());
         assertEquals("Failed to connect.", exception.getCause().getMessage());
         assertFalse(transport.isActive());
@@ -41,7 +41,7 @@ public class LongPollingTransportTest {
         Map<String, String> headers = new HashMap<>();
         LongPollingTransport transport = new LongPollingTransport(headers, client, Single.just(""));
         ByteBuffer sendBuffer = TestUtils.stringToByteBuffer("First");
-        Throwable exception = assertThrows(RuntimeException.class, () -> transport.send(sendBuffer).timeout(1, TimeUnit.SECONDS).blockingAwait());
+        Throwable exception = assertThrows(RuntimeException.class, () -> transport.send(sendBuffer).timeout(30, TimeUnit.SECONDS).blockingAwait());
         assertEquals(Exception.class, exception.getCause().getClass());
         assertEquals("Cannot send unless the transport is active.", exception.getCause().getMessage());
         assertFalse(transport.isActive());
@@ -69,7 +69,7 @@ public class LongPollingTransportTest {
         });
 
         assertFalse(onClosedRan.get());
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(block.blockingAwait(1, TimeUnit.SECONDS));
         assertTrue(onClosedRan.get());
         assertFalse(transport.isActive());
@@ -98,7 +98,7 @@ public class LongPollingTransportTest {
             blocker.onComplete();
         });
 
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(blocker.blockingAwait(1, TimeUnit.SECONDS));
         assertFalse(transport.isActive());
         assertTrue(onClosedRan.get());
@@ -155,7 +155,7 @@ public class LongPollingTransportTest {
 
         transport.setOnClose((error) -> {});
 
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(block.blockingAwait(1,TimeUnit.SECONDS));
         assertTrue(onReceiveCalled.get());
         assertEquals("TEST", message.get());
@@ -200,7 +200,7 @@ public class LongPollingTransportTest {
 
         transport.setOnClose((error) -> {});
 
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(blocker.blockingAwait(1, TimeUnit.SECONDS));
         assertTrue(onReceiveCalled.get());
         assertEquals("FIRSTSECONDTHIRD", message.get());
@@ -230,7 +230,7 @@ public class LongPollingTransportTest {
         LongPollingTransport transport = new LongPollingTransport(headers, client, Single.just(""));
         transport.setOnClose((error) -> {});
 
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         ByteBuffer sendBuffer = TestUtils.stringToByteBuffer("TEST");
         assertTrue(transport.send(sendBuffer).blockingAwait(1, TimeUnit.SECONDS));
         close.onComplete();
@@ -262,7 +262,7 @@ public class LongPollingTransportTest {
         LongPollingTransport transport = new LongPollingTransport(headers, client, tokenProvider);
         transport.setOnClose((error) -> {});
 
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         ByteBuffer sendBuffer = TestUtils.stringToByteBuffer("TEST");
         assertTrue(transport.send(sendBuffer).blockingAwait(1, TimeUnit.SECONDS));
         assertEquals(headerValue.get(), "Bearer TOKEN");
@@ -298,7 +298,7 @@ public class LongPollingTransportTest {
         LongPollingTransport transport = new LongPollingTransport(headers, client, tokenProvider);
         transport.setOnClose((error) -> {});
 
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         secondGet.blockingAwait(1, TimeUnit.SECONDS);
         ByteBuffer sendBuffer = TestUtils.stringToByteBuffer("TEST");
         assertTrue(transport.send(sendBuffer).blockingAwait(1, TimeUnit.SECONDS));
@@ -330,7 +330,7 @@ public class LongPollingTransportTest {
         });
 
         assertFalse(onClosedRan.get());
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(block.blockingAwait(1, TimeUnit.SECONDS));
         assertEquals(1, onCloseCount.get());
         assertTrue(onClosedRan.get());
@@ -368,7 +368,7 @@ public class LongPollingTransportTest {
         });
 
         assertEquals(0, onCloseCount.get());
-        transport.start("http://example.com").timeout(1, TimeUnit.SECONDS).blockingAwait();
+        transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(transport.stop().blockingAwait(1, TimeUnit.SECONDS));
         assertEquals(1, onCloseCount.get());
         assertFalse(transport.isActive());


### PR DESCRIPTION
```
JUnit Jupiter:HubConnectionTest:LongPollingTransportAccessTokenProviderThrowsAfterHandshakeClosesConnection()
    MethodSource [className = 'com.microsoft.signalr.HubConnectionTest', methodName = 'LongPollingTransportAccessTokenProviderThrowsAfterHandshakeClosesConnection', methodParameterTypes = '']
    => java.lang.RuntimeException: java.util.concurrent.TimeoutException: The source did not signal an event for 1 seconds and has been terminated.
```
 
https://dev.azure.com/dnceng/public/_build/results?buildId=803044&view=logs&jobId=6c33d704-163a-5170-38fa-caa7bc99f17c&j=6c33d704-163a-5170-38fa-caa7bc99f17c&t=4a2ac175-72f0-54eb-c8b6-eb1e5d86c7d5

A test timeout failure caused PR checks to fail for a recent automated merge PR (#25555).

Since there's no way to quarantine Java tests, I'm increasing the test timeouts from 1 second to 30 seconds. The timeout being too short might not be the ultimate cause of the flakiness, but waiting longer for timeouts would only slow down failures which shouldn't be too common. Kestrel has successfully used 30 second test timeouts to avoid unnecessary flakiness for years.

https://github.com/dotnet/aspnetcore/blob/1e7d6d56a5ae6b9ddfc8680d6f4f8282a8f17400/src/Servers/Kestrel/shared/test/TestConstants.cs#L11