### PR TITLE
Cast ByteBuffer to Buffer before calling position(int)

### DIFF
--- a/src/SignalR/clients/java/signalr/messagepack/src/main/java/com/microsoft/signalr/messagepack/MessagePackHubProtocol.java
+++ b/src/SignalR/clients/java/signalr/messagepack/src/main/java/com/microsoft/signalr/messagepack/MessagePackHubProtocol.java
@@ -5,6 +5,7 @@ package com.microsoft.signalr.messagepack;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -121,13 +122,13 @@ public class MessagePackHubProtocol implements HubProtocol {
                     // Check what the last message was
                     // If it was an invocation binding failure, we have to correct the position of the buffer
                     if (hubMessages.get(hubMessages.size() - 1).getMessageType() == HubMessageType.INVOCATION_BINDING_FAILURE) {
-                        payload.position(payload.position() + (length - readBytes));
+                        ((Buffer) payload).position(payload.position() + (length - readBytes));
                     } else {
                         throw new RuntimeException(String.format("MessagePack message was length %d but claimed to be length %d.", readBytes, length));
                     }
                 }
                 unpacker.close();
-                payload.position(payload.position() + readBytes);
+                ((Buffer) payload).position(payload.position() + readBytes);
             } catch (MessagePackException | IOException ex) {
                 throw new RuntimeException("Error reading MessagePack data.", ex);
             }

--- a/src/SignalR/clients/java/signalr/messagepack/src/main/java/com/microsoft/signalr/messagepack/MessagePackHubProtocol.java
+++ b/src/SignalR/clients/java/signalr/messagepack/src/main/java/com/microsoft/signalr/messagepack/MessagePackHubProtocol.java
@@ -122,12 +122,16 @@ public class MessagePackHubProtocol implements HubProtocol {
                     // Check what the last message was
                     // If it was an invocation binding failure, we have to correct the position of the buffer
                     if (hubMessages.get(hubMessages.size() - 1).getMessageType() == HubMessageType.INVOCATION_BINDING_FAILURE) {
+                        // Cast to a Buffer to avoid the Java 9+ behavior where ByteBuffer.position(int) overrides Buffer.position(int),
+                        // Returning a ByteBuffer rather than a Buffer. This causes issues on Android - see https://github.com/dotnet/aspnetcore/pull/26614
                         ((Buffer) payload).position(payload.position() + (length - readBytes));
                     } else {
                         throw new RuntimeException(String.format("MessagePack message was length %d but claimed to be length %d.", readBytes, length));
                     }
                 }
                 unpacker.close();
+                // Cast to a Buffer to avoid the Java 9+ behavior where ByteBuffer.position(int) overrides Buffer.position(int),
+                // Returning a ByteBuffer rather than a Buffer. This causes issues on Android - see https://github.com/dotnet/aspnetcore/pull/26614
                 ((Buffer) payload).position(payload.position() + readBytes);
             } catch (MessagePackException | IOException ex) {
                 throw new RuntimeException("Error reading MessagePack data.", ex);


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspnetcore/issues/26552

#### Description

In Java 11, `ByteBuffer.position(int)` is overridden to return a ByteBuffer rather than a Buffer, which causes errors on Android that look like: 
> java.lang.NoSuchMethodError: No virtual method position(I)Ljava/nio/ByteBuffer; in class Ljava/nio/ByteBuffer; or its super classes (declaration of 'java.nio.ByteBuffer' appears in /system/framework/core-oj.jar)

The workaround is to cast to `Buffer` before calling `position(int)` so that we get the implementation from the superclass `Buffer`, which returns a `Buffer` as it does in Java 7/8. Thanks to @aaronoe for reporting this. I sent him a local build with this change, and he confirmed that it works on Android 9 & below.

#### Customer Impact

Allows the Your Phone team to continue working to adopt the Java SignalR client.

#### Regression?

No, this bug existed in our initial implementation of the MessagePack protocol.

#### Risk

Low, our test suite still passes and the Your Phone team confirmed that the fix worked for them. Behavior should remain as intended.