### PR TITLE
dotnet-watch: continue printing output to console after the app is ready

### DIFF
--- a/src/Tools/dotnet-watch/src/LaunchBrowserFilter.cs
+++ b/src/Tools/dotnet-watch/src/LaunchBrowserFilter.cs
@@ -62,6 +62,9 @@ namespace Microsoft.DotNet.Watcher.Tools
                     _canLaunchBrowser = true;
                     _launchPath = launchPath;
                     _cancellationToken = cancellationToken;
+
+                    // We've redirected the output, but want to ensure that it continues to appear in the user's console.
+                    context.ProcessSpec.OnOutput += (_, eventArgs) => Console.WriteLine(eventArgs.Data);
                     context.ProcessSpec.OnOutput += OnOutput;
 
                     if (!_suppressBrowserRefresh)
@@ -101,9 +104,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
         private void OnOutput(object sender, DataReceivedEventArgs eventArgs)
         {
-            // We've redirected the output, but want to ensure that it continues to appear in the user's console.
-            Console.WriteLine(eventArgs.Data);
-
             if (string.IsNullOrEmpty(eventArgs.Data))
             {
                 return;
@@ -116,7 +116,6 @@ namespace Microsoft.DotNet.Watcher.Tools
 
                 var process = (Process)sender;
                 process.OutputDataReceived -= OnOutput;
-                process.CancelOutputRead();
 
                 if (!_browserLaunched)
                 {


### PR DESCRIPTION
### Description
dotnet-watch redirects standard out to detect when the app is launched and
prints these redirected messages to the console. Unfortunately once the app
is launched, redirected messages are no longer printed. This wasn't caught earlier
since ASP.NET Core is very quiet by default.

### Customer impact
ASP.NET Core apps launched via dotnet watch do not print output to the console.

### Regression
Yes. This was introduced as part of changes to dotnet-watch to launch a browser in 5.0-preview8.

### Risk
Low. The changes are limited to the dotnet-watch tool with no runtime impact. It was tested manually.

