### PR TITLE
Fix flaky Java test

### DIFF
--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -16,7 +16,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;


### PR DESCRIPTION
Wait for correct amount of Poll's before stopping so we throw from the access token provider at the correct time.

```
JUnit Jupiter:HubConnectionTest:LongPollingTransportAccessTokenProviderThrowsDuringStop():repetition 804 of 1000
    MethodSource [className = 'com.microsoft.signalr.HubConnectionTest', methodName = 'LongPollingTransportAccessTokenProviderThrowsDuringStop', methodParameterTypes = '']
    => org.opentest4j.AssertionFailedError: expected: <Error from accessTokenProvider> but was: <Request has no handler: DELETE http://example.com?id=bVOiRPG8-6YiJ6d7ZcTOVQ>
```