### PR TITLE
Skip shim and handler tests when running build.cmd -test in IIS subfolder

### DIFF
--- a/src/Servers/IIS/build.cmd
+++ b/src/Servers/IIS/build.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 SET RepoRoot=%~dp0..\..\..
-%RepoRoot%\build.cmd -projects %~dp0**\*.csproj %*
+%RepoRoot%\build.cmd -projects %~dp0**\*.csproj %* /p:SkipIISNewHandlerTests=true /p:SkipIISNewShimTests=true

--- a/src/Servers/IIS/build.cmd
+++ b/src/Servers/IIS/build.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
 SET RepoRoot=%~dp0..\..\..
-%RepoRoot%\build.cmd -projects %~dp0**\*.csproj %* /p:SkipIISNewHandlerTests=true /p:SkipIISNewShimTests=true
+%RepoRoot%\build.cmd -projects %~dp0**\*.csproj /p:SkipIISNewHandlerTests=true /p:SkipIISNewShimTests=true %*


### PR DESCRIPTION
Right now, all three test assemblies are executed in parallel with IIS tests, which causes them to flakily fail. This skips shim and handler tests when doing build.cmd -test.