### PR TITLE
Fix graceful shutdown of connection close in HTTP/3

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -641,4 +641,10 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="FailedToOpenCertStore" xml:space="preserve">
     <value>Failed to open certificate store {StoreName}.</value>
   </data>
+  <data name="Http3ConnectionFaulted" xml:space="preserve">
+    <value>The HTTP/3 connection faulted.</value>
+  </data>
+  <data name="Http3StreamAborted" xml:space="preserve">
+    <value>The HTTP/3 request stream was aborted.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -10,16 +10,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
     /// </summary>
     public class Http3Limits
     {
-        private int _headerTableSize = 4096;
+        private int _headerTableSize = 0;
         private int _maxRequestHeaderFieldSize = 8192;
 
         /// <summary>
         /// Limits the size of the header compression table, in octets, the HPACK decoder on the server can use.
         /// <para>
-        /// Value must be greater than 0, defaults to 4096
+        /// Value must be greater than 0, defaults to 0
         /// </para>
         /// </summary>
-        public int HeaderTableSize
+        // TODO: Make public https://github.com/dotnet/aspnetcore/issues/26666
+        internal int HeaderTableSize
         {
             get => _headerTableSize;
             set

--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         private int _maxRequestHeaderFieldSize = 8192;
 
         /// <summary>
-        /// Limits the size of the header compression table, in octets, the HPACK decoder on the server can use.
+        /// Limits the size of the header compression table, in octets, the QPACK decoder on the server can use.
         /// <para>
         /// Value must be greater than 0, defaults to 0
         /// </para>

--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// <summary>
         /// Limits the size of the header compression table, in octets, the QPACK decoder on the server can use.
         /// <para>
-        /// Value must be greater than 0, defaults to 0
+        /// Value must be greater than 0, defaults to 0.
         /// </para>
         /// </summary>
         // TODO: Make public https://github.com/dotnet/aspnetcore/issues/26666

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1558,44 +1558,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        private class StreamCloseAwaitable : ICriticalNotifyCompletion
-        {
-            private static readonly Action _callbackCompleted = () => { };
-
-            // Initialize to completed so UpdateCompletedStreams runs at least once during connection teardown
-            // if there are still active streams.
-            private Action? _callback = _callbackCompleted;
-
-            public StreamCloseAwaitable GetAwaiter() => this;
-            public bool IsCompleted => ReferenceEquals(_callback, _callbackCompleted);
-
-            public void GetResult()
-            {
-                Debug.Assert(ReferenceEquals(_callback, _callbackCompleted));
-
-                _callback = null;
-            }
-
-            public void OnCompleted(Action continuation)
-            {
-                if (ReferenceEquals(_callback, _callbackCompleted) ||
-                    ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
-                {
-                    Task.Run(continuation);
-                }
-            }
-
-            public void UnsafeOnCompleted(Action continuation)
-            {
-                OnCompleted(continuation);
-            }
-
-            public void Complete()
-            {
-                Interlocked.Exchange(ref _callback, _callbackCompleted)?.Invoke();
-            }
-        }
-
         private enum RequestHeaderParsingState
         {
             Ready,

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -547,7 +547,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             |                        Value (32)                             |
             +---------------------------------------------------------------+
         */
-        public ValueTask<FlushResult> WriteSettingsAsync(IList<Http2PeerSetting> settings)
+        public ValueTask<FlushResult> WriteSettingsAsync(List<Http2PeerSetting> settings)
         {
             lock (_writeLock)
             {
@@ -569,7 +569,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        internal static void WriteSettings(IList<Http2PeerSetting> settings, Span<byte> destination)
+        internal static void WriteSettings(List<Http2PeerSetting> settings, Span<byte> destination)
         {
             foreach (var setting in settings)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -347,7 +347,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     {
                         // This throws when connection is shut down.
                         // TODO how to make it so we can distinguish between Abort from server vs client?
-                        // Different exception catches?
                         await SendGoAway(_highestOpenedStreamId);
                     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 previousState = _aborted;
             }
 
-            // TODO figure out how to gracefully close next requests
+            Log.Http3ConnectionClosed(_context.ConnectionId, _highestOpenedStreamId);
         }
 
         public void Abort(ConnectionAbortedException ex)
@@ -142,6 +142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             if (!previousState)
             {
+                OnConnectionClosed();
                 SendGoAway();
                 _context.ConnectionContext.Abort(ex);
             }
@@ -275,7 +276,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
             catch (OperationCanceledException)
             {
-                Log.Http3ConnectionClosed(_context.ConnectionId, _highestOpenedStreamId);
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -237,6 +237,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             // Don't create Encoder and Decoder as they aren't used now.
             Exception? error = null;
 
+            // TODO should we await the control stream task?
             var controlTask = CreateControlStream(application);
 
             _timeoutControl.SetTimeout(Limits.KeepAliveTimeout.Ticks, TimeoutReason.KeepAlive);

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -41,6 +41,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private readonly object _protocolSelectionLock = new object();
         private CancellationTokenSource _connectionAborted;
 
+        private readonly Http3PeerSettings _serverSettings = new Http3PeerSettings();
+
         public Http3Connection(Http3ConnectionContext context)
         {
             _multiplexedContext = context.ConnectionContext;
@@ -50,6 +52,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             _timeoutControl = new TimeoutControl(this);
             _context.TimeoutControl ??= _timeoutControl;
             _connectionAborted = new CancellationTokenSource();
+
+            var httpLimits = context.ServiceContext.ServerOptions.Limits;
+
+            _serverSettings.HeaderTableSize = (uint)httpLimits.Http3.HeaderTableSize;
+            _serverSettings.MaxRequestHeaderFieldSize = (uint)httpLimits.Http3.MaxRequestHeaderFieldSize;
         }
 
         internal long HighestStreamId
@@ -326,7 +333,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 streamContext.LocalEndPoint as IPEndPoint,
                 streamContext.RemoteEndPoint as IPEndPoint,
                 streamContext.Transport,
-                streamContext);
+                streamContext,
+                _serverSettings);
             httpConnectionContext.TimeoutControl = _context.TimeoutControl;
 
             return new Http3ControlStream<TContext>(application, this, httpConnectionContext);

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private bool _aborted;
         private ConnectionAbortedException _abortedException = null;
         private readonly object _protocolSelectionLock = new object();
-        private CancellationTokenSource _connectionAborted;
+        private readonly CancellationTokenSource _connectionAborted;
 
         private readonly Http3PeerSettings _serverSettings = new Http3PeerSettings();
 
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
             catch (OperationCanceledException)
             {
-                // Stream aborted/closed.
+                Log.Http3ConnectionClosed(_context.ConnectionId, _highestOpenedStreamId);
             }
             finally
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -328,35 +328,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
         }
 
-            // Abort all streams as connection has shutdown.
-            // TODO I think we don't need to be calling abort here?
-            //lock (_streams)
-            //{
-            //    if (_aborted)
-            //    {
-            //        foreach (var stream in _streams.Values)
-            //        {
-            //            // Don't think we should abort everything here.
-            //            stream.Abort(_abortedException);
-            //        }
-            //    }
-            //    else
-            //    {
-            //        foreach (var stream in _streams.Values)
-            //        {
-            //            stream.OnInputOrOutputCompleted();
-            //        }
-            //    }
-
-            //    ControlStream?.OnInputOrOutputCompleted();
-            //    EncoderStream?.OnInputOrOutputCompleted();
-            //    DecoderStream?.OnInputOrOutputCompleted();
-            //}
-
-            //OutboundControlStream?.Abort(new ConnectionAbortedException("Connection is shutting down."));
-
-            //await controlTask;
-
         public void ApplyMaxHeaderListSize(long value)
         {
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -34,7 +34,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private readonly ISystemClock _systemClock;
         private readonly TimeoutControl _timeoutControl;
         private bool _aborted;
-        private ConnectionAbortedException _abortedException = new ConnectionAbortedException();
         private readonly object _protocolSelectionLock = new object();
 
         private readonly Http3PeerSettings _serverSettings = new Http3PeerSettings();
@@ -113,6 +112,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 previousState = _aborted;
             }
 
+            // Attempt to send goaway 
             SendGoAway();
 
             // Abort with no exception to close the connection.
@@ -127,7 +127,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 previousState = _aborted;
             }
 
-            // IDK what to actually do here yet.
             // TODO figure out how to gracefully close next requests
         }
 
@@ -143,7 +142,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             if (!previousState)
             {
-                _abortedException = ex;
                 SendGoAway();
                 _context.ConnectionContext.Abort(ex);
             }
@@ -250,7 +248,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     }
                     else
                     {
-
                         var streamId = streamIdFeature.StreamId;
 
                         lock (_sync)
@@ -323,8 +320,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 }
 
                 _haveSentGoAway = true;
-
-                //OutboundControlStream.OnInputOrOutputCompleted();
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ConnectionException.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ConnectionException.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Runtime.Serialization;
 
-namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
     [Serializable]
     internal class Http3ConnectionException : Exception

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -75,7 +75,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         public void OnInputOrOutputCompleted()
         {
             TryClose();
-            _frameWriter.Abort(new ConnectionAbortedException(CoreStrings.ConnectionAbortedByClient));
+            // this closes input, don't abort?
+            //_frameWriter.Abort(new ConnectionAbortedException(CoreStrings.ConnectionAbortedByClient));
         }
 
         private bool TryClose()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -93,9 +93,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             await _frameWriter.WriteStreamIdAsync(id);
         }
 
-        internal async ValueTask SendGoAway(long id)
+        internal ValueTask<FlushResult> SendGoAway(long id)
         {
-            await _frameWriter.WriteGoAway(id);
+            return _frameWriter.WriteGoAway(id);
         }
 
         internal async ValueTask SendSettingsFrameAsync()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -22,23 +22,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private readonly Http3FrameWriter _frameWriter;
         private readonly Http3Connection _http3Connection;
-        private readonly HttpConnectionContext _context;
+        private readonly Http3StreamContext _context;
+        private readonly Http3PeerSettings _serverPeerSettings;
         private readonly Http3RawFrame _incomingFrame = new Http3RawFrame();
         private volatile int _isClosed;
         private int _gracefulCloseInitiator;
 
         private bool _haveReceivedSettingsFrame;
 
-        public Http3ControlStream(Http3Connection http3Connection, HttpConnectionContext context)
+        public Http3ControlStream(Http3Connection http3Connection, Http3StreamContext context)
         {
             var httpLimits = context.ServiceContext.ServerOptions.Limits;
-
             _http3Connection = http3Connection;
             _context = context;
+            _serverPeerSettings = context.ServerSettings;
 
             _frameWriter = new Http3FrameWriter(
                 context.Transport.Output,
-                context.ConnectionContext,
+                context.StreamContext,
                 context.TimeoutControl,
                 httpLimits.MinResponseDataRate,
                 context.ConnectionId,
@@ -133,7 +134,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         internal async ValueTask SendSettingsFrameAsync()
         {
-            await _frameWriter.WriteSettingsAsync(new List<Http3PeerSettings>());
+            await _frameWriter.WriteSettingsAsync(_serverPeerSettings.GetNonProtocolDefaults());
         }
 
         private async ValueTask<long> TryReadStreamIdAsync()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
     {
         private readonly IHttpApplication<TContext> _application;
 
-        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, HttpConnectionContext context) : base(connection, context)
+        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, Http3StreamContext context) : base(connection, context)
         {
             _application = application;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
@@ -213,15 +213,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         internal Task WriteGoAway(long id)
         {
             _outgoingFrame.PrepareGoAway();
-            var buffer = _outputWriter.GetSpan(9);
-            buffer[0] = (byte)_outgoingFrame.Type;
 
-            var length = VariableLengthIntegerHelper.WriteInteger(buffer.Slice(1), id);
+            var length = VariableLengthIntegerHelper.GetByteCount(id);
 
             _outgoingFrame.Length = length;
 
             WriteHeaderUnsynchronized();
 
+            var buffer = _outputWriter.GetSpan(8);
+            VariableLengthIntegerHelper.WriteInteger(buffer, id);
+            _outputWriter.Advance(length);
             return _outputWriter.FlushAsync().AsTask();
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
         }
 
-        internal Task WriteGoAway(long id)
+        internal ValueTask<FlushResult> WriteGoAway(long id)
         {
             _outgoingFrame.PrepareGoAway();
 
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             var buffer = _outputWriter.GetSpan(8);
             VariableLengthIntegerHelper.WriteInteger(buffer, id);
             _outputWriter.Advance(length);
-            return _outputWriter.FlushAsync().AsTask();
+            return _outputWriter.FlushAsync();
         }
 
         private void WriteHeaderUnsynchronized()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSetting.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSetting.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
+{
+    internal readonly struct Http3PeerSetting
+    {
+        public Http3PeerSetting(Http3SettingType parameter, uint value)
+        {
+            Parameter = parameter;
+            Value = value;
+        }
+
+        public Http3SettingType Parameter { get; }
+
+        public uint Value { get; }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
@@ -1,12 +1,37 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
     internal class Http3PeerSettings
     {
-        internal const uint DefaultMaxFrameSize = 16 * 1024;
+        // Note these are protocol defaults, not Kestrel defaults.
+        public const uint DefaultHeaderTableSize = 0;
+        public const uint DefaultMaxRequestHeaderFieldSize = uint.MaxValue;
 
-        public static int MinAllowedMaxFrameSize { get; internal set; } = 16 * 1024;
+        public uint HeaderTableSize { get; internal set; } = DefaultHeaderTableSize;
+        public uint MaxRequestHeaderFieldSize { get; internal set; } = DefaultMaxRequestHeaderFieldSize;
+
+        // Gets the settings that are different from the protocol defaults (as opposed to the server defaults).
+        internal List<Http3PeerSetting> GetNonProtocolDefaults()
+        {
+            // By default, there is only one setting that is sent from server to client.
+            // Set capacity to that value.
+            var list = new List<Http3PeerSetting>(1);
+
+            if (HeaderTableSize != DefaultHeaderTableSize)
+            {
+                list.Add(new Http3PeerSetting(Http3SettingType.QPackMaxTableCapacity, HeaderTableSize));
+            }
+
+            if (MaxRequestHeaderFieldSize != DefaultMaxRequestHeaderFieldSize)
+            {
+                list.Add(new Http3PeerSetting(Http3SettingType.MaxHeaderListSize, MaxRequestHeaderFieldSize));
+            }
+
+            return list;
+        }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3SettingType.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3SettingType.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
-    enum Http3SettingType : long
+    internal enum Http3SettingType : long
     {
         QPackMaxTableCapacity = 0x1,
         /// <summary>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -20,7 +20,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
-    internal abstract class Http3Stream : HttpProtocol, IHttpHeadersHandler, IThreadPoolWorkItem
+    internal abstract class Http3Stream : HttpProtocol, IHttpHeadersHandler, IThreadPoolWorkItem, ITimeoutHandler
     {
         private static ReadOnlySpan<byte> AuthorityBytes => new byte[10] { (byte)':', (byte)'a', (byte)'u', (byte)'t', (byte)'h', (byte)'o', (byte)'r', (byte)'i', (byte)'t', (byte)'y' };
         private static ReadOnlySpan<byte> MethodBytes => new byte[7] { (byte)':', (byte)'m', (byte)'e', (byte)'t', (byte)'h', (byte)'o', (byte)'d' };
@@ -741,6 +741,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         /// Used to kick off the request processing loop by derived classes.
         /// </summary>
         public abstract void Execute();
+
+        public void OnTimeout(TimeoutReason reason)
+        {
+            throw new NotImplementedException();
+        }
 
         protected enum RequestHeaderParsingState
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -308,7 +308,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         protected override void OnRequestProcessingEnded()
         {
             Debug.Assert(_appCompleted != null);
-
             _appCompleted.SetResult();
         }
 
@@ -360,6 +359,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     }
                 }
             }
+            // catch ConnectionResetException here?
             catch (Http3StreamErrorException ex)
             {
                 error = ex;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -20,7 +20,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
-    internal abstract class Http3Stream : HttpProtocol, IHttpHeadersHandler, IThreadPoolWorkItem, ITimeoutHandler
+    internal abstract class Http3Stream : HttpProtocol, IHttpHeadersHandler, IThreadPoolWorkItem, ITimeoutHandler, IRequestProcessor
     {
         private static ReadOnlySpan<byte> AuthorityBytes => new byte[10] { (byte)':', (byte)'a', (byte)'u', (byte)'t', (byte)'h', (byte)'o', (byte)'r', (byte)'i', (byte)'t', (byte)'y' };
         private static ReadOnlySpan<byte> MethodBytes => new byte[7] { (byte)':', (byte)'m', (byte)'e', (byte)'t', (byte)'h', (byte)'o', (byte)'d' };

--- a/src/Servers/Kestrel/Core/src/Internal/Http3StreamContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3StreamContext.cs
@@ -6,6 +6,7 @@ using System.IO.Pipelines;
 using System.Net;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -21,11 +22,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             IPEndPoint? localEndPoint,
             IPEndPoint? remoteEndPoint,
             IDuplexPipe transport,
-            ConnectionContext streamContext) : base(connectionId, protocols, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint, transport)
+            ConnectionContext streamContext,
+            Http3PeerSettings settings) : base(connectionId, protocols, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint, transport)
         {
             StreamContext = streamContext;
+            ServerSettings = settings;
         }
 
         public ConnectionContext StreamContext { get; }
+        public Http3PeerSettings ServerSettings { get; }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
@@ -78,7 +79,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         void Http2MaxConcurrentStreamsReached(string connectionId);
 
         void InvalidResponseHeaderRemoved();
-        
+
+        void Http3ConnectionError(string connectionId, Http3ConnectionException ex);
+
+        void Http3ConnectionClosing(string connectionId);
+
         void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId);
+
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -78,5 +78,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         void Http2MaxConcurrentStreamsReached(string connectionId);
 
         void InvalidResponseHeaderRemoved();
+        
+        void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             LoggerMessage.Define(LogLevel.Warning, new EventId(41, "InvalidResponseHeaderRemoved"),
                 "One or more of the following response headers have been removed because they are invalid for HTTP/2 and HTTP/3 responses: 'Connection', 'Transfer-Encoding', 'Keep-Alive', 'Upgrade' and 'Proxy-Connection'.");
         
-        private static readonly Action<ILogger, string, long, Exception> _http3ConnectionClosed =
+        private static readonly Action<ILogger, string, long, Exception?> _http3ConnectionClosed =
             LoggerMessage.Define<string, long>(LogLevel.Debug, new EventId(41, nameof(Http3ConnectionClosed)),
                 @"Connection id ""{ConnectionId}"" is closed. The last processed stream ID was {HighestOpenedStreamId}.");
 
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             _http3ConnectionClosed(_logger, connectionId, highestOpenedStreamId, null);
         }
 
-        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
             => _logger.Log(logLevel, eventId, state, exception, formatter);
 
         public virtual bool IsEnabled(LogLevel logLevel) => _logger.IsEnabled(logLevel);

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -120,6 +120,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private static readonly Action<ILogger, Exception?> _invalidResponseHeaderRemoved =
             LoggerMessage.Define(LogLevel.Warning, new EventId(41, "InvalidResponseHeaderRemoved"),
                 "One or more of the following response headers have been removed because they are invalid for HTTP/2 and HTTP/3 responses: 'Connection', 'Transfer-Encoding', 'Keep-Alive', 'Upgrade' and 'Proxy-Connection'.");
+        
+        private static readonly Action<ILogger, string, long, Exception> _http3ConnectionClosed =
+            LoggerMessage.Define<string, long>(LogLevel.Debug, new EventId(41, nameof(Http3ConnectionClosed)),
+                @"Connection id ""{ConnectionId}"" is closed. The last processed stream ID was {HighestOpenedStreamId}.");
 
         protected readonly ILogger _logger;
 
@@ -304,7 +308,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             _invalidResponseHeaderRemoved(_logger, null);
         }
 
-        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId)
+        {
+            _http3ConnectionClosed(_logger, connectionId, highestOpenedStreamId, null);
+        }
+
+        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             => _logger.Log(logLevel, eventId, state, exception, formatter);
 
         public virtual bool IsEnabled(LogLevel logLevel) => _logger.IsEnabled(logLevel);

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StreamCloseAwaitable.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StreamCloseAwaitable.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
+{
+    internal class StreamCloseAwaitable : ICriticalNotifyCompletion
+    {
+        private static readonly Action _callbackCompleted = () => { };
+
+        // Initialize to completed so UpdateCompletedStreams runs at least once during connection teardown
+        // if there are still active streams.
+        private Action? _callback = _callbackCompleted;
+
+        public StreamCloseAwaitable GetAwaiter() => this;
+        public bool IsCompleted => ReferenceEquals(_callback, _callbackCompleted);
+
+        public void GetResult()
+        {
+            Debug.Assert(ReferenceEquals(_callback, _callbackCompleted));
+
+            _callback = null;
+        }
+
+        public void OnCompleted(Action continuation)
+        {
+            if (ReferenceEquals(_callback, _callbackCompleted) ||
+                ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
+            {
+                Task.Run(continuation);
+            }
+        }
+
+        public void UnsafeOnCompleted(Action continuation)
+        {
+            OnCompleted(continuation);
+        }
+
+        public void Complete()
+        {
+            Interlocked.Exchange(ref _callback, _callbackCompleted)?.Invoke();
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Middleware/Http3ConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Http3ConnectionMiddleware.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
             var connection = new Http3Connection(http3ConnectionContext);
 
-            return connection.ProcessRequestsAsync(_application);
+            return connection.ProcessStreamsAsync(_application);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Shipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Shipped.txt
@@ -36,8 +36,6 @@ Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxRequestHeaderFieldSize.s
 Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxStreamsPerConnection.get -> int
 Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxStreamsPerConnection.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.Http3Limits
-Microsoft.AspNetCore.Server.Kestrel.Core.Http3Limits.HeaderTableSize.get -> int
-Microsoft.AspNetCore.Server.Kestrel.Core.Http3Limits.HeaderTableSize.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.Http3Limits.Http3Limits() -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.Http3Limits.MaxRequestHeaderFieldSize.get -> int
 Microsoft.AspNetCore.Server.Kestrel.Core.Http3Limits.MaxRequestHeaderFieldSize.set -> void

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Server.Kestrel.Core.Http3Limits.HeaderTableSize.get -> int
+*REMOVED*Microsoft.AspNetCore.Server.Kestrel.Core.Http3Limits.HeaderTableSize.set -> void

--- a/src/Servers/Kestrel/Core/test/Http3FrameWriterTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3FrameWriterTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class Http3FrameWriterTests
+    {
+        private MemoryPool<byte> _dirtyMemoryPool;
+
+        public Http3FrameWriterTests()
+        {
+            var memoryBlock = new Mock<IMemoryOwner<byte>>();
+            memoryBlock.Setup(block => block.Memory).Returns(() =>
+            {
+                var blockArray = new byte[4096];
+                for (int i = 0; i < 4096; i++)
+                {
+                    blockArray[i] = 0xff;
+                }
+                return new Memory<byte>(blockArray);
+            });
+
+            var dirtyMemoryPool = new Mock<MemoryPool<byte>>();
+            dirtyMemoryPool.Setup(pool => pool.Rent(It.IsAny<int>())).Returns(memoryBlock.Object);
+            _dirtyMemoryPool = dirtyMemoryPool.Object;
+        }
+
+        [Fact]
+        public async Task WriteSettings_NoSettingsWrittenWithProtocolDefault()
+        {
+            var pipe = new Pipe(new PipeOptions(_dirtyMemoryPool, PipeScheduler.Inline, PipeScheduler.Inline));
+            var frameWriter = new Http3FrameWriter(pipe.Writer, null, null, null, null, _dirtyMemoryPool, null);
+
+            var settings = new Http3PeerSettings();
+            await frameWriter.WriteSettingsAsync(settings.GetNonProtocolDefaults());
+
+            var payload = await pipe.Reader.ReadForLengthAsync(2);
+
+            Assert.Equal(new byte[] { 0x04, 0x00 }, payload.ToArray());
+        }
+
+        [Fact]
+        public async Task WriteSettings_OneSettingsWrittenWithKestrelDefaults()
+        {
+            var pipe = new Pipe(new PipeOptions(_dirtyMemoryPool, PipeScheduler.Inline, PipeScheduler.Inline));
+            var frameWriter = new Http3FrameWriter(pipe.Writer, null, null, null, null, _dirtyMemoryPool, null);
+
+            var limits = new Http3Limits();
+            var settings = new Http3PeerSettings();
+            settings.HeaderTableSize = (uint)limits.HeaderTableSize;
+            settings.MaxRequestHeaderFieldSize = (uint)limits.MaxRequestHeaderFieldSize;
+
+            await frameWriter.WriteSettingsAsync(settings.GetNonProtocolDefaults());
+
+            // variable length ints make it so the results isn't know without knowing the values 
+            var payload = await pipe.Reader.ReadForLengthAsync(5);
+
+            Assert.Equal(new byte[] { 0x04, 0x03, 0x06, 0x60, 0x00 }, payload.ToArray());
+        }
+
+        [Fact]
+        public async Task WriteSettings_TwoSettingsWritten()
+        {
+            var pipe = new Pipe(new PipeOptions(_dirtyMemoryPool, PipeScheduler.Inline, PipeScheduler.Inline));
+            var frameWriter = new Http3FrameWriter(pipe.Writer, null, null, null, null, _dirtyMemoryPool, null);
+
+            var settings = new Http3PeerSettings();
+            settings.HeaderTableSize = 1234;
+            settings.MaxRequestHeaderFieldSize = 567890;
+
+            await frameWriter.WriteSettingsAsync(settings.GetNonProtocolDefaults());
+
+            // variable length ints make it so the results isn't know without knowing the values 
+            var payload = await pipe.Reader.ReadForLengthAsync(10);
+
+            Assert.Equal(new byte[] { 0x04, 0x08, 0x01, 0x44, 0xD2, 0x06, 0x80, 0x08, 0xAA, 0x52 }, payload.ToArray());
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/test/Http3FrameWriterTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3FrameWriterTests.cs
@@ -1,12 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Moq;
 using Xunit;
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
         private QuicConnection _connection;
         private readonly QuicTransportContext _context;
         private readonly IQuicTrace _log;
+        private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
 
         private ValueTask _closeTask;
 
@@ -27,6 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             _log = context.Log;
             _context = context;
             _connection = connection;
+            ConnectionClosed = _connectionClosedTokenSource.Token;
             Features.Set<ITlsConnectionFeature>(new FakeTlsConnectionFeature());
             Features.Set<IProtocolErrorCodeFeature>(this);
 
@@ -36,13 +38,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
         public ValueTask<ConnectionContext> StartUnidirectionalStreamAsync()
         {
             var stream = _connection.OpenUnidirectionalStream();
-            return new ValueTask<ConnectionContext>(new QuicStreamContext(stream, this, _context));
+            var context = new QuicStreamContext(stream, this, _context);
+            context.Start();
+            return new ValueTask<ConnectionContext>(context);
         }
 
         public ValueTask<ConnectionContext> StartBidirectionalStreamAsync()
         {
             var stream = _connection.OpenBidirectionalStream();
-            return new ValueTask<ConnectionContext>(new QuicStreamContext(stream, this, _context));
+            var context = new QuicStreamContext(stream, this, _context);
+            context.Start();
+            return new ValueTask<ConnectionContext>(context);
         }
 
         public override async ValueTask DisposeAsync()
@@ -54,7 +60,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
                     _closeTask  = _connection.CloseAsync(errorCode: 0);
                     await _closeTask;
                 }
-                else 
+                else
                 {
                     await _closeTask;
                 }
@@ -71,6 +77,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 
         public override void Abort(ConnectionAbortedException abortReason)
         {
+            // dedup calls to abort here.
             _closeTask = _connection.CloseAsync(errorCode: Error);
         }
 
@@ -79,11 +86,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             try
             {
                 var stream = await _connection.AcceptStreamAsync(cancellationToken);
-                return new QuicStreamContext(stream, this, _context);
+                var context = new QuicStreamContext(stream, this, _context);
+                context.Start();
+                return context;
             }
             catch (QuicException ex)
             {
                 // Accept on graceful close throws an aborted exception rather than returning null.
+
+                // TODO cancel CTS here?
                 _log.LogDebug($"Accept loop ended with exception: {ex.Message}");
             }
 
@@ -111,7 +122,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
                 quicStream = _connection.OpenBidirectionalStream();
             }
 
-            return new ValueTask<ConnectionContext>(new QuicStreamContext(quicStream, this, _context));
+            var context = new QuicStreamContext(quicStream, this, _context);
+            context.Start();
+
+            return new ValueTask<ConnectionContext>(context);
         }
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             quicListenerOptions.CertificateFilePath = options.CertificateFilePath;
             quicListenerOptions.PrivateKeyFilePath = options.PrivateKeyFilePath;
             quicListenerOptions.ListenEndPoint = endpoint as IPEndPoint;
-            quicListenerOptions.IdleTimeout = TimeSpan.FromDays(1);
+            quicListenerOptions.IdleTimeout = TimeSpan.FromMinutes(2);
 
             _listener = new QuicListener(QuicImplementationProviders.MsQuic, quicListenerOptions);
             _listener.Start();

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             quicListenerOptions.CertificateFilePath = options.CertificateFilePath;
             quicListenerOptions.PrivateKeyFilePath = options.PrivateKeyFilePath;
             quicListenerOptions.ListenEndPoint = endpoint as IPEndPoint;
+            quicListenerOptions.IdleTimeout = TimeSpan.FromDays(1);
 
             _listener = new QuicListener(QuicImplementationProviders.MsQuic, quicListenerOptions);
             _listener.Start();

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 {
     internal class QuicStreamContext : TransportConnection, IStreamDirectionFeature, IProtocolErrorCodeFeature, IStreamIdFeature
     {
-        private readonly Task _processingTask;
+        private Task _processingTask = Task.CompletedTask;
         private readonly QuicStream _stream;
         private readonly QuicConnectionContext _connection;
         private readonly QuicTransportContext _context;
@@ -25,6 +25,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
         private string? _connectionId;
         private const int MinAllocBufferSize = 4096;
         private volatile Exception? _shutdownReason;
+        private bool _streamClosed;
+        private bool _aborted;
         private readonly TaskCompletionSource _waitForConnectionClosedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly object _shutdownLock = new object();
 
@@ -58,8 +60,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 
             Transport = pair.Transport;
             Application = pair.Application;
-
-            _processingTask = StartAsync();
         }
 
         public override MemoryPool<byte> MemoryPool { get; }
@@ -95,6 +95,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 
         public long Error { get; set; }
 
+        public void Start()
+        {
+            _processingTask = StartAsync();
+        }
+
         private async Task StartAsync()
         {
             try
@@ -117,7 +122,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
                 // Now wait for both to complete
                 await receiveTask;
                 await sendTask;
-
             }
             catch (Exception ex)
             {
@@ -197,6 +201,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 
         private void FireStreamClosed()
         {
+            // Guard against scheduling this multiple times
+            if (_streamClosed)
+            {
+                return;
+            }
+
+            _streamClosed = true;
+
             ThreadPool.UnsafeQueueUserWorkItem(state =>
             {
                 state.CancelConnectionClosedToken();
@@ -285,7 +297,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 
         public override void Abort(ConnectionAbortedException abortReason)
         {
+            // This abort is called twice, make sure that doesn't happen.
             // Don't call _stream.Shutdown and _stream.Abort at the same time.
+            if (_aborted)
+            {
+                return;
+            }
+
+            _aborted = true;
+
             _log.StreamAbort(ConnectionId, abortReason);
 
             lock (_shutdownLock)

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockTrace.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
@@ -57,6 +59,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public void Http2FrameSending(string connectionId, Http2Frame frame) { }
         public void Http2MaxConcurrentStreamsReached(string connectionId) { }
         public void InvalidResponseHeaderRemoved() { }
+        public void Http3ConnectionError(string connectionId, Http3ConnectionException ex) { }
+        public void Http3ConnectionClosing(string connectionId) { }
         public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId) { }
     }
 }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockTrace.cs
@@ -57,5 +57,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public void Http2FrameSending(string connectionId, Http2Frame frame) { }
         public void Http2MaxConcurrentStreamsReached(string connectionId) { }
         public void InvalidResponseHeaderRemoved() { }
+        public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId) { }
     }
 }

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -241,5 +241,10 @@ namespace Microsoft.AspNetCore.Testing
             _trace1.InvalidResponseHeaderRemoved();
             _trace2.InvalidResponseHeaderRemoved();
         }
+        public void Http3ConnectionClosed(string connectionId, int highestOpenedStreamId)
+        {
+            _trace1.Http3ConnectionClosed(connectionId, highestOpenedStreamId);
+            _trace2.Http3ConnectionClosed(connectionId, highestOpenedStreamId);
+        }
     }
 }

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -241,7 +241,8 @@ namespace Microsoft.AspNetCore.Testing
             _trace1.InvalidResponseHeaderRemoved();
             _trace2.InvalidResponseHeaderRemoved();
         }
-        public void Http3ConnectionClosed(string connectionId, int highestOpenedStreamId)
+        
+        public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId)
         {
             _trace1.Http3ConnectionClosed(connectionId, highestOpenedStreamId);
             _trace2.Http3ConnectionClosed(connectionId, highestOpenedStreamId);

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -5,7 +5,9 @@ using System;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
@@ -241,7 +243,19 @@ namespace Microsoft.AspNetCore.Testing
             _trace1.InvalidResponseHeaderRemoved();
             _trace2.InvalidResponseHeaderRemoved();
         }
-        
+
+        public void Http3ConnectionError(string connectionId, Http3ConnectionException ex)
+        {
+            _trace1.Http3ConnectionError(connectionId, ex);
+            _trace2.Http3ConnectionError(connectionId, ex);
+        }
+
+        public void Http3ConnectionClosing(string connectionId)
+        {
+            _trace1.Http3ConnectionClosing(connectionId);
+            _trace2.Http3ConnectionClosing(connectionId);
+        }
+
         public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId)
         {
             _trace1.Http3ConnectionClosed(connectionId, highestOpenedStreamId);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class Http3ConnectionTests : Http3TestBase
+    {
+        [Fact]
+        public async Task GoAwayReceived()
+        {
+            await InitializeConnectionAsync(_echoApplication);
+
+            var outboundcontrolStream = await CreateControlStream();
+            var inboundControlStream = await GetInboundControlStream();
+
+            Connection.Abort(new ConnectionAbortedException());
+            await _closedStateReached.Task.DefaultTimeout();
+            await WaitForConnectionErrorAsync(ignoreNonGoAwayFrames: true, expectedLastStreamId: 0, expectedErrorCode: 0);
+        }
+
+        [Fact]
+        public async Task GracefulServerShutdownSendsGoawayClosesConnection()
+        {
+            await InitializeConnectionAsync(_echoApplication);
+            // Trigger server shutdown.
+            MultiplexedConnectionContext.ConnectionClosingCts.Cancel();
+            Assert.Null(await MultiplexedConnectionContext.AcceptAsync().DefaultTimeout());
+        }
+    }
+}

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -654,6 +654,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var requestStream = await InitializeConnectionAndStreamsAsync(_echoApplication);
 
             var doneWithHeaders = await requestStream.SendHeadersAsync(headers);
+            // Need to figure out how to trigger goaway from server?
+            // Trigger ConnectionClose
+
             await requestStream.SendDataAsync(Encoding.ASCII.GetBytes("Hello world"), endStream: true);
 
             var responseHeaders = await requestStream.ExpectHeadersAsync();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -1,10 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing;
@@ -639,39 +640,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await requestStream.SendHeadersAsync(headers, endStream: true);
 
             await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.ProtocolError, CoreStrings.Http3StreamErrorLessDataThanLength);
-        }
-
-        [Fact]
-        public async Task GoAwayReceived()
-        {
-            var headers = new[]
-            {
-                new KeyValuePair<string, string>(HeaderNames.Method, "Custom"),
-                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
-                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
-                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
-            };
-
-            var requestStream = await InitializeConnectionAndStreamsAsync(_echoApplication);
-
-            var doneWithHeaders = await requestStream.SendHeadersAsync(headers);
-            // Need to figure out how to trigger goaway from server?
-            // Trigger ConnectionClose
-
-            await requestStream.SendDataAsync(Encoding.ASCII.GetBytes("Hello world"), endStream: true);
-
-            var responseHeaders = await requestStream.ExpectHeadersAsync();
-            var responseData = await requestStream.ExpectDataAsync();
-            Assert.Equal("Hello world", Encoding.ASCII.GetString(responseData.ToArray()));
-        }
-
-        [Fact]
-        public async Task GracefulServerShutdownSendsGoawayClosesConnection()
-        {
-            await InitializeConnectionAsync(_echoApplication);
-            // Trigger server shutdown.
-            MultiplexedConnectionContext.ConnectionClosingCts.Cancel();
-            Assert.Null(await MultiplexedConnectionContext.AcceptAsync().DefaultTimeout());
         }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -639,5 +639,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.ProtocolError, CoreStrings.Http3StreamErrorLessDataThanLength);
         }
+
+        [Fact]
+        public async Task GoAwayReceived()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "Custom"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+
+            var requestStream = await InitializeConnectionAndStreamsAsync(_echoApplication);
+
+            var doneWithHeaders = await requestStream.SendHeadersAsync(headers);
+            await requestStream.SendDataAsync(Encoding.ASCII.GetBytes("Hello world"), endStream: true);
+
+            var responseHeaders = await requestStream.ExpectHeadersAsync();
+            var responseData = await requestStream.ExpectDataAsync();
+            Assert.Equal("Hello world", Encoding.ASCII.GetString(responseData.ToArray()));
+        }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing;
@@ -662,6 +663,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var responseHeaders = await requestStream.ExpectHeadersAsync();
             var responseData = await requestStream.ExpectDataAsync();
             Assert.Equal("Hello world", Encoding.ASCII.GetString(responseData.ToArray()));
+        }
+
+        [Fact]
+        public async Task GracefulServerShutdownSendsGoawayClosesConnection()
+        {
+            await InitializeConnectionAsync(_echoApplication);
+            // Trigger server shutdown.
+            MultiplexedConnectionContext.ConnectionClosingCts.Cancel();
+            Assert.Null(await MultiplexedConnectionContext.AcceptAsync().DefaultTimeout());
         }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             }
 
             // Skip all heartbeat and lifetime notification feature registrations.
-            _connectionTask = _connection.InnerProcessRequestsAsync(new DummyApplication(application));
+            _connectionTask = _connection.InnerProcessStreamsAsync(new DummyApplication(application));
 
             await Task.CompletedTask;
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _echoApplication = async context =>
             {
-                var buffer = new byte[Http3PeerSettings.MinAllowedMaxFrameSize];
+                var buffer = new byte[16 * 1024];
                 var received = 0;
 
                 while ((received = await context.Request.Body.ReadAsync(buffer, 0, buffer.Length)) > 0)
@@ -234,7 +234,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             public long Error { get; set; }
 
-            private readonly byte[] _headerEncodingBuffer = new byte[Http3PeerSettings.MinAllowedMaxFrameSize];
+            private readonly byte[] _headerEncodingBuffer = new byte[16 * 1024];
             private QPackEncoder _qpackEncoder = new QPackEncoder();
             private QPackDecoder _qpackDecoder = new QPackDecoder(8192);
             private long _bytesReceived;
@@ -300,7 +300,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 return http3WithPayload.Payload;
             }
 
-            internal async Task<Http3FrameWithPayload> ReceiveFrameAsync(uint maxFrameSize = Http3PeerSettings.DefaultMaxFrameSize)
+            internal async Task<Http3FrameWithPayload> ReceiveFrameAsync(uint maxFrameSize = 16 * 1024)
             {
                 var frame = new Http3FrameWithPayload();
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -1,6 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
 using System.Net.Http;
@@ -32,14 +36,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
     public class Http3TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable
     {
         internal TestServiceContext _serviceContext;
-        internal Http3Connection _connection;
         internal readonly TimeoutControl _timeoutControl;
         internal readonly Mock<IKestrelTrace> _mockKestrelTrace = new Mock<IKestrelTrace>();
         internal readonly Mock<ITimeoutHandler> _mockTimeoutHandler = new Mock<ITimeoutHandler>();
         internal readonly Mock<MockTimeoutControlBase> _mockTimeoutControl;
         internal readonly MemoryPool<byte> _memoryPool = SlabMemoryPoolFactory.Create();
         protected Task _connectionTask;
-        private readonly CancellationTokenSource _connectionClosingCts = new CancellationTokenSource();
+        protected readonly TaskCompletionSource _closedStateReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
 
         protected readonly RequestDelegate _noopApplication;
         protected readonly RequestDelegate _echoApplication;
@@ -47,11 +51,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected readonly RequestDelegate _echoPath;
         protected readonly RequestDelegate _echoHost;
 
+        private Http3ControlStream _inboundControlStream;
+
         public Http3TestBase()
         {
             _timeoutControl = new TimeoutControl(_mockTimeoutHandler.Object);
             _mockTimeoutControl = new Mock<MockTimeoutControlBase>(_timeoutControl) { CallBase = true };
             _timeoutControl.Debugger = Mock.Of<IDebugger>();
+
+            _mockKestrelTrace
+                .Setup(m => m.Http3ConnectionClosed(It.IsAny<string>(), It.IsAny<long>()))
+                .Callback(() => _closedStateReached.SetResult());
+
 
             _noopApplication = context => Task.CompletedTask;
 
@@ -89,6 +100,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
         }
 
+        internal Http3Connection Connection { get; private set; }
+
+        internal Http3ControlStream OutboundControlStream { get; private set; }
+
         public TestMultiplexedConnectionContext MultiplexedConnectionContext { get; set; }
 
         public override void Initialize(TestContext context, MethodInfo methodInfo, object[] testMethodArguments, ITestOutputHelper testOutputHelper)
@@ -101,15 +116,58 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             };
         }
 
+        internal async ValueTask<Http3ControlStream> GetInboundControlStream()
+        {
+            if (_inboundControlStream == null)
+            {
+                var reader = MultiplexedConnectionContext.ToClientAcceptQueue.Reader;
+                while (await reader.WaitToReadAsync())
+                {
+                    while (reader.TryRead(out var stream))
+                    {
+                        _inboundControlStream = stream;
+                        var streamId = await stream.TryReadStreamIdAsync();
+                        Debug.Assert(streamId == 0, "StreamId sent that was non-zero, which isn't handled by tests");
+                        return _inboundControlStream;
+                    }
+                }
+            }    
+            
+            return null;
+        }
+
+        internal async Task WaitForConnectionErrorAsync(bool ignoreNonGoAwayFrames, long expectedLastStreamId, Http3ErrorCode expectedErrorCode)
+        {
+            var frame = await _inboundControlStream.ReceiveFrameAsync();
+
+            if (ignoreNonGoAwayFrames)
+            {
+                while (frame.Type != Http3FrameType.GoAway)
+                {
+                    frame = await _inboundControlStream.ReceiveFrameAsync();
+                }
+            }
+
+            VerifyGoAway(frame, expectedLastStreamId, expectedErrorCode);
+        }
+
+        internal void VerifyGoAway(Http3FrameWithPayload frame, long expectedLastStreamId, Http3ErrorCode expectedErrorCode)
+        {
+            Assert.Equal(Http3FrameType.GoAway, frame.Type);
+            var payload = frame.Payload;
+            Assert.True(VariableLengthIntegerHelper.TryRead(payload.Span, out var streamId, out var _));
+            Assert.Equal(expectedLastStreamId, streamId);
+        }
+
         protected async Task InitializeConnectionAsync(RequestDelegate application)
         {
-            if (_connection == null)
+            if (Connection == null)
             {
                 CreateConnection();
             }
 
             // Skip all heartbeat and lifetime notification feature registrations.
-            _connectionTask = _connection.ProcessStreamsAsync(new DummyApplication(application));
+            _connectionTask = Connection.ProcessStreamsAsync(new DummyApplication(application));
 
             await Task.CompletedTask;
         }
@@ -118,9 +176,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             await InitializeConnectionAsync(application);
 
-            var controlStream1 = await CreateControlStream(0);
-            var controlStream2 = await CreateControlStream(2);
-            var controlStream3 = await CreateControlStream(3);
+            OutboundControlStream = await CreateControlStream();
 
             return await CreateRequestStream();
         }
@@ -142,9 +198,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 remoteEndPoint: null);
             httpConnectionContext.TimeoutControl = _mockTimeoutControl.Object;
 
-            _connection = new Http3Connection(httpConnectionContext);
+            Connection = new Http3Connection(httpConnectionContext);
             _mockTimeoutHandler.Setup(h => h.OnTimeout(It.IsAny<TimeoutReason>()))
-                           .Callback<TimeoutReason>(r => _connection.OnTimeout(r));
+                           .Callback<TimeoutReason>(r => Connection.OnTimeout(r));
         }
 
         protected void ConnectionClosed()
@@ -187,33 +243,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return bufferSize ?? 0;
         }
 
-        internal async ValueTask<Http3ControlStream> CreateControlStream(int id)
+        public ValueTask<Http3ControlStream> CreateControlStream()
+        {
+            return CreateControlStream(id: 0);
+        }
+
+        public async ValueTask<Http3ControlStream> CreateControlStream(int id)
         {
             var stream = new Http3ControlStream(this);
-            MultiplexedConnectionContext.AcceptQueue.Writer.TryWrite(stream.StreamContext);
+            MultiplexedConnectionContext.ToServerAcceptQueue.Writer.TryWrite(stream.StreamContext);
             await stream.WriteStreamIdAsync(id);
             return stream;
         }
 
         internal ValueTask<Http3RequestStream> CreateRequestStream()
         {
-            var stream = new Http3RequestStream(this, _connection);
-            MultiplexedConnectionContext.AcceptQueue.Writer.TryWrite(stream.StreamContext);
+            var stream = new Http3RequestStream(this, Connection);
+            MultiplexedConnectionContext.ToServerAcceptQueue.Writer.TryWrite(stream.StreamContext);
             return new ValueTask<Http3RequestStream>(stream);
         }
 
         public ValueTask<ConnectionContext> StartBidirectionalStreamAsync()
         {
-            var stream = new Http3RequestStream(this, _connection);
+            var stream = new Http3RequestStream(this, Connection);
             // TODO put these somewhere to be read.
             return new ValueTask<ConnectionContext>(stream.StreamContext);
         }
 
-        internal class Http3StreamBase
+        public class Http3StreamBase
         {
-            protected DuplexPipe.DuplexPipePair _pair;
-            protected Http3TestBase _testBase;
-            protected Http3Connection _connection;
+            internal DuplexPipe.DuplexPipePair _pair;
+            internal Http3TestBase _testBase;
+            internal Http3Connection _connection;
+            private long _bytesReceived;
 
             protected Task SendAsync(ReadOnlySpan<byte> span)
             {
@@ -225,6 +287,46 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             protected static async Task FlushAsync(PipeWriter writableBuffer)
             {
                 await writableBuffer.FlushAsync().AsTask().DefaultTimeout();
+            }
+
+            internal async Task<Http3FrameWithPayload> ReceiveFrameAsync(uint maxFrameSize = 16 * 1024)
+            {
+                var frame = new Http3FrameWithPayload();
+
+                while (true)
+                {
+                    var result = await _pair.Application.Input.ReadAsync().AsTask().DefaultTimeout();
+                    var buffer = result.Buffer;
+                    var consumed = buffer.Start;
+                    var examined = buffer.Start;
+                    var copyBuffer = buffer;
+
+                    try
+                    {
+                        Assert.True(buffer.Length > 0);
+
+                        if (Http3FrameReader.TryReadFrame(ref buffer, frame, maxFrameSize, out var framePayload))
+                        {
+                            consumed = examined = framePayload.End;
+                            frame.Payload = framePayload.ToArray();
+                            return frame;
+                        }
+                        else
+                        {
+                            examined = buffer.End;
+                        }
+
+                        if (result.IsCompleted)
+                        {
+                            throw new IOException("The reader completed without returning a frame.");
+                        }
+                    }
+                    finally
+                    {
+                        _bytesReceived += copyBuffer.Slice(copyBuffer.Start, consumed).Length;
+                        _pair.Application.Input.AdvanceTo(consumed, examined);
+                    }
+                }
             }
         }
 
@@ -242,7 +344,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             private readonly byte[] _headerEncodingBuffer = new byte[16 * 1024];
             private QPackEncoder _qpackEncoder = new QPackEncoder();
             private QPackDecoder _qpackDecoder = new QPackDecoder(8192);
-            private long _bytesReceived;
             protected readonly Dictionary<string, string> _decodedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             public Http3RequestStream(Http3TestBase testBase, Http3Connection connection)
@@ -305,46 +406,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 return http3WithPayload.Payload;
             }
 
-            internal async Task<Http3FrameWithPayload> ReceiveFrameAsync(uint maxFrameSize = 16 * 1024)
-            {
-                var frame = new Http3FrameWithPayload();
-
-                while (true)
-                {
-                    var result = await _pair.Application.Input.ReadAsync().AsTask().DefaultTimeout();
-                    var buffer = result.Buffer;
-                    var consumed = buffer.Start;
-                    var examined = buffer.Start;
-                    var copyBuffer = buffer;
-
-                    try
-                    {
-                        Assert.True(buffer.Length > 0);
-
-                        if (Http3FrameReader.TryReadFrame(ref buffer, frame, maxFrameSize, out var framePayload))
-                        {
-                            consumed = examined = framePayload.End;
-                            frame.Payload = framePayload.ToArray();
-                            return frame;
-                        }
-                        else
-                        {
-                            examined = buffer.End;
-                        }
-
-                        if (result.IsCompleted)
-                        {
-                            throw new IOException("The reader completed without returning a frame.");
-                        }
-                    }
-                    finally
-                    {
-                        _bytesReceived += copyBuffer.Slice(copyBuffer.Start, consumed).Length;
-                        _pair.Application.Input.AdvanceTo(consumed, examined);
-                    }
-                }
-            }
-
             internal async Task ExpectReceiveEndOfStream()
             {
                 var result = await _pair.Application.Input.ReadAsync().AsTask().DefaultTimeout();
@@ -398,8 +459,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             public ReadOnlySequence<byte> PayloadSequence => new ReadOnlySequence<byte>(Payload);
         }
 
-
-        internal class Http3ControlStream : Http3StreamBase, IProtocolErrorCodeFeature
+        public class Http3ControlStream : Http3StreamBase, IProtocolErrorCodeFeature
         {
             internal ConnectionContext StreamContext { get; }
 
@@ -419,6 +479,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 StreamContext = new TestStreamContext(canRead: false, canWrite: true, _pair, this);
             }
 
+            public Http3ControlStream(ConnectionContext streamContext)
+            {
+                StreamContext = streamContext;
+            }
+
             public async Task WriteStreamIdAsync(int id)
             {
                 var writableBuffer = _pair.Application.Output;
@@ -434,11 +499,49 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 await FlushAsync(writableBuffer);
             }
+
+            public async ValueTask<long> TryReadStreamIdAsync()
+            {
+                while (true)
+                {
+                    var result = await _pair.Application.Input.ReadAsync();
+                    var readableBuffer = result.Buffer;
+                    var consumed = readableBuffer.Start;
+                    var examined = readableBuffer.End;
+
+                    try
+                    {
+                        if (!readableBuffer.IsEmpty)
+                        {
+                            var id = VariableLengthIntegerHelper.GetInteger(readableBuffer, out consumed, out examined);
+                            if (id != -1)
+                            {
+                                return id;
+                            }
+                        }
+
+                        if (result.IsCompleted)
+                        {
+                            return -1;
+                        }
+                    }
+                    finally
+                    {
+                        _pair.Application.Input.AdvanceTo(consumed, examined);
+                    }
+                }
+            }
         }
 
         public class TestMultiplexedConnectionContext : MultiplexedConnectionContext, IConnectionLifetimeNotificationFeature, IConnectionLifetimeFeature, IConnectionHeartbeatFeature
         {
-            public readonly Channel<ConnectionContext> AcceptQueue = Channel.CreateUnbounded<ConnectionContext>(new UnboundedChannelOptions
+            public readonly Channel<ConnectionContext> ToServerAcceptQueue = Channel.CreateUnbounded<ConnectionContext>(new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = true
+            });
+
+            public readonly Channel<Http3ControlStream> ToClientAcceptQueue = Channel.CreateUnbounded<Http3ControlStream>(new UnboundedChannelOptions
             {
                 SingleReader = true,
                 SingleWriter = true
@@ -460,6 +563,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             public override IFeatureCollection Features { get; }
 
             public override IDictionary<object, object> Items { get; set; }
+
             public CancellationToken ConnectionClosedRequested { get; set; }
 
             public CancellationTokenSource ConnectionClosingCts { get; set; } = new CancellationTokenSource();
@@ -471,14 +575,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             public override void Abort(ConnectionAbortedException abortReason)
             {
-                AcceptQueue.Writer.TryComplete();
+                ToServerAcceptQueue.Writer.TryComplete();
             }
 
             public override async ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
             {
-                while (await AcceptQueue.Reader.WaitToReadAsync())
+                while (await ToServerAcceptQueue.Reader.WaitToReadAsync())
                 {
-                    while (AcceptQueue.Reader.TryRead(out var connection))
+                    while (ToServerAcceptQueue.Reader.TryRead(out var connection))
                     {
                         return connection;
                     }
@@ -490,7 +594,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             public override ValueTask<ConnectionContext> ConnectAsync(IFeatureCollection features = null, CancellationToken cancellationToken = default)
             {
                 var stream = new Http3ControlStream(_testBase);
-                // TODO put these somewhere to be read.
+                ToClientAcceptQueue.Writer.WriteAsync(stream);
                 return new ValueTask<ConnectionContext>(stream.StreamContext);
             }
 

--- a/src/Shared/ServerInfrastructure/Http2/Http2PeerSettings.cs
+++ b/src/Shared/ServerInfrastructure/Http2/Http2PeerSettings.cs
@@ -88,8 +88,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         }
 
         // Gets the settings that are different from the protocol defaults (as opposed to the server defaults).
-        internal IList<Http2PeerSetting> GetNonProtocolDefaults()
+        internal List<Http2PeerSetting> GetNonProtocolDefaults()
         {
+            // By default, there is only one setting that is sent from server to client.
+            // Set capacity to that value.
             var list = new List<Http2PeerSetting>(1);
 
             if (HeaderTableSize != DefaultHeaderTableSize)

--- a/src/Shared/runtime/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/Shared/runtime/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -32,9 +32,9 @@ namespace System.Net.Http
         private const ulong EightByteLengthMask = 0xC000000000000000;
 
         public const uint OneByteLimit = (1U << 6) - 1;
-        private const uint TwoByteLimit = (1U << 16) - 1;
-        private const uint FourByteLimit = (1U << 30) - 1;
-        private const long EightByteLimit = (1L << 62) - 1;
+        public const uint TwoByteLimit = (1U << 16) - 1;
+        public const uint FourByteLimit = (1U << 30) - 1;
+        public const long EightByteLimit = (1L << 62) - 1;
 
         public static bool TryRead(ReadOnlySpan<byte> buffer, out long value, out int bytesRead)
         {


### PR DESCRIPTION
Right now, if you CTRL+C when a connection is still active in HTTP/3, the connection will not gracefully shutdown. This is because we never have anything that interrupts the loop accepting new streams for a connection.

This change adds a CTS which is canceled in abort and StopProcessingNextRequest, which causes the Accept loop to exit.

This change also tries to centralize access to the stream dictionary, which ends/aborts all streams. Instead of aborting all streams inside of the InnerAbort, we check state in the finally block of the accept loop. Things are locked, so it should be all fine and dandy. 