### PR TITLE
[SignalR] Copy cookies from negotiate to WebSockets (#24572)

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1514,6 +1514,34 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             }
         }
 
+        [ConditionalFact]
+        [WebSocketsSupportedCondition]
+        public async Task CookiesFromNegotiateAreAppliedToWebSockets()
+        {
+            using (StartServer<Startup>(out var server))
+            {
+                var hubConnection = new HubConnectionBuilder()
+                    .WithLoggerFactory(LoggerFactory)
+                    .WithUrl(server.Url + "/default", HttpTransportType.WebSockets)
+                    .Build();
+                try
+                {
+                    await hubConnection.StartAsync().OrTimeout();
+                    var cookieValue = await hubConnection.InvokeAsync<string>(nameof(TestHub.GetCookieValue), "fromNegotiate").OrTimeout();
+                    Assert.Equal("a value", cookieValue);
+                }
+                catch (Exception ex)
+                {
+                    LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                    throw;
+                }
+                finally
+                {
+                    await hubConnection.DisposeAsync().OrTimeout();
+                }
+            }
+        }
+
         [Fact(Skip = "Returning object from Hub method not support by System.Text.Json yet")]
         public async Task CheckHttpConnectionFeatures()
         {

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
@@ -58,6 +58,18 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests
             app.UseAuthentication();
             app.UseAuthorization();
 
+            app.Use(next =>
+            {
+                return context =>
+                {
+                    if (context.Request.Path.Value.EndsWith("/negotiate"))
+                    {
+                        context.Response.Cookies.Append("fromNegotiate", "a value");
+                    }
+                    return next(context);
+                };
+            });
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapHub<TestHub>("/default");

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.Log.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.Log.cs
@@ -69,6 +69,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             private static readonly Action<ILogger, Exception> _serverSentEventsNotSupportedByBrowser =
                 LoggerMessage.Define(LogLevel.Debug, new EventId(19, "ServerSentEventsNotSupportedByBrowser"), "Skipping ServerSentEvents because they are not supported by the browser.");
 
+            private static readonly Action<ILogger, Exception> _cookiesNotSupported =
+                LoggerMessage.Define(LogLevel.Trace, new EventId(20, "CookiesNotSupported"), "Cookies are not supported on this platform.");
+
             public static void Starting(ILogger logger)
             {
                 _starting(logger, null);
@@ -174,6 +177,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
             public static void ServerSentEventsNotSupportedByBrowser(ILogger logger)
             {
                 _serverSentEventsNotSupportedByBrowser(logger, null);
+            }
+
+            public static void CookiesNotSupported(ILogger logger)
+            {
+                _cookiesNotSupported(logger, null);
             }
         }
     }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -153,7 +153,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
 
             _isRunningInBrowser = Utils.IsRunningInBrowser();
 
-
             if (httpConnectionOptions.Transports == HttpTransportType.ServerSentEvents && _isRunningInBrowser)
             {
                 throw new ArgumentException("ServerSentEvents can not be the only transport specified when running in the browser.", nameof(httpConnectionOptions));
@@ -534,13 +533,21 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                     httpClientHandler.Proxy = _httpConnectionOptions.Proxy;
                 }
 
-                // Only access HttpClientHandler.ClientCertificates and HttpClientHandler.CookieContainer
-                // if the user has configured those options
-                // Some variants of Mono do not support client certs or cookies and will throw NotImplementedException
-                if (_httpConnectionOptions.Cookies.Count > 0)
+                try
                 {
+                    // On supported platforms, we need to pass the cookie container to the http client
+                    // so that we can capture any cookies from the negotiate response and give them to WebSockets.
                     httpClientHandler.CookieContainer = _httpConnectionOptions.Cookies;
                 }
+                // Some variants of Mono do not support client certs or cookies and will throw NotImplementedException or NotSupportedException
+                // Also WASM doesn't support some settings in the browser
+                catch (Exception ex) when (ex is NotSupportedException || ex is NotImplementedException)
+                {
+                    Log.CookiesNotSupported(_logger);
+                }
+
+                // Only access HttpClientHandler.ClientCertificates
+                // if the user has configured those options
                 // https://github.com/aspnet/SignalR/issues/2232
                 var clientCertificates = _httpConnectionOptions.ClientCertificates;
                 if (clientCertificates?.Count > 0)


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/24572

#### Description

When using a loadbalancer with sticky sessions via cookies enabled the .NET client will not properly propagate cookies from the initial negotiate to the WebSocket connection which can result in random 404's when connecting to the server.

#### Customer Impact

Bug was reported by a customer at https://github.com/dotnet/aspnetcore/issues/23679 and multiple others have chimed in. On the PR and issue.

There is a possible workaround (https://github.com/dotnet/aspnetcore/discussions/23350#discussioncomment-31578), but it is very un-obvious and ugly, it also results in an extra network call that shouldn't be needed.

#### Regression?

No, looks like this has always been there.

#### Risk

Low
