### PR TITLE
Use EphemeralDataProtection for identity tests

### DIFF
--- a/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
+++ b/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -42,6 +43,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         protected override void SetupIdentityServices(IServiceCollection services, object context)
         {
             services.AddHttpContextAccessor();
+            services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
             services.AddIdentity<TUser, TRole>(options =>
             {
                 options.Password.RequireDigit = false;

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -57,6 +58,7 @@ namespace Microsoft.AspNetCore.Identity.Test
         {
             services.AddHttpContextAccessor();
             services.AddDataProtection();
+            services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
             var builder = services.AddIdentityCore<TUser>(options =>
             {
                 options.Password.RequireDigit = false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/25716

There's a rare race condition with dataprotection keyrings on disk, since our tests don't rely on anything that survives across restarts, using in memory data protection is sufficient