### PR TITLE
Increase Http2Timeout 

### DIFF
--- a/src/Shared/Http2cat/TaskTimeoutExtensions.cs
+++ b/src/Shared/Http2cat/TaskTimeoutExtensions.cs
@@ -8,7 +8,7 @@ namespace System.Threading.Tasks
 {
     internal static class TaskTimeoutExtensions
     {
-        public static TimeSpan DefaultTimeoutTimeSpan { get; } = TimeSpan.FromSeconds(5);
+        public static TimeSpan DefaultTimeoutTimeSpan { get; } = TimeSpan.FromSeconds(30);
 
         public static Task<T> DefaultTimeout<T>(this ValueTask<T> task)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/26060

For some reason, the Http2Cat timeout was set to 5 seconds, while all other default timeouts in Kestrel/IIS are 30 seconds.