### PR TITLE
Implement the async dispose pattern and the dispose pattern for JSObjectReference and JSInProcessObjectReference respectively

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSInProcessObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSInProcessObjectReference.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.JSInterop.Implementation
@@ -32,14 +33,21 @@ namespace Microsoft.JSInterop.Implementation
         }
 
         /// <inheritdoc />
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
             if (!Disposed)
             {
-                Disposed = true;
+                base.Dispose(disposing);
 
                 _jsRuntime.InvokeVoid("DotNet.jsCallDispatcher.disposeJSObjectReferenceById", Id);
             }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSObjectReference.cs
@@ -14,7 +14,7 @@ namespace Microsoft.JSInterop.Implementation
     {
         private readonly JSRuntime _jsRuntime;
 
-        internal bool Disposed { get; set; }
+        internal bool Disposed { get; private set; }
 
         /// <summary>
         /// The unique identifier assigned to this instance.
@@ -48,9 +48,22 @@ namespace Microsoft.JSInterop.Implementation
 
             return _jsRuntime.InvokeAsync<TValue>(Id, identifier, cancellationToken, args);
         }
+        
+        protected virtual void Dispose(bool disposing)
+        {
+            Disposed = true;
+        }
 
         /// <inheritdoc />
         public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore();
+            
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
+        
+        protected virtual async ValueTask DisposeAsyncCore()
         {
             if (!Disposed)
             {
@@ -67,6 +80,11 @@ namespace Microsoft.JSInterop.Implementation
             {
                 throw new ObjectDisposedException(GetType().Name);
             }
+        }
+        
+        ~JSObjectReference()
+        {
+            Dispose(false);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -34,6 +34,7 @@ Microsoft.JSInterop.Implementation.JSObjectReference.InvokeAsync<TValue>(string!
 Microsoft.JSInterop.Implementation.JSObjectReference.InvokeAsync<TValue>(string! identifier, object?[]? args) -> System.Threading.Tasks.ValueTask<TValue>
 Microsoft.JSInterop.Implementation.JSObjectReference.JSObjectReference(Microsoft.JSInterop.JSRuntime! jsRuntime, long id) -> void
 Microsoft.JSInterop.Implementation.JSObjectReference.ThrowIfDisposed() -> void
+Microsoft.JSInterop.Implementation.JSObjectReference.~JSObjectReference() -> void
 Microsoft.JSInterop.Infrastructure.DotNetDispatcher
 Microsoft.JSInterop.Infrastructure.DotNetInvocationInfo
 Microsoft.JSInterop.Infrastructure.DotNetInvocationInfo.AssemblyName.get -> string?
@@ -75,6 +76,7 @@ Microsoft.JSInterop.JSRuntimeExtensions
 abstract Microsoft.JSInterop.JSInProcessRuntime.InvokeJS(string! identifier, string? argsJson, Microsoft.JSInterop.JSCallResultType resultType, long targetInstanceId) -> string?
 abstract Microsoft.JSInterop.JSRuntime.BeginInvokeJS(long taskId, string! identifier, string? argsJson, Microsoft.JSInterop.JSCallResultType resultType, long targetInstanceId) -> void
 abstract Microsoft.JSInterop.JSRuntime.EndInvokeDotNet(Microsoft.JSInterop.Infrastructure.DotNetInvocationInfo invocationInfo, in Microsoft.JSInterop.Infrastructure.DotNetInvocationResult invocationResult) -> void
+override Microsoft.JSInterop.Implementation.JSInProcessObjectReference.Dispose(bool disposing) -> void
 static Microsoft.JSInterop.DotNetObjectReference.Create<TValue>(TValue! value) -> Microsoft.JSInterop.DotNetObjectReference<TValue!>!
 static Microsoft.JSInterop.Infrastructure.DotNetDispatcher.BeginInvokeDotNet(Microsoft.JSInterop.JSRuntime! jsRuntime, Microsoft.JSInterop.Infrastructure.DotNetInvocationInfo invocationInfo, string! argsJson) -> void
 static Microsoft.JSInterop.Infrastructure.DotNetDispatcher.EndInvokeJS(Microsoft.JSInterop.JSRuntime! jsRuntime, string! arguments) -> void
@@ -93,5 +95,7 @@ static Microsoft.JSInterop.JSRuntimeExtensions.InvokeAsync<TValue>(this Microsof
 static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, System.Threading.CancellationToken cancellationToken, params object![]! args) -> System.Threading.Tasks.ValueTask
 static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, System.TimeSpan timeout, params object![]! args) -> System.Threading.Tasks.ValueTask
 static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, params object![]! args) -> System.Threading.Tasks.ValueTask
+virtual Microsoft.JSInterop.Implementation.JSObjectReference.Dispose(bool disposing) -> void
+virtual Microsoft.JSInterop.Implementation.JSObjectReference.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask
 virtual Microsoft.JSInterop.JSInProcessRuntime.InvokeJS(string! identifier, string? argsJson) -> string?
 virtual Microsoft.JSInterop.JSRuntime.BeginInvokeJS(long taskId, string! identifier, string? argsJson) -> void


### PR DESCRIPTION
I believe the JS object reference ID that is disposed with the call to `DotNet.jsCallDispatcher.disposeJSObjectReferenceById` is an unmanaged resource, so `JSObjectReference` and `JSInProcessObjectReference` should implement [the async dispose pattern](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync#implement-the-async-dispose-pattern) and [the dispose pattern](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose#implement-the-dispose-pattern) respectively.
