### PR TITLE
Replace Thread.CurrentThread.ManagedThreadId with Env.CurrentManagedThreadId

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/ServerProtocol/ServerLogger.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/ServerProtocol/ServerLogger.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Microsoft.AspNetCore.Razor.Tools
 {
     /// <summary>
-    /// Class for logging information about what happens in the server and client parts of the 
+    /// Class for logging information about what happens in the server and client parts of the
     /// Razor command line compiler and build tasks. Useful for debugging what is going on.
     /// </summary>
     /// <remarks>
@@ -132,8 +132,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
 
         private static int GetCurrentThreadId()
         {
-            var thread = Thread.CurrentThread;
-            return thread.ManagedThreadId;
+            return Environment.CurrentManagedThreadId;
         }
 
         /// <summary>

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/Networking/UvAsyncHandle.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/Networking/UvAsyncHandle.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networkin
             {
                 handle = IntPtr.Zero;
 
-                if (Thread.CurrentThread.ManagedThreadId == ThreadId)
+                if (Environment.CurrentManagedThreadId == ThreadId)
                 {
                     _uv.close(memory, _destroyMemory);
                 }

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/Networking/UvHandle.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/Networking/UvHandle.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networkin
             {
                 handle = IntPtr.Zero;
 
-                if (Thread.CurrentThread.ManagedThreadId == ThreadId)
+                if (Environment.CurrentManagedThreadId == ThreadId)
                 {
                     _uv.close(memory, _destroyMemory);
                 }

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/Networking/UvLoopHandle.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/Networking/UvLoopHandle.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networkin
         {
             CreateMemory(
                 uv,
-                Thread.CurrentThread.ManagedThreadId,
+                Environment.CurrentManagedThreadId,
                 uv.loop_size());
 
             _uv.loop_init(this);

--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/Networking/UvMemory.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/Networking/UvMemory.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal.Networkin
         {
             Debug.Assert(closed || !IsClosed, "Handle is closed");
             Debug.Assert(!IsInvalid, "Handle is invalid");
-            Debug.Assert(_threadId == Thread.CurrentThread.ManagedThreadId, "ThreadId is incorrect");
+            Debug.Assert(_threadId == Environment.CurrentManagedThreadId, "ThreadId is incorrect");
         }
 
         unsafe public static THandle FromIntPtr<THandle>(IntPtr handle)

--- a/src/Servers/Kestrel/Transport.Libuv/test/LibuvConnectionTests.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/test/LibuvConnectionTests.cs
@@ -31,8 +31,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
             {
                 await thread.StartAsync();
                 await thread.PostAsync(_ =>
-                {      
-                    var socket = new MockSocket(mockLibuv, Thread.CurrentThread.ManagedThreadId, transportContext.Log);
+                {
+                    var socket = new MockSocket(mockLibuv, Environment.CurrentManagedThreadId, transportContext.Log);
                     listenerContext.HandleConnection(socket);
 
                     mockLibuv.AllocCallback(socket.InternalGetHandle(), 2048, out var ignored);
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                 // Write enough to make sure back pressure will be applied
                 await thread.PostAsync<object>(_ =>
                 {
-                    var socket = new MockSocket(mockLibuv, Thread.CurrentThread.ManagedThreadId, transportContext.Log);
+                    var socket = new MockSocket(mockLibuv, Environment.CurrentManagedThreadId, transportContext.Log);
                     listenerContext.HandleConnection(socket);
 
                     mockLibuv.AllocCallback(socket.InternalGetHandle(), 2048, out var ignored);
@@ -144,9 +144,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                 // Write enough to make sure back pressure will be applied
                 await thread.PostAsync<object>(_ =>
                 {
-                    var socket = new MockSocket(mockLibuv, Thread.CurrentThread.ManagedThreadId, transportContext.Log);
+                    var socket = new MockSocket(mockLibuv, Environment.CurrentManagedThreadId, transportContext.Log);
                     listenerContext.HandleConnection(socket);
-                    
+
                     mockLibuv.AllocCallback(socket.InternalGetHandle(), 2048, out var ignored);
                     mockLibuv.ReadCallback(socket.InternalGetHandle(), 5, ref ignored);
 
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
 
                 // Now complete the output writer and wait for the connection to close
                 await connection.DisposeAsync();
-                
+
                 // Assert that we don't try to start reading
                 Assert.Null(mockLibuv.AllocCallback);
                 Assert.Null(mockLibuv.ReadCallback);
@@ -203,9 +203,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                 await thread.StartAsync();
                 await thread.PostAsync(_ =>
                 {
-                    var socket = new MockSocket(mockLibuv, Thread.CurrentThread.ManagedThreadId, transportContext.Log);
+                    var socket = new MockSocket(mockLibuv, Environment.CurrentManagedThreadId, transportContext.Log);
                     listenerContext.HandleConnection(socket);
-                    
+
                     var ignored = new LibuvFunctions.uv_buf_t();
                     mockLibuv.ReadCallback(socket.InternalGetHandle(), TestConstants.EOF, ref ignored);
                 }, (object)null);

--- a/src/Testing/src/CultureReplacer.cs
+++ b/src/Testing/src/CultureReplacer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Testing
         {
             _originalCulture = CultureInfo.CurrentCulture;
             _originalUICulture = CultureInfo.CurrentUICulture;
-            _threadId = Thread.CurrentThread.ManagedThreadId;
+            _threadId = Environment.CurrentManagedThreadId;
             CultureInfo.CurrentCulture = culture;
             CultureInfo.CurrentUICulture = uiCulture;
         }
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Testing
         {
             if (disposing)
             {
-                Assert.True(Thread.CurrentThread.ManagedThreadId == _threadId,
+                Assert.True(Environment.CurrentManagedThreadId == _threadId,
                     "The current thread is not the same as the thread invoking the constructor. This should never happen.");
                 CultureInfo.CurrentCulture = _originalCulture;
                 CultureInfo.CurrentUICulture = _originalUICulture;


### PR DESCRIPTION
For perf reasons (after https://github.com/dotnet/runtime/pull/41360 was merged)
```
|                                 Method |      Mean |     Error |    StdDev |
|--------------------------------------- |----------:|----------:|----------:|
|     Environment.CurrentManagedThreadId |  0.859 ns | 0.0075 ns | 0.0071 ns |
|   Thread.CurrentThread.ManagedThreadId |  3.270 ns | 0.0163 ns | 0.0136 ns |
```
I changed it even in tests because we're going to have an analyzer for it (https://github.com/dotnet/runtime/issues/43257).