### PR TITLE
Fix DefaultRazorSourceLineCollection edge case

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorSourceLineCollection.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorSourceLineCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         internal override SourceLocation GetLocation(int position)
         {
-            if (position < 0 || position >= _document.Length)
+            if (position < 0 || position > _document.Length)
             {
                 throw new IndexOutOfRangeException(nameof(position));
             }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorSourceLineCollectionTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorSourceLineCollectionTest.cs
@@ -1,0 +1,107 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Test
+{
+    public class DefaultRazorSourceLineCollectionTest
+    {
+        [Fact]
+        public void GetLocation_Negative()
+        {
+            var content = @"@addTagHelper, * Stuff
+@* A comment *@";
+            var document = TestRazorSourceDocument.Create(content);
+            var collection = new DefaultRazorSourceLineCollection(document);
+
+            Assert.Throws<IndexOutOfRangeException>(() => collection.GetLocation(-1));
+        }
+
+        [Fact]
+        public void GetLocation_TooBig()
+        {
+            var content = @"addTagHelper, * Stuff
+@* A comment *@";
+            var document = TestRazorSourceDocument.Create(content);
+            var collection = new DefaultRazorSourceLineCollection(document);
+
+            Assert.Throws<IndexOutOfRangeException>(() => collection.GetLocation(40));
+        }
+
+        [Fact]
+        public void GetLocation_AtStart()
+        {
+            var content = @"@addTaghelper, * Stuff
+@* A comment *@";
+            var document = TestRazorSourceDocument.Create(content);
+            var collection = new DefaultRazorSourceLineCollection(document);
+
+            var location = collection.GetLocation(0);
+
+            var expected = new SourceLocation("test.cshtml", 0, 0, 0);
+            Assert.Equal(expected, location);
+        }
+
+        [Fact]
+        public void GetLocation_AtEnd()
+        {
+            var content = @"@addTagHelper, * Stuff
+@* A comment *@";
+            var document = TestRazorSourceDocument.Create(content);
+            var collection = new DefaultRazorSourceLineCollection(document);
+
+            var location = collection.GetLocation(39);
+
+            var expected = new SourceLocation("test.cshtml", 39, 1, 15);
+            Assert.Equal(expected, location);
+        }
+
+        [Fact]
+        public void GetLineLength_Negative()
+        {
+            var content = @"@addTagHelper, * Stuff
+@* A comment *@";
+            var document = TestRazorSourceDocument.Create(content);
+            var collection = new DefaultRazorSourceLineCollection(document);
+
+            Assert.Throws<IndexOutOfRangeException>(() => collection.GetLineLength(-1));
+        }
+
+        [Fact]
+        public void GetLineLength_Bigger()
+        {
+            var content = @"@addTagHelper, * Stuff
+@* A comment *@";
+            var document = TestRazorSourceDocument.Create(content);
+            var collection = new DefaultRazorSourceLineCollection(document);
+
+            Assert.Throws<IndexOutOfRangeException>(() => collection.GetLineLength(40));
+        }
+
+        [Fact]
+        public void GetLineLength_AtStart()
+        {
+            var content = @"@addTagHelper, * Stuff
+@* A comment *@";
+            var document = TestRazorSourceDocument.Create(content);
+            var collection = new DefaultRazorSourceLineCollection(document);
+
+            var lineLength = collection.GetLineLength(0);
+            Assert.Equal(24, lineLength);
+        }
+
+        [Fact]
+        public void GetLineLength_AtEnd()
+        {
+            var content = @"@addTagHelper, * Stuff
+@* A comment *@";
+            var document = TestRazorSourceDocument.Create(content);
+            var collection = new DefaultRazorSourceLineCollection(document);
+
+            var lineLength = collection.GetLineLength(1);
+            Assert.Equal(15, lineLength);
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorSourceLineCollectionTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorSourceLineCollectionTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language.Test
@@ -51,10 +52,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
+            var length = content.Length;
 
-            var location = collection.GetLocation(39);
+            var location = collection.GetLocation(length);
 
-            var expected = new SourceLocation("test.cshtml", 39, 1, 15);
+            var expected = new SourceLocation("test.cshtml", length, 1, 15);
             Assert.Equal(expected, location);
         }
 
@@ -89,7 +91,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
             var collection = new DefaultRazorSourceLineCollection(document);
 
             var lineLength = collection.GetLineLength(0);
-            Assert.Equal(24, lineLength);
+
+            var expectedLineLength = 22 + Environment.NewLine.Length;
+            Assert.Equal(expectedLineLength, lineLength);
         }
 
         [Fact]
@@ -101,7 +105,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
             var collection = new DefaultRazorSourceLineCollection(document);
 
             var lineLength = collection.GetLineLength(1);
-            Assert.Equal(15, lineLength);
+
+            var expectedLineLength = 15;
+            Assert.Equal(expectedLineLength, lineLength);
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorSourceLineCollectionTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorSourceLineCollectionTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text.RegularExpressions;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language.Test
@@ -12,35 +11,42 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
         [Fact]
         public void GetLocation_Negative()
         {
+            // Arrange
             var content = @"@addTagHelper, * Stuff
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
 
+            // Act & Assert
             Assert.Throws<IndexOutOfRangeException>(() => collection.GetLocation(-1));
         }
 
         [Fact]
         public void GetLocation_TooBig()
         {
+            // Arrange
             var content = @"addTagHelper, * Stuff
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
 
+            // Act & Assert
             Assert.Throws<IndexOutOfRangeException>(() => collection.GetLocation(40));
         }
 
         [Fact]
         public void GetLocation_AtStart()
         {
+            // Arrange
             var content = @"@addTaghelper, * Stuff
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
 
+            // Act
             var location = collection.GetLocation(0);
 
+            // Assert
             var expected = new SourceLocation("test.cshtml", 0, 0, 0);
             Assert.Equal(expected, location);
         }
@@ -48,14 +54,17 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
         [Fact]
         public void GetLocation_AtEnd()
         {
+            // Arrange
             var content = @"@addTagHelper, * Stuff
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
             var length = content.Length;
 
+            // Act
             var location = collection.GetLocation(length);
 
+            // Assert
             var expected = new SourceLocation("test.cshtml", length, 1, 15);
             Assert.Equal(expected, location);
         }
@@ -63,35 +72,42 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
         [Fact]
         public void GetLineLength_Negative()
         {
+            // Arrange
             var content = @"@addTagHelper, * Stuff
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
 
+            // Act & Assert
             Assert.Throws<IndexOutOfRangeException>(() => collection.GetLineLength(-1));
         }
 
         [Fact]
         public void GetLineLength_Bigger()
         {
+            // Arrange
             var content = @"@addTagHelper, * Stuff
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
 
+            // Act & Assert
             Assert.Throws<IndexOutOfRangeException>(() => collection.GetLineLength(40));
         }
 
         [Fact]
         public void GetLineLength_AtStart()
         {
+            // Arrange
             var content = @"@addTagHelper, * Stuff
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
 
+            // Act
             var lineLength = collection.GetLineLength(0);
 
+            // Assert
             var expectedLineLength = 22 + Environment.NewLine.Length;
             Assert.Equal(expectedLineLength, lineLength);
         }
@@ -99,13 +115,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Test
         [Fact]
         public void GetLineLength_AtEnd()
         {
+            // Arrange
             var content = @"@addTagHelper, * Stuff
 @* A comment *@";
             var document = TestRazorSourceDocument.Create(content);
             var collection = new DefaultRazorSourceLineCollection(document);
 
+            // Act
             var lineLength = collection.GetLineLength(1);
 
+            // Assert
             var expectedLineLength = 15;
             Assert.Equal(expectedLineLength, lineLength);
         }


### PR DESCRIPTION
This was broken for the end of lines in the SemanticTokenSyntaxWalker.