### PR TITLE
Virtualize component: method to trigger data refresh

### DIFF
--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -296,9 +296,22 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
         private async ValueTask RefreshDataCoreAsync(bool renderOnSuccess)
         {
             _refreshCts?.Cancel();
-            _refreshCts = new CancellationTokenSource();
+            CancellationToken cancellationToken;
 
-            var cancellationToken = _refreshCts.Token;
+            if (_itemsProvider == DefaultItemsProvider)
+            {
+                // If we're using the DefaultItemsProvider (because the developer supplied a fixed
+                // Items collection) we know it will complete synchronously, and there's no point
+                // instantiating a new CancellationTokenSource
+                _refreshCts = null;
+                cancellationToken = CancellationToken.None;
+            }
+            else
+            {
+                _refreshCts = new CancellationTokenSource();
+                cancellationToken = _refreshCts.Token;
+            }
+
             var request = new ItemsProviderRequest(_itemsBefore, _visibleItemCapacity, cancellationToken);
 
             try

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
         /// This is useful if external data may have changed. There is no need to call this
         /// when using <see cref="Items"/>.
         /// </summary>
-        /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
+        /// <returns>A <see cref="Task"/> representing the completion of the operation.</returns>
         public async Task RefreshDataAsync()
         {
             // We don't auto-render after this operation because in the typical use case, the

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -139,6 +140,14 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
             else if (Items != null)
             {
                 _itemsProvider = DefaultItemsProvider;
+
+                // When we have a fixed set of in-memory data, it doesn't cost anything to
+                // re-query it on each cycle, so do that. This means the developer can add/remove
+                // items in the collection and see the UI update without having to call RefreshDataAsync.
+                var refreshTask = RefreshDataCoreAsync(renderOnSuccess: false);
+
+                // We know it's synchronous and has its own error handling
+                Debug.Assert(refreshTask.IsCompletedSuccessfully);
             }
             else
             {

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -13,6 +13,7 @@
         <option value="BasicTestApp.ComponentRefComponent">Component ref component</option>
         <option value="BasicTestApp.ConcurrentRenderParent">Concurrent rendering</option>
         <option value="BasicTestApp.ConfigurationComponent">Configuration</option>
+        <option value="BasicTestApp.ContentEditable">Content-editable</option>
         <option value="BasicTestApp.CounterComponent">Counter</option>
         <option value="BasicTestApp.CounterComponentUsingChild">Counter using child component</option>
         <option value="BasicTestApp.CounterComponentWrapper">Counter wrapped in parent</option>
@@ -80,16 +81,16 @@
         <option value="BasicTestApp.RouterTest.TestRouterWithOnNavigate">Router with OnNavigate</option>
         <option value="BasicTestApp.RouterTest.TestRouterWithLazyAssembly">Router with dynamic assembly</option>
         <option value="BasicTestApp.RouterTest.TestRouterWithAdditionalAssembly">Router with additional assembly</option>
+        <option value="BasicTestApp.SelectVariantsComponent">Select with component options</option>
         <option value="BasicTestApp.SignalRClientComponent">SignalR client</option>
         <option value="BasicTestApp.StringComparisonComponent">StringComparison</option>
         <option value="BasicTestApp.SvgComponent">SVG</option>
         <option value="BasicTestApp.SvgWithChildComponent">SVG with child component</option>
         <option value="BasicTestApp.TextOnlyComponent">Plain text</option>
+        <option value="BasicTestApp.ToggleEventComponent">Toggle Event</option>
         <option value="BasicTestApp.TouchEventComponent">Touch events</option>
         <option value="BasicTestApp.VirtualizationComponent">Virtualization</option>
-        <option value="BasicTestApp.SelectVariantsComponent">Select with component options</option>
-        <option value="BasicTestApp.ToggleEventComponent">Toggle Event</option>
-        <option value="BasicTestApp.ContentEditable">Content-editable</option>
+        <option value="BasicTestApp.VirtualizationDataChanges">Virtualization data changes</option>
     </select>
 
     <span id="runtime-info"><code><tt>@System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription</tt></code></span>

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationDataChanges.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationDataChanges.razor
@@ -22,7 +22,7 @@
 <h4>Using ItemsProvider parameter</h4>
 <p>
     <button id="add-person-to-itemsprovider" @onclick="AddPersonToItemsProvider">Add person</button>
-    <button id="refresh-itemsprovider" @onclick="() => asyncVirtualize.RefreshAsync()">Refresh</button>
+    <button id="refresh-itemsprovider" @onclick="() => asyncVirtualize.RefreshDataAsync()">Refresh</button>
 </p>
 
 <div id="using-itemsprovider" style="overflow-y: auto; height: 200px; border: 1px dashed gray;">

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationDataChanges.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationDataChanges.razor
@@ -1,0 +1,84 @@
+﻿<h3 id="virtualization-data-changes">Virtualization data changes</h3>
+
+<p>This scenario shows how the data behind a Virtualize component can change.</p>
+
+<button id="add-person-to-fixed-list" @onclick="AddPersonToFixedList">Add person</button>
+
+<h4>Using Items parameter</h4>
+
+<div id="using-items" style="overflow-y: auto; height: 200px; border: 1px dashed gray;">
+    <Virtualize Items="@fixedPeople" Context="person">
+        @*
+        Note that for best performance, you really should use @key on the top-level elements within the <Virtualize>.
+        This test case doesn't do so only as a way of verifying it's not strictly required (though it is recommended).
+        *@
+        <div class="person" style="border-bottom: 1px dashed red; display: flex; justify-content: space-between; padding: 4px;">
+            <span>@person.Name</span>
+            <button @onclick="@person.Mutate">Mutate</button>
+        </div>
+    </Virtualize>
+</div>
+
+<h4>Using ItemsProvider parameter</h4>
+<p>
+    <button id="add-person-to-itemsprovider" @onclick="AddPersonToItemsProvider">Add person</button>
+    <button id="refresh-itemsprovider" @onclick="() => asyncVirtualize.RefreshAsync()">Refresh</button>
+</p>
+
+<div id="using-itemsprovider" style="overflow-y: auto; height: 200px; border: 1px dashed gray;">
+    <Virtualize @ref="asyncVirtualize" ItemsProvider="GetPeopleAsync" Context="person">
+        @*
+        Note that for best performance, you really should use @key on the top-level elements within the <Virtualize>.
+        This test case doesn't do so only as a way of verifying it's not strictly required (though it is recommended).
+        *@
+        <div class="person" style="border-bottom: 1px dashed red; display: flex; justify-content: space-between; padding: 4px;">
+            <span>@person.Name</span>
+            <button @onclick="@person.Mutate">Mutate</button>
+        </div>
+    </Virtualize>
+</div>
+
+@code {
+    Virtualize<Person> asyncVirtualize;
+    List<Person> fixedPeople = Enumerable.Range(1, 3).Select(GeneratePerson).ToList();
+    int numPeopleInItemsProvider = 3;
+
+    void AddPersonToFixedList()
+    {
+        // When using Items (not ItemsProvider), the Virtualize component re-queries
+        // the data on every refresh cycle without requiring you to call RefreshDataAsync.
+        // This is because there's no cost involved in doing so. Thus, the following
+        // line is enough to make the UI change on its own.
+        fixedPeople.Add(GeneratePerson(fixedPeople.Count + 1));
+    }
+
+    void AddPersonToItemsProvider()
+    {
+        // On its own, this isn't going to make the UI change, because it doesn't know
+        // to re-query the underlying items provider until you call RefreshDataAsync.
+        numPeopleInItemsProvider++;
+    }
+
+    async ValueTask<ItemsProviderResult<Person>> GetPeopleAsync(ItemsProviderRequest request)
+    {
+        await Task.Delay(500);
+
+        var lastIndexExcl = Math.Min(request.StartIndex + request.Count, numPeopleInItemsProvider);
+        return new ItemsProviderResult<Person>(
+            Enumerable.Range(1 + request.StartIndex, lastIndexExcl - request.StartIndex).Select(GeneratePerson).ToList(),
+            numPeopleInItemsProvider);
+    }
+
+    class Person
+    {
+        public string Name { get; set; }
+
+        public void Mutate()
+        {
+            Name += " MUTATED";
+        }
+    }
+
+    static Person GeneratePerson(int index)
+        => new Person { Name = $"Person {index}" };
+}


### PR DESCRIPTION
## Description

`<Virtualize>` is a new feature first shipped in 5.0 RC1. We were very keen to get it into RC1 so we could capture customer feedback about its usability. Overall it's been well received. Customers have used it in a wide range of scenarios successfully.

However, one bit of feedback showed there's an important functional gap: #26110 

That is, there isn't any reasonable way to make the `<Virtualize>` list update when the number of items in the list changes. It does update when the items are mutated in place, but not when items are added or removed. More generally there isn't a way to tell the `ItemsProvider` to re-query the external data source, so there wouldn't be any way to implement a "Refresh" button in the application UI.

Since this kind of feedback is exactly what we hoped to get from shipping in RC1, it makes sense to address it in RC2.

## Customer impact

Without this change, developers using `<Virtualize>` have no reasonable way to make their UI update when items are added/removed in their list. That will be a common scenario.

## Regression?

No, it's a new feature since 5.0 RC1.

## Risk

The changes are completely scoped to the `<Virtualize>` component and its tests. So the worst case would be causing some new problem in `<Virtualize>`, but nothing else could be affected.

Looking at the changes in this PR, I don't personally think they are likely to trigger any new unwanted behaviors. The implementation is fairly straightforwards.