### PR TITLE
Nullability feedback for public types in Components

### DIFF
--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Components
         private static readonly object BoxedFalse = false;
 
         private delegate object? BindFormatter<T>(T value, CultureInfo? culture);
-        private delegate object BindFormatterWithFormat<T>(T value, CultureInfo? culture, string format);
 
         internal delegate bool BindParser<T>(object? obj, CultureInfo? culture, [MaybeNullWhen(false)] out T value);
         internal delegate bool BindParserWithFormat<T>(object? obj, CultureInfo? culture, string? format, [MaybeNullWhen(false)] out T value);

--- a/src/Components/Components/src/EventCallback.cs
+++ b/src/Components/Components/src/EventCallback.cs
@@ -51,11 +51,11 @@ namespace Microsoft.AspNetCore.Components
         /// </summary>
         /// <param name="arg">The argument.</param>
         /// <returns>A <see cref="Task"/> which completes asynchronously once event processing has completed.</returns>
-        public Task InvokeAsync(object arg)
+        public Task InvokeAsync(object? arg)
         {
             if (Receiver == null)
             {
-                return EventCallbackWorkItem.InvokeAsync<object>(Delegate, arg);
+                return EventCallbackWorkItem.InvokeAsync<object?>(Delegate, arg);
             }
 
             return Receiver.HandleEventAsync(new EventCallbackWorkItem(Delegate), arg);


### PR DESCRIPTION
* EventCallback.InvokeAsync can pass a null value
* Remove unused BindFormatterWithFormat

Based on feedback in https://github.com/pranavkm/refs/pull/1
