### PR TITLE
Use JsonSerializerDefaults instead of specifying individual options

### DIFF
--- a/src/Mvc/Mvc.Core/src/JsonOptions.cs
+++ b/src/Mvc/Mvc.Core/src/JsonOptions.cs
@@ -12,20 +12,12 @@ namespace Microsoft.AspNetCore.Mvc
         /// Gets the <see cref="System.Text.Json.JsonSerializerOptions"/> used by <see cref="SystemTextJsonInputFormatter"/> and
         /// <see cref="SystemTextJsonOutputFormatter"/>.
         /// </summary>
-        public JsonSerializerOptions JsonSerializerOptions { get; } = new JsonSerializerOptions
+        public JsonSerializerOptions JsonSerializerOptions { get; } = new JsonSerializerOptions(JsonSerializerDefaults.Web)
         {
             // Limit the object graph we'll consume to a fixed depth. This prevents stackoverflow exceptions
             // from deserialization errors that might occur from deeply nested objects.
             // This value is the same for model binding and Json.Net's serialization.
             MaxDepth = MvcOptions.DefaultMaxModelBindingRecursionDepth,
-
-            // We're using case-insensitive because there's a TON of code that there that does uses JSON.NET's default
-            // settings (preserve case) - including the WebAPIClient. This worked when we were using JSON.NET + camel casing
-            // because JSON.NET is case-insensitive by default.
-            PropertyNameCaseInsensitive = true,
-
-            // Use camel casing for properties
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         };
     }
 }


### PR DESCRIPTION
This lets MVC use the defaults as specified by System.Text.Json. Right now, these defaults are identical
to the two properties that were removed. However this allows MVC to pick up new S.T.J defaults in 6.0 including when
users attempt to use a 6.0 versioned package with 5.0


