### PR TITLE
Place ref/ layout where SDK can find it

### DIFF
--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -166,9 +166,9 @@ namespace RunTests
             {
                 if (File.Exists(Options.AspNetRef))
                 {
-                    var refPath = $"Microsoft.AspNetCore.App.Ref";
+                    var refPath = $"{Options.DotnetRoot}/packs/Microsoft.AspNetCore.App.Ref/{Options.RuntimeVersion}";
                     Console.WriteLine($"Found AspNetRef: {Options.AspNetRef}, extracting to {refPath}");
-                    ZipFile.ExtractToDirectory(Options.AspNetRef, "Microsoft.AspNetCore.App.Ref");
+                    ZipFile.ExtractToDirectory(Options.AspNetRef, refPath);
 
                     DisplayContents(refPath);
                 }

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -28,9 +28,14 @@ namespace Microsoft.AspNetCore
             _output = output;
             _expectedRid = TestData.GetSharedFxRuntimeIdentifier();
             _targetingPackTfm = "net" + TestData.GetSharedFxVersion().Substring(0, 3);
-            _targetingPackRoot = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix"))
-                ? Path.Combine(TestData.GetTestDataValue("TargetingPackLayoutRoot"), "packs", "Microsoft.AspNetCore.App.Ref", TestData.GetTestDataValue("TargetingPackVersion"))
-                : Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), "Microsoft.AspNetCore.App.Ref");
+            var root = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")) ?
+                TestData.GetTestDataValue("TargetingPackLayoutRoot") :
+                Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            _targetingPackRoot = Path.Combine(
+                root,
+                "packs",
+                "Microsoft.AspNetCore.App.Ref",
+                TestData.GetTestDataValue("TargetingPackVersion"));
             _isTargetingPackBuilding = bool.Parse(TestData.GetTestDataValue("IsTargetingPackBuilding"));
         }
 


### PR DESCRIPTION
- correct Helix test failures with stable versions, where SDK's packs aren't enough

E.g. from https://dev.azure.com/dnceng/internal/_build/results?buildId=813814
``` text
...\.dotnet\sdk\5.0.100-rc.1.20379.10\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(318,5): error MSB4018: The "ResolveTargetingPackAssets" task failed unexpectedly. [...\src\ProjectTemplates\test\bin\Release\net5.0\TestTemplates\AspNet.m0yq3xrporu\AspNet.m0yq3xrporu.csproj]
...\.dotnet\sdk\5.0.100-rc.1.20379.10\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(318,5): error MSB4018: System.IO.DirectoryNotFoundException: Could not find a part of the path '...\.dotnet\packs\Microsoft.AspNetCore.App.Ref\5.0.0\data\FrameworkList.xml'. [...\src\ProjectTemplates\test\bin\Release\net5.0\TestTemplates\AspNet.m0yq3xrporu\AspNet.m0yq3xrporu.csproj]
```