### PR TITLE
Fix WriteAsJsonAsync docs

### DIFF
--- a/src/Http/Http.Extensions/src/HttpResponseJsonExtensions.cs
+++ b/src/Http/Http.Extensions/src/HttpResponseJsonExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Http
     {
         /// <summary>
         /// Write the specified value as JSON to the response body. The response content-type will be set to
-        /// <c>application/json; charset=utf-8</c> and the status code set to <c>200</c>.
+        /// <c>application/json; charset=utf-8</c>.
         /// </summary>
         /// <typeparam name="TValue">The type of object to write.</typeparam>
         /// <param name="response">The response to write JSON to.</param>
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Http
 
         /// <summary>
         /// Write the specified value as JSON to the response body. The response content-type will be set to
-        /// <c>application/json; charset=utf-8</c> and the status code set to <c>200</c>.
+        /// <c>application/json; charset=utf-8</c>.
         /// </summary>
         /// <typeparam name="TValue">The type of object to write.</typeparam>
         /// <param name="response">The response to write JSON to.</param>
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Http
 
         /// <summary>
         /// Write the specified value as JSON to the response body. The response content-type will be set to
-        /// the specified content-type and the status code set to <c>200</c>.
+        /// the specified content-type.
         /// </summary>
         /// <typeparam name="TValue">The type of object to write.</typeparam>
         /// <param name="response">The response to write JSON to.</param>
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Http
 
         /// <summary>
         /// Write the specified value as JSON to the response body. The response content-type will be set to
-        /// <c>application/json; charset=utf-8</c> and the status code set to <c>200</c>.
+        /// <c>application/json; charset=utf-8</c>.
         /// </summary>
         /// <param name="response">The response to write JSON to.</param>
         /// <param name="value">The value to write as JSON.</param>
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.Http
 
         /// <summary>
         /// Write the specified value as JSON to the response body. The response content-type will be set to
-        /// <c>application/json; charset=utf-8</c> and the status code set to <c>200</c>.
+        /// <c>application/json; charset=utf-8</c>.
         /// </summary>
         /// <param name="response">The response to write JSON to.</param>
         /// <param name="value">The value to write as JSON.</param>
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Http
 
         /// <summary>
         /// Write the specified value as JSON to the response body. The response content-type will be set to
-        /// the specified content-type and the status code set to <c>200</c>.
+        /// the specified content-type.
         /// </summary>
         /// <param name="response">The response to write JSON to.</param>
         /// <param name="value">The value to write as JSON.</param>


### PR DESCRIPTION
Behavior changed in https://github.com/dotnet/aspnetcore/pull/23583 to not set `StatusCode` but xml docs weren't updated to match.