### PR TITLE
Fix race with TestApplicationErrorLogger

### DIFF
--- a/src/Servers/Kestrel/shared/test/TestApplicationErrorLogger.cs
+++ b/src/Servers/Kestrel/shared/test/TestApplicationErrorLogger.cs
@@ -106,8 +106,11 @@ namespace Microsoft.AspNetCore.Testing
 
             if (_messageFilter?.Invoke(logMessage) == true)
             {
-                _messageFilterTcs.TrySetResult(logMessage);
+                var localTcs = _messageFilterTcs;
+                // need to set tcs to null before calling TrySetResult
+                // to prevent the next WaitForMessage possibly throwing for a non-null tcs
                 _messageFilterTcs = null;
+                localTcs.TrySetResult(logMessage);
             }
         }
 


### PR DESCRIPTION
The race was between `tcs.TrySetResult()` and `tcs = null`, if the next `WaitForMessage()` (which was waiting for `tcs.TrySetResult()`) is called before the tcs is set to null it'll throw.