### PR TITLE
Update ci.yml

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -586,9 +586,9 @@ stages:
         steps:
         - script: ./build.cmd -ci -nobl -all -pack $(_InternalRuntimeDownloadArgs)
           displayName: Build Repo
-        - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -pack -NoRestore -noBuildNative -NoBuilddeps "/p:RunTemplateTests=true"
+        - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -pack -NoRestore -NoBuildNative -NoBuilddeps "/p:RunTemplateTests=true"
           displayName: Pack Templates
-        - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
+        - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -test -NoRestore -NoBuildNative -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
           displayName: Test Templates
         artifacts:
         - name: Windows_Test_Templates_Dumps


### PR DESCRIPTION
This produces a bunch of warnings and causes the quarantine build to fail. Passing NoBuildNative keeps with the theme of -NoBuild also being passed to this script


