### PR TITLE
Enable windows tests in helix nightly

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -37,7 +37,6 @@
   <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true'">
     <HelixAvailableTargetQueue Include="Windows.7.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows" />
-    <HelixAvailableTargetQueue Include="Windows.10.Amd64.Open" Platform="Windows" />
   </ItemGroup>
 
   <!-- arm64 queues for helix-matrix.yml pipeline -->

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -27,8 +27,6 @@
 
   <!-- queues for helix-matrix.yml pipeline -->
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true'">
-    <HelixAvailableTargetQueue Include="Windows.7.Amd64.Open" Platform="Windows" />
-    <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.10.Amd64.Server20H1.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
@@ -36,6 +34,11 @@
     <HelixAvailableTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Fedora.28.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-09ca40b-20190508143249" Platform="Linux" />
+  </ItemGroup>  
+  <ItemGroup Condition="'$(IsWindowsOnlyTest)' == 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true'">
+    <HelixAvailableTargetQueue Include="Windows.7.Amd64.Open" Platform="Windows" />
+    <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows" />
+    <HelixAvailableTargetQueue Include="Windows.10.Amd64.Open" Platform="Windows" />
   </ItemGroup>
 
   <!-- arm64 queues for helix-matrix.yml pipeline -->

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -26,8 +26,7 @@
   </ItemGroup>
 
   <!-- queues for helix-matrix.yml pipeline -->
-  <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true'">
-    <HelixAvailableTargetQueue Include="Windows.10.Amd64.Server20H1.Open" Platform="Windows" />
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="Linux" />
@@ -35,15 +34,17 @@
     <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Fedora.28.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-09ca40b-20190508143249" Platform="Linux" />
   </ItemGroup>  
-  <ItemGroup Condition="'$(IsWindowsOnlyTest)' == 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true'">
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true'">
     <HelixAvailableTargetQueue Include="Windows.7.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.81.Amd64.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="Windows.10.Amd64.Open" Platform="Windows" />
   </ItemGroup>
 
   <!-- arm64 queues for helix-matrix.yml pipeline -->
-  <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true'">
-    <HelixAvailableTargetQueue Include="Windows.10.Arm64.Open" Platform="Windows" />
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailableTargetQueue Include="(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036" Platform="Linux" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true'">
+    <HelixAvailableTargetQueue Include="Windows.10.Arm64.Open" Platform="Windows" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We're not currently running windows-only tests in the helix nightly test pass due to how the agent conditions were set up. I've re-worked the conditions. This temporarily reverts the use of Windows.10.Amd64.Server20H1.Open, but I'll address that in https://github.com/dotnet/aspnetcore/pull/26037 once the Windows only tests work there.