### PR TITLE
Fix path data in FrameworkList.xml

### DIFF
--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -106,7 +106,7 @@ namespace RunTests
                             // These are the only extensions that end up in the shared fx directory
                             if (entry.Name.EndsWith(".txt", StringComparison.OrdinalIgnoreCase) ||
                                 entry.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ||
-                                entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) ||
+                                entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ||
                                 entry.Name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
                             {
                                 entry.ExtractToFile(Path.Combine(appRuntimePath, entry.Name), overwrite: true);

--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -98,7 +98,7 @@ namespace RunTests
                     Directory.CreateDirectory(appRuntimePath);
                     Console.WriteLine($"Set ASPNET_RUNTIME_PATH: {appRuntimePath}");
                     EnvironmentVariables.Add("ASPNET_RUNTIME_PATH", appRuntimePath);
-                    Console.WriteLine($"Found AspNetRuntime: {Options.AspNetRuntime}, extracting *.txt,json,dll to {appRuntimePath}");
+                    Console.WriteLine($"Found AspNetRuntime: {Options.AspNetRuntime}, extracting *.txt,json,dll,xml to {appRuntimePath}");
                     using (var archive = ZipFile.OpenRead(Options.AspNetRuntime))
                     {
                         foreach (var entry in archive.Entries)
@@ -106,7 +106,8 @@ namespace RunTests
                             // These are the only extensions that end up in the shared fx directory
                             if (entry.Name.EndsWith(".txt", StringComparison.OrdinalIgnoreCase) ||
                                 entry.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ||
-                                entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                                entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) ||
+                                entry.Name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
                             {
                                 entry.ExtractToFile(Path.Combine(appRuntimePath, entry.Name), overwrite: true);
                             }

--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -23,10 +23,6 @@ namespace RepoTasks
         [Required]
         public string TargetFile { get; set; }
 
-        public string ManagedRoot { get; set; } = "";
-
-        public string NativeRoot { get; set; } = "";
-
         /// <summary>
         /// Extra attributes to place on the root node.
         ///
@@ -53,7 +49,8 @@ namespace RepoTasks
                     AssemblyName = FileUtilities.GetAssemblyName(item.ItemSpec),
                     FileVersion = FileUtilities.GetFileVersion(item.ItemSpec),
                     IsNative = item.GetMetadata("IsNativeImage") == "true",
-                    IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true"
+                    IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true",
+                    PackagePath = item.GetMetadata("PackagePath")
                 })
                 .Where(f =>
                     !f.IsSymbolFile &&
@@ -65,7 +62,7 @@ namespace RepoTasks
                     new XAttribute("Type", f.IsNative ? "Native" : "Managed"),
                     new XAttribute(
                         "Path",
-                        Path.Combine(f.IsNative ? NativeRoot : ManagedRoot, f.Filename).Replace('\\', '/')));
+                        Path.Combine(f.PackagePath, f.Filename).Replace('\\', '/')));
 
                 if (f.AssemblyName != null)
                 {

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -109,9 +109,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <AssetTargetFallback>$(AssetTargetFallback);native,Version=0.0</AssetTargetFallback>
 
-    <FrameworkListFileName>RuntimeList.xml</FrameworkListFileName>
-    <FrameworkListOutputPath>$(ArtifactsObjDir)$(FrameworkListFileName)</FrameworkListOutputPath>
-
     <NativePlatform>$(TargetArchitecture)</NativePlatform>
     <NativePlatform Condition=" '$(NativePlatform)' == 'x86' ">Win32</NativePlatform>
   </PropertyGroup>
@@ -155,6 +152,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <SharedFxLayoutTargetDir>$(SharedFrameworkLayoutRoot)$(SharedRuntimeSubPath)</SharedFxLayoutTargetDir>
     <RedistLayoutTargetDir>$(RedistSharedFrameworkLayoutRoot)$(SharedRuntimeSubPath)</RedistLayoutTargetDir>
     <LocalInstallationOutputPath>$(LocalDotNetRoot)$(SharedRuntimeSubPath)</LocalInstallationOutputPath>
+
+    <FrameworkListFileName>RuntimeList.xml</FrameworkListFileName>
+    <FrameworkListOutputPath>$(SharedFxLayoutTargetDir)$(FrameworkListFileName)</FrameworkListOutputPath>
 
     <InternalArchiveOutputFileName>$(InternalInstallerBaseName)-$(PackageVersion)-$(TargetRuntimeIdentifier)$(ArchiveExtension)</InternalArchiveOutputFileName>
     <InternalArchiveOutputPath>$(InstallersOutputPath)$(InternalArchiveOutputFileName)</InternalArchiveOutputPath>

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -531,11 +531,17 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           DependsOnTargets="_ResolveSharedFrameworkContent"
           BeforeTargets="_GetPackageFiles"
           Condition="'$(ManifestsPackagePath)' != ''">
+          
+    <ItemGroup>
+      <SharedFxContent Condition="'%(SharedFxContent.Extension)' == '.dll'">
+        <PackagePath Condition="'%(SharedFxContent.IsNativeImage)' == 'true'">$(NativeAssetsPackagePath)</PackagePath>
+        <PackagePath Condition="'%(SharedFxContent.IsNativeImage)' != 'true'">$(ManagedAssetsPackagePath)</PackagePath>
+      </SharedFxContent>
+    </ItemGroup>
+
     <RepoTasks.CreateFrameworkListFile
       Files="@(SharedFxContent)"
       TargetFile="$(FrameworkListOutputPath)"
-      ManagedRoot="$(ManagedAssetsPackagePath)"
-      NativeRoot="$(NativeAssetsPackagePath)"
       RootAttributes="@(FrameworkListRootAttributes)" />
 
     <ItemGroup>

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -285,7 +285,7 @@ namespace Microsoft.AspNetCore
             var runtimeListDoc = XDocument.Load(runtimeListPath);
             var runtimeListEntries = runtimeListDoc.Root.Descendants();
 
-            var sharedFxPath = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), ("Microsoft.AspNetCore.App.Runtime.win-x64." + TestData.GetSharedFxVersion() + ".nupkg" + Path.DirectorySeparatorChar));
+            var sharedFxPath = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), ("Microsoft.AspNetCore.App.Runtime.win-x64." + TestData.GetSharedFxVersion() + ".nupkg"));
 
             ZipArchive archive = ZipFile.OpenRead(sharedFxPath);
 

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -313,14 +313,14 @@ namespace Microsoft.AspNetCore
             var frameworkListEntries = frameworkListDoc.Root.Descendants();
 
             _output.WriteLine("==== file contents ====");
-            _output.WriteLine(string.Join('\n', frameworkListEntries.Select(i => i.Attribute("Path").Value).OrderBy(i => i)));
+            _output.WriteLine(string.Join('\n', frameworkListEntries.Select(i => i.Attribute("AssemblyName").Value).OrderBy(i => i)));
             _output.WriteLine("==== expected assemblies ====");
             _output.WriteLine(string.Join('\n', expectedAssemblies.OrderBy(i => i)));
 
              var actualAssemblies = frameworkListEntries
                 .Select(i =>
                 {
-                    var fileName = i.Attribute("Path").Value;
+                    var fileName = i.Attribute("AssemblyName").Value;
                     return fileName.EndsWith(".dll", StringComparison.Ordinal)
                         ? fileName.Substring(0, fileName.Length - 4)
                         : fileName;

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -365,7 +365,7 @@ namespace Microsoft.AspNetCore
             var frameworkListDoc = XDocument.Load(frameworkListPath);
             var frameworkListEntries = frameworkListDoc.Root.Descendants();
 
-            var targetingPackPath = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), ("Microsoft.AspNetCore.App.Ref." + TestData.GetSharedFxVersion() + ".nupkg" + Path.DirectorySeparatorChar));
+            var targetingPackPath = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT"), ("Microsoft.AspNetCore.App.Ref." + TestData.GetSharedFxVersion() + ".nupkg"));
 
             ZipArchive archive = ZipFile.OpenRead(targetingPackPath);
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspnetcore/issues/25167

Set `PackagePath` metadata on all inputs to `CreateFrameworkListFile`, and use that to resolve the asset path rather than the Native/Managed output locations. I verified locally that this produces .xml files that look correct for both the SharedFx & Targeting pack

CC @wli3 