### PR TITLE
Fix tests modifying static ListenOptions member data

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -28,6 +28,7 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
@@ -37,10 +38,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         private const int _connectionResetEventId = 19;
         private static readonly int _semaphoreWaitTimeout = Debugger.IsAttached ? 10000 : 2500;
 
-        public static TheoryData<Func<ListenOptions>> ConnectionMiddlewareData => new TheoryData<Func<ListenOptions>>
+        public static Dictionary<string, Func<ListenOptions>> ConnectionMiddlewareData => new Dictionary<string, Func<ListenOptions>>
         {
-            () => new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)),
-            () => new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)).UsePassThrough()
+            { "Loopback", () => new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)) },
+            { "PassThrough", () => new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)).UsePassThrough() }
+        };
+
+        public static TheoryData<string> ConnectionMiddlewareDataName => new TheoryData<string>
+        {
+            "Loopback",
+            "PassThrough"
         };
 
         [Theory]
@@ -515,9 +522,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(ConnectionMiddlewareData))]
+        [MemberData(nameof(ConnectionMiddlewareDataName))]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23043")]
-        public async Task ConnectionClosedTokenFiresOnClientFIN(Func<ListenOptions> listenOptions)
+        public async Task ConnectionClosedTokenFiresOnClientFIN(string listenOptionsName)
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var appStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -531,7 +538,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult());
 
                 return Task.CompletedTask;
-            }, testContext, listenOptions()))
+            }, testContext, ConnectionMiddlewareData[listenOptionsName]()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -551,8 +558,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task ConnectionClosedTokenFiresOnServerFIN(Func<ListenOptions> listenOptions)
+        [MemberData(nameof(ConnectionMiddlewareDataName))]
+        public async Task ConnectionClosedTokenFiresOnServerFIN(string listenOptionsName)
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var connectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -563,7 +570,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult());
 
                 return Task.CompletedTask;
-            }, testContext, listenOptions()))
+            }, testContext, ConnectionMiddlewareData[listenOptionsName]()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -587,8 +594,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task ConnectionClosedTokenFiresOnServerAbort(Func<ListenOptions> listenOptions)
+        [MemberData(nameof(ConnectionMiddlewareDataName))]
+        public async Task ConnectionClosedTokenFiresOnServerAbort(string listenOptionsName)
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var connectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -601,7 +608,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 context.Abort();
 
                 return Task.CompletedTask;
-            }, testContext, listenOptions()))
+            }, testContext, ConnectionMiddlewareData[listenOptionsName]()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -628,8 +635,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task RequestsCanBeAbortedMidRead(Func<ListenOptions> listenOptions)
+        [MemberData(nameof(ConnectionMiddlewareDataName))]
+        public async Task RequestsCanBeAbortedMidRead(string listenOptionsName)
         {
             // This needs a timeout.
             const int applicationAbortedConnectionId = 34;
@@ -678,7 +685,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                     readTcs.SetException(new Exception("This shouldn't be reached."));
                 }
-            }, testContext, listenOptions()))
+            }, testContext, ConnectionMiddlewareData[listenOptionsName]()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -718,8 +725,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task ServerCanAbortConnectionAfterUnobservedClose(Func<ListenOptions> listenOptions)
+        [MemberData(nameof(ConnectionMiddlewareDataName))]
+        public async Task ServerCanAbortConnectionAfterUnobservedClose(string listenOptionsName)
         {
             const int connectionPausedEventId = 4;
             const int connectionFinSentEventId = 7;
@@ -773,7 +780,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 await serverClosedConnection.Task;
 
                 appFuncCompleted.SetResult();
-            }, testContext, listenOptions()))
+            }, testContext, ConnectionMiddlewareData[listenOptionsName]()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -799,8 +806,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task AppCanHandleClientAbortingConnectionMidRequest(Func<ListenOptions> listenOptions)
+        [MemberData(nameof(ConnectionMiddlewareDataName))]
+        public async Task AppCanHandleClientAbortingConnectionMidRequest(string listenOptionsName)
         {
             var readTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var appStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -826,7 +833,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 readTcs.SetException(new Exception("This shouldn't be reached."));
 
-            }, testContext, listenOptions()))
+            }, testContext, ConnectionMiddlewareData[listenOptionsName]()))
             {
                 using (var connection = server.CreateConnection())
                 {

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -37,10 +37,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         private const int _connectionResetEventId = 19;
         private static readonly int _semaphoreWaitTimeout = Debugger.IsAttached ? 10000 : 2500;
 
-        public static TheoryData<ListenOptions> ConnectionMiddlewareData => new TheoryData<ListenOptions>
+        public static TheoryData<Func<ListenOptions>> ConnectionMiddlewareData => new TheoryData<Func<ListenOptions>>
         {
-            new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)),
-            new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)).UsePassThrough()
+            () => new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)),
+            () => new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)).UsePassThrough()
         };
 
         [Theory]
@@ -517,7 +517,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareData))]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23043")]
-        public async Task ConnectionClosedTokenFiresOnClientFIN(ListenOptions listenOptions)
+        public async Task ConnectionClosedTokenFiresOnClientFIN(Func<ListenOptions> listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var appStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -531,7 +531,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult());
 
                 return Task.CompletedTask;
-            }, testContext, listenOptions))
+            }, testContext, listenOptions()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -552,7 +552,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task ConnectionClosedTokenFiresOnServerFIN(ListenOptions listenOptions)
+        public async Task ConnectionClosedTokenFiresOnServerFIN(Func<ListenOptions> listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var connectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -563,7 +563,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 connectionLifetimeFeature.ConnectionClosed.Register(() => connectionClosedTcs.SetResult());
 
                 return Task.CompletedTask;
-            }, testContext, listenOptions))
+            }, testContext, listenOptions()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -588,7 +588,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task ConnectionClosedTokenFiresOnServerAbort(ListenOptions listenOptions)
+        public async Task ConnectionClosedTokenFiresOnServerAbort(Func<ListenOptions> listenOptions)
         {
             var testContext = new TestServiceContext(LoggerFactory);
             var connectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -601,7 +601,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 context.Abort();
 
                 return Task.CompletedTask;
-            }, testContext, listenOptions))
+            }, testContext, listenOptions()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -629,7 +629,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task RequestsCanBeAbortedMidRead(ListenOptions listenOptions)
+        public async Task RequestsCanBeAbortedMidRead(Func<ListenOptions> listenOptions)
         {
             // This needs a timeout.
             const int applicationAbortedConnectionId = 34;
@@ -678,7 +678,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                     readTcs.SetException(new Exception("This shouldn't be reached."));
                 }
-            }, testContext, listenOptions))
+            }, testContext, listenOptions()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -719,7 +719,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task ServerCanAbortConnectionAfterUnobservedClose(ListenOptions listenOptions)
+        public async Task ServerCanAbortConnectionAfterUnobservedClose(Func<ListenOptions> listenOptions)
         {
             const int connectionPausedEventId = 4;
             const int connectionFinSentEventId = 7;
@@ -773,7 +773,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 await serverClosedConnection.Task;
 
                 appFuncCompleted.SetResult();
-            }, testContext, listenOptions))
+            }, testContext, listenOptions()))
             {
                 using (var connection = server.CreateConnection())
                 {
@@ -800,7 +800,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareData))]
-        public async Task AppCanHandleClientAbortingConnectionMidRequest(ListenOptions listenOptions)
+        public async Task AppCanHandleClientAbortingConnectionMidRequest(Func<ListenOptions> listenOptions)
         {
             var readTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var appStartedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -826,7 +826,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
                 readTcs.SetException(new Exception("This shouldn't be reached."));
 
-            }, testContext, listenOptions))
+            }, testContext, listenOptions()))
             {
                 using (var connection = server.CreateConnection())
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/23043

Two things I haven't figured out yet:
1. Who is modifying the ListenOptions and is that a bug?
1. ~~How is the second test runs' client hitting the first test runs' "app"?~~ ListenOptions has the app func inside it