### PR TITLE
Fix MSB4109 error in 5.0 RC1

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <_IsMicrosoftNETCoreApp20OrOlder>false</_IsMicrosoftNETCoreApp20OrOlder>
     <_IsMicrosoftNETCoreApp20OrOlder Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
-      $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '2.0') ">true</_IsMicrosoftNETCoreApp20OrOlder>
+      $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '2.0')) ">true</_IsMicrosoftNETCoreApp20OrOlder>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OpenApiGenerateDocuments)' == '' ">
     <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>


### PR DESCRIPTION
Fix MSB4109 error when the `Microsoft.Extensions.ApiDescription.Server` NuGet package is installed with ASP.NET 5 RC1.

```
C:\Users\martin.costello\.nuget\packages\microsoft.extensions.apidescription.server\5.0.0-rc.1.20451.17\build\Microsoft.Extensions.ApiDescription.Server.targets(5,38): error MSB4109: Expected a property at position 61 in condition " '$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND [Project.csproj]
C:\Users\martin.costello\.nuget\packages\microsoft.extensions.apidescription.server\5.0.0-rc.1.20451.17\build\Microsoft.Extensions.ApiDescription.Server.targets(5,38): error MSB4109:       $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '2.0') ". Did you forget the closing parenthesis? [Project.csproj]
```

Appears to have been introduced by #25428.

/cc @dougbu 