### PR TITLE
IsCheckbox based on role and not only for input DOM elements

### DIFF
--- a/src/Components/Web.JS/src/Rendering/EventForDotNet.ts
+++ b/src/Components/Web.JS/src/Rendering/EventForDotNet.ts
@@ -216,7 +216,8 @@ function parseMouseEvent(event: MouseEvent) {
 }
 
 function isCheckbox(element: Element | null): boolean {
-  return !!element && element.tagName === 'INPUT' && element.getAttribute('type') === 'checkbox';
+  return (!!element && element.tagName === 'INPUT' && element.getAttribute('type') === 'checkbox') 
+      || (!!element && element.getAttribute('role') === 'checkbox'); 
 }
 
 const timeBasedInputs = [


### PR DESCRIPTION
To use Fluent or [Fast WebComponents ](https://www.fast.design/)which doesn't use an `input` element as a checkbox this is needed. A checkbox can now also be based on a `role` attribute and not only on a `input` element with the `type='checkbox'`.

The `fast-switch` component has the same issue, but it's possible to override the `role='checkbox'` to also make this possible.
e.g. 
`<fast-switch role='checkbox'>Switch</fast-switch>`

Fixes #24916