### PR TITLE
V3 publishing

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -750,6 +750,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
+      publishingInfraVersion: 3
       enableSymbolValidation: false
       enableSigningValidation: false
       enableNugetValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -3,6 +3,7 @@
     <PublishingVersion>3</PublishingVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
     <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
     <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <PropertyGroup>
     <PublishingVersion>3</PublishingVersion>
   </PropertyGroup>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,9 @@
 <Project>
   <PropertyGroup>
+    <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
+
     <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
     <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Use v3 publishing in aspnetcore 

test build =>  https://dnceng.visualstudio.com/internal/_build/results?buildId=808539&view=results
without default channel => https://dev.azure.com/dnceng/internal/_build/results?buildId=809506&view=logs&s=380ab8c6-4139-55ff-15c4-fb48260f4dca

Addresses #bugnumber (in this specific format)
