### PR TITLE
Remove photo from showprofile

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/ShowProfile.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/ShowProfile.razor
@@ -24,61 +24,21 @@ else
             <td>Name</td>
             <td>@user.DisplayName</td>
         </tr>
-        <tr>
-            <td>Photo</td>
-            <td>
-                @{
-                    if (photo != null)
-                    {
-                        <img style="margin: 5px 0; width: 150px" src="data:image/jpeg;base64, @photo" />
-                    }
-                    else
-                    {
-                        <h3>NO PHOTO</h3>
-                        <p>Check user profile in Azure Active Directory to add a photo.</p>
-                    }
-                }
-            </td>
-        </tr>
     </table>
 }
 
 @code {
     User user;
-    string photo;
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
             user = await GraphServiceClient.Me.Request().GetAsync();
-            photo = await GetPhoto();
         }
         catch (Exception ex)
         {
             ConsentHandler.HandleException(ex);
         }
     }
-
-    protected async Task<string> GetPhoto()
-    {
-        string photo;
-
-        try
-        {
-            using (var photoStream = await GraphServiceClient.Me.Photo.Content.Request().GetAsync())
-            {
-                byte[] photoByte = ((System.IO.MemoryStream)photoStream).ToArray();
-                photo = Convert.ToBase64String(photoByte);
-                this.StateHasChanged();
-            }
-
-        }
-        catch (Exception)
-        {
-            photo = null;
-        }
-        return photo;
-    }
-
 }


### PR DESCRIPTION
Cherry pick of https://github.com/dotnet/aspnetcore/pull/26226#issuecomment-698025442

### Description

As part of 5.0, we added snippets to ASP.NET Core's project templates that show the use of Microsoft Graph APIs. In this case, a Blazor Server page attempted to show an image retrieved from the Graph API by base64 encoding the image as a string. This has really poor scale up characteristics as this allocates multi-mb strings. When hosted thru Azure SignalR Service, this also causes the SignalR connection Blazor uses to often timeout since the payload is so large.

The correct way to use this feature would be to have an API endpoint that served images. That would take more time and testing which we would not like to invest in at this this. Instead this removes the offending code.

### Customer impact

Customers will no have a sample that demonstrates how to do this in the project template. We can point them at our docs that demonstrates how to serve dynamically retrieved content.


### Regression

Yes. The changes to the template are new to 5.0

### Risk

Low. The changes is limited to the project templates.