### PR TITLE
Fixed potential torn reads in EventCounters

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingEventSource.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingEventSource.cs
@@ -87,23 +87,23 @@ namespace Microsoft.AspNetCore.Hosting
                 // This is the convention for initializing counters in the RuntimeEventSource (lazily on the first enable command).
                 // They aren't disabled afterwards...
 
-                _requestsPerSecondCounter ??= new IncrementingPollingCounter("requests-per-second", this, () => _totalRequests)
+                _requestsPerSecondCounter ??= new IncrementingPollingCounter("requests-per-second", this, () => Volatile.Read(ref _totalRequests))
                 {
                     DisplayName = "Request Rate",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _totalRequestsCounter ??= new PollingCounter("total-requests", this, () => _totalRequests)
+                _totalRequestsCounter ??= new PollingCounter("total-requests", this, () => Volatile.Read(ref _totalRequests))
                 {
                     DisplayName = "Total Requests",
                 };
 
-                _currentRequestsCounter ??= new PollingCounter("current-requests", this, () => _currentRequests)
+                _currentRequestsCounter ??= new PollingCounter("current-requests", this, () => Volatile.Read(ref _currentRequests))
                 {
                     DisplayName = "Current Requests"
                 };
 
-                _failedRequestsCounter ??= new PollingCounter("failed-requests", this, () => _failedRequests)
+                _failedRequestsCounter ??= new PollingCounter("failed-requests", this, () => Volatile.Read(ref _failedRequests))
                 {
                     DisplayName = "Failed Requests"
                 };

--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEventSource.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEventSource.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics.Tracing;
 using System.Threading;
-using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.ConcurrencyLimiter
 {
@@ -87,12 +86,12 @@ namespace Microsoft.AspNetCore.ConcurrencyLimiter
         {
             if (command.Command == EventCommand.Enable)
             {
-                _rejectedRequestsCounter ??= new PollingCounter("requests-rejected", this, () => _rejectedRequests)
+                _rejectedRequestsCounter ??= new PollingCounter("requests-rejected", this, () => Volatile.Read(ref _rejectedRequests))
                 {
                     DisplayName = "Rejected Requests",
                 };
 
-                _queueLengthCounter ??= new PollingCounter("queue-length", this, () => _queueLength)
+                _queueLengthCounter ??= new PollingCounter("queue-length", this, () => Volatile.Read(ref _queueLength))
                 {
                     DisplayName = "Queue Length",
                 };

--- a/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEventSource.cs
+++ b/src/Middleware/ConcurrencyLimiter/src/ConcurrencyLimiterEventSource.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics.Tracing;
 using System.Threading;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.ConcurrencyLimiter
 {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -3,12 +3,9 @@
 
 using System;
 using System.Diagnostics.Tracing;
-using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
-using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
@@ -318,54 +315,54 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 // This is the convention for initializing counters in the RuntimeEventSource (lazily on the first enable command).
                 // They aren't disabled afterwards...
 
-                _connectionsPerSecondCounter ??= new IncrementingPollingCounter("connections-per-second", this, () => _totalConnections)
+                _connectionsPerSecondCounter ??= new IncrementingPollingCounter("connections-per-second", this, () => Volatile.Read(ref _totalConnections))
                 {
                     DisplayName = "Connection Rate",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _totalConnectionsCounter ??= new PollingCounter("total-connections", this, () => _totalConnections)
+                _totalConnectionsCounter ??= new PollingCounter("total-connections", this, () => Volatile.Read(ref _totalConnections))
                 {
                     DisplayName = "Total Connections",
                 };
 
-                _tlsHandshakesPerSecondCounter ??= new IncrementingPollingCounter("tls-handshakes-per-second", this, () => _totalTlsHandshakes)
+                _tlsHandshakesPerSecondCounter ??= new IncrementingPollingCounter("tls-handshakes-per-second", this, () => Volatile.Read(ref _totalTlsHandshakes))
                 {
                     DisplayName = "TLS Handshake Rate",
                     DisplayRateTimeScale = TimeSpan.FromSeconds(1)
                 };
 
-                _totalTlsHandshakesCounter ??= new PollingCounter("total-tls-handshakes", this, () => _totalTlsHandshakes)
+                _totalTlsHandshakesCounter ??= new PollingCounter("total-tls-handshakes", this, () => Volatile.Read(ref _totalTlsHandshakes))
                 {
                     DisplayName = "Total TLS Handshakes",
                 };
 
-                _currentTlsHandshakesCounter ??= new PollingCounter("current-tls-handshakes", this, () => _currentTlsHandshakes)
+                _currentTlsHandshakesCounter ??= new PollingCounter("current-tls-handshakes", this, () => Volatile.Read(ref _currentTlsHandshakes))
                 {
                     DisplayName = "Current TLS Handshakes"
                 };
 
-                _failedTlsHandshakesCounter ??= new PollingCounter("failed-tls-handshakes", this, () => _failedTlsHandshakes)
+                _failedTlsHandshakesCounter ??= new PollingCounter("failed-tls-handshakes", this, () => Volatile.Read(ref _failedTlsHandshakes))
                 {
                     DisplayName = "Failed TLS Handshakes"
                 };
 
-                _currentConnectionsCounter ??= new PollingCounter("current-connections", this, () => _currentConnections)
+                _currentConnectionsCounter ??= new PollingCounter("current-connections", this, () => Volatile.Read(ref _currentConnections))
                 {
                     DisplayName = "Current Connections"
                 };
 
-                _connectionQueueLengthCounter ??= new PollingCounter("connection-queue-length", this, () => _connectionQueueLength)
+                _connectionQueueLengthCounter ??= new PollingCounter("connection-queue-length", this, () => Volatile.Read(ref _connectionQueueLength))
                 {
                     DisplayName = "Connection Queue Length"
                 };
 
-                _httpRequestQueueLengthCounter ??= new PollingCounter("request-queue-length", this, () => _httpRequestQueueLength)
+                _httpRequestQueueLengthCounter ??= new PollingCounter("request-queue-length", this, () => Volatile.Read(ref _httpRequestQueueLength))
                 {
                     DisplayName = "Request Queue Length"
                 };
 
-                _currrentUpgradedHttpRequestsCounter ??= new PollingCounter("current-upgraded-requests", this, () => _currentUpgradedHttpRequests)
+                _currrentUpgradedHttpRequestsCounter ??= new PollingCounter("current-upgraded-requests", this, () => Volatile.Read(ref _currentUpgradedHttpRequests))
                 {
                     DisplayName = "Current Upgraded Requests (WebSockets)"
                 };

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Net.Security;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsEventSource.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsEventSource.cs
@@ -5,6 +5,7 @@
 
 using System.Diagnostics.Tracing;
 using System.Threading;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal
 {

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsEventSource.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsEventSource.cs
@@ -5,7 +5,6 @@
 
 using System.Diagnostics.Tracing;
 using System.Threading;
-using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Http.Connections.Internal
 {
@@ -90,19 +89,19 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 // This is the convention for initializing counters in the RuntimeEventSource (lazily on the first enable command).
                 // They aren't disabled afterwards...
 
-                _connectionsStartedCounter ??= new PollingCounter("connections-started", this, () => _connectionsStarted)
+                _connectionsStartedCounter ??= new PollingCounter("connections-started", this, () => Volatile.Read(ref _connectionsStarted))
                 {
                     DisplayName = "Total Connections Started",
                 };
-                _connectionsStoppedCounter ??= new PollingCounter("connections-stopped", this, () => _connectionsStopped)
+                _connectionsStoppedCounter ??= new PollingCounter("connections-stopped", this, () => Volatile.Read(ref _connectionsStopped))
                 {
                     DisplayName = "Total Connections Stopped",
                 };
-                _connectionsTimedOutCounter ??= new PollingCounter("connections-timed-out", this, () => _connectionsTimedOut)
+                _connectionsTimedOutCounter ??= new PollingCounter("connections-timed-out", this, () => Volatile.Read(ref _connectionsTimedOut))
                 {
                     DisplayName = "Total Connections Timed Out",
                 };
-                _currentConnectionsCounter ??= new PollingCounter("current-connections", this, () => _currentConnections)
+                _currentConnectionsCounter ??= new PollingCounter("current-connections", this, () => Volatile.Read(ref _currentConnections))
                 {
                     DisplayName = "Current Connections",
                 };


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/22888

Used `Volatile.Read`.
* x64: ordinary read as before
* x86: `Interlocked.CompareExchange(ref _loc, 0, 0)` (what's actually used by `Interlocked.Read`)
* arm: read with memory barrier / assume it's less "heavy" than interlocked

/cc: @halter73 