### PR TITLE
Attempt to fix race with client disconnect

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -345,7 +345,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             HasStartedConsumingRequestBody = false;
 
             // Upgrade async will cause the stream processing to go into duplex mode
-            AsyncIO = new WebSocketsAsyncIOEngine(_contextLock, _requestNativeHandle);
+            AsyncIO = new WebSocketsAsyncIOEngine(this, _requestNativeHandle);
 
             await InitializeResponse(flushHeaders: true);
 

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
     internal partial class IISHttpContext
     {
         private long _consumedBytes;
-        internal bool _clientDisconnected;
+        internal bool ClientDisconnected { get; private set; }
 
         /// <summary>
         /// Reads data from the Input pipe to the user.
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
             lock (_contextLock)
             {
-                _clientDisconnected = clientDisconnect;
+                ClientDisconnected = clientDisconnect;
             }
 
             if (clientDisconnect)

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
     internal partial class IISHttpContext
     {
         private long _consumedBytes;
+        internal bool _clientDisconnected;
 
         /// <summary>
         /// Reads data from the Input pipe to the user.
@@ -224,6 +225,11 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
                 shouldScheduleCancellation = _abortedCts != null;
                 _requestAborted = true;
+            }
+
+            lock (_contextLock)
+            {
+                _clientDisconnected = clientDisconnect;
             }
 
             if (clientDisconnect)

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
         private int _statusCode;
         private string _reasonPhrase;
         // Used to synchronize callback registration and native method calls
-        private readonly object _contextLock = new object();
+        internal readonly object _contextLock = new object();
 
         protected Stack<KeyValuePair<Func<object, Task>, object>> _onStarting;
         protected Stack<KeyValuePair<Func<object, Task>, object>> _onCompleted;
@@ -324,7 +324,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             // If at this point request was not upgraded just start a normal IO engine
             if (AsyncIO == null)
             {
-                AsyncIO = new AsyncIOEngine(_contextLock, _requestNativeHandle);
+                AsyncIO = new AsyncIOEngine(this, _requestNativeHandle);
             }
         }
 

--- a/src/Servers/IIS/IIS/src/Core/IO/AsyncIOEngine.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/AsyncIOEngine.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
                 _stopped = true;
 
                 // Should only call CancelIO if the client hasn't disconnected
-                if (!_context._clientDisconnected)
+                if (!_context.ClientDisconnected)
                 {
                     NativeMethods.HttpTryCancelIO(_handler);
                 }

--- a/src/Servers/IIS/IIS/src/Core/IO/AsyncIOEngine.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/AsyncIOEngine.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 {
     internal partial class AsyncIOEngine : IAsyncIOEngine
     {
-        private readonly object _contextSync;
+        private readonly IISHttpContext _context;
         private readonly NativeSafeHandle _handler;
 
         private bool _stopped;
@@ -24,9 +24,9 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
         private AsyncWriteOperation _cachedAsyncWriteOperation;
         private AsyncFlushOperation _cachedAsyncFlushOperation;
 
-        public AsyncIOEngine(object contextSync, NativeSafeHandle handler)
+        public AsyncIOEngine(IISHttpContext context, NativeSafeHandle handler)
         {
-            _contextSync = contextSync;
+            _context = context;
             _handler = handler;
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 
         private void Run(AsyncIOOperation ioOperation)
         {
-            lock (_contextSync)
+            lock (_context._contextLock)
             {
                 if (_stopped)
                 {
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
             AsyncIOOperation.AsyncContinuation continuation;
             AsyncIOOperation.AsyncContinuation? nextContinuation = null;
 
-            lock (_contextSync)
+            lock (_context._contextLock)
             {
                 Debug.Assert(_runningOperation != null);
 
@@ -138,10 +138,15 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 
         public void Complete()
         {
-            lock (_contextSync)
+            lock (_context._contextLock)
             {
                 _stopped = true;
-                NativeMethods.HttpTryCancelIO(_handler);
+
+                // Should only call CancelIO if the client hasn't disconnected
+                if (!_context._clientDisconnected)
+                {
+                    NativeMethods.HttpTryCancelIO(_handler);
+                }
             }
         }
 

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
             lock (_context._contextLock)
             {
                 // Should only call CancelIO if the client hasn't disconnected
-                if (!_context._clientDisconnected)
+                if (!_context.ClientDisconnected)
                 {
                     NativeMethods.HttpTryCancelIO(_handler);
                 }

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 {
     internal partial class WebSocketsAsyncIOEngine: IAsyncIOEngine
     {
-        private readonly object _contextLock;
+        private readonly IISHttpContext _context;
 
         private readonly NativeSafeHandle _handler;
 
@@ -24,15 +24,15 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 
         private AsyncInitializeOperation _cachedAsyncInitializeOperation;
 
-        public WebSocketsAsyncIOEngine(object contextLock, NativeSafeHandle handler)
+        public WebSocketsAsyncIOEngine(IISHttpContext context, NativeSafeHandle handler)
         {
-            _contextLock = contextLock;
+            _context = context;
             _handler = handler;
         }
 
         public ValueTask<int> ReadAsync(Memory<byte> memory)
         {
-            lock (_contextLock)
+            lock (_context._contextLock)
             {
                 ThrowIfNotInitialized();
 
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 
         public ValueTask<int> WriteAsync(ReadOnlySequence<byte> data)
         {
-            lock (_contextLock)
+            lock (_context._contextLock)
             {
                 ThrowIfNotInitialized();
 
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 
         public ValueTask FlushAsync(bool moreData)
         {
-            lock (_contextLock)
+            lock (_context._contextLock)
             {
                 if (_isInitialized)
                 {
@@ -112,9 +112,13 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO
 
         public void Complete()
         {
-            lock (_contextLock)
+            lock (_context._contextLock)
             {
-                NativeMethods.HttpTryCancelIO(_handler);
+                // Should only call CancelIO if the client hasn't disconnected
+                if (!_context._clientDisconnected)
+                {
+                    NativeMethods.HttpTryCancelIO(_handler);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/25179

I'm not a fan of locking on an internal field, but I needed the context to check if client disconnect has been called.

