### PR TITLE
Use latest chrome in Blazor benchmarks

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -28,7 +28,7 @@ RUN .dotnet/dotnet publish -c Release --no-restore -o /app ./src/Components/benc
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app
-FROM selenium/standalone-chrome:3.141.59-mercury as final
+FROM selenium/standalone-chrome:latest as final
 COPY --from=build ./app ./
 COPY ./exec.sh ./
 

--- a/src/Components/benchmarkapps/Wasm.Performance/local.dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/local.dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome:3.141.59-mercury as final
+FROM selenium/standalone-chrome:latest as final
 
 ENV StressRunDuration=0
 


### PR DESCRIPTION
This bumps Chrome to v86 (while also pointing to latest). There's a bunch of improvements in my local runs just from doing this.

| Scenario |  Description | Before (ms) | After (ms) | Percent change | 
|-----------------------------------------------|----------------------------------|-------------|-------------|-----|
|  blazorwasm/time-to-first-ui                  |  Time to first UI                | 595.775     | 422.455     | 29% |
|  blazorwasm/render-10-items                   |  Render 10 items                 | 5.09221519  | 4.094540816 | 20% |
|  blazorwasm/render-100-items                  |  Render 100 items                | 23.1125     | 18.47136364 | 20% |
|  blazorwasm/render-1000-items                 |  Render 1000 items               | 204.9375    | 165.7416667 | 19% |
|  blazorwasm/jsonserialize-1kb                 |  Serialize 1kb                   | 2.995447761 | 2.323583815 | 22% |
|  blazorwasm/jsonserialize-340kb               |  Serialize 340kb                 | 239.28      | 184.535     | 23% |
|  blazorwasm/jsondeserialize-1kb               |  Deserialize 1kb                 | 4.507303371 | 3.461594828 | 23% |
|  blazorwasm/jsondeserialize-340kb             |  Deserialize 340kb               | 661.65      | 495.43      | 25% |
|  blazorwasm/jsonserialize-javascript-340kb    |  Serialize 340kb (JavaScript)    | 1.081310811 | 1.122927171 | 4%  |
|  blazorwasm/jsondeserialize-javascript-340kb  |  Deserialize 340kb (JavaScript)  | 1.532681992 | 1.200523952 | 22% |
|  blazorwasm/orgchart-1-4-org                  |  Render small nested component   | 30.81214286 | 24.66529412 | 20% |
|  blazorwasm/orgchart-3-3-org                  |  Render large nested component   | 220.44      | 179.24      | 19% |
|  blazorwasm/edit-orgchart-3-2                 |  Render component with edit      | 97.418      | 66.20285714 | 32% |
|  blazorwasm/render-plaintable-from-blank      |  PlainTable: From blank          | 464.39      | 373.2925    | 20% |
|  blazorwasm/render-plaintable-switch-pages    |  PlainTable: Switch pages        | 295.4       | 226.7725    | 23% |
|  blazorwasm/render-complextable-from-blank    |  ComplexTable: From blank        | 796.76      | 627.625     | 21% |
|  blazorwasm/render-complextable-switch-pages  |  ComplexTable: Switch pages      | 883.275     | 671.13      | 24% |
|  blazorwasm/render-fastgrid-from-blank        |  FastGrid: From blank            | 96.632      | 79.75916667 | 17% |
|  blazorwasm/render-fastgrid-switch-pages      |  FastGrid: Switch pages          | 80.234      | 65.31571428 | 19% |


Our benchmarks targets the master branch, which is why this is change is targeted at that branch. FYI @BrzVlad