### PR TITLE
Obsolete ResponseMode in MicrosoftChallengeProperties

### DIFF
--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
@@ -54,7 +54,9 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             };
 
             AddQueryString(queryStrings, properties, MicrosoftChallengeProperties.ScopeKey, FormatScope, Options.Scope);
+#pragma warning disable CS0618 // Type or member is obsolete
             AddQueryString(queryStrings, properties, MicrosoftChallengeProperties.ResponseModeKey);
+#pragma warning restore CS0618 // Type or member is obsolete
             AddQueryString(queryStrings, properties, MicrosoftChallengeProperties.DomainHintKey);
             AddQueryString(queryStrings, properties, MicrosoftChallengeProperties.LoginHintKey);
             AddQueryString(queryStrings, properties, MicrosoftChallengeProperties.PromptKey);

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftChallengeProperties.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftChallengeProperties.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.OAuth;
 
@@ -11,6 +12,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
         /// <summary>
         /// The parameter key for the "response_mode" argument being used for a challenge request.
         /// </summary>
+        [Obsolete("This parameter is not supported in MicrosoftAccountHandler.")]
         public static readonly string ResponseModeKey = "response_mode";
 
         /// <summary>
@@ -42,6 +44,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
         /// <summary>
         /// The "response_mode" parameter value being used for a challenge request.
         /// </summary>
+        [Obsolete("This parameter is not supported in MicrosoftAccountHandler.")]
         public string ResponseMode
         {
             get => GetParameter<string>(ResponseModeKey);

--- a/src/Security/Authentication/test/MicrosoftAccountTests.cs
+++ b/src/Security/Authentication/test/MicrosoftAccountTests.cs
@@ -374,7 +374,9 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
                                         Prompt = "select_account",
                                         LoginHint = "username",
                                         DomainHint = "consumers",
+#pragma warning disable CS0618 // Type or member is obsolete
                                         ResponseMode = "query",
+#pragma warning restore CS0618 // Type or member is obsolete
                                         RedirectUri = "/me"
                                     });
                                 }


### PR DESCRIPTION
Deprecate `ResponseMode` since only the default value is supported in Microsoft Account authentication.

@Tratcher