### PR TITLE
Increase TS Client Functional test timeout

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/scripts/run-tests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/scripts/run-tests.ts
@@ -35,11 +35,11 @@ process.on("unhandledRejection", (reason) => {
     process.exit(1);
 });
 
-// Don't let us hang the build. If this process takes more than 10 minutes, we're outta here
+// Don't let us hang the build. If this process takes more than 20 minutes, we're outta here
 setTimeout(() => {
-    console.error("Bail out! Tests took more than 10 minutes to run. Aborting.");
+    console.error("Bail out! Tests took more than 20 minutes to run. Aborting.");
     process.exit(1);
-}, 1000 * 60 * 10);
+}, 1000 * 60 * 20);
 
 function waitForMatches(command: string, process: ChildProcess, regex: RegExp, matchCount: number): Promise<RegExpMatchArray> {
     return new Promise<string[]>((resolve, reject) => {


### PR DESCRIPTION
The timeout was a little aggressive. It currently takes ~3 minutes to run tests per browser with saucelabs. And there are 3 browsers running serially.