### PR TITLE
Antiforgery: Preserve user-supplied Cache-Control header

### DIFF
--- a/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
@@ -380,8 +380,8 @@ namespace Microsoft.AspNetCore.Antiforgery
 		    // Because Pragma is non-standard, deprecated, and only has one possible value ("no-cache"), set it unconditionally:
 		    httpContext.Response.Headers[HeaderNames.Pragma] = "no-cache";
     
-		    CacheControlHeaderValue.TryParse(httpContext.Response.Headers[HeaderNames.CacheControl].ToString(), out var cacheControlHeaderValue);
-		    if (cacheControlHeaderValue == null)
+		    if (!httpContext.Response.Headers.TryGetValue(HeaderNames.CacheControl, out var cacheControlHeader) ||  
+		      !CacheControlHeaderValue.TryParse(cacheControlHeader.ToString(), out var cacheControlHeaderValue))
 		    {
 		    	httpContext.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store";
 		    	return;

--- a/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
@@ -377,42 +377,42 @@ namespace Microsoft.AspNetCore.Antiforgery
         /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
         protected virtual void SetDoNotCacheHeaders(HttpContext httpContext)
         {
-						// Because Pragma is non-standard, deprecated, and only has one possible value ("no-cache"), set it unconditionally:
-						httpContext.Response.Headers[HeaderNames.Pragma] = "no-cache";
+		// Because Pragma is non-standard, deprecated, and only has one possible value ("no-cache"), set it unconditionally:
+		httpContext.Response.Headers[HeaderNames.Pragma] = "no-cache";
 
-						CacheControlHeaderValue.TryParse(httpContext.Response.Headers[HeaderNames.CacheControl].ToString(), out var cacheControlHeaderValue);
-						if (cacheControlHeaderValue == null)
-						{
-							httpContext.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store";
-							return;
-						}
+		CacheControlHeaderValue.TryParse(httpContext.Response.Headers[HeaderNames.CacheControl].ToString(), out var cacheControlHeaderValue);
+		if (cacheControlHeaderValue == null)
+		{
+			httpContext.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store";
+			return;
+		}
 
-						var headerOverridden = false;
-						if (cacheControlHeaderValue.NoCache != true)
-						{
-							cacheControlHeaderValue.NoCache = true;
-							headerOverridden = true;
-						}
-						if (cacheControlHeaderValue.NoStore != true)
-						{
-							cacheControlHeaderValue.NoStore = true;
-							headerOverridden = true;
-						}
-						if (cacheControlHeaderValue.Public == true)
-						{
-							cacheControlHeaderValue.Public = false;
-							headerOverridden = true;
-						}
+		var headerOverridden = false;
+		if (cacheControlHeaderValue.NoCache != true)
+		{
+			cacheControlHeaderValue.NoCache = true;
+			headerOverridden = true;
+		}
+		if (cacheControlHeaderValue.NoStore != true)
+		{
+			cacheControlHeaderValue.NoStore = true;
+			headerOverridden = true;
+		}
+		if (cacheControlHeaderValue.Public == true)
+		{
+			cacheControlHeaderValue.Public = false;
+			headerOverridden = true;
+		}
 
-						if (headerOverridden == true)
-						{
-							httpContext.Response.Headers[HeaderNames.CacheControl] = cacheControlHeaderValue.ToString();
+		if (headerOverridden == true)
+		{
+			httpContext.Response.Headers[HeaderNames.CacheControl] = cacheControlHeaderValue.ToString();
 
-							// Since antiforgery token generation is not very obvious to the end users (ex: MVC's form tag generates them
-							// by default), log a warning to let users know of the change in behavior to any cache headers they might
-							// have set explicitly.
-            	_logger.ResponseCacheHeadersOverridenToNoCache();
-						}
+			// Since antiforgery token generation is not very obvious to the end users (ex: MVC's form tag generates them
+			// by default), log a warning to let users know of the change in behavior to any cache headers they might
+			// have set explicitly.
+			_logger.ResponseCacheHeadersOverridenToNoCache();
+		}
         }
 
         private AntiforgeryTokenSet Serialize(IAntiforgeryFeature antiforgeryFeature)

--- a/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
@@ -377,42 +377,42 @@ namespace Microsoft.AspNetCore.Antiforgery
         /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
         protected virtual void SetDoNotCacheHeaders(HttpContext httpContext)
         {
-		// Because Pragma is non-standard, deprecated, and only has one possible value ("no-cache"), set it unconditionally:
-		httpContext.Response.Headers[HeaderNames.Pragma] = "no-cache";
-
-		CacheControlHeaderValue.TryParse(httpContext.Response.Headers[HeaderNames.CacheControl].ToString(), out var cacheControlHeaderValue);
-		if (cacheControlHeaderValue == null)
-		{
-			httpContext.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store";
-			return;
-		}
-
-		var headerOverridden = false;
-		if (cacheControlHeaderValue.NoCache != true)
-		{
-			cacheControlHeaderValue.NoCache = true;
-			headerOverridden = true;
-		}
-		if (cacheControlHeaderValue.NoStore != true)
-		{
-			cacheControlHeaderValue.NoStore = true;
-			headerOverridden = true;
-		}
-		if (cacheControlHeaderValue.Public == true)
-		{
-			cacheControlHeaderValue.Public = false;
-			headerOverridden = true;
-		}
-
-		if (headerOverridden == true)
-		{
-			httpContext.Response.Headers[HeaderNames.CacheControl] = cacheControlHeaderValue.ToString();
-
-			// Since antiforgery token generation is not very obvious to the end users (ex: MVC's form tag generates them
-			// by default), log a warning to let users know of the change in behavior to any cache headers they might
-			// have set explicitly.
-			_logger.ResponseCacheHeadersOverridenToNoCache();
-		}
+		    // Because Pragma is non-standard, deprecated, and only has one possible value ("no-cache"), set it unconditionally:
+		    httpContext.Response.Headers[HeaderNames.Pragma] = "no-cache";
+    
+		    CacheControlHeaderValue.TryParse(httpContext.Response.Headers[HeaderNames.CacheControl].ToString(), out var cacheControlHeaderValue);
+		    if (cacheControlHeaderValue == null)
+		    {
+		    	httpContext.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store";
+		    	return;
+		    }
+    
+		    var headerOverridden = false;
+		    if (cacheControlHeaderValue.NoCache != true)
+		    {
+		    	cacheControlHeaderValue.NoCache = true;
+		    	headerOverridden = true;
+		    }
+		    if (cacheControlHeaderValue.NoStore != true)
+		    {
+		    	cacheControlHeaderValue.NoStore = true;
+		    	headerOverridden = true;
+		    }
+		    if (cacheControlHeaderValue.Public == true)
+		    {
+		    	cacheControlHeaderValue.Public = false;
+		    	headerOverridden = true;
+		    }
+    
+		    if (headerOverridden == true)
+		    {
+		    	httpContext.Response.Headers[HeaderNames.CacheControl] = cacheControlHeaderValue.ToString();
+    
+		    	// Since antiforgery token generation is not very obvious to the end users (ex: MVC's form tag generates them
+		    	// by default), log a warning to let users know of the change in behavior to any cache headers they might
+		    	// have set explicitly.
+		    	_logger.ResponseCacheHeadersOverridenToNoCache();
+		    }
         }
 
         private AntiforgeryTokenSet Serialize(IAntiforgeryFeature antiforgeryFeature)


### PR DESCRIPTION
This is a lightweight implementation that sets the appropriate Cache-Control header values required by Antiforgery while still preserving other existing content of the header (if any).

- Only overrides header values if it has to
- Leaves other consumer-supplied values intact
- Simplifies the logic for logging warnings

The laundry list of if blocks isn't as elegant as it could be,
but it's dead simple, easy to update, and doesn't instantiate
any new expensive parser or builder objects

Addresses #21176
(see also discussion in: https://github.com/aspnet/Antiforgery/pull/117)