### PR TITLE
Fix MaxRequestBodySize in IIS for 3.1

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
@@ -19,6 +19,6 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
         public bool fAnonymousAuthEnable;
         [MarshalAs(UnmanagedType.BStr)]
         public string pwzBindings;
-        public int maxRequestBodySize;
+        public uint maxRequestBodySize;
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Servers/IIS/IIS/src/IISServerOptions.cs
+++ b/src/Servers/IIS/IIS/src/IISServerOptions.cs
@@ -42,16 +42,17 @@ namespace Microsoft.AspNetCore.Builder
         // https://www.iis.net/configreference/system.webserver/security/requestfiltering/requestlimits#005
         private long? _maxRequestBodySize = 30000000;
 
-        internal long IisMaxRequestSizeLimit;
+        internal long IisMaxRequestSizeLimit; // Used for verifying if limit set in managed exceeds native 
 
         /// <summary>
         /// Gets or sets the maximum allowed size of any request body in bytes.
-        /// When set to null, the maximum request body size is unlimited.
+        /// When set to null, the maximum request length will not be restricted in ASP.NET Core.
+        /// However, the IIS maxAllowedContentLength will still restrict content length requests (30,000,000 by default).
         /// This limit has no effect on upgraded connections which are always unlimited.
         /// This can be overridden per-request via <see cref="IHttpMaxRequestBodySizeFeature"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to null (unlimited).
+        /// Defaults to 30,000,000 bytes (~28.6 MB).
         /// </remarks>
         public long? MaxRequestBodySize
         {

--- a/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
+++ b/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Hosting
                             options => {
                                 options.ServerAddresses = iisConfigData.pwzBindings.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                                 options.ForwardWindowsAuthentication = iisConfigData.fWindowsAuthEnabled || iisConfigData.fBasicAuthEnabled;
+                                options.MaxRequestBodySize = iisConfigData.maxRequestBodySize;
                                 options.IisMaxRequestSizeLimit = iisConfigData.maxRequestBodySize;
                             }
                         );

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
@@ -56,6 +56,46 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
 
         [ConditionalFact]
         [RequiresNewHandler]
+        public async Task SetIISLimitMaxRequestBodySizeE2EWorksWithLargerLimit()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+            deploymentParameters.ServerConfigActionList.Add(
+                (config, _) => {
+                    config
+                        .RequiredElement("system.webServer")
+                        .GetOrAdd("security")
+                        .GetOrAdd("requestFiltering")
+                        .GetOrAdd("requestLimits", "maxAllowedContentLength", "100000000");
+                });
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 100000000)));
+
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [ConditionalFact]
+        [RequiresNewHandler]
+        public async Task SetIISLimitMaxRequestBodySizeE2EWorksWithIntMaxValue()
+        {
+            var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+            deploymentParameters.ServerConfigActionList.Add(
+                (config, _) => {
+                    config
+                        .RequiredElement("system.webServer")
+                        .GetOrAdd("security")
+                        .GetOrAdd("requestFiltering")
+                        .GetOrAdd("requestLimits", "maxAllowedContentLength", "4294967295");
+                });
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 10000)));
+
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [ConditionalFact]
+        [RequiresNewHandler]
         public async Task IISRejectsContentLengthTooLargeByDefault()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters();
@@ -94,7 +134,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
                 });
             var deploymentResult = await DeployAsync(deploymentParameters);
 
-            var result = await deploymentResult.HttpClient.PostAsync("/DecreaseRequestLimit", new StringContent("1"));
+            var result = await deploymentResult.HttpClient.PostAsync("/IncreaseRequestLimit", new StringContent("1"));
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
             StopServer();

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1029,5 +1029,12 @@ namespace TestSite
             Assert.Equal("�", value);
             return Task.CompletedTask;
         }
+
+        public Task IncreaseRequestLimit(HttpContext httpContext)
+        {
+            var maxRequestBodySizeFeature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
+            maxRequestBodySizeFeature.MaxRequestBodySize = 2;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -462,6 +462,16 @@ namespace TestSite
             }
         }
 
+        private async Task ReadRequestBodyLarger(HttpContext ctx)
+        {
+            var readBuffer = new byte[4096];
+            var result = await ctx.Request.Body.ReadAsync(readBuffer, 0, 4096);
+            while (result != 0)
+            {
+                result = await ctx.Request.Body.ReadAsync(readBuffer, 0, 4096);
+            }
+        }
+
         private int _requestsInFlight = 0;
         private async Task ReadAndCountRequestBody(HttpContext ctx)
         {


### PR DESCRIPTION
# Description
There are two bugs in the IIS MaxRequestBodySize feature which made it so it wouldn't read the value from IIS correctly and couldn't accept a value larger than Int.MaxValue. This made the middleware too restrictive, causing people difficulties who were trying to increase the limit.

# Customer Impact

Fixes the feature by reading the correct value from native as well as accepting UInt.MaxValue, matching the max limit in IIS. Workarounds are not intuitive and will always log a warning message with the workaround.

Reported by a customer via Customer Support

# Regression?

No

# Risk

Low. This fixes an already existing feature and people who were working around it today wouldn't be affected.