### PR TITLE
Send CloseMessage in more cases

### DIFF
--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -146,61 +146,20 @@ namespace Microsoft.AspNetCore.SignalR
         // Currently used only for streaming methods
         internal ConcurrentDictionary<string, CancellationTokenSource> ActiveRequestCancellationSources { get; } = new ConcurrentDictionary<string, CancellationTokenSource>(StringComparer.Ordinal);
 
-        // Only used when writing CloseMessage, it ignores _connectionAborted to be the final message sent to the client
-        internal ValueTask WriteCloseAsync(CloseMessage message, CancellationToken cancellationToken = default)
-        {
-            // Try to grab the lock synchronously, if we fail, go to the slower path
-            if (!_writeLock.Wait(0))
-            {
-                return new ValueTask(WriteCloseSlowAsync(message, cancellationToken));
-            }
-
-            // This method should never throw synchronously
-            var task = WriteCore(message, cancellationToken);
-
-            // The write didn't complete synchronously so await completion
-            if (!task.IsCompletedSuccessfully)
-            {
-                return new ValueTask(CompleteWriteAsync(task));
-            }
-
-            // Otherwise, release the lock acquired when entering WriteAsync
-            _writeLock.Release();
-
-            return default;
-        }
-
-        private async Task WriteCloseSlowAsync(CloseMessage message, CancellationToken cancellationToken)
-        {
-            // Failed to get the lock immediately when entering WriteAsync so await until it is available
-            await _writeLock.WaitAsync(cancellationToken);
-
-            try
-            {
-
-                await WriteCore(message, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                CloseException = ex;
-                Log.FailedWritingMessage(_logger, ex);
-                AbortAllowReconnect();
-            }
-            finally
-            {
-                _writeLock.Release();
-            }
-        }
-
         public virtual ValueTask WriteAsync(HubMessage message, CancellationToken cancellationToken = default)
         {
+            return WriteAsync(message, ignoreAbort: false, cancellationToken);
+        }
+
+        internal ValueTask WriteAsync(HubMessage message, bool ignoreAbort, CancellationToken cancellationToken = default)
+        {
             // Try to grab the lock synchronously, if we fail, go to the slower path
             if (!_writeLock.Wait(0))
             {
-                return new ValueTask(WriteSlowAsync(message, cancellationToken));
+                return new ValueTask(WriteSlowAsync(message, ignoreAbort, cancellationToken));
             }
 
-            if (_connectionAborted)
+            if (_connectionAborted && !ignoreAbort)
             {
                 _writeLock.Release();
                 return default;
@@ -318,14 +277,14 @@ namespace Microsoft.AspNetCore.SignalR
             }
         }
 
-        private async Task WriteSlowAsync(HubMessage message, CancellationToken cancellationToken)
+        private async Task WriteSlowAsync(HubMessage message, bool ignoreAbort, CancellationToken cancellationToken)
         {
             // Failed to get the lock immediately when entering WriteAsync so await until it is available
             await _writeLock.WaitAsync(cancellationToken);
 
             try
             {
-                if (_connectionAborted)
+                if (_connectionAborted && !ignoreAbort)
                 {
                     return;
                 }
@@ -347,7 +306,7 @@ namespace Microsoft.AspNetCore.SignalR
         private async Task WriteSlowAsync(SerializedHubMessage message, CancellationToken cancellationToken)
         {
             // Failed to get the lock immediately when entering WriteAsync so await until it is available
-            await _writeLock.WaitAsync();
+            await _writeLock.WaitAsync(cancellationToken);
 
             try
             {

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.SignalR
 
             try
             {
-                await connection.WriteAsync(closeMessage);
+                await connection.WriteCloseAsync(closeMessage);
             }
             catch (Exception ex)
             {

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.SignalR
 
             try
             {
-                await connection.WriteCloseAsync(closeMessage);
+                await connection.WriteAsync(closeMessage, ignoreAbort: true);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The `CloseMessage(allowReconnect: false)` was not being sent when `Context.Abort()` was called, which resulted in clients potentially attempting a reconnect. This fixes it so that the `CloseMessage` can be sent now so well behaved clients wont attempt an unwanted reconnect.

Fixes https://github.com/dotnet/aspnetcore/issues/21422