### PR TITLE
Update TFM workaround to reference 5.0 instead of 3.1

### DIFF
--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -43,14 +43,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Workaround when there is no vNext SDK available, copy known apphost/framework reference info from 3.1 -->
+    <!-- Workaround when there is no vNext SDK available, copy known apphost/framework reference info from 5.0 -->
     <KnownAppHostPack
-      Include="@(KnownAppHostPack->WithMetadataValue('TargetFramework', 'netcoreapp3.1'))"
+      Include="@(KnownAppHostPack->WithMetadataValue('TargetFramework', 'netcoreapp5.0'))"
       TargetFramework="$(KnownAppHostPackOrFrameworkReferenceTfm)"
       Condition="@(KnownAppHostPack->Count()) != '0' AND !(@(KnownAppHostPack->AnyHaveMetadataValue('TargetFramework', '$(KnownAppHostPackOrFrameworkReferenceTfm)')))"
       />
     <KnownFrameworkReference
-      Include="@(KnownFrameworkReference->WithMetadataValue('TargetFramework', 'netcoreapp3.1'))"
+      Include="@(KnownFrameworkReference->WithMetadataValue('TargetFramework', 'netcoreapp5.0'))"
       TargetFramework="$(KnownAppHostPackOrFrameworkReferenceTfm)"
       Condition="@(KnownFrameworkReference->Count()) != '0' AND !(@(KnownFrameworkReference->AnyHaveMetadataValue('TargetFramework', '$(KnownAppHostPackOrFrameworkReferenceTfm)')))"
       />


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspnetcore/pull/26788

Once we move the TFM to 6.0, we should update this workaround to reference vLast, which is 5.0, not 3.1.

I'd expect the TFM here to be `net5.0`, but binlogs show that it's `netcoreapp5.0` for all referenced packs - @dougbu any idea what gives?