### PR TITLE
Support override of PackageOverrides.txt content in servicing

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -87,7 +87,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' != 'false'">
       $(BuildDependsOn);
       _ResolveTargetingPackContent;
-      GeneratePackageConflictManifest;
+      GeneratePackageOverrides;
       IncludeFrameworkListFile;
       _BatchCopyToLayoutTargetDir;
       _InstallTargetingPackIntoLocalDotNet;

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -35,8 +35,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- This project should not be referenced via the `<Reference>` implementation. -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
 
-    <PackageConflictManifestFileName>PackageOverrides.txt</PackageConflictManifestFileName>
-
     <!--
       We are ignoring MSB3243 warnings since implementation and reference assemblies are versioned differently.
       We need both to compose the targeting pack with reference assemblies and xml docs.
@@ -52,7 +50,12 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- Runtime extensions transport paths -->
     <RuntimeExtensionsReferenceDirectory>$(PkgMicrosoft_Extensions_Internal_Transport)\ref\$(TargetFramework)\</RuntimeExtensionsReferenceDirectory>
 
-    <!-- Platform manifest override metadata. -->
+    <!-- Package overrides and platform manifest metadata. -->
+    <PackageOverridesFileName>PackageOverrides.txt</PackageOverridesFileName>
+    <!-- PackageOverrides.txt is written in GeneratePackageOverrides target unless servicing. -->
+    <ReferencePackageOverridesPath Condition="'$(IsServicingBuild)' != 'true'">$(TargetDir)$(PackageOverridesFileName)</ReferencePackageOverridesPath>
+    <ReferencePackageOverridesPath Condition="'$(IsServicingBuild)' == 'true'">$(RepoRoot)eng\$(PackageOverridesFileName)</ReferencePackageOverridesPath>
+    <!-- PlatformManifest.txt is written in App.Runtime's GenerateSharedFxDepsFile target but not used here when servicing. -->
     <ReferencePlatformManifestPath Condition="'$(IsServicingBuild)' != 'true'">$(PlatformManifestOutputPath)</ReferencePlatformManifestPath>
     <ReferencePlatformManifestPath Condition="'$(IsServicingBuild)' == 'true'">$(RepoRoot)eng\PlatformManifest.txt</ReferencePlatformManifestPath>
   </PropertyGroup>
@@ -144,26 +147,22 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Condition="Exists('%(RootDir)%(Directory)%(FileName).xml')" />
       <AspNetCoreReferenceDocXml Include="@(_SelectedExtensionsRefAssemblies->'$(RuntimeExtensionsReferenceDirectory)%(FileName).xml')" />
       <!-- Grab remaining .xml files from packages -->
-      <AspNetCoreReferenceDocXml 
-          Include="@(AspNetCoreReferenceAssemblyPath->WithMetadataValue('ExternallyResolved', 'true')->'%(RootDir)%(Directory)%(Filename).xml')" 
+      <AspNetCoreReferenceDocXml
+          Include="@(AspNetCoreReferenceAssemblyPath->WithMetadataValue('ExternallyResolved', 'true')->'%(RootDir)%(Directory)%(Filename).xml')"
           Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
 
       <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
-      <RefPackContent Include="$(TargetDir)$(PackageConflictManifestFileName)" PackagePath="$(ManifestsPackagePath)" />
+      <RefPackContent Include="$(ReferencePackageOverridesPath)" PackagePath="$(ManifestsPackagePath)" />
       <RefPackContent Include="$(ReferencePlatformManifestPath)" PackagePath="$(ManifestsPackagePath)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="GeneratePackageConflictManifest"
+  <Target Name="GeneratePackageOverrides"
+          Condition=" '$(IsServicingBuild)' != 'true' "
           DependsOnTargets="_ResolveTargetingPackContent"
           Inputs="$(MSBuildAllProjects)"
-          Outputs="$(TargetDir)$(PackageConflictManifestFileName)">
-    <PropertyGroup>
-      <_PinnedNETCoreAppRuntimeVersion>$(MicrosoftNETCoreAppRuntimeVersion)</_PinnedNETCoreAppRuntimeVersion>
-      <_PinnedNETCoreAppRuntimeVersion
-          Condition=" '$(IsServicingBuild)' == 'true' ">$(_PinnedNETCoreAppRuntimeVersion.Split('.')[0]).$(_PinnedNETCoreAppRuntimeVersion.Split('.')[1]).0</_PinnedNETCoreAppRuntimeVersion>
-    </PropertyGroup>
+          Outputs="$(ReferencePackageOverridesPath">
     <ItemGroup>
       <!-- Use package version for non-Extensions references. -->
       <_AspNetCoreAppPackageOverrides Include="@(AspNetCoreReferenceAssemblyPath->'%(NuGetPackageId)|%(NuGetPackageVersion)')"
@@ -172,8 +171,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
             '%(AspNetCoreReferenceAssemblyPath.NuGetPackageId)' != 'Microsoft.Extensions.Internal.Transport' AND
             '%(AspNetCoreReferenceAssemblyPath.NuGetSourceType)' == 'Package' " />
 
-      <!-- Use pinned NETCore.App version for Extensions references. -->
-      <_AspNetCoreAppPackageOverrides Include="@(_SelectedExtensionsRefAssemblies->'%(FileName)|$(_PinnedNETCoreAppRuntimeVersion)')" />
+      <!-- Use NETCore.App.Runtime version for Extensions references. -->
+      <_AspNetCoreAppPackageOverrides Include="@(_SelectedExtensionsRefAssemblies->'%(FileName)|$(MicrosoftNETCoreAppRuntimeVersion)')" />
 
       <_AspNetCoreAppPackageOverrides Include="@(AspNetCoreReferenceAssemblyPath->'%(FileName)|$(ReferencePackSharedFxVersion)')"
           Condition=" '%(AspNetCoreReferenceAssemblyPath.ReferenceSourceTarget)' == 'ProjectReference' " />
@@ -181,7 +180,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <WriteLinesToFile
         Lines="@(_AspNetCoreAppPackageOverrides)"
-        File="$(TargetDir)$(PackageConflictManifestFileName)"
+        File="$(ReferencePackageOverridesPath)"
         Overwrite="true" />
   </Target>
 


### PR DESCRIPTION
- doing now ensures we don't forget if we need to service targeting packs
- not needed in release/3.1 because that branch still pins packages at `X.Y.0` in targeting packs
  - did not do bfc1ec6792 / #25851 work in 3.1 because dotnet/runtime ref/ assemblies change there
- revert no-longer-necessary parts of 6418c8f78a93 / #25986
  - `$(MicrosoftNETCoreAppRuntimeVersion)` is now correct whenever `GeneratePackageOverrides` runs