### PR TITLE
Write HTTP/3 settings to client based on Kestrel settings

### DIFF
--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -7,16 +7,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 {
     public class Http3Limits
     {
-        private int _headerTableSize = 4096;
+        private int _headerTableSize = 0;
         private int _maxRequestHeaderFieldSize = 8192;
 
         /// <summary>
         /// Limits the size of the header compression table, in octets, the HPACK decoder on the server can use.
         /// <para>
-        /// Value must be greater than 0, defaults to 4096
+        /// Value must be greater than 0, defaults to 0
         /// </para>
         /// </summary>
-        public int HeaderTableSize
+        internal int HeaderTableSize
         {
             get => _headerTableSize;
             set

--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// Value must be greater than 0, defaults to 0
         /// </para>
         /// </summary>
+        // TODO: Make public https://github.com/dotnet/aspnetcore/issues/26666
         internal int HeaderTableSize
         {
             get => _headerTableSize;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -547,7 +547,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             |                        Value (32)                             |
             +---------------------------------------------------------------+
         */
-        public ValueTask<FlushResult> WriteSettingsAsync(IList<Http2PeerSetting> settings)
+        public ValueTask<FlushResult> WriteSettingsAsync(List<Http2PeerSetting> settings)
         {
             lock (_writeLock)
             {
@@ -569,7 +569,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        internal static void WriteSettings(IList<Http2PeerSetting> settings, Span<byte> destination)
+        internal static void WriteSettings(List<Http2PeerSetting> settings, Span<byte> destination)
         {
             foreach (var setting in settings)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -41,6 +41,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private readonly object _protocolSelectionLock = new object();
         private CancellationTokenSource _connectionAborted;
 
+        private readonly Http3PeerSettings _serverSettings = new Http3PeerSettings();
+
         public Http3Connection(Http3ConnectionContext context)
         {
             _multiplexedContext = context.ConnectionContext;
@@ -50,6 +52,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             _timeoutControl = new TimeoutControl(this);
             _context.TimeoutControl ??= _timeoutControl;
             _connectionAborted = new CancellationTokenSource();
+
+            var httpLimits = context.ServiceContext.ServerOptions.Limits;
+
+            _serverSettings.HeaderTableSize = (uint)httpLimits.Http3.HeaderTableSize;
+            _serverSettings.MaxRequestHeaderFieldSize = (uint)httpLimits.Http3.MaxRequestHeaderFieldSize;
         }
 
         internal long HighestStreamId
@@ -234,7 +241,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     if (!quicStreamFeature.CanWrite)
                     {
                         // Unidirectional stream
-                        var stream = new Http3ControlStream<TContext>(application, this, httpConnectionContext);
+                        var stream = new Http3ControlStream<TContext>(application, this, httpConnectionContext, _serverSettings);
                         ThreadPool.UnsafeQueueUserWorkItem(stream, preferLocal: false);
                     }
                     else
@@ -330,7 +337,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 RemoteEndPoint = streamContext.RemoteEndPoint as IPEndPoint
             };
 
-            return new Http3ControlStream<TContext>(application, this, httpConnectionContext);
+            return new Http3ControlStream<TContext>(application, this, httpConnectionContext, _serverSettings);
         }
 
         public void HandleRequestHeadersTimeout()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -334,10 +334,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 Transport = streamContext.Transport,
                 TimeoutControl = _context.TimeoutControl,
                 LocalEndPoint = streamContext.LocalEndPoint as IPEndPoint,
-                RemoteEndPoint = streamContext.RemoteEndPoint as IPEndPoint
+                RemoteEndPoint = streamContext.RemoteEndPoint as IPEndPoint,
+                ServerSettings = _serverSettings,
             };
 
-            return new Http3ControlStream<TContext>(application, this, httpConnectionContext, _serverSettings);
+            return new Http3ControlStream<TContext>(application, this, httpConnectionContext);
         }
 
         public void HandleRequestHeadersTimeout()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     if (!quicStreamFeature.CanWrite)
                     {
                         // Unidirectional stream
-                        var stream = new Http3ControlStream<TContext>(application, this, httpConnectionContext, _serverSettings);
+                        var stream = new Http3ControlStream<TContext>(application, this, httpConnectionContext);
                         ThreadPool.UnsafeQueueUserWorkItem(stream, preferLocal: false);
                     }
                     else

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -23,18 +23,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private readonly Http3FrameWriter _frameWriter;
         private readonly Http3Connection _http3Connection;
         private readonly HttpConnectionContext _context;
+        private readonly Http3PeerSettings _serverPeerSettings;
         private readonly Http3RawFrame _incomingFrame = new Http3RawFrame();
         private volatile int _isClosed;
         private int _gracefulCloseInitiator;
 
         private bool _haveReceivedSettingsFrame;
 
-        public Http3ControlStream(Http3Connection http3Connection, HttpConnectionContext context)
+        public Http3ControlStream(Http3Connection http3Connection, HttpConnectionContext context, Http3PeerSettings serverPeerSettings)
         {
             var httpLimits = context.ServiceContext.ServerOptions.Limits;
-
             _http3Connection = http3Connection;
             _context = context;
+            _serverPeerSettings = serverPeerSettings;
 
             _frameWriter = new Http3FrameWriter(
                 context.Transport.Output,
@@ -133,7 +134,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         internal async ValueTask SendSettingsFrameAsync()
         {
-            await _frameWriter.WriteSettingsAsync(null);
+            await _frameWriter.WriteSettingsAsync(_serverPeerSettings.GetNonProtocolDefaults());
         }
 
         private async ValueTask<long> TryReadStreamIdAsync()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private readonly Http3FrameWriter _frameWriter;
         private readonly Http3Connection _http3Connection;
-        private readonly HttpConnectionContext _context;
+        private readonly Http3StreamContext _context;
         private readonly Http3PeerSettings _serverPeerSettings;
         private readonly Http3RawFrame _incomingFrame = new Http3RawFrame();
         private volatile int _isClosed;
@@ -30,16 +30,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private bool _haveReceivedSettingsFrame;
 
-        public Http3ControlStream(Http3Connection http3Connection, HttpConnectionContext context, Http3PeerSettings serverPeerSettings)
+        public Http3ControlStream(Http3Connection http3Connection, Http3StreamContext context)
         {
             var httpLimits = context.ServiceContext.ServerOptions.Limits;
             _http3Connection = http3Connection;
             _context = context;
-            _serverPeerSettings = serverPeerSettings;
+            _serverPeerSettings = context.ServerSettings;
 
             _frameWriter = new Http3FrameWriter(
                 context.Transport.Output,
-                context.ConnectionContext,
+                context.StreamContext,
                 context.TimeoutControl,
                 httpLimits.MinResponseDataRate,
                 context.ConnectionId,

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
     {
         private readonly IHttpApplication<TContext> _application;
 
-        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, HttpConnectionContext context) : base(connection, context)
+        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, Http3StreamContext context) : base(connection, context)
         {
             _application = application;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
     {
         private readonly IHttpApplication<TContext> _application;
 
-        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, HttpConnectionContext context, Http3PeerSettings serverSettings) : base(connection, context, serverSettings)
+        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, HttpConnectionContext context) : base(connection, context)
         {
             _application = application;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
     {
         private readonly IHttpApplication<TContext> _application;
 
-        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, HttpConnectionContext context) : base(connection, context)
+        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, HttpConnectionContext context, Http3PeerSettings serverSettings) : base(connection, context, serverSettings)
         {
             _application = application;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
@@ -67,8 +67,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
         }
 
-        // TODO actually write settings here.
-        internal Task WriteSettingsAsync(IList<Http3PeerSetting> settings)
+        internal Task WriteSettingsAsync(List<Http3PeerSetting> settings)
         {
             _outgoingFrame.PrepareSettings();
 
@@ -95,7 +94,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             return _outputWriter.FlushAsync().AsTask();
         }
 
-        internal static int CalculateSettingsSize(IList<Http3PeerSetting> settings)
+        internal static int CalculateSettingsSize(List<Http3PeerSetting> settings)
         {
             var length = 0;
             foreach (var setting in settings)
@@ -106,7 +105,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             return length;
         }
 
-        internal static void WriteSettings(IList<Http3PeerSetting> settings, Span<byte> destination)
+        internal static void WriteSettings(List<Http3PeerSetting> settings, Span<byte> destination)
         {
             foreach (var setting in settings)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
@@ -68,17 +68,54 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         }
 
         // TODO actually write settings here.
-        internal Task WriteSettingsAsync(IList<Http3PeerSettings> settings)
+        internal Task WriteSettingsAsync(IList<Http3PeerSetting> settings)
         {
             _outgoingFrame.PrepareSettings();
-            var buffer = _outputWriter.GetSpan(2);
 
+            // Two encoded length ints per setting.
+            // One encoded length int for setting size
+            // 1 byte for setting type
+            var buffer = _outputWriter.GetSpan(
+                VariableLengthIntegerHelper.MaximumEncodedLength * 2 * settings.Count + VariableLengthIntegerHelper.MaximumEncodedLength + 1);
+
+            var totalLength = 1;
             buffer[0] = (byte)_outgoingFrame.Type;
-            buffer[1] = 0;
+            buffer = buffer[1..];
 
-            _outputWriter.Advance(2);
+            var settingsLength = CalculateSettingsSize(settings);
+            var settingsBytesWritten = VariableLengthIntegerHelper.WriteInteger(buffer, settingsLength);
+            totalLength += settingsBytesWritten + settingsLength;
+
+            WriteSettings(settings, buffer);
+
+            _outgoingFrame.Length = totalLength;
+
+            _outputWriter.Advance(totalLength);
 
             return _outputWriter.FlushAsync().AsTask();
+        }
+
+        internal static int CalculateSettingsSize(IList<Http3PeerSetting> settings)
+        {
+            var length = 0;
+            foreach (var setting in settings)
+            {
+                length += VariableLengthIntegerHelper.GetByteCount((long)setting.Parameter);
+                length += VariableLengthIntegerHelper.GetByteCount(setting.Value);
+            }
+            return length;
+        }
+
+        internal static void WriteSettings(IList<Http3PeerSetting> settings, Span<byte> destination)
+        {
+            foreach (var setting in settings)
+            {
+                var parameterLength = VariableLengthIntegerHelper.WriteInteger(destination, (long)setting.Parameter);
+                destination = destination.Slice(parameterLength);
+
+                var valueLength = VariableLengthIntegerHelper.WriteInteger(destination, (long)setting.Value);
+                destination = destination.Slice(valueLength);
+            }
         }
 
         internal Task WriteStreamIdAsync(long id)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSetting.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSetting.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
+{
+    internal readonly struct Http3PeerSetting
+    {
+        public Http3PeerSetting(Http3SettingType parameter, uint value)
+        {
+            Parameter = parameter;
+            Value = value;
+        }
+
+        public Http3SettingType Parameter { get; }
+
+        public uint Value { get; }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
@@ -17,6 +17,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         // Gets the settings that are different from the protocol defaults (as opposed to the server defaults).
         internal List<Http3PeerSetting> GetNonProtocolDefaults()
         {
+            // By default, there is only one setting that is sent from server to client.
+            // Set capacity to that value.
             var list = new List<Http3PeerSetting>(1);
 
             if (HeaderTableSize != DefaultHeaderTableSize)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         public uint MaxRequestHeaderFieldSize { get; internal set; }
 
         // Gets the settings that are different from the protocol defaults (as opposed to the server defaults).
-        internal IList<Http3PeerSetting> GetNonProtocolDefaults()
+        internal List<Http3PeerSetting> GetNonProtocolDefaults()
         {
             var list = new List<Http3PeerSetting>(1);
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
@@ -1,12 +1,35 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
     internal class Http3PeerSettings
     {
-        internal const uint DefaultMaxFrameSize = 16 * 1024;
+        // Note these are protocol defaults, not Kestrel defaults.
+        public const uint DefaultHeaderTableSize = 0;
+        public const uint DefaultMaxRequestHeaderFieldSize = uint.MaxValue;
 
-        public static int MinAllowedMaxFrameSize { get; internal set; } = 16 * 1024;
+        public uint HeaderTableSize { get; internal set; }
+        public uint MaxRequestHeaderFieldSize { get; internal set; }
+
+        // Gets the settings that are different from the protocol defaults (as opposed to the server defaults).
+        internal IList<Http3PeerSetting> GetNonProtocolDefaults()
+        {
+            var list = new List<Http3PeerSetting>(1);
+
+            if (HeaderTableSize != DefaultHeaderTableSize)
+            {
+                list.Add(new Http3PeerSetting(Http3SettingType.QPackMaxTableCapacity, HeaderTableSize));
+            }
+
+            if (MaxRequestHeaderFieldSize != DefaultMaxRequestHeaderFieldSize)
+            {
+                list.Add(new Http3PeerSetting(Http3SettingType.MaxHeaderListSize, MaxRequestHeaderFieldSize));
+            }
+
+            return list;
+        }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3PeerSettings.cs
@@ -11,8 +11,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         public const uint DefaultHeaderTableSize = 0;
         public const uint DefaultMaxRequestHeaderFieldSize = uint.MaxValue;
 
-        public uint HeaderTableSize { get; internal set; }
-        public uint MaxRequestHeaderFieldSize { get; internal set; }
+        public uint HeaderTableSize { get; internal set; } = DefaultHeaderTableSize;
+        public uint MaxRequestHeaderFieldSize { get; internal set; } = DefaultMaxRequestHeaderFieldSize;
 
         // Gets the settings that are different from the protocol defaults (as opposed to the server defaults).
         internal List<Http3PeerSetting> GetNonProtocolDefaults()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3SettingType.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3SettingType.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
-    enum Http3SettingType : long
+    internal enum Http3SettingType : long
     {
         QPackMaxTableCapacity = 0x1,
         /// <summary>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3StreamContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3StreamContext.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
     internal class Http3StreamContext : HttpConnectionContext
     {
         public ConnectionContext StreamContext { get; set; }
+        public Http3PeerSettings ServerSettings { get; set; }
     }
 }

--- a/src/Servers/Kestrel/Core/test/Http3FrameWriterTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3FrameWriterTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class Http3FrameWriterTests
+    {
+        private MemoryPool<byte> _dirtyMemoryPool;
+
+        public Http3FrameWriterTests()
+        {
+            var memoryBlock = new Mock<IMemoryOwner<byte>>();
+            memoryBlock.Setup(block => block.Memory).Returns(() =>
+            {
+                var blockArray = new byte[4096];
+                for (int i = 0; i < 4096; i++)
+                {
+                    blockArray[i] = 0xff;
+                }
+                return new Memory<byte>(blockArray);
+            });
+
+            var dirtyMemoryPool = new Mock<MemoryPool<byte>>();
+            dirtyMemoryPool.Setup(pool => pool.Rent(It.IsAny<int>())).Returns(memoryBlock.Object);
+            _dirtyMemoryPool = dirtyMemoryPool.Object;
+        }
+
+        [Fact]
+        public async Task WriteSettings_NoSettingsWrittenWithProtocolDefault()
+        {
+            var pipe = new Pipe(new PipeOptions(_dirtyMemoryPool, PipeScheduler.Inline, PipeScheduler.Inline));
+            var frameWriter = new Http3FrameWriter(pipe.Writer, null, null, null, null, _dirtyMemoryPool, null);
+
+            var settings = new Http3PeerSettings();
+            await frameWriter.WriteSettingsAsync(settings.GetNonProtocolDefaults());
+
+            var payload = await pipe.Reader.ReadForLengthAsync(2);
+
+            Assert.Equal(new byte[] { 0x04, 0x00 }, payload.ToArray());
+        }
+
+        [Fact]
+        public async Task WriteSettings_OneSettingsWrittenWithKestrelDefaults()
+        {
+            var pipe = new Pipe(new PipeOptions(_dirtyMemoryPool, PipeScheduler.Inline, PipeScheduler.Inline));
+            var frameWriter = new Http3FrameWriter(pipe.Writer, null, null, null, null, _dirtyMemoryPool, null);
+
+            var limits = new Http3Limits();
+            var settings = new Http3PeerSettings();
+            settings.HeaderTableSize = (uint)limits.HeaderTableSize;
+            settings.MaxRequestHeaderFieldSize = (uint)limits.MaxRequestHeaderFieldSize;
+
+            await frameWriter.WriteSettingsAsync(settings.GetNonProtocolDefaults());
+
+            // variable length ints make it so the results isn't know without knowing the values 
+            var payload = await pipe.Reader.ReadForLengthAsync(5);
+
+            Assert.Equal(new byte[] { 0x04, 0x03, 0x06, 0x60, 0x00 }, payload.ToArray());
+        }
+
+        [Fact]
+        public async Task WriteSettings_TwoSettingsWritten()
+        {
+            var pipe = new Pipe(new PipeOptions(_dirtyMemoryPool, PipeScheduler.Inline, PipeScheduler.Inline));
+            var frameWriter = new Http3FrameWriter(pipe.Writer, null, null, null, null, _dirtyMemoryPool, null);
+
+            var settings = new Http3PeerSettings();
+            settings.HeaderTableSize = 1234;
+            settings.MaxRequestHeaderFieldSize = 567890;
+
+            await frameWriter.WriteSettingsAsync(settings.GetNonProtocolDefaults());
+
+            // variable length ints make it so the results isn't know without knowing the values 
+            var payload = await pipe.Reader.ReadForLengthAsync(10);
+
+            Assert.Equal(new byte[] { 0x04, 0x08, 0x01, 0x44, 0xD2, 0x06, 0x80, 0x08, 0xAA, 0x52 }, payload.ToArray());
+        }
+    }
+}

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _echoApplication = async context =>
             {
-                var buffer = new byte[Http3PeerSettings.MinAllowedMaxFrameSize];
+                var buffer = new byte[16 * 1024];
                 var received = 0;
 
                 while ((received = await context.Request.Body.ReadAsync(buffer, 0, buffer.Length)) > 0)
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             public long Error { get; set; }
 
-            private readonly byte[] _headerEncodingBuffer = new byte[Http3PeerSettings.MinAllowedMaxFrameSize];
+            private readonly byte[] _headerEncodingBuffer = new byte[16 * 1024];
             private QPackEncoder _qpackEncoder = new QPackEncoder();
             private QPackDecoder _qpackDecoder = new QPackDecoder(8192);
             private long _bytesReceived;
@@ -299,7 +299,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 return http3WithPayload.Payload;
             }
 
-            internal async Task<Http3FrameWithPayload> ReceiveFrameAsync(uint maxFrameSize = Http3PeerSettings.DefaultMaxFrameSize)
+            internal async Task<Http3FrameWithPayload> ReceiveFrameAsync(uint maxFrameSize = 16 * 1024)
             {
                 var frame = new Http3FrameWithPayload();
 

--- a/src/Shared/ServerInfrastructure/Http2/Http2PeerSettings.cs
+++ b/src/Shared/ServerInfrastructure/Http2/Http2PeerSettings.cs
@@ -88,8 +88,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         }
 
         // Gets the settings that are different from the protocol defaults (as opposed to the server defaults).
-        internal IList<Http2PeerSetting> GetNonProtocolDefaults()
+        internal List<Http2PeerSetting> GetNonProtocolDefaults()
         {
+            // By default, there is only one setting that is sent from server to client.
+            // Set capacity to that value.
             var list = new List<Http2PeerSetting>(1);
 
             if (HeaderTableSize != DefaultHeaderTableSize)


### PR DESCRIPTION
- Make header table size (dynamic table size) internal for now as we don't support dynamic table.
- Set default max header field size to 8KB.
- Remove MinAllowedMaxFrameSize as it isn't used.