### PR TITLE
Make timezone and ICU data available offline for PWA

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
@@ -8,7 +8,7 @@ self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
-const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/ ];
+const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.blat$/, /\.dat$/ ];
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
 async function onInstall(event) {


### PR DESCRIPTION
## Description

We've added two new file types to the default Blazor WebAssembly PWA template:

 * Timezone data with `.blat` extension
 * ICU data with `.dat` extension

However, we didn't update the `service-worker.published.js` file to tell it to include those file types in the offline cache.

We do have E2E and CTI tests to show that PWAs work correctly offline, but they didn't identify a fault here because out of the box, it doesn't actually break offline support, because there's a secondary layer of caching (that applies to all apps, not just PWAs) in which those files are cached. Based on that we could arguably choose not to fix this, but doing so creates a strange inconsistency and means that `.blat`/`.dat` files are the ones that would cause errors if the developer had chosen to disable that secondary layer of caching.

## Customer impact

Using the project template defaults, none - the PWA still works offline due to an unrelated feature.

However as soon as the developer enables `<BlazorCacheBootResources>false</BlazorCacheBootResources>` (which disables the "secondary layer of caching" I mentioned above) then PWAs would become broken when they are not meant to. The main reason why people disable the secondary caching is because it enforces integrity checks which some people don't want due to limitations in their hosting environment.

It won't make any sense why `<BlazorCacheBootResources>false</BlazorCacheBootResources>` causes this problem and why it only fails on the `.dat`/`.blat` files.

## Regression?

Yes. In 3.2, PWAs worked offline even when not caching boot resources.

## Risk

There is almost no risk of unintentional side effects considering how tiny and obvious the code change is. It's very tightly scoped.

## Caveat

This change does create a caveat that the PWA will be offline-caching *all* the ICU shards, not just the one corresponding to the current user's locale. This is arguably desirable, since we can't know which locales they are going to use in the future while offline. However some developers might want to customize the `service-worker.published.js` logic further to limit the set of ICU shards that get cached, and they are free to do so. In the worst case in 5.0, the PWA will fetch a few hundred KB more data in the background as an async task that the user most likely cannot notice since it's happening in the background while they are already using the application, but longer term if we end up creating a lot more possible ICU shards we'll want to have some built-in way to not cache them all inside PWAs.