### PR TITLE
Fix 16840: Navigate to special URLs without throwing errors

### DIFF
--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -89,8 +89,8 @@ namespace Microsoft.AspNetCore.Components.Server
 
             if (baseUri == null ||
                 uri == null ||
-                !Uri.IsWellFormedUriString(baseUri, UriKind.Absolute) ||
-                !Uri.IsWellFormedUriString(uri, UriKind.Absolute))
+                !Uri.TryCreate(baseUri, UriKind.Absolute, out _) ||
+                !Uri.TryCreate(uri, UriKind.Absolute, out _))
             {
                 // We do some really minimal validation here to prevent obviously wrong data from getting in
                 // without duplicating too much logic.

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.E2ETesting;
 using Microsoft.AspNetCore.Testing;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Interactions;
-using OpenQA.Selenium.Support.UI;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -608,18 +607,30 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("This is a long page you can scroll.", () => app.FindElement(By.Id("test-info")).Text);
         }
 
+        [Theory]
+        [InlineData("/WithParameters/Name/Ñoño ñi/LastName/O'Jkl")]
+        [InlineData("/WithParameters/Name/[Ñoño ñi]/LastName/O'Jkl")]
+        [InlineData("/other?abc=Ñoño ñi")]
+        [InlineData("/other?abc=[Ñoño ñi]")]
+        public void CanArriveAtPageWithSpecialURL(string relativeUrl)
+        {
+            SetUrlViaPushState(relativeUrl, true);
+            var errorUi = Browser.Exists(By.Id("blazor-error-ui"));
+            Browser.Equal("none", () => errorUi.GetCssValue("display"));
+        }
+
         private long BrowserScrollY
         {
             get => (long)((IJavaScriptExecutor)Browser).ExecuteScript("return window.scrollY");
             set => ((IJavaScriptExecutor)Browser).ExecuteScript($"window.scrollTo(0, {value})");
         }
 
-        private string SetUrlViaPushState(string relativeUri)
+        private string SetUrlViaPushState(string relativeUri, bool forceLoad = false)
         {
             var pathBaseWithoutHash = ServerPathBase.Split('#')[0];
             var jsExecutor = (IJavaScriptExecutor)Browser;
             var absoluteUri = new Uri(_serverFixture.RootUri, $"{pathBaseWithoutHash}{relativeUri}");
-            jsExecutor.ExecuteScript($"Blazor.navigateTo('{absoluteUri.ToString().Replace("'", "\\'")}')");
+            jsExecutor.ExecuteScript($"Blazor.navigateTo('{absoluteUri.ToString().Replace("'", "\\'")}', {(forceLoad ? "true" : "false")})");
 
             return absoluteUri.AbsoluteUri;
         }


### PR DESCRIPTION
### Summary
Allow the [manual] navigation to special URL like `https://localhost:5001?keyword=你好 世界`


### Details
`Uri.IsWellFormedUriString` does not tell you whether the URL is valid or not instead it tells if the URL needs to be escaped to further work with it [At least that's how it is currently described and implemented].  To know if a URL is valid `Uri.TryCreate` will do correct job, for additional information please check [Runtime#37634](https://github.com/dotnet/runtime/issues/37634)

ℹ For consideration, other [places in the repo](https://github.com/dotnet/aspnetcore/search?q=Uri.IsWellFormedUriString) might have the same problem.


Addresses #16840