### PR TITLE
Correct `$(SharedFxVersion)` and `$(TargetingPackVersion)` values

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -36,13 +36,15 @@
     <SiteExtensionPackageVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix.Replace('.','-'))</SiteExtensionPackageVersion>
 
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
-    <PackageVersion Condition=" '$(NoSemVer20)' == 'true' ">$(SiteExtensionPackageVersion)</PackageVersion>
+
     <SharedFxVersion>$(PackageVersion)</SharedFxVersion>
+    <SharedFxVersion Condition=" '$(StabilizePackageVersion)' == 'true' ">$(VersionPrefix)</SharedFxVersion>
+    <SharedFxProductName>$(Product) $(SharedFxVersion) Shared Framework</SharedFxProductName>
 
-    <TargetingPackVersion>$(TargetingPackVersionPrefix)</TargetingPackVersion>
-    <TargetingPackVersion Condition=" '$(VersionSuffix)' != '' ">$(TargetingPackVersionPrefix)-$(VersionSuffix)</TargetingPackVersion>
+    <TargetingPackVersion>$(SharedFxVersion)</TargetingPackVersion>
+    <TargetingPackVersion Condition=" ! $(IsTargetingPackBuilding) ">$(TargetingPackVersionPrefix)</TargetingPackVersion>
 
-    <SharedFxProductName>$(Product) $(PackageVersion) Shared Framework</SharedFxProductName>
+    <PackageVersion Condition=" '$(NoSemVer20)' == 'true' ">$(SiteExtensionPackageVersion)</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -156,7 +158,7 @@
     <KnownFrameworkReference Condition="'$(UseAspNetCoreSharedRuntime)' == 'true' AND '$(DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp)' != 'true'" Update="Microsoft.AspNetCore.App">
       <LatestRuntimeFrameworkVersion>$(SharedFxVersion)</LatestRuntimeFrameworkVersion>
       <DefaultRuntimeFrameworkVersion Condition="'$(IsServicingBuild)' != 'true'">$(SharedFxVersion)</DefaultRuntimeFrameworkVersion>
-      <TargetingPackVersion Condition="'$(IsServicingBuild)' != 'true'">$(SharedFxVersion)</TargetingPackVersion>
+      <TargetingPackVersion Condition="'$(IsServicingBuild)' != 'true'">$(TargetingPackVersion)</TargetingPackVersion>
     </KnownFrameworkReference>
 
     <!-- Track compiler separately from Arcade.-->

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -73,7 +73,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="System.Reflection.Metadata" />
     <LatestPackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <LatestPackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
-    <!-- System.Security.AccessControl should only be referenced in Dependencies.props and RTMVersions.csproj. -->
+    <!-- System.Security.AccessControl should only be referenced in Dependencies.props and RepoTasks.csproj. -->
     <LatestPackageReference Include="System.Security.AccessControl" />
     <LatestPackageReference Include="System.Security.Cryptography.Cng" />
     <LatestPackageReference Include="System.Security.Cryptography.Pkcs" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -241,7 +241,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7d39776332446d8a84f5d542c80d264fa1cadbe7</Sha>
     </Dependency>
-    <!-- System.Security.AccessControl should only be referenced in Dependencies.props and RTMVersions.csproj. -->
+    <!-- System.Security.AccessControl should only be referenced in Dependencies.props and RepoTasks.csproj. -->
     <Dependency Name="System.Security.AccessControl" Version="5.0.0-rc.2.20461.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7d39776332446d8a84f5d542c80d264fa1cadbe7</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -118,7 +118,7 @@
     <SystemReflectionMetadataPackageVersion>5.0.0-rc.2.20461.4</SystemReflectionMetadataPackageVersion>
     <SystemResourcesExtensionsPackageVersion>5.0.0-rc.2.20461.4</SystemResourcesExtensionsPackageVersion>
     <SystemRuntimeCompilerServicesUnsafePackageVersion>5.0.0-rc.2.20461.4</SystemRuntimeCompilerServicesUnsafePackageVersion>
-    <!-- System.Security.AccessControl should only be referenced in Dependencies.props and RTMVersions.csproj. -->
+    <!-- System.Security.AccessControl should only be referenced in Dependencies.props and RepoTasks.csproj. -->
     <SystemSecurityAccessControlPackageVersion>5.0.0-rc.2.20461.4</SystemSecurityAccessControlPackageVersion>
     <SystemSecurityCryptographyCngPackageVersion>5.0.0-rc.2.20461.4</SystemSecurityCryptographyCngPackageVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>5.0.0-rc.2.20461.4</SystemSecurityCryptographyPkcsPackageVersion>
@@ -170,7 +170,7 @@
     runtime packages for everything else. This is not an issue for assemblies available in Microsoft.NETCore.App.Ref or
     Microsoft.Extensions.Internal.Transport because it is next to impossible we would service those packages.
 
-    System.Security.AccessControl should only be referenced in Dependencies.props and RTMVersions.csproj. Because
+    System.Security.AccessControl should only be referenced in Dependencies.props and RepoTasks.csproj. Because
     it's a transitive reference, we reship the ref/ assembly in Microsoft.AspNetCore.App.Ref. dotnet/runtime ships
     the implementation assemblies in Microsoft.NETCore.App.Runtime.* packages.
 

--- a/eng/helix/content/RunTests/RunTestsOptions.cs
+++ b/eng/helix/content/RunTests/RunTestsOptions.cs
@@ -47,50 +47,47 @@ namespace RunTests
                 { Argument = new Argument<string>(), Required = true },
 
                 new Option(
-                    aliases: new string[] { "--aspnetruntime" },
-                    description: "The path to the aspnet runtime nupkg to install")
-                { Argument = new Argument<string>(), Required = true },
-
-                new Option(
-                    aliases: new string[] { "--aspnetref" },
-                    description: "The path to the aspnet ref nupkg to install")
-                { Argument = new Argument<string>(), Required = true },
-
-                new Option(
                     aliases: new string[] { "--helixTimeout" },
                     description: "The timeout duration of the Helix job")
                 { Argument = new Argument<string>(), Required = true },
             };
 
             var parseResult = command.Parse(args);
-            var options = new RunTestsOptions();
-            options.Target = parseResult.ValueForOption<string>("--target");
-            options.RuntimeVersion = parseResult.ValueForOption<string>("--runtime");
-            options.HelixQueue = parseResult.ValueForOption<string>("--queue");
-            options.Architecture = parseResult.ValueForOption<string>("--arch");
-            options.Quarantined = parseResult.ValueForOption<bool>("--quarantined");
-            options.EfVersion = parseResult.ValueForOption<string>("--ef");
-            options.AspNetRuntime = parseResult.ValueForOption<string>("--aspnetruntime");
-            options.AspNetRef = parseResult.ValueForOption<string>("--aspnetref");
-            options.Timeout = TimeSpan.Parse(parseResult.ValueForOption<string>("--helixTimeout"));
-            options.HELIX_WORKITEM_ROOT = Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT");
-            options.Path = Environment.GetEnvironmentVariable("PATH");
-            options.DotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            var sharedFxVersion = parseResult.ValueForOption<string>("--runtime");
+            var options = new RunTestsOptions
+            {
+                Architecture = parseResult.ValueForOption<string>("--arch"),
+                EfVersion = parseResult.ValueForOption<string>("--ef"),
+                HelixQueue = parseResult.ValueForOption<string>("--queue"),
+                Quarantined = parseResult.ValueForOption<bool>("--quarantined"),
+                RuntimeVersion = sharedFxVersion,
+                Target = parseResult.ValueForOption<string>("--target"),
+                Timeout = TimeSpan.Parse(parseResult.ValueForOption<string>("--helixTimeout")),
+
+                // When targeting pack builds, it has exactly the same version as the shared framework.
+                AspNetRef = $"Microsoft.AspNetCore.App.Ref.{sharedFxVersion}.nupkg",
+                AspNetRuntime = $"Microsoft.AspNetCore.App.Runtime.win-x64.{sharedFxVersion}.nupkg",
+
+                DotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT"),
+                HELIX_WORKITEM_ROOT = Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"),
+                Path = Environment.GetEnvironmentVariable("PATH"),
+            };
+
             return options;
         }
 
-        public string Target { get; set;}
-        public string SdkVersion { get; set;}
-        public string RuntimeVersion { get; set;}
-        public string AspNetRuntime { get; set;}
-        public string AspNetRef { get; set;}
-        public string HelixQueue { get; set;}
-        public string Architecture { get; set;}
-        public bool Quarantined { get; set;}
-        public string EfVersion { get; set;}
-        public string HELIX_WORKITEM_ROOT { get; set;}
-        public string DotnetRoot { get; set; }
+        public string Architecture { get; private set; }
+        public string EfVersion { get; private set; }
+        public string HelixQueue { get; private set; }
+        public bool Quarantined { get; private set; }
+        public string RuntimeVersion { get; private set; }
+        public string Target { get; private set; }
+        public TimeSpan Timeout { get; private set; }
+
+        public string AspNetRef { get; private set; }
+        public string AspNetRuntime { get; private set; }
+        public string HELIX_WORKITEM_ROOT { get; private set; }
+        public string DotnetRoot { get; private set; }
         public string Path { get; set; }
-        public TimeSpan Timeout { get; set; }
     }
 }

--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -10,12 +10,8 @@ set $queue=%5
 set $arch=%6
 set $quarantined=%7
 set $ef=%8
-set $aspnetruntime=%9
-REM Batch only supports up to 9 arguments using the %# syntax, need to shift to get more
-shift
-set $aspnetref=%9
-shift
 set $helixTimeout=%9
+REM Batch only supports up to 9 arguments using the %# syntax, need to shift to get more
 shift
 set $feedCred=%9
 
@@ -40,8 +36,8 @@ set exit_code=0
 echo "Restore: dotnet restore RunTests\RunTests.csproj --ignore-failed-sources"
 dotnet restore RunTests\RunTests.csproj --ignore-failed-sources
 
-echo "Running tests: dotnet run --no-restore --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%"
-dotnet run --no-restore --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --aspnetruntime %$aspnetruntime% --aspnetref %$aspnetref% --helixTimeout %$helixTimeout%
+echo "Running tests: dotnet run --no-restore --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --helixTimeout %$helixTimeout%"
+dotnet run --no-restore --project RunTests\RunTests.csproj -- --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --ef %$ef% --helixTimeout %$helixTimeout%
 if errorlevel neq 0 (
     set exit_code=%errorlevel%
 )

--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -36,14 +36,14 @@ InstallDotNet $DOTNET_ROOT $dotnet_sdk_version "" "" true || {
   Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "dotnet-install.sh failed (exit code '$exit_code')." >&2
   ExitWithExitCode $exit_code
 }
-if [[ -z "${11:-}" ]]; then
+if [[ -z "${10:-}" ]]; then
     InstallDotNet $DOTNET_ROOT $dotnet_runtime_version "" dotnet true || {
       exit_code=$?
       Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "dotnet-install.sh failed (exit code '$exit_code')." >&2
       ExitWithExitCode $exit_code
     }
 else
-    InstallDotNet $DOTNET_ROOT $dotnet_runtime_version "" dotnet true https://dotnetclimsrc.blob.core.windows.net/dotnet ${11} || {
+    InstallDotNet $DOTNET_ROOT $dotnet_runtime_version "" dotnet true https://dotnetclimsrc.blob.core.windows.net/dotnet ${10} || {
       exit_code=$?
       Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "dotnet-install.sh failed (exit code '$exit_code')." >&2
       ExitWithExitCode $exit_code
@@ -65,8 +65,8 @@ exit_code=0
 echo "Restore: $DOTNET_ROOT/dotnet restore RunTests/RunTests.csproj --ignore-failed-sources"
 $DOTNET_ROOT/dotnet restore RunTests/RunTests.csproj --ignore-failed-sources
 
-echo "Running tests: $DOTNET_ROOT/dotnet run --no-restore --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --aspnetruntime $9 --aspnetref ${10} --helixTimeout ${11}"
-$DOTNET_ROOT/dotnet run --no-restore --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --aspnetruntime $9 --aspnetref ${10} --helixTimeout ${11}
+echo "Running tests: $DOTNET_ROOT/dotnet run --no-restore --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --helixTimeout $9"
+$DOTNET_ROOT/dotnet run --no-restore --project RunTests/RunTests.csproj -- --target $1 --runtime $4 --queue $5 --arch $6 --quarantined $7 --ef $8 --helixTimeout $9
 exit_code=$?
 echo "Finished tests...exit_code=$exit_code"
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -106,14 +106,8 @@ Usage: dotnet msbuild /t:Helix src/MyTestProject.csproj
       <HelixContent Include="$(OutputPath)/Microsoft.VisualStudio.TestPlatform.Extension.Xunit.Xml.TestLogger.dll" />
     </ItemGroup>
 
-    <!--
-      Could use _GetPackageVersionInfo target (defined in eng/targets/Packaging.targets and included in every C#
-      and F# project) instead of the $(SharedFxVersion) property but the property works everywhere except in site
-      extensions projects. Could also use $(TargetingPackVersion) but that has slightly more complicated semantics
-      and doesn't keep up when in servicing.
-    -->
     <ItemGroup Condition=" '$(TestDependsOnAspNetRef)' == 'true' AND '$(IsTargetingPackBuilding)' == 'true' ">
-      <HelixContent Include="$(RepoRoot)artifacts\packages\Release\Shipping\Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg" />
+      <HelixContent Include="$(RepoRoot)artifacts\packages\Release\Shipping\Microsoft.AspNetCore.App.Ref.$(TargetingPackVersion).nupkg" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TestDependsOnAspNetRuntime)' == 'true' ">
@@ -139,8 +133,12 @@ Usage: dotnet msbuild /t:Helix src/MyTestProject.csproj
         <TestAssembly>$(TargetFileName)</TestAssembly>
         <PreCommands>@(HelixPreCommand)</PreCommands>
         <PostCommands>@(HelixPostCommand)</PostCommands>
-        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg $(HelixTimeout)</Command>
-        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg $(HelixTimeout)</Command>
+        <!--
+          When the targeting pack builds, it has exactly the same version as the shared framework. Passing
+          SharedFxVersion because that's needed even when the targeting pack isn't building.
+        -->
+        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg Microsoft.AspNetCore.App.Ref.$(TargetingPackVersion).nupkg $(HelixTimeout)</Command>
+        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg Microsoft.AspNetCore.App.Ref.$(TargetingPackVersion).nupkg $(HelixTimeout)</Command>
         <Command Condition="$(HelixCommand) != ''">$(HelixCommand)</Command>
         <Timeout>$(HelixTimeout)</Timeout>
       </HelixWorkItem>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -137,8 +137,8 @@ Usage: dotnet msbuild /t:Helix src/MyTestProject.csproj
           When the targeting pack builds, it has exactly the same version as the shared framework. Passing
           SharedFxVersion because that's needed even when the targeting pack isn't building.
         -->
-        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg Microsoft.AspNetCore.App.Ref.$(TargetingPackVersion).nupkg $(HelixTimeout)</Command>
-        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) Microsoft.AspNetCore.App.Runtime.win-x64.$(SharedFxVersion).nupkg Microsoft.AspNetCore.App.Ref.$(TargetingPackVersion).nupkg $(HelixTimeout)</Command>
+        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) $(HelixTimeout) $(DotNetRuntimeSourceFeedKey)</Command>
+        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(NETCoreSdkVersion) $(MicrosoftNETCoreAppRuntimeVersion) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfPackageVersion) $(HelixTimeout) $(DotNetRuntimeSourceFeedKey)</Command>
         <Command Condition="$(HelixCommand) != ''">$(HelixCommand)</Command>
         <Timeout>$(HelixTimeout)</Timeout>
       </HelixWorkItem>

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -70,20 +70,6 @@
       <Output TaskParameter="TargetOutputs" ItemName="_TargetingPackDependencies" />
     </MSBuild>
 
-    <!-- This target is defined in eng/targets/Packaging.targets and included in every C# and F# project. -->
-    <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
-      <Output TaskParameter="TargetOutputs" ItemName="_RuntimePackageVersionInfo" />
-    </MSBuild>
-
-    <!-- Runtime and Ref packs may have separate versions. -->
-    <MSBuild Projects="$(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
-      <Output TaskParameter="TargetOutputs" ItemName="_TargetingPackVersionInfo" />
-    </MSBuild>
-
     <ItemGroup>
       <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
         <_Parameter1>TargetingPackDependencies</_Parameter1>
@@ -119,12 +105,12 @@
 
       <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
         <_Parameter1>RuntimePackageVersion</_Parameter1>
-        <_Parameter2>@(_RuntimePackageVersionInfo->'%(PackageVersion)')</_Parameter2>
+        <_Parameter2>$(SharedFxVersion)</_Parameter2>
       </AssemblyAttribute>
 
       <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
         <_Parameter1>TargetingPackVersion</_Parameter1>
-        <_Parameter2>@(_TargetingPackVersionInfo->'%(PackageVersion)')</_Parameter2>
+        <_Parameter2>$(TargetingPackVersion)</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/Grpc/test/testassets/InteropWebsite/Directory.Build.targets
+++ b/src/Grpc/test/testassets/InteropWebsite/Directory.Build.targets
@@ -4,8 +4,6 @@
 
   <PropertyGroup>
     <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir)</RestoreAdditionalProjectSources>
-    <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' != 'false'">$(TargetingPackVersion)</MicrosoftAspNetCoreAppRefPackageVersion>
-    <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' == 'false'">$(AspNetCoreBaselineVersion)</MicrosoftAspNetCoreAppRefPackageVersion>
   </PropertyGroup>
 
   <!-- Use the shared framework that was produced -->
@@ -18,7 +16,7 @@
       RuntimePackNamePatterns="Microsoft.AspNetCore.App.Runtime.**RID**"
       DefaultRuntimeFrameworkVersion="$(SharedFxVersion)"
       LatestRuntimeFrameworkVersion="$(SharedFxVersion)"
-      TargetingPackVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)"
+      TargetingPackVersion="$(TargetingPackVersion)"
       RuntimePackRuntimeIdentifiers="$(SupportedRuntimeIdentifiers)" />
   </ItemGroup>
 </Project>

--- a/src/ProjectTemplates/BlazorTemplates.Tests/Infrastructure/GenerateTestProps.targets
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/Infrastructure/GenerateTestProps.targets
@@ -3,28 +3,6 @@
       BeforeTargets="CoreCompile"
       DependsOnTargets="PrepareForTest"
       Condition="$(DesignTimeBuild) != true">
-    <!-- The version of the shared framework. This is used in tests to ensure they run against the shared framework version we just built. -->
-    <!-- If we aren't building the targeting pack, use the baseline version -->
-    <MSBuild Projects="$(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false"
-        Condition="'$(IsTargetingPackBuilding)' != 'false'">
-      <Output TaskParameter="TargetOutputs" ItemName="_TargetingPackVersionInfo" />
-    </MSBuild>
-
-    <!-- Targeting pack version should be the one we just built, if we're building it. Otherwise we use the baseline version -->
-    <PropertyGroup>
-      <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' != 'false'">%(_TargetingPackVersionInfo.PackageVersion)</MicrosoftAspNetCoreAppRefPackageVersion>
-      <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' == 'false'">$(TargetingPackVersionPrefix)</MicrosoftAspNetCoreAppRefPackageVersion>
-    </PropertyGroup>
-
-    <!-- Runtime and Ref packs may have separate versions. -->
-    <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
-      <Output TaskParameter="TargetOutputs" ItemName="_RuntimePackageVersionInfo" />
-    </MSBuild>
-
     <PropertyGroup>
       <PropsProperties>
         RestoreAdditionalProjectSources=$([MSBuild]::Escape("$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)"));
@@ -33,8 +11,8 @@
         MicrosoftNETCoreAppRefPackageVersion=$(MicrosoftNETCoreAppRefPackageVersion);
         MicrosoftNETCorePlatformsPackageVersion=$(MicrosoftNETCorePlatformsPackageVersion);
         MicrosoftNETSdkRazorPackageVersion=$(MicrosoftNETSdkRazorPackageVersion);
-        MicrosoftAspNetCoreAppRefPackageVersion=$(MicrosoftAspNetCoreAppRefPackageVersion);
-        MicrosoftAspNetCoreAppRuntimePackageVersion=@(_RuntimePackageVersionInfo->'%(PackageVersion)');
+        MicrosoftAspNetCoreAppRefPackageVersion=$(TargetingPackVersion);
+        MicrosoftAspNetCoreAppRuntimePackageVersion=$(SharedFxVersion);
         SupportedRuntimeIdentifiers=$(SupportedRuntimeIdentifiers.Trim());
         DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
         RepoRoot=$(RepoRoot);

--- a/src/ProjectTemplates/test/Infrastructure/GenerateTestProps.targets
+++ b/src/ProjectTemplates/test/Infrastructure/GenerateTestProps.targets
@@ -3,28 +3,6 @@
       BeforeTargets="CoreCompile"
       DependsOnTargets="PrepareForTest"
       Condition="$(DesignTimeBuild) != true">
-    <!-- The version of the shared framework. This is used in tests to ensure they run against the shared framework version we just built. -->
-    <!-- If we aren't building the targeting pack, use the baseline version -->
-    <MSBuild Projects="$(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false"
-        Condition="'$(IsTargetingPackBuilding)' != 'false'">
-      <Output TaskParameter="TargetOutputs" ItemName="_TargetingPackVersionInfo" />
-    </MSBuild>
-
-    <!-- Targeting pack version should be the one we just built, if we're building it. Otherwise we use the baseline version -->
-    <PropertyGroup>
-      <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' != 'false'">%(_TargetingPackVersionInfo.PackageVersion)</MicrosoftAspNetCoreAppRefPackageVersion>
-      <MicrosoftAspNetCoreAppRefPackageVersion Condition="'$(IsTargetingPackBuilding)' == 'false'">$(TargetingPackVersionPrefix)</MicrosoftAspNetCoreAppRefPackageVersion>
-    </PropertyGroup>
-
-    <!-- Runtime and Ref packs may have separate versions. -->
-    <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
-      <Output TaskParameter="TargetOutputs" ItemName="_RuntimePackageVersionInfo" />
-    </MSBuild>
-
     <PropertyGroup>
       <PropsProperties>
         RestoreAdditionalProjectSources=$([MSBuild]::Escape("$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)"));
@@ -33,8 +11,8 @@
         MicrosoftNETCoreAppRefPackageVersion=$(MicrosoftNETCoreAppRefPackageVersion);
         MicrosoftNETCorePlatformsPackageVersion=$(MicrosoftNETCorePlatformsPackageVersion);
         MicrosoftNETSdkRazorPackageVersion=$(MicrosoftNETSdkRazorPackageVersion);
-        MicrosoftAspNetCoreAppRefPackageVersion=$(MicrosoftAspNetCoreAppRefPackageVersion);
-        MicrosoftAspNetCoreAppRuntimePackageVersion=@(_RuntimePackageVersionInfo->'%(PackageVersion)');
+        MicrosoftAspNetCoreAppRefPackageVersion=$(TargetingPackVersion);
+        MicrosoftAspNetCoreAppRuntimePackageVersion=$(SharedFxVersion);
         SupportedRuntimeIdentifiers=$(SupportedRuntimeIdentifiers.Trim());
         DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
         RepoRoot=$(RepoRoot);

--- a/src/SiteExtensions/LoggingBranch/Directory.Build.targets
+++ b/src/SiteExtensions/LoggingBranch/Directory.Build.targets
@@ -2,10 +2,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
 
-  <PropertyGroup>
-    <MicrosoftAspNetCoreAppPackageVersion>$(PackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
-  </PropertyGroup>
-
   <Import Project="..\Sdk\SiteExtension.targets" />
 
   <PropertyGroup>

--- a/src/SiteExtensions/Sdk/SiteExtension.targets
+++ b/src/SiteExtensions/Sdk/SiteExtension.targets
@@ -85,7 +85,7 @@
               HostingStartupPackageName=%(_HostingStartupPackageReference.Identity);
               HostingStartupPackageVersion=%(_HostingStartupPackageReference.Version);
               RuntimeFrameworkVersion=$(HostingStartupRuntimeFrameworkVersion);
-              MicrosoftAspNetCoreAppPackageVersion=$(MicrosoftAspNetCoreAppPackageVersion);
+              MicrosoftAspNetCoreAppPackageVersion=$(SharedFxVersion);
               UseAppHost=false;
               NoBuild=false;
               RestoreAdditionalProjectSources=$(_RsRestoreSources)" />
@@ -97,7 +97,7 @@
               HostingStartupPackageName=%(_HostingStartupPackageReference.Identity);
               HostingStartupPackageVersion=%(_HostingStartupPackageReference.Version);
               RuntimeFrameworkVersion=$(HostingStartupRuntimeFrameworkVersion);
-              MicrosoftAspNetCoreAppPackageVersion=$(MicrosoftAspNetCoreAppPackageVersion);
+              MicrosoftAspNetCoreAppPackageVersion=$(SharedFxVersion);
               UseAppHost=false;
               NoBuild=false;
               IncludeMainProjectInDepsFile=false" />


### PR DESCRIPTION
- Ensure `$(SharedFxVersion)` doesn't change in `$(NoSemVer20)` projects
- Ignore current project's `$(VersionSuffix)` in `$(TargetingPackVersion)`
    - Never assume `$(AspNetCoreBaselineVersion)` matches released targeting pack
- Stabilize both versions correctly
- Use these properties more widely
    - Remove other mechanisms to get the same values
    - Reduce use of the `_GetPackageVersionInfo` target
    - Reduce use of `$(SharedFxVersion)` for the targeting pack

nits:
- Correct comments about old RTMVersions.csproj project
- Fix or remove a few other comments