### PR TITLE
Fix VS crash with malformed tag helpers

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 if (endTag != null)
                 {
                     var tagName = endTag.GetTagNameWithOptionalBang();
-                    if (TryRewriteTagHelperEnd(endTag, out tagHelperEnd))
+                    if (TryRewriteTagHelperEnd(startTag, endTag, out tagHelperEnd))
                     {
                         // This is a tag helper
                         if (startTag == null)
@@ -289,10 +289,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 return true;
             }
 
-            private bool TryRewriteTagHelperEnd(MarkupEndTagSyntax tagBlock, out MarkupTagHelperEndTagSyntax rewritten)
+            private bool TryRewriteTagHelperEnd(MarkupStartTagSyntax startTag, MarkupEndTagSyntax endTag, out MarkupTagHelperEndTagSyntax rewritten)
             {
                 rewritten = null;
-                var tagName = tagBlock.GetTagNameWithOptionalBang();
+                var tagName = endTag.GetTagNameWithOptionalBang();
                 // Could not determine tag name, it can't be a TagHelper, continue on and track the element.
                 if (string.IsNullOrEmpty(tagName) || tagName.StartsWith("!"))
                 {
@@ -301,13 +301,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
                 var tracker = CurrentTagHelperTracker;
                 var tagNameScope = tracker?.TagName ?? string.Empty;
-                if (!IsPotentialTagHelperEnd(tagName, tagBlock))
+                if (!IsPotentialTagHelperEnd(tagName, endTag))
                 {
                     return false;
                 }
 
                 // Validate that our end tag matches the currently scoped tag, if not we may need to error.
-                if (tagNameScope.Equals(tagName, StringComparison.OrdinalIgnoreCase))
+                if (startTag != null && tagNameScope.Equals(tagName, StringComparison.OrdinalIgnoreCase))
                 {
                     // If there are additional end tags required before we can build our block it means we're in a
                     // situation like this: <myth req="..."><myth></myth></myth> where we're at the inside </myth>.
@@ -318,7 +318,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         return false;
                     }
 
-                    ValidateEndTagSyntax(tagName, tagBlock);
+                    ValidateEndTagSyntax(tagName, endTag);
 
                     _trackerStack.Pop();
                 }
@@ -347,7 +347,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                             // End tag TagHelper that states it shouldn't have an end tag.
                             _errorSink.OnError(
                                 RazorDiagnosticFactory.CreateParsing_TagHelperMustNotHaveAnEndTag(
-                                    new SourceSpan(SourceLocationTracker.Advance(tagBlock.GetSourceLocation(_source), "</"), tagName.Length),
+                                    new SourceSpan(SourceLocationTracker.Advance(endTag.GetSourceLocation(_source), "</"), tagName.Length),
                                     tagName,
                                     descriptor.DisplayName,
                                     invalidRule.TagStructure));
@@ -358,7 +358,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 }
 
                 rewritten = SyntaxFactory.MarkupTagHelperEndTag(
-                    tagBlock.OpenAngle, tagBlock.ForwardSlash, tagBlock.Bang, tagBlock.Name, tagBlock.MiscAttributeContent, tagBlock.CloseAngle);
+                    endTag.OpenAngle, endTag.ForwardSlash, endTag.Bang, endTag.Name, endTag.MiscAttributeContent, endTag.CloseAngle);
 
                 return true;
             }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -1271,6 +1271,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             EvaluateData(MalformedRequiredAttribute_Descriptors, "<p notRequired=\"hi\" class=\"btn\" </p");
         }
 
+        [Fact]
+        public void RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11()
+        {
+            var document = "<p class='foo'>@if(true){</p>}</p>";
+            EvaluateData(MalformedRequiredAttribute_Descriptors, document);
+        }
+
         public static TagHelperDescriptor[] PrefixedTagHelperColon_Descriptors = new TagHelperDescriptor[]
         {
             TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11.cspans.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11.cspans.txt
@@ -1,0 +1,5 @@
+Markup span at (10:0,10 [3] ) (Accepts:Any) - Parent: Tag block at (0:0,0 [34] )
+Transition span at (15:0,15 [1] ) (Accepts:None) - Parent: Statement block at (15:0,15 [15] )
+Code span at (16:0,16 [9] ) (Accepts:Any) - Parent: Statement block at (15:0,15 [15] )
+Markup span at (25:0,25 [4] ) (Accepts:None) - Parent: Tag block at (25:0,25 [4] )
+Code span at (29:0,29 [1] ) (Accepts:Any) - Parent: Statement block at (15:0,15 [15] )

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11.diag.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11.diag.txt
@@ -1,0 +1,1 @@
+(1,28): Error RZ1026: Encountered end tag "p" with no matching start tag.  Are your start/end tags properly balanced?

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11.stree.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11.stree.txt
@@ -1,0 +1,44 @@
+RazorDocument - [0..34)::34 - [<p class='foo'>@if(true){</p>}</p>]
+    MarkupBlock - [0..34)::34
+        MarkupTagHelperElement - [0..34)::34 - p[StartTagAndEndTag] - pTagHelper
+            MarkupTagHelperStartTag - [0..15)::15 - [<p class='foo'>] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                OpenAngle;[<];
+                Text;[p];
+                MarkupTagHelperAttribute - [2..14)::12 - class - SingleQuotes - Unbound - [ class='foo']
+                    MarkupTextLiteral - [2..3)::1 - [ ] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Whitespace;[ ];
+                    MarkupTextLiteral - [3..8)::5 - [class] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        Text;[class];
+                    Equals;[=];
+                    MarkupTextLiteral - [9..10)::1 - ['] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        SingleQuote;['];
+                    MarkupTagHelperAttributeValue - [10..13)::3
+                        MarkupLiteralAttributeValue - [10..13)::3 - [foo]
+                            MarkupTextLiteral - [10..13)::3 - [foo] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                                Text;[foo];
+                    MarkupTextLiteral - [13..14)::1 - ['] - Gen<Markup> - SpanEditHandler;Accepts:Any
+                        SingleQuote;['];
+                CloseAngle;[>];
+            CSharpCodeBlock - [15..30)::15
+                CSharpTransition - [15..16)::1 - Gen<None> - SpanEditHandler;Accepts:None
+                    Transition;[@];
+                CSharpStatementLiteral - [16..25)::9 - [if(true){] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                    Keyword;[if];
+                    LeftParenthesis;[(];
+                    Keyword;[true];
+                    RightParenthesis;[)];
+                    LeftBrace;[{];
+                MarkupBlock - [25..29)::4
+                    MarkupElement - [25..29)::4
+                        MarkupEndTag - [25..29)::4 - [</p>] - Gen<Markup> - SpanEditHandler;Accepts:None
+                            OpenAngle;[<];
+                            ForwardSlash;[/];
+                            Text;[p];
+                            CloseAngle;[>];
+                CSharpStatementLiteral - [29..30)::1 - [}] - Gen<Stmt> - SpanEditHandler;Accepts:Any
+                    RightBrace;[}];
+            MarkupTagHelperEndTag - [30..34)::4 - [</p>]
+                OpenAngle;[<];
+                ForwardSlash;[/];
+                Text;[p];
+                CloseAngle;[>];

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11.tspans.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/TagHelperParseTreeRewriterTest/RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly11.tspans.txt
@@ -1,0 +1,1 @@
+TagHelper span at (0:0,0 [34] ) - pTagHelper


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1226741

Example,
```razor
<a @onclick="...">
@if (true) {
    </a> <----
}
</a>
```

Consider the above example. In this case, the parser groups the start/end tags correctly (i.e. the `</a>` in the middle has no start tag).
But in the tag helper rewriting phase, we end up incorrectly identifying the middle `</a>` as the end tag for the start tag and pop the stack causing it to throw when it reaches the final `</a>` tag.
The fix: In addition to checking if the tag name matches, pop the stack only when there is a corresponding start tag available.