### PR TITLE
Generate non-stable version for installer

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -1,5 +1,3 @@
-
-
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
     <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)"

--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -27,7 +27,7 @@
         <?endif?>
 
         <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
-        <?if $(var.Version)=3.1.0.0?>
+        <?if $(var.MajorVersion)=3 and $(var.MinorVersion)=1?>
         <?if $(var.Platform)=x64?>
         <!--'Microsoft ASP.NET Core 3.1.8 - Shared Framework'-->
         <RelatedBundle Action="Upgrade" Id="{BA264433-7668-3F63-BA27-0B842B591B41}"/>
@@ -48,10 +48,8 @@
         <!--'Microsoft ASP.NET Core 3.1.0 - Shared Framework'-->
         <RelatedBundle Action="Upgrade" Id="{A65A6022-E10B-3AEF-802C-B9AFE0B000E2}"/>
         <?endif?>
-        <?endif?>
 
         <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
-        <?if $(var.Version)=3.1.0.0?>
         <?if $(var.Platform)=x86?>
         <!--'Microsoft ASP.NET Core 3.1.8 - Shared Framework'-->
         <RelatedBundle Action="Upgrade" Id="{F9E1048A-39B9-3AE1-8AA1-6B054A204A84}"/>

--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -24,9 +24,11 @@
         <?endif?>
         <?endif?>
 
-        <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
+        <!-- Ensure upgrades from 3.1.0 thru 3.1.9 for x64. -->
         <?if $(var.MajorVersion)=3 and $(var.MinorVersion)=1?>
         <?if $(var.Platform)=x64?>
+        <!--'Microsoft ASP.NET Core 3.1.9 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{9BD9F5C9-7DE4-3A3C-AB10-29B30D48CB39}"/>
         <!--'Microsoft ASP.NET Core 3.1.8 - Shared Framework'-->
         <RelatedBundle Action="Upgrade" Id="{BA264433-7668-3F63-BA27-0B842B591B41}"/>
         <!--'Microsoft ASP.NET Core 3.1.7 - Shared Framework'-->
@@ -47,8 +49,10 @@
         <RelatedBundle Action="Upgrade" Id="{A65A6022-E10B-3AEF-802C-B9AFE0B000E2}"/>
         <?endif?>
 
-        <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
+        <!-- Ensure upgrades from 3.1.0 thru 3.1.9 for x64. -->
         <?if $(var.Platform)=x86?>
+        <!--'Microsoft ASP.NET Core 3.1.9 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{BE2349EF-BC78-3E42-B29C-E61D12E02FE4}"/>
         <!--'Microsoft ASP.NET Core 3.1.8 - Shared Framework'-->
         <RelatedBundle Action="Upgrade" Id="{F9E1048A-39B9-3AE1-8AA1-6B054A204A84}"/>
         <!--'Microsoft ASP.NET Core 3.1.7 - Shared Framework'-->

--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -1,3 +1,5 @@
+
+
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
     <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)"
@@ -21,6 +23,54 @@
         <RelatedBundle Action="Upgrade" Id="{F5C19B0F-77DF-3353-96D9-3F398FA38CF7}"/>
         <RelatedBundle Action="Upgrade" Id="{DFC9DEC7-307D-39B5-AF9C-4E8CE923B1BA}"/>
         <RelatedBundle Action="Upgrade" Id="{FDCA5106-C69E-34BB-A3B8-A24ADD0B4769}"/>
+        <?endif?>
+        <?endif?>
+
+        <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
+        <?if $(var.Version)=3.1.0.0?>
+        <?if $(var.Platform)=x64?>
+        <!--'Microsoft ASP.NET Core 3.1.8 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{BA264433-7668-3F63-BA27-0B842B591B41}"/>
+        <!--'Microsoft ASP.NET Core 3.1.7 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{E843D8AB-9AE4-3BBA-B417-E920A145D4D2}"/>
+        <!--'Microsoft ASP.NET Core 3.1.6 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{598E3E3B-DFA5-3F58-B2CF-EA59B0CD04E6}"/>
+        <!--'Microsoft ASP.NET Core 3.1.5 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{C2718AD8-4EC1-300D-A871-E98A1AC69180}"/>
+        <!--'Microsoft ASP.NET Core 3.1.4 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{F6D32B6E-2736-3FCC-B0F8-CB4C5AF95B2E}"/>
+        <!--'Microsoft ASP.NET Core 3.1.3 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{33468842-C5B0-3189-96D7-8CD8D28585B9}"/>
+        <!--'Microsoft ASP.NET Core 3.1.2 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{54EE87B3-B909-37F1-85AD-EE2296ABD2F1}"/>
+        <!--'Microsoft ASP.NET Core 3.1.1 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{90F6AF22-13B2-3D34-9CF0-C7F407DF4195}"/>
+        <!--'Microsoft ASP.NET Core 3.1.0 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{A65A6022-E10B-3AEF-802C-B9AFE0B000E2}"/>
+        <?endif?>
+        <?endif?>
+
+        <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
+        <?if $(var.Version)=3.1.0.0?>
+        <?if $(var.Platform)=x86?>
+        <!--'Microsoft ASP.NET Core 3.1.8 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{F9E1048A-39B9-3AE1-8AA1-6B054A204A84}"/>
+        <!--'Microsoft ASP.NET Core 3.1.7 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{48272B78-3954-3D58-AB75-27B31E0D0DBD}"/>
+        <!--'Microsoft ASP.NET Core 3.1.6 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{52FF933A-F022-3A0A-8200-4C0E8E3934C3}"/>
+        <!--'Microsoft ASP.NET Core 3.1.5 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{F8C888A3-46C2-3306-8C90-5622C65BEBE3}"/>
+        <!--'Microsoft ASP.NET Core 3.1.4 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{EC496CB3-526B-366D-B667-3A20354DB136}"/>
+        <!--'Microsoft ASP.NET Core 3.1.3 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{05780385-0142-3FAA-9B97-F785C4798EC1}"/>
+        <!--'Microsoft ASP.NET Core 3.1.2 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{4EBEC6A2-DB4C-396B-BAE7-890D1D7EB9B3}"/>
+        <!--'Microsoft ASP.NET Core 3.1.1 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{5F160755-5B95-32A7-8D4F-ED1BA9F959D1}"/>
+        <!--'Microsoft ASP.NET Core 3.1.0 - Shared Framework'-->
+        <RelatedBundle Action="Upgrade" Id="{AC05AAAB-C217-3B65-95FE-11D2CB07A485}"/>
         <?endif?>
         <?endif?>
 

--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -47,7 +47,7 @@
         <RelatedBundle Action="Upgrade" Id="{A65A6022-E10B-3AEF-802C-B9AFE0B000E2}"/>
         <?endif?>
 
-        <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
+        <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x86. -->
         <?if $(var.Platform)=x86?>
         <!--'Microsoft ASP.NET Core 3.1.8 - Shared Framework'-->
         <RelatedBundle Action="Upgrade" Id="{F9E1048A-39B9-3AE1-8AA1-6B054A204A84}"/>

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -19,8 +19,10 @@
         <RelatedBundle Action="Upgrade" Id="{EA47395A-BC9B-3ECC-8229-229BC9528DF6}"/>
         <?endif?>
 
-        <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
+        <!-- Ensure upgrades from 3.1.0 thru 3.1.9 for x64. -->
         <?if $(var.MajorVersion)=3 and $(var.MinorVersion)=1?>
+        <!--'Microsoft .NET Core 3.1.9 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{E4913286-9840-380A-8743-3DF839147FF0}"/>
         <!--'Microsoft .NET Core 3.1.8 - Windows Server Hosting'-->
         <RelatedBundle Action="Upgrade" Id="{81D96996-6F29-3BAC-82C6-9156FE1BD5FB}"/>
         <!--'Microsoft .NET Core 3.1.7 - Windows Server Hosting'-->

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -19,6 +19,28 @@
         <RelatedBundle Action="Upgrade" Id="{EA47395A-BC9B-3ECC-8229-229BC9528DF6}"/>
         <?endif?>
 
+        <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
+        <?if $(var.Version)=3.1.0.0?>
+        <!--'Microsoft .NET Core 3.1.8 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{81D96996-6F29-3BAC-82C6-9156FE1BD5FB}"/>
+        <!--'Microsoft .NET Core 3.1.7 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{44D6EE78-0248-36AD-9B2C-26FA728E477D}"/>
+        <!--'Microsoft .NET Core 3.1.6 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{C0453F97-42DD-3CD5-9FCE-018DD1F1A020}"/>
+        <!--'Microsoft .NET Core 3.1.5 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{8BF71BDA-9BF7-3AD5-9E6B-3656FEEC95AA}"/>
+        <!--'Microsoft .NET Core 3.1.4 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{6CF8B606-EE26-3536-BEFE-410EA70DBB94}"/>
+        <!--'Microsoft .NET Core 3.1.3 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{71F4232E-75BF-32AF-9A8F-1E87CC17CC6C}"/>
+        <!--'Microsoft .NET Core 3.1.2 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{3CDBE509-D166-335B-BD17-EA6FDAC4E03A}"/>
+        <!--'Microsoft .NET Core 3.1.1 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{62155173-E27B-3936-997F-56DA96ED19B5}"/>
+        <!--'Microsoft .NET Core 3.1.0 - Windows Server Hosting'-->
+        <RelatedBundle Action="Upgrade" Id="{6F741175-2F75-3845-B30B-6C364101EAA2}"/>
+        <?endif?>
+
         <PayloadGroup Id="PG_Resources">
             <?foreach lcid in 2052;1028;1029;1031;3082;1036;1040;1041;1042;1045;1046;1049;1055?>
             <Payload Id="PL_thm_$(var.lcid)" SourceFile="$(var.lcid)\thm.wxl" Name="$(var.lcid)\thm.wxl" Compressed="yes"/>

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -20,7 +20,7 @@
         <?endif?>
 
         <!-- Ensure upgrades from 3.1.0 thru 3.1.8 for x64. -->
-        <?if $(var.Version)=3.1.0.0?>
+        <?if $(var.MajorVersion)=3 and $(var.MinorVersion)=1?>
         <!--'Microsoft .NET Core 3.1.8 - Windows Server Hosting'-->
         <RelatedBundle Action="Upgrade" Id="{81D96996-6F29-3BAC-82C6-9156FE1BD5FB}"/>
         <!--'Microsoft .NET Core 3.1.7 - Windows Server Hosting'-->

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -1,12 +1,12 @@
 <Project>
   <!-- Set versioning properties after Arcade SDK targets have been imported. -->
   <PropertyGroup>
-    <!-- Used for generating stable upgrade codes for bundles -->
-    <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(FileRevisionVersion)</Version>
     <!-- Actual upgrade code used in bundles to ensure upgrades withing a version band, e.g. 3.0.0.xxx -->
     <_FileRevisionVersion>$(VersionSuffixDateStamp)</_FileRevisionVersion>
     <_FileRevisionVersion Condition=" '$(_FileRevisionVersion)' == '' ">42424</_FileRevisionVersion>
-    <BundleVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(_FileRevisionVersion)</BundleVersion>
+    <BundleVersion>$(AspNetCoreMajorMinorVersion).$(AspNetCorePatchVersion).$(_FileRevisionVersion)</BundleVersion>
+    <!-- Used for generating stable upgrade codes for bundles -->
+    <Version>$(BundleVersion)</Version>
 
     <!-- ARM64 MSIs require the installer version to be at least 500. -->
     <!-- See: https://docs.microsoft.com/en-us/windows/win32/msi/64-bit-windows-installer-packages -->
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <GuidInputs>$(Version);$(Platform);$(VersionSuffix);$(_BuildNumberLabels)</GuidInputs>
+    <GuidInputs>$(Version);$(Platform);$(VersionSuffix)</GuidInputs>
   </PropertyGroup>
 
   <ItemGroup>
@@ -61,7 +61,7 @@
          the upgrade code. Bundle upgrades pivot on Major.Minor.Patch changes. For example, 3.0.1-preview 1 can upgrade to 3.0.1-preview 8, but 3.0.1
          cannot upgrade to 3.0.2 or 3.1. -->
     <PropertyGroup>
-      <BundleGuidInputs>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion);$(Platform)</BundleGuidInputs>
+      <BundleGuidInputs>$(AspNetCoreMajorMinorVersion);$(Platform)</BundleGuidInputs>
     </PropertyGroup>
     <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleGuidInputs)">
       <Output TaskParameter="Guid" PropertyName="BundleProviderKey" />

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -2,7 +2,7 @@
   <!-- Set versioning properties after Arcade SDK targets have been imported. -->
   <PropertyGroup>
     <!-- Used for generating stable upgrade codes for bundles -->
-    <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).0</Version>
+    <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(FileRevisionVersion)</Version>
     <!-- Actual upgrade code used in bundles to ensure upgrades withing a version band, e.g. 3.0.0.xxx -->
     <_FileRevisionVersion>$(VersionSuffixDateStamp)</_FileRevisionVersion>
     <_FileRevisionVersion Condition=" '$(_FileRevisionVersion)' == '' ">42424</_FileRevisionVersion>


### PR DESCRIPTION
Generate a non-stable ProductVersion for installers so that updates can occur between installers in the same Major.Minor.Patch band (e.g. previewN to previewN+1)

Internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=821086&view=results