### PR TITLE
Fix null ref in UrlGroup.Dispose due to logger not set

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             try
             {
-                UrlGroup = new UrlGroup(this, UrlPrefix.Create(urlPrefix));
+                UrlGroup = new UrlGroup(this, UrlPrefix.Create(urlPrefix), logger);
             }
             catch
             {

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -38,8 +38,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             Id = urlGroupId;
         }
 
-        internal unsafe UrlGroup(RequestQueue requestQueue, UrlPrefix url)
+        internal unsafe UrlGroup(RequestQueue requestQueue, UrlPrefix url, ILogger logger)
         {
+            _logger = logger;
+
             ulong urlGroupId = 0;
             var statusCode = HttpApi.HttpFindUrlGroupId(
                 url.FullPrefix, requestQueue.Handle, &urlGroupId);

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -16,8 +16,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private static readonly int RequestPropertyInfoSize =
             Marshal.SizeOf<HttpApiTypes.HTTP_BINDING_INFO>();
 
+        private readonly ILogger _logger;
+
         private ServerSession _serverSession;
-        private ILogger _logger;
         private bool _disposed;
 
         internal unsafe UrlGroup(ServerSession serverSession, ILogger logger)

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -326,6 +326,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal unsafe void Delegate(DelegationRule destination)
         {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
             if (Request.HasRequestBodyStarted)
             {
                 throw new InvalidOperationException("This request cannot be delegated, the request body has already started.");


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Fixing #26982 by passing the logger through to the new version of the UrlGroup constructor used by the HttpSysRequestDelegationFeature.
 - Also fixing a null ref case I hit while calling DelegateRequest when passing a null DelegationRule, yes my bad but should probably do the check :)