### PR TITLE
Deflaking IIS tests

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ClientCertificateTests.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
-using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.Common;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;


### PR DESCRIPTION
Fixing https://github.com/dotnet/aspnetcore/issues/22329
Fixing https://github.com/dotnet/aspnetcore/issues/22319

In these tests, we see that the previous test run's apphost.config file is still being used instead of the newer one. So adding more logging for checking the redirect.config file. Also adds a check to make sure that redirection is disabled before adding a new apphost.config.
