### PR TITLE
Move the runtime code sync back to master.

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -21,14 +21,14 @@ jobs:
         # Test this script using changes in a fork 
         repository: 'dotnet/aspnetcore'
         path: aspnetcore
-        ref: release/5.0
+        ref: master
     - name: Checkout runtime
       uses: actions/checkout@v2.0.0
       with:
         # Test this script using changes in a fork 
         repository: 'dotnet/runtime'
         path: runtime
-        ref: release/5.0
+        ref: master
     - name: Copy
       shell: cmd
       working-directory: .\runtime\src\libraries\Common\src\System\Net\Http\aspnetcore\
@@ -67,6 +67,6 @@ jobs:
         title: 'Sync shared code from runtime'
         body: 'This PR was automatically generated to sync shared code changes from runtime. Fixes #18943'
         labels: area-servers
-        base: release/5.0
+        base: master
         branch: github-action/sync-runtime
         branch-suffix: timestamp


### PR DESCRIPTION
Now that 5.0 is effectively done, we can change the code sync bot back to the master branch for 6.0. Note if there are any more changes in 5.0 then we can run this manually in that branch.