### PR TITLE
Add an option to allow 404 responses from ExceptionHandlers

### DIFF
--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Diagnostics
 
                 await _options.ExceptionHandler(context);
 
-                if (context.Response.StatusCode != StatusCodes.Status404NotFound)
+                if (context.Response.StatusCode != StatusCodes.Status404NotFound || _options.AllowStatusCode404Response)
                 {
                     if (_diagnosticListener.IsEnabled() && _diagnosticListener.IsEnabled("Microsoft.AspNetCore.Diagnostics.HandledException"))
                     {

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerOptions.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerOptions.cs
@@ -22,5 +22,14 @@ namespace Microsoft.AspNetCore.Builder
         /// explicitly provided, the subsequent middleware pipeline will be used by default.
         /// </summary>
         public RequestDelegate ExceptionHandler { get; set; }
+
+        /// <summary>
+        /// This value controls whether the <see cref="ExceptionHandlerMiddleware" /> should
+        /// consider a response with a 404 status code to be a valid result of executing the
+        /// <see cref="ExceptionHandler"/>. The default value is false and the middleware will
+        /// consider 404 status codes to be an error on the server and will therefore rethrow
+        /// the original exception.
+        /// </summary>
+        public bool AllowStatusCode404Response { get; set; }
     }
 }

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -542,5 +542,59 @@ namespace Microsoft.AspNetCore.Diagnostics
                 && w.EventId == 4
                 && w.Message == "No exception handler was found, rethrowing original exception.");
         }
+
+        [Fact]
+        public async Task ExceptionHandler_CanReturn404Responses_WhenAllowed()
+        {
+            var sink = new TestSink(TestSink.EnableWithTypeName<ExceptionHandlerMiddleware>);
+            var loggerFactory = new TestLoggerFactory(sink, enabled: true);
+
+            using var host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddSingleton<ILoggerFactory>(loggerFactory);
+                        services.Configure<ExceptionHandlerOptions>(options =>
+                        {
+                            options.AllowStatusCode404Response = true;
+                            options.ExceptionHandler = httpContext =>
+                            {
+                                httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                                return Task.CompletedTask;
+                            };
+                        });
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseExceptionHandler();
+
+                        app.Map("/throw", (innerAppBuilder) =>
+                        {
+                            innerAppBuilder.Run(httpContext =>
+                            {
+                                throw new InvalidOperationException("Something bad happened.");
+                            });
+                        });
+                    });
+                }).Build();
+
+            await host.StartAsync();
+
+            using (var server = host.GetTestServer())
+            {
+                var client = server.CreateClient();
+                var response = await client.GetAsync("throw");
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+                Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
+            }
+
+            Assert.DoesNotContain(sink.Writes, w =>
+                w.LogLevel == LogLevel.Warning
+                && w.EventId == 4
+                && w.Message == "No exception handler was found, rethrowing original exception.");
+        }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/26528

#### Description

We addressed the issue https://github.com/dotnet/aspnetcore/issues/21510 in RC1 but introduced a breaking change in the default behaviour of the middleware. Specifically, we decided that a 404 response from the exception handler should be considered an error in the server and we will rethrow the original exception instead of returning the 404 response. This is to address a common pitfall where the exception handler middleware was misconfigured with a non-existent path. 

However, the change in default behaviour regressed use cases where the exception handler intentionally produces a 404 response as mentioned in https://github.com/dotnet/aspnetcore/issues/26528. This PR introduces a fix where we add an option on the middleware to allow such responses. When enabled, this option considers 404 responses produced by the exception handler to be valid and will not rethrow the original exception.

#### Customer Impact

This issue was reported by @danikun in https://github.com/dotnet/aspnetcore/issues/26528. The breaking change introduced in 5.0 RC1 regressed the customer's exception handling logic which maps some exceptions to 404s. There is no acceptable workaround. We considered alternatives such as invoking CompleteAsync in the exception handler to flush the 404 response but this won't work in all environments; for example, unit testing using TestServer would not work since it doesn't implement CompleteAsync as discussed in https://github.com/dotnet/aspnetcore/issues/25288#issuecomment-702421024.

#### Regression?

Yes this is a regression that was introduced in https://github.com/dotnet/aspnetcore/pull/25062 in 5.0 RC1

#### Risk

Low. The solution is limited to this middleware and an unit test is added to verify its correctness.