### PR TITLE
Improve control stream handling with HTTP/3

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -23,9 +23,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
     {
         public DynamicTable DynamicTable { get; set; }
 
-        public Http3ControlStream ControlStream { get; set; }
-        public Http3ControlStream EncoderStream { get; set; }
-        public Http3ControlStream DecoderStream { get; set; }
+        public Http3ControlStream OutboundControlStream { get; set; }
+        public Http3ControlStream OutboundEncoderStream { get; set; }
+        public Http3ControlStream OutboundDecoderStream { get; set; }
+
+        private Http3ControlStream _inboundControlStream;
+        private Http3ControlStream _inboundEncoderStream;
+        private Http3ControlStream _inboundDecoderStream;
 
         internal readonly Dictionary<long, Http3Stream> _streams = new Dictionary<long, Http3Stream>();
 
@@ -286,9 +290,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     }
                 }
 
-                ControlStream?.Abort(new ConnectionAbortedException("Connection is shutting down."));
-                EncoderStream?.Abort(new ConnectionAbortedException("Connection is shutting down."));
-                DecoderStream?.Abort(new ConnectionAbortedException("Connection is shutting down."));
+                OutboundControlStream?.Abort(new ConnectionAbortedException("Connection is shutting down."));
+                OutboundEncoderStream?.Abort(new ConnectionAbortedException("Connection is shutting down."));
+                OutboundDecoderStream?.Abort(new ConnectionAbortedException("Connection is shutting down."));
 
                 await controlTask;
                 await encoderTask;
@@ -299,7 +303,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private async ValueTask CreateControlStream<TContext>(IHttpApplication<TContext> application)
         {
             var stream = await CreateNewUnidirectionalStreamAsync(application);
-            ControlStream = stream;
+            OutboundControlStream = stream;
             await stream.SendStreamIdAsync(id: 0);
             await stream.SendSettingsFrameAsync();
         }
@@ -307,14 +311,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private async ValueTask CreateEncoderStream<TContext>(IHttpApplication<TContext> application)
         {
             var stream = await CreateNewUnidirectionalStreamAsync(application);
-            EncoderStream = stream;
+            OutboundEncoderStream = stream;
             await stream.SendStreamIdAsync(id: 2);
         }
 
         private async ValueTask CreateDecoderStream<TContext>(IHttpApplication<TContext> application)
         {
             var stream = await CreateNewUnidirectionalStreamAsync(application);
-            DecoderStream = stream;
+            OutboundDecoderStream = stream;
             await stream.SendStreamIdAsync(id: 3);
         }
 
@@ -364,10 +368,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             lock (_sync)
             {
-                if (ControlStream != null)
+                if (OutboundControlStream != null)
                 {
                     // TODO need to await this somewhere or allow this to be called elsewhere?
-                    ControlStream.SendGoAway(_highestOpenedStreamId).GetAwaiter().GetResult();
+                    OutboundControlStream.SendGoAway(_highestOpenedStreamId).GetAwaiter().GetResult();
                 }
 
                 _haveSentGoAway = true;
@@ -396,6 +400,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             {
                 _streams.Remove(streamId);
             }
+        }
+
+        public bool SetInboundControlStream(Http3ControlStream stream)
+        {
+            return Interlocked.CompareExchange(ref _inboundControlStream, stream, stream) == null;
+        }
+
+        public bool SetInboundEncoderStream(Http3ControlStream stream)
+        {
+            return Interlocked.CompareExchange(ref _inboundEncoderStream, stream, stream) == null;
+        }
+
+        public bool SetInboundDecoderStream(Http3ControlStream stream)
+        {
+            return Interlocked.CompareExchange(ref _inboundDecoderStream, stream, stream) == null;
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -82,6 +82,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         {
             if (Interlocked.Exchange(ref _isClosed, 1) == 0)
             {
+                Input.Complete();
                 return true;
             }
 
@@ -163,6 +164,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 {
                     throw new Http3ConnectionException("HTTP_STREAM_CREATION_ERROR");
                 }
+
                 await HandleEncodingTask();
             }
             else if (streamType == DecoderStream)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -89,39 +89,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             return false;
         }
 
-        private async ValueTask HandleEncodingTask()
-        {
-            var encoder = new EncoderStreamReader(10000); // TODO get value from limits
-            while (_isClosed == 0)
-            {
-                var result = await Input.ReadAsync();
-                var readableBuffer = result.Buffer;
-                if (!readableBuffer.IsEmpty)
-                {
-                    // This should always read all bytes in the input no matter what.
-                    encoder.Read(readableBuffer);
-                }
-                Input.AdvanceTo(readableBuffer.End);
-            }
-        }
-
-        private async ValueTask HandleDecodingTask()
-        {
-            var decoder = new DecoderStreamReader();
-            while (_isClosed == 0)
-            {
-                var result = await Input.ReadAsync();
-                var readableBuffer = result.Buffer;
-                var consumed = readableBuffer.Start;
-                var examined = readableBuffer.Start;
-                if (!readableBuffer.IsEmpty)
-                {
-                    decoder.Read(readableBuffer);
-                }
-                Input.AdvanceTo(readableBuffer.End);
-            }
-        }
-
         internal async ValueTask SendStreamIdAsync(long id)
         {
             await _frameWriter.WriteStreamIdAsync(id);
@@ -182,8 +149,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             if (streamType == ControlStream)
             {
-                if (_http3Connection.ControlStream != null)
+                if (!_http3Connection.SetInboundControlStream(this))
                 {
+                    // TODO propagate these errors to connection.
                     throw new Http3ConnectionException("HTTP_STREAM_CREATION_ERROR");
                 }
 
@@ -191,16 +159,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
             else if (streamType == EncoderStream)
             {
-                if (_http3Connection.EncoderStream != null)
+                if (!_http3Connection.SetInboundEncoderStream(this))
                 {
                     throw new Http3ConnectionException("HTTP_STREAM_CREATION_ERROR");
                 }
                 await HandleEncodingTask();
-                return;
             }
             else if (streamType == DecoderStream)
             {
-                if (_http3Connection.DecoderStream != null)
+                if (!_http3Connection.SetInboundDecoderStream(this))
                 {
                     throw new Http3ConnectionException("HTTP_STREAM_CREATION_ERROR");
                 }
@@ -210,7 +177,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             {
                 // TODO Close the control stream as it's unexpected.
             }
-            return;
         }
 
         private async Task HandleControlStream()
@@ -250,6 +216,33 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
         }
 
+        private async ValueTask HandleEncodingTask()
+        {
+            // Noop encoding task. Settings make it so we don't need to read content of encoder and decoder.
+            // An endpoint MUST allow its peer to create an encoder stream and a
+            // decoder stream even if the connection's settings prevent their use.
+
+            while (_isClosed == 0)
+            {
+                var result = await Input.ReadAsync();
+                var readableBuffer = result.Buffer;
+                Input.AdvanceTo(readableBuffer.End);
+            }
+        }
+
+        private async ValueTask HandleDecodingTask()
+        {
+            // Noop encoding task. Settings make it so we don't need to read content of encoder and decoder.
+            // An endpoint MUST allow its peer to create an encoder stream and a
+            // decoder stream even if the connection's settings prevent their use.
+            while (_isClosed == 0)
+            {
+                var result = await Input.ReadAsync();
+                var readableBuffer = result.Buffer;
+                Input.AdvanceTo(readableBuffer.End);
+            }
+        }
+
         private ValueTask ProcessHttp3ControlStream(in ReadOnlySequence<byte> payload)
         {
             // Two things:
@@ -283,7 +276,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
 
             _haveReceivedSettingsFrame = true;
-            using var closedRegistration = _context.ConnectionContext.ConnectionClosed.Register(state => ((Http3ControlStream)state).OnStreamClosed(), this);
+            using var closedRegistration = _context.StreamContext.ConnectionClosed.Register(state => ((Http3ControlStream)state).OnStreamClosed(), this);
 
             while (true)
             {


### PR DESCRIPTION
- Don't create outbound encoder and decoder streams as they aren't required now in the spec
- Correctly check if inbound streams have been created to throw exceptions
- Don't allocate a huge amount for encoding.