### PR TITLE
Log more to test logger in HTTP/2 Kestrel tests

### DIFF
--- a/src/Servers/Kestrel/shared/test/TestApplicationErrorLoggerLoggedTest.cs
+++ b/src/Servers/Kestrel/shared/test/TestApplicationErrorLoggerLoggedTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Testing
     {
         private TestApplicationErrorLogger TestApplicationErrorLogger { get; set; }
 
-        public ConcurrentQueue<LogMessage> Messages => TestApplicationErrorLogger.Messages;
+        public ConcurrentQueue<LogMessage> LogMessages => TestApplicationErrorLogger.Messages;
 
         public bool ThrowOnUngracefulShutdown
         {
@@ -23,9 +23,9 @@ namespace Microsoft.AspNetCore.Testing
             set => TestApplicationErrorLogger.ThrowOnUngracefulShutdown = value;
         }
 
-        public List<Type> IgnoredExceptions => TestApplicationErrorLogger.IgnoredExceptions;
+        public List<Type> IgnoredCriticalLogExceptions => TestApplicationErrorLogger.IgnoredExceptions;
 
-        public Task<LogMessage> WaitForMessage(Func<LogMessage, bool> messageFilter)
+        public Task<LogMessage> WaitForLogMessage(Func<LogMessage, bool> messageFilter)
             => TestApplicationErrorLogger.WaitForMessage(messageFilter);
 
         public override void Initialize(TestContext context, MethodInfo methodInfo, object[] testMethodArguments, ITestOutputHelper testOutputHelper)

--- a/src/Servers/Kestrel/shared/test/TestApplicationErrorLoggerLoggedTest.cs
+++ b/src/Servers/Kestrel/shared/test/TestApplicationErrorLoggerLoggedTest.cs
@@ -1,15 +1,32 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.Extensions.Logging.Testing;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
+using static Microsoft.AspNetCore.Testing.TestApplicationErrorLogger;
 
 namespace Microsoft.AspNetCore.Testing
 {
     public class TestApplicationErrorLoggerLoggedTest : LoggedTest
     {
-        public TestApplicationErrorLogger TestApplicationErrorLogger { get; private set; }
+        private TestApplicationErrorLogger TestApplicationErrorLogger { get; set; }
+
+        public ConcurrentQueue<LogMessage> Messages => TestApplicationErrorLogger.Messages;
+
+        public bool ThrowOnUngracefulShutdown
+        {
+            get => TestApplicationErrorLogger.ThrowOnUngracefulShutdown;
+            set => TestApplicationErrorLogger.ThrowOnUngracefulShutdown = value;
+        }
+
+        public List<Type> IgnoredExceptions => TestApplicationErrorLogger.IgnoredExceptions;
+
+        public Task<LogMessage> WaitForMessage(Func<LogMessage, bool> messageFilter)
+            => TestApplicationErrorLogger.WaitForMessage(messageFilter);
 
         public override void Initialize(TestContext context, MethodInfo methodInfo, object[] testMethodArguments, ITestOutputHelper testOutputHelper)
         {

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -533,7 +533,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     Assert.Contains(5001, host.GetPorts());
                 }
 
-                Assert.Single(TestApplicationErrorLogger.Messages, log => log.LogLevel == LogLevel.Debug &&
+                Assert.Single(Messages, log => log.LogLevel == LogLevel.Debug &&
                     (string.Equals(CoreStrings.FormatBindingToDefaultAddresses(Constants.DefaultServerAddress, Constants.DefaultServerHttpsAddress), log.Message, StringComparison.Ordinal)
                         || string.Equals(CoreStrings.FormatBindingToDefaultAddress(Constants.DefaultServerAddress), log.Message, StringComparison.Ordinal)));
 
@@ -578,7 +578,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [IPv6SupportedCondition]
         public async Task ThrowsWhenBindingToIPv6AddressInUse()
         {
-            TestApplicationErrorLogger.IgnoredExceptions.Add(typeof(IOException));
+            IgnoredExceptions.Add(typeof(IOException));
 
             using (var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
             {
@@ -640,7 +640,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 var useUrlsAddressWithPort = $"http://127.0.0.1:{port}";
                 Assert.Equal(serverAddresses.First(), useUrlsAddressWithPort);
 
-                Assert.Single(TestApplicationErrorLogger.Messages, log => log.LogLevel == LogLevel.Information &&
+                Assert.Single(Messages, log => log.LogLevel == LogLevel.Information &&
                     string.Equals(CoreStrings.FormatOverridingWithPreferHostingUrls(nameof(IServerAddressesFeature.PreferHostingUrls), useUrlsAddress),
                     log.Message, StringComparison.Ordinal));
 
@@ -685,7 +685,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 var endPointAddress = $"https://127.0.0.1:{port}";
                 Assert.Equal(serverAddresses.First(), endPointAddress);
 
-                Assert.Single(TestApplicationErrorLogger.Messages, log => log.LogLevel == LogLevel.Warning &&
+                Assert.Single(Messages, log => log.LogLevel == LogLevel.Warning &&
                     string.Equals(CoreStrings.FormatOverridingWithKestrelOptions(useUrlsAddress, "UseKestrel()"),
                     log.Message, StringComparison.Ordinal));
 
@@ -747,7 +747,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ThrowsWhenBindingLocalhostToDynamicPort()
         {
-            TestApplicationErrorLogger.IgnoredExceptions.Add(typeof(InvalidOperationException));
+            IgnoredExceptions.Add(typeof(InvalidOperationException));
 
             var hostBuilder = TransportSelector.GetHostBuilder()
                 .ConfigureWebHost(webHostBuilder =>
@@ -772,7 +772,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [InlineData("ssh://localhost")]
         public async Task ThrowsForUnsupportedAddressFromHosting(string address)
         {
-            TestApplicationErrorLogger.IgnoredExceptions.Add(typeof(InvalidOperationException));
+            IgnoredExceptions.Add(typeof(InvalidOperationException));
 
             var hostBuilder = TransportSelector.GetHostBuilder()
                 .ConfigureWebHost(webHostBuilder =>
@@ -931,7 +931,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         private void ThrowsWhenBindingLocalhostToAddressInUse(AddressFamily addressFamily)
         {
-            TestApplicationErrorLogger.IgnoredExceptions.Add(typeof(IOException));
+            IgnoredExceptions.Add(typeof(IOException));
 
             var addressInUseCount = 0;
             var wrongMessageCount = 0;

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -533,7 +533,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     Assert.Contains(5001, host.GetPorts());
                 }
 
-                Assert.Single(Messages, log => log.LogLevel == LogLevel.Debug &&
+                Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Debug &&
                     (string.Equals(CoreStrings.FormatBindingToDefaultAddresses(Constants.DefaultServerAddress, Constants.DefaultServerHttpsAddress), log.Message, StringComparison.Ordinal)
                         || string.Equals(CoreStrings.FormatBindingToDefaultAddress(Constants.DefaultServerAddress), log.Message, StringComparison.Ordinal)));
 
@@ -578,7 +578,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [IPv6SupportedCondition]
         public async Task ThrowsWhenBindingToIPv6AddressInUse()
         {
-            IgnoredExceptions.Add(typeof(IOException));
+            IgnoredCriticalLogExceptions.Add(typeof(IOException));
 
             using (var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
             {
@@ -640,7 +640,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 var useUrlsAddressWithPort = $"http://127.0.0.1:{port}";
                 Assert.Equal(serverAddresses.First(), useUrlsAddressWithPort);
 
-                Assert.Single(Messages, log => log.LogLevel == LogLevel.Information &&
+                Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Information &&
                     string.Equals(CoreStrings.FormatOverridingWithPreferHostingUrls(nameof(IServerAddressesFeature.PreferHostingUrls), useUrlsAddress),
                     log.Message, StringComparison.Ordinal));
 
@@ -685,7 +685,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 var endPointAddress = $"https://127.0.0.1:{port}";
                 Assert.Equal(serverAddresses.First(), endPointAddress);
 
-                Assert.Single(Messages, log => log.LogLevel == LogLevel.Warning &&
+                Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Warning &&
                     string.Equals(CoreStrings.FormatOverridingWithKestrelOptions(useUrlsAddress, "UseKestrel()"),
                     log.Message, StringComparison.Ordinal));
 
@@ -747,7 +747,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ThrowsWhenBindingLocalhostToDynamicPort()
         {
-            IgnoredExceptions.Add(typeof(InvalidOperationException));
+            IgnoredCriticalLogExceptions.Add(typeof(InvalidOperationException));
 
             var hostBuilder = TransportSelector.GetHostBuilder()
                 .ConfigureWebHost(webHostBuilder =>
@@ -772,7 +772,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [InlineData("ssh://localhost")]
         public async Task ThrowsForUnsupportedAddressFromHosting(string address)
         {
-            IgnoredExceptions.Add(typeof(InvalidOperationException));
+            IgnoredCriticalLogExceptions.Add(typeof(InvalidOperationException));
 
             var hostBuilder = TransportSelector.GetHostBuilder()
                 .ConfigureWebHost(webHostBuilder =>
@@ -931,7 +931,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         private void ThrowsWhenBindingLocalhostToAddressInUse(AddressFamily addressFamily)
         {
-            IgnoredExceptions.Add(typeof(IOException));
+            IgnoredCriticalLogExceptions.Add(typeof(IOException));
 
             var addressInUseCount = 0;
             var wrongMessageCount = 0;

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
             var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var requestUnblocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var requestStopping = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var mockKestrelTrace = new Mock<KestrelTrace>(TestApplicationErrorLogger)
+            var mockKestrelTrace = new Mock<KestrelTrace>(Logger)
             {
                 CallBase = true
             };
@@ -92,9 +92,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
                 await stopTask.DefaultTimeout();
             }
 
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Request finished "));
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closing."));
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
+            Assert.Contains(Messages, m => m.Message.Contains("Request finished "));
+            Assert.Contains(Messages, m => m.Message.Contains("is closing."));
+            Assert.Contains(Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
         }
 
         [ConditionalFact]
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
                 MemoryPoolFactory = memoryPoolFactory.Create
             };
 
-            TestApplicationErrorLogger.ThrowOnUngracefulShutdown = false;
+            ThrowOnUngracefulShutdown = false;
 
             // Abortive shutdown leaves one request hanging
             await using (var server = new TestServer(async context =>
@@ -136,14 +136,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
 
                 // Wait for the graceful shutdown log before canceling the token passed to StopAsync and triggering an ungraceful shutdown.
                 // Otherwise, graceful shutdown might be skipped causing there to be no corresponding log. https://github.com/dotnet/aspnetcore/issues/6556
-                var closingMessageTask = TestApplicationErrorLogger.WaitForMessage(m => m.Message.Contains("is closing.")).DefaultTimeout();
+                var closingMessageTask = WaitForMessage(m => m.Message.Contains("is closing.")).DefaultTimeout();
 
                 var cts = new CancellationTokenSource();
                 var stopServerTask = server.StopAsync(cts.Token).DefaultTimeout();
 
                 await closingMessageTask;
 
-                var closedMessageTask = TestApplicationErrorLogger.WaitForMessage(m => m.Message.Contains("is closed. The last processed stream ID was 1.")).DefaultTimeout();
+                var closedMessageTask = WaitForMessage(m => m.Message.Contains("is closed. The last processed stream ID was 1.")).DefaultTimeout();
                 cts.Cancel();
 
                 // Wait for "is closed" message as this is logged from a different thread and aborting
@@ -153,10 +153,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
                 await stopServerTask;
             }
 
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closing."));
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Some connections failed to close gracefully during server shutdown."));
-            Assert.DoesNotContain(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Request finished in"));
+            Assert.Contains(Messages, m => m.Message.Contains("is closing."));
+            Assert.Contains(Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
+            Assert.Contains(Messages, m => m.Message.Contains("Some connections failed to close gracefully during server shutdown."));
+            Assert.DoesNotContain(Messages, m => m.Message.Contains("Request finished in"));
 
             await memoryPoolFactory.WhenAllBlocksReturned(TestConstants.DefaultTimeout);
         }

--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -92,9 +92,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
                 await stopTask.DefaultTimeout();
             }
 
-            Assert.Contains(Messages, m => m.Message.Contains("Request finished "));
-            Assert.Contains(Messages, m => m.Message.Contains("is closing."));
-            Assert.Contains(Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("Request finished "));
+            Assert.Contains(LogMessages, m => m.Message.Contains("is closing."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
         }
 
         [ConditionalFact]
@@ -136,14 +136,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
 
                 // Wait for the graceful shutdown log before canceling the token passed to StopAsync and triggering an ungraceful shutdown.
                 // Otherwise, graceful shutdown might be skipped causing there to be no corresponding log. https://github.com/dotnet/aspnetcore/issues/6556
-                var closingMessageTask = WaitForMessage(m => m.Message.Contains("is closing.")).DefaultTimeout();
+                var closingMessageTask = WaitForLogMessage(m => m.Message.Contains("is closing.")).DefaultTimeout();
 
                 var cts = new CancellationTokenSource();
                 var stopServerTask = server.StopAsync(cts.Token).DefaultTimeout();
 
                 await closingMessageTask;
 
-                var closedMessageTask = WaitForMessage(m => m.Message.Contains("is closed. The last processed stream ID was 1.")).DefaultTimeout();
+                var closedMessageTask = WaitForLogMessage(m => m.Message.Contains("is closed. The last processed stream ID was 1.")).DefaultTimeout();
                 cts.Cancel();
 
                 // Wait for "is closed" message as this is logged from a different thread and aborting
@@ -153,10 +153,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests.Http2
                 await stopServerTask;
             }
 
-            Assert.Contains(Messages, m => m.Message.Contains("is closing."));
-            Assert.Contains(Messages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
-            Assert.Contains(Messages, m => m.Message.Contains("Some connections failed to close gracefully during server shutdown."));
-            Assert.DoesNotContain(Messages, m => m.Message.Contains("Request finished in"));
+            Assert.Contains(LogMessages, m => m.Message.Contains("is closing."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("is closed. The last processed stream ID was 1."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("Some connections failed to close gracefully during server shutdown."));
+            Assert.DoesNotContain(LogMessages, m => m.Message.Contains("Request finished in"));
 
             await memoryPoolFactory.WhenAllBlocksReturned(TestConstants.DefaultTimeout);
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionMiddlewareTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
 
             var serviceContext = new TestServiceContext(LoggerFactory);
 
-            TestApplicationErrorLogger.ThrowOnUngracefulShutdown = false;
+            ThrowOnUngracefulShutdown = false;
 
             var stopTask = Task.CompletedTask;
             await using (var server = new TestServer(requestDelegate, serviceContext, listenOptions))
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("Unhandled exception while processing " + connectionId + "."));
+            Assert.Contains(Messages, m => m.Message.Contains("Unhandled exception while processing " + connectionId + "."));
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionMiddlewareTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Contains(Messages, m => m.Message.Contains("Unhandled exception while processing " + connectionId + "."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("Unhandled exception while processing " + connectionId + "."));
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -37,16 +37,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _connection.ServerSettings.MaxConcurrentStreams = 2;
 
             await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
-            Assert.Equal(0, TestApplicationErrorLogger.Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
+            Assert.Equal(0, Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
 
             // Log message because we've reached the stream limit
             await StartStreamAsync(3, _browserRequestHeaders, endStream: false);
-            Assert.Equal(1, TestApplicationErrorLogger.Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
+            Assert.Equal(1, Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
 
             // This stream will error because it exceeds max concurrent streams
             await StartStreamAsync(5, _browserRequestHeaders, endStream: true);
             await WaitForStreamErrorAsync(5, Http2ErrorCode.REFUSED_STREAM, CoreStrings.Http2ErrorMaxStreams);
-            Assert.Equal(1, TestApplicationErrorLogger.Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
+            Assert.Equal(1, Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
 
             await StopConnectionAsync(expectedLastStreamId: 5, ignoreNonGoAwayFrames: false);
         }
@@ -1171,7 +1171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(expectedStreamId: 1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             // Writing over half the initial window size induces a connection-level window update.
             // But no stream window update since this is the last frame.
@@ -4426,7 +4426,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _pair.Application.Output.Complete(new ConnectionResetException(string.Empty));
 
             await StopConnectionAsync(1, ignoreNonGoAwayFrames: false);
-            Assert.Single(TestApplicationErrorLogger.Messages, m => m.Exception is ConnectionResetException);
+            Assert.Single(Messages, m => m.Exception is ConnectionResetException);
         }
 
         [Fact]
@@ -4437,7 +4437,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _pair.Application.Output.Complete(new ConnectionResetException(string.Empty));
 
             await WaitForConnectionStopAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
-            Assert.DoesNotContain(TestApplicationErrorLogger.Messages, m => m.Exception is ConnectionResetException);
+            Assert.DoesNotContain(Messages, m => m.Exception is ConnectionResetException);
         }
 
         [Fact]
@@ -4628,9 +4628,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.Equal(TaskStatus.RanToCompletion, _connection.ProcessRequestsAsync(new DummyApplication(_noopApplication)).Status);
 
-            Assert.All(TestApplicationErrorLogger.Messages, w => Assert.InRange(w.LogLevel, LogLevel.Trace, LogLevel.Debug));
+            Assert.All(Messages, w => Assert.InRange(w.LogLevel, LogLevel.Trace, LogLevel.Debug));
 
-            var logMessage = TestApplicationErrorLogger.Messages.Single(m => m.EventId == 20);
+            var logMessage = Messages.Single(m => m.EventId == 20);
 
             Assert.Equal("Connection id \"(null)\" request processing ended abnormally.", logMessage.Message);
             Assert.Same(ioException, logMessage.Exception);
@@ -4646,7 +4646,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.Equal(TaskStatus.RanToCompletion, _connection.ProcessRequestsAsync(new DummyApplication(_noopApplication)).Status);
 
-            var logMessage = TestApplicationErrorLogger.Messages.Single(m => m.LogLevel >= LogLevel.Information);
+            var logMessage = Messages.Single(m => m.LogLevel >= LogLevel.Information);
 
             Assert.Equal(LogLevel.Warning, logMessage.LogLevel);
             Assert.Equal(CoreStrings.RequestProcessingEndError, logMessage.Message);
@@ -4679,7 +4679,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             // These would be refused if the cool-down period had expired
             switch (finalFrameType)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -37,16 +37,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _connection.ServerSettings.MaxConcurrentStreams = 2;
 
             await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
-            Assert.Equal(0, Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
+            Assert.Equal(0, LogMessages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
 
             // Log message because we've reached the stream limit
             await StartStreamAsync(3, _browserRequestHeaders, endStream: false);
-            Assert.Equal(1, Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
+            Assert.Equal(1, LogMessages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
 
             // This stream will error because it exceeds max concurrent streams
             await StartStreamAsync(5, _browserRequestHeaders, endStream: true);
             await WaitForStreamErrorAsync(5, Http2ErrorCode.REFUSED_STREAM, CoreStrings.Http2ErrorMaxStreams);
-            Assert.Equal(1, Messages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
+            Assert.Equal(1, LogMessages.Count(m => m.EventId.Name == "Http2MaxConcurrentStreamsReached"));
 
             await StopConnectionAsync(expectedLastStreamId: 5, ignoreNonGoAwayFrames: false);
         }
@@ -1171,7 +1171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(expectedStreamId: 1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             // Writing over half the initial window size induces a connection-level window update.
             // But no stream window update since this is the last frame.
@@ -4426,7 +4426,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _pair.Application.Output.Complete(new ConnectionResetException(string.Empty));
 
             await StopConnectionAsync(1, ignoreNonGoAwayFrames: false);
-            Assert.Single(Messages, m => m.Exception is ConnectionResetException);
+            Assert.Single(LogMessages, m => m.Exception is ConnectionResetException);
         }
 
         [Fact]
@@ -4437,7 +4437,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _pair.Application.Output.Complete(new ConnectionResetException(string.Empty));
 
             await WaitForConnectionStopAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
-            Assert.DoesNotContain(Messages, m => m.Exception is ConnectionResetException);
+            Assert.DoesNotContain(LogMessages, m => m.Exception is ConnectionResetException);
         }
 
         [Fact]
@@ -4628,9 +4628,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.Equal(TaskStatus.RanToCompletion, _connection.ProcessRequestsAsync(new DummyApplication(_noopApplication)).Status);
 
-            Assert.All(Messages, w => Assert.InRange(w.LogLevel, LogLevel.Trace, LogLevel.Debug));
+            Assert.All(LogMessages, w => Assert.InRange(w.LogLevel, LogLevel.Trace, LogLevel.Debug));
 
-            var logMessage = Messages.Single(m => m.EventId == 20);
+            var logMessage = LogMessages.Single(m => m.EventId == 20);
 
             Assert.Equal("Connection id \"(null)\" request processing ended abnormally.", logMessage.Message);
             Assert.Same(ioException, logMessage.Exception);
@@ -4646,7 +4646,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             Assert.Equal(TaskStatus.RanToCompletion, _connection.ProcessRequestsAsync(new DummyApplication(_noopApplication)).Status);
 
-            var logMessage = Messages.Single(m => m.LogLevel >= LogLevel.Information);
+            var logMessage = LogMessages.Single(m => m.LogLevel >= LogLevel.Information);
 
             Assert.Equal(LogLevel.Warning, logMessage.LogLevel);
             Assert.Equal(CoreStrings.RequestProcessingEndError, logMessage.Message);
@@ -4679,7 +4679,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             // These would be refused if the cool-down period had expired
             switch (finalFrameType)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -1161,7 +1161,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 1);
 
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Exception?.Message.Contains("Response Content-Length mismatch: too many bytes written (12 of 11).") ?? false);
+            Assert.Contains(Messages, m => m.Exception?.Message.Contains("Response Content-Length mismatch: too many bytes written (12 of 11).") ?? false);
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1234,7 +1234,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
                 withStreamId: 1);
 
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Exception?.Message.Contains(CoreStrings.FormatTooFewBytesWritten(0, 11)) ?? false);
+            Assert.Contains(Messages, m => m.Exception?.Message.Contains(CoreStrings.FormatTooFewBytesWritten(0, 11)) ?? false);
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1739,7 +1739,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(expectedStreamId: 1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1826,7 +1826,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1889,7 +1889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -2243,7 +2243,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _pair.Application.Output.Complete();
             await _connectionTask;
 
-            var message = Assert.Single(TestApplicationErrorLogger.Messages, m => m.Exception is HPackEncodingException);
+            var message = Assert.Single(Messages, m => m.Exception is HPackEncodingException);
             Assert.Contains(SR.net_http_hpack_encode_failure, message.Exception.Message);
         }
 
@@ -2389,7 +2389,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
                 withStreamId: 1);
 
-            Assert.Contains(TestApplicationErrorLogger.Messages, m => (m.Exception?.Message.Contains("App Faulted") ?? false) && m.LogLevel == LogLevel.Error);
+            Assert.Contains(Messages, m => (m.Exception?.Message.Contains("App Faulted") ?? false) && m.LogLevel == LogLevel.Error);
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -1161,7 +1161,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)Http2DataFrameFlags.NONE,
                 withStreamId: 1);
 
-            Assert.Contains(Messages, m => m.Exception?.Message.Contains("Response Content-Length mismatch: too many bytes written (12 of 11).") ?? false);
+            Assert.Contains(LogMessages, m => m.Exception?.Message.Contains("Response Content-Length mismatch: too many bytes written (12 of 11).") ?? false);
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1234,7 +1234,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
                 withStreamId: 1);
 
-            Assert.Contains(Messages, m => m.Exception?.Message.Contains(CoreStrings.FormatTooFewBytesWritten(0, 11)) ?? false);
+            Assert.Contains(LogMessages, m => m.Exception?.Message.Contains(CoreStrings.FormatTooFewBytesWritten(0, 11)) ?? false);
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1739,7 +1739,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(expectedStreamId: 1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1826,7 +1826,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -1889,7 +1889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForStreamErrorAsync(1, Http2ErrorCode.NO_ERROR, null);
             // Logged without an exception.
-            Assert.Contains(Messages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Contains(LogMessages, m => m.Message.Contains("the application completed without reading the entire request body."));
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 
@@ -2243,7 +2243,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _pair.Application.Output.Complete();
             await _connectionTask;
 
-            var message = Assert.Single(Messages, m => m.Exception is HPackEncodingException);
+            var message = Assert.Single(LogMessages, m => m.Exception is HPackEncodingException);
             Assert.Contains(SR.net_http_hpack_encode_failure, message.Exception.Message);
         }
 
@@ -2389,7 +2389,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
                 withStreamId: 1);
 
-            Assert.Contains(Messages, m => (m.Exception?.Message.Contains("App Faulted") ?? false) && m.LogLevel == LogLevel.Error);
+            Assert.Contains(LogMessages, m => (m.Exception?.Message.Contains("App Faulted") ?? false) && m.LogLevel == LogLevel.Error);
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -1205,7 +1205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             if (expectedErrorMessage?.Length > 0)
             {
-                var message = Assert.Single(Messages, m => m.Exception is TException);
+                var message = Assert.Single(LogMessages, m => m.Exception is TException);
 
                 Assert.Contains(expectedErrorMessage, expected => message.Exception.Message.Contains(expected));
             }
@@ -1227,7 +1227,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             if (expectedErrorMessage != null)
             {
-                Assert.Contains(Messages, m => m.Exception?.Message.Contains(expectedErrorMessage) ?? false);
+                Assert.Contains(LogMessages, m => m.Exception?.Message.Contains(expectedErrorMessage) ?? false);
             }
         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -1205,7 +1205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             if (expectedErrorMessage?.Length > 0)
             {
-                var message = Assert.Single(TestApplicationErrorLogger.Messages, m => m.Exception is TException);
+                var message = Assert.Single(Messages, m => m.Exception is TException);
 
                 Assert.Contains(expectedErrorMessage, expected => message.Exception.Message.Contains(expected));
             }
@@ -1227,7 +1227,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             if (expectedErrorMessage != null)
             {
-                Assert.Contains(TestApplicationErrorLogger.Messages, m => m.Exception?.Message.Contains(expectedErrorMessage) ?? false);
+                Assert.Contains(Messages, m => m.Exception?.Message.Contains(expectedErrorMessage) ?? false);
             }
         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 // Emulate transport abort so the _connectionTask completes.
                 Task.Run(() =>
                 {
-                    TestApplicationErrorLogger.LogInformation(0, ex, "ConnectionContext.Abort() was called. Completing _pair.Application.Output.");
+                    Logger.LogInformation(0, ex, "ConnectionContext.Abort() was called. Completing _pair.Application.Output.");
                     _pair.Application.Output.Complete(ex);
                 });
             });
@@ -1210,8 +1210,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.Contains(expectedErrorMessage, expected => message.Exception.Message.Contains(expected));
             }
 
+            Logger.LogInformation("Waiting for Connection task");
             await _connectionTask.DefaultTimeout();
-            TestApplicationErrorLogger.LogInformation("Stopping Connection From ConnectionErrorAsync");
+            Logger.LogInformation("Stopping Connection From ConnectionErrorAsync");
         }
 
         internal async Task WaitForStreamErrorAsync(int expectedStreamId, Http2ErrorCode expectedErrorCode, string expectedErrorMessage)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -247,7 +247,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 var outputPipeOptions = GetOutputPipeOptions(_testBase._serviceContext, _testBase._memoryPool, PipeScheduler.ThreadPool);
 
                 _pair = DuplexPipe.CreateConnectionPair(inputPipeOptions, outputPipeOptions);
-                
+
                 StreamContext = new TestStreamContext(canRead: true, canWrite: true, _pair, this);
             }
 
@@ -375,7 +375,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 if (expectedErrorMessage != null)
                 {
-                    Assert.Contains(_testBase.TestApplicationErrorLogger.Messages, m => m.Exception?.Message.Contains(expectedErrorMessage) ?? false);
+                    Assert.Contains(_testBase.Messages, m => m.Exception?.Message.Contains(expectedErrorMessage) ?? false);
                 }
             }
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -375,7 +375,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 if (expectedErrorMessage != null)
                 {
-                    Assert.Contains(_testBase.Messages, m => m.Exception?.Message.Contains(expectedErrorMessage) ?? false);
+                    Assert.Contains(_testBase.LogMessages, m => m.Exception?.Message.Contains(expectedErrorMessage) ?? false);
                 }
             }
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpProtocolSelectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpProtocolSelectionTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Single(Messages, message => message.LogLevel == LogLevel.Error
+            Assert.Single(LogMessages, message => message.LogLevel == LogLevel.Error
                 && message.EventId.Id == 0
                 && message.Message == expectedErrorMessage);
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpProtocolSelectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpProtocolSelectionTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Single(TestApplicationErrorLogger.Messages, message => message.LogLevel == LogLevel.Error
+            Assert.Single(Messages, message => message.LogLevel == LogLevel.Error
                 && message.EventId.Id == 0
                 && message.Message == expectedErrorMessage);
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -1783,7 +1783,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(Messages.Where(m => m.LogLevel >= LogLevel.Warning));
+            Assert.Empty(LogMessages.Where(m => m.LogLevel >= LogLevel.Warning));
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -1783,7 +1783,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(TestApplicationErrorLogger.Messages.Where(m => m.LogLevel >= LogLevel.Warning));
+            Assert.Empty(Messages.Where(m => m.LogLevel >= LogLevel.Warning));
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseDrainingTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseDrainingTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     Assert.NotNull(transportConnection.AbortReason);
                     Assert.Equal(CoreStrings.ConnectionTimedBecauseResponseMininumDataRateNotSatisfied, transportConnection.AbortReason.Message);
 
-                    Assert.Single(TestApplicationErrorLogger.Messages, w => w.EventId.Id == 28 && w.LogLevel <= LogLevel.Debug);
+                    Assert.Single(Messages, w => w.EventId.Id == 28 && w.LogLevel <= LogLevel.Debug);
                 }
             }
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseDrainingTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseDrainingTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     Assert.NotNull(transportConnection.AbortReason);
                     Assert.Equal(CoreStrings.ConnectionTimedBecauseResponseMininumDataRateNotSatisfied, transportConnection.AbortReason.Message);
 
-                    Assert.Single(Messages, w => w.EventId.Id == 28 && w.LogLevel <= LogLevel.Debug);
+                    Assert.Single(LogMessages, w => w.EventId.Id == 28 && w.LogLevel <= LogLevel.Debug);
                 }
             }
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -714,7 +714,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var logMessage = Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
+            var logMessage = Assert.Single(LogMessages, message => message.LogLevel == LogLevel.Error);
 
             Assert.Equal(
                 $"Response Content-Length mismatch: too many bytes written (12 of 11).",
@@ -750,7 +750,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var logMessage = Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
+            var logMessage = Assert.Single(LogMessages, message => message.LogLevel == LogLevel.Error);
             Assert.Equal(
                 $"Response Content-Length mismatch: too many bytes written (12 of 11).",
                 logMessage.Exception.Message);
@@ -788,7 +788,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var logMessage = Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
+            var logMessage = Assert.Single(LogMessages, message => message.LogLevel == LogLevel.Error);
             Assert.Equal(
                 $"Response Content-Length mismatch: too many bytes written (12 of 5).",
                 logMessage.Exception.Message);
@@ -823,7 +823,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var logMessage = Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
+            var logMessage = Assert.Single(LogMessages, message => message.LogLevel == LogLevel.Error);
             Assert.Equal(
                 $"Response Content-Length mismatch: too many bytes written (12 of 5).",
                 logMessage.Exception.Message);
@@ -1024,7 +1024,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var error = Messages.Where(message => message.LogLevel == LogLevel.Error);
+            var error = LogMessages.Where(message => message.LogLevel == LogLevel.Error);
             Assert.Equal(2, error.Count());
             Assert.All(error, message => message.Message.Equals(CoreStrings.FormatTooFewBytesWritten(0, 5)));
         }
@@ -1062,7 +1062,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(Messages.Where(message => message.LogLevel == LogLevel.Error));
+            Assert.Empty(LogMessages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
         // https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -1098,7 +1098,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(Messages.Where(message => message.LogLevel == LogLevel.Error));
+            Assert.Empty(LogMessages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
         // https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -1134,7 +1134,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(Messages.Where(message => message.LogLevel == LogLevel.Error));
+            Assert.Empty(LogMessages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
         [Fact]
@@ -1758,7 +1758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Contains(Messages, w => w.EventId.Id == 17 && w.LogLevel <= LogLevel.Debug && w.Exception is BadHttpRequestException
+            Assert.Contains(LogMessages, w => w.EventId.Id == 17 && w.LogLevel <= LogLevel.Debug && w.Exception is BadHttpRequestException
                 && ((BadHttpRequestException)w.Exception).StatusCode == StatusCodes.Status400BadRequest);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
@@ -1809,7 +1809,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     // Time out after 10 seconds
                     for (int i = 0; i < 10 && !foundMessage; i++)
                     {
-                        while (Messages.TryDequeue(out var message))
+                        while (LogMessages.TryDequeue(out var message))
                         {
 #pragma warning disable CS0618 // Type or member is obsolete
                             if (message.EventId.Id == 17 && message.LogLevel <= LogLevel.Debug && message.Exception is BadHttpRequestException
@@ -1875,7 +1875,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Contains(Messages, w => w.EventId.Id == 17 && w.LogLevel <= LogLevel.Debug && w.Exception is BadHttpRequestException
+            Assert.Contains(LogMessages, w => w.EventId.Id == 17 && w.LogLevel <= LogLevel.Debug && w.Exception is BadHttpRequestException
                 && ((BadHttpRequestException)w.Exception).StatusCode == StatusCodes.Status400BadRequest);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
@@ -2192,7 +2192,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
             Assert.False(onStartingCalled);
-            Assert.Equal(2, Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
+            Assert.Equal(2, LogMessages.Where(message => message.LogLevel == LogLevel.Error).Count());
         }
 
 
@@ -2251,7 +2251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             // since they are called LIFO order and the other one failed.
             Assert.False(callback1Called);
             Assert.Equal(2, callback2CallCount);
-            Assert.Equal(2, Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
+            Assert.Equal(2, LogMessages.Where(message => message.LogLevel == LogLevel.Error).Count());
         }
 
         [Fact]
@@ -2387,7 +2387,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
             // All OnCompleted callbacks should be called even if they throw.
-            Assert.Equal(2, Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
+            Assert.Equal(2, LogMessages.Where(message => message.LogLevel == LogLevel.Error).Count());
             Assert.True(onCompletedCalled1);
             Assert.True(onCompletedCalled2);
         }
@@ -2430,7 +2430,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
             Assert.True(onStartingCalled);
-            Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
+            Assert.Single(LogMessages, message => message.LogLevel == LogLevel.Error);
         }
 
         [Fact]
@@ -2471,7 +2471,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
             Assert.True(onStartingCalled);
-            Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
+            Assert.Single(LogMessages, message => message.LogLevel == LogLevel.Error);
         }
 
 
@@ -2503,7 +2503,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(Messages.Where(message => message.LogLevel == LogLevel.Error));
+            Assert.Empty(LogMessages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
         [Fact]
@@ -2551,7 +2551,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Single(Messages.Where(m => m.Message.Contains(CoreStrings.ConnectionAbortedByApplication)));
+            Assert.Single(LogMessages.Where(m => m.Message.Contains(CoreStrings.ConnectionAbortedByApplication)));
         }
 
         [Fact]
@@ -2586,7 +2586,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Single(Messages.Where(m => m.Message.Contains("The connection was aborted by the application via IConnectionLifetimeFeature.Abort().")));
+            Assert.Single(LogMessages.Where(m => m.Message.Contains("The connection was aborted by the application via IConnectionLifetimeFeature.Abort().")));
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -714,7 +714,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var logMessage = Assert.Single(TestApplicationErrorLogger.Messages, message => message.LogLevel == LogLevel.Error);
+            var logMessage = Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
 
             Assert.Equal(
                 $"Response Content-Length mismatch: too many bytes written (12 of 11).",
@@ -750,7 +750,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var logMessage = Assert.Single(TestApplicationErrorLogger.Messages, message => message.LogLevel == LogLevel.Error);
+            var logMessage = Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
             Assert.Equal(
                 $"Response Content-Length mismatch: too many bytes written (12 of 11).",
                 logMessage.Exception.Message);
@@ -788,7 +788,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var logMessage = Assert.Single(TestApplicationErrorLogger.Messages, message => message.LogLevel == LogLevel.Error);
+            var logMessage = Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
             Assert.Equal(
                 $"Response Content-Length mismatch: too many bytes written (12 of 5).",
                 logMessage.Exception.Message);
@@ -823,7 +823,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var logMessage = Assert.Single(TestApplicationErrorLogger.Messages, message => message.LogLevel == LogLevel.Error);
+            var logMessage = Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
             Assert.Equal(
                 $"Response Content-Length mismatch: too many bytes written (12 of 5).",
                 logMessage.Exception.Message);
@@ -1024,7 +1024,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            var error = TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error);
+            var error = Messages.Where(message => message.LogLevel == LogLevel.Error);
             Assert.Equal(2, error.Count());
             Assert.All(error, message => message.Message.Equals(CoreStrings.FormatTooFewBytesWritten(0, 5)));
         }
@@ -1062,7 +1062,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error));
+            Assert.Empty(Messages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
         // https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -1098,7 +1098,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error));
+            Assert.Empty(Messages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
         // https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -1134,7 +1134,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error));
+            Assert.Empty(Messages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
         [Fact]
@@ -1758,7 +1758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Contains(TestApplicationErrorLogger.Messages, w => w.EventId.Id == 17 && w.LogLevel <= LogLevel.Debug && w.Exception is BadHttpRequestException
+            Assert.Contains(Messages, w => w.EventId.Id == 17 && w.LogLevel <= LogLevel.Debug && w.Exception is BadHttpRequestException
                 && ((BadHttpRequestException)w.Exception).StatusCode == StatusCodes.Status400BadRequest);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
@@ -1809,7 +1809,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     // Time out after 10 seconds
                     for (int i = 0; i < 10 && !foundMessage; i++)
                     {
-                        while (TestApplicationErrorLogger.Messages.TryDequeue(out var message))
+                        while (Messages.TryDequeue(out var message))
                         {
 #pragma warning disable CS0618 // Type or member is obsolete
                             if (message.EventId.Id == 17 && message.LogLevel <= LogLevel.Debug && message.Exception is BadHttpRequestException
@@ -1875,7 +1875,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Contains(TestApplicationErrorLogger.Messages, w => w.EventId.Id == 17 && w.LogLevel <= LogLevel.Debug && w.Exception is BadHttpRequestException
+            Assert.Contains(Messages, w => w.EventId.Id == 17 && w.LogLevel <= LogLevel.Debug && w.Exception is BadHttpRequestException
                 && ((BadHttpRequestException)w.Exception).StatusCode == StatusCodes.Status400BadRequest);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
@@ -2192,7 +2192,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
             Assert.False(onStartingCalled);
-            Assert.Equal(2, TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
+            Assert.Equal(2, Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
         }
 
 
@@ -2251,7 +2251,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             // since they are called LIFO order and the other one failed.
             Assert.False(callback1Called);
             Assert.Equal(2, callback2CallCount);
-            Assert.Equal(2, TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
+            Assert.Equal(2, Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
         }
 
         [Fact]
@@ -2387,7 +2387,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
             // All OnCompleted callbacks should be called even if they throw.
-            Assert.Equal(2, TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
+            Assert.Equal(2, Messages.Where(message => message.LogLevel == LogLevel.Error).Count());
             Assert.True(onCompletedCalled1);
             Assert.True(onCompletedCalled2);
         }
@@ -2430,7 +2430,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
             Assert.True(onStartingCalled);
-            Assert.Single(TestApplicationErrorLogger.Messages, message => message.LogLevel == LogLevel.Error);
+            Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
         }
 
         [Fact]
@@ -2471,7 +2471,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
 
             Assert.True(onStartingCalled);
-            Assert.Single(TestApplicationErrorLogger.Messages, message => message.LogLevel == LogLevel.Error);
+            Assert.Single(Messages, message => message.LogLevel == LogLevel.Error);
         }
 
 
@@ -2503,7 +2503,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Empty(TestApplicationErrorLogger.Messages.Where(message => message.LogLevel == LogLevel.Error));
+            Assert.Empty(Messages.Where(message => message.LogLevel == LogLevel.Error));
         }
 
         [Fact]
@@ -2551,7 +2551,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Single(TestApplicationErrorLogger.Messages.Where(m => m.Message.Contains(CoreStrings.ConnectionAbortedByApplication)));
+            Assert.Single(Messages.Where(m => m.Message.Contains(CoreStrings.ConnectionAbortedByApplication)));
         }
 
         [Fact]
@@ -2586,7 +2586,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 }
             }
 
-            Assert.Single(TestApplicationErrorLogger.Messages.Where(m => m.Message.Contains("The connection was aborted by the application via IConnectionLifetimeFeature.Abort().")));
+            Assert.Single(Messages.Where(m => m.Message.Contains("The connection was aborted by the application via IConnectionLifetimeFeature.Abort().")));
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/26291 is about up for unquarantine, I looked into the test and couldn't repro and there are no test failure logs to look at.

I added a new log and fixed a couple logs that weren't logging to the test logger. We can probably close the issue and unquarantine the test while waiting for a new failure.

My best guess is that the stream draining code is taking too long sometimes on the CI when there are 200 streams
https://github.com/dotnet/aspnetcore/blob/ad34c65a58d09975fdc3523494a6743d7663166e/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs#L344-L348