### PR TITLE
[Routing] Use correct catch all behavior by default

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/AppContextSwitches.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/AppContextSwitches.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BlazorServerWeb_CSharp
+{
+    public static class AppContextSwitches
+    {
+        public static void Apply()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", true);
+        }
+    }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Program.cs
@@ -15,6 +15,7 @@ namespace BlazorServerWeb_CSharp
     {
         public static void Main(string[] args)
         {
+            AppContextSwitches.Apply();
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/AppContextSwitches.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/AppContextSwitches.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Company.WebApplication1
+{
+    public static class AppContextSwitches
+    {
+        public static void Apply()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", true);
+        }
+    }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Program.cs
@@ -13,6 +13,7 @@ namespace Company.WebApplication1
     {
         public static void Main(string[] args)
         {
+            AppContextSwitches.Apply();
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/AppContextSwitches.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/AppContextSwitches.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace GrpcService_CSharp
+{
+    public static class AppContextSwitches
+    {
+        public static void Apply()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", true);
+        }
+    }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
@@ -12,6 +12,7 @@ namespace GrpcService_CSharp
     {
         public static void Main(string[] args)
         {
+            AppContextSwitches.Apply();
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/AppContextSwitches.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/AppContextSwitches.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Company.WebApplication1
+{
+    public static class AppContextSwitches
+    {
+        public static void Apply()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", true);
+        }
+    }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Program.cs
@@ -13,6 +13,7 @@ namespace Company.WebApplication1
     {
         public static void Main(string[] args)
         {
+            AppContextSwitches.Apply();
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/AppContextSwitches.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/AppContextSwitches.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Company.WebApplication1
+{
+    public static class AppContextSwitches
+    {
+        public static void Apply()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", true);
+        }
+    }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Program.cs
@@ -13,6 +13,7 @@ namespace Company.WebApplication1
     {
         public static void Main(string[] args)
         {
+            AppContextSwitches.Apply();
             CreateHostBuilder(args).Build().Run();
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/AppContextSwitches.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/AppContextSwitches.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Company.WebApplication1
+{
+    public static class AppContextSwitches
+    {
+        public static void Apply()
+        {
+            AppContext.SetSwitch("Microsoft.AspNetCore.Routing.UseCorrectCatchAllBehavior", true);
+        }
+    }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
@@ -13,6 +13,7 @@ namespace Company.WebApplication1
     {
         public static void Main(string[] args)
         {
+            AppContextSwitches.Apply();
             CreateHostBuilder(args).Build().Run();
         }
 


### PR DESCRIPTION
Updates routing to use the correct catch all behavior by default.

We introduced a compatibility switch when we fixed https://github.com/dotnet/aspnetcore/issues/18677 but we didn't turn it on by default on the templates. We regularly get issues filed due to the default behavior being wrong. We want to minimize customer issues as well as making sure that customers get the right behavior when they start new projects to avoid them taking a dependency on a wrong/legacy behavior.

This PR enables the switch by default on the templates. I took  the approach of creating a new class for holding all the switches configurations to make it easy to add more switches in the future if needed without them cluttering the application.