### PR TITLE
Eliminate duplicates in Helix `TestRunner`

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -50,10 +50,10 @@ jobs:
     agentOs: Linux
     timeoutInMinutes: 480
     steps:
-    - script: ./restore.sh -ci -nobl
+    - script: ./restore.sh --ci --nobl --arch arm64
       displayName: Restore
-    - script: ./build.sh --ci --nobl --noBuildRepoTasks --arch arm64 -test --no-build-nodejs --all --projects
-              $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
+    - script: ./build.sh --ci --nobl --arch arm64 --noBuildRepoTasks --no-build-nodejs --no-restore --test --all
+              --projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
               /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.sh helix arm64 target
       env:

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -53,11 +53,11 @@ jobs:
     agentOs: Linux
     timeoutInMinutes: 480
     steps:
-    - script: ./restore.sh -ci -nobl
+    - script: ./restore.sh --ci --nobl --arch arm64
       displayName: Restore
-    - script: ./build.sh --ci --nobl --noBuildRepoTasks --arch arm64 -test --no-build-nodejs --all --projects
-              $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true /p:RunQuarantinedTests=true
-              /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+    - script: ./build.sh --ci --nobl  --arch arm64 --noBuildRepoTasks --no-build-nodejs --no-restore --test --all
+              --projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
+              /p:RunQuarantinedTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.sh helix arm64 target
       continueOnError: true
       env:

--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -34,7 +34,6 @@ namespace RunTests
                 }
 
                 EnvironmentVariables.Add("PATH", Options.Path);
-                EnvironmentVariables.Add("DOTNET_ROOT", Options.DotnetRoot);
                 EnvironmentVariables.Add("helix", Options.HelixQueue);
 
                 Console.WriteLine($"Current Directory: {Options.HELIX_WORKITEM_ROOT}");
@@ -126,14 +125,6 @@ namespace RunTests
                         throwOnError: false,
                         cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
-                    await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
-                        "nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json --configfile NuGet.config",
-                        environmentVariables: EnvironmentVariables,
-                        outputDataReceived: Console.WriteLine,
-                        errorDataReceived: Console.Error.WriteLine,
-                        throwOnError: false,
-                        cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
-
                     // Write nuget sources to console, useful for debugging purposes
                     await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                         "nuget list source",
@@ -199,8 +190,7 @@ namespace RunTests
             try
             {
                 await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
-                            $"tool install dotnet-dump --tool-path {Options.HELIX_WORKITEM_ROOT} " +
-                              "--version 5.0.0-* --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json",
+                            $"tool install dotnet-dump --tool-path {Options.HELIX_WORKITEM_ROOT} --version 5.0.0-*",
                             environmentVariables: EnvironmentVariables,
                             outputDataReceived: Console.WriteLine,
                             errorDataReceived: Console.Error.WriteLine,
@@ -247,7 +237,7 @@ namespace RunTests
             {
                 // Timeout test run 5 minutes before the Helix job would timeout
                 var cts = new CancellationTokenSource(Options.Timeout.Subtract(TimeSpan.FromMinutes(5)));
-                var commonTestArgs = $"test {Options.Target} --logger:xunit --logger:\"console;verbosity=normal\" --blame \"CollectHangDump;TestTimeout=5m\"";                
+                var commonTestArgs = $"test {Options.Target} --logger:xunit --logger:\"console;verbosity=normal\" --blame \"CollectHangDump;TestTimeout=5m\"";
                 if (Options.Quarantined)
                 {
                     Console.WriteLine("Running quarantined tests.");
@@ -346,7 +336,7 @@ namespace RunTests
             else
             {
                 Console.WriteLine("No dmps found in TestResults");
-            }            
+            }
         }
     }
 }

--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -1,6 +1,4 @@
 @echo off
-REM Need delayed expansion !PATH! so parens in the path don't mess up the parens for the if statements that use parens for blocks
-setlocal enabledelayedexpansion
 
 REM Use '$' as a variable name prefix to avoid MSBuild variable collisions with these variables
 set $target=%1
@@ -26,8 +24,8 @@ set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 set DOTNET_MULTILEVEL_LOOKUP=0
 set DOTNET_CLI_HOME=%HELIX_CORRELATION_PAYLOAD%\home
 
-set PATH=%DOTNET_ROOT%;!PATH!;%HELIX_CORRELATION_PAYLOAD%\node\bin
-echo Set path to: %PATH%
+set "PATH=%DOTNET_ROOT%;%PATH%;%HELIX_CORRELATION_PAYLOAD%\node\bin"
+echo Set path to: "%PATH%"
 
 powershell.exe -noLogo -NoProfile -ExecutionPolicy unrestricted -command ". eng\common\tools.ps1; InstallDotNet %DOTNET_ROOT% %$sdkVersion% %$arch% '' $true '' '' $true"
 IF [%$feedCred%] == [] (

--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -36,11 +36,11 @@ IF [%$feedCred%] == [] (
 
 set exit_code=0
 
-echo "Restore: dotnet restore RunTests\RunTests.csproj --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json --source https://api.nuget.org/v3/index.json --ignore-failed-sources..."
-dotnet restore RunTests\RunTests.csproj --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json --source https://api.nuget.org/v3/index.json --ignore-failed-sources
+echo "Restore: dotnet restore RunTests\RunTests.csproj --ignore-failed-sources"
+dotnet restore RunTests\RunTests.csproj --ignore-failed-sources
 
-echo "Running tests: dotnet run --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%..."
-dotnet run --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%
+echo "Running tests: dotnet run --no-restore --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%"
+dotnet run --no-restore --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%
 if errorlevel neq 0 (
     set exit_code=%errorlevel%
 )

--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -1,4 +1,5 @@
 @echo off
+SETLOCAL
 
 REM Use '$' as a variable name prefix to avoid MSBuild variable collisions with these variables
 set $target=%1

--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -61,10 +61,12 @@ fi
 sync
 
 exit_code=0
-echo "Restore: $DOTNET_ROOT/dotnet restore RunTests/RunTests.csproj --source https://api.nuget.org/v3/index.json --ignore-failed-sources..."
-$DOTNET_ROOT/dotnet restore RunTests/RunTests.csproj --source https://api.nuget.org/v3/index.json --ignore-failed-sources
-echo "Running tests: $DOTNET_ROOT/dotnet run --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --aspnetruntime $9 --aspnetref ${10} --helixTimeout ${11}"
-$DOTNET_ROOT/dotnet run --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --aspnetruntime $9 --aspnetref ${10} --helixTimeout ${11}
+
+echo "Restore: $DOTNET_ROOT/dotnet restore RunTests/RunTests.csproj --ignore-failed-sources"
+$DOTNET_ROOT/dotnet restore RunTests/RunTests.csproj --ignore-failed-sources
+
+echo "Running tests: $DOTNET_ROOT/dotnet run --no-restore --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --aspnetruntime $9 --aspnetref ${10} --helixTimeout ${11}"
+$DOTNET_ROOT/dotnet run --no-restore --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --aspnetruntime $9 --aspnetref ${10} --helixTimeout ${11}
 exit_code=$?
 echo "Finished tests...exit_code=$exit_code"
 


### PR DESCRIPTION
- do not add source that's already in NuGet.config
  - configuration file now part of Helix content
- do not set env variable set in `runtests.*`

nit: simplify `%Path% setting in runtests.cmd
- always quote the value