### PR TITLE
Tiny typo on doc for ServicesModelBinder

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ServicesModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ServicesModelBinder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 {
     /// <summary>
     /// An <see cref="IModelBinder"/> which binds models from the request services when a model 
-    /// has the binding source <see cref="BindingSource.Services"/>/
+    /// has the binding source <see cref="BindingSource.Services"/>.
     /// </summary>
     public class ServicesModelBinder : IModelBinder
     {


### PR DESCRIPTION
Tiny typo that also shows up on https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ServicesModelBinder?view=aspnetcore-3.1