### PR TITLE
Add pause between computing lastModified date and executing task

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
@@ -325,7 +325,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         [Fact]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25623")]
-        public void BundlesScopedCssFiles_UpdatesBundleWhenContentsChange()
+        public async Task BundlesScopedCssFiles_UpdatesBundleWhenContentsChange()
         {
             // Arrange
             var expectedFile = Path.Combine(Directory.GetCurrentDirectory(), $"{Guid.NewGuid():N}.css");
@@ -351,12 +351,6 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 ProjectBundles = Array.Empty<ITaskItem>(),
                 OutputFile = expectedFile
             };
-            
-            var modified = false;
-            using FileSystemWatcher watcher = new FileSystemWatcher();
-            
-            watcher.Path = expectedFile;
-            watcher.Changed += (object source, FileSystemEventArgs e) => modified = true;
 
             // Act
             var result = taskInstance.Execute();
@@ -388,14 +382,15 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     }),
             };
 
+            await Task.Delay(500);
             taskInstance.Execute();
 
             // Assert
-            Assert.True(modified);
             Assert.True(result);
             Assert.True(File.Exists(expectedFile));
             var actualContents = File.ReadAllText(expectedFile);
             Assert.Equal(UpdatedBundleContent, actualContents, ignoreLineEndingDifferences: true);
+            Assert.NotEqual(lastModified, File.GetLastWriteTimeUtc(expectedFile));
         }
     }
 }

--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -326,7 +325,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         [Fact]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25623")]
-        public void BundlesScopedCssFiles_UpdatesBundleWhenContentsChange()
+        public async System.Threading.Tasks.Task BundlesScopedCssFiles_UpdatesBundleWhenContentsChange()
         {
             // Arrange
             var expectedFile = Path.Combine(Directory.GetCurrentDirectory(), $"{Guid.NewGuid():N}.css");
@@ -383,7 +382,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     }),
             };
 
-            Thread.Sleep(TimeSpan.FromSeconds(1));
+            await System.Threading.Tasks.Task.Delay(1000);
             taskInstance.Execute();
 
             // Assert

--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
@@ -382,10 +382,9 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     }),
             };
 
-            taskInstance.Execute();
-
             var modified = false;
             using (FileSystemWatcher watcher = new FileSystemWatcher()) {
+                taskInstance.Execute();
                 watcher.Path = expectedFile;
                 watcher.Changed += (object source, FileSystemEventArgs e) => modified = true;
             }

--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
@@ -325,7 +325,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         [Fact]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25623")]
-        public async Task BundlesScopedCssFiles_UpdatesBundleWhenContentsChange()
+        public void BundlesScopedCssFiles_UpdatesBundleWhenContentsChange()
         {
             // Arrange
             var expectedFile = Path.Combine(Directory.GetCurrentDirectory(), $"{Guid.NewGuid():N}.css");
@@ -382,7 +382,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     }),
             };
 
-            await Task.Delay(500);
+            Thread.Sleep(TimeSpan.FromSeconds(1));
             taskInstance.Execute();
 
             // Assert

--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
@@ -384,13 +384,18 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
             taskInstance.Execute();
 
+            var modified = false;
+            using (FileSystemWatcher watcher = new FileSystemWatcher()) {
+                watcher.Path = expectedFile;
+                watcher.Changed += (object source, FileSystemEventArgs e) => modified = true;
+            }
+
             // Assert
+            Assert.True(modified);
             Assert.True(result);
             Assert.True(File.Exists(expectedFile));
             var actualContents = File.ReadAllText(expectedFile);
             Assert.Equal(UpdatedBundleContent, actualContents, ignoreLineEndingDifferences: true);
-
-            Assert.NotEqual(lastModified, File.GetLastWriteTimeUtc(expectedFile));
         }
     }
 }

--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
@@ -351,6 +351,12 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                 ProjectBundles = Array.Empty<ITaskItem>(),
                 OutputFile = expectedFile
             };
+            
+            var modified = false;
+            using FileSystemWatcher watcher = new FileSystemWatcher();
+            
+            watcher.Path = expectedFile;
+            watcher.Changed += (object source, FileSystemEventArgs e) => modified = true;
 
             // Act
             var result = taskInstance.Execute();
@@ -381,13 +387,8 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                         ["RelativePath"] = "TestFiles/Generated/FetchData.razor.rz.scp.css",
                     }),
             };
-
-            var modified = false;
-            using (FileSystemWatcher watcher = new FileSystemWatcher()) {
-                taskInstance.Execute();
-                watcher.Path = expectedFile;
-                watcher.Changed += (object source, FileSystemEventArgs e) => modified = true;
-            }
+     
+            taskInstance.Execute();
 
             // Assert
             Assert.True(modified);

--- a/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/test/ConcatenateFilesTest.cs
@@ -387,7 +387,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                         ["RelativePath"] = "TestFiles/Generated/FetchData.razor.rz.scp.css",
                     }),
             };
-     
+
             taskInstance.Execute();
 
             // Assert


### PR DESCRIPTION
Addresses #25623 

Instead of checking the last modified date on the file to check it was modified, this PR uses an FS watcher to check if the file has been changed, making it more defensive towards any issues that come up with the last write time on the file.

Edit: This uses a wait now.