### PR TITLE
Allow BaselineGenerator to build after updating version

### DIFF
--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -1,7 +1,10 @@
 <Project>
 
   <Target Name="EnsureBaselineIsUpdated"
-          Condition="'$(IsServicingBuild)' == 'true' AND '$(AspNetCoreBaselineVersion)' != '$(PreviousAspNetCoreReleaseVersion)'"
+          Condition=" '$(IsServicingBuild)' == 'true' AND
+              '$(AspNetCoreBaselineVersion)' != '$(PreviousAspNetCoreReleaseVersion)' AND
+              '$(MSBuildProjectName)' != 'BaselineGenerator' AND
+              '$(MSBuildProjectName)' != 'RepoTasks' "
           BeforeTargets="BeforeBuild">
     <Error Text="The package baseline ($(AspNetCoreBaselineVersion)) is out of date with the latest release of this repo ($(PreviousAspNetCoreReleaseVersion)).
                  See $(RepoRoot)eng\tools\BaselineGenerator\README.md for instructions on updating this baseline." />


### PR DESCRIPTION
- avoid problems when re-branding in a clean clone
  - attempts to build `BaselineGenerator` failed due to out-of-date baselines
