### PR TITLE
Allow dotnet-watch to look for changes to .razor.css files

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildIntrospectionTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/BuildIntrospectionTest.cs
@@ -275,5 +275,17 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.BuildPassed(result);
             Assert.BuildOutputContainsLine(result, $"RazorTasksPath: {expected}");
         }
+
+        [Fact]
+        [InitializeTestProject("ComponentApp")]
+        public async Task IntrospectRazorSdkWatchItems()
+        {
+            // Arrange
+            var result = await DotnetMSBuild("_IntrospectWatchItems");
+
+            Assert.BuildPassed(result);
+            Assert.BuildOutputContainsLine(result, "Watch: Index.razor");
+            Assert.BuildOutputContainsLine(result, "Watch: Index.razor.css");
+        }
     }
 }

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -871,7 +871,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_RazorSdkCustomCollectWatchItems">
     <ItemGroup>
       <Watch Include="%(Content.FullPath)" Condition="'%(Content.Extension)' == '.razor' AND '%(Content.Watch)' != 'false'" />
-      <Watch Include="%(Content.FullPath)" Condition="'%(Content.Extension)' == '.razor.css' AND '%(Content.Watch)' != 'false'" />
+      <Watch Include="%(None.FullPath)" Condition="$([System.String]::Copy('%(None.FullPath)').EndsWith('.razor.css')) AND '%(None.Watch)' != 'false'" />
       <Watch Include="%(Content.FullPath)"
         Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true' AND '$(AddCshtmlFilesToDotNetWatchList)' != 'false' AND '%(Content.Extension)' == '.cshtml' AND '%(Content.Watch)' != 'false'" />
     </ItemGroup>

--- a/src/Razor/test/testassets/RazorTest.Introspection.targets
+++ b/src/Razor/test/testassets/RazorTest.Introspection.targets
@@ -47,6 +47,10 @@
     <Message Text="Content: %(Content.Identity) CopyToOutputDirectory=%(Content.CopyToOutputDirectory) CopyToPublishDirectory=%(Content.CopyToPublishDirectory) ExcludeFromSingleFile=%(Content.ExcludeFromSingleFile)" Importance="High" />
   </Target>
 
+  <Target Name="_IntrospectWatchItems" DependsOnTargets="_RazorSdkCustomCollectWatchItems">
+    <Message Text="Watch: %(Watch.FileName)%(Watch.Extension)" Importance="High" />
+  </Target>
+
   <Target Name="_IntrospectRazorTasks">
     <PropertyGroup>
       <_SdkTaskPath>$([System.IO.Path]::GetFullPath('$(RazorSdkBuildTasksAssembly)'))</_SdkTaskPath>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/25483

The previous change to add .razor.css to dotnet-watch's list of files was added untested and had a bug in it's implementation. This addresses the bug and adds a test to verify that we're watching the right set of files.