### PR TITLE
[SPA][Blazor] Update identity server version to 4.1.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -220,11 +220,11 @@
     <GrpcAuthPackageVersion>2.32.0-pre1</GrpcAuthPackageVersion>
     <GrpcNetClientPackageVersion>2.32.0-pre1</GrpcNetClientPackageVersion>
     <GrpcToolsPackageVersion>2.32.0-pre1</GrpcToolsPackageVersion>
-    <IdentityServer4AspNetIdentityPackageVersion>4.0.4</IdentityServer4AspNetIdentityPackageVersion>
-    <IdentityServer4EntityFrameworkPackageVersion>4.0.4</IdentityServer4EntityFrameworkPackageVersion>
-    <IdentityServer4PackageVersion>4.0.4</IdentityServer4PackageVersion>
-    <IdentityServer4StoragePackageVersion>4.0.4</IdentityServer4StoragePackageVersion>
-    <IdentityServer4EntityFrameworkStoragePackageVersion>4.0.4</IdentityServer4EntityFrameworkStoragePackageVersion>
+    <IdentityServer4AspNetIdentityPackageVersion>4.1.0</IdentityServer4AspNetIdentityPackageVersion>
+    <IdentityServer4EntityFrameworkPackageVersion>4.1.0</IdentityServer4EntityFrameworkPackageVersion>
+    <IdentityServer4PackageVersion>4.1.0</IdentityServer4PackageVersion>
+    <IdentityServer4StoragePackageVersion>4.1.0</IdentityServer4StoragePackageVersion>
+    <IdentityServer4EntityFrameworkStoragePackageVersion>4.1.0</IdentityServer4EntityFrameworkStoragePackageVersion>
     <MessagePackPackageVersion>2.1.90</MessagePackPackageVersion>
     <MicrosoftIdentityWebPackageVersion>0.4.0-preview</MicrosoftIdentityWebPackageVersion>
     <MicrosoftIdentityWebMicrosoftGraphPackageVersion>0.4.0-preview</MicrosoftIdentityWebMicrosoftGraphPackageVersion>


### PR DESCRIPTION
# Description

The new single-file publish feature does not work well with earlier versions of IdentityServer due to the usage of Assembly.Location. The version we are updating to contains a fix they published to enable this.

# Customer Impact
* Customers won't be able to use single-file publish if their app uses Individual auth (Blazor, Angular, React templates).

# Regression?

Yes. This worked with single file publish in 3.1.0

# Risk

Low, we are just bumping up the version and I did validation with RC1 (lifting the dependency) to ensure it worked.

## Fixes
https://github.com/aspnet/AspNetCore-ManualTests/issues/178