### PR TITLE
Adding build check for invalid BlazorWebAssemblyLazyLoad property

### DIFF
--- a/src/Components/WebAssembly/Sdk/integrationtests/WasmBuildLazyLoadTest.cs
+++ b/src/Components/WebAssembly/Sdk/integrationtests/WasmBuildLazyLoadTest.cs
@@ -207,6 +207,20 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.BuildFailed(result);
         }
 
+        [Fact]
+        public async Task Build_Without_LazyLoadExplicitAssembly_Works()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("blazorwasm", additionalProjects: new[] { "razorclasslibrary" });
+            project.Configuration = "Release";
+
+            // Act
+            var result = await MSBuildProcessManager.DotnetMSBuild(project, "Publish");
+
+            // Assert
+            Assert.BuildPassed(result);
+        }
+
         private static BootJsonData ReadBootJsonData(MSBuildResult result, string path)
         {
             return JsonSerializer.Deserialize<BootJsonData>(

--- a/src/Components/WebAssembly/Sdk/integrationtests/WasmBuildLazyLoadTest.cs
+++ b/src/Components/WebAssembly/Sdk/integrationtests/WasmBuildLazyLoadTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/Components/WebAssembly/Sdk/integrationtests/WasmBuildLazyLoadTest.cs
+++ b/src/Components/WebAssembly/Sdk/integrationtests/WasmBuildLazyLoadTest.cs
@@ -207,20 +207,6 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.BuildFailed(result);
         }
 
-        [Fact]
-        public async Task Build_Without_LazyLoadExplicitAssembly_Works()
-        {
-            // Arrange
-            using var project = ProjectDirectory.Create("blazorwasm", additionalProjects: new[] { "razorclasslibrary" });
-            project.Configuration = "Release";
-
-            // Act
-            var result = await MSBuildProcessManager.DotnetMSBuild(project, "Publish");
-
-            // Assert
-            Assert.BuildPassed(result);
-        }
-
         private static BootJsonData ReadBootJsonData(MSBuildResult result, string path)
         {
             return JsonSerializer.Deserialize<BootJsonData>(

--- a/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -500,6 +500,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="Items" ItemName="_BlazorPublishBootResourceWithHash" />
     </GetFileHash>
 
+    <PropertyGroup>
+      <_BlazorOutputContent>@(_BlazorPublishBootResourceWithHash)</_BlazorOutputContent>
+    </PropertyGroup>
+    
+    <Error
+      Text="Unable to find %(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded later. Confirm that project or package references are included and the reference is used in the project."
+      Code="BLAZORSDK1001"
+      Condition="'@(BlazorWebAssemblyLazyLoad)' != '' And !($([System.String]::Copy('$(_BlazorOutputContent)').Contains('%(BlazorWebAssemblyLazyLoad.Identity)')))" />
+
     <GenerateBlazorWebAssemblyBootJson
       AssemblyPath="@(IntermediateAssembly)"
       Resources="@(_BlazorPublishBootResourceWithHash)"

--- a/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -281,13 +281,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_BlazorWasmPrepareForRun" DependsOnTargets="_ProcessBlazorWasmOutputs" BeforeTargets="_RazorPrepareForRun" AfterTargets="GetCurrentProjectStaticWebAssets">
     <PropertyGroup>
       <_BlazorBuildBootJsonPath>$(IntermediateOutputPath)blazor.boot.json</_BlazorBuildBootJsonPath>
+      <_BlazorOutputContent>@(_BlazorOutputWithHash)</_BlazorOutputContent>
     </PropertyGroup>
 
     <Error
-      Text="Unable to find $(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded later (are you missing an assembly reference?)"
+      Text="Unable to find %(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded later. Confirm that project or package references are included and the reference is used in the project."
       Code="BLAZORSDK1001"
-      Condition="'@(BlazorWebAssemblyLazyLoad)' != '' And !Exists('$(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity)')" />
-    
+      Condition="'@(BlazorWebAssemblyLazyLoad)' != '' And !($([System.String]::Copy('$(_BlazorOutputContent)').Contains('%(BlazorWebAssemblyLazyLoad.Identity)')))" />
+
     <GenerateBlazorWebAssemblyBootJson
       AssemblyPath="@(IntermediateAssembly)"
       Resources="@(_BlazorOutputWithHash)"
@@ -498,11 +499,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GetFileHash Files="@(_BlazorPublishBootResource)" Algorithm="SHA256" HashEncoding="base64">
       <Output TaskParameter="Items" ItemName="_BlazorPublishBootResourceWithHash" />
     </GetFileHash>
-
-    <Error
-        Text="Unable to find $(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded. (are you missing an assembly reference?)"
-        Code="BLAZORSDK1001"
-        Condition="'@(BlazorWebAssemblyLazyLoad)' != '' And !Exists('$(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity)')" />
 
     <GenerateBlazorWebAssemblyBootJson
       AssemblyPath="@(IntermediateAssembly)"

--- a/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -283,6 +283,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_BlazorBuildBootJsonPath>$(IntermediateOutputPath)blazor.boot.json</_BlazorBuildBootJsonPath>
     </PropertyGroup>
 
+    <Error
+      Text="Unable to find $(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded later (are you missing an assembly reference?)"
+      Code="BLAZORSDK1001"
+      Condition="!Exists('$(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity)')" />
+    
     <GenerateBlazorWebAssemblyBootJson
       AssemblyPath="@(IntermediateAssembly)"
       Resources="@(_BlazorOutputWithHash)"
@@ -493,6 +498,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GetFileHash Files="@(_BlazorPublishBootResource)" Algorithm="SHA256" HashEncoding="base64">
       <Output TaskParameter="Items" ItemName="_BlazorPublishBootResourceWithHash" />
     </GetFileHash>
+
+    <Error
+        Text="Unable to find $(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded later (are you missing an assembly reference?)"
+        Code="BLAZORSDK1001"
+        Condition="!Exists('$(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity)')" />
 
     <GenerateBlazorWebAssemblyBootJson
       AssemblyPath="@(IntermediateAssembly)"

--- a/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -286,7 +286,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Error
       Text="Unable to find $(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded later (are you missing an assembly reference?)"
       Code="BLAZORSDK1001"
-      Condition="!Exists('$(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity)')" />
+      Condition="'@(BlazorWebAssemblyLazyLoad)' != '' And !Exists('$(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity)')" />
     
     <GenerateBlazorWebAssemblyBootJson
       AssemblyPath="@(IntermediateAssembly)"
@@ -500,9 +500,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetFileHash>
 
     <Error
-        Text="Unable to find $(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded later (are you missing an assembly reference?)"
+        Text="Unable to find $(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity) to be lazy loaded. (are you missing an assembly reference?)"
         Code="BLAZORSDK1001"
-        Condition="!Exists('$(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity)')" />
+        Condition="'@(BlazorWebAssemblyLazyLoad)' != '' And !Exists('$(OutDir)$(_BlazorOutputPath)%(BlazorWebAssemblyLazyLoad.Identity)')" />
 
     <GenerateBlazorWebAssemblyBootJson
       AssemblyPath="@(IntermediateAssembly)"


### PR DESCRIPTION
#Summary

This add build check for invalid BlazorWebAssemblyLazyLoad property:

- [x] For Build
- [x] For Publish
- [x] Add tests

Note: The check are added just before `BlazorWebAssemblyLazyLoad` if your think the error should be checked as soon as possible I can spend a bit more time figuring out where could be the best place 

Addresses #24880
