### PR TITLE
Fix SignalR+WebSockets on WASM

### DIFF
--- a/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
@@ -7,6 +7,7 @@ using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Http.Connections;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit;
@@ -37,11 +38,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Exists(By.Id("signalr-client"));
         }
 
-        [Fact]
-        public void SignalRClientWorks()
+        [Theory]
+        [InlineData(HttpTransportType.WebSockets)]
+        [InlineData(HttpTransportType.LongPolling)]
+        public void SignalRClientWorks(HttpTransportType transportType)
         {
             Browser.FindElement(By.Id("hub-url")).SendKeys(
                 new Uri(_apiServerFixture.RootUri, "/subdir/chathub").AbsoluteUri);
+            Browser.FindElement(By.Id("transport-type")).SendKeys(
+                transportType.ToString());
             Browser.FindElement(By.Id("hub-connect")).Click();
 
             Browser.Equal("SignalR Client: Echo",

--- a/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
@@ -38,15 +38,26 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Exists(By.Id("signalr-client"));
         }
 
-        [Theory]
-        [InlineData(HttpTransportType.WebSockets)]
-        [InlineData(HttpTransportType.LongPolling)]
-        public void SignalRClientWorks(HttpTransportType transportType)
+        [Fact]
+        public void SignalRClientWorksWithLongPolling()
         {
             Browser.FindElement(By.Id("hub-url")).SendKeys(
                 new Uri(_apiServerFixture.RootUri, "/subdir/chathub").AbsoluteUri);
             Browser.FindElement(By.Id("transport-type")).SendKeys(
-                transportType.ToString());
+                HttpTransportType.LongPolling.ToString());
+            Browser.FindElement(By.Id("hub-connect")).Click();
+
+            Browser.Equal("SignalR Client: Echo",
+                () => Browser.FindElements(By.CssSelector("li")).FirstOrDefault()?.Text);
+        }
+
+        [Fact]
+        public void SignalRClientWorksWithWebSockets()
+        {
+            Browser.FindElement(By.Id("hub-url")).SendKeys(
+                new Uri(_apiServerFixture.RootUri, "/subdir/chathub").AbsoluteUri);
+            Browser.FindElement(By.Id("transport-type")).SendKeys(
+                HttpTransportType.WebSockets.ToString());
             Browser.FindElement(By.Id("hub-connect")).Click();
 
             Browser.Equal("SignalR Client: Echo",

--- a/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
 using Microsoft.AspNetCore.Http.Connections;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
 using TestServer;
 using Xunit;
 using Xunit.Abstractions;
@@ -43,11 +44,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.FindElement(By.Id("hub-url")).SendKeys(
                 new Uri(_apiServerFixture.RootUri, "/subdir/chathub").AbsoluteUri);
-            Browser.FindElement(By.Id("transport-type")).SendKeys(
-                HttpTransportType.LongPolling.ToString());
+            var target = new SelectElement(Browser.FindElement(By.Id("transport-type")));
+            target.SelectByText("LongPolling");
             Browser.FindElement(By.Id("hub-connect")).Click();
 
-            Browser.Equal("SignalR Client: Echo",
+            Browser.Equal("SignalR Client: Echo LongPolling",
                 () => Browser.FindElements(By.CssSelector("li")).FirstOrDefault()?.Text);
         }
 
@@ -56,11 +57,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.FindElement(By.Id("hub-url")).SendKeys(
                 new Uri(_apiServerFixture.RootUri, "/subdir/chathub").AbsoluteUri);
-            Browser.FindElement(By.Id("transport-type")).SendKeys(
-                HttpTransportType.WebSockets.ToString());
+            var target = new SelectElement(Browser.FindElement(By.Id("transport-type")));
+            target.SelectByText("WebSockets");
             Browser.FindElement(By.Id("hub-connect")).Click();
 
-            Browser.Equal("SignalR Client: Echo",
+            Browser.Equal("SignalR Client: Echo WebSockets",
                 () => Browser.FindElements(By.CssSelector("li")).FirstOrDefault()?.Text);
         }
     }

--- a/src/Components/test/testassets/BasicTestApp/SignalRClientComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/SignalRClientComponent.razor
@@ -1,4 +1,6 @@
-﻿@using Microsoft.AspNetCore.SignalR.Client
+﻿@using System
+@using Microsoft.AspNetCore.SignalR.Client
+@using Microsoft.AspNetCore.Http.Connections
 
 <h1 id="signalr-client">SignalR Client</h1>
 
@@ -7,6 +9,7 @@
 <p>
     Hub URL:
     <input id="hub-url" @bind="hubUrl" />
+    <input id="transport-type" @bind="transportType" />
     <button id="hub-connect" @onclick="Connect">Connect</button>
 </p>
 
@@ -21,13 +24,14 @@
 
 @code {
     private string hubUrl;
+    private string transportType;
     private HubConnection hubConnection;
     private List<string> messages = new List<string>();
 
     protected async Task Connect()
     {
         hubConnection = new HubConnectionBuilder()
-            .WithUrl(hubUrl)
+            .WithUrl(hubUrl, Enum.Parse<HttpTransportType>(transportType))
             .Build();
 
         hubConnection.On<string, string>("ReceiveMessage", (user, message) =>

--- a/src/Components/test/testassets/BasicTestApp/SignalRClientComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/SignalRClientComponent.razor
@@ -1,5 +1,4 @@
-﻿@using System
-@using Microsoft.AspNetCore.SignalR.Client
+﻿@using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.AspNetCore.Http.Connections
 
 <h1 id="signalr-client">SignalR Client</h1>
@@ -9,7 +8,10 @@
 <p>
     Hub URL:
     <input id="hub-url" @bind="hubUrl" />
-    <input id="transport-type" @bind="transportType" />
+    <select id="transport-type" @bind="transportType">
+        <option value=@HttpTransportType.LongPolling>LongPolling</option>
+        <option value=@HttpTransportType.WebSockets>WebSockets</option>
+    </select>
     <button id="hub-connect" @onclick="Connect">Connect</button>
 </p>
 
@@ -24,14 +26,14 @@
 
 @code {
     private string hubUrl;
-    private string transportType;
+    private HttpTransportType transportType;
     private HubConnection hubConnection;
     private List<string> messages = new List<string>();
 
     protected async Task Connect()
     {
         hubConnection = new HubConnectionBuilder()
-            .WithUrl(hubUrl, Enum.Parse<HttpTransportType>(transportType))
+            .WithUrl(hubUrl, transportType)
             .Build();
 
         hubConnection.On<string, string>("ReceiveMessage", (user, message) =>
@@ -42,7 +44,7 @@
         });
 
         await hubConnection.StartAsync();
-        await hubConnection.SendAsync("SendMessage", "SignalR Client", "Echo");
+        await hubConnection.SendAsync("SendMessage", "SignalR Client", $"Echo {transportType}");
     }
 
     public bool IsConnected =>

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/DefaultTransportFactory.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/DefaultTransportFactory.cs
@@ -39,8 +39,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                 {
                     return new WebSocketsTransport(_httpConnectionOptions, _loggerFactory, _accessTokenProvider);
                 }
-                catch (PlatformNotSupportedException)
+                catch (PlatformNotSupportedException ex)
                 {
+                    Log.TransportNotSupported(_loggerFactory.CreateLogger<DefaultTransportFactory>(), HttpTransportType.WebSockets, ex);
                     _websocketsSupported = false;
                 }
             }
@@ -58,6 +59,17 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             }
 
             throw new InvalidOperationException("No requested transports available on the server.");
+        }
+
+        private static class Log
+        {
+            private static readonly Action<ILogger, HttpTransportType, Exception> _transportNotSupported =
+                LoggerMessage.Define<HttpTransportType>(LogLevel.Debug, new EventId(1, "TransportNotSupported"), "Transport '{TransportType}' is not supported.");
+
+            public static void TransportNotSupported(ILogger logger, HttpTransportType transportType, Exception ex)
+            {
+                _transportNotSupported(logger, transportType, ex);
+            }
         }
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -37,66 +37,69 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
         public WebSocketsTransport(HttpConnectionOptions httpConnectionOptions, ILoggerFactory loggerFactory, Func<Task<string>> accessTokenProvider)
         {
             _webSocket = new ClientWebSocket();
+            _isRunningInBrowser = Utils.IsRunningInBrowser();
 
-            // Full Framework will throw when trying to set the User-Agent header
-            // So avoid setting it in netstandard2.0 and only set it in netstandard2.1 and higher
+            // ClientWebSocketOptions throws PNSE when accessing and setting properties
+            if (!_isRunningInBrowser)
+            {
+                // Full Framework will throw when trying to set the User-Agent header
+                // So avoid setting it in netstandard2.0 and only set it in netstandard2.1 and higher
 #if !NETSTANDARD2_0
-            _webSocket.Options.SetRequestHeader("User-Agent", Constants.UserAgentHeader.ToString());
+                _webSocket.Options.SetRequestHeader("User-Agent", Constants.UserAgentHeader.ToString());
 #else
-            // Set an alternative user agent header on Full framework
-            _webSocket.Options.SetRequestHeader("X-SignalR-User-Agent", Constants.UserAgentHeader.ToString());
+                // Set an alternative user agent header on Full framework
+                _webSocket.Options.SetRequestHeader("X-SignalR-User-Agent", Constants.UserAgentHeader.ToString());
 #endif
 
-            if (httpConnectionOptions != null)
-            {
-                if (httpConnectionOptions.Headers != null)
+                if (httpConnectionOptions != null)
                 {
-                    foreach (var header in httpConnectionOptions.Headers)
+                    if (httpConnectionOptions.Headers != null)
                     {
-                        _webSocket.Options.SetRequestHeader(header.Key, header.Value);
+                        foreach (var header in httpConnectionOptions.Headers)
+                        {
+                            _webSocket.Options.SetRequestHeader(header.Key, header.Value);
+                        }
+                    }
+
+                    if (httpConnectionOptions.Cookies != null)
+                    {
+                        _webSocket.Options.Cookies = httpConnectionOptions.Cookies;
+                    }
+
+                    if (httpConnectionOptions.ClientCertificates != null)
+                    {
+                        _webSocket.Options.ClientCertificates.AddRange(httpConnectionOptions.ClientCertificates);
+                    }
+
+                    if (httpConnectionOptions.Credentials != null)
+                    {
+                        _webSocket.Options.Credentials = httpConnectionOptions.Credentials;
+                    }
+
+                    if (httpConnectionOptions.Proxy != null)
+                    {
+                        _webSocket.Options.Proxy = httpConnectionOptions.Proxy;
+                    }
+
+                    if (httpConnectionOptions.UseDefaultCredentials != null)
+                    {
+                        _webSocket.Options.UseDefaultCredentials = httpConnectionOptions.UseDefaultCredentials.Value;
                     }
                 }
 
-                if (httpConnectionOptions.Cookies != null)
-                {
-                    _webSocket.Options.Cookies = httpConnectionOptions.Cookies;
-                }
-
-                if (httpConnectionOptions.ClientCertificates != null)
-                {
-                    _webSocket.Options.ClientCertificates.AddRange(httpConnectionOptions.ClientCertificates);
-                }
-
-                if (httpConnectionOptions.Credentials != null)
-                {
-                    _webSocket.Options.Credentials = httpConnectionOptions.Credentials;
-                }
-
-                if (httpConnectionOptions.Proxy != null)
-                {
-                    _webSocket.Options.Proxy = httpConnectionOptions.Proxy;
-                }
-
-                if (httpConnectionOptions.UseDefaultCredentials != null)
-                {
-                    _webSocket.Options.UseDefaultCredentials = httpConnectionOptions.UseDefaultCredentials.Value;
-                }
-
-                httpConnectionOptions.WebSocketConfiguration?.Invoke(_webSocket.Options);
-
-                _closeTimeout = httpConnectionOptions.CloseTimeout;
+                // Set this header so the server auth middleware will set an Unauthorized instead of Redirect status code
+                // See: https://github.com/aspnet/Security/blob/ff9f145a8e89c9756ea12ff10c6d47f2f7eb345f/src/Microsoft.AspNetCore.Authentication.Cookies/Events/CookieAuthenticationEvents.cs#L42
+                _webSocket.Options.SetRequestHeader("X-Requested-With", "XMLHttpRequest");
             }
 
-            // Set this header so the server auth middleware will set an Unauthorized instead of Redirect status code
-            // See: https://github.com/aspnet/Security/blob/ff9f145a8e89c9756ea12ff10c6d47f2f7eb345f/src/Microsoft.AspNetCore.Authentication.Cookies/Events/CookieAuthenticationEvents.cs#L42
-            _webSocket.Options.SetRequestHeader("X-Requested-With", "XMLHttpRequest");
+            // Allow this callback to run in the browser in case it has code that will not throw PNSE
+            httpConnectionOptions.WebSocketConfiguration?.Invoke(_webSocket.Options);
+            _closeTimeout = httpConnectionOptions.CloseTimeout;
 
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<WebSocketsTransport>();
 
             // Ignore the HttpConnectionOptions access token provider. We were given an updated delegate from the HttpConnection.
             _accessTokenProvider = accessTokenProvider;
-
-            _isRunningInBrowser = Utils.IsRunningInBrowser();
         }
 
         public async Task StartAsync(Uri url, TransferFormat transferFormat, CancellationToken cancellationToken = default)

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -87,13 +87,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                     }
                 }
 
+                httpConnectionOptions.WebSocketConfiguration?.Invoke(_webSocket.Options);
+
                 // Set this header so the server auth middleware will set an Unauthorized instead of Redirect status code
                 // See: https://github.com/aspnet/Security/blob/ff9f145a8e89c9756ea12ff10c6d47f2f7eb345f/src/Microsoft.AspNetCore.Authentication.Cookies/Events/CookieAuthenticationEvents.cs#L42
                 _webSocket.Options.SetRequestHeader("X-Requested-With", "XMLHttpRequest");
             }
 
-            // Allow this callback to run in the browser in case it has code that will not throw PNSE
-            httpConnectionOptions.WebSocketConfiguration?.Invoke(_webSocket.Options);
             _closeTimeout = httpConnectionOptions.CloseTimeout;
 
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<WebSocketsTransport>();

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -85,16 +85,17 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
                     {
                         _webSocket.Options.UseDefaultCredentials = httpConnectionOptions.UseDefaultCredentials.Value;
                     }
+
+                    httpConnectionOptions.WebSocketConfiguration?.Invoke(_webSocket.Options);
                 }
 
-                httpConnectionOptions.WebSocketConfiguration?.Invoke(_webSocket.Options);
 
                 // Set this header so the server auth middleware will set an Unauthorized instead of Redirect status code
                 // See: https://github.com/aspnet/Security/blob/ff9f145a8e89c9756ea12ff10c6d47f2f7eb345f/src/Microsoft.AspNetCore.Authentication.Cookies/Events/CookieAuthenticationEvents.cs#L42
                 _webSocket.Options.SetRequestHeader("X-Requested-With", "XMLHttpRequest");
             }
 
-            _closeTimeout = httpConnectionOptions.CloseTimeout;
+            _closeTimeout = httpConnectionOptions?.CloseTimeout ?? default;
 
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<WebSocketsTransport>();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/25913 + adds additional smoke test

#### Description

ClientWebSocketOptions now throws when using it in WASM, this breaks SignalR client usage on WASM.

#### Customer Impact

Bug reported by customer in https://github.com/dotnet/aspnetcore/issues/25913
Websockets will never be used by the client on WASM. It will either fallback to LongPolling or if WebSockets is specified it'll fail.
Workaround is to provide your own copy of the websockets transport (copy paste from github and modify it)

#### Regression?

Yes, used to work in 3.1 and some versions of 5.0 previews. ClientWebSocketOptions as some point changed to throw on most property/method usage.

#### Risk

Low