### PR TITLE
Make Virtualize recover from having incorrect ItemSize info. Fixes #25915

### DIFF
--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -253,6 +253,15 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
         {
             CalcualteItemDistribution(spacerSize, spacerSeparation, containerSize, out var itemsBefore, out var visibleItemCapacity);
 
+            // Since we know the before spacer is now visible, we absolutely have to slide the window up
+            // by at least one element. If we're not doing that, the previous item size info we had must
+            // have been wrong, so just move along by one in that case to trigger an update and apply the
+            // new size info.
+            if (itemsBefore == _itemsBefore && itemsBefore > 0)
+            {
+                itemsBefore--;
+            }
+
             UpdateItemDistribution(itemsBefore, visibleItemCapacity);
         }
 
@@ -261,6 +270,15 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
             CalcualteItemDistribution(spacerSize, spacerSeparation, containerSize, out var itemsAfter, out var visibleItemCapacity);
 
             var itemsBefore = Math.Max(0, _itemCount - itemsAfter - visibleItemCapacity);
+
+            // Since we know the after spacer is now visible, we absolutely have to slide the window down
+            // by at least one element. If we're not doing that, the previous item size info we had must
+            // have been wrong, so just move along by one in that case to trigger an update and apply the
+            // new size info.
+            if (itemsBefore == _itemsBefore && itemsBefore < _itemCount - visibleItemCapacity)
+            {
+                itemsBefore++;
+            }
 
             UpdateItemDistribution(itemsBefore, visibleItemCapacity);
         }

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Threading.Tasks;
 using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
@@ -209,6 +210,33 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Validate that the top spacer has expanded.
             Browser.NotEqual(expectedInitialSpacerStyle, () => topSpacer.GetAttribute("style"));
+        }
+
+        [Fact]
+        public async Task ToleratesIncorrectItemSize()
+        {
+            Browser.MountTestComponent<VirtualizationComponent>();
+            var topSpacer = Browser.Exists(By.Id("incorrect-size-container")).FindElement(By.TagName("div"));
+            var expectedInitialSpacerStyle = "height: 0px;";
+
+            // Wait until items have been rendered.
+            Browser.True(() => GetItemCount() > 0);
+            Browser.Equal(expectedInitialSpacerStyle, () => topSpacer.GetAttribute("style"));
+
+            // Scroll slowly, in increments of 50px at a time. At one point this would trigger a bug
+            // due to the incorrect item size, whereby it would not realise it's necessary to show more
+            // items because the first time the spacer became visible, the size calculation said that
+            // we're already showing all the items we need to show.
+            for (var pos = 0; pos < 1000; pos += 50)
+            {
+                Browser.ExecuteJavaScript($"document.getElementById('incorrect-size-container').scrollTop = {pos};");
+                await Task.Delay(200);
+            }
+
+            // Validate that the top spacer did change
+            Browser.NotEqual(expectedInitialSpacerStyle, () => topSpacer.GetAttribute("style"));
+
+            int GetItemCount() => Browser.FindElements(By.ClassName("incorrect-size-item")).Count;
         }
 
         [Fact]

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationComponent.razor
@@ -28,6 +28,15 @@
     </div>
 </p>
 
+<p>
+    Slightly incorrect item size:<br />
+    <div id="incorrect-size-container" style="background-color: #eee; height: 500px; overflow-y: auto">
+        <Virtualize Items="@fixedItems" ItemSize="50">
+            <div @key="context" class="incorrect-size-item" style="height: 49px; background-color: rgb(@((context % 2) * 255), @((1-(context % 2)) * 255), 255);">Item @context</div>
+        </Virtualize>
+    </div>
+</p>
+
 <p id="viewport-as-root">
     Viewport as root:<br />
     <Virtualize Items="@fixedItems" ItemSize="itemSize">


### PR DESCRIPTION
Fixes #25915

## Description

If the new `<Virtualize>` component was given a slightly incorrect value for `ItemSize` (or if the default value of 50 was very close to the true value, but not exactly equal), then it could get stuck and fail to display new items while scrolling. This is because it would compute the new set of items to show, and the incorrect size info might tell it that it was already displaying the correct items (even though it's not), and then it would not update the UI.

## Customer impact

This has now been reported by about 4 different customers from preview usage. One example is https://github.com/dotnet/aspnetcore/issues/25915. Another is https://github.com/dotnet/aspnetcore/issues/25915.

Unless fixed, it means developers must work out and supply an exactly-correct value for `ItemSize`. This can be tricky to do because even if you put (say) `style="height: 50px"` on a table row, the browser might actually render it at (say) 48.89px due to border collapse CSS rules. Our goal for `<Virtualize>` was to spare developers from this pain by auto-detecting and fixing the height information. If we don't make that work in all cases, then sometimes the UI can get stuck.

One reason why customers hit this so often is due to an unlucky coincidence. The component's default `ItemSize` when not specified is 50px, and our default project template contains a table whose rows happen to be 48.89px high. This specific combination happens to trigger the problem. But of course it could happen with other sizes too if the true value and the given value are sufficiently close but not exactly equal.

## Regression

No, `<Virtualize>` is new in 5.0.

## Risk

The change is limited to the `<Virtualize>` component, so nothing else will be affected.

Theoretically this change could trigger some other unwanted behavior in `<Virtualize>`. However I've designed this solution to be as risk-averse as possible. We have good E2E test coverage plus manual verification.

There's a good argument that it's inevitable we have to fix this because so many customers are hitting it. It's safer to fix in 5.0 GA than in some later patch, because if it goes out in a patch, then it might land on production webservers before developers even see it running on their local machines.