### PR TITLE
Correct bundle upgrade behavior for 2.1

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -10,6 +10,124 @@
                                                     LocalizationFile="thm.wxl"/>
         </BootstrapperApplicationRef>
 
+        <!-- Ensure upgrades from 2.1.0 thru 2.1.23 for x64. -->
+        <?if $(var.MajorVersion)=2 and $(var.MinorVersion)=1?>
+        <?if $(var.Platform)=x64?>
+        <!--'Microsoft ASP.NET Core 2.1.23 - Shared Framework'-->
+        <RelatedBundle Id="{0712373C-EAC4-36FA-A33F-21A63858EFA7}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.22 - Shared Framework'-->
+        <RelatedBundle Id="{49A46B72-F6E0-33CF-8135-875A76045F10}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.21 - Shared Framework'-->
+        <RelatedBundle Id="{3128CBDD-47D8-345B-8416-993E028BBBE2}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.20 - Shared Framework'-->
+        <RelatedBundle Id="{DBBB894A-16EA-33DF-A1AD-17A1C07B1FE3}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.19 - Shared Framework'-->
+        <RelatedBundle Id="{27F55CDC-C188-3DB7-8020-94AF8144243A}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.18 - Shared Framework'-->
+        <RelatedBundle Id="{3589369F-8952-3A99-B102-2F40B673B7A7}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.17 - Shared Framework'-->
+        <RelatedBundle Id="{4A3B5396-5326-36CB-974C-D03F7442C9F1}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.16 - Shared Framework'-->
+        <RelatedBundle Id="{1D763AE0-563D-315B-97D9-A3026619AA1E}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.15 - Shared Framework'-->
+        <RelatedBundle Id="{E4FAADFB-4273-38A7-8E01-3E0E1FE40CFD}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.14 - Shared Framework'-->
+        <RelatedBundle Id="{E0D6C0F1-C362-3697-AD4F-BC3967BE1F68}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.13 - Shared Framework'-->
+        <RelatedBundle Id="{7683D539-563A-3F4D-9664-79FA52E7A893}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.12 - Shared Framework'-->
+        <RelatedBundle Id="{BA2E3A8D-6118-3CC3-BD81-51B0AA4A165C}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.11 - Shared Framework'-->
+        <RelatedBundle Id="{CF0DE7B0-8EFA-39EF-B413-13EE8C657BA7}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.10 - Shared Framework'-->
+        <RelatedBundle Id="{F5DA7AD4-9479-3B3F-97D4-469AD07209EF}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.9 - Shared Framework'-->
+        <RelatedBundle Id="{403E8DE6-3564-3C10-B86F-9C697A4B89ED}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.8 - Shared Framework'-->
+        <RelatedBundle Id="{38580A17-729D-376F-AC0D-B8E80E77CE20}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.7 - Shared Framework'-->
+        <RelatedBundle Id="{05D79AF1-C5B9-39AB-95B8-8BEEB5F6EE8D}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.6 - Shared Framework'-->
+        <RelatedBundle Id="{DCC2A848-E51F-3525-9AEC-6F3AD09E8E4E}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.5 - Shared Framework'-->
+        <RelatedBundle Id="{4FF26B15-D19E-33DE-B3B9-0048CB452719}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.4 - Shared Framework'-->
+        <RelatedBundle Id="{516DDC47-3178-3854-80B3-69A5924BA645}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.3 - Shared Framework'-->
+        <RelatedBundle Id="{AED22235-ACC3-38AD-8AA6-3A05CA2D3ADA}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.2 - Shared Framework'-->
+        <RelatedBundle Id="{842F7946-BF3F-30F0-9136-68B9666857CC}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.1 - Shared Framework'-->
+        <RelatedBundle Id="{54785C17-D593-3E17-B4DB-71204B69804B}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.0 - Shared Framework'-->
+        <RelatedBundle Id="{30CB480C-ADF0-3B81-8F50-48376E153BFA}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.0 Release Candidate 1 - Shared Framework'-->
+        <RelatedBundle Id="{83D09AED-0BC7-3254-A011-2FDCF79D8859}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.0 Preview 2 - Shared Framework'-->
+        <RelatedBundle Id="{9E1909B0-7040-3B58-9F51-1862DA343256}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.0 Preview 1 - Shared Framework'-->
+        <RelatedBundle Id="{1434C698-C3C8-3021-BAAC-F65A5139E5D0}" Action="Upgrade" />
+        <?endif?>
+
+        <!-- Ensure upgrades from 2.1.0 thru 2.1.23 for x86. -->
+        <?if $(var.Platform)=x86?>
+        <!--'Microsoft ASP.NET Core 2.1.23 - Shared Framework'-->
+        <RelatedBundle Id="{09248E80-C295-3428-8EB4-3159552244EC}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.22 - Shared Framework'-->
+        <RelatedBundle Id="{5ECAAEF0-4844-306B-95BC-39F74570FB71}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.21 - Shared Framework'-->
+        <RelatedBundle Id="{5946602B-3AF7-367E-A2F6-C8D55D02765F}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.20 - Shared Framework'-->
+        <RelatedBundle Id="{B87377E1-C127-3725-9A17-E2CFB1924939}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.19 - Shared Framework'-->
+        <RelatedBundle Id="{3CE4046A-E352-3CD4-B33F-AB6975DABD48}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.18 - Shared Framework'-->
+        <RelatedBundle Id="{516B48A4-1C41-3C71-824A-EFDE2FFBE460}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.17 - Shared Framework'-->
+        <RelatedBundle Id="{502432A7-056C-36AE-A063-8C666325C085}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.16 - Shared Framework'-->
+        <RelatedBundle Id="{BE23E50E-87CB-36A0-BF02-B9454F54E485}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.15 - Shared Framework'-->
+        <RelatedBundle Id="{1974CAA5-06EF-3B2A-B1C0-642820CAE7AD}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.14 - Shared Framework'-->
+        <RelatedBundle Id="{00131A6A-FBEE-3D58-9675-D3625F20F443}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.13 - Shared Framework'-->
+        <RelatedBundle Id="{12D8AEA0-C9C1-3816-83E6-52205C27F9EF}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.12 - Shared Framework'-->
+        <RelatedBundle Id="{6B055917-6871-3F6A-9DB8-136CAAC94FC1}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.11 - Shared Framework'-->
+        <RelatedBundle Id="{54D6799C-AA5C-3FBE-8F8D-D7A1BA02E080}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.10 - Shared Framework'-->
+        <RelatedBundle Id="{20D074C5-A251-3387-8E5B-DB9840D97199}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.9 - Shared Framework'-->
+        <RelatedBundle Id="{6CA73165-99C8-3A40-A5DE-B52563E54B36}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.8 - Shared Framework'-->
+        <RelatedBundle Id="{70D80ED0-BE96-30CF-8BD8-CDEB74A1FA44}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.7 - Shared Framework'-->
+        <RelatedBundle Id="{35188EAF-50A8-36B1-89E1-65A048879A8A}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.6 - Shared Framework'-->
+        <RelatedBundle Id="{52B39EEB-6453-35C7-82C3-0A3E32D7A7E3}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.5 - Shared Framework'-->
+        <RelatedBundle Id="{2396ABF1-286C-35AC-9D73-6DA0C1488697}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.4 - Shared Framework'-->
+        <RelatedBundle Id="{C43E83C3-55D5-339B-9AEB-CCF6EF0C3E88}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.3 - Shared Framework'-->
+        <RelatedBundle Id="{D629A358-61C2-326F-A491-55E29C064E30}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.2 - Shared Framework'-->
+        <RelatedBundle Id="{649622E9-21EF-3C33-8121-3AE51E01ECD8}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.1 - Shared Framework'-->
+        <RelatedBundle Id="{B71D596D-762B-343B-AA62-A49344C9C5E8}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.0 - Shared Framework'-->
+        <RelatedBundle Id="{E880C10C-463E-3D37-AD6E-EAF52D736BCB}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.0 Release Candidate 1 - Shared Framework'-->
+        <RelatedBundle Id="{6E0B3327-43F4-3EE3-9E64-6C395C2CFFA8}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.0 Preview 2 - Shared Framework'-->
+        <RelatedBundle Id="{87DA165A-7B38-3BE2-8954-F4D3237E5CE5}" Action="Upgrade" />
+        <!--'Microsoft ASP.NET Core 2.1.0 Preview 1 - Shared Framework'-->
+        <RelatedBundle Id="{2F9AD35A-B7C3-3CCF-9ADA-EFBC876815F8}" Action="Upgrade" />
+        <?endif?>
+        <?endif?>
+
         <!-- Customizations of the default BA -->
         <Log Prefix="dd_$(var.BundleLogPrefix)_" Extension=".log" />
         <OptionalUpdateRegistration Manufacturer="$(var.BundleRegManufacturer)" ProductFamily="$(var.BundleRegFamily)" Name="$(var.BundleRegName)" />

--- a/src/Installers/Windows/SharedFrameworkBundle/Product.props
+++ b/src/Installers/Windows/SharedFrameworkBundle/Product.props
@@ -27,5 +27,7 @@
       <DefineConstants>$(DefineConstants);BundleRegManufacturer=$(BundleRegManufacturer)</DefineConstants>
       <DefineConstants>$(DefineConstants);BundleRegFamily=$(BundleRegFamily)</DefineConstants>
       <DefineConstants>$(DefineConstants);BundleRegName=$(BundleRegName)</DefineConstants>
+      <DefineConstants>$(DefineConstants);MajorVersion=$(AspNetCoreMajorVersion)</DefineConstants>
+      <DefineConstants>$(DefineConstants);MinorVersion=$(AspNetCoreMinorVersion)</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -11,6 +11,50 @@
                                                     LocalizationFile="thm.wxl"/>
         </BootstrapperApplicationRef>
 
+        <!-- Ensure upgrades from 2.1.0 thru 2.1.23 for x64. -->
+        <?if $(var.MajorVersion)=2 and $(var.MinorVersion)=1?>
+        <!--'Microsoft .NET Core 2.1.23 - Windows Server Hosting'-->
+        <RelatedBundle Id="{51DC181C-C29B-31D7-96CA-08B2B9322269}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.22 - Windows Server Hosting'-->
+        <RelatedBundle Id="{0629F7DA-FD3D-3C43-9C74-7CAB326D8408}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.21 - Windows Server Hosting'-->
+        <RelatedBundle Id="{20C43973-8701-31FF-B9F4-ED31D88182AC}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.20 - Windows Server Hosting'-->
+        <RelatedBundle Id="{AB66B18F-8B14-3FF3-A5F1-97435938BA40}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.19 - Windows Server Hosting'-->
+        <RelatedBundle Id="{9A7F3800-1BCF-3C0A-B1B2-948D6AE80CCB}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.18 - Windows Server Hosting'-->
+        <RelatedBundle Id="{B137EB6B-4CBA-32A0-A4E7-D2B8F3FE334A}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.17 - Windows Server Hosting'-->
+        <RelatedBundle Id="{F0A8977D-AA93-3745-9727-1DBAD0EC9BA4}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.16 - Windows Server Hosting'-->
+        <RelatedBundle Id="{C9D00CC1-53C8-38DD-85C5-F07298DCE93C}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.15 - Windows Server Hosting'-->
+        <RelatedBundle Id="{7CBFCC91-2F4E-3C4F-9F02-269BF67D0EF3}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.14 - Windows Server Hosting'-->
+        <RelatedBundle Id="{790FD6ED-06E1-3CA0-B4FA-8CC0690001F5}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.12 - Windows Server Hosting'-->
+        <RelatedBundle Id="{127E0E5D-65E8-339B-9E56-710CD7CAE521}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.11 - Windows Server Hosting'-->
+        <RelatedBundle Id="{3B4D8EC5-02AC-3F77-9ECE-83B92C6232D9}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.10 - Windows Server Hosting'-->
+        <RelatedBundle Id="{A265BA58-64C8-31B5-92DC-7C071095667E}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.9 - Windows Server Hosting'-->
+        <RelatedBundle Id="{91B539CE-A269-32B4-8EB9-66A3285DED97}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.8 - Windows Server Hosting'-->
+        <RelatedBundle Id="{9F1D5735-B2F6-3C74-8F6B-2390BB739697}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.7 - Windows Server Hosting'-->
+        <RelatedBundle Id="{E5555A4A-7AF5-3733-BB60-EC74A4874842}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.6 - Windows Server Hosting'-->
+        <RelatedBundle Id="{EC44441A-0A96-39C4-A4A3-C6D65FEA6E3C}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.5 - Windows Server Hosting'-->
+        <RelatedBundle Id="{E22164E9-31C6-3C19-8FB9-F9EA2711EEAC}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.4 - Windows Server Hosting'-->
+        <RelatedBundle Id="{38010573-29EA-472C-91FA-779DC0A6CDED}" Action="Upgrade" />
+        <!--'Microsoft .NET Core 2.1.3 - Windows Server Hosting'-->
+        <RelatedBundle Id="{0ECB5C6B-3FD7-36C2-8138-61AE2E999E76}" Action="Upgrade" />
+        <?endif?>
+
         <!-- Customizations of the default BA -->
         <Log Prefix="dd_$(var.BundleLogPrefix)_" Extension=".log" />
         <OptionalUpdateRegistration Manufacturer="$(var.BundleRegManufacturer)" ProductFamily="$(var.BundleRegFamily)" Name="$(var.BundleRegName)" />

--- a/src/Installers/Windows/WindowsHostingBundle/Product.props
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.props
@@ -27,5 +27,7 @@
     <DefineConstants>$(DefineConstants);BundleRegManufacturer=$(BundleRegManufacturer)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleRegFamily=$(BundleRegFamily)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleRegName=$(BundleRegName)</DefineConstants>
+    <DefineConstants>$(DefineConstants);MajorVersion=$(AspNetCoreMajorVersion)</DefineConstants>
+    <DefineConstants>$(DefineConstants);MinorVersion=$(AspNetCoreMinorVersion)</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Installers/Windows/Wix.props
+++ b/src/Installers/Windows/Wix.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).0</Version>
+    <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(BuildNumber)</Version>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Lang Condition="'$(Lang)' == ''">ENU</Lang>

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <GuidInputs>$(Version);$(Platform);$(BuildNumber)</GuidInputs>
+    <GuidInputs>$(Version);$(Platform)</GuidInputs>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(OutputPath)..\InstallerTasks\InstallerTasks.dll" TaskName="RepoTasks.GenerateGuid" />

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -6,7 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <GuidInputs>$(Version);$(Platform)</GuidInputs>
+    <PackageGuidInputs>$(Version);$(Platform)</PackageGuidInputs>
+    <BundleGuidInputs>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion);$(Platform)</BundleGuidInputs>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(OutputPath)..\InstallerTasks\InstallerTasks.dll" TaskName="RepoTasks.GenerateGuid" />
@@ -14,10 +15,10 @@
   <Target Name="GenerateGUIDs" BeforeTargets="BeforeBuild" DependsOnTargets="_GeneratePackageGuids;_GenerateBundleGuids" Condition=" '$(DisableGuidGeneration)' != 'true' " />
 
   <Target Name="_GeneratePackageGuids" Condition="'$(OutputType)' == 'package'">
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(ProductNameShort);$(GuidInputs)">
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(ProductNameShort);$(PackageGuidInputs)">
       <Output TaskParameter="Guid" PropertyName="ProductCode" />
     </GenerateGuid>
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(ProductNameShort);$(GuidInputs);$(OutputType)">
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(ProductNameShort);$(PackageGuidInputs);$(OutputType)">
       <Output TaskParameter="Guid" PropertyName="UpgradeCode" />
     </GenerateGuid>
 
@@ -27,10 +28,10 @@
   </Target>
 
   <Target Name="_GenerateBundleGuids" Condition="'$(OutputType)' == 'bundle'">
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleNameShort);$(GuidInputs)">
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleNameShort);$(BundleGuidInputs)">
       <Output TaskParameter="Guid" PropertyName="BundleProviderKey" />
     </GenerateGuid>
-    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleNameShort);$(GuidInputs);$(OutputType)">
+    <GenerateGuid NamespaceGuid="$(NamespaceGuid)" Values="$(BundleNameShort);$(BundleGuidInputs);$(OutputType)">
       <Output TaskParameter="Guid" PropertyName="BundleUpgradeCode" />
     </GenerateGuid>
 


### PR DESCRIPTION
2.1 backport of the logic from https://github.com/dotnet/aspnetcore/pull/26065. Should cause 2.1.N+1 to overwrite 2.1.N when installing, but 2.2.N should install SxS with 2.1.N.

CC @jamshedd 