### PR TITLE
Fix render tree updater bug

### DIFF
--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -667,15 +667,16 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
         // internal because this should only be used during the post-event tree patching logic
         // It's expensive because it involves copying all the subsequent memory in the array
-        internal void InsertAttributeExpensive(int insertAtIndex, int sequence, string attributeName, object? attributeValue)
+        internal bool InsertAttributeExpensive(int insertAtIndex, int sequence, string attributeName, object? attributeValue)
         {
             // Replicate the same attribute omission logic as used elsewhere
             if ((attributeValue == null) || (attributeValue is bool boolValue && !boolValue))
             {
-                return;
+                return false;
             }
 
             _entries.InsertExpensive(insertAtIndex, RenderTreeFrame.Attribute(sequence, attributeName, attributeValue));
+            return true;
         }
 
         /// <summary>

--- a/src/Components/Components/src/Rendering/RenderTreeUpdater.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeUpdater.cs
@@ -75,7 +75,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
 
             // If we get here, we didn't find the desired attribute, so we have to insert a new frame for it
             var insertAtIndex = elementFrameIndex + 1;
-            renderTreeBuilder.InsertAttributeExpensive(insertAtIndex, RenderTreeDiffBuilder.SystemAddedAttributeSequenceNumber, attributeName, attributeValue);
+            var didInsertFrame = renderTreeBuilder.InsertAttributeExpensive(insertAtIndex, RenderTreeDiffBuilder.SystemAddedAttributeSequenceNumber, attributeName, attributeValue);
+            if (!didInsertFrame)
+            {
+                // The builder decided to omit the new frame, e.g., because it's a false-valued bool
+                // In this case there's nothing else to update
+                return;
+            }
+
             framesArray = renderTreeBuilder.GetFrames().Array; // Refresh in case it mutated due to the expansion
 
             // Update subtree length for this and all ancestor containers

--- a/src/Components/Components/test/RenderTreeUpdaterTest.cs
+++ b/src/Components/Components/test/RenderTreeUpdaterTest.cs
@@ -128,6 +128,30 @@ namespace Microsoft.AspNetCore.Components.Test
         }
 
         [Fact]
+        public void OmitsAttributeIfNotFoundButValueIsOmissible()
+        {
+            // Arrange
+            var valuePropName = "testprop";
+            var renderer = new TestRenderer();
+            var builder = new RenderTreeBuilder();
+            builder.OpenElement(0, "elem");
+            builder.AddAttribute(1, "eventname", (Action)(() => { }));
+            builder.SetUpdatesAttributeName(valuePropName);
+            builder.CloseElement();
+            var frames = builder.GetFrames();
+            frames.Array[1] = frames.Array[1].WithAttributeEventHandlerId(123);
+
+            // Act
+            RenderTreeUpdater.UpdateToMatchClientState(builder, 123, false);
+            frames = builder.GetFrames();
+
+            // Assert
+            Assert.Collection(frames.AsEnumerable(),
+                frame => AssertFrame.Element(frame, "elem", 2, 0),
+                frame => AssertFrame.Attribute(frame, "eventname", v => Assert.IsType<Action>(v), 1));
+        }
+
+        [Fact]
         public void ExpandsAllAncestorsWhenAddingAttribute()
         {
             // Arrange


### PR DESCRIPTION
### Description

As reported in #24014, there is a possible combination of event handlers that leads to a crash. Part of the rendertree logic produces an invalid render tree update, so the diffing system later rejects the render tree state and throws. The fix in this PR covers this gap (correcting the render tree update), without any drawbacks that I'm aware of.

### Customer impact

If this particular combination of events occurs, then the renderer will throw an unhandled exception. On Blazor Server, this terminates the circuit. On Blazor WebAssembly, this terminates the application (so the user would have to reload the page).

**This is definitely an edge case** (explaining why it wasn't reported before, even though the issue was present in 3.x all along). However, since the consequence is so bad, and the fix is so clear, I think there's less product risk in taking this fix than in not taking it.

### Regression?

No. The issue has been present since 3.0.

### Risk

Low. The code being changed here is objectively wrong. I don't see any realistic way in which fixing this definite bug would give rise to different bugs.

### Appendix: Minimal repro

Given a scenario like: `<input type="checkbox" @bind="someValue" @oninput="SomeEventHandler" />`, if the logic inside `SomeEventHandler` changes `someValue` from `true` to `false`, then the problem will occur. When the user unchecks the box, the first event is `oninput` which removes the `checked` attribute, and then the second event is `onchange` which also tries to remove the `checked` attribute. The fact that the attribute was already removed (without any render update occuring between the events) leads to the exception. This is just one example - there's a more general class of event pairs that could experience this problem.
