### PR TITLE
Pin PackageOverrides.txt Extensions versions at Major.Minor.0 in servicing

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -169,6 +169,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Moq" />
     <LatestPackageReference Include="Newtonsoft.Json.Bson" />
     <LatestPackageReference Include="NSwag.ApiDescription.Client" />
+    <LatestPackageReference Include="NuGet.Versioning" />
     <LatestPackageReference Include="Selenium.Support" />
     <LatestPackageReference Include="Selenium.WebDriver" />
     <LatestPackageReference Include="Selenium.WebDriver.ChromeDriver" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -205,6 +205,7 @@
     <MicrosoftWebAdministrationPackageVersion>11.1.0</MicrosoftWebAdministrationPackageVersion>
     <MicrosoftWebXdtPackageVersion>1.4.0</MicrosoftWebXdtPackageVersion>
     <SystemIdentityModelTokensJwtPackageVersion>6.7.1</SystemIdentityModelTokensJwtPackageVersion>
+    <NuGetVersioningPackageVersion>5.7.0</NuGetVersioningPackageVersion>
     <!-- Packages from 2.1, 2.2, and 3.1 branches used for site extension build. -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21PackageVersion>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>2.2.0</MicrosoftAspNetCoreAzureAppServicesSiteExtension22PackageVersion>

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -155,14 +155,24 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           DependsOnTargets="_ResolveTargetingPackContent"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(TargetDir)$(PackageConflictManifestFileName)">
+    <PropertyGroup>
+      <_PinnedNETCoreAppRuntimeVersion>$(MicrosoftNETCoreAppRuntimeVersion)</_PinnedNETCoreAppRuntimeVersion>
+      <_PinnedNETCoreAppRuntimeVersion
+          Condition=" '$(IsServicingBuild)' == 'true' ">$(_PinnedNETCoreAppRuntimeVersion.Split('.')[0]).$(_PinnedNETCoreAppRuntimeVersion.Split('.')[1]).0</_PinnedNETCoreAppRuntimeVersion>
+    </PropertyGroup>
     <ItemGroup>
-      <!-- Use package version for non-Extensions references -->
-      <_AspNetCoreAppPackageOverrides Include="@(AspNetCoreReferenceAssemblyPath->'%(NuGetPackageId)|%(NuGetPackageVersion)')" Condition="!Exists('$(RuntimeExtensionsReferenceDirectory)%(AspNetCoreReferenceAssemblyPath.NuGetPackageId).dll') AND '%(AspNetCoreReferenceAssemblyPath.NuGetPackageId)' != 'Microsoft.NETCore.App' AND '%(AspNetCoreReferenceAssemblyPath.NuGetPackageId)' != 'Microsoft.Extensions.Internal.Transport' AND '%(AspNetCoreReferenceAssemblyPath.NuGetSourceType)' == 'Package' " />
+      <!-- Use package version for non-Extensions references. -->
+      <_AspNetCoreAppPackageOverrides Include="@(AspNetCoreReferenceAssemblyPath->'%(NuGetPackageId)|%(NuGetPackageVersion)')"
+          Condition="!Exists('$(RuntimeExtensionsReferenceDirectory)%(AspNetCoreReferenceAssemblyPath.NuGetPackageId).dll') AND
+            '%(AspNetCoreReferenceAssemblyPath.NuGetPackageId)' != 'Microsoft.NETCore.App' AND
+            '%(AspNetCoreReferenceAssemblyPath.NuGetPackageId)' != 'Microsoft.Extensions.Internal.Transport' AND
+            '%(AspNetCoreReferenceAssemblyPath.NuGetSourceType)' == 'Package' " />
 
-      <!-- Pin version for extensions references -->
-      <_AspNetCoreAppPackageOverrides Include="@(_SelectedExtensionsRefAssemblies->'%(FileName)|$(MicrosoftExtensionsInternalTransportPackageVersion)')" />
+      <!-- Use pinned NETCore.App version for Extensions references. -->
+      <_AspNetCoreAppPackageOverrides Include="@(_SelectedExtensionsRefAssemblies->'%(FileName)|$(_PinnedNETCoreAppRuntimeVersion)')" />
 
-      <_AspNetCoreAppPackageOverrides Include="@(AspNetCoreReferenceAssemblyPath->'%(FileName)|$(ReferencePackSharedFxVersion)')" Condition=" '%(AspNetCoreReferenceAssemblyPath.ReferenceSourceTarget)' == 'ProjectReference' " />
+      <_AspNetCoreAppPackageOverrides Include="@(AspNetCoreReferenceAssemblyPath->'%(FileName)|$(ReferencePackSharedFxVersion)')"
+          Condition=" '%(AspNetCoreReferenceAssemblyPath.ReferenceSourceTarget)' == 'ProjectReference' " />
     </ItemGroup>
 
     <WriteLinesToFile

--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -7,7 +7,7 @@
     <PlatformManifestFileName>PlatformManifest.txt</PlatformManifestFileName>
     <PlatformManifestOutputPath>$(ArtifactsObjDir)$(PlatformManifestFileName)</PlatformManifestOutputPath>
 
-    <!-- Platform manifest and package override metatdata -->
+    <!-- Platform manifest and package override metadata. -->
     <ReferencePackSharedFxVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).0</ReferencePackSharedFxVersion>
     <ReferencePackSharedFxVersion Condition="'$(VersionSuffix)' != ''">$(ReferencePackSharedFxVersion)-$(VersionSuffix)</ReferencePackSharedFxVersion>
   </PropertyGroup>

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -48,6 +48,7 @@
 
   <ItemGroup>
     <Reference Include="Newtonsoft.Json" />
+    <Reference Include="NuGet.Versioning" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -10,6 +10,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Xml.Linq;
+using NuGet.Versioning;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -143,25 +144,46 @@ namespace Microsoft.AspNetCore
 
             Assert.Equal(packageOverrideFileLines.Length, runtimeDependencies.Count + aspnetcoreDependencies.Count);
 
-            foreach (var entry in packageOverrideFileLines)
+            // PackageOverrides versions should remain at Major.Minor.0 while servicing.
+            var netCoreAppPackageVersion = TestData.GetMicrosoftNETCoreAppPackageVersion();
+            Assert.True(
+                NuGetVersion.TryParse(netCoreAppPackageVersion, out var parsedVersion),
+                "MicrosoftNETCoreAppPackageVersion must be convertable to a NuGetVersion.");
+            if (parsedVersion.Patch != 0 && !parsedVersion.IsPrerelease)
+            {
+                netCoreAppPackageVersion = $"{parsedVersion.Major}.{parsedVersion.Minor}.0";
+            }
+
+            var aspNetCoreAppPackageVersion = TestData.GetReferencePackSharedFxVersion();
+            Assert.True(
+                NuGetVersion.TryParse(aspNetCoreAppPackageVersion, out parsedVersion),
+                "ReferencePackSharedFxVersion must be convertable to a NuGetVersion.");
+            if (parsedVersion.Patch != 0 && !parsedVersion.IsPrerelease)
+            {
+                aspNetCoreAppPackageVersion = $"{parsedVersion.Major}.{parsedVersion.Minor}.0";
+            }
+
+            Assert.All(packageOverrideFileLines, entry =>
             {
                 var packageOverrideParts = entry.Split("|");
+                Assert.Equal(2, packageOverrideParts.Length);
+
                 var packageName = packageOverrideParts[0];
                 var packageVersion = packageOverrideParts[1];
 
                 if (runtimeDependencies.Contains(packageName))
                 {
-                    Assert.Equal(TestData.GetMicrosoftNETCoreAppPackageVersion(), packageVersion);
+                    Assert.Equal(netCoreAppPackageVersion, packageVersion);
                 }
                 else if (aspnetcoreDependencies.Contains(packageName))
                 {
-                    Assert.Equal(TestData.GetReferencePackSharedFxVersion(), packageVersion);
+                    Assert.Equal(aspNetCoreAppPackageVersion, packageVersion);
                 }
                 else
                 {
                     Assert.True(false, $"{packageName} is not a recognized aspNetCore or runtime dependency");
                 }
-            }
+            });
         }
 
         [Fact]


### PR DESCRIPTION
- set the package version of Extensions assemblies using NETCore.App version
  - ignore Microsoft.Extensions.Internal.Transport package version
    - transport package has a non-stable version and isn't shipped
    - just got lucky this worked before versions stabilize
- update test expectations when checking PackageOverrides.txt
  - use NuGet.Versioning to make this easier