### PR TITLE
Fix casing in test data in HtmlGenerationWebSite_GeneratesExpectedResults

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25206")]
         public async Task HtmlGenerationWebSite_GeneratesExpectedResults_WithImageData()
         {
-            await HtmlGenerationWebSite_GeneratesExpectedResults("image", antiforgeryPath: null);
+            await HtmlGenerationWebSite_GeneratesExpectedResults("Image", antiforgeryPath: null);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/25206

This test was originally quarantined due to a timeout issue, but I noticed that there seems to be a legit failure because the incorrect casing was provided on the resource name to verify and resource names are case-sensitive.

Update: @pranavkm pointed me to the fact that this typo seems to have been introduced when the test was quarantined in https://github.com/dotnet/aspnetcore/commit/ed45c768105e9876a56ff1d33e941b11439f1603.
