### PR TITLE
Skip TlsHandshakeRejectsTlsLessThan12 on linux 

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/TlsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/TlsTests.cs
@@ -16,21 +16,19 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.Http2
 {
-    [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing SslStream ALPN support: https://github.com/dotnet/runtime/issues/27727")]
-    [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10,
-        SkipReason = "Missing Windows ALPN support: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation#Support or incompatible ciphers on Windows 8.1")]
     public class TlsTests : LoggedTest
     {
         private static X509Certificate2 _x509Certificate2 = TestResources.GetTestCertificate();
 
         [ConditionalFact]
-        [QuarantinedTest]
-        [SkipOnHelix("Ubuntu 20.04 disables TLS1.1 by default which SslStream requires in this scenario", Queues = "Ubuntu.2004.Amd64.Open")]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing SslStream ALPN support: https://github.com/dotnet/runtime/issues/27727")]
+        [OSSkipCondition(OperatingSystems.Linux, SkipReason = "TLS 1.1 ciphers are now disabled by default: https://github.com/dotnet/docs/issues/20842")]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10,
+            SkipReason = "Missing Windows ALPN support: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation#Support or incompatible ciphers on Windows 8.1")]
         public async Task TlsHandshakeRejectsTlsLessThan12()
         {
             await using (var server = new TestServer(context =>


### PR DESCRIPTION
Fixes #26154 The runtime disabled all TLS 1.1 ciphers by default on linux so that explains why the test was failing. Marking the test as not supported on Linux.
I un-quarantined it because the test has been passing on Windows.