### PR TITLE
[MVC] Fix global MVC data sources state

### DIFF
--- a/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
@@ -5,10 +5,10 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Core;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Constraints;
-using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Builder
@@ -213,7 +213,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureControllerServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var dataSource = GetOrCreateDataSource(endpoints);
+            dataSource.CreateInertEndpoints = true;
+            RegisterInCache(endpoints.ServiceProvider, dataSource);
 
             // Maps a fallback endpoint with an empty delegate. This is OK because
             // we don't expect the delegate to run.
@@ -222,6 +224,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 // MVC registers a policy that looks for this metadata.
                 b.Metadata.Add(CreateDynamicControllerMetadata(action, controller, area: null));
+                b.Metadata.Add(new ControllerEndpointDataSourceIdMetadata(dataSource.DataSourceId));
             });
             return builder;
         }
@@ -289,7 +292,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureControllerServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var dataSource = GetOrCreateDataSource(endpoints);
+            dataSource.CreateInertEndpoints = true;
+            RegisterInCache(endpoints.ServiceProvider, dataSource);
 
             // Maps a fallback endpoint with an empty delegate. This is OK because
             // we don't expect the delegate to run.
@@ -298,6 +303,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 // MVC registers a policy that looks for this metadata.
                 b.Metadata.Add(CreateDynamicControllerMetadata(action, controller, area: null));
+                b.Metadata.Add(new ControllerEndpointDataSourceIdMetadata(dataSource.DataSourceId));
             });
             return builder;
         }
@@ -357,7 +363,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureControllerServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var dataSource = GetOrCreateDataSource(endpoints);
+            dataSource.CreateInertEndpoints = true;
+            RegisterInCache(endpoints.ServiceProvider, dataSource);
 
             // Maps a fallback endpoint with an empty delegate. This is OK because
             // we don't expect the delegate to run.
@@ -366,6 +374,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 // MVC registers a policy that looks for this metadata.
                 b.Metadata.Add(CreateDynamicControllerMetadata(action, controller, area));
+                b.Metadata.Add(new ControllerEndpointDataSourceIdMetadata(dataSource.DataSourceId));
             });
             return builder;
         }
@@ -435,7 +444,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureControllerServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var dataSource = GetOrCreateDataSource(endpoints);
+            dataSource.CreateInertEndpoints = true;
+            RegisterInCache(endpoints.ServiceProvider, dataSource);
 
             // Maps a fallback endpoint with an empty delegate. This is OK because
             // we don't expect the delegate to run.
@@ -444,6 +455,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 // MVC registers a policy that looks for this metadata.
                 b.Metadata.Add(CreateDynamicControllerMetadata(action, controller, area));
+                b.Metadata.Add(new ControllerEndpointDataSourceIdMetadata(dataSource.DataSourceId));
             });
             return builder;
         }
@@ -507,9 +519,48 @@ namespace Microsoft.AspNetCore.Builder
 
             // Called for side-effect to make sure that the data source is registered.
             var controllerDataSource = GetOrCreateDataSource(endpoints);
-            
+            RegisterInCache(endpoints.ServiceProvider, controllerDataSource);
+
             // The data source is just used to share the common order with conventionally routed actions.
             controllerDataSource.AddDynamicControllerEndpoint(endpoints, pattern, typeof(TTransformer), state);
+        }
+
+        /// <summary>
+        /// Adds a specialized <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that will
+        /// attempt to select a controller action using the route values produced by <typeparamref name="TTransformer"/>.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The URL pattern of the route.</param>
+        /// <param name="state">A state object to provide to the <typeparamref name="TTransformer" /> instance.</param>
+        /// <param name="order">The matching order for the dynamic route.</param>
+        /// <typeparam name="TTransformer">The type of a <see cref="DynamicRouteValueTransformer"/>.</typeparam>
+        /// <remarks>
+        /// <para>
+        /// This method allows the registration of a <see cref="RouteEndpoint"/> and <see cref="DynamicRouteValueTransformer"/>
+        /// that combine to dynamically select a controller action using custom logic.
+        /// </para>
+        /// <para>
+        /// The instance of <typeparamref name="TTransformer"/> will be retrieved from the dependency injection container.
+        /// Register <typeparamref name="TTransformer"/> as transient in <c>ConfigureServices</c>. Using the transient lifetime
+        /// is required when using <paramref name="state" />.
+        /// </para>
+        /// </remarks>
+        public static void MapDynamicControllerRoute<TTransformer>(this IEndpointRouteBuilder endpoints, string pattern, object state, int order)
+            where TTransformer : DynamicRouteValueTransformer
+        {
+            if (endpoints == null)
+            {
+                throw new ArgumentNullException(nameof(endpoints));
+            }
+
+            EnsureControllerServices(endpoints);
+
+            // Called for side-effect to make sure that the data source is registered.
+            var controllerDataSource = GetOrCreateDataSource(endpoints);
+            RegisterInCache(endpoints.ServiceProvider, controllerDataSource);
+
+            // The data source is just used to share the common order with conventionally routed actions.
+            controllerDataSource.AddDynamicControllerEndpoint(endpoints, pattern, typeof(TTransformer), state, order);
         }
 
         private static DynamicControllerMetadata CreateDynamicControllerMetadata(string action, string controller, string area)
@@ -539,11 +590,19 @@ namespace Microsoft.AspNetCore.Builder
             var dataSource = endpoints.DataSources.OfType<ControllerActionEndpointDataSource>().FirstOrDefault();
             if (dataSource == null)
             {
-                dataSource = endpoints.ServiceProvider.GetRequiredService<ControllerActionEndpointDataSource>();
+                var orderProvider = endpoints.ServiceProvider.GetRequiredService<OrderedEndpointsSequenceProviderCache>();
+                var factory = endpoints.ServiceProvider.GetRequiredService<ControllerActionEndpointDataSourceFactory>();
+                dataSource = factory.Create(orderProvider.GetOrCreateOrderedEndpointsSequenceProvider(endpoints));
                 endpoints.DataSources.Add(dataSource);
             }
 
             return dataSource;
+        }
+
+        private static void RegisterInCache(IServiceProvider serviceProvider, ControllerActionEndpointDataSource dataSource)
+        {
+            var cache = serviceProvider.GetRequiredService<DynamicControllerEndpointSelectorCache>();
+            cache.AddDataSource(dataSource);
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -506,18 +506,10 @@ namespace Microsoft.AspNetCore.Builder
             EnsureControllerServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
-
-            endpoints.Map(
-                pattern, 
-                context =>
-                {
-                    throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
-                })
-                .Add(b =>
-                {
-                    b.Metadata.Add(new DynamicControllerRouteValueTransformerMetadata(typeof(TTransformer), state));
-                });
+            var controllerDataSource = GetOrCreateDataSource(endpoints);
+            
+            // The data source is just used to share the common order with conventionally routed actions.
+            controllerDataSource.AddDynamicControllerEndpoint(endpoints, pattern, typeof(TTransformer), state);
         }
 
         private static DynamicControllerMetadata CreateDynamicControllerMetadata(string action, string controller, string area)

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -269,10 +269,11 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             // Endpoint Routing / Endpoints
             //
-            services.TryAddSingleton<OrderedEndpointsSequenceProvider>();
-            services.TryAddSingleton<ControllerActionEndpointDataSource>();
+            services.TryAddSingleton<ControllerActionEndpointDataSourceFactory>();
+            services.TryAddSingleton<OrderedEndpointsSequenceProviderCache>();
+            services.TryAddSingleton<ControllerActionEndpointDataSourceIdProvider>();
             services.TryAddSingleton<ActionEndpointFactory>();
-            services.TryAddSingleton<DynamicControllerEndpointSelector>();
+            services.TryAddSingleton<DynamicControllerEndpointSelectorCache>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, DynamicControllerEndpointMatcherPolicy>());
 
             //

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -269,6 +269,7 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             // Endpoint Routing / Endpoints
             //
+            services.TryAddSingleton<OrderedEndpointsSequenceProvider>();
             services.TryAddSingleton<ControllerActionEndpointDataSource>();
             services.TryAddSingleton<ActionEndpointFactory>();
             services.TryAddSingleton<DynamicControllerEndpointSelector>();

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/OrderedEndpointsSequenceProvider.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/OrderedEndpointsSequenceProvider.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
+{
+    internal class OrderedEndpointsSequenceProvider
+    {
+        private object Lock = new object();
+
+        // In traditional conventional routing setup, the routes defined by a user have a order
+        // defined by how they are added into the list. We would like to maintain the same order when building
+        // up the endpoints too.
+        //
+        // Start with an order of '1' for conventional routes as attribute routes have a default order of '0'.
+        // This is for scenarios dealing with migrating existing Router based code to Endpoint Routing world.
+        private int _current = 1;
+
+        public int GetNext()
+        {
+            lock (Lock)
+            {
+                return _current++;
+            }
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Infrastructure/OrderedEndpointsSequenceProvider.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/OrderedEndpointsSequenceProvider.cs
@@ -1,26 +1,23 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Microsoft.AspNetCore.Mvc.Infrastructure
 {
     internal class OrderedEndpointsSequenceProvider
     {
-        private object Lock = new object();
-
         // In traditional conventional routing setup, the routes defined by a user have a order
         // defined by how they are added into the list. We would like to maintain the same order when building
         // up the endpoints too.
         //
         // Start with an order of '1' for conventional routes as attribute routes have a default order of '0'.
         // This is for scenarios dealing with migrating existing Router based code to Endpoint Routing world.
-        private int _current = 1;
+        private int _current = 0;
 
         public int GetNext()
         {
-            lock (Lock)
-            {
-                return _current++;
-            }
+            return Interlocked.Increment(ref _current);
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/OrderedEndpointsSequenceProviderCache.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/OrderedEndpointsSequenceProviderCache.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
+{
+    internal class OrderedEndpointsSequenceProviderCache
+    {
+        private readonly ConcurrentDictionary<IEndpointRouteBuilder, OrderedEndpointsSequenceProvider> _sequenceProviderCache = new();
+
+        public OrderedEndpointsSequenceProvider GetOrCreateOrderedEndpointsSequenceProvider(IEndpointRouteBuilder endpoints)
+        {
+            return _sequenceProviderCache.GetOrAdd(endpoints, new OrderedEndpointsSequenceProvider());
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSource.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,26 +15,18 @@ namespace Microsoft.AspNetCore.Mvc.Routing
     internal class ControllerActionEndpointDataSource : ActionEndpointDataSourceBase
     {
         private readonly ActionEndpointFactory _endpointFactory;
+        private readonly OrderedEndpointsSequenceProvider _orderSequence;
         private readonly List<ConventionalRouteEntry> _routes;
-
-        private int _order;
 
         public ControllerActionEndpointDataSource(
             IActionDescriptorCollectionProvider actions,
-            ActionEndpointFactory endpointFactory)
+            ActionEndpointFactory endpointFactory,
+            OrderedEndpointsSequenceProvider orderSequence)
             : base(actions)
         {
             _endpointFactory = endpointFactory;
-
+            _orderSequence = orderSequence;
             _routes = new List<ConventionalRouteEntry>();
-
-            // In traditional conventional routing setup, the routes defined by a user have a order
-            // defined by how they are added into the list. We would like to maintain the same order when building
-            // up the endpoints too.
-            //
-            // Start with an order of '1' for conventional routes as attribute routes have a default order of '0'.
-            // This is for scenarios dealing with migrating existing Router based code to Endpoint Routing world.
-            _order = 1;
 
             DefaultBuilder = new ControllerActionEndpointConventionBuilder(Lock, Conventions);
 
@@ -59,7 +51,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             lock (Lock)
             {
                 var conventions = new List<Action<EndpointBuilder>>();
-                _routes.Add(new ConventionalRouteEntry(routeName, pattern, defaults, constraints, dataTokens, _order++, conventions));
+                _routes.Add(new ConventionalRouteEntry(routeName, pattern, defaults, constraints, dataTokens, _orderSequence.GetNext(), conventions));
                 return new ControllerActionEndpointConventionBuilder(Lock, conventions);
             }
         }
@@ -107,6 +99,27 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             }
 
             return endpoints;
+        }
+
+        internal void AddDynamicControllerEndpoint(IEndpointRouteBuilder endpoints, string pattern, Type transformerType, object state)
+        {
+            CreateInertEndpoints = true;
+            lock (Lock)
+            {
+                var order = _orderSequence.GetNext();
+
+                endpoints.Map(
+                    pattern,
+                    context =>
+                    {
+                        throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
+                    })
+                    .Add(b =>
+                    {
+                        ((RouteEndpointBuilder)b).Order = order;
+                        b.Metadata.Add(new DynamicControllerRouteValueTransformerMetadata(transformerType, state));
+                    });
+            }
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSourceFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSourceFactory.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.Routing;
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure
+{
+    internal class ControllerActionEndpointDataSourceFactory
+    {
+        private readonly ControllerActionEndpointDataSourceIdProvider _dataSourceIdProvider;
+        private readonly IActionDescriptorCollectionProvider _actions;
+        private readonly ActionEndpointFactory _factory;
+
+        public ControllerActionEndpointDataSourceFactory(
+            ControllerActionEndpointDataSourceIdProvider dataSourceIdProvider,
+            IActionDescriptorCollectionProvider actions,
+            ActionEndpointFactory factory)
+        {
+            _dataSourceIdProvider = dataSourceIdProvider;
+            _actions = actions;
+            _factory = factory;
+        }
+
+        public ControllerActionEndpointDataSource Create(OrderedEndpointsSequenceProvider orderProvider)
+        {
+            return new ControllerActionEndpointDataSource(_dataSourceIdProvider, _actions, _factory, orderProvider);
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSourceIdProvider.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerActionEndpointDataSourceIdProvider.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Mvc.Routing
+{
+    internal class ControllerActionEndpointDataSourceIdProvider
+    {
+        private int _nextId = 1;
+
+        internal int CreateId()
+        {
+            return Interlocked.Increment(ref _nextId);
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Routing/ControllerEndpointDataSourceIdMetadata.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerEndpointDataSourceIdMetadata.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.Routing
+{
+    internal class ControllerEndpointDataSourceIdMetadata
+    {
+        public ControllerEndpointDataSourceIdMetadata(int id)
+        {
+            Id = id;
+        }
+
+        public int Id { get; }
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointSelector.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointSelector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,24 +11,14 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 {
     internal class DynamicControllerEndpointSelector : IDisposable
     {
-        private readonly EndpointDataSource _dataSource;
         private readonly DataSourceDependentCache<ActionSelectionTable<Endpoint>> _cache;
 
-        public DynamicControllerEndpointSelector(ControllerActionEndpointDataSource dataSource)
-            : this((EndpointDataSource)dataSource)
-        {
-        }
-
-        // Exposed for tests. We need to accept a more specific type in the constructor for DI
-        // to work.
-        protected DynamicControllerEndpointSelector(EndpointDataSource dataSource)
+        public DynamicControllerEndpointSelector(EndpointDataSource dataSource)
         {
             if (dataSource == null)
             {
                 throw new ArgumentNullException(nameof(dataSource));
             }
-
-            _dataSource = dataSource;
 
             _cache = new DataSourceDependentCache<ActionSelectionTable<Endpoint>>(dataSource, Initialize);
         }

--- a/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointSelectorCache.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointSelectorCache.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Mvc.Routing
+{
+    internal class DynamicControllerEndpointSelectorCache
+    {
+        private readonly ConcurrentDictionary<int, EndpointDataSource> _dataSourceCache = new();
+        private readonly ConcurrentDictionary<int, DynamicControllerEndpointSelector> _endpointSelectorCache = new();
+
+        public void AddDataSource(ControllerActionEndpointDataSource dataSource)
+        {
+            _dataSourceCache.GetOrAdd(dataSource.DataSourceId, dataSource);
+        }
+
+        // For testing purposes only
+        internal void AddDataSource(EndpointDataSource dataSource, int key) =>
+            _dataSourceCache.GetOrAdd(key, dataSource);
+
+        public DynamicControllerEndpointSelector GetEndpointSelector(Endpoint endpoint)
+        {
+            if (endpoint?.Metadata == null)
+            {
+                return null;
+            }
+
+            var dataSourceId = endpoint.Metadata.GetMetadata<ControllerEndpointDataSourceIdMetadata>();
+            return _endpointSelectorCache.GetOrAdd(dataSourceId.Id, key => EnsureDataSource(key));
+        }
+
+        private DynamicControllerEndpointSelector EnsureDataSource(int key)
+        {
+            if (!_dataSourceCache.TryGetValue(key, out var dataSource))
+            {
+                throw new InvalidOperationException($"Data source with key '{key}' not registered.");
+            }
+
+            return new DynamicControllerEndpointSelector(dataSource);
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/test/Routing/ControllerActionEndpointDataSourceTest.cs
+++ b/src/Mvc/Mvc.Core/test/Routing/ControllerActionEndpointDataSourceTest.cs
@@ -245,8 +245,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
             var dataSource = (ControllerActionEndpointDataSource)CreateDataSource(mockDescriptorProvider.Object);
             dataSource.AddRoute("1", "/1/{controller}/{action}/{id?}", null, null, null);
             dataSource.AddRoute("2", "/2/{controller}/{action}/{id?}", null, null, null);
-            
-            
+
             dataSource.DefaultBuilder.Add(b =>
             {
                 if (b.Metadata.OfType<ActionDescriptor>().FirstOrDefault()?.AttributeRouteInfo != null)
@@ -385,7 +384,11 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
         private protected override ActionEndpointDataSourceBase CreateDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
         {
-            return new ControllerActionEndpointDataSource(actions, endpointFactory, new OrderedEndpointsSequenceProvider());
+            return new ControllerActionEndpointDataSource(
+                new ControllerActionEndpointDataSourceIdProvider(),
+                actions,
+                endpointFactory,
+                new OrderedEndpointsSequenceProvider());
         }
 
         protected override ActionDescriptor CreateActionDescriptor(

--- a/src/Mvc/Mvc.Core/test/Routing/ControllerActionEndpointDataSourceTest.cs
+++ b/src/Mvc/Mvc.Core/test/Routing/ControllerActionEndpointDataSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -385,7 +385,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
 
         private protected override ActionEndpointDataSourceBase CreateDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
         {
-            return new ControllerActionEndpointDataSource(actions, endpointFactory);
+            return new ControllerActionEndpointDataSource(actions, endpointFactory, new OrderedEndpointsSequenceProvider());
         }
 
         protected override ActionDescriptor CreateActionDescriptor(

--- a/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -75,7 +76,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureRazorPagesServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var pageDataSource = GetOrCreateDataSource(endpoints);
+            pageDataSource.CreateInertEndpoints = true;
+            RegisterInCache(endpoints.ServiceProvider, pageDataSource);
 
             // Maps a fallback endpoint with an empty delegate. This is OK because
             // we don't expect the delegate to run.
@@ -84,6 +87,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 // MVC registers a policy that looks for this metadata.
                 b.Metadata.Add(CreateDynamicPageMetadata(page, area: null));
+                b.Metadata.Add(new PageEndpointDataSourceIdMetadata(pageDataSource.DataSourceId));
             });
             return builder;
         }
@@ -141,7 +145,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureRazorPagesServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var pageDataSource = GetOrCreateDataSource(endpoints);
+            pageDataSource.CreateInertEndpoints = true;
+            RegisterInCache(endpoints.ServiceProvider, pageDataSource);
 
             // Maps a fallback endpoint with an empty delegate. This is OK because
             // we don't expect the delegate to run.
@@ -150,6 +156,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 // MVC registers a policy that looks for this metadata.
                 b.Metadata.Add(CreateDynamicPageMetadata(page, area: null));
+                b.Metadata.Add(new PageEndpointDataSourceIdMetadata(pageDataSource.DataSourceId));
             });
             return builder;
         }
@@ -199,7 +206,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureRazorPagesServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var pageDataSource = GetOrCreateDataSource(endpoints);
+            pageDataSource.CreateInertEndpoints = true;
+            RegisterInCache(endpoints.ServiceProvider, pageDataSource);
 
             // Maps a fallback endpoint with an empty delegate. This is OK because
             // we don't expect the delegate to run.
@@ -208,6 +217,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 // MVC registers a policy that looks for this metadata.
                 b.Metadata.Add(CreateDynamicPageMetadata(page, area));
+                b.Metadata.Add(new PageEndpointDataSourceIdMetadata(pageDataSource.DataSourceId));
             });
             return builder;
         }
@@ -267,7 +277,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureRazorPagesServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var pageDataSource = GetOrCreateDataSource(endpoints);
+            pageDataSource.CreateInertEndpoints = true;
+            RegisterInCache(endpoints.ServiceProvider, pageDataSource);
 
             // Maps a fallback endpoint with an empty delegate. This is OK because
             // we don't expect the delegate to run.
@@ -276,6 +288,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 // MVC registers a policy that looks for this metadata.
                 b.Metadata.Add(CreateDynamicPageMetadata(page, area));
+                b.Metadata.Add(new PageEndpointDataSourceIdMetadata(pageDataSource.DataSourceId));
             });
             return builder;
         }
@@ -337,9 +350,51 @@ namespace Microsoft.AspNetCore.Builder
             EnsureRazorPagesServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            var dataSource = GetOrCreateDataSource(endpoints);
+            var pageDataSource = GetOrCreateDataSource(endpoints);
+            RegisterInCache(endpoints.ServiceProvider, pageDataSource);
 
-            dataSource.AddDynamicPageEndpoint(endpoints, pattern, typeof(TTransformer), state);
+            pageDataSource.AddDynamicPageEndpoint(endpoints, pattern, typeof(TTransformer), state);
+        }
+
+        /// <summary>
+        /// Adds a specialized <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that will
+        /// attempt to select a page using the route values produced by <typeparamref name="TTransformer"/>.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The URL pattern of the route.</param>
+        /// <param name="state">A state object to provide to the <typeparamref name="TTransformer" /> instance.</param>
+        /// <param name="order">The matching order for the dynamic route.</param>
+        /// <typeparam name="TTransformer">The type of a <see cref="DynamicRouteValueTransformer"/>.</typeparam>
+        /// <remarks>
+        /// <para>
+        /// This method allows the registration of a <see cref="RouteEndpoint"/> and <see cref="DynamicRouteValueTransformer"/>
+        /// that combine to dynamically select a page using custom logic.
+        /// </para>
+        /// <para>
+        /// The instance of <typeparamref name="TTransformer"/> will be retrieved from the dependency injection container.
+        /// Register <typeparamref name="TTransformer"/> with the desired service lifetime in <c>ConfigureServices</c>.
+        /// </para>
+        /// </remarks>
+        public static void MapDynamicPageRoute<TTransformer>(this IEndpointRouteBuilder endpoints, string pattern, object state, int order)
+            where TTransformer : DynamicRouteValueTransformer
+        {
+            if (endpoints == null)
+            {
+                throw new ArgumentNullException(nameof(endpoints));
+            }
+
+            if (pattern == null)
+            {
+                throw new ArgumentNullException(nameof(pattern));
+            }
+
+            EnsureRazorPagesServices(endpoints);
+
+            // Called for side-effect to make sure that the data source is registered.
+            var pageDataSource = GetOrCreateDataSource(endpoints);
+            RegisterInCache(endpoints.ServiceProvider, pageDataSource);
+
+            pageDataSource.AddDynamicPageEndpoint(endpoints, pattern, typeof(TTransformer), state, order);
         }
 
         private static DynamicPageMetadata CreateDynamicPageMetadata(string page, string area)
@@ -353,7 +408,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private static void EnsureRazorPagesServices(IEndpointRouteBuilder endpoints)
         {
-            var marker = endpoints.ServiceProvider.GetService<PageActionEndpointDataSource>();
+            var marker = endpoints.ServiceProvider.GetService<PageActionEndpointDataSourceFactory>();
             if (marker == null)
             {
                 throw new InvalidOperationException(Mvc.Core.Resources.FormatUnableToFindServices(
@@ -368,11 +423,19 @@ namespace Microsoft.AspNetCore.Builder
             var dataSource = endpoints.DataSources.OfType<PageActionEndpointDataSource>().FirstOrDefault();
             if (dataSource == null)
             {
-                dataSource = endpoints.ServiceProvider.GetRequiredService<PageActionEndpointDataSource>();
+                var orderProviderCache = endpoints.ServiceProvider.GetRequiredService<OrderedEndpointsSequenceProviderCache>();
+                var factory = endpoints.ServiceProvider.GetRequiredService<PageActionEndpointDataSourceFactory>();
+                dataSource = factory.Create(orderProviderCache.GetOrCreateOrderedEndpointsSequenceProvider(endpoints));
                 endpoints.DataSources.Add(dataSource);
             }
 
             return dataSource;
+        }
+
+        private static void RegisterInCache(IServiceProvider serviceProvider, PageActionEndpointDataSource dataSource)
+        {
+            var cache = serviceProvider.GetRequiredService<DynamicPageEndpointSelectorCache>();
+            cache.AddDataSource(dataSource);
         }
     }
 }

--- a/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
@@ -337,18 +337,9 @@ namespace Microsoft.AspNetCore.Builder
             EnsureRazorPagesServices(endpoints);
 
             // Called for side-effect to make sure that the data source is registered.
-            GetOrCreateDataSource(endpoints).CreateInertEndpoints = true;
+            var dataSource = GetOrCreateDataSource(endpoints);
 
-            endpoints.Map(
-                pattern,
-                context =>
-                {
-                    throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
-                })
-                .Add(b =>
-                {
-                    b.Metadata.Add(new DynamicPageRouteValueTransformerMetadata(typeof(TTransformer), state));
-                });
+            dataSource.AddDynamicPageEndpoint(endpoints, pattern, typeof(TTransformer), state);
         }
 
         private static DynamicPageMetadata CreateDynamicPageMetadata(string page, string area)

--- a/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcCoreBuilderExtensions.cs
@@ -89,15 +89,15 @@ namespace Microsoft.Extensions.DependencyInjection
             // Routing
             services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, PageLoaderMatcherPolicy>());
             services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, DynamicPageEndpointMatcherPolicy>());
-            services.TryAddSingleton<DynamicPageEndpointSelector>();
+            services.TryAddSingleton<DynamicPageEndpointSelectorCache>();
+            services.TryAddSingleton<PageActionEndpointDataSourceIdProvider>();
 
             // Action description and invocation
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IActionDescriptorProvider, PageActionDescriptorProvider>());
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IPageRouteModelProvider, CompiledPageRouteModelProvider>());
-            services.TryAddSingleton<PageActionEndpointDataSource>();
-            services.TryAddSingleton<DynamicPageEndpointSelector>();
+            services.TryAddSingleton<PageActionEndpointDataSourceFactory>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, DynamicPageEndpointMatcherPolicy>());
 
             services.TryAddEnumerable(

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/DynamicPageEndpointSelector.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/DynamicPageEndpointSelector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -14,14 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         private readonly EndpointDataSource _dataSource;
         private readonly DataSourceDependentCache<ActionSelectionTable<Endpoint>> _cache;
 
-        public DynamicPageEndpointSelector(PageActionEndpointDataSource dataSource)
-            : this((EndpointDataSource)dataSource)
-        {
-        }
-
-        // Exposed for tests. We need to accept a more specific type in the constructor for DI
-        // to work.
-        protected DynamicPageEndpointSelector(EndpointDataSource dataSource)
+        public DynamicPageEndpointSelector(EndpointDataSource dataSource)
         {
             if (dataSource == null)
             {

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/DynamicPageEndpointSelectorCache.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/DynamicPageEndpointSelectorCache.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
+{
+    internal class DynamicPageEndpointSelectorCache
+    {
+        private readonly ConcurrentDictionary<int, EndpointDataSource> _dataSourceCache = new();
+        private readonly ConcurrentDictionary<int, DynamicPageEndpointSelector> _endpointSelectorCache = new();
+
+        public void AddDataSource(PageActionEndpointDataSource dataSource)
+        {
+            _dataSourceCache.GetOrAdd(dataSource.DataSourceId, dataSource);
+        }
+
+        // For testing purposes only
+        internal void AddDataSource(EndpointDataSource dataSource, int key) =>
+            _dataSourceCache.GetOrAdd(key, dataSource);
+
+        public DynamicPageEndpointSelector GetEndpointSelector(Endpoint endpoint)
+        {
+            if (endpoint?.Metadata == null)
+            {
+                return null;
+            }
+
+            var dataSourceId = endpoint.Metadata.GetMetadata<PageEndpointDataSourceIdMetadata>();
+            return _endpointSelectorCache.GetOrAdd(dataSourceId.Id, key => EnsureDataSource(key));
+        }
+
+        private DynamicPageEndpointSelector EnsureDataSource(int key)
+        {
+            if (!_dataSourceCache.TryGetValue(key, out var dataSource))
+            {
+                throw new InvalidOperationException($"Data source with key '{key}' not registered.");
+            }
+
+            return new DynamicPageEndpointSelector(dataSource);
+        }
+    }
+}

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSource.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,18 +8,23 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 {
     internal class PageActionEndpointDataSource : ActionEndpointDataSourceBase
     {
         private readonly ActionEndpointFactory _endpointFactory;
+        private readonly OrderedEndpointsSequenceProvider _orderSequence;
 
-        public PageActionEndpointDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
+        public PageActionEndpointDataSource(
+            IActionDescriptorCollectionProvider actions,
+            ActionEndpointFactory endpointFactory,
+            OrderedEndpointsSequenceProvider orderedEndpoints)
             : base(actions)
         {
             _endpointFactory = endpointFactory;
-
+            _orderSequence = orderedEndpoints;
             DefaultBuilder = new PageActionEndpointConventionBuilder(Lock, Conventions);
 
             // IMPORTANT: this needs to be the last thing we do in the constructor.
@@ -46,6 +51,27 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             }
 
             return endpoints;
+        }
+
+        internal void AddDynamicPageEndpoint(IEndpointRouteBuilder endpoints, string pattern, Type transformerType, object state)
+        {
+            CreateInertEndpoints = true;
+            lock (Lock)
+            {
+                var order = _orderSequence.GetNext();
+
+                endpoints.Map(
+                    pattern,
+                    context =>
+                    {
+                        throw new InvalidOperationException("This endpoint is not expected to be executed directly.");
+                    })
+                    .Add(b =>
+                    {
+                        ((RouteEndpointBuilder)b).Order = order;
+                        b.Metadata.Add(new DynamicPageRouteValueTransformerMetadata(transformerType, state));
+                    });
+            }
         }
     }
 }

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSourceFactory.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSourceFactory.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
+
+namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
+{
+    internal class PageActionEndpointDataSourceFactory
+    {
+        private readonly PageActionEndpointDataSourceIdProvider _dataSourceIdProvider;
+        private readonly IActionDescriptorCollectionProvider _actions;
+        private readonly ActionEndpointFactory _endpointFactory;
+
+        public PageActionEndpointDataSourceFactory(
+            PageActionEndpointDataSourceIdProvider dataSourceIdProvider,
+            IActionDescriptorCollectionProvider actions,
+            ActionEndpointFactory endpointFactory)
+        {
+            _dataSourceIdProvider = dataSourceIdProvider;
+            _actions = actions;
+            _endpointFactory = endpointFactory;
+        }
+
+        public PageActionEndpointDataSource Create(OrderedEndpointsSequenceProvider orderProvider)
+        {
+            return new PageActionEndpointDataSource(_dataSourceIdProvider, _actions, _endpointFactory, orderProvider);
+        }
+    }
+}

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSourceIdProvider.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSourceIdProvider.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
+{
+    internal class PageActionEndpointDataSourceIdProvider
+    {
+        private int _nextId = 1;
+
+        internal int CreateId()
+        {
+            return Interlocked.Increment(ref _nextId);
+        }
+    }
+}

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageEndpointDataSourceIdMetadata.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageEndpointDataSourceIdMetadata.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
+{
+    internal class PageEndpointDataSourceIdMetadata
+    {
+        public PageEndpointDataSourceIdMetadata(int id)
+        {
+            Id = id;
+        }
+
+        public int Id { get; }
+    }
+}

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/DynamicPageEndpointMatcherPolicyTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/DynamicPageEndpointMatcherPolicyTest.cs
@@ -51,12 +51,13 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 new EndpointMetadataCollection(new object[]
                 {
                     new DynamicPageRouteValueTransformerMetadata(typeof(CustomTransformer), State),
+                    new PageEndpointDataSourceIdMetadata(1),
                 }),
                 "dynamic");
 
             DataSource = new DefaultEndpointDataSource(PageEndpoints);
 
-            Selector = new TestDynamicPageEndpointSelector(DataSource);
+            SelectorCache = new TestDynamicPageEndpointSelectorCache(DataSource);
 
             var services = new ServiceCollection();
             services.AddRouting();
@@ -106,7 +107,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
         private PageLoader Loader { get; }
 
-        private DynamicPageEndpointSelector Selector { get; }
+        private DynamicPageEndpointSelectorCache SelectorCache { get; }
 
         private object State { get; }
 
@@ -120,7 +121,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         public async Task ApplyAsync_NoMatch()
         {
             // Arrange
-            var policy = new DynamicPageEndpointMatcherPolicy(Selector, Loader, Comparer);
+            var policy = new DynamicPageEndpointMatcherPolicy(SelectorCache, Loader, Comparer);
 
             var endpoints = new[] { DynamicEndpoint, };
             var values = new RouteValueDictionary[] { null, };
@@ -150,7 +151,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         public async Task ApplyAsync_HasMatchNoEndpointFound()
         {
             // Arrange
-            var policy = new DynamicPageEndpointMatcherPolicy(Selector, Loader, Comparer);
+            var policy = new DynamicPageEndpointMatcherPolicy(SelectorCache, Loader, Comparer);
 
             var endpoints = new[] { DynamicEndpoint, };
             var values = new RouteValueDictionary[] { null, };
@@ -181,7 +182,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         public async Task ApplyAsync_HasMatchFindsEndpoint_WithoutRouteValues()
         {
             // Arrange
-            var policy = new DynamicPageEndpointMatcherPolicy(Selector, Loader, Comparer);
+            var policy = new DynamicPageEndpointMatcherPolicy(SelectorCache, Loader, Comparer);
 
             var endpoints = new[] { DynamicEndpoint, };
             var values = new RouteValueDictionary[] { null, };
@@ -221,7 +222,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         public async Task ApplyAsync_HasMatchFindsEndpoint_WithRouteValues()
         {
             // Arrange
-            var policy = new DynamicPageEndpointMatcherPolicy(Selector, Loader, Comparer);
+            var policy = new DynamicPageEndpointMatcherPolicy(SelectorCache, Loader, Comparer);
 
             var endpoints = new[] { DynamicEndpoint, };
             var values = new RouteValueDictionary[] { new RouteValueDictionary(new { slug = "test", }), };
@@ -272,7 +273,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         public async Task ApplyAsync_Throws_ForTransformersWithInvalidLifetime()
         {
             // Arrange
-            var policy = new DynamicPageEndpointMatcherPolicy(Selector, Loader, Comparer);
+            var policy = new DynamicPageEndpointMatcherPolicy(SelectorCache, Loader, Comparer);
 
             var endpoints = new[] { DynamicEndpoint, };
             var values = new RouteValueDictionary[] { new RouteValueDictionary(new { slug = "test", }), };
@@ -302,7 +303,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         public async Task ApplyAsync_CanDiscardFoundEndpoints()
         {
             // Arrange
-            var policy = new DynamicPageEndpointMatcherPolicy(Selector, Loader, Comparer);
+            var policy = new DynamicPageEndpointMatcherPolicy(SelectorCache, Loader, Comparer);
 
             var endpoints = new[] { DynamicEndpoint, };
             var values = new RouteValueDictionary[] { new RouteValueDictionary(new { slug = "test", }), };
@@ -340,7 +341,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         public async Task ApplyAsync_CanReplaceFoundEndpoints()
         {
             // Arrange
-            var policy = new DynamicPageEndpointMatcherPolicy(Selector, Loader, Comparer);
+            var policy = new DynamicPageEndpointMatcherPolicy(SelectorCache, Loader, Comparer);
 
             var endpoints = new[] { DynamicEndpoint, };
             var values = new RouteValueDictionary[] { new RouteValueDictionary(new { slug = "test", }), };
@@ -400,7 +401,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         public async Task ApplyAsync_CanExpandTheListOfFoundEndpoints()
         {
             // Arrange
-            var policy = new DynamicPageEndpointMatcherPolicy(Selector, Loader, Comparer);
+            var policy = new DynamicPageEndpointMatcherPolicy(SelectorCache, Loader, Comparer);
 
             var endpoints = new[] { DynamicEndpoint, };
             var values = new RouteValueDictionary[] { new RouteValueDictionary(new { slug = "test", }), };
@@ -438,11 +439,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             Assert.Same(LoadedEndpoints[1], candidates[1].Endpoint);
         }
 
-        private class TestDynamicPageEndpointSelector : DynamicPageEndpointSelector
+        private class TestDynamicPageEndpointSelectorCache : DynamicPageEndpointSelectorCache
         {
-            public TestDynamicPageEndpointSelector(EndpointDataSource dataSource)
-                : base(dataSource)
+            public TestDynamicPageEndpointSelectorCache(EndpointDataSource dataSource)
             {
+                AddDataSource(dataSource, 1);
             }
         }
 

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionEndpointDataSourceTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionEndpointDataSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
         private protected override ActionEndpointDataSourceBase CreateDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
         {
-            return new PageActionEndpointDataSource(actions, endpointFactory);
+            return new PageActionEndpointDataSource(actions, endpointFactory, new OrderedEndpointsSequenceProvider());
         }
 
         protected override ActionDescriptor CreateActionDescriptor(

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionEndpointDataSourceTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionEndpointDataSourceTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
         private protected override ActionEndpointDataSourceBase CreateDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
         {
-            return new PageActionEndpointDataSource(actions, endpointFactory, new OrderedEndpointsSequenceProvider());
+            return new PageActionEndpointDataSource(new PageActionEndpointDataSourceIdProvider(), actions, endpointFactory, new OrderedEndpointsSequenceProvider());
         }
 
         protected override ActionDescriptor CreateActionDescriptor(

--- a/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance/ControllerActionEndpointDatasourceBenchmark.cs
+++ b/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance/ControllerActionEndpointDatasourceBenchmark.cs
@@ -109,6 +109,7 @@ namespace Microsoft.AspNetCore.Mvc.Performance
         private ControllerActionEndpointDataSource CreateDataSource(IActionDescriptorCollectionProvider actionDescriptorCollectionProvider)
         {
             var dataSource = new ControllerActionEndpointDataSource(
+                new ControllerActionEndpointDataSourceIdProvider(),
                 actionDescriptorCollectionProvider,
                 new ActionEndpointFactory(new MockRoutePatternTransformer()),
                 new OrderedEndpointsSequenceProvider());

--- a/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance/ControllerActionEndpointDatasourceBenchmark.cs
+++ b/src/Mvc/benchmarks/Microsoft.AspNetCore.Mvc.Performance/ControllerActionEndpointDatasourceBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -110,7 +110,8 @@ namespace Microsoft.AspNetCore.Mvc.Performance
         {
             var dataSource = new ControllerActionEndpointDataSource(
                 actionDescriptorCollectionProvider,
-                new ActionEndpointFactory(new MockRoutePatternTransformer()));
+                new ActionEndpointFactory(new MockRoutePatternTransformer()),
+                new OrderedEndpointsSequenceProvider());
 
             return dataSource;
         }

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingAcrossPipelineBranchesTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingAcrossPipelineBranchesTest.cs
@@ -1,0 +1,172 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using RoutingWebSite;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests
+{
+    public class RoutingAcrossPipelineBranchesTests : IClassFixture<MvcTestFixture<RoutingWebSite.StartupRoutingDifferentBranches>>
+    {
+        public RoutingAcrossPipelineBranchesTests(MvcTestFixture<RoutingWebSite.StartupRoutingDifferentBranches> fixture)
+        {
+            Factory = fixture.Factories.FirstOrDefault() ?? fixture.WithWebHostBuilder(ConfigureWebHostBuilder);
+        }
+
+        private static void ConfigureWebHostBuilder(IWebHostBuilder builder) => builder.UseStartup<RoutingWebSite.StartupRoutingDifferentBranches>();
+
+        public WebApplicationFactory<StartupRoutingDifferentBranches> Factory { get; }
+
+        [Fact]
+        public async Task MatchesConventionalRoutesInTheirBranches()
+        {
+            var client = Factory.CreateClient();
+
+            // Arrange
+            var subdirRequest = new HttpRequestMessage(HttpMethod.Get, "subdir/literal/Branches/Index/s");
+            var commonRequest = new HttpRequestMessage(HttpMethod.Get, "common/Branches/Index/c/literal");
+            var defaultRequest = new HttpRequestMessage(HttpMethod.Get, "Branches/literal/Index/d");
+
+            // Act
+            var subdirResponse = await client.SendAsync(subdirRequest);
+            var subdirContent = await subdirResponse.Content.ReadFromJsonAsync<RouteInfo>();
+
+            var commonResponse = await client.SendAsync(commonRequest);
+            var commonContent = await commonResponse.Content.ReadFromJsonAsync<RouteInfo>();
+
+            var defaultResponse = await client.SendAsync(defaultRequest);
+            var defaultContent = await defaultResponse.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, subdirResponse.StatusCode);
+            Assert.True(subdirContent.RouteValues.TryGetValue("subdir", out var subdir));
+            Assert.Equal("s", subdir);
+
+            Assert.Equal(HttpStatusCode.OK, commonResponse.StatusCode);
+            Assert.True(commonContent.RouteValues.TryGetValue("common", out var common));
+            Assert.Equal("c", common);
+
+            Assert.Equal(HttpStatusCode.OK, defaultResponse.StatusCode);
+            Assert.True(defaultContent.RouteValues.TryGetValue("default", out var @default));
+            Assert.Equal("d", @default);
+        }
+
+        [Fact]
+        public async Task LinkGenerationWorksOnEachBranch()
+        {
+            var client = Factory.CreateClient();
+            var linkQuery = "?link";
+
+                // Arrange
+            var subdirRequest = new HttpRequestMessage(HttpMethod.Get, "subdir/literal/Branches/Index/s" + linkQuery);
+            var commonRequest = new HttpRequestMessage(HttpMethod.Get, "common/Branches/Index/c/literal" + linkQuery);
+            var defaultRequest = new HttpRequestMessage(HttpMethod.Get, "Branches/literal/Index/d" + linkQuery);
+
+            // Act
+            var subdirResponse = await client.SendAsync(subdirRequest);
+            var subdirContent = await subdirResponse.Content.ReadFromJsonAsync<RouteInfo>();
+
+            var commonResponse = await client.SendAsync(commonRequest);
+            var commonContent = await commonResponse.Content.ReadFromJsonAsync<RouteInfo>();
+
+            var defaultResponse = await client.SendAsync(defaultRequest);
+            var defaultContent = await defaultResponse.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, subdirResponse.StatusCode);
+            Assert.Equal("/subdir/literal/Branches/Index/s", subdirContent.Link);
+
+            Assert.Equal(HttpStatusCode.OK, commonResponse.StatusCode);
+            Assert.Equal("/common/Branches/Index/c/literal", commonContent.Link);
+
+            Assert.Equal(HttpStatusCode.OK, defaultResponse.StatusCode);
+            Assert.Equal("/Branches/literal/Index/d", defaultContent.Link);
+        }
+
+        // This still works because even though each middleware now gets its own data source,
+        // those data sources still get added to a global collection in IOptions<RouteOptions>>.DataSources
+        [Fact]
+        public async Task LinkGenerationStillWorksAcrossBranches()
+        {
+            var client = Factory.CreateClient();
+            var linkQuery = "?link";
+
+            // Arrange
+            var subdirRequest = new HttpRequestMessage(HttpMethod.Get, "subdir/literal/Branches/Index/s" + linkQuery + "&link_common=c&link_subdir");
+            var defaultRequest = new HttpRequestMessage(HttpMethod.Get, "Branches/literal/Index/d" + linkQuery + "&link_subdir=s");
+
+            // Act
+            var subdirResponse = await client.SendAsync(subdirRequest);
+            var subdirContent = await subdirResponse.Content.ReadFromJsonAsync<RouteInfo>();
+
+            var defaultResponse = await client.SendAsync(defaultRequest);
+            var defaultContent = await defaultResponse.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, subdirResponse.StatusCode);
+            // Note that this link and the one below don't account for the path base being in a different branch.
+            // The recommendation for customers doing link generation across branches will be to always generate absolute
+            // URIs by explicitly passing the path base to the link generator.
+            // In the future there are improvements we might be able to do in most common cases to lift this limitation if we receive
+            // feedback about it.
+            Assert.Equal("/subdir/Branches/Index/c/literal", subdirContent.Link);
+
+            Assert.Equal(HttpStatusCode.OK, defaultResponse.StatusCode);
+            Assert.Equal("/literal/Branches/Index/s", defaultContent.Link);
+        }
+
+        [Fact]
+        public async Task DoesNotMatchConventionalRoutesDefinedInOtherBranches()
+        {
+            var client = Factory.CreateClient();
+
+            // Arrange
+            var commonRequest = new HttpRequestMessage(HttpMethod.Get, "common/literal/Branches/Index/s");
+            var subdirRequest = new HttpRequestMessage(HttpMethod.Get, "subdir/Branches/Index/c/literal");
+            var defaultRequest = new HttpRequestMessage(HttpMethod.Get, "common/Branches/literal/Index/d");
+
+            // Act
+            var commonResponse = await client.SendAsync(commonRequest);
+
+            var subdirResponse = await client.SendAsync(subdirRequest);
+
+            var defaultResponse = await client.SendAsync(defaultRequest);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, commonResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, subdirResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, defaultResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task ConventionalAndDynamicRouteOrdersAreScopedPerBranch()
+        {
+            var client = Factory.CreateClient();
+
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "dynamicattributeorder/dynamic/route/rest");
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(content.RouteValues.TryGetValue("action", out var action));
+
+            // The dynamic route wins because it has Order 1 (scope to that router) and
+            // has higher precedence.
+            Assert.Equal("Index", action);
+        }
+
+        private record RouteInfo(string RouteName, IDictionary<string, string> RouteValues, string Link);
+    }
+}

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingDynamicOrderTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingDynamicOrderTest.cs
@@ -1,0 +1,165 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using RoutingWebSite;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests
+{
+    public class RoutingDynamicOrderTest : IClassFixture<MvcTestFixture<RoutingWebSite.StartupForDynamic>>
+    {
+        public RoutingDynamicOrderTest(MvcTestFixture<RoutingWebSite.StartupForDynamic> fixture)
+        {
+            Factory = fixture.Factories.FirstOrDefault() ?? fixture.WithWebHostBuilder(ConfigureWebHostBuilder);
+        }
+
+        private static void ConfigureWebHostBuilder(IWebHostBuilder builder) => builder.UseStartup<RoutingWebSite.StartupForDynamicOrder>();
+
+        public WebApplicationFactory<StartupForDynamic> Factory { get; }
+
+        [Fact]
+        public async Task PrefersAttributeRoutesOverDynamicControllerRoutes()
+        {
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.AttributeRouteDynamicRoute));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/attribute-dynamic-order/Controller=Home,Action=Index";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("AttributeRouteSlug", content.RouteName);
+        }
+
+        [Fact]
+        public async Task DynamicRoutesAreMatchedInDefinitionOrderOverPrecedence()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", isEnabled: true);
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.MultipleDynamicRoute));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/dynamic-order/specific/Controller=Home,Action=Index";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(content.RouteValues.TryGetValue("identifier", out var identifier));
+            Assert.Equal("slug", identifier);
+        }
+
+        [Fact]
+        public async Task ConventionalRoutesDefinedEarlierWinOverDynamicControllerRoutes()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", isEnabled: true);
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.ConventionalRouteDynamicRoute));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/conventional-dynamic-order-before";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.False(content.RouteValues.TryGetValue("identifier", out var identifier));
+        }
+
+        [Fact]
+        public async Task ConventionalRoutesDefinedLaterLooseToDynamicControllerRoutes()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", isEnabled: true);
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.ConventionalRouteDynamicRoute));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/conventional-dynamic-order-after";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(content.RouteValues.TryGetValue("identifier", out var identifier));
+            Assert.Equal("slug", identifier);
+        }
+
+        [Fact]
+        public async Task DynamicPagesDefinedEarlierWinOverDynamicControllers()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", isEnabled: true);
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.DynamicControllerAndPages));
+
+            var client = factory.CreateClient();
+            // Arrange
+            var url = "http://localhost/dynamic-order-page-controller-before";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Hello from dynamic page: /DynamicPagebefore", content);
+        }
+
+        [Fact]
+        public async Task DynamicPagesDefinedLaterLooseOverDynamicControllers()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", isEnabled: true);
+            var factory = Factory
+                .WithWebHostBuilder(b => b.UseSetting("Scenario", RoutingWebSite.StartupForDynamicOrder.DynamicOrderScenarios.DynamicControllerAndPages));
+
+            var client = factory.CreateClient();
+
+            // Arrange
+            var url = "http://localhost/dynamic-order-page-controller-after";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadFromJsonAsync<RouteInfo>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(content.RouteValues.TryGetValue("identifier", out var identifier));
+            Assert.Equal("controller", identifier);
+        }
+
+        private record RouteInfo(string RouteName, IDictionary<string,string> RouteValues);
+    }
+}

--- a/src/Mvc/test/WebSites/Common/TestResponseGenerator.cs
+++ b/src/Mvc/test/WebSites/Common/TestResponseGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Mvc/test/WebSites/RoutingWebSite/Controllers/BranchesController.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Controllers/BranchesController.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mvc.RoutingWebSite.Controllers
+{
+    public class BranchesController : Controller
+    {
+        private readonly TestResponseGenerator _generator;
+
+        public BranchesController(TestResponseGenerator generator)
+        {
+            _generator = generator;
+        }
+
+        public IActionResult Index()
+        {
+            return _generator.Generate();
+        }
+
+        [HttpGet("dynamicattributeorder/{some}/{value}/{**slug}", Order = 1)]
+        public IActionResult Attribute()
+        {
+            return _generator.Generate();
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/Controllers/DynamicOrderController.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Controllers/DynamicOrderController.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mvc.RoutingWebSite.Controllers
+{
+    public class DynamicOrderController : Controller
+    {
+        private readonly TestResponseGenerator _generator;
+
+        public DynamicOrderController(TestResponseGenerator generator)
+        {
+            _generator = generator;
+        }
+
+        [HttpGet("attribute-dynamic-order/{**slug}", Name = "AttributeRouteSlug")]
+        public IActionResult Get(string slug)
+        {
+            return _generator.Generate(Url.RouteUrl("AttributeRouteSlug", new { slug }));
+        }
+
+        [HttpGet]
+        public IActionResult Index()
+        {
+            return _generator.Generate(Url.RouteUrl(null, new { controller = "DynamicOrder", action = "Index" }));
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/Pages/DynamicPage.cshtml
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Pages/DynamicPage.cshtml
@@ -1,3 +1,3 @@
 ﻿@page
 @model RoutingWebSite.Pages.DynamicPageModel
-Hello from dynamic page: @Url.Page("")
+Hello from dynamic page: @Url.Page("")@RouteData.Values["identifier"]

--- a/src/Mvc/test/WebSites/RoutingWebSite/Program.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamic.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamic.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,8 @@ namespace RoutingWebSite
                 .SetCompatibilityVersion(CompatibilityVersion.Latest);
 
             services.AddTransient<Transformer>();
+            services.AddScoped<TestResponseGenerator>();
+            services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
 
             // Used by some controllers defined in this project.
             services.Configure<RouteOptions>(options => options.ConstraintMap["slugify"] = typeof(SlugifyParameterTransformer));

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamicOrder.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamicOrder.cs
@@ -1,0 +1,132 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RoutingWebSite
+{
+    // For by tests for dynamic routing to pages/controllers
+    public class StartupForDynamicOrder
+    {
+        public static class DynamicOrderScenarios
+        {
+            public const string AttributeRouteDynamicRoute = nameof(AttributeRouteDynamicRoute);
+            public const string MultipleDynamicRoute = nameof(MultipleDynamicRoute);
+            public const string ConventionalRouteDynamicRoute = nameof(ConventionalRouteDynamicRoute);
+            public const string DynamicControllerAndPages = nameof(DynamicControllerAndPages);
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public StartupForDynamicOrder(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services
+                .AddMvc()
+                .AddNewtonsoftJson()
+                .SetCompatibilityVersion(CompatibilityVersion.Latest);
+
+            services.AddTransient<Transformer>();
+            services.AddScoped<TestResponseGenerator>();
+            services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
+
+            // Used by some controllers defined in this project.
+            services.Configure<RouteOptions>(options => options.ConstraintMap["slugify"] = typeof(SlugifyParameterTransformer));
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            var scenario = Configuration.GetValue<string>("Scenario");
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                // Route order definition is important for all these routes:
+                switch (scenario)
+                {
+                    case DynamicOrderScenarios.AttributeRouteDynamicRoute:
+                        endpoints.MapDynamicControllerRoute<Transformer>("attribute-dynamic-order/{**slug}", new TransformerState() { Identifier = "slug" });
+                        endpoints.MapControllers();
+                        break;
+                    case DynamicOrderScenarios.ConventionalRouteDynamicRoute:
+                        endpoints.MapControllerRoute(null, "{**conventional-dynamic-order-before:regex(^((?!conventional\\-dynamic\\-order\\-after).)*$)}", new { controller = "DynamicOrder", action = "Index" });
+                        endpoints.MapDynamicControllerRoute<Transformer>("{conventional-dynamic-order}", new TransformerState() { Identifier = "slug" });
+                        endpoints.MapControllerRoute(null, "conventional-dynamic-order-after", new { controller = "DynamicOrder", action = "Index" });
+                        break;
+                    case DynamicOrderScenarios.MultipleDynamicRoute:
+                        endpoints.MapDynamicControllerRoute<Transformer>("dynamic-order/{**slug}", new TransformerState() { Identifier = "slug" });
+                        endpoints.MapDynamicControllerRoute<Transformer>("dynamic-order/specific/{**slug}", new TransformerState() { Identifier = "specific" });
+                        break;
+                    case DynamicOrderScenarios.DynamicControllerAndPages:
+                        endpoints.MapDynamicPageRoute<Transformer>("{**dynamic-order-page-controller-before:regex(^((?!dynamic\\-order\\-page\\-controller\\-after).)*$)}", new TransformerState() { Identifier = "before", ForPages = true });
+                        endpoints.MapDynamicControllerRoute<Transformer>("{dynamic-order-page-controller}", new TransformerState() { Identifier = "controller" });
+                        endpoints.MapDynamicPageRoute<Transformer>("dynamic-order-page-controller-after", new TransformerState() { Identifier = "after", ForPages = true });
+                        break;
+                    default:
+                        throw new InvalidOperationException("Invalid scenario configuration.");
+                }
+            });
+
+            app.Map("/afterrouting", b => b.Run(c =>
+            {
+                return c.Response.WriteAsync("Hello from middleware after routing");
+            }));
+        }
+
+        private class TransformerState
+        {
+            public string Identifier { get; set; }
+            public bool ForPages { get; set; }
+        }
+
+        private class Transformer : DynamicRouteValueTransformer
+        {
+            // Turns a format like `controller=Home,action=Index` into an RVD
+            public override ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
+            {
+                var kvps = ((string)values?["slug"])?.Split("/")?.LastOrDefault()?.Split(",") ?? Array.Empty<string>();
+
+                // Go to index by default if the route doesn't follow the slug pattern, we want to make sure always match to
+                // test the order is applied
+                var state = (TransformerState)State;
+                var results = new RouteValueDictionary();
+                if (!state.ForPages)
+                {
+                    results["controller"] = "Home";
+                    results["action"] = "Index";
+                }
+                else
+                {
+                    results["Page"] = "/DynamicPage";
+                }
+
+                foreach (var kvp in kvps)
+                {
+                    var split = kvp.Split("=");
+                    if (split.Length == 2)
+                    {
+                        results[split[0]] = split[1];
+                    }
+                }
+
+                results["identifier"] = ((TransformerState)State).Identifier;
+
+                return new ValueTask<RouteValueDictionary>(results);
+            }
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupRoutingDifferentBranches.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupRoutingDifferentBranches.cs
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RoutingWebSite
+{
+    public class StartupRoutingDifferentBranches
+    {
+        // Set up application services
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var pageRouteTransformerConvention = new PageRouteTransformerConvention(new SlugifyParameterTransformer());
+
+            services
+                .AddMvc(ConfigureMvcOptions)
+                .AddNewtonsoftJson()
+                .AddRazorPagesOptions(options =>
+                {
+                    options.Conventions.AddPageRoute("/PageRouteTransformer/PageWithConfiguredRoute", "/PageRouteTransformer/NewConventionRoute/{id?}");
+                    options.Conventions.AddFolderRouteModelConvention("/PageRouteTransformer", model =>
+                    {
+                        pageRouteTransformerConvention.Apply(model);
+                    });
+                })
+                .SetCompatibilityVersion(CompatibilityVersion.Latest);
+
+            ConfigureRoutingServices(services);
+
+            services.AddScoped<TestResponseGenerator>();
+            // This is used by test response generator
+            services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
+            services.AddSingleton<BranchesTransformer>();
+        }
+
+        public virtual void Configure(IApplicationBuilder app)
+        {
+            app.Map("/subdir", branch =>
+            {
+                branch.UseRouting();
+
+                branch.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapRazorPages();
+                    endpoints.MapControllerRoute(null, "literal/{controller}/{action}/{subdir}");
+                    endpoints.MapDynamicControllerRoute<BranchesTransformer>("literal/dynamic/controller/{**slug}");
+                });
+            });
+
+            app.Map("/common", branch =>
+            {
+                branch.UseRouting();
+
+                branch.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapControllerRoute(null, "{controller}/{action}/{common}/literal");
+                    endpoints.MapDynamicControllerRoute<BranchesTransformer>("dynamic/controller/literal/{**slug}");
+                });
+            });
+
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapDynamicControllerRoute<BranchesTransformer>("dynamicattributeorder/dynamic/route/{**slug}");
+                endpoints.MapControllerRoute(null, "{controller}/literal/{action}/{default}");
+            });
+
+            app.Run(c =>
+            {
+                return c.Response.WriteAsync("Hello from middleware after routing");
+            });
+        }
+
+        protected virtual void ConfigureMvcOptions(MvcOptions options)
+        {
+            // Add route token transformer to one controller
+            options.Conventions.Add(new ControllerRouteTokenTransformerConvention(
+                typeof(ParameterTransformerController),
+                new SlugifyParameterTransformer()));
+        }
+
+        protected virtual void ConfigureRoutingServices(IServiceCollection services)
+        {
+            services.AddRouting(options => options.ConstraintMap["slugify"] = typeof(SlugifyParameterTransformer));
+        }
+    }
+
+    public class BranchesTransformer : DynamicRouteValueTransformer
+    {
+        public override ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
+        {
+            return new ValueTask<RouteValueDictionary>(new RouteValueDictionary(new { controller = "Branches", action = "Index" }));
+        }
+    }
+}


### PR DESCRIPTION
# Description

Conventional MVC routes mapped in a router within a branch on the middleware pipeline are also mapped in other branches, and the order for the conventional and dynamic routes is global instead of scoped to a given router middleware.

This change registers a controller and page endpoint data sources per router instead of globally as singletons and makes sure the route order is also done on a "per-router" instance basis.

# Customer Impact
* Endpoints can be reachable from unexpected request paths, which can lead to issues on the application.
* The order of conventional routes can be affected by a change in another branch of the middleware pipeline, which is really hard to detect.

# Regression?

No, this bug was introduced in endpoint routing 3.1 and we will likely patch it (with an AppCompat switch for 3.1)

# Risk

Medium-low. This will alter the way matching works for existing applications that have relied on this behavior, but the same "legacy" behavior can be achieved modifying the startup code, and we don't think the scenario is not common enough for a lot of people to have started unconsciously depending on it.

## Fixes
https://github.com/dotnet/aspnetcore/issues/19330