### PR TITLE
Fix client validation for record types

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -300,6 +300,32 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [Fact]
+        public async Task ClientValidators_AreGeneratedDuringInitialRender()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/Customer/HtmlGeneration_Customer/CustomerWithRecords");
+
+            // Act
+            var response = await Client.SendAsync(request);
+
+            // Assert
+            var document = await response.GetHtmlDocumentAsync();
+
+            var numberInput = document.RequiredQuerySelector("input[id=Number]");
+            Assert.Equal("true", numberInput.GetAttribute("data-val"));
+            Assert.Equal("The field Number must be between 1 and 100.", numberInput.GetAttribute("data-val-range"));
+            Assert.Equal("The Number field is required.", numberInput.GetAttribute("data-val-required"));
+
+            var passwordInput = document.RequiredQuerySelector("input[id=Password]");
+            Assert.Equal("true", passwordInput.GetAttribute("data-val"));
+            Assert.Equal("The Password field is required.", passwordInput.GetAttribute("data-val-required"));
+
+            var addressInput = document.RequiredQuerySelector("input[id=Address]");
+            Assert.Equal("true", addressInput.GetAttribute("data-val"));
+            Assert.Equal("The Address field is required.", addressInput.GetAttribute("data-val-required"));
+        }
+
+        [Fact]
         public async Task ValidationTagHelpers_UsingRecords()
         {
             // Arrange
@@ -310,7 +336,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 new KeyValuePair<string,string>("Name", string.Empty),
                 new KeyValuePair<string,string>("Email", string.Empty),
                 new KeyValuePair<string,string>("PhoneNumber", string.Empty),
-                new KeyValuePair<string,string>("Password", string.Empty)
+                new KeyValuePair<string,string>("Password", string.Empty),
+                new KeyValuePair<string,string>("Address", string.Empty),
             };
             request.Content = new FormUrlEncodedContent(nameValueCollection);
 
@@ -331,6 +358,9 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 
             validation = document.QuerySelector("span[data-valmsg-for=Password]");
             Assert.Equal("The Password field is required.", validation.TextContent);
+
+            validation = document.QuerySelector("span[data-valmsg-for=Address]");
+            Assert.Equal("The Address field is required.", validation.TextContent);
         }
 
         [Fact]

--- a/src/Mvc/test/WebSites/HtmlGenerationWebSite/Areas/Customer/Controllers/HtmlGeneration_CustomerController.cs
+++ b/src/Mvc/test/WebSites/HtmlGenerationWebSite/Areas/Customer/Controllers/HtmlGeneration_CustomerController.cs
@@ -13,6 +13,12 @@ namespace HtmlGenerationWebSite.Areas.Customer.Controllers
             return View("Customer");
         }
 
+        [HttpGet]
+        public IActionResult CustomerWithRecords()
+        {
+            return View("CustomerWithRecords");
+        }
+
         public IActionResult CustomerWithRecords(Models.CustomerRecord customer)
         {
             return View("CustomerWithRecords");

--- a/src/Mvc/test/WebSites/HtmlGenerationWebSite/Models/CustomerRecord.cs
+++ b/src/Mvc/test/WebSites/HtmlGenerationWebSite/Models/CustomerRecord.cs
@@ -25,5 +25,9 @@ namespace HtmlGenerationWebSite.Models
         string Email,
 
         string Key
-    );
+    )
+    {
+        [Required]
+        public string Address { get; set; }
+    }
 }

--- a/src/Mvc/test/WebSites/HtmlGenerationWebSite/Views/Shared/CustomerWithRecords.cshtml
+++ b/src/Mvc/test/WebSites/HtmlGenerationWebSite/Views/Shared/CustomerWithRecords.cshtml
@@ -38,6 +38,11 @@
             <input asp-for="Gender" type="radio" value="Female" /> Female
             <span asp-validation-for="Gender"></span>
         </div>
+         <div>
+            <label asp-for="Address" class="order"></label>
+            <input asp-for="Address" type="text" />
+            <span asp-validation-for="Address"></span>
+        </div>
         <div id="validation-summary-all" asp-validation-summary="All" class="order"></div>
         <div id="validation-summary-model" asp-validation-summary="ModelOnly" class="order"></div>
         <input type="submit"/>

--- a/src/Tools/dotnet-watch/test/BrowserLaunchTests.cs
+++ b/src/Tools/dotnet-watch/test/BrowserLaunchTests.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 {
-    public class BrowserLaunchTests
+    public class BrowserLaunchTests : IDisposable
     {
         private readonly WatchableApp _app;
 
@@ -63,6 +63,11 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
             // Verify we launched the browser.
             await _app.Process.GetOutputLineStartsWithAsync(launchBrowserMessage, TimeSpan.FromMinutes(2));
+        }
+
+         public void Dispose()
+        {
+            _app.Dispose();
         }
     }
 }


### PR DESCRIPTION
### Description
Server validation for record types uses metadata from parameters
when validating record type properties. However client validation
does not use the parameter to harvest client validation attributes.

In the absence of this change, validation on parameters would require server
round trips which is unexcepted and not at parity with validation applied
to properties on regular classes or record types.

### Customer impact
Validation experience with record types is subpar and requires server
round trips.

### Regression
No. This feature is new to 5.0.

### Risk
Low. The change is isolated to record types and does not affect other code paths. We have
unit and functional test coverage to verify this change.