### PR TITLE
Reenable e2e template tests

### DIFF
--- a/src/Shared/E2ETesting/E2ETesting.props
+++ b/src/Shared/E2ETesting/E2ETesting.props
@@ -21,9 +21,6 @@
 
     <!-- WebDriver is not strong-named, so this test project cannot be strong named either. -->
     <SignAssembly>false</SignAssembly>
-  
-    <!-- Tests are disabled due to https://github.com/dotnet/aspnetcore/issues/25322 -->
-    <SkipTests>true</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These were disabled/reenabled in 3.1 but the changes to reenable never flowed back to master