### PR TITLE
Unquarantine 2 build and publish template tests

### DIFF
--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
@@ -190,7 +190,6 @@ namespace Templates.Test
         }
 
         [Theory]
-        [QuarantinedTest]
         [InlineData("IndividualB2C", null)]
         [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
         [InlineData("SingleOrg", null)]

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -306,7 +306,6 @@ namespace Templates.Test
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23993")]
         public async Task MvcTemplate_RazorRuntimeCompilation_BuildsAndPublishes()
         {
             var project = await MvcTemplateBuildsAndPublishes(auth: null, args: new[] { "--razor-runtime-compilation" });


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/23993

BlazorServerTemplates_Identity_BuildAndPublish stats: passed 284/284 in quarantine
Templates.Test.MvcTemplateTest.MvcTemplate_RazorRuntimeCompilation_BuildsAndPublishes: passed 707/707 quarantine

Per https://dev.azure.com/dnceng/public/_test/analytics?definitionId=869&contextType=build

