### PR TITLE
Enable PostBuildSign flag and include signing information in the manifest

### DIFF
--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,9 +1,7 @@
 <Project>
   <PropertyGroup Condition="'$(GenerateChecksums)' == 'true'">
-    <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
-    <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
     <!-- $(InstallersOutputPath) is not defined. Root Directory.Build.props is not imported. -->
-    <InstallersOutputPath>$(ArtifactsDir)\installers\</InstallersOutputPath>
+    <InstallersOutputPath>$(ArtifactsDir)installers\</InstallersOutputPath>
     <_SuppressSdkImports>false</_SuppressSdkImports>
   </PropertyGroup>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -4,9 +4,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- The one use of ArtifactsDir in Publish.proj adds an additional slash, confusing itself. -->
-    <ArtifactsDir Condition=" HasTrailingSlash('$(ArtifactsDir)') ">$(ArtifactsDir.Substring(0, $([MSBuild]::Subtract($(ArtifactsDir.Length), 1))))</ArtifactsDir>
-
     <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallersAndChecksums</PublishDependsOnTargets>
 
     <_UploadPathRoot>aspnetcore</_UploadPathRoot>
@@ -15,23 +12,23 @@
   <!-- $(InstallersOutputPath), $(SymbolsOutputPath), and $(ChecksumExtensions) are not defined. Root Directory.Build.props is not imported. -->
   <ItemGroup>
     <!-- Include our "loose" PDBs when publishing symbols. -->
-    <FilesToPublishToSymbolServer Include="$(ArtifactsDir)\symbols\**\*.pdb" />
+    <FilesToPublishToSymbolServer Include="$(ArtifactsDir)symbols\**\*.pdb" />
 
     <!-- Prepare for _PublishInstallersAndChecksums target. -->
     <_InstallersToPublish Remove="@(_InstallersToPublish)" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\packages\**\*.jar" UploadPathSegment="jar" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\packages\**\*.pom" UploadPathSegment="jar" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\packages\**\*.tgz" UploadPathSegment="npm" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\installers\**\*.deb" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\installers\**\*.exe" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\installers\**\*.msi" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\installers\**\*.rpm" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\installers\**\*.tar.gz" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\installers\**\*.version" UploadPathSegment="Runtime"
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.jar" UploadPathSegment="jar" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.pom" UploadPathSegment="jar" />
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.tgz" UploadPathSegment="npm" />
+    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.deb" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.exe" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.msi" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.rpm" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.tar.gz" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.version" UploadPathSegment="Runtime"
         Condition=" '$(PublishInstallerBaseVersion)' == 'true' " />
-    <_InstallersToPublish Include="$(ArtifactsDir)\installers\**\*.wixlib" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsDir)\installers\**\*.zip" UploadPathSegment="Runtime" />
-    <_ChecksumsToPublish Include="$(ArtifactsDir)\**\*.sha512" />
+    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.wixlib" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.zip" UploadPathSegment="Runtime" />
+    <_ChecksumsToPublish Include="$(ArtifactsDir)**\*.sha512" />
   </ItemGroup>
 
   <Target Name="_PublishInstallersAndChecksums">
@@ -67,6 +64,10 @@
         <PublishFlatContainer>true</PublishFlatContainer>
         <RelativeBlobPath>$(_UploadPathRoot)/%(_InstallersToPublish.UploadPathSegment)/$(_PackageVersion)/%(Filename)%(Extension)</RelativeBlobPath>
       </ItemsToPushToBlobFeed>
+
+      <!-- Set up ItemsToSign for the push task to pick up. -->
+      <ItemsToSign Remove="@(ItemsToSign)" />
+      <ItemsToSign Include="@(ItemsToSignPostBuild)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -9,12 +9,43 @@
     <FileExtensionSignInfo Remove="@(FileExtensionSignInfo)" />
   </ItemGroup>
 
-  <ItemGroup Label="Signing config">
-    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" Exclude="$(ArtifactsPackagesDir)**\*symbols.nupkg" />
-    <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
-    <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.jar"  />
-    <ItemsToSign Include="$(ArtifactsDir)installers\$(Configuration)\**\*.zip" />
+  <!-- Files that should be always be signed between in-build and post-build signing -->
+  <ItemGroup Label="Common Files to Sign">
+    <CommonFilesToSign Include="$(ArtifactsPackagesDir)**\*.nupkg" />
+    <CommonFilesToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />
+    <CommonFilesToSign Include="$(ArtifactsPackagesDir)**\*.jar"  />
+    <CommonFilesToSign Include="$(ArtifactsDir)installers\$(Configuration)\**\*.zip" />
+  </ItemGroup>
+  <Choose>
+    <!-- When post build signing is false - Sign as normal.
+         When post build signing is true - Sign all of our signable artifacts
+          that we would publish. Use a different ItemGroup name so that
+          the signing stage signs nothing. We then set ItemToSign during
+          publishing to this ItemGroup.
+        -->
+    <When Condition="'$(PostBuildSign)' != 'true'">
+      <ItemGroup Label="Files To Sign">
+        <ItemsToSign Include="@(CommonFilesToSign)" />
+        <ItemsToSign Remove="$(ArtifactsPackagesDir)**\*symbols.nupkg" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(PostBuildSign)' == 'true'">
+      <PropertyGroup>
+        <AllowEmptySignList>true</AllowEmptySignList>
+      </PropertyGroup>
+      <ItemGroup Label="Files To Sign">
+        <!-- Sign symbol nupkgs so that shared files between layouts and msis end up identical. -->
+        <ItemsToSignPostBuild Include="@(CommonFilesToSign)" />
+        <ItemsToSignPostBuild Include="$(ArtifactsDir)installers\$(Configuration)\**\*.exe" />
+        <ItemsToSignPostBuild Include="$(ArtifactsDir)installers\$(Configuration)\**\*.msi" />
+        <!-- Wixlibs are signed because they are containers of other files -->
+        <ItemsToSignPostBuild Include="$(ArtifactsDir)installers\$(Configuration)\**\*.wixlib" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
+
+  <ItemGroup Label="File signing information">
     <!--
       Map file extensions to a code-sign cert.
       "None" means don't sign the file itself, but still scan the contents for signable files.
@@ -88,6 +119,11 @@
       These files should already be signed by the .NET Core team. They have to be listed again here because we recreate a redistributable which includes the Microsoft.NETCore.App runtime.
       List all combinations of Windows RID's because CI may build multiple combinations of artitectures on the same machine.
       This uses globs because some of the file names change on every build of .NET Core, like sos_amd64_$(fileversion).dll.
+
+      Technically, this may not be necessary. SignTool does a good deal of detection to determine
+      whether files are already signed.
+
+      Do not include these with cert "None" when doing post-build signing. In that case, we will recognize that
     -->
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-x64\shared\Microsoft.NETCore.App\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-x86\shared\Microsoft.NETCore.App\**\*.dll" CertificateName="None" />
@@ -98,7 +134,11 @@
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-arm\host\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(BaseRedistNetCorePath)win-arm64\host\**\*.dll" CertificateName="None" />
     <_DotNetFilesToExclude Include="$(RedistNetCorePath)dotnet.exe" CertificateName="None" />
-    <FileSignInfo Include="@(_DotNetFilesToExclude->'%(FileName)%(Extension)'->Distinct())" CertificateName="None" />
+    <FileSignInfo Include="@(_DotNetFilesToExclude->'%(FileName)%(Extension)'->Distinct())" CertificateName="None" Condition="'$(PostBuildSign)' != 'true'" />
+
+    <!-- Symbol packages should get no NuGet signature -->
+    <!-- Requires https://github.com/dotnet/arcade/issues/6192 to be fixed -->
+    <!-- <FileSignInfo Include="@(_SymbolPackages->'%(FileName)%(Extension)'->Distinct())" CertificateName="None" /> -->
 
     <!--
       We include the Microsoft.Build.Locator.dll assembly in our global tool 'Microsoft.dotnet-openapi'.

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -3,7 +3,7 @@
     <BlazorWebAssemblyJSPath>$(RepoRoot)src\Components\Web.JS\dist\$(Configuration)\blazor.webassembly.js</BlazorWebAssemblyJSPath>
     <BlazorWebAssemblyJSMapPath>$(BlazorWebAssemblyJSPath).map</BlazorWebAssemblyJSMapPath>
 
-    <_BlazorDevServerPath>$(ArtifactsDir)/bin/Microsoft.AspNetCore.Components.WebAssembly.DevServer/$(Configuration)/$(DefaultNetCoreTargetFramework)/blazor-devserver.dll</_BlazorDevServerPath>
+    <_BlazorDevServerPath>$(ArtifactsDir)bin/Microsoft.AspNetCore.Components.WebAssembly.DevServer/$(Configuration)/$(DefaultNetCoreTargetFramework)/blazor-devserver.dll</_BlazorDevServerPath>
     <RunCommand>dotnet</RunCommand>
     <RunArguments>exec &quot;$(_BlazorDevServerPath)&quot; serve --applicationpath &quot;$(TargetPath)&quot; $(AdditionalRunArguments)</RunArguments>
   </PropertyGroup>


### PR DESCRIPTION
This change is prep for post build signing. When PostBuildSign=true, signing is not performed during the build. Instead, pass the top-level artifacts that are signable to PushToAzureDevOpsArtifacts (via Publish.proj).
Also fix up ArtifactsDir. As far as I can tell, it's been fixed up in Arcade to always include the trailing \, and Publish.proj should no longer be messed up.