### PR TITLE
Include all .xml files in targeting pack

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -143,7 +143,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <!-- Grab remaining .xml files from packages -->
       <AspNetCoreReferenceDocXml 
           Include="@(AspNetCoreReferenceAssemblyPath->WithMetadataValue('ExternallyResolved', 'true')->'%(RootDir)%(Directory)%(Filename).xml')" 
-          Condition="Exists('%(AspNetCoreReferenceAssemblyPath.RootDir)%(AspNetCoreReferenceAssemblyPath.Directory)%(AspNetCoreReferenceAssemblyPath.Filename).xml')" />
+          Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
 
       <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="@(AspNetCoreReferenceDocXml->Distinct())" PackagePath="$(RefAssemblyPackagePath)" />

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -146,7 +146,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
 
       <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
-      <RefPackContent Include="@(AspNetCoreReferenceDocXml->Distinct())" PackagePath="$(RefAssemblyPackagePath)" />
+      <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(ManifestsPackagePath)" />
       <RefPackContent Include="$(PlatformManifestOutputPath)" PackagePath="$(ManifestsPackagePath)" />
     </ItemGroup>

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -140,9 +140,13 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <AspNetCoreReferenceDocXml Include="@(_ResolvedProjectReferencePaths->'%(RootDir)%(Directory)%(FileName).xml')"
           Condition="Exists('%(RootDir)%(Directory)%(FileName).xml')" />
       <AspNetCoreReferenceDocXml Include="@(_SelectedExtensionsRefAssemblies->'$(RuntimeExtensionsReferenceDirectory)%(FileName).xml')" />
+      <!-- Grab remaining .xml files from packages -->
+      <AspNetCoreReferenceDocXml 
+          Include="@(AspNetCoreReferenceAssemblyPath->WithMetadataValue('ExternallyResolved', 'true')->'%(RootDir)%(Directory)%(Filename).xml')" 
+          Condition="Exists('%(AspNetCoreReferenceAssemblyPath.RootDir)%(AspNetCoreReferenceAssemblyPath.Directory)%(AspNetCoreReferenceAssemblyPath.Filename).xml')" />
 
       <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
-      <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
+      <RefPackContent Include="@(AspNetCoreReferenceDocXml->Distinct())" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(ManifestsPackagePath)" />
       <RefPackContent Include="$(PlatformManifestOutputPath)" PackagePath="$(ManifestsPackagePath)" />
     </ItemGroup>


### PR DESCRIPTION
Resolve the 5.0 part of https://github.com/dotnet/aspnetcore/issues/26073. We were intentionally including the .xml files for project references & Extensions references, but not other package references. 

@Pilchie is this OK for GA tell-mode?