### PR TITLE
Strip duplicate files from SharedFx input to Nuget Pack

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -288,7 +288,14 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <!-- Crossgen symbols for Linux include a GUID in the file name which cannot be predicted. -->
       <BuiltProjectOutputGroupOutput Include="$(TargetDir)*.map" Condition="'$(CrossGenSymbolsType)' == 'PerfMap'" />
 
-      <NuGetPackInput Include="@(BuiltProjectOutputGroupOutput)" />
+      <!-- Strip duplicate Files by checking for distinct %(FileName)%(Extension) -->
+      <OutputFileNames Include="%(BuiltProjectOutputGroupOutput.FileName)%(BuiltProjectOutputGroupOutput.Extension)">
+        <ItemPath>%(BuiltProjectOutputGroupOutput.Identity)</ItemPath>
+      </OutputFileNames>
+
+      <DistinctOutputFileNames Include="@(OutputFileNames->Distinct())"></DistinctOutputFileNames>
+
+      <NuGetPackInput Include="%(DistinctOutputFileNames.ItemPath)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Should resolve https://github.com/dotnet/aspnetcore/issues/25293

Sometimes, the call to `ResolveReferences` in the SharedFx project will add .pdb's to `ReferenceCopyLocalPaths` that are in the output directory of individual projects. This means we add the same .pdb twice (w/ 2 different paths) to the input of Nuget Pack, causing nuget errors. We're still investigating why this behavior exists, but we should also be defensive about duplicate files and strip them out.

@Pilchie can this go in as tell-mode for rc2?