### PR TITLE
Debug gradle

### DIFF
--- a/src/SignalR/clients/java/signalr/core/signalr.client.java.core.javaproj
+++ b/src/SignalR/clients/java/signalr/core/signalr.client.java.core.javaproj
@@ -47,7 +47,7 @@
 
   <Target Name="Build">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Build" />
-    <Exec Command="../gradlew $(GradleOptions) compileJava" />
+    <Exec Command="../gradlew --debug $(GradleOptions) compileJava" />
   </Target>
 
   <Target Name="Test" />


### PR DESCRIPTION
Let's see if we can reproduce an error like the one in https://dev.azure.com/dnceng/public/_build/results?buildId=803056&view=results

```
 FAILURE: Build failed with an exception. 
 
 * What went wrong: 
 Timeout waiting to connect to the Gradle daemon. 
 Daemon uid: dc385680-ff40-400b-a7ed-9bf7e8fcf63b with diagnostics: 
 Daemon pid: 51465 
 log file: /Users/runner/.gradle/daemon/6.5/daemon-51465.out.log
 ----- Last 20 lines from daemon log file - daemon-51465.out.log -----
 2020-09-05T01:47:38.126+0000 [DEBUG] [org.gradle.launcher.daemon.registry.PersistentDaemonRegistry] Removing daemon address: [d72b1286-0554-416b-9fd8-fcca65a01851 port:50145, addresses:[localhost/127.0.0.1]] 
 2020-09-05T01:47:38.127+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire exclusive lock on daemon addresses registry. 
 2020-09-05T01:47:38.127+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry. 
 2020-09-05T01:47:38.130+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry. 
 2020-09-05T01:47:38.131+0000 [DEBUG] [org.gradle.launcher.daemon.server.DaemonRegistryUpdater] Address removed from registry. 
 Daemon vm is shutting down... The daemon has exited normally or was terminated in response to a user interrupt. 
 2020-09-05T01:47:38.135+0000 [DEBUG] [org.gradle.launcher.daemon.registry.PersistentDaemonRegistry] Removing daemon address: [d72b1286-0554-416b-9fd8-fcca65a01851 port:50145, addresses:[localhost/127.0.0.1]] 
 2020-09-05T01:47:38.135+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire exclusive lock on daemon addresses registry. 
 2020-09-05T01:47:38.136+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry. 
 2020-09-05T01:47:38.137+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry. 
 ----- End of the daemon log -----
 * Try:
 Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
 * Get more help at https://help.gradle.org
/Users/runner/work/1/s/src/SignalR/clients/java/signalr/core/signalr.client.java.core.javaproj(50,5): error MSB3073: The command "../gradlew -Dorg.gradle.daemon=false -PpackageVersion="5.0.0-ci" compileJava" exited with code 1.
##[error]src/SignalR/clients/java/signalr/core/signalr.client.java.core.javaproj(50,5): error MSB3073: (NETCORE_ENGINEERING_TELEMETRY=Build) The command "../gradlew -Dorg.gradle.daemon=false -PpackageVersion="5.0.0-ci" compileJava" exited with code 1.
```