### PR TITLE
Remove unused SignInManager.CreateIdentity

### DIFF
--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -763,22 +763,7 @@ namespace Microsoft.AspNetCore.Identity
             }
             return new ClaimsPrincipal(rememberBrowserIdentity);
         }
-
-        private ClaimsIdentity CreateIdentity(TwoFactorAuthenticationInfo info)
-        {
-            if (info == null)
-            {
-                return null;
-            }
-            var identity = new ClaimsIdentity(IdentityConstants.TwoFactorUserIdScheme);
-            identity.AddClaim(new Claim(ClaimTypes.Name, info.UserId));
-            if (info.LoginProvider != null)
-            {
-                identity.AddClaim(new Claim(ClaimTypes.AuthenticationMethod, info.LoginProvider));
-            }
-            return identity;
-        }
-
+        
         private async Task<bool> IsTfaEnabled(TUser user)
             => UserManager.SupportsUserTwoFactor &&
             await UserManager.GetTwoFactorEnabledAsync(user) &&


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - The private method CreateIdentity on SignInManager is not called from anywhere

Was looking at the code for SignInManager and noticied that `CreateIdentity` doesn't seem to be called from anywhere, so here's a simple PR to remove it.