### PR TITLE
Include commit SHA in `[AssemblyInformationalVersion]` value

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,8 +20,6 @@
     <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>
     <IncludePreReleaseLabelInPackageVersion Condition=" '$(DotNetFinalVersionKind)' == 'release' ">false</IncludePreReleaseLabelInPackageVersion>
     <AspNetCoreMajorMinorVersion>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)</AspNetCoreMajorMinorVersion>
-    <!-- Additional assembly attributes are already configured to include the source revision ID. -->
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!--
       Until package baselines are updated (see dotnet/aspnetcore#12702), ignore them and PatchConfig.props. This also
       gives us time to build the entire repo and settle the infrastructure. Do _not_ do this when stabilizing versions.


### PR DESCRIPTION
- see dotnet/arcade#5866 discussion
- leaving redundant `[AssemblyMetadata("CommitHash", ...)]` because it's used in this repo
  - e.g. src\Components\benchmarkapps\Wasm.Performance\Driver\Program.cs
  - also consistent with native images
