### PR TITLE
OpenIdConnectHandler Redirect to Identity Provider Need Consider Ajax request to avoid CORS error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ msbuild.ProjectImports.zip
 StyleCop.Cache
 UpgradeLog.htm
 .idea
+/src/Framework/App.Ref/src/PackageOverrides.txt

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -468,7 +468,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                     Response.StatusCode = 401;
                 }
                 else
+               {
                     Response.Redirect(redirectUri);
+               }
                 return;
             }
             else if (Options.AuthenticationMethod == OpenIdConnectRedirectBehavior.FormPost)

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -462,8 +462,13 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 {
                     Logger.InvalidAuthenticationRequestUrl(redirectUri);
                 }
-
-                Response.Redirect(redirectUri);
+                if (IsAjaxRequest(Context.Request))
+                {
+                    Response.Headers["Location"] = redirectUri;
+                    Response.StatusCode = 401;
+                }
+                else
+                    Response.Redirect(redirectUri);
                 return;
             }
             else if (Options.AuthenticationMethod == OpenIdConnectRedirectBehavior.FormPost)
@@ -1334,6 +1339,12 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             ex.Data["error_description"] = description;
             ex.Data["error_uri"] = errorUri;
             return ex;
+        }
+
+        private static bool IsAjaxRequest(HttpRequest request)
+        {
+            return string.Equals(request.Query["X-Requested-With"], "XMLHttpRequest", StringComparison.Ordinal) ||
+                string.Equals(request.Headers["X-Requested-With"], "XMLHttpRequest", StringComparison.Ordinal);
         }
     }
 }


### PR DESCRIPTION
The issue is raised in Microsoft.Identity.Web project, where a dynamic consent on controller action called by ajax method cause user agent CORS error. A seperate PR https://github.com/AzureAD/microsoft-identity-web/pull/665 is suggested by the team.

Suggest enhancement
(1) in Microsoft.Identity.Web project, update AuthorizeForScopesAttribute to extract a return url from ajax custom header. This return url is for **user agent to return to after the challenge is satisfied**.
(2) in aspnetcore project, for OpenIdConnentHandler,  after the **redirect url for Identity Provider** is calculated, for ajax request, the handler will return a 401 with the redirect url in the header location.

Added a test project in a seperate PR https://github.com/AzureAD/microsoft-identity-web/pull/665 for Microsoft.Identity.Web to test modified AuthorizeForScopesAttribute to handle Ajax call. It depends on a locally built microsoft.aspnetcore.authentication.openidconnect dev nupkg within which associate change on ajax call redirection is handled differently (OpenIdConnectHandler need to be updated at Asp.net Core side).

