### PR TITLE
Fix Java packaging

### DIFF
--- a/src/SignalR/clients/java/signalr/core/build.gradle
+++ b/src/SignalR/clients/java/signalr/core/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'java'
+    id 'maven'
+}
+
 group 'com.microsoft.signalr'
 
 dependencies {
@@ -22,6 +27,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task generatePOM {
     pom {
         project {
+            artifactId 'signalr'
             inceptionYear '2018'
             description 'ASP.NET Core SignalR Client for Java applications'
             url 'https://github.com/dotnet/aspnetcore'

--- a/src/SignalR/clients/java/signalr/messagepack/build.gradle
+++ b/src/SignalR/clients/java/signalr/messagepack/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'java'
+    id 'maven'
+}
+
 group 'com.microsoft.signalr.messagepack'
 
 dependencies {
@@ -21,6 +26,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task generatePOM {
     pom {
         project {
+            artifactId 'signalr-messagepack'
             inceptionYear '2020'
             description 'MessagePack protocol implementation for ASP.NET Core SignalR Client for Java applications'
             url 'https://github.com/dotnet/aspnetcore'

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -2974,7 +2974,10 @@ class HubConnectionTest {
                     assertTrue(close.blockingAwait(5, TimeUnit.SECONDS));
                     return Single.just(new HttpResponse(204, "", TestUtils.emptyByteBuffer));
                 })
-                .on("DELETE", (req) -> Single.just(new HttpResponse(200, "", TestUtils.stringToByteBuffer(""))));
+                .on("DELETE", (req) -> {
+                    close.onComplete();
+                    return Single.just(new HttpResponse(200, "", TestUtils.stringToByteBuffer("")));
+                });
 
         HubConnection hubConnection = HubConnectionBuilder
                 .create("http://example.com")
@@ -2984,7 +2987,6 @@ class HubConnectionTest {
 
         hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertTrue(hubConnection.getTransport() instanceof LongPollingTransport);
-        close.onComplete();
         hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
     }
 


### PR DESCRIPTION
Needed to include the maven plugin to fix the POM, as well as setting the `artifactid` as it is the folder name by default.

#### Description

Java packing is currently broken and producing an invalid POM file. This is stopping us from shipping the package currently.

#### Customer Impact

Can't ship new packages for customers to consume.

#### Regression?

Yes, change in RC1 to add a new Java package broke both the new and old package.

#### Risk

Low, packaging only change, verified that the change allows packages to upload, and that the previous POM is similar/identical.
