### PR TITLE
add missing startvs.cmd

### DIFF
--- a/src/DefaultBuilder/startvs.cmd
+++ b/src/DefaultBuilder/startvs.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+%~dp0..\..\startvs.cmd %~dp0DefaultBuilder.slnf

--- a/src/Features/JsonPatch/startvs.cmd
+++ b/src/Features/JsonPatch/startvs.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+%~dp0..\..\..\startvs.cmd %~dp0JsonPatch.slnf

--- a/src/Razor/startvs.cmd
+++ b/src/Razor/startvs.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+%~dp0..\..\startvs.cmd %~dp0Razor.slnf


### PR DESCRIPTION
Some projects that have `.slnf` files don't have `startvs.cmd` files, so I've added them accordingly to the project.