### PR TITLE
Point to the correct directory for SDK test assets

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -25,7 +25,7 @@
                       $(RepoRoot)src\Installers\**\*.*proj;
                       $(RepoRoot)src\SignalR\clients\ts\**\node_modules\**\*.*proj;
                       $(RepoRoot)src\Components\Web.JS\node_modules\**\*.*proj;
-                      $(RepoRoot)src\Components\WebAssembly\Build\testassets\**\*.csproj;
+                      $(RepoRoot)src\Components\WebAssembly\Sdk\testassets\**\*.csproj;
                       $(RepoRoot)src\ProjectTemplates\Web.ProjectTemplates\content\**\*.csproj;
                       $(RepoRoot)src\ProjectTemplates\Web.ProjectTemplates\content\**\*.fsproj;
                       $(RepoRoot)src\ProjectTemplates\Web.Spa.ProjectTemplates\content\**\*.csproj;


### PR DESCRIPTION
This ends up building SDK's test assets as part of a regular build which ends up failing in a clean build.

