### PR TITLE
Use assertion library more consistently

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppWebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppWebDriverExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest
             var testSelector = browser.WaitUntilTestSelectorReady();
             testSelector.SelectByValue("none");
             testSelector.SelectByValue(componentTypeName);
-            return browser.FindElement(By.TagName("app"));
+            return browser.Exists(By.TagName("app"));
         }
 
         public static SelectElement WaitUntilTestSelectorReady(this IWebDriver browser)

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
             Navigate(ServerPathBase, noReload: false);
             Browser.MountTestComponent<GracefulTermination>();
-            Browser.Equal("Graceful Termination", () => Browser.FindElement(By.TagName("h1")).Text);
+            Browser.Equal("Graceful Termination", () => Browser.Exists(By.TagName("h1")).Text);
 
             GracefulDisconnectCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             Sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task NavigatingToProtocolLink_DoesNotGracefullyDisconnect_TheCurrentCircuit()
         {
             // Arrange & Act
-            var element = Browser.FindElement(By.Id("mailto-link"));
+            var element = Browser.Exists(By.Id("mailto-link"));
             element.Click();
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task DownloadAction_DoesNotGracefullyDisconnect_TheCurrentCircuit()
         {
             // Arrange & Act
-            var element = Browser.FindElement(By.Id("download-link"));
+            var element = Browser.Exists(By.Id("download-link"));
             element.Click();
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task DownloadHref_DoesNotGracefullyDisconnect_TheCurrentCircuit()
         {
             // Arrange & Act
-            var element = Browser.FindElement(By.Id("download-href"));
+            var element = Browser.Exists(By.Id("download-href"));
             element.Click();
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/ComponentWithParametersTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ComponentWithParametersTest.cs
@@ -35,13 +35,13 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             Browser.Exists(By.CssSelector(".interactive"));
 
-            var parameter1 = Browser.FindElement(By.CssSelector(".Param1"));
+            var parameter1 = Browser.Exists(By.CssSelector(".Param1"));
             Assert.Equal(100, parameter1.FindElements(By.CssSelector("li")).Count);
             Assert.Equal("99 99", parameter1.FindElement(By.CssSelector("li:last-child")).Text);
 
             // The assigned value is of a more derived type than the declared model type. This check
             // verifies we use the actual model type during round tripping.
-            var parameter2 = Browser.FindElement(By.CssSelector(".Param2"));
+            var parameter2 = Browser.Exists(By.CssSelector(".Param2"));
             Assert.Equal("Value Derived-Value", parameter2.Text);
 
             // This check verifies CaptureUnmatchedValues works
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
         private void BeginInteractivity()
         {
-            Browser.FindElement(By.Id("load-boot-script")).Click();
+            Browser.Exists(By.Id("load-boot-script")).Click();
         }
     }
 }

--- a/src/Components/test/E2ETest/ServerExecutionTests/MultipleRootComponentsTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/MultipleRootComponentsTest.cs
@@ -65,6 +65,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
             Navigate("/multiple-components");
 
+            Browser.Exists(By.CssSelector(".greet-wrapper .greet"));
             var greets = Browser.FindElements(By.CssSelector(".greet-wrapper .greet")).Select(e => e.Text).ToArray();
 
             Assert.Equal(7, greets.Length); // 1 statically rendered + 5 prerendered + 1 server prerendered
@@ -73,7 +74,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Single(greets, "Hello Abraham");
             Assert.Equal(2, greets.Where(g => g == "Hello Blue fish").Count());
             Assert.Equal(3, greets.Where(g => string.Equals("Hello", g)).Count()); // 3 server prerendered without parameters
-            var content = Browser.FindElement(By.Id("test-container")).GetAttribute("innerHTML");
+            var content = Browser.Exists(By.Id("test-container")).GetAttribute("innerHTML");
             var markers = ReadMarkers(content);
             var componentSequence = markers.Select(m => m.Item1.PrerenderId != null).ToArray();
             var expectedComponentSequence = new bool[]
@@ -123,7 +124,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
         private void BeginInteractivity()
         {
-            Browser.FindElement(By.Id("load-boot-script")).Click();
+            Browser.Exists(By.Id("load-boot-script")).Click();
         }
     }
 }

--- a/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
@@ -34,15 +34,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Navigate("/prerendered/prerendered-transition");
 
             // Prerendered output shows "not connected"
-            Browser.Equal("not connected", () => Browser.FindElement(By.Id("connected-state")).Text);
+            Browser.Equal("not connected", () => Browser.Exists(By.Id("connected-state")).Text);
 
             // Once connected, output changes
             BeginInteractivity();
-            Browser.Equal("connected", () => Browser.FindElement(By.Id("connected-state")).Text);
+            Browser.Equal("connected", () => Browser.Exists(By.Id("connected-state")).Text);
 
             // ... and now the counter works
-            Browser.FindElement(By.Id("increment-count")).Click();
-            Browser.Equal("1", () => Browser.FindElement(By.Id("count")).Text);
+            Browser.Exists(By.Id("increment-count")).Click();
+            Browser.Equal("1", () => Browser.Exists(By.Id("count")).Text);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Navigate("/prerendered/prerendered-async-disposal");
 
             // Prerendered output shows "not connected"
-            Browser.Equal("After async disposal", () => Browser.FindElement(By.Id("disposal-message")).Text);
+            Browser.Equal("After async disposal", () => Browser.Exists(By.Id("disposal-message")).Text);
         }
 
         [Fact]
@@ -60,14 +60,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Navigate("/prerendered/prerendered-interop");
 
             // Prerendered output can't use JSInterop
-            Browser.Equal("No value yet", () => Browser.FindElement(By.Id("val-get-by-interop")).Text);
-            Browser.Equal(string.Empty, () => Browser.FindElement(By.Id("val-set-by-interop")).GetAttribute("value"));
+            Browser.Equal("No value yet", () => Browser.Exists(By.Id("val-get-by-interop")).Text);
+            Browser.Equal(string.Empty, () => Browser.Exists(By.Id("val-set-by-interop")).GetAttribute("value"));
 
             BeginInteractivity();
 
             // Once connected, we can
-            Browser.Equal("Hello from interop call", () => Browser.FindElement(By.Id("val-get-by-interop")).Text);
-            Browser.Equal("Hello from interop call", () => Browser.FindElement(By.Id("val-set-by-interop")).GetAttribute("value"));
+            Browser.Equal("Hello from interop call", () => Browser.Exists(By.Id("val-get-by-interop")).Text);
+            Browser.Equal("Hello from interop call", () => Browser.Exists(By.Id("val-set-by-interop")).GetAttribute("value"));
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
             Navigate("/prerendered/WithLazyAssembly");
 
-            var button = Browser.FindElement(By.Id("use-package-button"));
+            var button = Browser.Exists(By.Id("use-package-button"));
 
             button.Click();
 
@@ -93,13 +93,13 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Navigate(url);
             Browser.Equal(
                 _serverFixture.RootUri + urlWithoutHash,
-                () => Browser.FindElement(By.TagName("strong")).Text);
+                () => Browser.Exists(By.TagName("strong")).Text);
 
             // Once connected, you do have access to the full URL
             BeginInteractivity();
             Browser.Equal(
                 _serverFixture.RootUri + url,
-                () => Browser.FindElement(By.TagName("strong")).Text);
+                () => Browser.Exists(By.TagName("strong")).Text);
         }
 
         [Theory]
@@ -130,17 +130,17 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             // See that the authentication state is usable during the initial prerendering
             SignInAs(initialUsername, null);
             Navigate("/prerendered/prerendered-transition");
-            Browser.Equal($"Hello, {initialUsername ?? "anonymous"}!", () => Browser.FindElement(By.TagName("h1")).Text);
+            Browser.Equal($"Hello, {initialUsername ?? "anonymous"}!", () => Browser.Exists(By.TagName("h1")).Text);
 
             // See that during connection, we update to whatever the latest authentication state now is
             SignInAs(interactiveUsername, null, useSeparateTab: true);
             BeginInteractivity();
-            Browser.Equal($"Hello, {interactiveUsername ?? "anonymous"}!", () => Browser.FindElement(By.TagName("h1")).Text);
+            Browser.Equal($"Hello, {interactiveUsername ?? "anonymous"}!", () => Browser.Exists(By.TagName("h1")).Text);
         }
 
         private void BeginInteractivity()
         {
-            Browser.FindElement(By.Id("load-boot-script")).Click();
+            Browser.Exists(By.Id("load-boot-script")).Click();
         }
 
         private void AssertLogDoesNotContainCriticalMessages(params string[] messages)

--- a/src/Components/test/E2ETest/ServerExecutionTests/ProtectedBrowserStorageUsageTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ProtectedBrowserStorageUsageTest.cs
@@ -43,8 +43,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public void LocalStoragePersistsOnRefresh()
         {
             // Local storage initially cleared
-            var incrementLocalButton = Browser.FindElement(By.Id("increment-local"));
-            var localCount = Browser.FindElement(By.Id("local-count"));
+            var incrementLocalButton = Browser.Exists(By.Id("increment-local"));
+            var localCount = Browser.Exists(By.Id("local-count"));
             Browser.Equal("0", () => localCount.Text);
 
             // Local storage updates
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Navigate().Refresh();
             Browser.MountTestComponent<ProtectedBrowserStorageUsageComponent>();
 
-            localCount = Browser.FindElement(By.Id("local-count"));
+            localCount = Browser.Exists(By.Id("local-count"));
             Browser.Equal("1", () => localCount.Text);
         }
 
@@ -63,8 +63,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public void LocalStoragePersistsAcrossTabs()
         {
             // Local storage initially cleared
-            var incrementLocalButton = Browser.FindElement(By.Id("increment-local"));
-            var localCount = Browser.FindElement(By.Id("local-count"));
+            var incrementLocalButton = Browser.Exists(By.Id("increment-local"));
+            var localCount = Browser.Exists(By.Id("local-count"));
             Browser.Equal("0", () => localCount.Text);
 
             // Local storage updates in current tab
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             // Local storage persists across tabs
             OpenNewSession();
-            localCount = Browser.FindElement(By.Id("local-count"));
+            localCount = Browser.Exists(By.Id("local-count"));
             Browser.Equal("1", () => localCount.Text);
         }
 
@@ -81,8 +81,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public void SessionStoragePersistsOnRefresh()
         {
             // Session storage initially cleared
-            var incrementSessionButton = Browser.FindElement(By.Id("increment-session"));
-            var sessionCount = Browser.FindElement(By.Id("session-count"));
+            var incrementSessionButton = Browser.Exists(By.Id("increment-session"));
+            var sessionCount = Browser.Exists(By.Id("session-count"));
             Browser.Equal("0", () => sessionCount.Text);
 
             // Session storage updates
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Navigate().Refresh();
             Browser.MountTestComponent<ProtectedBrowserStorageUsageComponent>();
 
-            sessionCount = Browser.FindElement(By.Id("session-count"));
+            sessionCount = Browser.Exists(By.Id("session-count"));
             Browser.Equal("1", () => sessionCount.Text);
         }
 
@@ -101,8 +101,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public void SessionStorageDoesNotPersistAcrossTabs()
         {
             // Session storage initially cleared
-            var incrementSessionButton = Browser.FindElement(By.Id("increment-session"));
-            var sessionCount = Browser.FindElement(By.Id("session-count"));
+            var incrementSessionButton = Browser.Exists(By.Id("increment-session"));
+            var sessionCount = Browser.Exists(By.Id("session-count"));
             Browser.Equal("0", () => sessionCount.Text);
 
             // Session storage updates in current tab
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             // Session storage does not persist across tabs
             OpenNewSession();
-            sessionCount = Browser.FindElement(By.Id("session-count"));
+            sessionCount = Browser.Exists(By.Id("session-count"));
             Browser.Equal("0", () => sessionCount.Text);
         }
 
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 Keys.Command :
                 Keys.Control;
 
-            var newTabLink = Browser.FindElement(By.Id("new-tab"));
+            var newTabLink = Browser.Exists(By.Id("new-tab"));
             var action = new Actions(Browser);
             action.KeyDown(modifierKey).MoveToElement(newTabLink).Click().KeyUp(modifierKey).Perform();
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerGlobalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerGlobalizationTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
         protected override void SetCulture(string culture)
         {
-            var selector = new SelectElement(Browser.FindElement(By.Id("culture-selector")));
+            var selector = new SelectElement(Browser.Exists(By.Id("culture-selector")));
             selector.SelectByValue(culture);
 
             // Click the link to return back to the test page

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestDefaultExceptionsBehavior.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestDefaultExceptionsBehavior.cs
@@ -45,14 +45,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var actualValues = new Dictionary<string, string>();
 
             // Act
-            var interopButton = Browser.FindElement(By.Id("btn-interop"));
+            var interopButton = Browser.Exists(By.Id("btn-interop"));
             interopButton.Click();
 
             Browser.Exists(By.Id("done-with-interop"));
 
             foreach (var expectedValue in expectedValues)
             {
-                var currentValue = Browser.FindElement(By.Id(expectedValue.Key));
+                var currentValue = Browser.Exists(By.Id(expectedValue.Key));
                 actualValues.Add(expectedValue.Key, currentValue.Text);
             }
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestJsInvocationsTimeoutsBehavior.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestJsInvocationsTimeoutsBehavior.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         public async Task LongRunningJavaScriptFunctionsResultInCancellationAndWorkingAppAfterFunctionCompletion()
         {
             // Act & Assert
-            var interopButton = Browser.FindElement(By.Id("btn-interop"));
+            var interopButton = Browser.Exists(By.Id("btn-interop"));
             interopButton.Click();
 
             Browser.Exists(By.Id("done-with-interop"));
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             // wait 10 seconds, js method completes in 5 seconds, after this point it would have triggered a completion for sure.
             await Task.Delay(10000);
 
-            var circuitFunctional = Browser.FindElement(By.Id("circuit-functional"));
+            var circuitFunctional = Browser.Exists(By.Id("circuit-functional"));
             circuitFunctional.Click();
 
             Browser.Exists(By.Id("done-circuit-functional"));

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerLocalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerLocalizationTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         [InlineData("fr-FR", "Bonjour!")]
         public void CanSetCultureAndReadLocalizedResources(string culture, string message)
         {
-            var selector = new SelectElement(Browser.FindElement(By.Id("culture-selector")));
+            var selector = new SelectElement(Browser.Exists(By.Id("culture-selector")));
             selector.SelectByValue(culture);
 
             // Click the link to return back to the test page
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var cultureDisplay = Browser.Exists(By.Id("culture-name-display"));
             Assert.Equal($"Culture is: {culture}", cultureDisplay.Text);
 
-            var messageDisplay = Browser.FindElement(By.Id("message-display"));
+            var messageDisplay = Browser.Exists(By.Id("message-display"));
             Assert.Equal(message, messageDisplay.Text);
         }
     }

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerReconnectionTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerReconnectionTest.cs
@@ -35,28 +35,28 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         [Fact]
         public void ReconnectUI()
         {
-            Browser.FindElement(By.Id("increment")).Click();
+            Browser.Exists(By.Id("increment")).Click();
 
             var javascript = (IJavaScriptExecutor)Browser;
             javascript.ExecuteScript("Blazor._internal.forceCloseConnection()");
 
             // We should see the 'reconnecting' UI appear
-            Browser.Equal("block", () => Browser.FindElement(By.Id("components-reconnect-modal")).GetCssValue("display"));
+            Browser.Equal("block", () => Browser.Exists(By.Id("components-reconnect-modal")).GetCssValue("display"));
 
             // Then it should disappear
-            Browser.Equal("none", () => Browser.FindElement(By.Id("components-reconnect-modal")).GetCssValue("display"));
+            Browser.Equal("none", () => Browser.Exists(By.Id("components-reconnect-modal")).GetCssValue("display"));
 
-            Browser.FindElement(By.Id("increment")).Click();
+            Browser.Exists(By.Id("increment")).Click();
 
             // Can dispatch events after reconnect
-            Browser.Equal("2", () => Browser.FindElement(By.Id("count")).Text);
+            Browser.Equal("2", () => Browser.Exists(By.Id("count")).Text);
         }
 
         [Fact]
         public void RendersContinueAfterReconnect()
         {
             var selector = By.Id("ticker");
-            var element = Browser.FindElement(selector);
+            var element = Browser.Exists(selector);
 
             var initialValue = element.Text;
 
@@ -64,24 +64,24 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             javascript.ExecuteScript("Blazor._internal.forceCloseConnection()");
 
             // We should see the 'reconnecting' UI appear
-            Browser.Equal("block", () => Browser.FindElement(By.Id("components-reconnect-modal")).GetCssValue("display"));
+            Browser.Equal("block", () => Browser.Exists(By.Id("components-reconnect-modal")).GetCssValue("display"));
 
             // Then it should disappear
-            Browser.Equal("none", () => Browser.FindElement(By.Id("components-reconnect-modal")).GetCssValue("display"));
+            Browser.Equal("none", () => Browser.Exists(By.Id("components-reconnect-modal")).GetCssValue("display"));
 
             // We should receive a render that occurred while disconnected
-            var currentValue = Browser.FindElement(selector).Text;
+            var currentValue = Browser.Exists(selector).Text;
             Assert.NotEqual(initialValue, currentValue);
 
             // Verify it continues to tick
             Thread.Sleep(5);
-            Browser.False(() => Browser.FindElement(selector).Text == currentValue);
+            Browser.False(() => Browser.Exists(selector).Text == currentValue);
         }
 
         [Fact(Skip = "Browser logs cannot be retrieved: https://github.com/dotnet/aspnetcore/issues/25803")]
         public void ErrorsStopTheRenderingProcess()
         {
-            Browser.FindElement(By.Id("cause-error")).Click();
+            Browser.Exists(By.Id("cause-error")).Click();
             Browser.True(() => Browser.Manage().Logs.GetLog(LogType.Browser)
                 .Any(l => l.Level == LogLevel.Info && l.Message.Contains("Connection disconnected.")));
         }

--- a/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         private void SetValue(string elementId, string value)
         {
-            var element = Browser.FindElement(By.Id(elementId));
+            var element = Browser.Exists(By.Id(elementId));
             element.Clear();
             element.SendKeys(value);
         }

--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -37,10 +37,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextbox_InitiallyBlank()
         {
-            var target = Browser.FindElement(By.Id("textbox-initially-blank"));
-            var boundValue = Browser.FindElement(By.Id("textbox-initially-blank-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-initially-blank-mirror"));
-            var setNullButton = Browser.FindElement(By.Id("textbox-initially-blank-setnull"));
+            var target = Browser.Exists(By.Id("textbox-initially-blank"));
+            var boundValue = Browser.Exists(By.Id("textbox-initially-blank-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-initially-blank-mirror"));
+            var setNullButton = Browser.Exists(By.Id("textbox-initially-blank-setnull"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -63,10 +63,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextbox_InitiallyPopulated()
         {
-            var target = Browser.FindElement(By.Id("textbox-initially-populated"));
-            var boundValue = Browser.FindElement(By.Id("textbox-initially-populated-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-initially-populated-mirror"));
-            var setNullButton = Browser.FindElement(By.Id("textbox-initially-populated-setnull"));
+            var target = Browser.Exists(By.Id("textbox-initially-populated"));
+            var boundValue = Browser.Exists(By.Id("textbox-initially-populated-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-initially-populated-mirror"));
+            var setNullButton = Browser.Exists(By.Id("textbox-initially-populated-setnull"));
             Assert.Equal("Hello", target.GetAttribute("value"));
             Assert.Equal("Hello", boundValue.Text);
             Assert.Equal("Hello", mirrorValue.GetAttribute("value"));
@@ -87,10 +87,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextbox_WithBindSuffixInitiallyPopulated()
         {
-            var target = Browser.FindElement(By.Id("bind-with-suffix-textbox-initially-populated"));
-            var boundValue = Browser.FindElement(By.Id("bind-with-suffix-textbox-initially-populated-value"));
-            var mirrorValue = Browser.FindElement(By.Id("bind-with-suffix-textbox-initially-populated-mirror"));
-            var setNullButton = Browser.FindElement(By.Id("bind-with-suffix-textbox-initially-populated-setnull"));
+            var target = Browser.Exists(By.Id("bind-with-suffix-textbox-initially-populated"));
+            var boundValue = Browser.Exists(By.Id("bind-with-suffix-textbox-initially-populated-value"));
+            var mirrorValue = Browser.Exists(By.Id("bind-with-suffix-textbox-initially-populated-mirror"));
+            var setNullButton = Browser.Exists(By.Id("bind-with-suffix-textbox-initially-populated-setnull"));
             Assert.Equal("Hello", target.GetAttribute("value"));
             Assert.Equal("Hello", boundValue.Text);
             Assert.Equal("Hello", mirrorValue.GetAttribute("value"));
@@ -111,8 +111,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextArea_InitiallyBlank()
         {
-            var target = Browser.FindElement(By.Id("textarea-initially-blank"));
-            var boundValue = Browser.FindElement(By.Id("textarea-initially-blank-value"));
+            var target = Browser.Exists(By.Id("textarea-initially-blank"));
+            var boundValue = Browser.Exists(By.Id("textarea-initially-blank-value"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
 
@@ -126,8 +126,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextArea_InitiallyPopulated()
         {
-            var target = Browser.FindElement(By.Id("textarea-initially-populated"));
-            var boundValue = Browser.FindElement(By.Id("textarea-initially-populated-value"));
+            var target = Browser.Exists(By.Id("textarea-initially-populated"));
+            var boundValue = Browser.Exists(By.Id("textarea-initially-populated-value"));
             Assert.Equal("Hello", target.GetAttribute("value"));
             Assert.Equal("Hello", boundValue.Text);
 
@@ -140,9 +140,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindCheckbox_InitiallyNull()
         {
-            var target = Browser.FindElement(By.Id("checkbox-initially-null"));
-            var boundValue = Browser.FindElement(By.Id("checkbox-initially-null-value"));
-            var invertButton = Browser.FindElement(By.Id("checkbox-initially-null-invert"));
+            var target = Browser.Exists(By.Id("checkbox-initially-null"));
+            var boundValue = Browser.Exists(By.Id("checkbox-initially-null-value"));
+            var invertButton = Browser.Exists(By.Id("checkbox-initially-null-invert"));
             Assert.False(target.Selected);
             Assert.Equal(string.Empty, boundValue.Text);
 
@@ -160,9 +160,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindCheckbox_InitiallyUnchecked()
         {
-            var target = Browser.FindElement(By.Id("checkbox-initially-unchecked"));
-            var boundValue = Browser.FindElement(By.Id("checkbox-initially-unchecked-value"));
-            var invertButton = Browser.FindElement(By.Id("checkbox-initially-unchecked-invert"));
+            var target = Browser.Exists(By.Id("checkbox-initially-unchecked"));
+            var boundValue = Browser.Exists(By.Id("checkbox-initially-unchecked-value"));
+            var invertButton = Browser.Exists(By.Id("checkbox-initially-unchecked-invert"));
             Assert.False(target.Selected);
             Assert.Equal("False", boundValue.Text);
 
@@ -180,9 +180,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindCheckbox_InitiallyChecked()
         {
-            var target = Browser.FindElement(By.Id("checkbox-initially-checked"));
-            var boundValue = Browser.FindElement(By.Id("checkbox-initially-checked-value"));
-            var invertButton = Browser.FindElement(By.Id("checkbox-initially-checked-invert"));
+            var target = Browser.Exists(By.Id("checkbox-initially-checked"));
+            var boundValue = Browser.Exists(By.Id("checkbox-initially-checked-value"));
+            var invertButton = Browser.Exists(By.Id("checkbox-initially-checked-invert"));
             Assert.True(target.Selected);
             Assert.Equal("True", boundValue.Text);
 
@@ -200,8 +200,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindSelect()
         {
-            var target = new SelectElement(Browser.FindElement(By.Id("select-box")));
-            var boundValue = Browser.FindElement(By.Id("select-box-value"));
+            var target = new SelectElement(Browser.Exists(By.Id("select-box")));
+            var boundValue = Browser.Exists(By.Id("select-box-value"));
             Assert.Equal("Second choice", target.SelectedOption.Text);
             Assert.Equal("Second", boundValue.Text);
 
@@ -212,12 +212,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // Also verify we can add and select new options atomically
             // Don't move this into a separate test, because then the previous assertions
             // would be dependent on test execution order (or would require a full page reload)
-            Browser.FindElement(By.Id("select-box-add-option")).Click();
+            Browser.Exists(By.Id("select-box-add-option")).Click();
             Browser.Equal("Fourth", () => boundValue.Text);
             Assert.Equal("Fourth choice", target.SelectedOption.Text);
 
             // verify that changing an option value and selected value at the same time works.
-            Browser.FindElement(By.Id("change-variable-value")).Click();
+            Browser.Exists(By.Id("change-variable-value")).Click();
             Browser.Equal("Sixth", () => boundValue.Text);
 
             // Verify we can select options whose value is empty
@@ -230,8 +230,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindSelectToMarkup()
         {
-            var target = new SelectElement(Browser.FindElement(By.Id("select-markup-box")));
-            var boundValue = Browser.FindElement(By.Id("select-markup-box-value"));
+            var target = new SelectElement(Browser.Exists(By.Id("select-markup-box")));
+            var boundValue = Browser.Exists(By.Id("select-markup-box-value"));
             Assert.Equal("Second choice", target.SelectedOption.Text);
             Assert.Equal("Second", boundValue.Text);
 
@@ -249,9 +249,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxInt()
         {
-            var target = Browser.FindElement(By.Id("textbox-int"));
-            var boundValue = Browser.FindElement(By.Id("textbox-int-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-int-mirror"));
+            var target = Browser.Exists(By.Id("textbox-int"));
+            var boundValue = Browser.Exists(By.Id("textbox-int-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-int-mirror"));
             Assert.Equal("-42", target.GetAttribute("value"));
             Assert.Equal("-42", boundValue.Text);
             Assert.Equal("-42", mirrorValue.GetAttribute("value"));
@@ -275,9 +275,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableInt()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-int"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-int-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-int-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-int"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-int-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-int-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -308,9 +308,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxLong()
         {
-            var target = Browser.FindElement(By.Id("textbox-long"));
-            var boundValue = Browser.FindElement(By.Id("textbox-long-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-long-mirror"));
+            var target = Browser.Exists(By.Id("textbox-long"));
+            var boundValue = Browser.Exists(By.Id("textbox-long-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-long-mirror"));
             Assert.Equal("3000000000", target.GetAttribute("value"));
             Assert.Equal("3000000000", boundValue.Text);
             Assert.Equal("3000000000", mirrorValue.GetAttribute("value"));
@@ -332,9 +332,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableLong()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-long"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-long-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-long-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-long"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-long-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-long-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -365,9 +365,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxShort()
         {
-            var target = Browser.FindElement(By.Id("textbox-short"));
-            var boundValue = Browser.FindElement(By.Id("textbox-short-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-short-mirror"));
+            var target = Browser.Exists(By.Id("textbox-short"));
+            var boundValue = Browser.Exists(By.Id("textbox-short-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-short-mirror"));
             Assert.Equal("-42", target.GetAttribute("value"));
             Assert.Equal("-42", boundValue.Text);
             Assert.Equal("-42", mirrorValue.GetAttribute("value"));
@@ -392,9 +392,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23826")]
         public void CanBindTextboxNullableShort()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-short"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-short-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-short-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-short"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-short-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-short-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -407,13 +407,13 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // Modify target; verify value is updated and that textboxes linked to the same data are updated
             target.SendKeys("-42\t");
             Browser.Equal("-42", () => boundValue.Text);
-            Assert.Equal("-42", mirrorValue.GetAttribute("value"));
+            Browser.Equal("-42", () => mirrorValue.GetAttribute("value"));
 
             // Modify target; verify value is updated and that textboxes linked to the same data are updated
             target.Clear();
             target.SendKeys("42\t");
             Browser.Equal("42", () => boundValue.Text);
-            Assert.Equal("42", mirrorValue.GetAttribute("value"));
+            Browser.Equal("42", () => mirrorValue.GetAttribute("value"));
 
             // Modify target; verify value is updated and that textboxes linked to the same data are updated
             target.Clear();
@@ -425,9 +425,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxFloat()
         {
-            var target = Browser.FindElement(By.Id("textbox-float"));
-            var boundValue = Browser.FindElement(By.Id("textbox-float-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-float-mirror"));
+            var target = Browser.Exists(By.Id("textbox-float"));
+            var boundValue = Browser.Exists(By.Id("textbox-float-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-float-mirror"));
             Assert.Equal("3.141", target.GetAttribute("value"));
             Assert.Equal("3.141", boundValue.Text);
             Assert.Equal("3.141", mirrorValue.GetAttribute("value"));
@@ -442,16 +442,16 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             target.SendKeys(Keys.Backspace);
             target.SendKeys("-3.141\t");
             Browser.Equal("-3.141", () => target.GetAttribute("value"));
-            Assert.Equal("-3.141", boundValue.Text);
-            Assert.Equal("-3.141", mirrorValue.GetAttribute("value"));
+            Browser.Equal("-3.141", () => boundValue.Text);
+            Browser.Equal("-3.141", () => mirrorValue.GetAttribute("value"));
         }
 
         [Fact]
         public void CanBindTextboxNullableFloat()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-float"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-float-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-float-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-float"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-float-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-float-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -482,9 +482,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxDouble()
         {
-            var target = Browser.FindElement(By.Id("textbox-double"));
-            var boundValue = Browser.FindElement(By.Id("textbox-double-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-double-mirror"));
+            var target = Browser.Exists(By.Id("textbox-double"));
+            var boundValue = Browser.Exists(By.Id("textbox-double-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-double-mirror"));
             Assert.Equal("3.14159265359", target.GetAttribute("value"));
             Assert.Equal("3.14159265359", boundValue.Text);
             Assert.Equal("3.14159265359", mirrorValue.GetAttribute("value"));
@@ -515,9 +515,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23596")]
         public void CanBindTextboxNullableDouble()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-double"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-double-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-double-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-double"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-double-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-double-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -555,9 +555,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxDecimal()
         {
-            var target = Browser.FindElement(By.Id("textbox-decimal"));
-            var boundValue = Browser.FindElement(By.Id("textbox-decimal-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-decimal-mirror"));
+            var target = Browser.Exists(By.Id("textbox-decimal"));
+            var boundValue = Browser.Exists(By.Id("textbox-decimal-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-decimal-mirror"));
             Assert.Equal("0.0000000000000000000000000001", target.GetAttribute("value"));
             Assert.Equal("0.0000000000000000000000000001", boundValue.Text);
             Assert.Equal("0.0000000000000000000000000001", mirrorValue.GetAttribute("value"));
@@ -578,9 +578,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableDecimal()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-decimal"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-decimal-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-decimal-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-decimal"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-decimal-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-decimal-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -600,7 +600,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             target.Clear();
             target.SendKeys("0.010\t");
             Browser.Equal("0.010", () => boundValue.Text);
-            Assert.Equal("0.010", mirrorValue.GetAttribute("value"));
+            Browser.Equal("0.010", () => mirrorValue.GetAttribute("value"));
 
             // Modify target; verify value is updated and that textboxes linked to the same data are updated
             target.Clear();
@@ -615,9 +615,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24756")]
         public void CanBindTextbox_Decimal_InvalidInput()
         {
-            var target = Browser.FindElement(By.Id("textbox-decimal-invalid"));
-            var boundValue = Browser.FindElement(By.Id("textbox-decimal-invalid-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-decimal-invalid-mirror"));
+            var target = Browser.Exists(By.Id("textbox-decimal-invalid"));
+            var boundValue = Browser.Exists(By.Id("textbox-decimal-invalid-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-decimal-invalid-mirror"));
             Assert.Equal("0.0000000000000000000000000001", target.GetAttribute("value"));
             Assert.Equal("0.0000000000000000000000000001", boundValue.Text);
             Assert.Equal("0.0000000000000000000000000001", mirrorValue.GetAttribute("value"));
@@ -634,14 +634,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Assert.Equal("0.012A", target.GetAttribute("value"));
             target.SendKeys("\t");
             Browser.Equal("0.01", () => boundValue.Text);
-            Assert.Equal("0.01", mirrorValue.GetAttribute("value"));
-            Assert.Equal("0.01", target.GetAttribute("value"));
+            Browser.Equal("0.01", () => mirrorValue.GetAttribute("value"));
+            Browser.Equal("0.01", () => target.GetAttribute("value"));
 
             // Continue editing with valid inputs
             target.SendKeys(Keys.Backspace);
             target.SendKeys("2\t");
             Browser.Equal("0.02", () => boundValue.Text);
-            Assert.Equal("0.02", mirrorValue.GetAttribute("value"));
+            Browser.Equal("0.02", () => mirrorValue.GetAttribute("value"));
         }
 
         // This tests what happens you put invalid (unconvertable) input in. This is separate from the
@@ -649,9 +649,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextbox_NullableDecimal_InvalidInput()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-decimal-invalid"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-decimal-invalid-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-decimal-invalid-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-decimal-invalid"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-decimal-invalid-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-decimal-invalid-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -681,9 +681,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxGenericInt()
         {
-            var target = Browser.FindElement(By.Id("textbox-generic-int"));
-            var boundValue = Browser.FindElement(By.Id("textbox-generic-int-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-generic-int-mirror"));
+            var target = Browser.Exists(By.Id("textbox-generic-int"));
+            var boundValue = Browser.Exists(By.Id("textbox-generic-int-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-generic-int-mirror"));
             Assert.Equal("-42", target.GetAttribute("value"));
             Assert.Equal("-42", boundValue.Text);
             Assert.Equal("-42", mirrorValue.GetAttribute("value"));
@@ -703,9 +703,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxGenericGuid()
         {
-            var target = Browser.FindElement(By.Id("textbox-generic-guid"));
-            var boundValue = Browser.FindElement(By.Id("textbox-generic-guid-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-generic-guid-mirror"));
+            var target = Browser.Exists(By.Id("textbox-generic-guid"));
+            var boundValue = Browser.Exists(By.Id("textbox-generic-guid-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-generic-guid-mirror"));
             Assert.Equal("00000000-0000-0000-0000-000000000000", target.GetAttribute("value"));
             Assert.Equal("00000000-0000-0000-0000-000000000000", boundValue.Text);
             Assert.Equal("00000000-0000-0000-0000-000000000000", mirrorValue.GetAttribute("value"));
@@ -727,9 +727,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxDateTime()
         {
-            var target = Browser.FindElement(By.Id("textbox-datetime"));
-            var boundValue = Browser.FindElement(By.Id("textbox-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-datetime-mirror"));
+            var target = Browser.Exists(By.Id("textbox-datetime"));
+            var boundValue = Browser.Exists(By.Id("textbox-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-datetime-mirror"));
             var expected = new DateTime(1985, 3, 4);
             Assert.Equal(expected, DateTime.Parse(target.GetAttribute("value")));
             Assert.Equal(expected, DateTime.Parse(boundValue.Text));
@@ -755,9 +755,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableDateTime()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-datetime"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-datetime-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-datetime"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-datetime-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -785,9 +785,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxDateTimeOffset()
         {
-            var target = Browser.FindElement(By.Id("textbox-datetimeoffset"));
-            var boundValue = Browser.FindElement(By.Id("textbox-datetimeoffset-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-datetimeoffset-mirror"));
+            var target = Browser.Exists(By.Id("textbox-datetimeoffset"));
+            var boundValue = Browser.Exists(By.Id("textbox-datetimeoffset-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-datetimeoffset-mirror"));
             var expected = new DateTimeOffset(new DateTime(1985, 3, 4), TimeSpan.FromHours(8));
             Assert.Equal(expected, DateTimeOffset.Parse(target.GetAttribute("value")));
             Assert.Equal(expected, DateTimeOffset.Parse(boundValue.Text));
@@ -813,9 +813,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableDateTimeOffset()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-datetimeoffset"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-datetimeoffset-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-datetimeoffset-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -843,9 +843,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxDateTimeWithFormat()
         {
-            var target = Browser.FindElement(By.Id("textbox-datetime-format"));
-            var boundValue = Browser.FindElement(By.Id("textbox-datetime-format-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-datetime-format-mirror"));
+            var target = Browser.Exists(By.Id("textbox-datetime-format"));
+            var boundValue = Browser.Exists(By.Id("textbox-datetime-format-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-datetime-format-mirror"));
             var expected = new DateTime(1985, 3, 4);
             Assert.Equal("03-04", target.GetAttribute("value"));
             Assert.Equal(expected, DateTime.Parse(boundValue.Text));
@@ -872,9 +872,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableDateTimeWithFormat()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-datetime-format"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-datetime-format-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-datetime-format-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-datetime-format"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-datetime-format-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-datetime-format-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -902,9 +902,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxDateTimeOffsetWithFormat()
         {
-            var target = Browser.FindElement(By.Id("textbox-datetimeoffset-format"));
-            var boundValue = Browser.FindElement(By.Id("textbox-datetimeoffset-format-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-datetimeoffset-format-mirror"));
+            var target = Browser.Exists(By.Id("textbox-datetimeoffset-format"));
+            var boundValue = Browser.Exists(By.Id("textbox-datetimeoffset-format-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-datetimeoffset-format-mirror"));
             var expected = new DateTimeOffset(new DateTime(1985, 3, 4), TimeSpan.FromHours(8));
             Assert.Equal("03-04", target.GetAttribute("value"));
             Assert.Equal(expected, DateTimeOffset.Parse(boundValue.Text));
@@ -933,9 +933,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableDateTimeOffsetWithFormat()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-datetimeoffset"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-datetimeoffset-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-datetimeoffset-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -963,9 +963,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableDateTime_InvalidValue()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-datetime-invalid"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-datetime-invalid-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-datetime-invalid-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-datetime-invalid"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-datetime-invalid-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-datetime-invalid-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -999,9 +999,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxDateTimeOffset_InvalidValue()
         {
-            var target = Browser.FindElement(By.Id("textbox-datetimeoffset-invalid"));
-            var boundValue = Browser.FindElement(By.Id("textbox-datetimeoffset-invalid-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-datetimeoffset-invalid-mirror"));
+            var target = Browser.Exists(By.Id("textbox-datetimeoffset-invalid"));
+            var boundValue = Browser.Exists(By.Id("textbox-datetimeoffset-invalid-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-datetimeoffset-invalid-mirror"));
             var expected = new DateTimeOffset(new DateTime(1985, 3, 4), TimeSpan.FromHours(8));
             Assert.Equal(expected, DateTimeOffset.Parse(target.GetAttribute("value")));
             Assert.Equal(expected, DateTimeOffset.Parse(boundValue.Text));
@@ -1037,9 +1037,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxDateTimeWithFormat_InvalidValue()
         {
-            var target = Browser.FindElement(By.Id("textbox-datetime-format-invalid"));
-            var boundValue = Browser.FindElement(By.Id("textbox-datetime-format-invalid-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-datetime-format-invalid-mirror"));
+            var target = Browser.Exists(By.Id("textbox-datetime-format-invalid"));
+            var boundValue = Browser.Exists(By.Id("textbox-datetime-format-invalid-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-datetime-format-invalid-mirror"));
             var expected = new DateTime(1985, 3, 4);
             Assert.Equal("03-04", target.GetAttribute("value"));
             Assert.Equal(expected, DateTime.Parse(boundValue.Text));
@@ -1068,9 +1068,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTextboxNullableDateTimeOffsetWithFormat_InvalidValue()
         {
-            var target = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset-format-invalid"));
-            var boundValue = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset-format-invalid-value"));
-            var mirrorValue = Browser.FindElement(By.Id("textbox-nullable-datetimeoffset-format-invalid-mirror"));
+            var target = Browser.Exists(By.Id("textbox-nullable-datetimeoffset-format-invalid"));
+            var boundValue = Browser.Exists(By.Id("textbox-nullable-datetimeoffset-format-invalid-value"));
+            var mirrorValue = Browser.Exists(By.Id("textbox-nullable-datetimeoffset-format-invalid-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -1105,9 +1105,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindDateTimeLocalTextboxDateTime()
         {
-            var target = Browser.FindElement(By.Id("datetime-local-textbox-datetime"));
-            var boundValue = Browser.FindElement(By.Id("datetime-local-textbox-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("datetime-local-textbox-datetime-mirror"));
+            var target = Browser.Exists(By.Id("datetime-local-textbox-datetime"));
+            var boundValue = Browser.Exists(By.Id("datetime-local-textbox-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("datetime-local-textbox-datetime-mirror"));
             var expected = new DateTime(1985, 3, 4);
             Assert.Equal(expected, DateTime.Parse(target.GetAttribute("value")));
             Assert.Equal(expected, DateTime.Parse(boundValue.Text));
@@ -1133,9 +1133,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindDateTimeLocalTextboxNullableDateTime()
         {
-            var target = Browser.FindElement(By.Id("datetime-local-textbox-nullable-datetime"));
-            var boundValue = Browser.FindElement(By.Id("datetime-local-textbox-nullable-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("datetime-local-textbox-nullable-datetime-mirror"));
+            var target = Browser.Exists(By.Id("datetime-local-textbox-nullable-datetime"));
+            var boundValue = Browser.Exists(By.Id("datetime-local-textbox-nullable-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("datetime-local-textbox-nullable-datetime-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -1165,9 +1165,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindMonthTextboxDateTime()
         {
-            var target = Browser.FindElement(By.Id("month-textbox-datetime"));
-            var boundValue = Browser.FindElement(By.Id("month-textbox-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("month-textbox-datetime-mirror"));
+            var target = Browser.Exists(By.Id("month-textbox-datetime"));
+            var boundValue = Browser.Exists(By.Id("month-textbox-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("month-textbox-datetime-mirror"));
             var expected = new DateTime(1985, 3, 1);
             Assert.Equal(expected, DateTime.Parse(target.GetAttribute("value")));
             // When the value gets displayed the first time it gets truncated to the 1st day,
@@ -1195,9 +1195,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindMonthTextboxNullableDateTime()
         {
-            var target = Browser.FindElement(By.Id("month-textbox-nullable-datetime"));
-            var boundValue = Browser.FindElement(By.Id("month-textbox-nullable-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("month-textbox-nullable-datetime-mirror"));
+            var target = Browser.Exists(By.Id("month-textbox-nullable-datetime"));
+            var boundValue = Browser.Exists(By.Id("month-textbox-nullable-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("month-textbox-nullable-datetime-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -1227,9 +1227,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTimeTextboxDateTime()
         {
-            var target = Browser.FindElement(By.Id("time-textbox-datetime"));
-            var boundValue = Browser.FindElement(By.Id("time-textbox-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("time-textbox-datetime-mirror"));
+            var target = Browser.Exists(By.Id("time-textbox-datetime"));
+            var boundValue = Browser.Exists(By.Id("time-textbox-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("time-textbox-datetime-mirror"));
             var expected = DateTime.Now.Date.AddHours(8).AddMinutes(5);
             Assert.Equal(expected, DateTime.Parse(target.GetAttribute("value")));
             Assert.Equal(expected, DateTime.Parse(boundValue.Text));
@@ -1255,9 +1255,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTimeTextboxNullableDateTime()
         {
-            var target = Browser.FindElement(By.Id("time-textbox-nullable-datetime"));
-            var boundValue = Browser.FindElement(By.Id("time-textbox-nullable-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("time-textbox-nullable-datetime-mirror"));
+            var target = Browser.Exists(By.Id("time-textbox-nullable-datetime"));
+            var boundValue = Browser.Exists(By.Id("time-textbox-nullable-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("time-textbox-nullable-datetime-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
@@ -1287,9 +1287,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTimeStepTextboxDateTime()
         {
-            var target = Browser.FindElement(By.Id("time-step-textbox-datetime"));
-            var boundValue = Browser.FindElement(By.Id("time-step-textbox-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("time-step-textbox-datetime-mirror"));
+            var target = Browser.Exists(By.Id("time-step-textbox-datetime"));
+            var boundValue = Browser.Exists(By.Id("time-step-textbox-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("time-step-textbox-datetime-mirror"));
             var expected = DateTime.Now.Date.Add(new TimeSpan(8, 5, 30));
             Assert.Equal(expected, DateTime.Parse(target.GetAttribute("value")));
             Assert.Equal(expected, DateTime.Parse(boundValue.Text));
@@ -1315,9 +1315,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanBindTimeStepTextboxNullableDateTime()
         {
-            var target = Browser.FindElement(By.Id("time-step-textbox-nullable-datetime"));
-            var boundValue = Browser.FindElement(By.Id("time-step-textbox-nullable-datetime-value"));
-            var mirrorValue = Browser.FindElement(By.Id("time-step-textbox-nullable-datetime-mirror"));
+            var target = Browser.Exists(By.Id("time-step-textbox-nullable-datetime"));
+            var boundValue = Browser.Exists(By.Id("time-step-textbox-nullable-datetime-value"));
+            var mirrorValue = Browser.Exists(By.Id("time-step-textbox-nullable-datetime-mirror"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
             Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));

--- a/src/Components/test/E2ETest/Tests/CascadingValueTest.cs
+++ b/src/Components/test/E2ETest/Tests/CascadingValueTest.cs
@@ -31,8 +31,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void CanUpdateValuesMatchedByType()
         {
-            var currentCount = Browser.FindElement(By.Id("current-count"));
-            var incrementButton = Browser.FindElement(By.Id("increment-count"));
+            var currentCount = Browser.Exists(By.Id("current-count"));
+            var incrementButton = Browser.Exists(By.Id("increment-count"));
 
             // We have the correct initial value
             Browser.Equal("100", () => currentCount.Text);
@@ -44,35 +44,35 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("102", () => currentCount.Text);
 
             // Didn't re-render unrelated descendants
-            Assert.Equal("1", Browser.FindElement(By.Id("receive-by-interface-num-renders")).Text);
+            Assert.Equal("1", Browser.Exists(By.Id("receive-by-interface-num-renders")).Text);
         }
 
         [Fact]
         public void CanUpdateValuesMatchedByName()
         {
-            var currentFlag1Value = Browser.FindElement(By.Id("flag-1"));
-            var currentFlag2Value = Browser.FindElement(By.Id("flag-2"));
+            var currentFlag1Value = Browser.Exists(By.Id("flag-1"));
+            var currentFlag2Value = Browser.Exists(By.Id("flag-2"));
 
             Browser.Equal("False", () => currentFlag1Value.Text);
             Browser.Equal("False", () => currentFlag2Value.Text);
 
             // Observe that the correct cascading parameter updates
-            Browser.FindElement(By.Id("toggle-flag-1")).Click();
+            Browser.Exists(By.Id("toggle-flag-1")).Click();
             Browser.Equal("True", () => currentFlag1Value.Text);
             Browser.Equal("False", () => currentFlag2Value.Text);
-            Browser.FindElement(By.Id("toggle-flag-2")).Click();
+            Browser.Exists(By.Id("toggle-flag-2")).Click();
             Browser.Equal("True", () => currentFlag1Value.Text);
             Browser.Equal("True", () => currentFlag2Value.Text);
 
             // Didn't re-render unrelated descendants
-            Assert.Equal("1", Browser.FindElement(By.Id("receive-by-interface-num-renders")).Text);
+            Assert.Equal("1", Browser.Exists(By.Id("receive-by-interface-num-renders")).Text);
         }
 
         [Fact]
         public void CanUpdateFixedValuesMatchedByInterface()
         {
-            var currentCount = Browser.FindElement(By.Id("current-count"));
-            var decrementButton = Browser.FindElement(By.Id("decrement-count"));
+            var currentCount = Browser.Exists(By.Id("current-count"));
+            var decrementButton = Browser.Exists(By.Id("decrement-count"));
 
             // We have the correct initial value
             Browser.Equal("100", () => currentCount.Text);
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("98", () => currentCount.Text);
 
             // Didn't re-render descendants
-            Assert.Equal("1", Browser.FindElement(By.Id("receive-by-interface-num-renders")).Text);
+            Assert.Equal("1", Browser.Exists(By.Id("receive-by-interface-num-renders")).Text);
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/ClientRenderingMultpleComponentsTest.cs
+++ b/src/Components/test/E2ETest/Tests/ClientRenderingMultpleComponentsTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Assert.Single(greets, "Hello Abraham");
             Assert.Equal(2, greets.Where(g => g == "Hello Blue fish").Count());
             Assert.Equal(3, greets.Where(g => string.Equals("Hello", g)).Count()); // 3 server prerendered without parameters
-            var content = Browser.FindElement(By.Id("test-container")).GetAttribute("innerHTML");
+            var content = Browser.Exists(By.Id("test-container")).GetAttribute("innerHTML");
             var markers = ReadMarkers(content);
             var componentSequence = markers.Select(m => m.Item1.PrerenderId != null).ToArray();
             Assert.Equal(13, componentSequence.Length);
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         private void BeginInteractivity()
         {
-            Browser.FindElement(By.Id("load-boot-script")).Click();
+            Browser.Exists(By.Id("load-boot-script")).Click();
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/ClientSideHostingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ClientSideHostingTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Navigate("/subdir/filepath");
             WaitUntilLoaded();
-            Assert.NotNull(Browser.FindElement(By.Id("test-selector")));
+            Assert.NotNull(Browser.Exists(By.Id("test-selector")));
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Navigate("/subdir/pattern_filepath/test");
             WaitUntilLoaded();
-            Assert.NotNull(Browser.FindElement(By.Id("test-selector")));
+            Assert.NotNull(Browser.Exists(By.Id("test-selector")));
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Navigate("/subdir/assemblypath_filepath");
             WaitUntilLoaded();
-            Assert.NotNull(Browser.FindElement(By.Id("test-selector")));
+            Assert.NotNull(Browser.Exists(By.Id("test-selector")));
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Navigate("/subdir/assemblypath_pattern_filepath/test");
             WaitUntilLoaded();
-            Assert.NotNull(Browser.FindElement(By.Id("test-selector")));
+            Assert.NotNull(Browser.Exists(By.Id("test-selector")));
         }
 
         private void WaitUntilLoaded()

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -485,7 +485,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void CanUseJsInteropForRefElementsDuringOnAfterRender()
         {
             var appElement = Browser.MountTestComponent<AfterRenderInteropComponent>();
-            Browser.Equal("Value set after render", () => Browser.FindElement(By.TagName("input")).GetAttribute("value"));
+            Browser.Equal("Value set after render", () => Browser.Exists(By.TagName("input")).GetAttribute("value"));
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/Tests/ErrorNotificationTest.cs
+++ b/src/Components/test/E2ETest/Tests/ErrorNotificationTest.cs
@@ -37,15 +37,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23643")]
         public void ShowsErrorNotification_OnError_Dismiss()
         {
-            var errorUi = Browser.FindElement(By.Id("blazor-error-ui"));
+            var errorUi = Browser.Exists(By.Id("blazor-error-ui"));
             Assert.Equal("none", errorUi.GetCssValue("display"));
 
-            var causeErrorButton = Browser.FindElement(By.Id("throw-simple-exception"));
+            var causeErrorButton = Browser.Exists(By.Id("throw-simple-exception"));
             causeErrorButton.Click();
 
             Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"), TimeSpan.FromSeconds(10));
 
-            var reload = Browser.FindElement(By.ClassName("reload"));
+            var reload = Browser.Exists(By.ClassName("reload"));
             reload.Click();
 
             Browser.DoesNotExist(By.TagName("button"));
@@ -56,13 +56,13 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void ShowsErrorNotification_OnError_Reload()
         {
             var causeErrorButton = Browser.Exists(By.Id("throw-simple-exception"));
-            var errorUi = Browser.FindElement(By.Id("blazor-error-ui"));
+            var errorUi = Browser.Exists(By.Id("blazor-error-ui"));
             Assert.Equal("none", errorUi.GetCssValue("display"));
 
             causeErrorButton.Click();
             Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"));
 
-            var dismiss = Browser.FindElement(By.ClassName("dismiss"));
+            var dismiss = Browser.Exists(By.ClassName("dismiss"));
             dismiss.Click();
             Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: none;']"));
         }

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void BubblingStandardEvent_FiredOnElementWithHandler()
         {
-            Browser.FindElement(By.Id("button-with-onclick")).Click();
+            Browser.Exists(By.Id("button-with-onclick")).Click();
 
             // Triggers event on target and ancestors with handler in upwards direction
             Browser.Equal(
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void BubblingStandardEvent_FiredOnElementWithoutHandler()
         {
-            Browser.FindElement(By.Id("button-without-onclick")).Click();
+            Browser.Exists(By.Id("button-without-onclick")).Click();
 
             // Triggers event on ancestors with handler in upwards direction
             Browser.Equal(
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void NonBubblingEvent_FiredOnElementWithHandler()
         {
-            Browser.FindElement(By.Id("input-with-onfocus")).Click();
+            Browser.Exists(By.Id("input-with-onfocus")).Click();
 
             // Triggers event only on target, not other ancestors with event handler
             Browser.Equal(
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void NonBubblingEvent_FiredOnElementWithoutHandler()
         {
-            Browser.FindElement(By.Id("input-without-onfocus")).Click();
+            Browser.Exists(By.Id("input-without-onfocus")).Click();
 
             // Triggers no event
             Browser.Empty(GetLogLines);
@@ -108,21 +108,21 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void StopPropagation(string whereToStopPropagation)
         {
             // If stopPropagation is off, we observe the event on the listener and all its ancestors
-            Browser.FindElement(By.Id("button-with-onclick")).Click();
+            Browser.Exists(By.Id("button-with-onclick")).Click();
             Browser.Equal(new[] { "target onclick", "parent onclick" }, GetLogLines);
 
             // If stopPropagation is on, the event doesn't reach the ancestor
             // Note that in the "intermediate element" case, the intermediate element does *not* itself
             // listen for this event, which shows that stopPropagation works independently of handling
             ClearLog();
-            Browser.FindElement(By.Id($"{whereToStopPropagation}-stop-propagation")).Click();
-            Browser.FindElement(By.Id("button-with-onclick")).Click();
+            Browser.Exists(By.Id($"{whereToStopPropagation}-stop-propagation")).Click();
+            Browser.Exists(By.Id("button-with-onclick")).Click();
             Browser.Equal(new[] { "target onclick" }, GetLogLines);
 
             // We can also toggle it back off
             ClearLog();
-            Browser.FindElement(By.Id($"{whereToStopPropagation}-stop-propagation")).Click();
-            Browser.FindElement(By.Id("button-with-onclick")).Click();
+            Browser.Exists(By.Id($"{whereToStopPropagation}-stop-propagation")).Click();
+            Browser.Exists(By.Id("button-with-onclick")).Click();
             Browser.Equal(new[] { "target onclick", "parent onclick" }, GetLogLines);
         }
 
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             // Clicking a checkbox without preventDefault produces both "click" and "change"
             // events, and it becomes checked
-            var checkboxWithoutPreventDefault = Browser.FindElement(By.Id("checkbox-with-preventDefault-false"));
+            var checkboxWithoutPreventDefault = Browser.Exists(By.Id("checkbox-with-preventDefault-false"));
             checkboxWithoutPreventDefault.Click();
             Browser.Equal(new[] { "Checkbox click", "Checkbox change" }, GetLogLines);
             Browser.True(() => checkboxWithoutPreventDefault.Selected);
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // Clicking a checkbox with preventDefault produces a "click" event, but no "change"
             // event, and it remains unchecked
             ClearLog();
-            var checkboxWithPreventDefault = Browser.FindElement(By.Id("checkbox-with-preventDefault-true"));
+            var checkboxWithPreventDefault = Browser.Exists(By.Id("checkbox-with-preventDefault-true"));
             checkboxWithPreventDefault.Click();
             Browser.Equal(new[] { "Checkbox click" }, GetLogLines);
             Browser.False(() => checkboxWithPreventDefault.Selected);
@@ -150,14 +150,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             // Even though the checkbox we're clicking this case does *not* have preventDefault,
             // if its ancestor does, then we don't get the "change" event and it remains unchecked
-            Browser.FindElement(By.Id($"ancestor-prevent-default")).Click();
-            var checkboxWithoutPreventDefault = Browser.FindElement(By.Id("checkbox-with-preventDefault-false"));
+            Browser.Exists(By.Id($"ancestor-prevent-default")).Click();
+            var checkboxWithoutPreventDefault = Browser.Exists(By.Id("checkbox-with-preventDefault-false"));
             checkboxWithoutPreventDefault.Click();
             Browser.Equal(new[] { "Checkbox click" }, GetLogLines);
             Browser.False(() => checkboxWithoutPreventDefault.Selected);
 
             // We can also toggle it back off dynamically
-            Browser.FindElement(By.Id($"ancestor-prevent-default")).Click();
+            Browser.Exists(By.Id($"ancestor-prevent-default")).Click();
             ClearLog();
             checkboxWithoutPreventDefault.Click();
             Browser.Equal(new[] { "Checkbox click", "Checkbox change" }, GetLogLines);
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void PreventDefaultCanBlockKeystrokes()
         {
             // By default, the textbox accepts keystrokes
-            var textbox = Browser.FindElement(By.Id($"textbox-that-can-block-keystrokes"));
+            var textbox = Browser.Exists(By.Id($"textbox-that-can-block-keystrokes"));
             textbox.SendKeys("a");
             Browser.Equal(new[] { "Received keydown" }, GetLogLines);
             Browser.Equal("a", () => textbox.GetAttribute("value"));
@@ -177,27 +177,27 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // We can turn on preventDefault to stop keystrokes
             // There will still be a keydown event, but we're preventing it from actually changing the textbox value
             ClearLog();
-            Browser.FindElement(By.Id($"prevent-keydown")).Click();
+            Browser.Exists(By.Id($"prevent-keydown")).Click();
             textbox.SendKeys("b");
             Browser.Equal(new[] { "Received keydown" }, GetLogLines);
             Browser.Equal("a", () => textbox.GetAttribute("value"));
 
             // We can turn it back off
             ClearLog();
-            Browser.FindElement(By.Id($"prevent-keydown")).Click();
+            Browser.Exists(By.Id($"prevent-keydown")).Click();
             textbox.SendKeys("c");
             Browser.Equal(new[] { "Received keydown" }, GetLogLines);
             Browser.Equal("ac", () => textbox.GetAttribute("value"));
         }
 
         private string[] GetLogLines()
-            => Browser.FindElement(By.TagName("textarea"))
+            => Browser.Exists(By.TagName("textarea"))
             .GetAttribute("value")
             .Replace("\r\n", "\n")
             .Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         void ClearLog()
-            => Browser.FindElement(By.Id("clear-log")).Click();
+            => Browser.Exists(By.Id("clear-log")).Click();
 
         private void TriggerCustomBubblingEvent(string elementId, string eventName)
         {

--- a/src/Components/test/E2ETest/Tests/EventCallbackTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventCallbackTest.cs
@@ -39,8 +39,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [InlineData("unbound_lambda_bind_to_component")]
         public void EventCallback_RerendersOuterComponent(string @case)
         {
-            var target = Browser.FindElement(By.CssSelector($"#{@case} button"));
-            var count = Browser.FindElement(By.Id("render_count"));
+            var target = Browser.Exists(By.CssSelector($"#{@case} button"));
+            var count = Browser.Exists(By.Id("render_count"));
             Browser.Equal("Render Count: 1", () => count.Text);
             target.Click();
             Browser.Equal("Render Count: 2", () => count.Text);

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -34,9 +34,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<FocusEventComponent>();
 
-            var input = Browser.FindElement(By.Id("input"));
+            var input = Browser.Exists(By.Id("input"));
 
-            var output = Browser.FindElement(By.Id("output"));
+            var output = Browser.Exists(By.Id("output"));
             Assert.Equal(string.Empty, output.Text);
 
             // Focus the target, verify onfocusin is fired
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("onfocus,onfocusin,", () => output.Text);
 
             // Focus something else, verify onfocusout is also fired
-            var other = Browser.FindElement(By.Id("other"));
+            var other = Browser.Exists(By.Id("other"));
             other.Click();
 
             Browser.Equal("onfocus,onfocusin,onblur,onfocusout,", () => output.Text);
@@ -56,12 +56,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<MouseEventComponent>();
 
-            var input = Browser.FindElement(By.Id("mouseover_input"));
+            var input = Browser.Exists(By.Id("mouseover_input"));
 
-            var output = Browser.FindElement(By.Id("output"));
+            var output = Browser.Exists(By.Id("output"));
             Assert.Equal(string.Empty, output.Text);
 
-            var other = Browser.FindElement(By.Id("other"));
+            var other = Browser.Exists(By.Id("other"));
 
             // Mouse over the button and then back off
             var actions = new Actions(Browser)
@@ -77,9 +77,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<MouseEventComponent>();
 
-            var input = Browser.FindElement(By.Id("mousemove_input"));
+            var input = Browser.Exists(By.Id("mousemove_input"));
 
-            var output = Browser.FindElement(By.Id("output"));
+            var output = Browser.Exists(By.Id("output"));
             Assert.Equal(string.Empty, output.Text);
 
             // Move a little bit
@@ -96,12 +96,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<MouseEventComponent>();
 
-            var input = Browser.FindElement(By.Id("mousedown_input"));
+            var input = Browser.Exists(By.Id("mousedown_input"));
 
-            var output = Browser.FindElement(By.Id("output"));
+            var output = Browser.Exists(By.Id("output"));
             Assert.Equal(string.Empty, output.Text);
 
-            var other = Browser.FindElement(By.Id("other"));
+            var other = Browser.Exists(By.Id("other"));
 
             // Mousedown
             var actions = new Actions(Browser).ClickAndHold(input);
@@ -121,9 +121,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<ToggleEventComponent>();
 
-            var detailsToggle = Browser.FindElement(By.Id("details-toggle"));
+            var detailsToggle = Browser.Exists(By.Id("details-toggle"));
 
-            var output = Browser.FindElement(By.Id("output"));
+            var output = Browser.Exists(By.Id("output"));
             Assert.Equal(string.Empty, output.Text);
 
             // Click
@@ -138,9 +138,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<MouseEventComponent>();
 
-            var input = Browser.FindElement(By.Id("pointerdown_input"));
+            var input = Browser.Exists(By.Id("pointerdown_input"));
 
-            var output = Browser.FindElement(By.Id("output"));
+            var output = Browser.Exists(By.Id("output"));
             Assert.Equal(string.Empty, output.Text);
 
             var actions = new Actions(Browser).ClickAndHold(input);
@@ -154,10 +154,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<MouseEventComponent>();
 
-            var input = Browser.FindElement(By.Id("drag_input"));
-            var target = Browser.FindElement(By.Id("drop"));
+            var input = Browser.Exists(By.Id("drag_input"));
+            var target = Browser.Exists(By.Id("drop"));
 
-            var output = Browser.FindElement(By.Id("output"));
+            var output = Browser.Exists(By.Id("output"));
             Assert.Equal(string.Empty, output.Text);
 
             var actions = new Actions(Browser).DragAndDrop(input, target);
@@ -190,8 +190,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<InputEventComponent>();
 
-            var input = Browser.FindElement(By.TagName("input"));
-            var output = Browser.FindElement(By.Id("test-result"));
+            var input = Browser.Exists(By.TagName("input"));
+            var output = Browser.Exists(By.Id("test-result"));
 
             Browser.Equal(string.Empty, () => output.Text);
 
@@ -214,8 +214,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             Browser.MountTestComponent<LaggyTypingComponent>();
 
-            var input = Browser.FindElement(By.TagName("input"));
-            var output = Browser.FindElement(By.Id("test-result"));
+            var input = Browser.Exists(By.TagName("input"));
+            var output = Browser.Exists(By.Id("test-result"));
 
             Browser.Equal(string.Empty, () => output.Text);
 
@@ -230,8 +230,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void NonInteractiveElementWithDisabledAttributeDoesRespondToMouseEvents()
         {
             Browser.MountTestComponent<EventDisablingComponent>();
-            var element = Browser.FindElement(By.Id("disabled-div"));
-            var eventLog = Browser.FindElement(By.Id("event-log"));
+            var element = Browser.Exists(By.Id("disabled-div"));
+            var eventLog = Browser.Exists(By.Id("event-log"));
 
             Browser.Equal(string.Empty, () => eventLog.GetAttribute("value"));
             element.Click();
@@ -245,15 +245,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void InteractiveElementWithDisabledAttributeDoesNotRespondToMouseEvents(string elementSelector)
         {
             Browser.MountTestComponent<EventDisablingComponent>();
-            var element = Browser.FindElement(By.CssSelector(elementSelector));
-            var eventLog = Browser.FindElement(By.Id("event-log"));
+            var element = Browser.Exists(By.CssSelector(elementSelector));
+            var eventLog = Browser.Exists(By.Id("event-log"));
 
             Browser.Equal(string.Empty, () => eventLog.GetAttribute("value"));
             element.Click();
 
             // It's no use observing that the log is still empty, since maybe the UI just hasn't updated yet
             // To be sure that the preceding action has no effect, we need to trigger a different action that does have an effect
-            Browser.FindElement(By.Id("enabled-button")).Click();
+            Browser.Exists(By.Id("enabled-button")).Click();
             Browser.Equal("Got event on enabled button", () => eventLog.GetAttribute("value"));
         }
 
@@ -262,8 +262,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<EventDuringBatchRendering>();
 
-            var input = Browser.FindElements(By.CssSelector("#reversible-list input"))[0];
-            var eventLog = Browser.FindElement(By.Id("event-log"));
+            var input = Browser.Exists(By.CssSelector("#reversible-list input"));
+            var eventLog = Browser.Exists(By.Id("event-log"));
 
             SendKeysSequentially(input, "abc");
             Browser.Equal("abc", () => input.GetAttribute("value"));
@@ -278,9 +278,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void EventDuringBatchRendering_CannotTriggerJSInterop()
         {
             Browser.MountTestComponent<EventDuringBatchRendering>();
-            var errorLog = Browser.FindElement(By.Id("web-component-error-log"));
+            var errorLog = Browser.Exists(By.Id("web-component-error-log"));
 
-            Browser.FindElement(By.Id("add-web-component")).Click();
+            Browser.Exists(By.Id("add-web-component")).Click();
             var expectedMessage = _serverFixture.ExecutionMode == ExecutionMode.Client
                 ? "Assertion failed - heap is currently locked"
                 : "There was an exception invoking 'SomeMethodThatDoesntNeedToExistForThisTest' on assembly 'SomeAssembly'";
@@ -292,7 +292,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void RenderAttributesBeforeConnectedCallBack()
         {
             Browser.MountTestComponent<RenderAttributesBeforeConnectedCallback>();
-            var element = Browser.FindElement(By.TagName("custom-web-component-data-from-attribute"));
+            var element = Browser.Exists(By.TagName("custom-web-component-data-from-attribute"));
 
             var expectedContent = "success";
 

--- a/src/Components/test/E2ETest/Tests/GlobalizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/GlobalizationTest.cs
@@ -32,8 +32,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             SetCulture(culture);
 
             // int
-            var input = Browser.FindElement(By.Id("input_type_text_int"));
-            var display = Browser.FindElement(By.Id("input_type_text_int_value"));
+            var input = Browser.Exists(By.Id("input_type_text_int"));
+            var display = Browser.Exists(By.Id("input_type_text_int_value"));
             Browser.Equal(42.ToString(cultureInfo), () => display.Text);
 
             input.Clear();
@@ -42,8 +42,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(9000.ToString(cultureInfo), () => display.Text);
 
             // decimal
-            input = Browser.FindElement(By.Id("input_type_text_decimal"));
-            display = Browser.FindElement(By.Id("input_type_text_decimal_value"));
+            input = Browser.Exists(By.Id("input_type_text_decimal"));
+            display = Browser.Exists(By.Id("input_type_text_decimal_value"));
             Browser.Equal(4.2m.ToString(cultureInfo), () => display.Text);
 
             input.Clear();
@@ -52,8 +52,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(9000.42m.ToString(cultureInfo), () => display.Text);
 
             // datetime
-            input = Browser.FindElement(By.Id("input_type_text_datetime"));
-            display = Browser.FindElement(By.Id("input_type_text_datetime_value"));
+            input = Browser.Exists(By.Id("input_type_text_datetime"));
+            display = Browser.Exists(By.Id("input_type_text_datetime_value"));
             Browser.Equal(new DateTime(1985, 3, 4).ToString(cultureInfo), () => display.Text);
 
             input.ReplaceText(new DateTime(2000, 1, 2).ToString(cultureInfo));
@@ -61,8 +61,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(new DateTime(2000, 1, 2).ToString(cultureInfo), () => display.Text);
 
             // datetimeoffset
-            input = Browser.FindElement(By.Id("input_type_text_datetimeoffset"));
-            display = Browser.FindElement(By.Id("input_type_text_datetimeoffset_value"));
+            input = Browser.Exists(By.Id("input_type_text_datetimeoffset"));
+            display = Browser.Exists(By.Id("input_type_text_datetimeoffset_value"));
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString(cultureInfo), () => display.Text);
 
             input.ReplaceText(new DateTimeOffset(new DateTime(2000, 1, 2)).ToString(cultureInfo));
@@ -96,8 +96,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             SetCulture(culture);
 
             // int
-            var input = Browser.FindElement(By.Id("input_type_number_int"));
-            var display = Browser.FindElement(By.Id("input_type_number_int_value"));
+            var input = Browser.Exists(By.Id("input_type_number_int"));
+            var display = Browser.Exists(By.Id("input_type_number_int_value"));
             Browser.Equal(42.ToString(cultureInfo), () => display.Text);
             Browser.Equal(42.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -108,8 +108,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(9000.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
             // decimal
-            input = Browser.FindElement(By.Id("input_type_number_decimal"));
-            display = Browser.FindElement(By.Id("input_type_number_decimal_value"));
+            input = Browser.Exists(By.Id("input_type_number_decimal"));
+            display = Browser.Exists(By.Id("input_type_number_decimal_value"));
             Browser.Equal(4.2m.ToString(cultureInfo), () => display.Text);
             Browser.Equal(4.2m.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -120,9 +120,9 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(9000.42m.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
             // datetime
-            input = Browser.FindElement(By.Id("input_type_date_datetime"));
-            display = Browser.FindElement(By.Id("input_type_date_datetime_value"));
-            var extraInput = Browser.FindElement(By.Id("input_type_date_datetime_extrainput"));
+            input = Browser.Exists(By.Id("input_type_date_datetime"));
+            display = Browser.Exists(By.Id("input_type_date_datetime_value"));
+            var extraInput = Browser.Exists(By.Id("input_type_date_datetime_extrainput"));
             Browser.Equal(new DateTime(1985, 3, 4).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTime(1985, 3, 4).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -132,9 +132,9 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(new DateTime(2000, 1, 2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
             // datetimeoffset
-            input = Browser.FindElement(By.Id("input_type_date_datetimeoffset"));
-            display = Browser.FindElement(By.Id("input_type_date_datetimeoffset_value"));
-            extraInput = Browser.FindElement(By.Id("input_type_date_datetimeoffset_extrainput"));
+            input = Browser.Exists(By.Id("input_type_date_datetimeoffset"));
+            display = Browser.Exists(By.Id("input_type_date_datetimeoffset_value"));
+            extraInput = Browser.Exists(By.Id("input_type_date_datetimeoffset_extrainput"));
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -153,8 +153,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             SetCulture(culture);
 
             // int
-            var input = Browser.FindElement(By.Id("inputnumber_int"));
-            var display = Browser.FindElement(By.Id("inputnumber_int_value"));
+            var input = Browser.Exists(By.Id("inputnumber_int"));
+            var display = Browser.Exists(By.Id("inputnumber_int_value"));
             Browser.Equal(42.ToString(cultureInfo), () => display.Text);
             Browser.Equal(42.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -165,8 +165,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(9000.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
             // long
-            input = Browser.FindElement(By.Id("inputnumber_long"));
-            display = Browser.FindElement(By.Id("inputnumber_long_value"));
+            input = Browser.Exists(By.Id("inputnumber_long"));
+            display = Browser.Exists(By.Id("inputnumber_long_value"));
             Browser.Equal(4200.ToString(cultureInfo), () => display.Text);
             Browser.Equal(4200.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -177,8 +177,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(90000000000.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
             // short
-            input = Browser.FindElement(By.Id("inputnumber_short"));
-            display = Browser.FindElement(By.Id("inputnumber_short_value"));
+            input = Browser.Exists(By.Id("inputnumber_short"));
+            display = Browser.Exists(By.Id("inputnumber_short_value"));
             Browser.Equal(42.ToString(cultureInfo), () => display.Text);
             Browser.Equal(42.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -189,8 +189,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(127.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
             // decimal
-            input = Browser.FindElement(By.Id("inputnumber_decimal"));
-            display = Browser.FindElement(By.Id("inputnumber_decimal_value"));
+            input = Browser.Exists(By.Id("inputnumber_decimal"));
+            display = Browser.Exists(By.Id("inputnumber_decimal_value"));
             Browser.Equal(4.2m.ToString(cultureInfo), () => display.Text);
             Browser.Equal(4.2m.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -201,9 +201,9 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(9000.42m.ToString(CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
             // datetime
-            input = Browser.FindElement(By.Id("inputdate_datetime"));
-            display = Browser.FindElement(By.Id("inputdate_datetime_value"));
-            var extraInput = Browser.FindElement(By.Id("inputdate_datetime_extrainput"));
+            input = Browser.Exists(By.Id("inputdate_datetime"));
+            display = Browser.Exists(By.Id("inputdate_datetime_value"));
+            var extraInput = Browser.Exists(By.Id("inputdate_datetime_extrainput"));
             Browser.Equal(new DateTime(1985, 3, 4).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTime(1985, 3, 4).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
@@ -213,9 +213,9 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
             Browser.Equal(new DateTime(2000, 1, 2).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 
             // datetimeoffset
-            input = Browser.FindElement(By.Id("inputdate_datetimeoffset"));
-            display = Browser.FindElement(By.Id("inputdate_datetimeoffset_value"));
-            extraInput = Browser.FindElement(By.Id("inputdate_datetimeoffset_extrainput"));
+            input = Browser.Exists(By.Id("inputdate_datetimeoffset"));
+            display = Browser.Exists(By.Id("inputdate_datetimeoffset_value"));
+            extraInput = Browser.Exists(By.Id("inputdate_datetimeoffset_extrainput"));
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString(cultureInfo), () => display.Text);
             Browser.Equal(new DateTimeOffset(new DateTime(1985, 3, 4)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), () => input.GetAttribute("value"));
 

--- a/src/Components/test/E2ETest/Tests/HttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/HttpClientTest.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var targetUri = new Uri(_apiServerFixture.RootUri, relativeUri);
             SetValue("request-uri", targetUri.AbsoluteUri);
             SetValue("request-body", requestBody ?? string.Empty);
-            new SelectElement(Browser.FindElement(By.Id("request-method")))
+            new SelectElement(Browser.Exists(By.Id("request-method")))
                 .SelectByText(requestMethod);
 
             _appElement.FindElement(By.Id("send-request")).Click();
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         private void SetValue(string elementId, string value)
         {
-            var element = Browser.FindElement(By.Id(elementId));
+            var element = Browser.Exists(By.Id(elementId));
             element.Clear();
             element.SendKeys(value);
         }

--- a/src/Components/test/E2ETest/Tests/InputFileTest.cs
+++ b/src/Components/test/E2ETest/Tests/InputFileTest.cs
@@ -45,10 +45,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var file = TempFile.Create(_tempDirectory, "txt", "This file was uploaded to the browser and read from .NET.");
 
             // Upload the file
-            var inputFile = Browser.FindElement(By.Id("input-file"));
+            var inputFile = Browser.Exists(By.Id("input-file"));
             inputFile.SendKeys(file.Path);
 
-            var fileContainer = Browser.FindElement(By.Id($"file-{file.Name}"));
+            var fileContainer = Browser.Exists(By.Id($"file-{file.Name}"));
             var fileNameElement = fileContainer.FindElement(By.Id("file-name"));
             var fileLastModifiedElement = fileContainer.FindElement(By.Id("file-last-modified"));
             var fileSizeElement = fileContainer.FindElement(By.Id("file-size"));
@@ -78,10 +78,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var file = TempFile.Create(_tempDirectory, "txt", contentBuilder.ToString());
 
             // Upload the file
-            var inputFile = Browser.FindElement(By.Id("input-file"));
+            var inputFile = Browser.Exists(By.Id("input-file"));
             inputFile.SendKeys(file.Path);
 
-            var fileContainer = Browser.FindElement(By.Id($"file-{file.Name}"));
+            var fileContainer = Browser.Exists(By.Id($"file-{file.Name}"));
             var fileNameElement = fileContainer.FindElement(By.Id("file-name"));
             var fileLastModifiedElement = fileContainer.FindElement(By.Id("file-last-modified"));
             var fileSizeElement = fileContainer.FindElement(By.Id("file-size"));
@@ -105,13 +105,13 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 .ToList();
 
             // Upload each file
-            var inputFile = Browser.FindElement(By.Id("input-file"));
+            var inputFile = Browser.Exists(By.Id("input-file"));
             inputFile.SendKeys(string.Join("\n", files.Select(f => f.Path)));
 
             // Validate that each file was uploaded correctly
             Assert.All(files, file =>
             {
-                var fileContainer = Browser.FindElement(By.Id($"file-{file.Name}"));
+                var fileContainer = Browser.Exists(By.Id($"file-{file.Name}"));
                 var fileNameElement = fileContainer.FindElement(By.Id("file-name"));
                 var fileLastModifiedElement = fileContainer.FindElement(By.Id("file-last-modified"));
                 var fileSizeElement = fileContainer.FindElement(By.Id("file-size"));
@@ -148,11 +148,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var file = TempFile.Create(_tempDirectory, "png", Convert.FromBase64String(base64));
 
             // Re-upload the image file (it will be converted to a JPEG and scaled to fix 640x480)
-            var inputFile = Browser.FindElement(By.Id("input-image"));
+            var inputFile = Browser.Exists(By.Id("input-image"));
             inputFile.SendKeys(file.Path);
 
             // Validate that the image was converted without error and is the correct size
-            var uploadedImage = Browser.FindElement(By.Id("image-uploaded"));
+            var uploadedImage = Browser.Exists(By.Id("image-uploaded"));
 
             Browser.Equal(480, () => uploadedImage.Size.Width);
             Browser.Equal(480, () => uploadedImage.Size.Height);
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void ThrowsWhenTooManyFilesAreSelected()
         {
-            var maxAllowedFilesElement = Browser.FindElement(By.Id("max-allowed-files"));
+            var maxAllowedFilesElement = Browser.Exists(By.Id("max-allowed-files"));
             maxAllowedFilesElement.Clear();
             maxAllowedFilesElement.SendKeys("1\n");
 
@@ -170,18 +170,18 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var file2 = TempFile.Create(_tempDirectory, "txt", "This is file 2.");
 
             // Select both files
-            var inputFile = Browser.FindElement(By.Id("input-file"));
+            var inputFile = Browser.Exists(By.Id("input-file"));
             inputFile.SendKeys($"{file1.Path}\n{file2.Path}");
 
             // Validate that the proper exception is thrown
-            var exceptionMessage = Browser.FindElement(By.Id("exception-message"));
+            var exceptionMessage = Browser.Exists(By.Id("exception-message"));
             Browser.Equal("The maximum number of files accepted is 1, but 2 were supplied.", () => exceptionMessage.Text);
         }
 
         [Fact]
         public void ThrowsWhenOversizedFileIsSelected()
         {
-            var maxFileSizeElement = Browser.FindElement(By.Id("max-file-size"));
+            var maxFileSizeElement = Browser.Exists(By.Id("max-file-size"));
             maxFileSizeElement.Clear();
             maxFileSizeElement.SendKeys("10\n");
 
@@ -189,11 +189,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var file = TempFile.Create(_tempDirectory, "txt", "This file is over 10 bytes long.");
 
             // Select the file
-            var inputFile = Browser.FindElement(By.Id("input-file"));
+            var inputFile = Browser.Exists(By.Id("input-file"));
             inputFile.SendKeys(file.Path);
 
             // Validate that the proper exception is thrown
-            var exceptionMessage = Browser.FindElement(By.Id("exception-message"));
+            var exceptionMessage = Browser.Exists(By.Id("exception-message"));
             Browser.Equal("Supplied file with size 32 bytes exceeds the maximum of 10 bytes.", () => exceptionMessage.Text);
         }
 

--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -132,14 +132,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var actualValues = new Dictionary<string, string>();
 
             // Act
-            var interopButton = Browser.FindElement(By.Id("btn-interop"));
+            var interopButton = Browser.Exists(By.Id("btn-interop"));
             interopButton.Click();
 
             Browser.Exists(By.Id("done-with-interop"));
 
             foreach (var expectedValue in expectedValues)
             {
-                var currentValue = Browser.FindElement(By.Id(expectedValue.Key));
+                var currentValue = Browser.Exists(By.Id(expectedValue.Key));
                 actualValues.Add(expectedValue.Key, currentValue.Text);
             }
 

--- a/src/Components/test/E2ETest/Tests/JsonSerializationTest.cs
+++ b/src/Components/test/E2ETest/Tests/JsonSerializationTest.cs
@@ -31,9 +31,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void JsonSerializationCasesWork()
         {
-            Browser.Equal("Lord Smythe", () => Browser.FindElement(By.Id("deserialized-name")).Text);
-            Browser.Equal("68", () => Browser.FindElement(By.Id("deserialized-age")).Text);
-            Browser.Equal("Vexed", () => Browser.FindElement(By.Id("deserialized-mood")).Text);
+            Browser.Equal("Lord Smythe", () => Browser.Exists(By.Id("deserialized-name")).Text);
+            Browser.Equal("68", () => Browser.Exists(By.Id("deserialized-age")).Text);
+            Browser.Equal("Vexed", () => Browser.Exists(By.Id("deserialized-mood")).Text);
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -42,10 +42,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // In CI, we only verify that the benchmarks run without throwing any
             // errors. To get actual perf numbers, you must run the E2EPerformance
             // site manually.
-            var verifyOnlyLabel = Browser.FindElement(By.XPath("//label[contains(text(), 'Verify only')]/input"));
+            var verifyOnlyLabel = Browser.Exists(By.XPath("//label[contains(text(), 'Verify only')]/input"));
             verifyOnlyLabel.Click();
 
-            var runAllButton = Browser.FindElement(By.CssSelector("button.btn-success.run-button"));
+            var runAllButton = Browser.Exists(By.CssSelector("button.btn-success.run-button"));
             runAllButton.Click();
 
             // The "run" button goes away while the benchmarks execute, then it comes back

--- a/src/Components/test/E2ETest/Tests/ProtectedBrowserStorageInjectionTest.cs
+++ b/src/Components/test/E2ETest/Tests/ProtectedBrowserStorageInjectionTest.cs
@@ -32,8 +32,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         [Fact]
         public void ThrowsWhenInjectingProtectedLocalStorageIfAndOnlyIfWebAssembly()
         {
-            var messageElement = Browser.FindElement(By.Id("message"));
-            var injectLocalButton = Browser.FindElement(By.Id("inject-local"));
+            var messageElement = Browser.Exists(By.Id("message"));
+            var injectLocalButton = Browser.Exists(By.Id("inject-local"));
 
             Browser.Equal("Waiting for injection...", () => messageElement.Text);
 
@@ -52,8 +52,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         [Fact]
         public void ThrowsWhenInjectingProtectedSessionStorageIfAndOnlyIfWebAssembly()
         {
-            var messageElement = Browser.FindElement(By.Id("message"));
-            var injectSessionButton = Browser.FindElement(By.Id("inject-session"));
+            var messageElement = Browser.Exists(By.Id("message"));
+            var injectSessionButton = Browser.Exists(By.Id("inject-session"));
 
             Browser.Equal("Waiting for injection...", () => messageElement.Text);
 

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             var app = Browser.MountTestComponent<TestRouter>();
             app.FindElement(By.LinkText("Not a component")).Click();
-            Browser.Equal("Not a component!", () => Browser.FindElement(By.Id("test-info")).Text);
+            Browser.Equal("Not a component!", () => Browser.Exists(By.Id("test-info")).Text);
         }
 
         [Fact]
@@ -345,7 +345,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Now follow a link out of the SPA entirely
             app.FindElement(By.LinkText("Not a component")).Click();
-            Browser.Equal("Not a component!", () => Browser.FindElement(By.Id("test-info")).Text);
+            Browser.Equal("Not a component!", () => Browser.Exists(By.Id("test-info")).Text);
             Browser.True(() => Browser.Url.EndsWith("/NotAComponent.html"));
 
             // Now click back

--- a/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
@@ -42,11 +42,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void SignalRClientWorksWithLongPolling()
         {
-            Browser.FindElement(By.Id("hub-url")).SendKeys(
+            Browser.Exists(By.Id("hub-url")).SendKeys(
                 new Uri(_apiServerFixture.RootUri, "/subdir/chathub").AbsoluteUri);
-            var target = new SelectElement(Browser.FindElement(By.Id("transport-type")));
+            var target = new SelectElement(Browser.Exists(By.Id("transport-type")));
             target.SelectByText("LongPolling");
-            Browser.FindElement(By.Id("hub-connect")).Click();
+            Browser.Exists(By.Id("hub-connect")).Click();
 
             Browser.Equal("SignalR Client: Echo LongPolling",
                 () => Browser.FindElements(By.CssSelector("li")).FirstOrDefault()?.Text);
@@ -55,11 +55,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void SignalRClientWorksWithWebSockets()
         {
-            Browser.FindElement(By.Id("hub-url")).SendKeys(
+            Browser.Exists(By.Id("hub-url")).SendKeys(
                 new Uri(_apiServerFixture.RootUri, "/subdir/chathub").AbsoluteUri);
-            var target = new SelectElement(Browser.FindElement(By.Id("transport-type")));
+            var target = new SelectElement(Browser.Exists(By.Id("transport-type")));
             target.SelectByText("WebSockets");
-            Browser.FindElement(By.Id("hub-connect")).Click();
+            Browser.Exists(By.Id("hub-connect")).Click();
 
             Browser.Equal("SignalR Client: Echo WebSockets",
                 () => Browser.FindElements(By.CssSelector("li")).FirstOrDefault()?.Text);

--- a/src/Components/test/E2ETest/Tests/StandaloneAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/StandaloneAppTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void HasHeading()
         {
-            Assert.Equal("Hello, world!", Browser.FindElement(By.TagName("h1")).Text);
+            Assert.Equal("Hello, world!", Browser.Exists(By.TagName("h1")).Text);
         }
 
         [Fact]
@@ -49,21 +49,21 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var mainHeaderSelector = By.TagName("h1");
 
             // Verify we start at home, with the home link highlighted
-            Assert.Equal("Hello, world!", Browser.FindElement(mainHeaderSelector).Text);
+            Assert.Equal("Hello, world!", Browser.Exists(mainHeaderSelector).Text);
             Assert.Collection(Browser.FindElements(activeNavLinksSelector),
                 item => Assert.Equal("Home", item.Text.Trim()));
 
             // Click on the "counter" link
-            Browser.FindElement(By.LinkText("Counter")).Click();
+            Browser.Exists(By.LinkText("Counter")).Click();
 
             // Verify we're now on the counter page, with that nav link (only) highlighted
-            Assert.Equal("Counter", Browser.FindElement(mainHeaderSelector).Text);
+            Assert.Equal("Counter", Browser.Exists(mainHeaderSelector).Text);
             Assert.Collection(Browser.FindElements(activeNavLinksSelector),
                 item => Assert.Equal("Counter", item.Text.Trim()));
 
             // Verify we can navigate back to home too
-            Browser.FindElement(By.LinkText("Home")).Click();
-            Assert.Equal("Hello, world!", Browser.FindElement(mainHeaderSelector).Text);
+            Browser.Exists(By.LinkText("Home")).Click();
+            Assert.Equal("Hello, world!", Browser.Exists(mainHeaderSelector).Text);
             Assert.Collection(Browser.FindElements(activeNavLinksSelector),
                 item => Assert.Equal("Home", item.Text.Trim()));
         }
@@ -72,15 +72,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void HasCounterPage()
         {
             // Navigate to "Counter"
-            Browser.FindElement(By.LinkText("Counter")).Click();
-            Assert.Equal("Counter", Browser.FindElement(By.TagName("h1")).Text);
+            Browser.Exists(By.LinkText("Counter")).Click();
+            Assert.Equal("Counter", Browser.Exists(By.TagName("h1")).Text);
 
             // Observe the initial value is zero
-            var countDisplayElement = Browser.FindElement(By.CssSelector("h1 + p"));
+            var countDisplayElement = Browser.Exists(By.CssSelector("h1 + p"));
             Assert.Equal("Current count: 0", countDisplayElement.Text);
 
             // Click the button; see it counts
-            var button = Browser.FindElement(By.CssSelector(".main button"));
+            var button = Browser.Exists(By.CssSelector(".main button"));
             button.Click();
             button.Click();
             button.Click();
@@ -91,8 +91,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void HasFetchDataPage()
         {
             // Navigate to "Fetch data"
-            Browser.FindElement(By.LinkText("Fetch data")).Click();
-            Assert.Equal("Weather forecast", Browser.FindElement(By.TagName("h1")).Text);
+            Browser.Exists(By.LinkText("Fetch data")).Click();
+            Assert.Equal("Weather forecast", Browser.Exists(By.TagName("h1")).Text);
 
             // Wait until loaded
             var tableSelector = By.CssSelector("table.table");
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             // Make the tests run faster by navigating back to the home page when we are done
             // If we don't, then the next test will reload the whole page before it starts
-            Browser.FindElement(By.LinkText("Home")).Click();
+            Browser.Exists(By.LinkText("Home")).Click();
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void AlwaysFillsVisibleCapacity_Sync()
         {
             Browser.MountTestComponent<VirtualizationComponent>();
-            var topSpacer = Browser.FindElement(By.Id("sync-container")).FindElement(By.TagName("div"));
+            var topSpacer = Browser.Exists(By.Id("sync-container")).FindElement(By.TagName("div"));
             var expectedInitialSpacerStyle = "height: 0px;";
 
             int initialItemCount = 0;
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void AlwaysFillsVisibleCapacity_Async()
         {
             Browser.MountTestComponent<VirtualizationComponent>();
-            var finishLoadingButton = Browser.FindElement(By.Id("finish-loading-button"));
+            var finishLoadingButton = Browser.Exists(By.Id("finish-loading-button"));
 
             // Check that no items or placeholders are visible.
             // No data fetches have happened so we don't know how many items there are.
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // Wait until items have been rendered.
             Browser.True(() => (initialItemCount = GetItemCount()) > 0);
 
-            var itemSizeInput = Browser.FindElement(By.Id("item-size-input"));
+            var itemSizeInput = Browser.Exists(By.Id("item-size-input"));
 
             // Change the item size.
             itemSizeInput.SendKeys("\b\b\b10\n");
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void RerendersWhenItemSizeShrinks_Async()
         {
             Browser.MountTestComponent<VirtualizationComponent>();
-            var finishLoadingButton = Browser.FindElement(By.Id("finish-loading-button"));
+            var finishLoadingButton = Browser.Exists(By.Id("finish-loading-button"));
 
             // Load the initial set of items.
             finishLoadingButton.Click();
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.True(() => (initialItemCount = GetItemCount()) > 0);
             Browser.Equal(0, GetPlaceholderCount);
 
-            var itemSizeInput = Browser.FindElement(By.Id("item-size-input"));
+            var itemSizeInput = Browser.Exists(By.Id("item-size-input"));
 
             // Change the item size.
             itemSizeInput.SendKeys("\b\b\b10\n");
@@ -170,8 +170,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void CancelsOutdatedRefreshes_Async()
         {
             Browser.MountTestComponent<VirtualizationComponent>();
-            var cancellationCount = Browser.FindElement(By.Id("cancellation-count"));
-            var finishLoadingButton = Browser.FindElement(By.Id("finish-loading-button"));
+            var cancellationCount = Browser.Exists(By.Id("cancellation-count"));
+            var finishLoadingButton = Browser.Exists(By.Id("finish-loading-button"));
 
             // Load the initial set of items.
             finishLoadingButton.Click();
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.MountTestComponent<VirtualizationComponent>();
             var expectedInitialSpacerStyle = "height: 0px;";
-            var topSpacer = Browser.FindElement(By.Id("viewport-as-root")).FindElement(By.TagName("div"));
+            var topSpacer = Browser.Exists(By.Id("viewport-as-root")).FindElement(By.TagName("div"));
 
             Browser.ExecuteJavaScript("const element = document.getElementById('viewport-as-root'); element.scrollIntoView();");
 
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.MountTestComponent<VirtualizationDataChanges>();
 
             // Initial data
-            var container = Browser.FindElement(By.Id("using-items"));
+            var container = Browser.Exists(By.Id("using-items"));
             Browser.Collection(() => GetPeopleNames(container),
                 name => Assert.Equal("Person 1", name),
                 name => Assert.Equal("Person 2", name),
@@ -240,7 +240,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.MountTestComponent<VirtualizationDataChanges>();
 
             // Initial data
-            var container = Browser.FindElement(By.Id("using-itemsprovider"));
+            var container = Browser.Exists(By.Id("using-itemsprovider"));
             Browser.Collection(() => GetPeopleNames(container),
                 name => Assert.Equal("Person 1", name),
                 name => Assert.Equal("Person 2", name),
@@ -263,14 +263,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.MountTestComponent<VirtualizationDataChanges>();
 
             // Initial data
-            var container = Browser.FindElement(By.Id("using-items"));
+            var container = Browser.Exists(By.Id("using-items"));
             Browser.Collection(() => GetPeopleNames(container),
                 name => Assert.Equal("Person 1", name),
                 name => Assert.Equal("Person 2", name),
                 name => Assert.Equal("Person 3", name));
 
             // Add another item
-            Browser.FindElement(By.Id("add-person-to-fixed-list")).Click();
+            Browser.Exists(By.Id("add-person-to-fixed-list")).Click();
 
             // See changes
             Browser.Collection(() => GetPeopleNames(container),
@@ -286,14 +286,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.MountTestComponent<VirtualizationDataChanges>();
 
             // Initial data
-            var container = Browser.FindElement(By.Id("using-itemsprovider"));
+            var container = Browser.Exists(By.Id("using-itemsprovider"));
             Browser.Collection(() => GetPeopleNames(container),
                 name => Assert.Equal("Person 1", name),
                 name => Assert.Equal("Person 2", name),
                 name => Assert.Equal("Person 3", name));
 
             // Add another item
-            Browser.FindElement(By.Id("add-person-to-itemsprovider")).Click();
+            Browser.Exists(By.Id("add-person-to-itemsprovider")).Click();
 
             // Initially this has no effect because we don't re-query the provider until told to do so
             Browser.Collection(() => GetPeopleNames(container),
@@ -302,7 +302,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 name => Assert.Equal("Person 3", name));
 
             // Request refresh
-            Browser.FindElement(By.Id("refresh-itemsprovider")).Click();
+            Browser.Exists(By.Id("refresh-itemsprovider")).Click();
 
             // See changes
             Browser.Collection(() => GetPeopleNames(container),
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.MountTestComponent<VirtualizationDataChanges>();
 
             // Mutate the data
-            var container = Browser.FindElement(By.Id("using-itemsprovider"));
+            var container = Browser.Exists(By.Id("using-itemsprovider"));
             var itemToMutate = container.FindElements(By.ClassName("person"))[1];
             itemToMutate.FindElement(By.TagName("button")).Click();
 
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 name => Assert.Equal("Person 3", name));
 
             // Refresh and verify the mutation was reverted
-            Browser.FindElement(By.Id("refresh-itemsprovider")).Click();
+            Browser.Exists(By.Id("refresh-itemsprovider")).Click();
             Browser.Collection(() => GetPeopleNames(container),
                 name => Assert.Equal("Person 1", name),
                 name => Assert.Equal("Person 2", name),

--- a/src/Components/test/E2ETest/Tests/WebAssemblyAuthenticationTests.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyAuthenticationTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         private void ClickAndNavigate(By link, string page)
         {
-            Browser.FindElement(link).Click();
+            Browser.Exists(link).Click();
             Browser.Contains(page, () => Browser.Url);
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             CompleteProfileDetails();
 
             // Need to navigate to fetch page
-            Browser.FindElement(By.PartialLinkText("Fetch data")).Click();
+            Browser.Exists(By.PartialLinkText("Fetch data")).Click();
 
             // Can navigate to the 'fetch data' page
             ValidateFetchData();
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             FirstTimeRegister(userName, password);
 
             Browser.Contains("user", () => Browser.Url);
-            Browser.Equal($"Welcome {userName}", () => Browser.FindElement(By.TagName("h1")).Text);
+            Browser.Equal($"Welcome {userName}", () => Browser.Exists(By.TagName("h1")).Text);
 
             var claims = Browser.FindElements(By.CssSelector("p.claim"))
                 .Select(e =>
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void RegisterAndBack_DoesNotCause_RedirectLoop()
         {
-            Browser.FindElement(By.PartialLinkText("Register")).Click();
+            Browser.Exists(By.PartialLinkText("Register")).Click();
 
             // We will be redirected to the identity UI
             Browser.Contains("/Identity/Account/Register", () => Browser.Url);
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact]
         public void LoginAndBack_DoesNotCause_RedirectLoop()
         {
-            Browser.FindElement(By.PartialLinkText("Log in")).Click();
+            Browser.Exists(By.PartialLinkText("Log in")).Click();
 
             // We will be redirected to the identity UI
             Browser.Contains("/Identity/Account/Login", () => Browser.Url);
@@ -333,11 +333,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         private void LoginCore(string userName, string password)
         {
-            Browser.FindElement(By.PartialLinkText("Login")).Click();
+            Browser.Exists(By.PartialLinkText("Login")).Click();
             Browser.Exists(By.Name("Input.Email"));
-            Browser.FindElement(By.Name("Input.Email")).SendKeys(userName);
-            Browser.FindElement(By.Name("Input.Password")).SendKeys(password);
-            Browser.FindElement(By.Id("login-submit")).Click();
+            Browser.Exists(By.Name("Input.Email")).SendKeys(userName);
+            Browser.Exists(By.Name("Input.Password")).SendKeys(password);
+            Browser.Exists(By.Id("login-submit")).Click();
         }
 
         private void ValidateLogout()
@@ -345,7 +345,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Exists(By.CssSelector("button.nav-link.btn.btn-link"));
 
             // Click logout button
-            Browser.FindElement(By.CssSelector("button.nav-link.btn.btn-link")).Click();
+            Browser.Exists(By.CssSelector("button.nav-link.btn.btn-link")).Click();
 
             Browser.Contains("/authentication/logged-out", () => Browser.Url);
             Browser.True(() => Browser.FindElements(By.TagName("p")).Any(e => e.Text == "You are logged out."));
@@ -355,7 +355,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             // Can navigate to the 'fetch data' page
             Browser.Contains("fetchdata", () => Browser.Url);
-            Browser.Equal("Weather forecast", () => Browser.FindElement(By.TagName("h1")).Text);
+            Browser.Equal("Weather forecast", () => Browser.Exists(By.TagName("h1")).Text);
 
             // Asynchronously loads and displays the table of weather forecasts
             Browser.Exists(By.CssSelector("table>tbody>tr"));
@@ -364,7 +364,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
         private void FirstTimeRegister(string userName, string password)
         {
-            Browser.FindElement(By.PartialLinkText("Register as a new user")).Click();
+            Browser.Exists(By.PartialLinkText("Register as a new user")).Click();
             RegisterCore(userName, password);
             CompleteProfileDetails();
         }
@@ -373,17 +373,17 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             Browser.Exists(By.PartialLinkText("Home"));
             Browser.Contains("/preferences", () => Browser.Url);
-            Browser.FindElement(By.Id("color-preference")).SendKeys("Red");
-            Browser.FindElement(By.Id("submit-preference")).Click();
+            Browser.Exists(By.Id("color-preference")).SendKeys("Red");
+            Browser.Exists(By.Id("submit-preference")).Click();
         }
 
         private void RegisterCore(string userName, string password)
         {
             Browser.Exists(By.Name("Input.Email"));
-            Browser.FindElement(By.Name("Input.Email")).SendKeys(userName);
-            Browser.FindElement(By.Name("Input.Password")).SendKeys(password);
-            Browser.FindElement(By.Name("Input.ConfirmPassword")).SendKeys(password);
-            Browser.FindElement(By.Id("registerSubmit")).Click();
+            Browser.Exists(By.Name("Input.Email")).SendKeys(userName);
+            Browser.Exists(By.Name("Input.Password")).SendKeys(password);
+            Browser.Exists(By.Name("Input.ConfirmPassword")).SendKeys(password);
+            Browser.Exists(By.Id("registerSubmit")).Click();
 
             // We will be redirected to the RegisterConfirmation
             Browser.Contains("/Identity/Account/RegisterConfirmation", () => Browser.Url);
@@ -399,17 +399,17 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             }
 
             // Now we can login
-            Browser.FindElement(By.PartialLinkText("Login")).Click();
+            Browser.Exists(By.PartialLinkText("Login")).Click();
             Browser.Exists(By.Name("Input.Email"));
-            Browser.FindElement(By.Name("Input.Email")).SendKeys(userName);
-            Browser.FindElement(By.Name("Input.Password")).SendKeys(password);
-            Browser.FindElement(By.Id("login-submit")).Click();
+            Browser.Exists(By.Name("Input.Email")).SendKeys(userName);
+            Browser.Exists(By.Name("Input.Password")).SendKeys(password);
+            Browser.Exists(By.Id("login-submit")).Click();
         }
 
         private void WaitUntilLoaded(bool skipHeader = false)
         {
             Browser.Exists(By.TagName("app"));
-            Browser.True(() => Browser.FindElement(By.TagName("app")).Text != "Loading...");
+            Browser.True(() => Browser.Exists(By.TagName("app")).Text != "Loading...");
 
             if (!skipHeader)
             {

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLazyLoadTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLazyLoadTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.MountTestComponent<TestRouterWithLazyAssembly>();
             Browser.Exists(By.Id("blazor-error-ui"));
 
-            var errorUi = Browser.FindElement(By.Id("blazor-error-ui"));
+            var errorUi = Browser.Exists(By.Id("blazor-error-ui"));
             Assert.Equal("none", errorUi.GetCssValue("display"));
         }
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLocalizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLocalizationTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var cultureDisplay = Browser.Exists(By.Id("culture-name-display"));
             Assert.Equal($"Culture is: {culture}", cultureDisplay.Text);
 
-            var messageDisplay = Browser.FindElement(By.Id("message-display"));
+            var messageDisplay = Browser.Exists(By.Id("message-display"));
             Assert.Equal(message, messageDisplay.Text);
         }
     }

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLoggingTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLoggingTest.cs
@@ -28,14 +28,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.MountTestComponent<ErrorComponent>();
             Browser.Exists(By.Id("blazor-error-ui"));
 
-            var errorUi = Browser.FindElement(By.Id("blazor-error-ui"));
+            var errorUi = Browser.Exists(By.Id("blazor-error-ui"));
             Assert.Equal("none", errorUi.GetCssValue("display"));
         }
 
         [Fact(Skip = "Browser logs cannot be retrieved: https://github.com/dotnet/aspnetcore/issues/25803")]
         public void LogsSimpleExceptionsUsingLogger()
         {
-            Browser.FindElement(By.Id("throw-simple-exception")).Click();
+            Browser.Exists(By.Id("throw-simple-exception")).Click();
             Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"), TimeSpan.FromSeconds(10));
             AssertLogContainsCriticalMessages(
                 "crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]",
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact(Skip = "Browser logs cannot be retrieved: https://github.com/dotnet/aspnetcore/issues/25803")]
         public void LogsInnerExceptionsUsingLogger()
         {
-            Browser.FindElement(By.Id("throw-inner-exception")).Click();
+            Browser.Exists(By.Id("throw-inner-exception")).Click();
             Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"), TimeSpan.FromSeconds(10));
             AssertLogContainsCriticalMessages(
                 "crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]",
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [Fact(Skip = "Browser logs cannot be retrieved: https://github.com/dotnet/aspnetcore/issues/25803")]
         public void LogsAggregateExceptionsUsingLogger()
         {
-            Browser.FindElement(By.Id("throw-aggregate-exception")).Click();
+            Browser.Exists(By.Id("throw-aggregate-exception")).Click();
             Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"), TimeSpan.FromSeconds(10));
             AssertLogContainsCriticalMessages(
                 "crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]",
@@ -83,27 +83,27 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // None of these severity levels are displayed by default, so at the end
             // we'll continue to see "Test log message" as the most recent output
-            Browser.FindElement(By.Id("log-none")).Click();
-            Browser.FindElement(By.Id("log-trace")).Click();
-            Browser.FindElement(By.Id("log-debug")).Click();
-            Browser.FindElement(By.Id("log-information")).Click();
+            Browser.Exists(By.Id("log-none")).Click();
+            Browser.Exists(By.Id("log-trace")).Click();
+            Browser.Exists(By.Id("log-debug")).Click();
+            Browser.Exists(By.Id("log-information")).Click();
             // The Warning minimum log-level is only set on the PrependMessage
             // logger so the last info log will be processed by the default
             // logger but not the PrependMessage one.
             AssertLastLogMessage(LogLevel.Info, "info: BasicTestApp.ErrorComponent[0]");
 
             // These severity levels are displayed
-            Browser.FindElement(By.Id("log-warning")).Click();
+            Browser.Exists(By.Id("log-warning")).Click();
             AssertLastLogMessage(LogLevel.Warning, "[Custom logger] This is a Warning message with count=5");
-            Browser.FindElement(By.Id("log-error")).Click();
+            Browser.Exists(By.Id("log-error")).Click();
             AssertLastLogMessage(LogLevel.Severe, "[Custom logger] This is a Error message with count=6");
 
             // All the preceding levels don't cause the error UI to appear
-            var errorUi = Browser.FindElement(By.Id("blazor-error-ui"));
+            var errorUi = Browser.Exists(By.Id("blazor-error-ui"));
             Assert.Equal("none", errorUi.GetCssValue("display"));
 
             // ... but "Critical" level does
-            Browser.FindElement(By.Id("log-critical")).Click();
+            Browser.Exists(By.Id("log-critical")).Click();
             AssertLastLogMessage(LogLevel.Severe, "[Custom logger] This is a Critical message with count=7");
             Assert.Equal("block", errorUi.GetCssValue("display"));
         }


### PR DESCRIPTION
Using Browser.Exists is equivalent to Browser.FindElement except it provides better logs
and diagnostics when the assertion fails. The additional waits will also rule out
failures due to the browser taking time to update possibly improving stability.

I looked at the implementation of WebDriverWait to verify that using it will not
introduce additional delays to our tests.
