### PR TITLE
API docs for HttpAbstractions

### DIFF
--- a/src/Http/Authentication.Abstractions/src/AuthenticationOptions.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationOptions.cs
@@ -4,22 +4,24 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Authentication
 {
+    /// <summary>
+    /// Options to configure authentication.
+    /// </summary>
     public class AuthenticationOptions
     {
         private readonly IList<AuthenticationSchemeBuilder> _schemes = new List<AuthenticationSchemeBuilder>();
 
         /// <summary>
-        /// Returns the schemes in the order they were added (important for request handling priority)
+        /// Gets the schemes in the order they were added (important for request handling priority)
         /// </summary>
         public IEnumerable<AuthenticationSchemeBuilder> Schemes => _schemes;
 
         /// <summary>
-        /// Maps schemes by name.
+        /// Gets a mapping of names to authentication schemes.
         /// </summary>
         public IDictionary<string, AuthenticationSchemeBuilder> SchemeMap { get; } = new Dictionary<string, AuthenticationSchemeBuilder>(StringComparer.Ordinal);
 

--- a/src/Http/Authentication.Abstractions/src/AuthenticationSchemeBuilder.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationSchemeBuilder.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Builds the <see cref="AuthenticationScheme"/> instance.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The <see cref="AuthenticationScheme"/>.</returns>
         public AuthenticationScheme Build()
         {
             if (HandlerType is null)

--- a/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         /// <param name="scheme">The <see cref="AuthenticationScheme"/> scheme.</param>
         /// <param name="context">The <see cref="HttpContext"/> context.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
         Task InitializeAsync(AuthenticationScheme scheme, HttpContext context);
 
         /// <summary>
@@ -29,14 +28,12 @@ namespace Microsoft.AspNetCore.Authentication
         /// Challenge behavior.
         /// </summary>
         /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
         Task ChallengeAsync(AuthenticationProperties? properties);
 
         /// <summary>
         /// Forbid behavior.
         /// </summary>
         /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
         Task ForbidAsync(AuthenticationProperties? properties);
     }
 }

--- a/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticationHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         /// <param name="scheme">The <see cref="AuthenticationScheme"/> scheme.</param>
         /// <param name="context">The <see cref="HttpContext"/> context.</param>
-        /// <returns></returns>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         Task InitializeAsync(AuthenticationScheme scheme, HttpContext context);
 
         /// <summary>
@@ -29,14 +29,14 @@ namespace Microsoft.AspNetCore.Authentication
         /// Challenge behavior.
         /// </summary>
         /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
-        /// <returns>A task.</returns>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         Task ChallengeAsync(AuthenticationProperties? properties);
 
         /// <summary>
         /// Forbid behavior.
         /// </summary>
         /// <param name="properties">The <see cref="AuthenticationProperties"/> that contains the extra meta-data arriving with the authentication.</param>
-        /// <returns>A task.</returns>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         Task ForbidAsync(AuthenticationProperties? properties);
     }
 }

--- a/src/Http/Authentication.Core/src/AuthenticationSchemeProvider.cs
+++ b/src/Http/Authentication.Core/src/AuthenticationSchemeProvider.cs
@@ -201,6 +201,10 @@ namespace Microsoft.AspNetCore.Authentication
             }
         }
 
+        /// <summary>
+        /// Returns all currently registered <see cref="AuthenticationScheme"/> instances.
+        /// </summary>
+        /// <returns>All currently registered <see cref="AuthenticationScheme"/> instances.</returns>
         public virtual Task<IEnumerable<AuthenticationScheme>> GetAllSchemesAsync()
             => Task.FromResult(_schemesCopy);
     }

--- a/src/Http/Authentication.Core/src/Microsoft.AspNetCore.Authentication.Core.csproj
+++ b/src/Http/Authentication.Core/src/Microsoft.AspNetCore.Authentication.Core.csproj
@@ -4,13 +4,11 @@
     <Description>ASP.NET Core common types used by the various authentication middleware components.</Description>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn.Replace('1591', ''))</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;authentication;security</PackageTags>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-
-    <NoWarn />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Http/Authentication.Core/src/Microsoft.AspNetCore.Authentication.Core.csproj
+++ b/src/Http/Authentication.Core/src/Microsoft.AspNetCore.Authentication.Core.csproj
@@ -9,6 +9,8 @@
     <PackageTags>aspnetcore;authentication;security</PackageTags>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+
+    <NoWarn />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Abstractions/src/ConnectionInfo.cs
+++ b/src/Http/Http.Abstractions/src/ConnectionInfo.cs
@@ -39,15 +39,15 @@ namespace Microsoft.AspNetCore.Http
         public abstract int LocalPort { get; set; }
 
         /// <summary>
-        /// Gets or sets client certificates associated with the connection.
+        /// Gets or sets the client certificate associated with the connection.
         /// </summary>
         public abstract X509Certificate2? ClientCertificate { get; set; }
 
         /// <summary>
-        /// Asynchronously retries the client certificate.
+        /// Asynchronously retrieves the client certificate.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <returns>The client certificate if available.</returns>
         public abstract Task<X509Certificate2?> GetClientCertificateAsync(CancellationToken cancellationToken = new CancellationToken());
     }
 }

--- a/src/Http/Http.Abstractions/src/ConnectionInfo.cs
+++ b/src/Http/Http.Abstractions/src/ConnectionInfo.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Http
 {
+    /// <summary>
+    /// Gets information about the current connection.
+    /// </summary>
     public abstract class ConnectionInfo
     {
         /// <summary>
@@ -15,16 +18,36 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         public abstract string Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the <see cref="IPAddress"/> for the connecting client.
+        /// </summary>
         public abstract IPAddress? RemoteIpAddress { get; set; }
 
+        /// <summary>
+        /// Gets or sets the port for the connecting client.
+        /// </summary>
         public abstract int RemotePort { get; set; }
 
+        /// <summary>
+        /// Gets or sets the <see cref="IPAddress"/> for the host.
+        /// </summary>
         public abstract IPAddress? LocalIpAddress { get; set; }
 
+        /// <summary>
+        /// Gets or sets the port for the host.
+        /// </summary>
         public abstract int LocalPort { get; set; }
 
+        /// <summary>
+        /// Gets or sets client certificates associated with the connection.
+        /// </summary>
         public abstract X509Certificate2? ClientCertificate { get; set; }
 
+        /// <summary>
+        /// Asynchronously retries the client certificate.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
         public abstract Task<X509Certificate2?> GetClientCertificateAsync(CancellationToken cancellationToken = new CancellationToken());
     }
 }

--- a/src/Http/Http.Abstractions/src/Extensions/HeaderDictionaryExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/HeaderDictionaryExtensions.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http
 {
+    /// <summary>
+    /// Extension methods for <see cref="IHeaderDictionary"/>.
+    /// </summary>
     public static class HeaderDictionaryExtensions
     {
         /// <summary>

--- a/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
         /// <param name="pathMatch">The request path to match.</param>
         /// <param name="configuration">The branch to take for positive path matches.</param>
-        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
         public static IApplicationBuilder Map(this IApplicationBuilder app, PathString pathMatch, Action<IApplicationBuilder> configuration)
         {
             return Map(app, pathMatch, preserveMatchedPathSegment: false, configuration);
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pathMatch">The request path to match.</param>
         /// <param name="preserveMatchedPathSegment">if false, matched path would be removed from Request.Path and added to Request.PathBase.</param>
         /// <param name="configuration">The branch to take for positive path matches.</param>
-        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
         public static IApplicationBuilder Map(this IApplicationBuilder app, PathString pathMatch, bool preserveMatchedPathSegment, Action<IApplicationBuilder> configuration)
         {
             if (app == null)

--- a/src/Http/Http.Abstractions/src/Extensions/MapWhenExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapWhenExtensions.cs
@@ -18,10 +18,10 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Branches the request pipeline based on the result of the given predicate.
         /// </summary>
-        /// <param name="app"></param>
+        /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
         /// <param name="predicate">Invoked with the request environment to determine if the branch should be taken</param>
         /// <param name="configuration">Configures a branch to take</param>
-        /// <returns></returns>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
         public static IApplicationBuilder MapWhen(this IApplicationBuilder app, Predicate predicate, Action<IApplicationBuilder> configuration)
         {
             if (app == null)

--- a/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
@@ -16,8 +16,8 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Gets the request "Trailer" header that lists which trailers to expect after the body.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <returns>The request "Trailer" header.</returns>
         public static StringValues GetDeclaredTrailers(this HttpRequest request)
         {
             return request.Headers.GetCommaSeparatedValues(HeaderNames.Trailer);
@@ -26,8 +26,9 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Indicates if the request supports receiving trailer headers.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <returns><see langword="true"/> if the request supports received trailer headers,
+        /// otherwise <see langword="false"/>.</returns>
         public static bool SupportsTrailers(this HttpRequest request)
         {
             return request.HttpContext.Features.Get<IHttpRequestTrailersFeature>() != null;
@@ -37,8 +38,9 @@ namespace Microsoft.AspNetCore.Http
         /// Checks if the request supports trailers and they are available to be read now.
         /// This does not mean that there are any trailers to read.
         /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <returns><see langword="true"/> if the request supports trailer that are are available to be read,
+        /// otherwise <see langword="false"/>.</returns>
         public static bool CheckTrailersAvailable(this HttpRequest request)
         {
             return request.HttpContext.Features.Get<IHttpRequestTrailersFeature>()?.Available == true;
@@ -46,11 +48,11 @@ namespace Microsoft.AspNetCore.Http
 
         /// <summary>
         /// Gets the requested trailing header from the response. Check <see cref="SupportsTrailers"/>
-        /// or a NotSupportedException may be thrown.
+        /// or a <see cref="NotSupportedException"/> may be thrown.
         /// Check <see cref="CheckTrailersAvailable" /> or an InvalidOperationException may be thrown.
         /// </summary>
-        /// <param name="request"></param>
-        /// <param name="trailerName"></param>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="trailerName">The trailer header to read.</param>
         public static StringValues GetTrailer(this HttpRequest request, string trailerName)
         {
             var feature = request.HttpContext.Features.Get<IHttpRequestTrailersFeature>();

--- a/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/RequestTrailerExtensions.cs
@@ -53,6 +53,7 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         /// <param name="request">The <see cref="HttpRequest"/>.</param>
         /// <param name="trailerName">The trailer header to read.</param>
+        <returns>The requested trailed header value.</returns>
         public static StringValues GetTrailer(this HttpRequest request, string trailerName)
         {
             var feature = request.HttpContext.Features.Get<IHttpRequestTrailersFeature>();

--- a/src/Http/Http.Abstractions/src/Extensions/ResponseTrailerExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/ResponseTrailerExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.Http
 {
     /// <summary>
-    /// Extension methods for <see cref="HttpResponse"/> to work with the 'Trailer' response header.
+    /// Extension methods for <see cref="HttpResponse"/> to work with response trailer headers.
     /// </summary>
     public static class ResponseTrailerExtensions
     {

--- a/src/Http/Http.Abstractions/src/Extensions/ResponseTrailerExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/ResponseTrailerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,13 +8,16 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Http
 {
+    /// <summary>
+    /// Extension methods for <see cref="HttpResponse"/> to work with the 'Trailer' response header.
+    /// </summary>
     public static class ResponseTrailerExtensions
     {
         /// <summary>
         /// Adds the given trailer name to the 'Trailer' response header. This must happen before the response headers are sent.
         /// </summary>
-        /// <param name="response"></param>
-        /// <param name="trailerName"></param>
+        /// <param name="response">The <see cref="HttpResponse"/>.</param>
+        /// <param name="trailerName">The trailer name to add to the 'Trailer' response header</param>
         public static void DeclareTrailer(this HttpResponse response, string trailerName)
         {
             response.Headers.AppendCommaSeparatedValues(HeaderNames.Trailer, trailerName);
@@ -23,8 +26,9 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Indicates if the server supports sending trailer headers for this response.
         /// </summary>
-        /// <param name="response"></param>
-        /// <returns></returns>
+        /// <param name="response">The <see cref="HttpResponse"/>.</param>
+        /// <returns><see langword="true"/> if the server supports sending trailer headers for this response,
+        /// otherwise <see langword="false"/>.</returns>
         public static bool SupportsTrailers(this HttpResponse response)
         {
             var feature = response.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
@@ -35,9 +39,9 @@ namespace Microsoft.AspNetCore.Http
         /// Adds the given trailer header to the trailers collection to be sent at the end of the response body.
         /// Check <see cref="SupportsTrailers" /> or an InvalidOperationException may be thrown.
         /// </summary>
-        /// <param name="response"></param>
-        /// <param name="trailerName"></param>
-        /// <param name="trailerValues"></param>
+        /// <param name="response">The <see cref="HttpResponse"/>.</param>
+        /// <param name="trailerName">The name of the trailer header.</param>
+        /// <param name="trailerValues">The trailer values to append.</param>
         public static void AppendTrailer(this HttpResponse response, string trailerName, StringValues trailerValues)
         {
             var feature = response.HttpContext.Features.Get<IHttpResponseTrailersFeature>();

--- a/src/Http/Http.Abstractions/src/Extensions/UseExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UseExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
         /// <param name="middleware">A function that handles the request or calls the given next function.</param>
-        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
         public static IApplicationBuilder Use(this IApplicationBuilder app, Func<HttpContext, Func<Task>, Task> middleware)
         {
             return app.Use(next =>

--- a/src/Http/Http.Abstractions/src/Extensions/UseMiddlewareExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UseMiddlewareExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <typeparam name="TMiddleware">The middleware type.</typeparam>
         /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
         /// <param name="args">The arguments to pass to the middleware type instance's constructor.</param>
-        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
         public static IApplicationBuilder UseMiddleware<[DynamicallyAccessedMembers(MiddlewareAccessibility)]TMiddleware>(this IApplicationBuilder app, params object[] args)
         {
             return app.UseMiddleware(typeof(TMiddleware), args);
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
         /// <param name="middleware">The middleware type.</param>
         /// <param name="args">The arguments to pass to the middleware type instance's constructor.</param>
-        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
         public static IApplicationBuilder UseMiddleware(this IApplicationBuilder app, [DynamicallyAccessedMembers(MiddlewareAccessibility)] Type middleware, params object[] args)
         {
             if (typeof(IMiddleware).GetTypeInfo().IsAssignableFrom(middleware.GetTypeInfo()))

--- a/src/Http/Http.Abstractions/src/Extensions/UsePathBaseExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UsePathBaseExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
         /// <param name="pathBase">The path base to extract.</param>
-        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
         public static IApplicationBuilder UsePathBase(this IApplicationBuilder app, PathString pathBase)
         {
             if (app == null)

--- a/src/Http/Http.Abstractions/src/Extensions/UseWhenExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UseWhenExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,10 +16,10 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Conditionally creates a branch in the request pipeline that is rejoined to the main pipeline.
         /// </summary>
-        /// <param name="app"></param>
+        /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
         /// <param name="predicate">Invoked with the request environment to determine if the branch should be taken</param>
         /// <param name="configuration">Configures a branch to take</param>
-        /// <returns></returns>
+        /// <returns>A reference to the <paramref name="app"/> after the operation has completed.</returns>
         public static IApplicationBuilder UseWhen(this IApplicationBuilder app, Predicate predicate, Action<IApplicationBuilder> configuration)
         {
             if (app == null)
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Builder
 
             return app.Use(main =>
             {
-                // This is called only when the main application builder 
+                // This is called only when the main application builder
                 // is built, not per request.
                 branchBuilder.Run(main);
                 var branch = branchBuilder.Build();

--- a/src/Http/Http.Abstractions/src/FragmentString.cs
+++ b/src/Http/Http.Abstractions/src/FragmentString.cs
@@ -105,6 +105,11 @@ namespace Microsoft.AspNetCore.Http
             return new FragmentString(fragmentValue);
         }
 
+        /// <summary>
+        /// Determines whether the specified <see cref="FragmentString "/> is equal to the current <see cref="FragmentString"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="FragmentString"/> to compare the current instance with.</param>
+        /// <returns><see langword="true"/> if the specified value is equal to the current instance; otherwise, <see langword="false"/>.</returns>
         public bool Equals(FragmentString other)
         {
             if (!HasValue && !other.HasValue)
@@ -114,6 +119,11 @@ namespace Microsoft.AspNetCore.Http
             return string.Equals(_value, other._value, StringComparison.Ordinal);
         }
 
+        /// <summary>
+        /// Determines whether the specified value is equal to the current <see cref="FragmentString"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="object"/> to compare the current instance with.</param>
+        /// <returns><see langword="true"/> if the specified value is equal to the current instance; otherwise, <see langword="false"/>.</returns>
         public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
@@ -123,16 +133,32 @@ namespace Microsoft.AspNetCore.Http
             return obj is FragmentString && Equals((FragmentString)obj);
         }
 
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
             return (HasValue ? _value.GetHashCode() : 0);
         }
 
+        /// <summary>
+        /// Determines if the two <see cref="FragmentString"/> have the same value.
+        /// </summary>
+        /// <param name="left">The first instance to compare.</param>
+        /// <param name="right">The second instance to compare.</param>
+        /// <returns><see langword="true" /> if the two are the same, otherwise <see langword="false" />.</returns>
         public static bool operator ==(FragmentString left, FragmentString right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Determines if the two <see cref="FragmentString"/> have the different values.
+        /// </summary>
+        /// <param name="left">The first instance to compare.</param>
+        /// <param name="right">The second instance to compare.</param>
+        /// <returns><see langword="true" /> if the two are different, otherwise <see langword="false" />.</returns>
         public static bool operator !=(FragmentString left, FragmentString right)
         {
             return !left.Equals(right);

--- a/src/Http/Http.Abstractions/src/HostString.cs
+++ b/src/Http/Http.Abstractions/src/HostString.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Net;
 using Microsoft.AspNetCore.Http.Abstractions;
 using Microsoft.Extensions.Primitives;
 
@@ -21,7 +22,8 @@ namespace Microsoft.AspNetCore.Http
         /// Creates a new HostString without modification. The value should be Unicode rather than punycode, and may have a port.
         /// IPv4 and IPv6 addresses are also allowed, and also may have ports.
         /// </summary>
-        /// <param name="value"></param>
+        /// <param name="value">The host portion of a URI.
+        /// The value should be Unicode rather than punycode. IPv6 addresses must use square braces.</param>
         public HostString(string value)
         {
             _value = value;
@@ -30,7 +32,8 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Creates a new HostString from its host and port parts.
         /// </summary>
-        /// <param name="host">The value should be Unicode rather than punycode. IPv6 addresses must use square braces.</param>
+        /// <param name="host">The host portion of a URI.
+        /// The value should be Unicode rather than punycode. IPv6 addresses must use square braces.</param>
         /// <param name="port">A positive, greater than 0 value representing the port in the host string.</param>
         public HostString(string host, int port)
         {
@@ -65,6 +68,9 @@ namespace Microsoft.AspNetCore.Http
             get { return _value; }
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if <see cref="Value"/> is not null or empty, otherwise <see langword="false"/>.
+        /// </summary>
         public bool HasValue
         {
             get { return !string.IsNullOrEmpty(_value); }

--- a/src/Http/Http.Abstractions/src/HttpMethods.cs
+++ b/src/Http/Http.Abstractions/src/HttpMethods.cs
@@ -18,14 +18,40 @@ namespace Microsoft.AspNetCore.Http
         // and allow us to optimize comparisons when these constants are used.
 
         // Please do NOT change these to 'const'
+        /// <summary>Represents an HTTP CONNECT protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc7231#section-4.3.6. </remarks>
         public static readonly string Connect = "CONNECT";
+
+        /// <summary>Represents an HTTP DELETE protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc7231#section-4.3.5</remarks>
         public static readonly string Delete = "DELETE";
+
+        /// <summary>Represents an HTTP GET protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc7231#section-4.3.1</remarks>
         public static readonly string Get = "GET";
+
+        /// <summary>Represents an HTTP GET protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc7231#section-4.3.2</remarks>
         public static readonly string Head = "HEAD";
+
+        /// <summary>Represents an HTTP GET protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc7231#section-4.3.7</remarks>
         public static readonly string Options = "OPTIONS";
+
+        /// <summary>Represents an HTTP GET protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc5789</remarks>
         public static readonly string Patch = "PATCH";
+
+        /// <summary>Represents an HTTP GET protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc7231#section-4.3.3</remarks>
         public static readonly string Post = "POST";
+
+        /// <summary>Represents an HTTP GET protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc7231#section-4.3.4</remarks>
         public static readonly string Put = "PUT";
+
+        /// <summary>Represents an HTTP GET protocol method.</summary>
+        /// <remarks>See https://tools.ietf.org/html/rfc7231#section-4.3.8</remarks>
         public static readonly string Trace = "TRACE";
 
         /// <summary>
@@ -137,10 +163,11 @@ namespace Microsoft.AspNetCore.Http
         }
 
         /// <summary>
-        ///  Returns the equivalent static instance, or the original instance if none match. This conversion is optional but allows for performance optimizations when comparing method values elsewhere.
+        ///  Returns the equivalent static instance, or the original instance if none match.
+        ///  This conversion is optional but allows for performance optimizations when comparing method values elsewhere.
         /// </summary>
-        /// <param name="method"></param>
-        /// <returns></returns>
+        /// <param name="method">The HTTP method name to canonicalize.</param>
+        /// <returns>The canonicalized HTTP method name.</returns>
         public static string GetCanonicalizedValue(string method) => method switch
         {
             string _ when IsGet(method) => Get,

--- a/src/Http/Http.Abstractions/src/HttpProtocol.cs
+++ b/src/Http/Http.Abstractions/src/HttpProtocol.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 
 namespace Microsoft.AspNetCore.Http
 {
@@ -18,9 +19,17 @@ namespace Microsoft.AspNetCore.Http
         // and allow us to optimize comparisons when these constants are used.
 
         // Please do NOT change these to 'const'
+
+        /// <summary>Represents the HTTP/1.0 protocol version.</summary>
         public static readonly string Http10 = "HTTP/1.0";
+
+        /// <summary>Represents the HTTP/1.1 protocol version.</summary>
         public static readonly string Http11 = "HTTP/1.1";
+
+        /// <summary>Represents the HTTP/2 protocol version.</summary>
         public static readonly string Http2 = "HTTP/2";
+
+        /// <summary>Represents the HTTP/3 protocol version.</summary>
         public static readonly string Http3 = "HTTP/3";
 
         /// <summary>

--- a/src/Http/Http.Abstractions/src/HttpRequest.cs
+++ b/src/Http/Http.Abstractions/src/HttpRequest.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Reads the request body if it is a form.
         /// </summary>
-        /// <returns>A <see cref="Task"/> that on completion returns the <see cref="IFormCollection"/>.</returns>
+        /// <returns>The <see cref="IFormCollection"/>.</returns>
         public abstract Task<IFormCollection> ReadFormAsync(CancellationToken cancellationToken = new CancellationToken());
 
         /// <summary>

--- a/src/Http/Http.Abstractions/src/HttpRequest.cs
+++ b/src/Http/Http.Abstractions/src/HttpRequest.cs
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Reads the request body if it is a form.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task"/> that on completion returns the <see cref="IFormCollection"/>.</returns>
         public abstract Task<IFormCollection> ReadFormAsync(CancellationToken cancellationToken = new CancellationToken());
 
         /// <summary>

--- a/src/Http/Http.Abstractions/src/HttpResponse.cs
+++ b/src/Http/Http.Abstractions/src/HttpResponse.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Http
 {
@@ -138,14 +137,14 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Starts the response by calling OnStarting() and making headers unmodifiable.
         /// </summary>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public virtual Task StartAsync(CancellationToken cancellationToken = default) { throw new NotImplementedException(); }
 
         /// <summary>
         /// Flush any remaining response headers, data, or trailers.
         /// This may throw if the response is in an invalid state such as a Content-Length mismatch.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
         public virtual Task CompleteAsync() { throw new NotImplementedException(); }
     }
 }

--- a/src/Http/Http.Abstractions/src/HttpResponse.cs
+++ b/src/Http/Http.Abstractions/src/HttpResponse.cs
@@ -144,7 +144,6 @@ namespace Microsoft.AspNetCore.Http
         /// Flush any remaining response headers, data, or trailers.
         /// This may throw if the response is in an invalid state such as a Content-Length mismatch.
         /// </summary>
-        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
         public virtual Task CompleteAsync() { throw new NotImplementedException(); }
     }
 }

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -12,9 +12,10 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+
+    <NoWarn />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -14,8 +14,7 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
     <PackageTags>aspnetcore</PackageTags>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-
-    <NoWarn />
+    <NoWarn>$(NoWarn.Replace('1591', ''))</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Abstractions/src/PathString.cs
+++ b/src/Http/Http.Abstractions/src/PathString.cs
@@ -461,7 +461,7 @@ namespace Microsoft.AspNetCore.Http
             => ConvertFromString(s);
 
         /// <summary>
-        /// Implicitly creates a string frm the given <see cref="PathString"/>.
+        /// Implicitly creates an escaped string from the given <see cref="PathString"/>.
         /// </summary>
         /// <param name="path">A path to implicitly convert.</param>
         public static implicit operator string(PathString path)

--- a/src/Http/Http.Abstractions/src/PathString.cs
+++ b/src/Http/Http.Abstractions/src/PathString.cs
@@ -456,14 +456,14 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Implicitly creates a new PathString from the given string.
         /// </summary>
-        /// <param name="s"></param>
+        /// <param name="s">A string to implicitly convert.</param>
         public static implicit operator PathString(string? s)
             => ConvertFromString(s);
 
         /// <summary>
-        /// Implicitly calls ToString().
+        /// Implicitly creates a string frm the given <see cref="PathString"/>.
         /// </summary>
-        /// <param name="path"></param>
+        /// <param name="path">A path to implicitly convert.</param>
         public static implicit operator string(PathString path)
             => path.ToString();
 

--- a/src/Http/Http.Abstractions/src/QueryString.cs
+++ b/src/Http/Http.Abstractions/src/QueryString.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Creates a query string composed from the given name value pairs.
         /// </summary>
-        /// <param name="parameters"></param>
+        /// <param name="parameters">A sequence of name and value pairs.</param>
         /// <returns>The resulting QueryString</returns>
         public static QueryString Create(IEnumerable<KeyValuePair<string, string?>> parameters)
         {
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Creates a query string composed from the given name value pairs.
         /// </summary>
-        /// <param name="parameters"></param>
+        /// <param name="parameters">A sequence of name value pairs.</param>
         /// <returns>The resulting QueryString</returns>
         public static QueryString Create(IEnumerable<KeyValuePair<string, StringValues>> parameters)
         {
@@ -170,6 +170,14 @@ namespace Microsoft.AspNetCore.Http
             return new QueryString(builder.ToString());
         }
 
+        /// <summary>
+        /// Adds the contents of <paramref name="other" /> to this <see cref="QueryString"/> instance.
+        /// </summary>
+        /// <param name="other">The <see cref="QueryString"/> to add.</param>
+        /// <returns>
+        /// The <paramref name="other" /> instance if this instance does not have a value. Otherwise, this instance
+        /// after the copy operation.
+        /// </returns>
         public QueryString Add(QueryString other)
         {
             if (!HasValue || Value!.Equals("?", StringComparison.Ordinal))
@@ -185,6 +193,12 @@ namespace Microsoft.AspNetCore.Http
             return new QueryString(Value + "&" + other.Value.Substring(1));
         }
 
+        /// <summary>
+        /// Adds the name and value pair to the <see cref="QueryString"/> instance.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>The <see cref="QueryString"/> instance after the operation has completed.</returns>
         public QueryString Add(string name, string value)
         {
             if (name == null)
@@ -202,6 +216,11 @@ namespace Microsoft.AspNetCore.Http
             return new QueryString(builder.ToString());
         }
 
+        /// <summary>
+        /// Determines whether the specified <see cref="QueryString "/> is equal to the current <see cref="QueryString"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="QueryString"/> to compare the current instance with.</param>
+        /// <returns><see langword="true"/> if the specified value is equal to the current instance; otherwise, <see langword="false"/>.</returns>
         public bool Equals(QueryString other)
         {
             if (!HasValue && !other.HasValue)
@@ -211,6 +230,11 @@ namespace Microsoft.AspNetCore.Http
             return string.Equals(Value, other.Value, StringComparison.Ordinal);
         }
 
+        /// <summary>
+        /// Determines whether the specified value is equal to the current <see cref="QueryString"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="object"/> to compare the current instance with.</param>
+        /// <returns><see langword="true"/> if the specified value is equal to the current instance; otherwise, <see langword="false"/>.</returns>
         public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
@@ -220,21 +244,43 @@ namespace Microsoft.AspNetCore.Http
             return obj is QueryString && Equals((QueryString)obj);
         }
 
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code.</returns>
         public override int GetHashCode()
         {
             return (HasValue ? Value!.GetHashCode() : 0);
         }
 
+        /// <summary>
+        /// Determines if the two <see cref="QueryString"/> have the same value.
+        /// </summary>
+        /// <param name="left">The first instance to compare.</param>
+        /// <param name="right">The second instance to compare.</param>
+        /// <returns><see langword="true" /> if the two are the same, otherwise <see langword="false" />.</returns>
         public static bool operator ==(QueryString left, QueryString right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Determines if the two <see cref="QueryString"/> have the different values.
+        /// </summary>
+        /// <param name="left">The first instance to compare.</param>
+        /// <param name="right">The second instance to compare.</param>
+        /// <returns><see langword="true" /> if the two are different, otherwise <see langword="false" />.</returns>
         public static bool operator !=(QueryString left, QueryString right)
         {
             return !left.Equals(right);
         }
 
+        /// <summary>
+        /// Adds the contents of the two query strings.
+        /// </summary>
+        /// <param name="left">The first instance to add.</param>
+        /// <param name="right">The second instance to add.</param>
+        /// <returns>The result of adding the two.</returns>
         public static QueryString operator +(QueryString left, QueryString right)
         {
             return left.Add(right);

--- a/src/Http/Http.Abstractions/src/Routing/Endpoint.cs
+++ b/src/Http/Http.Abstractions/src/Routing/Endpoint.cs
@@ -44,6 +44,10 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         public RequestDelegate RequestDelegate { get; }
 
+        /// <summary>
+        /// Returns a string that represents the current <see cref="Endpoint"/>.
+        /// </summary>
+        /// <returns>A string that represents the current <see cref="Endpoint"/>.</returns>
         public override string? ToString() => DisplayName ?? base.ToString();
     }
 }

--- a/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
+++ b/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
@@ -661,11 +661,18 @@ namespace Microsoft.AspNetCore.Routing
             return false;
         }
 
+        /// <summary>
+        /// Enumerates the elements of <see cref="RouteValueDictionary" />.
+        /// </summary>
         public struct Enumerator : IEnumerator<KeyValuePair<string, object?>>
         {
             private readonly RouteValueDictionary _dictionary;
             private int _index;
 
+            /// <summary>
+            /// Initializes a new instance of <see cref="Enumerator"/>.
+            /// </summary>
+            /// <param name="dictionary">The <see cref="RouteValueDictionary"/> to enumerate.</param>
             public Enumerator(RouteValueDictionary dictionary)
             {
                 if (dictionary == null)
@@ -679,14 +686,25 @@ namespace Microsoft.AspNetCore.Routing
                 _index = 0;
             }
 
+            /// <summary>
+            /// Gets the element at the current position of the enumerator.
+            /// </summary>
             public KeyValuePair<string, object?> Current { get; private set; }
 
             object IEnumerator.Current => Current;
 
+            /// <summary>
+            /// Releases resources used by <see cref="Enumerator"/>.
+            /// </summary>
             public void Dispose()
             {
             }
 
+            /// <summary>
+            /// Advances the enumerator to the next element of the <see cref="RouteValueDictionary"/>.
+            /// </summary>
+            /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element,
+            /// <see langword="false" /> if the enumerator has passed the end of the collection.</returns>
             // Similar to the design of List<T>.Enumerator - Split into fast path and slow path for inlining friendliness
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool MoveNext()
@@ -721,6 +739,9 @@ namespace Microsoft.AspNetCore.Routing
                 return false;
             }
 
+            /// <summary>
+            /// Sets the enumerator to its initial position, which is before the first element in the <see cref="RouteValueDictionary"/>.
+            /// </summary>
             public void Reset()
             {
                 Current = default;

--- a/src/Http/Http.Abstractions/src/StatusCodes.cs
+++ b/src/Http/Http.Abstractions/src/StatusCodes.cs
@@ -3,9 +3,12 @@
 
 namespace Microsoft.AspNetCore.Http
 {
-    // Status Codes listed at http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+    /// <summary>
+    /// Constants for status codes as listed on http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+    /// </summary>
     public static class StatusCodes
     {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public const int Status100Continue = 100;
         public const int Status101SwitchingProtocols = 101;
         public const int Status102Processing = 102;

--- a/src/Http/Metadata/src/Microsoft.AspNetCore.Metadata.csproj
+++ b/src/Http/Metadata/src/Microsoft.AspNetCore.Metadata.csproj
@@ -4,11 +4,10 @@
     <Description>ASP.NET Core metadata.</Description>
     <TargetFrameworks>$(DefaultNetFxTargetFramework);netstandard2.0;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn.Replace('1591', ''))</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
     <Nullable>enable</Nullable>
-    <NoWarn />
   </PropertyGroup>
 
 </Project>

--- a/src/Http/Metadata/src/Microsoft.AspNetCore.Metadata.csproj
+++ b/src/Http/Metadata/src/Microsoft.AspNetCore.Metadata.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
     <Nullable>enable</Nullable>
+    <NoWarn />
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
* Arcade suppresses doc errors and warnings by adding it to the NoWarn list.
  Override this so we get warning from arcade until we can update it.

* Finishing touches to API docs for Authentication.Abstractions, Http.Abstractions

