### PR TITLE
An attempt to fix database error page tests

### DIFF
--- a/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
@@ -398,10 +398,10 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
 
             await host.StartAsync();
 
-            var server = host.GetTestServer();
 
             try
             {
+                using var server = host.GetTestServer();
                 await server.CreateClient().GetAsync("http://localhost/");
             }
             catch (Exception exception)
@@ -446,10 +446,10 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
                 var logProvider = new TestLoggerProvider();
 
                 using var host = await SetupServer<BloggingContextWithSnapshotThatThrows, ExceptionInLogicMiddleware>(database, logProvider);
-                using var server = host.GetTestServer();
 
                 try
                 {
+                    using var server = host.GetTestServer();
                     await server.CreateClient().GetAsync("http://localhost/");
                 }
                 catch (Exception exception)


### PR DESCRIPTION
Idea to fix https://github.com/dotnet/runtime/issues/42342.

We think logs are simultaneously occurring when calling ToList(). Let's try to dispose the server before checking logs to see if that fixes it.