### PR TITLE
[Blazor] CSS isolation fix UpToDateCheck in Visual Studio

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Microsoft.NET.Sdk.Razor.ScopedCss.targets
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Microsoft.NET.Sdk.Razor.ScopedCss.targets
@@ -171,6 +171,11 @@ Integration with static web assets:
 
 </Target>
 
+<Target
+    Name="_ResolveScopedCssOutputsDesignTime"
+    DependsOnTargets="_ResolveScopedCssOutputs"
+    BeforeTargets="CollectUpToDateCheckInputDesignTime;CollectUpToDateCheckBuiltDesignTime" />
+
 <!-- Transforms the original scoped CSS files into their scoped versions on their designated output paths -->
 <Target Name="_GenerateScopedCssFiles" Inputs="@(_ScopedCss)" Outputs="@(_ScopedCssOutputs)" DependsOnTargets="_ResolveScopedCssOutputs">
 


### PR DESCRIPTION
# Description

We had support for the UpToDateCheck in Visual Studio with CSS isolation but the target was not being run at design time. This change introduces a new target that runs at design time and makes sure the UpToDateCheckInput and UpToDateCheckBuilt ItemGroups are populated.

# Customer Impact
* When using CSS isolation from within Visual Studio, a change in a scoped CSS file is not picked up and the project is not rebuilt as a result.

# Regression?

No. This feature was introduced in 5.0.

# Risk

Low. The new target we added only runs as part of Visual Studio builds.

## Fixes
https://github.com/dotnet/aspnetcore/issues/26843