### PR TITLE
Fix virtualization culture invariance

### DIFF
--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -246,7 +247,7 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
         }
 
         private string GetSpacerStyle(int itemsInSpacer)
-            => $"height: {itemsInSpacer * _itemSize}px;";
+            => $"height: {(itemsInSpacer * _itemSize).ToString(CultureInfo.InvariantCulture)}px;";
 
         void IVirtualizeJsCallbacks.OnBeforeSpacerVisible(float spacerSize, float spacerSeparation, float containerSize)
         {
@@ -367,7 +368,7 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
         private RenderFragment DefaultPlaceholder(PlaceholderContext context) => (builder) =>
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(1, "style", $"height: {_itemSize}px;");
+            builder.AddAttribute(1, "style", $"height: {_itemSize.ToString(CultureInfo.InvariantCulture)}px;");
             builder.CloseElement();
         };
 


### PR DESCRIPTION
Fixes #26424

### Description

Blazor's virtualization uses culture-specific formatting (`ToString()`) when emitting values for css heights. In cultures that use decimal separators for their heights, the generated height is not a valid css value. This change updates the heights to use invariant formatting.

### Customer impact

The Virtualize component does not function when executing in non-English locales. This affects both Blazor Server with request localization and Blazor WebAssembly.


### Regression
No. The feature is new to .NET 5 RC1.

### Risk
The change is isolated to the Virtualize component and was tested manually. 