### PR TITLE
[Java] Fix concurrent access to TestLogger

### DIFF
--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/TestLogger.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/TestLogger.java
@@ -5,15 +5,23 @@ package com.microsoft.signalr;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
 
 class TestLogger implements AutoCloseable {
     private Logger logger;
-    private ListAppender<ILoggingEvent> appender;
+    private Lock lock = new ReentrantLock();
+    private List<ILoggingEvent> list = new ArrayList<ILoggingEvent>();
+    private Appender<ILoggingEvent> appender;
 
     public TestLogger() {
         this("com.microsoft.signalr.HubConnection");
@@ -21,15 +29,30 @@ class TestLogger implements AutoCloseable {
 
     public TestLogger(String category) {
         this.logger = (Logger)LoggerFactory.getLogger(category);
-        this.appender = new ListAppender<ILoggingEvent>();
+        this.appender = new AppenderBase<ILoggingEvent>() {
+            public void append(ILoggingEvent event) {
+                lock.lock();
+                try {
+                    list.add(event);
+                } finally {
+                    lock.unlock();
+                }
+            }
+        };
         this.appender.start();
         this.logger.addAppender(this.appender);
     }
 
     public ILoggingEvent assertLog(String logMessage) {
-        // Only check logs after main test has completed
-        this.logger.detachAppender(this.appender);
-        for (ILoggingEvent log : appender.list) {
+        ILoggingEvent[] localList;
+        lock.lock();
+        try {
+            localList = list.toArray(new ILoggingEvent[0]);
+        } finally {
+            lock.unlock();
+        }
+
+        for (ILoggingEvent log : localList) {
             if (log.getFormattedMessage().startsWith(logMessage)) {
                 return log;
             }

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/TestLogger.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/TestLogger.java
@@ -27,7 +27,9 @@ class TestLogger implements AutoCloseable {
     }
 
     public ILoggingEvent assertLog(String logMessage) {
-        for (ILoggingEvent log : appender.list) {
+        // Copy items just in case logs are written while iterating
+        ILoggingEvent[] list = appender.list.toArray(new ILoggingEvent[1]);
+        for (ILoggingEvent log : list) {
             if (log.getFormattedMessage().startsWith(logMessage)) {
                 return log;
             }

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/TestLogger.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/TestLogger.java
@@ -27,9 +27,9 @@ class TestLogger implements AutoCloseable {
     }
 
     public ILoggingEvent assertLog(String logMessage) {
-        // Copy items just in case logs are written while iterating
-        ILoggingEvent[] list = appender.list.toArray(new ILoggingEvent[1]);
-        for (ILoggingEvent log : list) {
+        // Only check logs after main test has completed
+        this.logger.detachAppender(this.appender);
+        for (ILoggingEvent log : appender.list) {
             if (log.getFormattedMessage().startsWith(logMessage)) {
                 return log;
             }
@@ -43,5 +43,4 @@ class TestLogger implements AutoCloseable {
     public void close() {
         this.logger.detachAppender(this.appender);
     }
-
 }


### PR DESCRIPTION
```
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:937)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:891)
	at com.microsoft.signalr.TestLogger.assertLog(TestLogger.java:30)
	at com.microsoft.signalr.HubConnectionTest.throwFromOnHandlerRunsAllHandlers(HubConnectionTest.java:2596)
```