### PR TITLE
Add a test to verify NewtonsoftJsonInputFormatter disposes temporary buffer

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -123,7 +123,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            var request = context.HttpContext.Request;
+            var httpContext = context.HttpContext;
+            var request = httpContext.Request;
 
             var suppressInputFormatterBuffering = _options.SuppressInputFormatterBuffering;
 
@@ -153,7 +154,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
 
                 readStream = new FileBufferingReadStream(request.Body, memoryThreshold);
                 // Ensure the file buffer stream is always disposed at the end of a request.
-                request.HttpContext.Response.RegisterForDispose(readStream);
+                httpContext.Response.RegisterForDispose(readStream);
 
                 await readStream.DrainAsync(CancellationToken.None);
                 readStream.Seek(0L, SeekOrigin.Begin);


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/22342 was fixed in a patch release,
but we hadn't written a test for this at that time. This change adds a unit
test to verify this.

Fixes https://github.com/dotnet/aspnetcore/issues/22342
