### PR TITLE
Prevent null ref in FeatureCollection access

### DIFF
--- a/src/Http/Http.Features/src/FeatureReferences.cs
+++ b/src/Http/Http.Features/src/FeatureReferences.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Http.Features
@@ -122,6 +123,7 @@ namespace Microsoft.AspNetCore.Http.Features
             return 0;
         }
 
+        [DoesNotReturn]
         private static void ThrowContextDisposed()
         {
             throw new ObjectDisposedException(nameof(Collection), nameof(IFeatureCollection) + " has been disposed.");


### PR DESCRIPTION
If there is a race condition with Feature disposal (unawaited task or use after request end); it can pass the first Context Disposed check in `Fetch` and then null ref in `UpdateCached`

It should always throw Context Disposed rather than null ref

Seen in https://github.com/dotnet/aspnetcore/issues/25454