### PR TITLE
Simplify GetString() call

### DIFF
--- a/src/Localization/Localization/src/ResourceManagerStringLocalizer.cs
+++ b/src/Localization/Localization/src/ResourceManagerStringLocalizer.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Extensions.Localization
 
             try
             {
-                return culture == null ? _resourceManager.GetString(name, CultureInfo.CurrentUICulture) : _resourceManager.GetString(name, culture);
+                return _resourceManager.GetString(name, culture);
             }
             catch (MissingManifestResourceException)
             {


### PR DESCRIPTION
Noticed this while skimming through https://github.com/dotnet/aspnetcore/pull/26656#discussion_r505035331. No need to preemptively check `culture`, since `GetString()` does too:
https://github.com/dotnet/runtime/blob/ebf27bd9c53a0bdc5702177ba592a7ef2c3a9808/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs#L602-L607

cc @jkotalik @pranavkm