### PR TITLE
Use ClaimTypes instead of IdentityOptions.ClaimsIdentity in SignInManager

### DIFF
--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -667,7 +667,7 @@ namespace Microsoft.AspNetCore.Identity
                 }
             }
 
-            var providerKey = auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier);
+            var providerKey = auth.Principal.FindFirstValue(Options.ClaimsIdentity.UserIdClaimType);
             var provider = items[LoginProviderKey] as string;
             if (providerKey == null || provider == null)
             {


### PR DESCRIPTION
Used Options.ClaimsIdentity.UserIdClaimType instead of ClaimTypes.NameIdentifier

Addresses #26279
