### PR TITLE
[release/3.1] Include commit SHA in `[AssemblyInformationalVersion]` value

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,8 +26,6 @@
     <!-- The following property may need to be updated if ingesting new versions of Extensions.Refs package. The package override version is used to create PackageOverrides.txt in the targeting pack. -->
     <!-- !!! Update to 3.1.8 once we have a new official build of dotnet/extensions. -->
     <MicrosoftInternalExtensionsRefsPackageOverrideVersion>3.1.0</MicrosoftInternalExtensionsRefsPackageOverrideVersion>
-    <!-- Additional assembly attributes are already configured to include the source revision ID. -->
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- Servicing builds have different characteristics for the way dependencies, framework references, and versions are handled. -->
     <IsServicingBuild Condition=" '$(PreReleaseVersionLabel)' == 'servicing' ">true</IsServicingBuild>
     <VersionPrefix>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion)</VersionPrefix>


### PR DESCRIPTION
- see dotnet/arcade#5866 discussion
- leaving redundant `[AssemblyMetadata("CommitHash", ...)]` because it's used in this repo
  - e.g. src\Components\benchmarkapps\Wasm.Performance\Driver\Program.cs
  - also consistent with native images