### PR TITLE
[release/5.0-rc2] Add public API baselines for Components

### DIFF
--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 
@@ -35,6 +36,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(string? value, CultureInfo? culture = null) => FormatStringValueCore(value, culture);
 
         private static string? FormatStringValueCore(string? value, CultureInfo? culture)
@@ -50,6 +52,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static bool FormatValue(bool value, CultureInfo? culture = null)
         {
             // Formatting for bool is special-cased. We need to produce a boolean value for conditional attributes
@@ -73,6 +76,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static bool? FormatValue(bool? value, CultureInfo? culture = null)
         {
             // Formatting for bool is special-cased. We need to produce a boolean value for conditional attributes
@@ -96,6 +100,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(int value, CultureInfo? culture = null) => FormatIntValueCore(value, culture);
 
         private static string? FormatIntValueCore(int value, CultureInfo? culture)
@@ -111,6 +116,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(int? value, CultureInfo? culture = null) => FormatNullableIntValueCore(value, culture);
 
         private static string? FormatNullableIntValueCore(int? value, CultureInfo? culture)
@@ -131,6 +137,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string FormatValue(long value, CultureInfo? culture = null) => FormatLongValueCore(value, culture);
 
         private static string FormatLongValueCore(long value, CultureInfo? culture)
@@ -146,6 +153,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(long? value, CultureInfo? culture = null) => FormatNullableLongValueCore(value, culture);
 
         private static string? FormatNullableLongValueCore(long? value, CultureInfo? culture)
@@ -166,6 +174,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string FormatValue(short value, CultureInfo? culture = null) => FormatShortValueCore(value, culture);
 
         private static string FormatShortValueCore(short value, CultureInfo? culture)
@@ -181,6 +190,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(short? value, CultureInfo? culture = null) => FormatNullableShortValueCore(value, culture);
 
         private static string? FormatNullableShortValueCore(short? value, CultureInfo? culture)
@@ -201,6 +211,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string FormatValue(float value, CultureInfo? culture = null) => FormatFloatValueCore(value, culture);
 
         private static string FormatFloatValueCore(float value, CultureInfo? culture)
@@ -216,6 +227,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(float? value, CultureInfo? culture = null) => FormatNullableFloatValueCore(value, culture);
 
         private static string? FormatNullableFloatValueCore(float? value, CultureInfo? culture)
@@ -236,6 +248,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(double value, CultureInfo? culture = null) => FormatDoubleValueCore(value, culture);
 
         private static string FormatDoubleValueCore(double value, CultureInfo? culture)
@@ -251,6 +264,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(double? value, CultureInfo? culture = null) => FormatNullableDoubleValueCore(value, culture);
 
         private static string? FormatNullableDoubleValueCore(double? value, CultureInfo? culture)
@@ -271,6 +285,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string FormatValue(decimal value, CultureInfo? culture = null) => FormatDecimalValueCore(value, culture);
 
         private static string FormatDecimalValueCore(decimal value, CultureInfo? culture)
@@ -286,6 +301,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(decimal? value, CultureInfo? culture = null) => FormatNullableDecimalValueCore(value, culture);
 
         private static string? FormatNullableDecimalValueCore(decimal? value, CultureInfo? culture)
@@ -306,6 +322,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string FormatValue(DateTime value, CultureInfo? culture = null) => FormatDateTimeValueCore(value, format: null, culture);
 
         /// <summary>
@@ -317,6 +334,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string FormatValue(DateTime value, string format, CultureInfo? culture = null) => FormatDateTimeValueCore(value, format, culture);
 
         private static string FormatDateTimeValueCore(DateTime value, string? format, CultureInfo? culture)
@@ -342,6 +360,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(DateTime? value, CultureInfo? culture = null) => FormatNullableDateTimeValueCore(value, format: null, culture);
 
         /// <summary>
@@ -353,6 +372,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(DateTime? value, string? format, CultureInfo? culture = null) => FormatNullableDateTimeValueCore(value, format, culture);
 
         private static string? FormatNullableDateTimeValueCore(DateTime? value, string? format, CultureInfo? culture)
@@ -388,6 +408,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string FormatValue(DateTimeOffset value, CultureInfo? culture = null) => FormatDateTimeOffsetValueCore(value, format: null, culture);
 
 
@@ -400,6 +421,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string FormatValue(DateTimeOffset value, string format, CultureInfo? culture = null) => FormatDateTimeOffsetValueCore(value, format, culture);
 
         private static string FormatDateTimeOffsetValueCore(DateTimeOffset value, string? format, CultureInfo? culture)
@@ -425,6 +447,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(DateTimeOffset? value, CultureInfo? culture = null) => FormatNullableDateTimeOffsetValueCore(value, format: null, culture);
 
         /// <summary>
@@ -436,6 +459,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static string? FormatValue(DateTimeOffset? value, string format, CultureInfo? culture = null) => FormatNullableDateTimeOffsetValueCore(value, format, culture);
 
         private static string? FormatNullableDateTimeOffsetValueCore(DateTimeOffset? value, string? format, CultureInfo? culture)
@@ -486,6 +510,7 @@ namespace Microsoft.AspNetCore.Components
         /// The <see cref="CultureInfo"/> to use while formatting. Defaults to <see cref="CultureInfo.CurrentCulture"/>.
         /// </param>
         /// <returns>The formatted value.</returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static object? FormatValue<T>(T value, CultureInfo? culture = null)
         {
             var formatter = FormatterDelegateCache.Get<T>();

--- a/src/Components/Components/src/EventCallbackFactoryBinderExtensions.cs
+++ b/src/Components/Components/src/EventCallbackFactoryBinderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using static Microsoft.AspNetCore.Components.BindConverter;
 
@@ -31,6 +32,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -50,6 +52,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -69,6 +72,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -88,6 +92,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -107,6 +112,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -126,6 +132,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -145,6 +152,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -164,6 +172,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -183,6 +192,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -202,6 +212,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -221,6 +232,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -240,6 +252,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -259,6 +272,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -278,6 +292,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -297,6 +312,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -316,6 +332,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -336,6 +353,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="format"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -356,6 +374,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -376,6 +395,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="format"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -396,6 +416,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -416,6 +437,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="format"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -436,6 +458,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -456,6 +479,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="format"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder(
             this EventCallbackFactory factory,
             object receiver,
@@ -477,6 +501,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="existingValue"></param>
         /// <param name="culture"></param>
         /// <returns></returns>
+        [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Required to maintain compatibility")]
         public static EventCallback<ChangeEventArgs> CreateBinder<T>(
             this EventCallbackFactory factory,
             object receiver,

--- a/src/Components/Components/src/PublicAPI.Shipped.txt
+++ b/src/Components/Components/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,429 @@
+Microsoft.AspNetCore.Components.BindConverter
+Microsoft.AspNetCore.Components.BindElementAttribute
+Microsoft.AspNetCore.Components.BindElementAttribute.BindElementAttribute(string! element, string? suffix, string! valueAttribute, string! changeAttribute) -> void
+Microsoft.AspNetCore.Components.BindElementAttribute.ChangeAttribute.get -> string!
+Microsoft.AspNetCore.Components.BindElementAttribute.Element.get -> string!
+Microsoft.AspNetCore.Components.BindElementAttribute.Suffix.get -> string?
+Microsoft.AspNetCore.Components.BindElementAttribute.ValueAttribute.get -> string!
+Microsoft.AspNetCore.Components.CascadingParameterAttribute
+Microsoft.AspNetCore.Components.CascadingParameterAttribute.CascadingParameterAttribute() -> void
+Microsoft.AspNetCore.Components.CascadingParameterAttribute.Name.get -> string?
+Microsoft.AspNetCore.Components.CascadingParameterAttribute.Name.set -> void
+Microsoft.AspNetCore.Components.CascadingValue<TValue>
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) -> void
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.CascadingValue() -> void
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment!
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.ChildContent.set -> void
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.IsFixed.get -> bool
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.IsFixed.set -> void
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.Name.get -> string?
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.Name.set -> void
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.Value.get -> TValue
+Microsoft.AspNetCore.Components.CascadingValue<TValue>.Value.set -> void
+Microsoft.AspNetCore.Components.ChangeEventArgs
+Microsoft.AspNetCore.Components.ChangeEventArgs.ChangeEventArgs() -> void
+Microsoft.AspNetCore.Components.ChangeEventArgs.Value.get -> object?
+Microsoft.AspNetCore.Components.ChangeEventArgs.Value.set -> void
+Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers
+Microsoft.AspNetCore.Components.ComponentBase
+Microsoft.AspNetCore.Components.ComponentBase.ComponentBase() -> void
+Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync(System.Action! workItem) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync(System.Func<System.Threading.Tasks.Task!>! workItem) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged() -> void
+Microsoft.AspNetCore.Components.Dispatcher
+Microsoft.AspNetCore.Components.Dispatcher.AssertAccess() -> void
+Microsoft.AspNetCore.Components.Dispatcher.Dispatcher() -> void
+Microsoft.AspNetCore.Components.Dispatcher.OnUnhandledException(System.UnhandledExceptionEventArgs! e) -> void
+Microsoft.AspNetCore.Components.ElementReference
+Microsoft.AspNetCore.Components.ElementReference.Context.get -> Microsoft.AspNetCore.Components.ElementReferenceContext?
+Microsoft.AspNetCore.Components.ElementReference.ElementReference(string! id) -> void
+Microsoft.AspNetCore.Components.ElementReference.ElementReference(string! id, Microsoft.AspNetCore.Components.ElementReferenceContext? context) -> void
+Microsoft.AspNetCore.Components.ElementReference.Id.get -> string!
+Microsoft.AspNetCore.Components.ElementReferenceContext
+Microsoft.AspNetCore.Components.ElementReferenceContext.ElementReferenceContext() -> void
+Microsoft.AspNetCore.Components.EventCallback
+Microsoft.AspNetCore.Components.EventCallback.EventCallback(Microsoft.AspNetCore.Components.IHandleEvent? receiver, System.MulticastDelegate? delegate) -> void
+Microsoft.AspNetCore.Components.EventCallback.HasDelegate.get -> bool
+Microsoft.AspNetCore.Components.EventCallback.InvokeAsync() -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.EventCallback.InvokeAsync(object! arg) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallback<TValue>.EventCallback(Microsoft.AspNetCore.Components.IHandleEvent? receiver, System.MulticastDelegate? delegate) -> void
+Microsoft.AspNetCore.Components.EventCallback<TValue>.HasDelegate.get -> bool
+Microsoft.AspNetCore.Components.EventCallback<TValue>.InvokeAsync() -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.EventCallback<TValue>.InvokeAsync(TValue arg) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.EventCallbackFactory
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create(object! receiver, Microsoft.AspNetCore.Components.EventCallback callback) -> Microsoft.AspNetCore.Components.EventCallback
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create(object! receiver, System.Action! callback) -> Microsoft.AspNetCore.Components.EventCallback
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create(object! receiver, System.Action<object!>! callback) -> Microsoft.AspNetCore.Components.EventCallback
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create(object! receiver, System.Func<System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create(object! receiver, System.Func<object!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create<TValue>(object! receiver, Microsoft.AspNetCore.Components.EventCallback callback) -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create<TValue>(object! receiver, Microsoft.AspNetCore.Components.EventCallback<TValue> callback) -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create<TValue>(object! receiver, System.Action! callback) -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create<TValue>(object! receiver, System.Action<TValue>! callback) -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create<TValue>(object! receiver, System.Func<System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallbackFactory.Create<TValue>(object! receiver, System.Func<TValue, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallbackFactory.CreateInferred<TValue>(object! receiver, System.Action<TValue>! callback, TValue value) -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallbackFactory.CreateInferred<TValue>(object! receiver, System.Func<TValue, System.Threading.Tasks.Task!>! callback, TValue value) -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.EventCallbackFactory.EventCallbackFactory() -> void
+Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions
+Microsoft.AspNetCore.Components.EventCallbackFactoryEventArgsExtensions
+Microsoft.AspNetCore.Components.EventCallbackWorkItem
+Microsoft.AspNetCore.Components.EventCallbackWorkItem.EventCallbackWorkItem(System.MulticastDelegate? delegate) -> void
+Microsoft.AspNetCore.Components.EventCallbackWorkItem.InvokeAsync(object? arg) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.EventHandlerAttribute
+Microsoft.AspNetCore.Components.EventHandlerAttribute.AttributeName.get -> string!
+Microsoft.AspNetCore.Components.EventHandlerAttribute.EnablePreventDefault.get -> bool
+Microsoft.AspNetCore.Components.EventHandlerAttribute.EnableStopPropagation.get -> bool
+Microsoft.AspNetCore.Components.EventHandlerAttribute.EventArgsType.get -> System.Type!
+Microsoft.AspNetCore.Components.EventHandlerAttribute.EventHandlerAttribute(string! attributeName, System.Type! eventArgsType) -> void
+Microsoft.AspNetCore.Components.EventHandlerAttribute.EventHandlerAttribute(string! attributeName, System.Type! eventArgsType, bool enableStopPropagation, bool enablePreventDefault) -> void
+Microsoft.AspNetCore.Components.IComponent
+Microsoft.AspNetCore.Components.IComponent.Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) -> void
+Microsoft.AspNetCore.Components.IComponent.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.IComponentActivator
+Microsoft.AspNetCore.Components.IComponentActivator.CreateInstance(System.Type! componentType) -> Microsoft.AspNetCore.Components.IComponent!
+Microsoft.AspNetCore.Components.IHandleAfterRender
+Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync() -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.IHandleEvent
+Microsoft.AspNetCore.Components.IHandleEvent.HandleEventAsync(Microsoft.AspNetCore.Components.EventCallbackWorkItem item, object? arg) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.InjectAttribute
+Microsoft.AspNetCore.Components.InjectAttribute.InjectAttribute() -> void
+Microsoft.AspNetCore.Components.LayoutAttribute
+Microsoft.AspNetCore.Components.LayoutAttribute.LayoutAttribute(System.Type! layoutType) -> void
+Microsoft.AspNetCore.Components.LayoutAttribute.LayoutType.get -> System.Type!
+Microsoft.AspNetCore.Components.LayoutComponentBase
+Microsoft.AspNetCore.Components.LayoutComponentBase.Body.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.LayoutComponentBase.Body.set -> void
+Microsoft.AspNetCore.Components.LayoutComponentBase.LayoutComponentBase() -> void
+Microsoft.AspNetCore.Components.LayoutView
+Microsoft.AspNetCore.Components.LayoutView.Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) -> void
+Microsoft.AspNetCore.Components.LayoutView.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment!
+Microsoft.AspNetCore.Components.LayoutView.ChildContent.set -> void
+Microsoft.AspNetCore.Components.LayoutView.Layout.get -> System.Type!
+Microsoft.AspNetCore.Components.LayoutView.Layout.set -> void
+Microsoft.AspNetCore.Components.LayoutView.LayoutView() -> void
+Microsoft.AspNetCore.Components.LayoutView.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.LocationChangeException
+Microsoft.AspNetCore.Components.LocationChangeException.LocationChangeException(string! message, System.Exception! innerException) -> void
+Microsoft.AspNetCore.Components.MarkupString
+Microsoft.AspNetCore.Components.MarkupString.MarkupString(string! value) -> void
+Microsoft.AspNetCore.Components.MarkupString.Value.get -> string!
+Microsoft.AspNetCore.Components.NavigationException
+Microsoft.AspNetCore.Components.NavigationException.Location.get -> string!
+Microsoft.AspNetCore.Components.NavigationException.NavigationException(string! uri) -> void
+Microsoft.AspNetCore.Components.NavigationManager
+Microsoft.AspNetCore.Components.NavigationManager.BaseUri.get -> string!
+Microsoft.AspNetCore.Components.NavigationManager.BaseUri.set -> void
+Microsoft.AspNetCore.Components.NavigationManager.Initialize(string! baseUri, string! uri) -> void
+Microsoft.AspNetCore.Components.NavigationManager.LocationChanged -> System.EventHandler<Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs!>!
+Microsoft.AspNetCore.Components.NavigationManager.NavigateTo(string! uri, bool forceLoad = false) -> void
+Microsoft.AspNetCore.Components.NavigationManager.NavigationManager() -> void
+Microsoft.AspNetCore.Components.NavigationManager.NotifyLocationChanged(bool isInterceptedLink) -> void
+Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri(string! relativeUri) -> System.Uri!
+Microsoft.AspNetCore.Components.NavigationManager.ToBaseRelativePath(string! uri) -> string!
+Microsoft.AspNetCore.Components.NavigationManager.Uri.get -> string!
+Microsoft.AspNetCore.Components.NavigationManager.Uri.set -> void
+Microsoft.AspNetCore.Components.OwningComponentBase
+Microsoft.AspNetCore.Components.OwningComponentBase.IsDisposed.get -> bool
+Microsoft.AspNetCore.Components.OwningComponentBase.OwningComponentBase() -> void
+Microsoft.AspNetCore.Components.OwningComponentBase.ScopedServices.get -> System.IServiceProvider!
+Microsoft.AspNetCore.Components.OwningComponentBase<TService>
+Microsoft.AspNetCore.Components.OwningComponentBase<TService>.OwningComponentBase() -> void
+Microsoft.AspNetCore.Components.OwningComponentBase<TService>.Service.get -> TService
+Microsoft.AspNetCore.Components.ParameterAttribute
+Microsoft.AspNetCore.Components.ParameterAttribute.CaptureUnmatchedValues.get -> bool
+Microsoft.AspNetCore.Components.ParameterAttribute.CaptureUnmatchedValues.set -> void
+Microsoft.AspNetCore.Components.ParameterAttribute.ParameterAttribute() -> void
+Microsoft.AspNetCore.Components.ParameterValue
+Microsoft.AspNetCore.Components.ParameterValue.Cascading.get -> bool
+Microsoft.AspNetCore.Components.ParameterValue.Name.get -> string!
+Microsoft.AspNetCore.Components.ParameterValue.Value.get -> object!
+Microsoft.AspNetCore.Components.ParameterView
+Microsoft.AspNetCore.Components.ParameterView.Enumerator
+Microsoft.AspNetCore.Components.ParameterView.Enumerator.Current.get -> Microsoft.AspNetCore.Components.ParameterValue
+Microsoft.AspNetCore.Components.ParameterView.Enumerator.MoveNext() -> bool
+Microsoft.AspNetCore.Components.ParameterView.GetEnumerator() -> Microsoft.AspNetCore.Components.ParameterView.Enumerator
+Microsoft.AspNetCore.Components.ParameterView.GetValueOrDefault<TValue>(string! parameterName) -> TValue
+Microsoft.AspNetCore.Components.ParameterView.GetValueOrDefault<TValue>(string! parameterName, TValue defaultValue) -> TValue
+Microsoft.AspNetCore.Components.ParameterView.SetParameterProperties(object! target) -> void
+Microsoft.AspNetCore.Components.ParameterView.ToDictionary() -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
+Microsoft.AspNetCore.Components.ParameterView.TryGetValue<TValue>(string! parameterName, out TValue result) -> bool
+Microsoft.AspNetCore.Components.RenderFragment
+Microsoft.AspNetCore.Components.RenderFragment<TValue>
+Microsoft.AspNetCore.Components.RenderHandle
+Microsoft.AspNetCore.Components.RenderHandle.Dispatcher.get -> Microsoft.AspNetCore.Components.Dispatcher!
+Microsoft.AspNetCore.Components.RenderHandle.IsInitialized.get -> bool
+Microsoft.AspNetCore.Components.RenderHandle.Render(Microsoft.AspNetCore.Components.RenderFragment! renderFragment) -> void
+Microsoft.AspNetCore.Components.RenderTree.ArrayBuilderSegment<T>
+Microsoft.AspNetCore.Components.RenderTree.ArrayBuilderSegment<T>.Array.get -> T[]!
+Microsoft.AspNetCore.Components.RenderTree.ArrayBuilderSegment<T>.Count.get -> int
+Microsoft.AspNetCore.Components.RenderTree.ArrayBuilderSegment<T>.Offset.get -> int
+Microsoft.AspNetCore.Components.RenderTree.ArrayBuilderSegment<T>.this[int index].get -> T
+Microsoft.AspNetCore.Components.RenderTree.ArrayRange<T>
+Microsoft.AspNetCore.Components.RenderTree.ArrayRange<T>.ArrayRange(T[]! array, int count) -> void
+Microsoft.AspNetCore.Components.RenderTree.ArrayRange<T>.Clone() -> Microsoft.AspNetCore.Components.RenderTree.ArrayRange<T>
+Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo
+Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo.ComponentId.get -> int
+Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo.ComponentId.set -> void
+Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo.EventFieldInfo() -> void
+Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo.FieldValue.get -> object!
+Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo.FieldValue.set -> void
+Microsoft.AspNetCore.Components.RenderTree.RenderBatch
+Microsoft.AspNetCore.Components.RenderTree.RenderBatch.DisposedComponentIDs.get -> Microsoft.AspNetCore.Components.RenderTree.ArrayRange<int>
+Microsoft.AspNetCore.Components.RenderTree.RenderBatch.DisposedEventHandlerIDs.get -> Microsoft.AspNetCore.Components.RenderTree.ArrayRange<ulong>
+Microsoft.AspNetCore.Components.RenderTree.RenderBatch.ReferenceFrames.get -> Microsoft.AspNetCore.Components.RenderTree.ArrayRange<Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame>
+Microsoft.AspNetCore.Components.RenderTree.RenderBatch.UpdatedComponents.get -> Microsoft.AspNetCore.Components.RenderTree.ArrayRange<Microsoft.AspNetCore.Components.RenderTree.RenderTreeDiff>
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeDiff
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.PermutationListEnd = 10 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.PermutationListEntry = 9 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.PrependFrame = 1 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.RemoveAttribute = 4 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.RemoveFrame = 2 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.SetAttribute = 3 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.StepIn = 6 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.StepOut = 7 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.UpdateMarkup = 8 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType.UpdateText = 5 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.AttributeEventHandlerId.get -> ulong
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute(int sequence, string! name, string? value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddComponentReferenceCapture(int sequence, System.Action<object!>! componentReferenceCaptureAction) -> void
+Microsoft.AspNetCore.Components.Routing.Router.OnNavigateAsync.get -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Routing.NavigationContext!>
+Microsoft.AspNetCore.Components.Routing.Router.OnNavigateAsync.set -> void
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.AttributeEventUpdatesAttributeName.get -> string
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.AttributeName.get -> string
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.AttributeValue.get -> object
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.Component.get -> Microsoft.AspNetCore.Components.IComponent
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ComponentId.get -> int
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ComponentKey.get -> object
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ComponentReferenceCaptureAction.get -> System.Action<object>
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ComponentReferenceCaptureParentFrameIndex.get -> int
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ComponentSubtreeLength.get -> int
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ComponentType.get -> System.Type
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ElementKey.get -> object
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ElementName.get -> string
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ElementReferenceCaptureAction.get -> System.Action<Microsoft.AspNetCore.Components.ElementReference>
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ElementReferenceCaptureId.get -> string
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ElementSubtreeLength.get -> int
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.FrameType.get -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.MarkupContent.get -> string
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.RegionSubtreeLength.get -> int
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.Sequence.get -> int
+~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.TextContent.get -> string
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.Attribute = 3 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.Component = 4 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.ComponentReferenceCapture = 7 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.Element = 1 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.ElementReferenceCapture = 6 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.Markup = 8 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.None = 0 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.Region = 5 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType.Text = 2 -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrameType
+Microsoft.AspNetCore.Components.RenderTree.Renderer
+Microsoft.AspNetCore.Components.RenderTree.Renderer.AssignRootComponentId(Microsoft.AspNetCore.Components.IComponent! component) -> int
+Microsoft.AspNetCore.Components.RenderTree.Renderer.Dispose() -> void
+Microsoft.AspNetCore.Components.RenderTree.Renderer.ElementReferenceContext.get -> Microsoft.AspNetCore.Components.ElementReferenceContext?
+Microsoft.AspNetCore.Components.RenderTree.Renderer.ElementReferenceContext.set -> void
+Microsoft.AspNetCore.Components.RenderTree.Renderer.GetCurrentRenderTreeFrames(int componentId) -> Microsoft.AspNetCore.Components.RenderTree.ArrayRange<Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame>
+Microsoft.AspNetCore.Components.RenderTree.Renderer.InstantiateComponent(System.Type! componentType) -> Microsoft.AspNetCore.Components.IComponent!
+Microsoft.AspNetCore.Components.RenderTree.Renderer.RenderRootComponentAsync(int componentId) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.RenderTree.Renderer.RenderRootComponentAsync(int componentId, Microsoft.AspNetCore.Components.ParameterView initialParameters) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.RenderTree.Renderer.Renderer(System.IServiceProvider! serviceProvider, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.AspNetCore.Components.RenderTree.Renderer.Renderer(System.IServiceProvider! serviceProvider, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, Microsoft.AspNetCore.Components.IComponentActivator! componentActivator) -> void
+Microsoft.AspNetCore.Components.RenderTree.Renderer.UnhandledSynchronizationException -> System.UnhandledExceptionEventHandler!
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute(int sequence, Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame frame) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute(int sequence, string! name) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute(int sequence, string! name, Microsoft.AspNetCore.Components.EventCallback value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute(int sequence, string! name, System.MulticastDelegate? value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute(int sequence, string! name, bool value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute(int sequence, string! name, object? value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute<TArgument>(int sequence, string! name, Microsoft.AspNetCore.Components.EventCallback<TArgument> value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent(int sequence, Microsoft.AspNetCore.Components.MarkupString markupContent) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent(int sequence, Microsoft.AspNetCore.Components.RenderFragment? fragment) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent(int sequence, object? textContent) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent(int sequence, string? textContent) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent<TValue>(int sequence, Microsoft.AspNetCore.Components.RenderFragment<TValue>? fragment, TValue value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddElementReferenceCapture(int sequence, System.Action<Microsoft.AspNetCore.Components.ElementReference>! elementReferenceCaptureAction) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddMarkupContent(int sequence, string? markupContent) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddMultipleAttributes(int sequence, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object!>>? attributes) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.Clear() -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.CloseComponent() -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.CloseElement() -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.CloseRegion() -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.GetFrames() -> Microsoft.AspNetCore.Components.RenderTree.ArrayRange<Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame>
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.OpenComponent(int sequence, System.Type! componentType) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.OpenComponent<TComponent>(int sequence) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.OpenElement(int sequence, string! elementName) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.OpenRegion(int sequence) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.RenderTreeBuilder() -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.SetKey(object? value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.SetUpdatesAttributeName(string! updatesAttributeName) -> void
+Microsoft.AspNetCore.Components.RouteAttribute
+Microsoft.AspNetCore.Components.RouteAttribute.RouteAttribute(string! template) -> void
+Microsoft.AspNetCore.Components.RouteAttribute.Template.get -> string!
+Microsoft.AspNetCore.Components.RouteData
+Microsoft.AspNetCore.Components.RouteData.PageType.get -> System.Type!
+Microsoft.AspNetCore.Components.RouteData.RouteData(System.Type! pageType, System.Collections.Generic.IReadOnlyDictionary<string!, object!>! routeValues) -> void
+Microsoft.AspNetCore.Components.RouteData.RouteValues.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
+Microsoft.AspNetCore.Components.RouteView
+Microsoft.AspNetCore.Components.RouteView.Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) -> void
+Microsoft.AspNetCore.Components.RouteView.DefaultLayout.get -> System.Type!
+Microsoft.AspNetCore.Components.RouteView.DefaultLayout.set -> void
+Microsoft.AspNetCore.Components.RouteView.RouteData.get -> Microsoft.AspNetCore.Components.RouteData!
+Microsoft.AspNetCore.Components.RouteView.RouteData.set -> void
+Microsoft.AspNetCore.Components.RouteView.RouteView() -> void
+Microsoft.AspNetCore.Components.RouteView.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.Routing.IHostEnvironmentNavigationManager
+Microsoft.AspNetCore.Components.Routing.IHostEnvironmentNavigationManager.Initialize(string! baseUri, string! uri) -> void
+Microsoft.AspNetCore.Components.Routing.INavigationInterception
+Microsoft.AspNetCore.Components.Routing.INavigationInterception.EnableNavigationInterceptionAsync() -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs
+Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs.IsNavigationIntercepted.get -> bool
+Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs.Location.get -> string!
+Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs.LocationChangedEventArgs(string! location, bool isNavigationIntercepted) -> void
+Microsoft.AspNetCore.Components.Routing.NavigationContext
+Microsoft.AspNetCore.Components.Routing.NavigationContext.CancellationToken.get -> System.Threading.CancellationToken
+Microsoft.AspNetCore.Components.Routing.NavigationContext.Path.get -> string!
+Microsoft.AspNetCore.Components.Routing.Router
+Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies.get -> System.Collections.Generic.IEnumerable<System.Reflection.Assembly!>!
+Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies.set -> void
+Microsoft.AspNetCore.Components.Routing.Router.AppAssembly.get -> System.Reflection.Assembly!
+Microsoft.AspNetCore.Components.Routing.Router.AppAssembly.set -> void
+Microsoft.AspNetCore.Components.Routing.Router.Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) -> void
+Microsoft.AspNetCore.Components.Routing.Router.Dispose() -> void
+Microsoft.AspNetCore.Components.Routing.Router.Found.get -> Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.RouteData!>!
+Microsoft.AspNetCore.Components.Routing.Router.Found.set -> void
+Microsoft.AspNetCore.Components.Routing.Router.Navigating.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.Routing.Router.Navigating.set -> void
+Microsoft.AspNetCore.Components.Routing.Router.NotFound.get -> Microsoft.AspNetCore.Components.RenderFragment!
+Microsoft.AspNetCore.Components.Routing.Router.NotFound.set -> void
+Microsoft.AspNetCore.Components.Routing.Router.Router() -> void
+Microsoft.AspNetCore.Components.Routing.Router.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
+abstract Microsoft.AspNetCore.Components.Dispatcher.CheckAccess() -> bool
+abstract Microsoft.AspNetCore.Components.Dispatcher.InvokeAsync(System.Action! workItem) -> System.Threading.Tasks.Task!
+abstract Microsoft.AspNetCore.Components.Dispatcher.InvokeAsync(System.Func<System.Threading.Tasks.Task!>! workItem) -> System.Threading.Tasks.Task!
+abstract Microsoft.AspNetCore.Components.Dispatcher.InvokeAsync<TResult>(System.Func<System.Threading.Tasks.Task<TResult>!>! workItem) -> System.Threading.Tasks.Task<TResult>!
+abstract Microsoft.AspNetCore.Components.Dispatcher.InvokeAsync<TResult>(System.Func<TResult>! workItem) -> System.Threading.Tasks.Task<TResult>!
+abstract Microsoft.AspNetCore.Components.NavigationManager.NavigateToCore(string! uri, bool forceLoad) -> void
+abstract Microsoft.AspNetCore.Components.RenderTree.Renderer.Dispatcher.get -> Microsoft.AspNetCore.Components.Dispatcher!
+abstract Microsoft.AspNetCore.Components.RenderTree.Renderer.HandleException(System.Exception! exception) -> void
+abstract Microsoft.AspNetCore.Components.RenderTree.Renderer.UpdateDisplayAsync(in Microsoft.AspNetCore.Components.RenderTree.RenderBatch renderBatch) -> System.Threading.Tasks.Task!
+override Microsoft.AspNetCore.Components.MarkupString.ToString() -> string!
+~override Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ToString() -> string
+readonly Microsoft.AspNetCore.Components.RenderTree.ArrayRange<T>.Array -> T[]!
+readonly Microsoft.AspNetCore.Components.RenderTree.ArrayRange<T>.Count -> int
+readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeDiff.ComponentId -> int
+readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeDiff.Edits -> Microsoft.AspNetCore.Components.RenderTree.ArrayBuilderSegment<Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit>
+readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.MoveToSiblingIndex -> int
+readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.ReferenceFrameIndex -> int
+readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.RemovedAttributeName -> string!
+readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.SiblingIndex -> int
+readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.Type -> Microsoft.AspNetCore.Components.RenderTree.RenderTreeEditType
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTime value, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTime value, string! format, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTime? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTime? value, string? format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTimeOffset value, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTimeOffset value, string! format, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTimeOffset? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(System.DateTimeOffset? value, string! format, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(bool value, System.Globalization.CultureInfo? culture = null) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(bool? value, System.Globalization.CultureInfo? culture = null) -> bool?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(decimal value, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(decimal? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(double? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float value, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(float? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(int value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(int? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(long value, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(long? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(short value, System.Globalization.CultureInfo? culture = null) -> string!
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(short? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue(string? value, System.Globalization.CultureInfo? culture = null) -> string?
+static Microsoft.AspNetCore.Components.BindConverter.FormatValue<T>(T value, System.Globalization.CultureInfo? culture = null) -> object?
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertTo<T>(object? obj, System.Globalization.CultureInfo? culture, out T value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToBool(object? obj, System.Globalization.CultureInfo? culture, out bool value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToDateTime(object? obj, System.Globalization.CultureInfo? culture, out System.DateTime value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToDateTime(object? obj, System.Globalization.CultureInfo? culture, string! format, out System.DateTime value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToDateTimeOffset(object? obj, System.Globalization.CultureInfo? culture, out System.DateTimeOffset value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToDateTimeOffset(object? obj, System.Globalization.CultureInfo? culture, string! format, out System.DateTimeOffset value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToDecimal(object? obj, System.Globalization.CultureInfo? culture, out decimal value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToDouble(object? obj, System.Globalization.CultureInfo? culture, out double value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToFloat(object? obj, System.Globalization.CultureInfo? culture, out float value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToInt(object? obj, System.Globalization.CultureInfo? culture, out int value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToLong(object? obj, System.Globalization.CultureInfo? culture, out long value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableBool(object? obj, System.Globalization.CultureInfo? culture, out bool? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableDateTime(object? obj, System.Globalization.CultureInfo? culture, out System.DateTime? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableDateTime(object? obj, System.Globalization.CultureInfo? culture, string! format, out System.DateTime? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableDateTimeOffset(object? obj, System.Globalization.CultureInfo? culture, out System.DateTimeOffset? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableDateTimeOffset(object? obj, System.Globalization.CultureInfo? culture, string! format, out System.DateTimeOffset? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableDecimal(object? obj, System.Globalization.CultureInfo? culture, out decimal? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableDouble(object? obj, System.Globalization.CultureInfo? culture, out double? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableFloat(object? obj, System.Globalization.CultureInfo? culture, out float? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableInt(object? obj, System.Globalization.CultureInfo? culture, out int? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableLong(object? obj, System.Globalization.CultureInfo? culture, out long? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToNullableShort(object? obj, System.Globalization.CultureInfo? culture, out short? value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToShort(object? obj, System.Globalization.CultureInfo? culture, out short value) -> bool
+static Microsoft.AspNetCore.Components.BindConverter.TryConvertToString(object? obj, System.Globalization.CultureInfo? culture, out string? value) -> bool
+static Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback<T>(object! receiver, System.Action<T>! callback, T value) -> Microsoft.AspNetCore.Components.EventCallback<T>
+static Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback<T>(object! receiver, System.Func<T, System.Threading.Tasks.Task!>! callback, T value) -> Microsoft.AspNetCore.Components.EventCallback<T>
+static Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<T>(T value) -> T
+static Microsoft.AspNetCore.Components.Dispatcher.CreateDefault() -> Microsoft.AspNetCore.Components.Dispatcher!
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.DateTime>! setter, System.DateTime existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.DateTime>! setter, System.DateTime existingValue, string! format, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.DateTime?>! setter, System.DateTime? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.DateTime?>! setter, System.DateTime? existingValue, string! format, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.DateTimeOffset>! setter, System.DateTimeOffset existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.DateTimeOffset>! setter, System.DateTimeOffset existingValue, string! format, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.DateTimeOffset?>! setter, System.DateTimeOffset? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.DateTimeOffset?>! setter, System.DateTimeOffset? existingValue, string! format, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<bool>! setter, bool existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<bool?>! setter, bool? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<decimal>! setter, decimal existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<decimal?>! setter, decimal? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<double>! setter, double existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<double?>! setter, double? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<float>! setter, float existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<float?>! setter, float? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<int>! setter, int existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<int?>! setter, int? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<long>! setter, long existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<long?>! setter, long? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<short>! setter, short existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<short?>! setter, short? existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<string?>! setter, string! existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryBinderExtensions.CreateBinder<T>(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<T>! setter, T existingValue, System.Globalization.CultureInfo? culture = null) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.ChangeEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<System.EventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<System.EventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.ChangeEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.ChangeEventArgs!>
+static Microsoft.AspNetCore.Components.EventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<System.EventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<System.EventArgs!>
+static Microsoft.AspNetCore.Components.MarkupString.explicit operator Microsoft.AspNetCore.Components.MarkupString(string! value) -> Microsoft.AspNetCore.Components.MarkupString
+static Microsoft.AspNetCore.Components.ParameterView.Empty.get -> Microsoft.AspNetCore.Components.ParameterView
+static Microsoft.AspNetCore.Components.ParameterView.FromDictionary(System.Collections.Generic.IDictionary<string!, object!>! parameters) -> Microsoft.AspNetCore.Components.ParameterView
+static readonly Microsoft.AspNetCore.Components.EventCallback.Empty -> Microsoft.AspNetCore.Components.EventCallback
+static readonly Microsoft.AspNetCore.Components.EventCallback.Factory -> Microsoft.AspNetCore.Components.EventCallbackFactory!
+static readonly Microsoft.AspNetCore.Components.EventCallback<TValue>.Empty -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+static readonly Microsoft.AspNetCore.Components.EventCallbackWorkItem.Empty -> Microsoft.AspNetCore.Components.EventCallbackWorkItem
+virtual Microsoft.AspNetCore.Components.ComponentBase.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+virtual Microsoft.AspNetCore.Components.ComponentBase.OnAfterRender(bool firstRender) -> void
+virtual Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.ComponentBase.OnInitialized() -> void
+virtual Microsoft.AspNetCore.Components.ComponentBase.OnInitializedAsync() -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.ComponentBase.OnParametersSet() -> void
+virtual Microsoft.AspNetCore.Components.ComponentBase.OnParametersSetAsync() -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.ComponentBase.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.ComponentBase.ShouldRender() -> bool
+virtual Microsoft.AspNetCore.Components.NavigationManager.EnsureInitialized() -> void
+virtual Microsoft.AspNetCore.Components.OwningComponentBase.Dispose(bool disposing) -> void
+virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(ulong eventHandlerId, Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo! fieldInfo, System.EventArgs! eventArgs) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.Dispose(bool disposing) -> void
+virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.ProcessPendingRender() -> void
+virtual Microsoft.AspNetCore.Components.RouteView.Render(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void

--- a/src/Components/Forms/src/PublicAPI.Shipped.txt
+++ b/src/Components/Forms/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,59 @@
+﻿#nullable enable
+Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator
+Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.DataAnnotationsValidator() -> void
+Microsoft.AspNetCore.Components.Forms.EditContext
+Microsoft.AspNetCore.Components.Forms.EditContext.EditContext(object! model) -> void
+Microsoft.AspNetCore.Components.Forms.EditContext.Field(string! fieldName) -> Microsoft.AspNetCore.Components.Forms.FieldIdentifier
+Microsoft.AspNetCore.Components.Forms.EditContext.GetValidationMessages() -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.AspNetCore.Components.Forms.EditContext.GetValidationMessages(Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.AspNetCore.Components.Forms.EditContext.GetValidationMessages(System.Linq.Expressions.Expression<System.Func<object!>!>! accessor) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.AspNetCore.Components.Forms.EditContext.IsModified() -> bool
+Microsoft.AspNetCore.Components.Forms.EditContext.IsModified(System.Linq.Expressions.Expression<System.Func<object!>!>! accessor) -> bool
+Microsoft.AspNetCore.Components.Forms.EditContext.IsModified(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> bool
+Microsoft.AspNetCore.Components.Forms.EditContext.MarkAsUnmodified() -> void
+Microsoft.AspNetCore.Components.Forms.EditContext.MarkAsUnmodified(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> void
+Microsoft.AspNetCore.Components.Forms.EditContext.Model.get -> object!
+Microsoft.AspNetCore.Components.Forms.EditContext.NotifyFieldChanged(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> void
+Microsoft.AspNetCore.Components.Forms.EditContext.NotifyValidationStateChanged() -> void
+Microsoft.AspNetCore.Components.Forms.EditContext.OnFieldChanged -> System.EventHandler<Microsoft.AspNetCore.Components.Forms.FieldChangedEventArgs!>?
+Microsoft.AspNetCore.Components.Forms.EditContext.OnValidationRequested -> System.EventHandler<Microsoft.AspNetCore.Components.Forms.ValidationRequestedEventArgs!>?
+Microsoft.AspNetCore.Components.Forms.EditContext.OnValidationStateChanged -> System.EventHandler<Microsoft.AspNetCore.Components.Forms.ValidationStateChangedEventArgs!>?
+Microsoft.AspNetCore.Components.Forms.EditContext.Properties.get -> Microsoft.AspNetCore.Components.Forms.EditContextProperties!
+Microsoft.AspNetCore.Components.Forms.EditContext.Validate() -> bool
+Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions
+Microsoft.AspNetCore.Components.Forms.EditContextProperties
+Microsoft.AspNetCore.Components.Forms.EditContextProperties.EditContextProperties() -> void
+Microsoft.AspNetCore.Components.Forms.EditContextProperties.Remove(object! key) -> bool
+Microsoft.AspNetCore.Components.Forms.EditContextProperties.TryGetValue(object! key, out object? value) -> bool
+Microsoft.AspNetCore.Components.Forms.EditContextProperties.this[object! key].get -> object!
+Microsoft.AspNetCore.Components.Forms.EditContextProperties.this[object! key].set -> void
+Microsoft.AspNetCore.Components.Forms.FieldChangedEventArgs
+Microsoft.AspNetCore.Components.Forms.FieldChangedEventArgs.FieldChangedEventArgs(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> void
+Microsoft.AspNetCore.Components.Forms.FieldChangedEventArgs.FieldIdentifier.get -> Microsoft.AspNetCore.Components.Forms.FieldIdentifier
+Microsoft.AspNetCore.Components.Forms.FieldIdentifier
+Microsoft.AspNetCore.Components.Forms.FieldIdentifier.Equals(Microsoft.AspNetCore.Components.Forms.FieldIdentifier otherIdentifier) -> bool
+Microsoft.AspNetCore.Components.Forms.FieldIdentifier.FieldIdentifier(object! model, string! fieldName) -> void
+Microsoft.AspNetCore.Components.Forms.FieldIdentifier.FieldName.get -> string!
+Microsoft.AspNetCore.Components.Forms.FieldIdentifier.Model.get -> object!
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.Add(System.Linq.Expressions.Expression<System.Func<object!>!>! accessor, System.Collections.Generic.IEnumerable<string!>! messages) -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.Add(System.Linq.Expressions.Expression<System.Func<object!>!>! accessor, string! message) -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.Add(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier, System.Collections.Generic.IEnumerable<string!>! messages) -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.Add(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier, string! message) -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.Clear() -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.Clear(System.Linq.Expressions.Expression<System.Func<object!>!>! accessor) -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.Clear(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.ValidationMessageStore(Microsoft.AspNetCore.Components.Forms.EditContext! editContext) -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.this[Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier].get -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.AspNetCore.Components.Forms.ValidationMessageStore.this[System.Linq.Expressions.Expression<System.Func<object!>!>! accessor].get -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.AspNetCore.Components.Forms.ValidationRequestedEventArgs
+Microsoft.AspNetCore.Components.Forms.ValidationRequestedEventArgs.ValidationRequestedEventArgs() -> void
+Microsoft.AspNetCore.Components.Forms.ValidationStateChangedEventArgs
+Microsoft.AspNetCore.Components.Forms.ValidationStateChangedEventArgs.ValidationStateChangedEventArgs() -> void
+override Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.OnInitialized() -> void
+override Microsoft.AspNetCore.Components.Forms.FieldIdentifier.Equals(object? obj) -> bool
+override Microsoft.AspNetCore.Components.Forms.FieldIdentifier.GetHashCode() -> int
+static Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.AddDataAnnotationsValidation(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext) -> Microsoft.AspNetCore.Components.Forms.EditContext!
+static Microsoft.AspNetCore.Components.Forms.FieldIdentifier.Create<TField>(System.Linq.Expressions.Expression<System.Func<TField>!>! accessor) -> Microsoft.AspNetCore.Components.Forms.FieldIdentifier
+static readonly Microsoft.AspNetCore.Components.Forms.ValidationRequestedEventArgs.Empty -> Microsoft.AspNetCore.Components.Forms.ValidationRequestedEventArgs!
+static readonly Microsoft.AspNetCore.Components.Forms.ValidationStateChangedEventArgs.Empty -> Microsoft.AspNetCore.Components.Forms.ValidationStateChangedEventArgs!

--- a/src/Components/Ignitor/src/PublicAPI.Shipped.txt
+++ b/src/Components/Ignitor/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/Ignitor/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Ignitor/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,193 @@
+﻿#nullable enable
+Ignitor.ArrayBuilderSegment<T>
+Ignitor.ArrayBuilderSegment<T>.Array.get -> T[]!
+Ignitor.ArrayBuilderSegment<T>.Count.get -> int
+Ignitor.ArrayBuilderSegment<T>.Offset.get -> int
+Ignitor.ArrayBuilderSegment<T>.this[int index].get -> T
+Ignitor.ArrayRange<T>
+Ignitor.ArrayRange<T>.Clone() -> Ignitor.ArrayRange<T>
+Ignitor.BlazorClient
+Ignitor.BlazorClient.BlazorClient() -> void
+Ignitor.BlazorClient.Cancel() -> void
+Ignitor.BlazorClient.CaptureOperations.get -> bool
+Ignitor.BlazorClient.CaptureOperations.set -> void
+Ignitor.BlazorClient.CircuitId.get -> string?
+Ignitor.BlazorClient.ClickAsync(string! elementId, bool expectRenderBatch = true) -> System.Threading.Tasks.Task!
+Ignitor.BlazorClient.ConfirmBatch(int batchId, string? error = null) -> System.Threading.Tasks.Task!
+Ignitor.BlazorClient.ConfirmRenderBatch.get -> bool
+Ignitor.BlazorClient.ConfirmRenderBatch.set -> void
+Ignitor.BlazorClient.ConnectAsync(System.Uri! uri, bool connectAutomatically = true, System.Action<Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder!, System.Uri!>? configure = null) -> System.Threading.Tasks.Task<bool>!
+Ignitor.BlazorClient.DefaultConnectionTimeout.get -> System.TimeSpan?
+Ignitor.BlazorClient.DefaultConnectionTimeout.set -> void
+Ignitor.BlazorClient.DefaultOperationTimeout.get -> System.TimeSpan?
+Ignitor.BlazorClient.DefaultOperationTimeout.set -> void
+Ignitor.BlazorClient.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Ignitor.BlazorClient.DotNetInteropCompletion -> System.Action<string!>?
+Ignitor.BlazorClient.ExpectCircuitError(System.Func<System.Threading.Tasks.Task!>! action, System.TimeSpan? timeout = null) -> System.Threading.Tasks.Task<string?>!
+Ignitor.BlazorClient.ExpectCircuitErrorAndDisconnect(System.Func<System.Threading.Tasks.Task!>! action, System.TimeSpan? timeout = null) -> System.Threading.Tasks.Task<(string? error, System.Exception? exception)>!
+Ignitor.BlazorClient.ExpectDisconnect(System.Func<System.Threading.Tasks.Task!>! action, System.TimeSpan? timeout = null) -> System.Threading.Tasks.Task<System.Exception?>!
+Ignitor.BlazorClient.ExpectDotNetInterop(System.Func<System.Threading.Tasks.Task!>! action, System.TimeSpan? timeout = null) -> System.Threading.Tasks.Task<string?>!
+Ignitor.BlazorClient.ExpectJSInterop(System.Func<System.Threading.Tasks.Task!>! action, System.TimeSpan? timeout = null) -> System.Threading.Tasks.Task<Ignitor.CapturedJSInteropCall?>!
+Ignitor.BlazorClient.ExpectRenderBatch(System.Func<System.Threading.Tasks.Task!>! action, System.TimeSpan? timeout = null) -> System.Threading.Tasks.Task<Ignitor.CapturedRenderBatch?>!
+Ignitor.BlazorClient.FindElementById(string! id) -> Ignitor.ElementNode!
+Ignitor.BlazorClient.FormatError.get -> System.Func<string!, System.Exception!>?
+Ignitor.BlazorClient.FormatError.set -> void
+Ignitor.BlazorClient.GetPrerenderDescriptors(System.Uri! uri) -> System.Threading.Tasks.Task<string!>!
+Ignitor.BlazorClient.Hive.get -> Ignitor.ElementHive!
+Ignitor.BlazorClient.HubConnection.get -> Microsoft.AspNetCore.SignalR.Client.HubConnection!
+Ignitor.BlazorClient.ImplicitWait.get -> bool
+Ignitor.BlazorClient.InvokeDotNetMethod(object! callId, string! assemblyName, string! methodIdentifier, object! dotNetObjectId, string! argsJson) -> System.Threading.Tasks.Task!
+Ignitor.BlazorClient.JSInterop -> System.Action<Ignitor.CapturedJSInteropCall!>?
+Ignitor.BlazorClient.LoggerProvider.get -> Microsoft.Extensions.Logging.ILoggerProvider!
+Ignitor.BlazorClient.LoggerProvider.set -> void
+Ignitor.BlazorClient.OnCircuitError -> System.Action<string!>?
+Ignitor.BlazorClient.Operations.get -> Ignitor.Operations!
+Ignitor.BlazorClient.PrepareForNextBatch(System.TimeSpan? timeout) -> System.Threading.Tasks.Task<Ignitor.CapturedRenderBatch?>!
+Ignitor.BlazorClient.PrepareForNextCircuitError(System.TimeSpan? timeout) -> System.Threading.Tasks.Task<string?>!
+Ignitor.BlazorClient.PrepareForNextDisconnect(System.TimeSpan? timeout) -> System.Threading.Tasks.Task<System.Exception?>!
+Ignitor.BlazorClient.PrepareForNextDotNetInterop(System.TimeSpan? timeout) -> System.Threading.Tasks.Task<string?>!
+Ignitor.BlazorClient.PrepareForNextJSInterop(System.TimeSpan? timeout) -> System.Threading.Tasks.Task<Ignitor.CapturedJSInteropCall?>!
+Ignitor.BlazorClient.RenderBatchReceived -> System.Action<Ignitor.CapturedRenderBatch!>?
+Ignitor.BlazorClient.SelectAsync(string! elementId, string! value) -> System.Threading.Tasks.Task!
+Ignitor.CapturedAttachComponentCall
+Ignitor.CapturedAttachComponentCall.ComponentId.get -> int
+Ignitor.CapturedJSInteropCall
+Ignitor.CapturedJSInteropCall.AsyncHandle.get -> int
+Ignitor.CapturedJSInteropCall.ResultType.get -> int
+Ignitor.CapturedJSInteropCall.TargetInstanceId.get -> long
+Ignitor.CapturedRenderBatch
+Ignitor.CapturedRenderBatch.Id.get -> int
+Ignitor.ComponentNode
+Ignitor.ComponentNode.ComponentId.get -> int
+Ignitor.ComponentNode.ComponentNode(int componentId) -> void
+Ignitor.ComponentState
+Ignitor.ComponentState.Component.get -> Ignitor.IComponent?
+Ignitor.ComponentState.ComponentId.get -> int
+Ignitor.ComponentState.ComponentState(int componentId) -> void
+Ignitor.ContainerNode
+Ignitor.ContainerNode.Children.get -> System.Collections.Generic.IReadOnlyList<Ignitor.Node!>!
+Ignitor.ContainerNode.ContainerNode() -> void
+Ignitor.ContainerNode.CreateAndInsertComponent(int componentId, int childIndex) -> Ignitor.ComponentNode!
+Ignitor.ContainerNode.CreateAndInsertContainer(int childIndex) -> Ignitor.ContainerNode!
+Ignitor.ContainerNode.InsertLogicalChild(Ignitor.Node! child, int childIndex) -> void
+Ignitor.ContainerNode.RemoveLogicalChild(int childIndex) -> void
+Ignitor.ElementHive
+Ignitor.ElementHive.Components.get -> System.Collections.Generic.Dictionary<int, Ignitor.ComponentNode!>!
+Ignitor.ElementHive.ElementHive() -> void
+Ignitor.ElementHive.SerializedValue.get -> string!
+Ignitor.ElementHive.TryFindElementById(string! id, out Ignitor.ElementNode? element) -> bool
+Ignitor.ElementHive.Update(Ignitor.RenderBatch batch) -> void
+Ignitor.ElementNode
+Ignitor.ElementNode.Attributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
+Ignitor.ElementNode.ClickAsync(Microsoft.AspNetCore.SignalR.Client.HubConnection! connection) -> System.Threading.Tasks.Task!
+Ignitor.ElementNode.ElementEventDescriptor
+Ignitor.ElementNode.ElementEventDescriptor.ElementEventDescriptor(string! eventName, ulong eventId) -> void
+Ignitor.ElementNode.ElementEventDescriptor.EventId.get -> ulong
+Ignitor.ElementNode.ElementEventDescriptor.EventName.get -> string!
+Ignitor.ElementNode.ElementNode(string! tagName) -> void
+Ignitor.ElementNode.Events.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Ignitor.ElementNode.ElementEventDescriptor!>!
+Ignitor.ElementNode.Properties.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
+Ignitor.ElementNode.RemoveAttribute(string! key) -> void
+Ignitor.ElementNode.SetAttribute(string! key, object! value) -> void
+Ignitor.ElementNode.SetEvent(string! eventName, Ignitor.ElementNode.ElementEventDescriptor! descriptor) -> void
+Ignitor.ElementNode.SetProperty(string! key, object! value) -> void
+Ignitor.ElementNode.TagName.get -> string!
+Ignitor.ElementReference
+Ignitor.Error
+Ignitor.Error.Error() -> void
+Ignitor.Error.Stack.get -> string?
+Ignitor.Error.Stack.set -> void
+Ignitor.IComponent
+Ignitor.IgnitorMessagePackHubProtocol
+Ignitor.IgnitorMessagePackHubProtocol.IgnitorMessagePackHubProtocol() -> void
+Ignitor.MarkupNode
+Ignitor.Node
+Ignitor.Node.Node() -> void
+Ignitor.Node.SerializedValue.get -> string!
+Ignitor.Operations
+Ignitor.Operations.AttachComponent.get -> System.Collections.Concurrent.ConcurrentQueue<Ignitor.CapturedAttachComponentCall>!
+Ignitor.Operations.Batches.get -> System.Collections.Concurrent.ConcurrentQueue<Ignitor.CapturedRenderBatch!>!
+Ignitor.Operations.DotNetCompletions.get -> System.Collections.Concurrent.ConcurrentQueue<string!>!
+Ignitor.Operations.Errors.get -> System.Collections.Concurrent.ConcurrentQueue<string!>!
+Ignitor.Operations.JSInteropCalls.get -> System.Collections.Concurrent.ConcurrentQueue<Ignitor.CapturedJSInteropCall!>!
+Ignitor.Operations.Operations() -> void
+Ignitor.RenderBatch
+Ignitor.RenderBatch.DisposedComponentIDs.get -> Ignitor.ArrayRange<int>
+Ignitor.RenderBatch.DisposedEventHandlerIDs.get -> Ignitor.ArrayRange<ulong>
+Ignitor.RenderBatch.ReferenceFrames.get -> Ignitor.ArrayRange<Ignitor.RenderTreeFrame>
+Ignitor.RenderBatch.UpdatedComponents.get -> Ignitor.ArrayRange<Ignitor.RenderTreeDiff>
+Ignitor.RenderBatchReader
+Ignitor.RenderTreeDiff
+Ignitor.RenderTreeEdit
+Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.PermutationListEnd = 10 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.PermutationListEntry = 9 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.PrependFrame = 1 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.RemoveAttribute = 4 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.RemoveFrame = 2 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.SetAttribute = 3 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.StepIn = 6 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.StepOut = 7 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.UpdateMarkup = 8 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeEditType.UpdateText = 5 -> Ignitor.RenderTreeEditType
+Ignitor.RenderTreeFrame
+Ignitor.RenderTreeFrame.AttributeEventHandlerId.get -> ulong
+Ignitor.RenderTreeFrame.ComponentId.get -> int
+Ignitor.RenderTreeFrame.ComponentReferenceCaptureParentFrameIndex.get -> int
+Ignitor.RenderTreeFrame.ComponentSubtreeLength.get -> int
+Ignitor.RenderTreeFrame.ElementSubtreeLength.get -> int
+Ignitor.RenderTreeFrame.FrameType.get -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrame.RegionSubtreeLength.get -> int
+Ignitor.RenderTreeFrame.Sequence.get -> int
+Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.Attribute = 3 -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.Component = 4 -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.ComponentReferenceCapture = 7 -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.Element = 1 -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.ElementReferenceCapture = 6 -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.Markup = 8 -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.None = 0 -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.Region = 5 -> Ignitor.RenderTreeFrameType
+Ignitor.RenderTreeFrameType.Text = 2 -> Ignitor.RenderTreeFrameType
+Ignitor.TextNode
+readonly Ignitor.ArrayRange<T>.Count -> int
+readonly Ignitor.RenderTreeDiff.ComponentId -> int
+readonly Ignitor.RenderTreeDiff.Edits -> Ignitor.ArrayBuilderSegment<Ignitor.RenderTreeEdit>
+readonly Ignitor.RenderTreeEdit.MoveToSiblingIndex -> int
+readonly Ignitor.RenderTreeEdit.ReferenceFrameIndex -> int
+readonly Ignitor.RenderTreeEdit.SiblingIndex -> int
+readonly Ignitor.RenderTreeEdit.Type -> Ignitor.RenderTreeEditType
+static Ignitor.RenderBatchReader.Read(System.ReadOnlySpan<byte> data) -> Ignitor.RenderBatch
+virtual Ignitor.Node.Parent.get -> Ignitor.ContainerNode?
+virtual Ignitor.Node.Parent.set -> void
+~Ignitor.ArrayRange<T>.ArrayRange(T[] array, int count) -> void
+~Ignitor.CapturedAttachComponentCall.CapturedAttachComponentCall(int componentId, string selector) -> void
+~Ignitor.CapturedAttachComponentCall.Selector.get -> string
+~Ignitor.CapturedJSInteropCall.ArgsJson.get -> string
+~Ignitor.CapturedJSInteropCall.CapturedJSInteropCall(int asyncHandle, string identifier, string argsJson, int resultType, long targetInstanceId) -> void
+~Ignitor.CapturedJSInteropCall.Identifier.get -> string
+~Ignitor.CapturedRenderBatch.CapturedRenderBatch(int id, byte[] data) -> void
+~Ignitor.CapturedRenderBatch.Data.get -> byte[]
+~Ignitor.ElementReference.ElementReference(string id) -> void
+~Ignitor.ElementReference.Id.get -> string
+~Ignitor.MarkupNode.MarkupContent.get -> string
+~Ignitor.MarkupNode.MarkupNode(string markupContent) -> void
+~Ignitor.RenderTreeFrame.AttributeEventUpdatesAttributeName.get -> string
+~Ignitor.RenderTreeFrame.AttributeName.get -> string
+~Ignitor.RenderTreeFrame.AttributeValue.get -> object
+~Ignitor.RenderTreeFrame.Component.get -> Ignitor.IComponent
+~Ignitor.RenderTreeFrame.ComponentKey.get -> object
+~Ignitor.RenderTreeFrame.ComponentReferenceCaptureAction.get -> System.Action<object>
+~Ignitor.RenderTreeFrame.ComponentType.get -> System.Type
+~Ignitor.RenderTreeFrame.ElementKey.get -> object
+~Ignitor.RenderTreeFrame.ElementName.get -> string
+~Ignitor.RenderTreeFrame.ElementReferenceCaptureAction.get -> System.Action<Ignitor.ElementReference>
+~Ignitor.RenderTreeFrame.ElementReferenceCaptureId.get -> string
+~Ignitor.RenderTreeFrame.MarkupContent.get -> string
+~Ignitor.RenderTreeFrame.TextContent.get -> string
+~Ignitor.TextNode.TextContent.get -> string
+~Ignitor.TextNode.TextContent.set -> void
+~Ignitor.TextNode.TextNode(string text) -> void
+~override Ignitor.RenderTreeFrame.ToString() -> string
+~readonly Ignitor.ArrayRange<T>.Array -> T[]
+~readonly Ignitor.RenderTreeEdit.RemovedAttributeName -> string

--- a/src/Components/ProtectedBrowserStorage/src/PublicAPI.Shipped.txt
+++ b/src/Components/ProtectedBrowserStorage/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/ProtectedBrowserStorage/src/PublicAPI.Unshipped.txt
+++ b/src/Components/ProtectedBrowserStorage/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,17 @@
+﻿#nullable enable
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorage
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorage.DeleteAsync(string! key) -> System.Threading.Tasks.ValueTask
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorage.GetAsync<TValue>(string! key) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorageResult<TValue>>
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorage.GetAsync<TValue>(string! purpose, string! key) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorageResult<TValue>>
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorage.ProtectedBrowserStorage(string! storeName, Microsoft.JSInterop.IJSRuntime! jsRuntime, Microsoft.AspNetCore.DataProtection.IDataProtectionProvider! dataProtectionProvider) -> void
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorage.SetAsync(string! key, object! value) -> System.Threading.Tasks.ValueTask
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorage.SetAsync(string! purpose, string! key, object! value) -> System.Threading.Tasks.ValueTask
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorageResult<T>
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorageResult<T>.Success.get -> bool
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedBrowserStorageResult<T>.Value.get -> T
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedLocalStorage
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedLocalStorage.ProtectedLocalStorage(Microsoft.JSInterop.IJSRuntime! jsRuntime, Microsoft.AspNetCore.DataProtection.IDataProtectionProvider! dataProtectionProvider) -> void
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedSessionStorage
+Microsoft.AspNetCore.Components.ProtectedBrowserStorage.ProtectedSessionStorage.ProtectedSessionStorage(Microsoft.JSInterop.IJSRuntime! jsRuntime, Microsoft.AspNetCore.DataProtection.IDataProtectionProvider! dataProtectionProvider) -> void
+Microsoft.Extensions.DependencyInjection.ProtectedBrowserStorageServiceCollectionExtensions
+static Microsoft.Extensions.DependencyInjection.ProtectedBrowserStorageServiceCollectionExtensions.AddProtectedBrowserStorage(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void

--- a/src/Components/Server/src/PublicAPI.Shipped.txt
+++ b/src/Components/Server/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/Server/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Server/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,44 @@
+﻿Microsoft.AspNetCore.Builder.ComponentEndpointConventionBuilder
+Microsoft.AspNetCore.Builder.ComponentEndpointConventionBuilder.Add(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! convention) -> void
+Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions
+Microsoft.AspNetCore.Components.Server.CircuitOptions
+Microsoft.AspNetCore.Components.Server.CircuitOptions.CircuitOptions() -> void
+Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors.get -> bool
+Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors.set -> void
+Microsoft.AspNetCore.Components.Server.CircuitOptions.DisconnectedCircuitMaxRetained.get -> int
+Microsoft.AspNetCore.Components.Server.CircuitOptions.DisconnectedCircuitMaxRetained.set -> void
+Microsoft.AspNetCore.Components.Server.CircuitOptions.DisconnectedCircuitRetentionPeriod.get -> System.TimeSpan
+Microsoft.AspNetCore.Components.Server.CircuitOptions.DisconnectedCircuitRetentionPeriod.set -> void
+Microsoft.AspNetCore.Components.Server.CircuitOptions.JSInteropDefaultCallTimeout.get -> System.TimeSpan
+Microsoft.AspNetCore.Components.Server.CircuitOptions.JSInteropDefaultCallTimeout.set -> void
+Microsoft.AspNetCore.Components.Server.CircuitOptions.MaxBufferedUnacknowledgedRenderBatches.get -> int
+Microsoft.AspNetCore.Components.Server.CircuitOptions.MaxBufferedUnacknowledgedRenderBatches.set -> void
+Microsoft.AspNetCore.Components.Server.Circuits.Circuit
+Microsoft.AspNetCore.Components.Server.Circuits.Circuit.Id.get -> string!
+Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler
+Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler.CircuitHandler() -> void
+Microsoft.AspNetCore.Components.Server.RevalidatingServerAuthenticationStateProvider
+Microsoft.AspNetCore.Components.Server.RevalidatingServerAuthenticationStateProvider.RevalidatingServerAuthenticationStateProvider(Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.AspNetCore.Components.Server.ServerAuthenticationStateProvider
+Microsoft.AspNetCore.Components.Server.ServerAuthenticationStateProvider.ServerAuthenticationStateProvider() -> void
+Microsoft.AspNetCore.Components.Server.ServerAuthenticationStateProvider.SetAuthenticationState(System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.Authorization.AuthenticationState!>! authenticationStateTask) -> void
+Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions
+Microsoft.Extensions.DependencyInjection.IServerSideBlazorBuilder
+Microsoft.Extensions.DependencyInjection.IServerSideBlazorBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Microsoft.Extensions.DependencyInjection.ServerSideBlazorBuilderExtensions
+abstract Microsoft.AspNetCore.Components.Server.RevalidatingServerAuthenticationStateProvider.RevalidationInterval.get -> System.TimeSpan
+abstract Microsoft.AspNetCore.Components.Server.RevalidatingServerAuthenticationStateProvider.ValidateAuthenticationStateAsync(Microsoft.AspNetCore.Components.Authorization.AuthenticationState! authenticationState, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>!
+override Microsoft.AspNetCore.Components.Server.ServerAuthenticationStateProvider.GetAuthenticationStateAsync() -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.Authorization.AuthenticationState!>!
+static Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints) -> Microsoft.AspNetCore.Builder.ComponentEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, System.Action<Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions!>! configureOptions) -> Microsoft.AspNetCore.Builder.ComponentEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! path) -> Microsoft.AspNetCore.Builder.ComponentEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! path, System.Action<Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions!>! configureOptions) -> Microsoft.AspNetCore.Builder.ComponentEndpointConventionBuilder!
+static Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.Components.Server.CircuitOptions!>? configure = null) -> Microsoft.Extensions.DependencyInjection.IServerSideBlazorBuilder!
+static Microsoft.Extensions.DependencyInjection.ServerSideBlazorBuilderExtensions.AddCircuitOptions(this Microsoft.Extensions.DependencyInjection.IServerSideBlazorBuilder! builder, System.Action<Microsoft.AspNetCore.Components.Server.CircuitOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServerSideBlazorBuilder!
+static Microsoft.Extensions.DependencyInjection.ServerSideBlazorBuilderExtensions.AddHubOptions(this Microsoft.Extensions.DependencyInjection.IServerSideBlazorBuilder! builder, System.Action<Microsoft.AspNetCore.SignalR.HubOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServerSideBlazorBuilder!
+virtual Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler.OnCircuitClosedAsync(Microsoft.AspNetCore.Components.Server.Circuits.Circuit! circuit, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler.OnCircuitOpenedAsync(Microsoft.AspNetCore.Components.Server.Circuits.Circuit! circuit, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler.OnConnectionDownAsync(Microsoft.AspNetCore.Components.Server.Circuits.Circuit! circuit, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler.OnConnectionUpAsync(Microsoft.AspNetCore.Components.Server.Circuits.Circuit! circuit, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler.Order.get -> int
+virtual Microsoft.AspNetCore.Components.Server.RevalidatingServerAuthenticationStateProvider.Dispose(bool disposing) -> void

--- a/src/Components/Web.Extensions/src/PublicAPI.Shipped.txt
+++ b/src/Components/Web.Extensions/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/Web.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web.Extensions/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,18 @@
+﻿#nullable enable
+Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase
+Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase.Attributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
+Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase.Attributes.set -> void
+Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase.Dispose() -> void
+Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase.HeadTagBase() -> void
+Microsoft.AspNetCore.Components.Web.Extensions.Head.Link
+Microsoft.AspNetCore.Components.Web.Extensions.Head.Link.Link() -> void
+Microsoft.AspNetCore.Components.Web.Extensions.Head.Meta
+Microsoft.AspNetCore.Components.Web.Extensions.Head.Meta.Meta() -> void
+Microsoft.AspNetCore.Components.Web.Extensions.Head.Title
+Microsoft.AspNetCore.Components.Web.Extensions.Head.Title.Title() -> void
+Microsoft.AspNetCore.Components.Web.Extensions.Head.Title.Value.get -> string!
+Microsoft.AspNetCore.Components.Web.Extensions.Head.Title.Value.set -> void
+abstract Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase.TagName.get -> string!
+override Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override Microsoft.AspNetCore.Components.Web.Extensions.Head.HeadTagBase.OnParametersSet() -> void

--- a/src/Components/Web/src/PublicAPI.Shipped.txt
+++ b/src/Components/Web/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,413 @@
+﻿Microsoft.AspNetCore.Components.BindInputElementAttribute
+Microsoft.AspNetCore.Components.BindInputElementAttribute.BindInputElementAttribute(string? type, string? suffix, string? valueAttribute, string? changeAttribute, bool isInvariantCulture, string? format) -> void
+Microsoft.AspNetCore.Components.BindInputElementAttribute.ChangeAttribute.get -> string?
+Microsoft.AspNetCore.Components.BindInputElementAttribute.Format.get -> string?
+Microsoft.AspNetCore.Components.BindInputElementAttribute.IsInvariantCulture.get -> bool
+Microsoft.AspNetCore.Components.BindInputElementAttribute.Suffix.get -> string?
+Microsoft.AspNetCore.Components.BindInputElementAttribute.Type.get -> string?
+Microsoft.AspNetCore.Components.BindInputElementAttribute.ValueAttribute.get -> string?
+Microsoft.AspNetCore.Components.ElementReferenceExtensions
+Microsoft.AspNetCore.Components.Forms.BrowserFileExtensions
+Microsoft.AspNetCore.Components.Forms.EditContextFieldClassExtensions
+Microsoft.AspNetCore.Components.Forms.EditForm
+Microsoft.AspNetCore.Components.Forms.EditForm.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
+Microsoft.AspNetCore.Components.Forms.EditForm.AdditionalAttributes.set -> void
+Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Forms.EditContext!>?
+Microsoft.AspNetCore.Components.Forms.EditForm.ChildContent.set -> void
+Microsoft.AspNetCore.Components.Forms.EditForm.EditContext.get -> Microsoft.AspNetCore.Components.Forms.EditContext?
+Microsoft.AspNetCore.Components.Forms.EditForm.EditContext.set -> void
+Microsoft.AspNetCore.Components.Forms.EditForm.EditForm() -> void
+Microsoft.AspNetCore.Components.Forms.EditForm.Model.get -> object?
+Microsoft.AspNetCore.Components.Forms.EditForm.Model.set -> void
+Microsoft.AspNetCore.Components.Forms.EditForm.OnInvalidSubmit.get -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext!>
+Microsoft.AspNetCore.Components.Forms.EditForm.OnInvalidSubmit.set -> void
+Microsoft.AspNetCore.Components.Forms.EditForm.OnSubmit.get -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext!>
+Microsoft.AspNetCore.Components.Forms.EditForm.OnSubmit.set -> void
+Microsoft.AspNetCore.Components.Forms.EditForm.OnValidSubmit.get -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.EditContext!>
+Microsoft.AspNetCore.Components.Forms.EditForm.OnValidSubmit.set -> void
+Microsoft.AspNetCore.Components.Forms.FieldCssClassProvider
+Microsoft.AspNetCore.Components.Forms.FieldCssClassProvider.FieldCssClassProvider() -> void
+Microsoft.AspNetCore.Components.Forms.IBrowserFile
+Microsoft.AspNetCore.Components.Forms.IBrowserFile.ContentType.get -> string!
+Microsoft.AspNetCore.Components.Forms.IBrowserFile.LastModified.get -> System.DateTimeOffset
+Microsoft.AspNetCore.Components.Forms.IBrowserFile.Name.get -> string!
+Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream(long maxAllowedSize = 512000, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.IO.Stream!
+Microsoft.AspNetCore.Components.Forms.IBrowserFile.Size.get -> long
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.AdditionalAttributes.set -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.CssClass.get -> string!
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.CurrentValue.get -> TValue
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.CurrentValue.set -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.CurrentValueAsString.get -> string?
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.CurrentValueAsString.set -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.DisplayName.get -> string?
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.DisplayName.set -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.EditContext.get -> Microsoft.AspNetCore.Components.Forms.EditContext!
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.EditContext.set -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.FieldIdentifier.get -> Microsoft.AspNetCore.Components.Forms.FieldIdentifier
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.FieldIdentifier.set -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.InputBase() -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.Value.get -> TValue
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.Value.set -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.ValueChanged.get -> Microsoft.AspNetCore.Components.EventCallback<TValue>
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.ValueChanged.set -> void
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.ValueExpression.get -> System.Linq.Expressions.Expression<System.Func<TValue>!>?
+Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.ValueExpression.set -> void
+Microsoft.AspNetCore.Components.Forms.InputCheckbox
+Microsoft.AspNetCore.Components.Forms.InputCheckbox.InputCheckbox() -> void
+Microsoft.AspNetCore.Components.Forms.InputDate<TValue>
+Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.InputDate() -> void
+Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ParsingErrorMessage.get -> string!
+Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.ParsingErrorMessage.set -> void
+Microsoft.AspNetCore.Components.Forms.InputFile
+Microsoft.AspNetCore.Components.Forms.InputFile.AdditionalAttributes.get -> System.Collections.Generic.IDictionary<string!, object!>?
+Microsoft.AspNetCore.Components.Forms.InputFile.AdditionalAttributes.set -> void
+Microsoft.AspNetCore.Components.Forms.InputFile.InputFile() -> void
+Microsoft.AspNetCore.Components.Forms.InputFile.OnChange.get -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs!>
+Microsoft.AspNetCore.Components.Forms.InputFile.OnChange.set -> void
+Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs
+Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs.File.get -> Microsoft.AspNetCore.Components.Forms.IBrowserFile!
+Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs.FileCount.get -> int
+Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs.GetMultipleFiles(int maximumFileCount = 10) -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.Forms.IBrowserFile!>!
+Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs.InputFileChangeEventArgs(System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.Forms.IBrowserFile!>! files) -> void
+Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>
+Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.InputNumber() -> void
+Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ParsingErrorMessage.get -> string!
+Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.ParsingErrorMessage.set -> void
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.AdditionalAttributes.set -> void
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.InputRadio() -> void
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Name.get -> string?
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Name.set -> void
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Value.get -> TValue
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Value.set -> void
+Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>
+Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.ChildContent.set -> void
+Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.InputRadioGroup() -> void
+Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.Name.get -> string?
+Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.Name.set -> void
+Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>
+Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.ChildContent.set -> void
+Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.InputSelect() -> void
+Microsoft.AspNetCore.Components.Forms.InputText
+Microsoft.AspNetCore.Components.Forms.InputText.InputText() -> void
+Microsoft.AspNetCore.Components.Forms.InputTextArea
+Microsoft.AspNetCore.Components.Forms.InputTextArea.InputTextArea() -> void
+Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions
+Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.get -> int
+Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.set -> void
+Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxSegmentSize.get -> int
+Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxSegmentSize.set -> void
+Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.RemoteBrowserFileStreamOptions() -> void
+Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.SegmentFetchTimeout.get -> System.TimeSpan
+Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.SegmentFetchTimeout.set -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>
+Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
+Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.AdditionalAttributes.set -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.For.get -> System.Linq.Expressions.Expression<System.Func<TValue>!>?
+Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.For.set -> void
+Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.ValidationMessage() -> void
+Microsoft.AspNetCore.Components.Forms.ValidationSummary
+Microsoft.AspNetCore.Components.Forms.ValidationSummary.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
+Microsoft.AspNetCore.Components.Forms.ValidationSummary.AdditionalAttributes.set -> void
+Microsoft.AspNetCore.Components.Forms.ValidationSummary.Model.get -> object?
+Microsoft.AspNetCore.Components.Forms.ValidationSummary.Model.set -> void
+Microsoft.AspNetCore.Components.Forms.ValidationSummary.ValidationSummary() -> void
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.BrowserRendererId.get -> int
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.BrowserRendererId.set -> void
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventArgsType.get -> string!
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventArgsType.set -> void
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventFieldInfo.get -> Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo?
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventFieldInfo.set -> void
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventHandlerId.get -> ulong
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventHandlerId.set -> void
+Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.WebEventDescriptor() -> void
+Microsoft.AspNetCore.Components.Routing.NavLink
+Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass.get -> string?
+Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.AdditionalAttributes.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>?
+Microsoft.AspNetCore.Components.Routing.NavLink.AdditionalAttributes.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.Routing.NavLink.ChildContent.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.CssClass.get -> string?
+Microsoft.AspNetCore.Components.Routing.NavLink.CssClass.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.Dispose() -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.Match.get -> Microsoft.AspNetCore.Components.Routing.NavLinkMatch
+Microsoft.AspNetCore.Components.Routing.NavLink.Match.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.NavLink() -> void
+Microsoft.AspNetCore.Components.Routing.NavLinkMatch
+Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All = 1 -> Microsoft.AspNetCore.Components.Routing.NavLinkMatch
+Microsoft.AspNetCore.Components.Routing.NavLinkMatch.Prefix = 0 -> Microsoft.AspNetCore.Components.Routing.NavLinkMatch
+Microsoft.AspNetCore.Components.Web.BindAttributes
+Microsoft.AspNetCore.Components.Web.ClipboardEventArgs
+Microsoft.AspNetCore.Components.Web.ClipboardEventArgs.ClipboardEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.ClipboardEventArgs.Type.get -> string!
+Microsoft.AspNetCore.Components.Web.ClipboardEventArgs.Type.set -> void
+Microsoft.AspNetCore.Components.Web.DataTransfer
+Microsoft.AspNetCore.Components.Web.DataTransfer.DataTransfer() -> void
+Microsoft.AspNetCore.Components.Web.DataTransfer.DropEffect.get -> string!
+Microsoft.AspNetCore.Components.Web.DataTransfer.DropEffect.set -> void
+Microsoft.AspNetCore.Components.Web.DataTransfer.EffectAllowed.get -> string?
+Microsoft.AspNetCore.Components.Web.DataTransfer.EffectAllowed.set -> void
+Microsoft.AspNetCore.Components.Web.DataTransfer.Files.get -> string![]!
+Microsoft.AspNetCore.Components.Web.DataTransfer.Files.set -> void
+Microsoft.AspNetCore.Components.Web.DataTransfer.Items.get -> Microsoft.AspNetCore.Components.Web.DataTransferItem![]!
+Microsoft.AspNetCore.Components.Web.DataTransfer.Items.set -> void
+Microsoft.AspNetCore.Components.Web.DataTransfer.Types.get -> string![]!
+Microsoft.AspNetCore.Components.Web.DataTransfer.Types.set -> void
+Microsoft.AspNetCore.Components.Web.DataTransferItem
+Microsoft.AspNetCore.Components.Web.DataTransferItem.DataTransferItem() -> void
+Microsoft.AspNetCore.Components.Web.DataTransferItem.Kind.get -> string!
+Microsoft.AspNetCore.Components.Web.DataTransferItem.Kind.set -> void
+Microsoft.AspNetCore.Components.Web.DataTransferItem.Type.get -> string!
+Microsoft.AspNetCore.Components.Web.DataTransferItem.Type.set -> void
+Microsoft.AspNetCore.Components.Web.DragEventArgs
+Microsoft.AspNetCore.Components.Web.DragEventArgs.DataTransfer.get -> Microsoft.AspNetCore.Components.Web.DataTransfer!
+Microsoft.AspNetCore.Components.Web.DragEventArgs.DataTransfer.set -> void
+Microsoft.AspNetCore.Components.Web.DragEventArgs.DragEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Colno.get -> int
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Colno.set -> void
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.ErrorEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Filename.get -> string?
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Filename.set -> void
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Lineno.get -> int
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Lineno.set -> void
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Message.get -> string?
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Message.set -> void
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Type.get -> string?
+Microsoft.AspNetCore.Components.Web.ErrorEventArgs.Type.set -> void
+Microsoft.AspNetCore.Components.Web.EventHandlers
+Microsoft.AspNetCore.Components.Web.FocusEventArgs
+Microsoft.AspNetCore.Components.Web.FocusEventArgs.FocusEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.FocusEventArgs.Type.get -> string?
+Microsoft.AspNetCore.Components.Web.FocusEventArgs.Type.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.AltKey.get -> bool
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.AltKey.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Code.get -> string!
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Code.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.CtrlKey.get -> bool
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.CtrlKey.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Key.get -> string!
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Key.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.KeyboardEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Location.get -> float
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Location.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.MetaKey.get -> bool
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.MetaKey.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Repeat.get -> bool
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Repeat.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.ShiftKey.get -> bool
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.ShiftKey.set -> void
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Type.get -> string!
+Microsoft.AspNetCore.Components.Web.KeyboardEventArgs.Type.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.AltKey.get -> bool
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.AltKey.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.Button.get -> long
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.Button.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.Buttons.get -> long
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.Buttons.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ClientX.get -> double
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ClientX.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ClientY.get -> double
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ClientY.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.CtrlKey.get -> bool
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.CtrlKey.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.Detail.get -> long
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.Detail.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.MetaKey.get -> bool
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.MetaKey.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.MouseEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.OffsetX.get -> double
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.OffsetX.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.OffsetY.get -> double
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.OffsetY.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ScreenX.get -> double
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ScreenX.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ScreenY.get -> double
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ScreenY.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ShiftKey.get -> bool
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.ShiftKey.set -> void
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.Type.get -> string!
+Microsoft.AspNetCore.Components.Web.MouseEventArgs.Type.set -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.Height.get -> float
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.Height.set -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.IsPrimary.get -> bool
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.IsPrimary.set -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.PointerEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.PointerId.get -> long
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.PointerId.set -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.PointerType.get -> string!
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.PointerType.set -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.Pressure.get -> float
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.Pressure.set -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.TiltX.get -> float
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.TiltX.set -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.TiltY.get -> float
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.TiltY.set -> void
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.Width.get -> float
+Microsoft.AspNetCore.Components.Web.PointerEventArgs.Width.set -> void
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.LengthComputable.get -> bool
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.LengthComputable.set -> void
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.Loaded.get -> long
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.Loaded.set -> void
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.ProgressEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.Total.get -> long
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.Total.set -> void
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.Type.get -> string!
+Microsoft.AspNetCore.Components.Web.ProgressEventArgs.Type.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.AltKey.get -> bool
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.AltKey.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.ChangedTouches.get -> Microsoft.AspNetCore.Components.Web.TouchPoint![]!
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.ChangedTouches.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.CtrlKey.get -> bool
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.CtrlKey.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.Detail.get -> long
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.Detail.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.MetaKey.get -> bool
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.MetaKey.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.ShiftKey.get -> bool
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.ShiftKey.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.TargetTouches.get -> Microsoft.AspNetCore.Components.Web.TouchPoint![]!
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.TargetTouches.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.TouchEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.Touches.get -> Microsoft.AspNetCore.Components.Web.TouchPoint![]!
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.Touches.set -> void
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.Type.get -> string!
+Microsoft.AspNetCore.Components.Web.TouchEventArgs.Type.set -> void
+Microsoft.AspNetCore.Components.Web.TouchPoint
+Microsoft.AspNetCore.Components.Web.TouchPoint.ClientX.get -> double
+Microsoft.AspNetCore.Components.Web.TouchPoint.ClientX.set -> void
+Microsoft.AspNetCore.Components.Web.TouchPoint.ClientY.get -> double
+Microsoft.AspNetCore.Components.Web.TouchPoint.ClientY.set -> void
+Microsoft.AspNetCore.Components.Web.TouchPoint.Identifier.get -> long
+Microsoft.AspNetCore.Components.Web.TouchPoint.Identifier.set -> void
+Microsoft.AspNetCore.Components.Web.TouchPoint.PageX.get -> double
+Microsoft.AspNetCore.Components.Web.TouchPoint.PageX.set -> void
+Microsoft.AspNetCore.Components.Web.TouchPoint.PageY.get -> double
+Microsoft.AspNetCore.Components.Web.TouchPoint.PageY.set -> void
+Microsoft.AspNetCore.Components.Web.TouchPoint.ScreenX.get -> double
+Microsoft.AspNetCore.Components.Web.TouchPoint.ScreenX.set -> void
+Microsoft.AspNetCore.Components.Web.TouchPoint.ScreenY.get -> double
+Microsoft.AspNetCore.Components.Web.TouchPoint.ScreenY.set -> void
+Microsoft.AspNetCore.Components.Web.TouchPoint.TouchPoint() -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<TItem>
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest.CancellationToken.get -> System.Threading.CancellationToken
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest.Count.get -> int
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest.ItemsProviderRequest(int startIndex, int count, System.Threading.CancellationToken cancellationToken) -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderRequest.StartIndex.get -> int
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>.Items.get -> System.Collections.Generic.IEnumerable<TItem>!
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>.ItemsProviderResult(System.Collections.Generic.IEnumerable<TItem>! items, int totalItemCount) -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderResult<TItem>.TotalItemCount.get -> int
+Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext
+Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext.Index.get -> int
+Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext.PlaceholderContext(int index, float size = 0) -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext.Size.get -> float
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment<TItem>?
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ChildContent.set -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemContent.get -> Microsoft.AspNetCore.Components.RenderFragment<TItem>?
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemContent.set -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemSize.get -> float
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemSize.set -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Items.get -> System.Collections.Generic.ICollection<TItem>?
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Items.set -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemsProvider.get -> Microsoft.AspNetCore.Components.Web.Virtualization.ItemsProviderDelegate<TItem>?
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.ItemsProvider.set -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.OverscanCount.get -> int
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.OverscanCount.set -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Placeholder.get -> Microsoft.AspNetCore.Components.RenderFragment<Microsoft.AspNetCore.Components.Web.Virtualization.PlaceholderContext>?
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Placeholder.set -> void
+Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TItem>.Virtualize() -> void
+Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions
+Microsoft.AspNetCore.Components.Web.WebRenderTreeBuilderExtensions
+Microsoft.AspNetCore.Components.Web.WheelEventArgs
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.DeltaMode.get -> long
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.DeltaMode.set -> void
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.DeltaX.get -> double
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.DeltaX.set -> void
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.DeltaY.get -> double
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.DeltaY.set -> void
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.DeltaZ.get -> double
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.DeltaZ.set -> void
+Microsoft.AspNetCore.Components.Web.WheelEventArgs.WheelEventArgs() -> void
+Microsoft.AspNetCore.Components.WebElementReferenceContext
+Microsoft.AspNetCore.Components.WebElementReferenceContext.WebElementReferenceContext(Microsoft.JSInterop.IJSRuntime! jsRuntime) -> void
+abstract Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.TryParseValueFromString(string? value, out TValue result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.EditForm.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.EditForm.OnParametersSet() -> void
+override Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
+override Microsoft.AspNetCore.Components.Forms.InputCheckbox.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputCheckbox.TryParseValueFromString(string? value, out bool result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.FormatValueAsString(TValue value) -> string!
+override Microsoft.AspNetCore.Components.Forms.InputDate<TValue>.TryParseValueFromString(string? value, out TValue result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.InputFile.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputFile.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override Microsoft.AspNetCore.Components.Forms.InputFile.OnInitialized() -> void
+override Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.FormatValueAsString(TValue value) -> string?
+override Microsoft.AspNetCore.Components.Forms.InputNumber<TValue>.TryParseValueFromString(string? value, out TValue result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.OnParametersSet() -> void
+override Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.OnParametersSet() -> void
+override Microsoft.AspNetCore.Components.Forms.InputRadioGroup<TValue>.TryParseValueFromString(string? value, out TValue result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputSelect<TValue>.TryParseValueFromString(string? value, out TValue result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.InputText.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputText.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.InputTextArea.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputTextArea.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.OnParametersSet() -> void
+override Microsoft.AspNetCore.Components.Forms.ValidationSummary.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.ValidationSummary.OnParametersSet() -> void
+override Microsoft.AspNetCore.Components.Routing.NavLink.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Routing.NavLink.OnInitialized() -> void
+override Microsoft.AspNetCore.Components.Routing.NavLink.OnParametersSet() -> void
+static Microsoft.AspNetCore.Components.ElementReferenceExtensions.FocusAsync(this Microsoft.AspNetCore.Components.ElementReference elementReference) -> System.Threading.Tasks.ValueTask
+static Microsoft.AspNetCore.Components.Forms.BrowserFileExtensions.RequestImageFileAsync(this Microsoft.AspNetCore.Components.Forms.IBrowserFile! browserFile, string! format, int maxWith, int maxHeight) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Components.Forms.IBrowserFile!>
+static Microsoft.AspNetCore.Components.Forms.EditContextFieldClassExtensions.FieldCssClass(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext, in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> string!
+static Microsoft.AspNetCore.Components.Forms.EditContextFieldClassExtensions.FieldCssClass<TField>(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext, System.Linq.Expressions.Expression<System.Func<TField>!>! accessor) -> string!
+static Microsoft.AspNetCore.Components.Forms.EditContextFieldClassExtensions.SetFieldCssClassProvider(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext, Microsoft.AspNetCore.Components.Forms.FieldCssClassProvider! fieldCssClassProvider) -> void
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.DragEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.ErrorEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ErrorEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.FocusEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.MouseEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.PointerEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.ProgressEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.TouchEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Action<Microsoft.AspNetCore.Components.Web.WheelEventArgs!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ClipboardEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.DragEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.DragEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.ErrorEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ErrorEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.FocusEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.FocusEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.KeyboardEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.MouseEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.MouseEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.PointerEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.PointerEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.ProgressEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.TouchEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.WheelEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs!>
+static Microsoft.AspNetCore.Components.Web.WebRenderTreeBuilderExtensions.AddEventPreventDefaultAttribute(this Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder, int sequence, string! eventName, bool value) -> void
+static Microsoft.AspNetCore.Components.Web.WebRenderTreeBuilderExtensions.AddEventStopPropagationAttribute(this Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder, int sequence, string! eventName, bool value) -> void
+virtual Microsoft.AspNetCore.Components.Forms.FieldCssClassProvider.GetFieldCssClass(Microsoft.AspNetCore.Components.Forms.EditContext! editContext, in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> string!
+virtual Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.Dispose(bool disposing) -> void
+virtual Microsoft.AspNetCore.Components.Forms.InputBase<TValue>.FormatValueAsString(TValue value) -> string?
+virtual Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.Dispose(bool disposing) -> void
+virtual Microsoft.AspNetCore.Components.Forms.ValidationSummary.Dispose(bool disposing) -> void

--- a/src/Components/WebAssembly/Authentication.Msal/src/PublicAPI.Shipped.txt
+++ b/src/Components/WebAssembly/Authentication.Msal/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/WebAssembly/Authentication.Msal/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/Authentication.Msal/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,39 @@
+﻿#nullable enable
+Microsoft.Authentication.WebAssembly.Msal.Models.MsalCacheOptions
+Microsoft.Authentication.WebAssembly.Msal.Models.MsalCacheOptions.MsalCacheOptions() -> void
+Microsoft.Authentication.WebAssembly.Msal.Models.MsalCacheOptions.StoreAuthStateInCookie.get -> bool
+Microsoft.Authentication.WebAssembly.Msal.Models.MsalCacheOptions.StoreAuthStateInCookie.set -> void
+Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions
+Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.MsalProviderOptions() -> void
+Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions
+Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.MsalAuthenticationOptions() -> void
+Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.NavigateToLoginRequestUrl.get -> bool
+Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.NavigateToLoginRequestUrl.set -> void
+Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.ValidateAuthority.get -> bool
+Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.ValidateAuthority.set -> void
+Microsoft.Extensions.DependencyInjection.MsalWebAssemblyServiceCollectionExtensions
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalCacheOptions.CacheLocation.get -> string
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalCacheOptions.CacheLocation.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.AdditionalScopesToConsent.get -> System.Collections.Generic.IList<string>
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.AdditionalScopesToConsent.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.Authentication.get -> Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.Authentication.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.Cache.get -> Microsoft.Authentication.WebAssembly.Msal.Models.MsalCacheOptions
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.Cache.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.DefaultAccessTokenScopes.get -> System.Collections.Generic.IList<string>
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.DefaultAccessTokenScopes.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.LoginMode.get -> string
+~Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.LoginMode.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.Authority.get -> string
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.Authority.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.ClientId.get -> string
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.ClientId.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.KnownAuthorities.get -> System.Collections.Generic.IList<string>
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.KnownAuthorities.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.PostLogoutRedirectUri.get -> string
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.PostLogoutRedirectUri.set -> void
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.RedirectUri.get -> string
+~Microsoft.Authentication.WebAssembly.Msal.MsalAuthenticationOptions.RedirectUri.set -> void
+~static Microsoft.Extensions.DependencyInjection.MsalWebAssemblyServiceCollectionExtensions.AddMsalAuthentication(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.MsalWebAssemblyServiceCollectionExtensions.AddMsalAuthentication<TRemoteAuthenticationState, TAccount>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>
+~static Microsoft.Extensions.DependencyInjection.MsalWebAssemblyServiceCollectionExtensions.AddMsalAuthentication<TRemoteAuthenticationState>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>

--- a/src/Components/WebAssembly/DevServer/src/PublicAPI.Shipped.txt
+++ b/src/Components/WebAssembly/DevServer/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/WebAssembly/DevServer/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/DevServer/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebAssembly.DevServer.Server.Program
+Microsoft.AspNetCore.Components.WebAssembly.DevServer.Server.Program.Program() -> void
+~static Microsoft.AspNetCore.Components.WebAssembly.DevServer.Server.Program.BuildWebHost(string[] args) -> Microsoft.Extensions.Hosting.IHost

--- a/src/Components/WebAssembly/JSInterop/src/PublicAPI.Shipped.txt
+++ b/src/Components/WebAssembly/JSInterop/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/WebAssembly/JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/JSInterop/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,10 @@
+﻿#nullable enable
+Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime
+Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.WebAssemblyJSRuntime() -> void
+override Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.EndInvokeDotNet(Microsoft.JSInterop.Infrastructure.DotNetInvocationInfo callInfo, in Microsoft.JSInterop.Infrastructure.DotNetInvocationResult dispatchResult) -> void
+~Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.InvokeUnmarshalled<T0, T1, T2, TResult>(string identifier, T0 arg0, T1 arg1, T2 arg2) -> TResult
+~Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.InvokeUnmarshalled<T0, T1, TResult>(string identifier, T0 arg0, T1 arg1) -> TResult
+~Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.InvokeUnmarshalled<T0, TResult>(string identifier, T0 arg0) -> TResult
+~Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.InvokeUnmarshalled<TResult>(string identifier) -> TResult
+~override Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.BeginInvokeJS(long asyncHandle, string identifier, string argsJson, Microsoft.JSInterop.JSCallResultType resultType, long targetInstanceId) -> void
+~override Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.InvokeJS(string identifier, string argsJson, Microsoft.JSInterop.JSCallResultType resultType, long targetInstanceId) -> string

--- a/src/Components/WebAssembly/Server/src/PublicAPI.Shipped.txt
+++ b/src/Components/WebAssembly/Server/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/WebAssembly/Server/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/Server/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,9 @@
+﻿#nullable enable
+Microsoft.AspNetCore.Builder.ComponentsWebAssemblyApplicationBuilderExtensions
+Microsoft.AspNetCore.Builder.WebAssemblyNetDebugProxyAppBuilderExtensions
+Microsoft.AspNetCore.Components.WebAssembly.Server.TargetPickerUi
+~Microsoft.AspNetCore.Components.WebAssembly.Server.TargetPickerUi.Display(Microsoft.AspNetCore.Http.HttpContext context) -> System.Threading.Tasks.Task
+~Microsoft.AspNetCore.Components.WebAssembly.Server.TargetPickerUi.TargetPickerUi(string debugProxyUrl, string devToolsHost) -> void
+~static Microsoft.AspNetCore.Builder.ComponentsWebAssemblyApplicationBuilderExtensions.UseBlazorFrameworkFiles(this Microsoft.AspNetCore.Builder.IApplicationBuilder applicationBuilder) -> Microsoft.AspNetCore.Builder.IApplicationBuilder
+~static Microsoft.AspNetCore.Builder.ComponentsWebAssemblyApplicationBuilderExtensions.UseBlazorFrameworkFiles(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, Microsoft.AspNetCore.Http.PathString pathPrefix) -> Microsoft.AspNetCore.Builder.IApplicationBuilder
+~static Microsoft.AspNetCore.Builder.WebAssemblyNetDebugProxyAppBuilderExtensions.UseWebAssemblyDebugging(this Microsoft.AspNetCore.Builder.IApplicationBuilder app) -> void

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/PublicAPI.Shipped.txt
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,226 @@
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.AccessToken() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.Expires.get -> System.DateTimeOffset
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.Expires.set -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenNotAvailableException
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenNotAvailableException.Redirect() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenRequestOptions
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenRequestOptions.AccessTokenRequestOptions() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult.Status.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResultStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResultStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResultStatus.RequiresRedirect = 1 -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResultStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResultStatus.Success = 0 -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResultStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.ApiAuthorizationProviderOptions
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.ApiAuthorizationProviderOptions.ApiAuthorizationProviderOptions() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.BaseAddressAuthorizationMessageHandler
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.IAccessTokenProvider
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal.IAccessTokenProviderAccessor
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.OidcProviderOptions() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.RemoteAuthenticationActions() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.RemoteAuthenticationApplicationPathsOptions() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState>.RemoteAuthenticationContext() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.RemoteAuthenticationDefaults() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TRemoteAuthenticationProviderOptions>
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TRemoteAuthenticationProviderOptions>.ProviderOptions.get -> TRemoteAuthenticationProviderOptions
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TRemoteAuthenticationProviderOptions>.RemoteAuthenticationOptions() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>.RemoteAuthenticationResult() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>.Status.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>.Status.set -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState.RemoteAuthenticationState() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus.Failure = 2 -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus.OperationCompleted = 3 -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus.Redirect = 0 -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus.Success = 1 -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationStatus
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.RemoteAuthenticationUserOptions() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorView
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorView.RemoteAuthenticatorView() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.RemoteAuthenticatorViewCore() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount.RemoteUserAccount() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Authentication.SignOutSessionStateManager
+Microsoft.Extensions.DependencyInjection.RemoteAuthenticationBuilderExtensions
+Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions
+virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.SignOutSessionStateManager.SetSignOutState() -> System.Threading.Tasks.ValueTask
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.GrantedScopes.get -> System.Collections.Generic.IReadOnlyList<string>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.GrantedScopes.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.Value.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.Value.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenNotAvailableException.AccessTokenNotAvailableException(Microsoft.AspNetCore.Components.NavigationManager navigation, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult tokenResult, System.Collections.Generic.IEnumerable<string> scopes) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenRequestOptions.ReturnUrl.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenRequestOptions.ReturnUrl.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenRequestOptions.Scopes.get -> System.Collections.Generic.IEnumerable<string>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenRequestOptions.Scopes.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult.AccessTokenResult(Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResultStatus status, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken token, string redirectUrl) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult.RedirectUrl.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult.TryGetToken(out Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken accessToken) -> bool
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccountClaimsPrincipalFactory<TAccount>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccountClaimsPrincipalFactory<TAccount>.AccountClaimsPrincipalFactory(Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal.IAccessTokenProviderAccessor accessor) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccountClaimsPrincipalFactory<TAccount>.TokenProvider.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.IAccessTokenProvider
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.ApiAuthorizationProviderOptions.ConfigurationEndpoint.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.ApiAuthorizationProviderOptions.ConfigurationEndpoint.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler.AuthorizationMessageHandler(Microsoft.AspNetCore.Components.WebAssembly.Authentication.IAccessTokenProvider provider, Microsoft.AspNetCore.Components.NavigationManager navigation) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler.ConfigureHandler(System.Collections.Generic.IEnumerable<string> authorizedUrls, System.Collections.Generic.IEnumerable<string> scopes = null, string returnUrl = null) -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.BaseAddressAuthorizationMessageHandler.BaseAddressAuthorizationMessageHandler(Microsoft.AspNetCore.Components.WebAssembly.Authentication.IAccessTokenProvider provider, Microsoft.AspNetCore.Components.NavigationManager navigationManager) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.IAccessTokenProvider.RequestAccessToken() -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.IAccessTokenProvider.RequestAccessToken(Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenRequestOptions options) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.IRemoteAuthenticationService<TRemoteAuthenticationState>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.IRemoteAuthenticationService<TRemoteAuthenticationState>.CompleteSignInAsync(Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState> context) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.IRemoteAuthenticationService<TRemoteAuthenticationState>.CompleteSignOutAsync(Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState> context) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.IRemoteAuthenticationService<TRemoteAuthenticationState>.SignInAsync(Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState> context) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.IRemoteAuthenticationService<TRemoteAuthenticationState>.SignOutAsync(Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState> context) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal.IAccessTokenProviderAccessor.TokenProvider.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.IAccessTokenProvider
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.Authority.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.Authority.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.ClientId.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.ClientId.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.DefaultScopes.get -> System.Collections.Generic.IList<string>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.MetadataUrl.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.MetadataUrl.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.PostLogoutRedirectUri.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.PostLogoutRedirectUri.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.RedirectUri.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.RedirectUri.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.ResponseMode.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.ResponseMode.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.ResponseType.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.ResponseType.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogInCallbackPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogInCallbackPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogInFailedPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogInFailedPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogInPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogInPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogOutCallbackPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogOutCallbackPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogOutFailedPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogOutFailedPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogOutPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogOutPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogOutSucceededPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.LogOutSucceededPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.ProfilePath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.ProfilePath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.RegisterPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.RegisterPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.RemoteProfilePath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.RemoteProfilePath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.RemoteRegisterPath.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions.RemoteRegisterPath.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState>.State.get -> TRemoteAuthenticationState
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState>.State.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState>.Url.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState>.Url.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TRemoteAuthenticationProviderOptions>.AuthenticationPaths.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TRemoteAuthenticationProviderOptions>.UserOptions.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>.ErrorMessage.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>.ErrorMessage.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>.State.get -> TRemoteAuthenticationState
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>.State.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.AccountClaimsPrincipalFactory.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccountClaimsPrincipalFactory<TAccount>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.JsRuntime.get -> Microsoft.JSInterop.IJSRuntime
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.Navigation.get -> Microsoft.AspNetCore.Components.NavigationManager
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.Options.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TProviderOptions>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.RemoteAuthenticationService(Microsoft.JSInterop.IJSRuntime jsRuntime, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TProviderOptions>> options, Microsoft.AspNetCore.Components.NavigationManager navigation, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccountClaimsPrincipalFactory<TAccount> accountClaimsPrincipalFactory) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState.ReturnUrl.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState.ReturnUrl.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.AuthenticationType.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.AuthenticationType.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.NameClaim.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.NameClaim.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.RoleClaim.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.RoleClaim.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.ScopeClaim.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.ScopeClaim.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.Action.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.Action.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.ApplicationPaths.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationApplicationPathsOptions
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.ApplicationPaths.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.AuthenticationState.get -> TAuthenticationState
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.AuthenticationState.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.CompletingLogOut.get -> Microsoft.AspNetCore.Components.RenderFragment
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.CompletingLogOut.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.CompletingLoggingIn.get -> Microsoft.AspNetCore.Components.RenderFragment
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.CompletingLoggingIn.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LogInFailed.get -> Microsoft.AspNetCore.Components.RenderFragment<string>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LogInFailed.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LogOut.get -> Microsoft.AspNetCore.Components.RenderFragment
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LogOut.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LogOutFailed.get -> Microsoft.AspNetCore.Components.RenderFragment<string>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LogOutFailed.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LogOutSucceeded.get -> Microsoft.AspNetCore.Components.RenderFragment
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LogOutSucceeded.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LoggingIn.get -> Microsoft.AspNetCore.Components.RenderFragment
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.LoggingIn.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.OnLogInSucceeded.get -> Microsoft.AspNetCore.Components.EventCallback<TAuthenticationState>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.OnLogInSucceeded.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.OnLogOutSucceeded.get -> Microsoft.AspNetCore.Components.EventCallback<TAuthenticationState>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.OnLogOutSucceeded.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.Registering.get -> Microsoft.AspNetCore.Components.RenderFragment
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.Registering.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.UserProfile.get -> Microsoft.AspNetCore.Components.RenderFragment
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.UserProfile.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount.AdditionalProperties.get -> System.Collections.Generic.IDictionary<string, object>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount.AdditionalProperties.set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.SignOutSessionStateManager.SignOutSessionStateManager(Microsoft.JSInterop.IJSRuntime jsRuntime) -> void
+~Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>
+~Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.LogIn = "login" -> string
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.LogInCallback = "login-callback" -> string
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.LogInFailed = "login-failed" -> string
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.LogOut = "logout" -> string
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.LogOutCallback = "logout-callback" -> string
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.LogOutFailed = "logout-failed" -> string
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.LogOutSucceeded = "logged-out" -> string
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.Profile = "profile" -> string
+~const Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.Register = "register" -> string
+~override Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler.SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>
+~override Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.GetAuthenticationStateAsync() -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.Authorization.AuthenticationState>
+~override Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder) -> void
+~override Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore<TAuthenticationState>.OnParametersSetAsync() -> System.Threading.Tasks.Task
+~static Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationActions.IsAction(string action, string candidate) -> bool
+~static Microsoft.Extensions.DependencyInjection.RemoteAuthenticationBuilderExtensions.AddAccountClaimsPrincipalFactory<TAccountClaimsPrincipalFactory>(this Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount> builder) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.RemoteAuthenticationBuilderExtensions.AddAccountClaimsPrincipalFactory<TRemoteAuthenticationState, TAccount, TAccountClaimsPrincipalFactory>(this Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount> builder) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>
+~static Microsoft.Extensions.DependencyInjection.RemoteAuthenticationBuilderExtensions.AddAccountClaimsPrincipalFactory<TRemoteAuthenticationState, TAccountClaimsPrincipalFactory>(this Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount> builder) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddApiAuthorization(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddApiAuthorization(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.AspNetCore.Components.WebAssembly.Authentication.ApiAuthorizationProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddApiAuthorization<TRemoteAuthenticationState, TAccount>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddApiAuthorization<TRemoteAuthenticationState, TAccount>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.AspNetCore.Components.WebAssembly.Authentication.ApiAuthorizationProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddApiAuthorization<TRemoteAuthenticationState>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddApiAuthorization<TRemoteAuthenticationState>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.AspNetCore.Components.WebAssembly.Authentication.ApiAuthorizationProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication<TRemoteAuthenticationState, TAccount>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication<TRemoteAuthenticationState>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddRemoteAuthentication<TRemoteAuthenticationState, TAccount, TProviderOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>
+~static Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddRemoteAuthentication<TRemoteAuthenticationState, TAccount, TProviderOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TProviderOptions>> configure) -> Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.LoginCallbackPath -> string
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.LoginFailedPath -> string
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.LoginPath -> string
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.LogoutCallbackPath -> string
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.LogoutFailedPath -> string
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.LogoutPath -> string
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.LogoutSucceededPath -> string
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.ProfilePath -> string
+~static readonly Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationDefaults.RegisterPath -> string
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccountClaimsPrincipalFactory<TAccount>.CreateUserAsync(TAccount account, Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions options) -> System.Threading.Tasks.ValueTask<System.Security.Claims.ClaimsPrincipal>
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.CompleteSignInAsync(Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState> context) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>>
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.CompleteSignOutAsync(Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState> context) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>>
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.GetAuthenticatedUser() -> System.Threading.Tasks.ValueTask<System.Security.Claims.ClaimsPrincipal>
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.RequestAccessToken() -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult>
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.RequestAccessToken(Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenRequestOptions options) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult>
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.SignInAsync(Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState> context) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>>
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.SignOutAsync(Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext<TRemoteAuthenticationState> context) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationResult<TRemoteAuthenticationState>>
+~virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.SignOutSessionStateManager.ValidateSignOutState() -> System.Threading.Tasks.Task<bool>

--- a/src/Components/WebAssembly/WebAssembly/src/PublicAPI.Shipped.txt
+++ b/src/Components/WebAssembly/WebAssembly/src/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Components/WebAssembly/WebAssembly/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/WebAssembly/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,74 @@
+﻿#nullable enable
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMapping
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMapping.Parameters.get -> Microsoft.AspNetCore.Components.ParameterView
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMappingCollection
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMappingCollection.RootComponentMappingCollection() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.Dispose() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.Reload() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.WebAssemblyHostConfiguration() -> void
+Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostEnvironmentExtensions
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache.Default = 0 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache.ForceCache = 4 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache.NoCache = 3 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache.NoStore = 1 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache.OnlyIfCached = 5 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache.Reload = 2 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCredentials
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCredentials.Include = 2 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCredentials
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCredentials.Omit = 0 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCredentials
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCredentials.SameOrigin = 1 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCredentials
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode.Cors = 2 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode.Navigate = 3 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode.NoCors = 1 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode
+Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode.SameOrigin = 0 -> Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode
+Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions
+Microsoft.AspNetCore.Components.WebAssembly.Infrastructure.JSInteropMethods
+Microsoft.AspNetCore.Components.WebAssembly.Services.LazyAssemblyLoader
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment.BaseAddress.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment.Environment.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMapping.ComponentType.get -> System.Type
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMapping.RootComponentMapping(System.Type componentType, string selector) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMapping.RootComponentMapping(System.Type componentType, string selector, Microsoft.AspNetCore.Components.ParameterView parameters) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMapping.Selector.get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMappingCollection.Add(System.Type componentType, string selector) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMappingCollection.Add(System.Type componentType, string selector, Microsoft.AspNetCore.Components.ParameterView parameters) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMappingCollection.Add<TComponent>(string selector) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMappingCollection.AddRange(System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMapping> items) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost.RunAsync() -> System.Threading.Tasks.Task
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost.Services.get -> System.IServiceProvider
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.Build() -> Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.Configuration.get -> Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.ConfigureContainer<TBuilder>(Microsoft.Extensions.DependencyInjection.IServiceProviderFactory<TBuilder> factory, System.Action<TBuilder> configure = null) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.HostEnvironment.get -> Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.Logging.get -> Microsoft.Extensions.Logging.ILoggingBuilder
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents.get -> Microsoft.AspNetCore.Components.WebAssembly.Hosting.RootComponentMappingCollection
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.Add(Microsoft.Extensions.Configuration.IConfigurationSource source) -> Microsoft.Extensions.Configuration.IConfigurationBuilder
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.Build() -> Microsoft.Extensions.Configuration.IConfigurationRoot
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.GetReloadToken() -> Microsoft.Extensions.Primitives.IChangeToken
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.GetSection(string key) -> Microsoft.Extensions.Configuration.IConfigurationSection
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.this[string key].get -> string
+~Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostConfiguration.this[string key].set -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Services.LazyAssemblyLoader.LazyAssemblyLoader(Microsoft.JSInterop.IJSRuntime jsRuntime) -> void
+~Microsoft.AspNetCore.Components.WebAssembly.Services.LazyAssemblyLoader.LoadAssembliesAsync(System.Collections.Generic.IEnumerable<string> assembliesToLoad) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>>
+~static Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault(string[] args = null) -> Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder
+~static Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostEnvironmentExtensions.IsDevelopment(this Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment hostingEnvironment) -> bool
+~static Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostEnvironmentExtensions.IsEnvironment(this Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment hostingEnvironment, string environmentName) -> bool
+~static Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostEnvironmentExtensions.IsProduction(this Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment hostingEnvironment) -> bool
+~static Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostEnvironmentExtensions.IsStaging(this Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment hostingEnvironment) -> bool
+~static Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions.SetBrowserRequestCache(this System.Net.Http.HttpRequestMessage requestMessage, Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCache requestCache) -> System.Net.Http.HttpRequestMessage
+~static Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions.SetBrowserRequestCredentials(this System.Net.Http.HttpRequestMessage requestMessage, Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestCredentials requestCredentials) -> System.Net.Http.HttpRequestMessage
+~static Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions.SetBrowserRequestIntegrity(this System.Net.Http.HttpRequestMessage requestMessage, string integrity) -> System.Net.Http.HttpRequestMessage
+~static Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions.SetBrowserRequestMode(this System.Net.Http.HttpRequestMessage requestMessage, Microsoft.AspNetCore.Components.WebAssembly.Http.BrowserRequestMode requestMode) -> System.Net.Http.HttpRequestMessage
+~static Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions.SetBrowserRequestOption(this System.Net.Http.HttpRequestMessage requestMessage, string name, object value) -> System.Net.Http.HttpRequestMessage
+~static Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions.SetBrowserResponseStreamingEnabled(this System.Net.Http.HttpRequestMessage requestMessage, bool streamingEnabled) -> System.Net.Http.HttpRequestMessage
+~static Microsoft.AspNetCore.Components.WebAssembly.Infrastructure.JSInteropMethods.DispatchEvent(Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor eventDescriptor, string eventArgsJson) -> System.Threading.Tasks.Task
+~static Microsoft.AspNetCore.Components.WebAssembly.Infrastructure.JSInteropMethods.NotifyLocationChanged(string uri, bool isInterceptedLink) -> void


### PR DESCRIPTION
- part of #24347
- unable to do src/Components/Authorization due to contained `*.razor` file
- ignored src/Components/Analyzers and src/Components/WebAssembly/Sdk