### PR TITLE
Remove duplicate Load and Remove call

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
@@ -82,12 +82,9 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         {
             get
             {
-                Load();
                 object value;
                 if (TryGetValue(key, out value))
                 {
-                    // Mark the key for deletion since it is read.
-                    _initialKeys.Remove(key);
                     return value;
                 }
                 return null;


### PR DESCRIPTION
In TempDataDictionary, `TryGetValue` already calls `Load` and `Remove`, so there's no need to call these methods in the indexer.