### PR TITLE
Allow Detailed errors to use 1 or "true"

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitOptionsJSInteropDetailedErrorsConfiguration.cs
+++ b/src/Components/Server/src/Circuits/CircuitOptionsJSInteropDetailedErrorsConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -18,7 +19,9 @@ namespace Microsoft.AspNetCore.Components.Server
 
         public void Configure(CircuitOptions options)
         {
-            options.DetailedErrors = Configuration.GetValue<bool>(WebHostDefaults.DetailedErrorsKey);
+            var value = Configuration[WebHostDefaults.DetailedErrorsKey];
+            options.DetailedErrors = string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "1", StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
See https://github.com/dotnet/aspnetcore/blob/d4a2fa1ceb3b9c10054da8a7c6a4bd61801aea18/src/Servers/IIS/IIS/src/StartupHook.cs#L42-L44

Fixes https://github.com/dotnet/aspnetcore/issues/22592
