### PR TITLE
Virtualize: Refresh when estimated item size changes. Fixes #25915

### DIFF
--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -299,7 +299,7 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
 
         private void UpdateItemDistribution(int itemsBefore, int visibleItemCapacity, bool itemSizeChanged)
         {
-            if (itemsBefore != _itemsBefore || visibleItemCapacity != _visibleItemCapacity || itemSizeChanged)
+            if (itemsBefore != _itemsBefore || visibleItemCapacity != _visibleItemCapacity)
             {
                 _itemsBefore = itemsBefore;
                 _visibleItemCapacity = visibleItemCapacity;


### PR DESCRIPTION
This is a potential fix for #25915.

This PR is so we can have a conversation about whether to include this fix in 5.0. Personally, I don't think it's a clear-cut decision. We could argue either way. Obviously it's generally good to fix issues, but:

 * The issue only occurs in relatively special cases (when the actual item height is very close to the default height of 50px, but not exactly equal to 50px). It's an unfortunate coincidence that the rows in the `FetchData` table in the default template happen to be 48.89px high!
 * This issue has a fairly straightforward (albeit a bit inconvenient) workaround: developers can supply an `ItemHeight` value to `<Virtualize>` instead of relying on it auto-detecting the height. If they do that, the problem won't occur, as far as I can tell.
 * The fix in this PR is the sort of thing I'd really prefer to give quite a bit of bake-time for, and let people try it out in preview releases for a while, before being totally confident it will work everywhere and doesn't have any negative side-effects. In particular I'm nervous about whether this change could somehow cause extra unnecessary rendering, or even a loop of repeated rendering.
 * My gut sense is this is not the last quirk we're going to discover in `<Virtualize>`. As we all know, virtualization is fundamentally pretty hard to do and cover every edge case when it's not a native feature of the underlying UI technology. I think what we've got is really good and useful, but we should be prepared to refine it further as time goes on.
