### PR TITLE
Update Swashbuckle.AspNetCore package version to 5.6.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -243,7 +243,7 @@
     <SerilogSinksFilePackageVersion>4.0.0</SerilogSinksFilePackageVersion>
     <StackExchangeRedisPackageVersion>2.0.593</StackExchangeRedisPackageVersion>
     <SystemReactiveLinqPackageVersion>3.1.1</SystemReactiveLinqPackageVersion>
-    <SwashbuckleAspNetCorePackageVersion>5.5.1</SwashbuckleAspNetCorePackageVersion>
+    <SwashbuckleAspNetCorePackageVersion>5.6.3</SwashbuckleAspNetCorePackageVersion>
     <XunitAbstractionsPackageVersion>2.0.3</XunitAbstractionsPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitVersion>2.4.1</XunitVersion>


### PR DESCRIPTION
Fixes #26301

### Description
As part of 5.0-preview8, we added Swashbuckle to ASP.NET Core's API project templates. Swashbuckle's developer
team has been active of late and has issued a new minor version that has enhancements and bug fixes. We'd like
to pick this up. 

VS Web Tools needs to update to match this version. We discussed this with them and they're willing to make that change.

### Customer impact
Users currently see a package update prompt on a brand new template. Missing useful bug fixes with the current version.

### Regresion
No

### Risk
Low. This a minor version update that is recommended by Swashbuckle. I verified the update locally, our tests verify that the template builds and is usable with this change. We have CTI coverage for end-to-end scenarios with Swashbuckle.
