### PR TITLE
Strip duplicates from BuiltProjectOutputGroupOutput

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -281,21 +281,22 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <!-- This target resolves files into the BuiltProjectOutputGroupOutput which NuGet uses to generate the package files. -->
   <Target Name="_ResolveRuntimePackBuildOutput" DependsOnTargets="ResolveReferences;Crossgen">
     <ItemGroup>
-      <BuiltProjectOutputGroupOutput Include="$(ProjectDepsFilePath)" />
-      <BuiltProjectOutputGroupOutput Include="@(ReferenceCopyLocalPaths)" Condition=" '%(ReferenceCopyLocalPaths.IsNativeImage)' != 'true' " />
+      <BuildOutputFiles Include="$(ProjectDepsFilePath)" />
+      <BuildOutputFiles Include="@(ReferenceCopyLocalPaths)" Condition=" '%(ReferenceCopyLocalPaths.IsNativeImage)' != 'true' " />
       <!-- Include all .pdbs in build output. Some .pdb files are part of ReferenceCopyLocalPaths, but this can change when running /t:Pack /p:NoBuild=true. -->
-      <BuiltProjectOutputGroupOutput Include="$(TargetDir)*.pdb" Exclude="@(ReferenceCopyLocalPaths)" />
+      <BuildOutputFiles Include="$(TargetDir)*.pdb" Exclude="@(ReferenceCopyLocalPaths)" />
       <!-- Crossgen symbols for Linux include a GUID in the file name which cannot be predicted. -->
-      <BuiltProjectOutputGroupOutput Include="$(TargetDir)*.map" Condition="'$(CrossGenSymbolsType)' == 'PerfMap'" />
+      <BuildOutputFiles Include="$(TargetDir)*.map" Condition="'$(CrossGenSymbolsType)' == 'PerfMap'" />
 
       <!-- Strip duplicate Files by checking for distinct %(FileName)%(Extension) -->
-      <OutputFileNames Include="%(BuiltProjectOutputGroupOutput.FileName)%(BuiltProjectOutputGroupOutput.Extension)">
-        <ItemPath>%(BuiltProjectOutputGroupOutput.Identity)</ItemPath>
+      <OutputFileNames Include="%(BuildOutputFiles.FileName)%(BuildOutputFiles.Extension)">
+        <ItemPath>%(BuildOutputFiles.Identity)</ItemPath>
       </OutputFileNames>
-
       <DistinctOutputFileNames Include="@(OutputFileNames->Distinct())"></DistinctOutputFileNames>
 
-      <NuGetPackInput Include="%(DistinctOutputFileNames.ItemPath)" />
+      <!--BuiltProjectOutputGroupOuput is the item actually used by Nuget -->
+      <BuiltProjectOutputGroupOutput Include="%(DistinctOutputFileNames.ItemPath)" />
+      <NuGetPackInput Include="@(BuiltProjectOutputGroupOutput)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspnetcore/pull/25733, resolves https://github.com/dotnet/aspnetcore/issues/25293

While https://github.com/dotnet/aspnetcore/issues/25293 _did_ strip duplicates from `NuGetPackInput`, it did _not_ strip duplicates from `BuiltProjectOutputGroupOutput`, which is also used by Nuget to calculate inputs to `Nuget pack`. This should fix that issue as well.

More test builds: 
https://dev.azure.com/dnceng/internal/_build/results?buildId=810083&view=results
https://dev.azure.com/dnceng/internal/_build/results?buildId=810084&view=results

Nuget.Client uses this item here: https://github.com/NuGet/NuGet.Client/blob/3f573425ac74d90b96a61e5e85ed39a39aad8a7f/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets#L420-L428