### PR TITLE
Spelling mistake in doc comment

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/IRetryPolicy.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/IRetryPolicy.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
     {
         /// <summary>
         /// If passed to <see cref="HubConnectionBuilderExtensions.WithAutomaticReconnect(IHubConnectionBuilder, IRetryPolicy)"/>,
-        /// this will be called after the trasnport loses a connection to determine if and for how long to wait before the next reconnect attempt.
+        /// this will be called after the transport loses a connection to determine if and for how long to wait before the next reconnect attempt.
         /// </summary>
         /// <param name="retryContext">
         /// Information related to the next possible reconnect attempt including the number of consecutive failed retries so far, time spent


### PR DESCRIPTION
Correct spelling mistake in doc comment.

Unrelated question: is it the policy of this group to _not_ use Oxford commas (line 19 in this file)?