### PR TITLE
Allow Detailed errors to use 1 or "true"

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitOptionsJSInteropDetailedErrorsConfiguration.cs
+++ b/src/Components/Server/src/Circuits/CircuitOptionsJSInteropDetailedErrorsConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Components.Server
 
         public void Configure(CircuitOptions options)
         {
-            var value = Configuration.GetValue(WebHostDefaults.DetailedErrorsKey);
+            var value = Configuration[WebHostDefaults.DetailedErrorsKey];
             options.DetailedErrors = string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) || 
                 string.Equals(value, "1", StringComparison.OrdinalIgnoreCase);
         }

--- a/src/Components/Server/src/Circuits/CircuitOptionsJSInteropDetailedErrorsConfiguration.cs
+++ b/src/Components/Server/src/Circuits/CircuitOptionsJSInteropDetailedErrorsConfiguration.cs
@@ -18,7 +18,9 @@ namespace Microsoft.AspNetCore.Components.Server
 
         public void Configure(CircuitOptions options)
         {
-            options.DetailedErrors = Configuration.GetValue<bool>(WebHostDefaults.DetailedErrorsKey);
+            var value = Configuration.GetValue(WebHostDefaults.DetailedErrorsKey);
+            options.DetailedErrors = string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) || 
+                string.Equals(value, "1", StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
See https://github.com/dotnet/aspnetcore/blob/d4a2fa1ceb3b9c10054da8a7c6a4bd61801aea18/src/Servers/IIS/IIS/src/StartupHook.cs#L42-L44

Fixes https://github.com/dotnet/aspnetcore/issues/22592



Addresses #bugnumber (in this specific format)
