### PR TITLE
[release/5.0] Preserve client order of activity baggage items (#26302)

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -267,14 +267,14 @@ namespace Microsoft.AspNetCore.Hosting
                 // We expect baggage to be empty by default
                 // Only very advanced users will be using it in near future, we encourage them to keep baggage small (few items)
                 string[] baggage = headers.GetCommaSeparatedValues(HeaderNames.CorrelationContext);
-                if (baggage.Length > 0)
+
+                // AddBaggage adds items at the beginning  of the list, so we need to add them in reverse to keep the same order as the client
+                // An order could be important if baggage has two items with the same key (that is allowed by the contract)
+                for (var i = baggage.Length - 1; i >= 0; i--)
                 {
-                    foreach (var item in baggage)
+                    if (NameValueHeaderValue.TryParse(baggage[i], out var baggageItem))
                     {
-                        if (NameValueHeaderValue.TryParse(item, out var baggageItem))
-                        {
-                            activity.AddBaggage(baggageItem.Name.ToString(), HttpUtility.UrlDecode(baggageItem.Value.ToString()));
-                        }
+                        activity.AddBaggage(baggageItem.Name.ToString(), HttpUtility.UrlDecode(baggageItem.Value.ToString()));
                     }
                 }
             }

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -302,6 +302,43 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         }
 
         [Fact]
+        public void ActivityBaggagePreservesItemsOrder()
+        {
+            var diagnosticListener = new DiagnosticListener("DummySource");
+            var hostingApplication = CreateApplication(out var features, diagnosticListener: diagnosticListener);
+
+            diagnosticListener.Subscribe(new CallbackDiagnosticListener(pair => { }),
+                s =>
+                {
+                    if (s.StartsWith("Microsoft.AspNetCore.Hosting.HttpRequestIn"))
+                    {
+                        return true;
+                    }
+                    return false;
+                });
+
+            features.Set<IHttpRequestFeature>(new HttpRequestFeature()
+            {
+                Headers = new HeaderDictionary()
+                {
+                    {"Request-Id", "ParentId1"},
+                    {"Correlation-Context", "Key1=value1, Key2=value2, Key1=value3"} // duplicated keys allowed by the contract
+                }
+            });
+            hostingApplication.CreateContext(features);
+            Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", Activity.Current.OperationName);
+
+            var expectedBaggage = new []
+            {
+                KeyValuePair.Create("Key1","value1"),
+                KeyValuePair.Create("Key2","value2"),
+                KeyValuePair.Create("Key1","value3")
+            };
+
+            Assert.Equal(expectedBaggage, Activity.Current.Baggage);
+        }
+
+        [Fact]
         public void ActivityBaggageValuesAreUrlDecodedFromHeaders()
         {
             var diagnosticListener = new DiagnosticListener("DummySource");


### PR DESCRIPTION
Backport #26302 from master to release/5.0

# Description

ASP.NET Core populates `Activity.Baggage` items based on the incoming `Correlation-Context` HTTP header.
This PR changes the order in which items are added to `Activity.Baggage`.

# Customer Impact

Since the [W3C spec for baggage](https://github.com/w3c/baggage/blob/master/baggage/HTTP_HEADER_FORMAT.md) allows for duplicate keys order is important.

`Activity.GetBaggageItem()` doesn't have predictable behavior today in the presence of duplicate key since the order of items in `Activity.Baggage` gets flipped at every HTTP hop.

# Regression

This has always been broken since we never tested `Activity.GetBaggageItem()` with duplicate keys.

# Testing

We have a unit test verifying this is the desired behavior.

# Risk

The result of `Activity.GetBaggageItem()` will change in certain scenarios. Someone relying on the existing behavior could be impacted, however this is extremely unlikely.

We don't yet expect folks to directly be consuming this API. It's better to fix this API before OpenTelemetry (in beta, tracking towards GA) adoption increases usage of this API.
