### PR TITLE
IdentityUI - add aria-required to inputs

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ForgotPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ForgotPassword.cshtml
@@ -13,7 +13,7 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="Input.Email"></label>
-                <input asp-for="Input.Email" class="form-control" autocomplete="username" />
+                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <button type="submit" class="btn btn-primary">Reset Password</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Login.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Login.cshtml
@@ -15,12 +15,12 @@
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <div class="form-group">
                     <label asp-for="Input.Email"></label>
-                    <input asp-for="Input.Email" class="form-control" autocomplete="username" />
+                    <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
                     <span asp-validation-for="Input.Email" class="text-danger"></span>
                 </div>
                 <div class="form-group">
                     <label asp-for="Input.Password"></label>
-                    <input asp-for="Input.Password" class="form-control" autocomplete="current-password" />
+                    <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" />
                     <span asp-validation-for="Input.Password" class="text-danger"></span>
                 </div>
                 <div class="form-group">

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/ChangePassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/ChangePassword.cshtml
@@ -13,17 +13,17 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="Input.OldPassword"></label>
-                <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" />
+                <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" aria-required="true" />
                 <span asp-validation-for="Input.OldPassword" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Input.NewPassword"></label>
-                <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" />
+                <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" aria-required="true" />
                 <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Input.ConfirmPassword"></label>
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
+                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
             <button type="submit" class="btn btn-primary">Update password</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/DeletePersonalData.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/DeletePersonalData.cshtml
@@ -20,7 +20,7 @@
         {
             <div class="form-group">
                 <label asp-for="Input.Password"></label>
-                <input asp-for="Input.Password" class="form-control" autocomplete="current-password" />
+                <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" />
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>
         }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/Email.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/Email.cshtml
@@ -30,7 +30,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Input.NewEmail"></label>
-                <input asp-for="Input.NewEmail" class="form-control" autocomplete="email" />
+                <input asp-for="Input.NewEmail" class="form-control" autocomplete="email" aria-required="true" />
                 <span asp-validation-for="Input.NewEmail" class="text-danger"></span>
             </div>
             <button id="change-email-button" type="submit" asp-page-handler="ChangeEmail" class="btn btn-primary">Change email</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Register.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Register.cshtml
@@ -14,17 +14,17 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="Input.Email"></label>
-                <input asp-for="Input.Email" class="form-control" autocomplete="username" />
+                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Input.Password"></label>
-                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
+                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" />
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Input.ConfirmPassword"></label>
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
+                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
             <button id="registerSubmit" type="submit" class="btn btn-primary">Register</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ResendEmailConfirmation.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ResendEmailConfirmation.cshtml
@@ -13,7 +13,7 @@
             <div asp-validation-summary="All" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="Input.Email"></label>
-                <input asp-for="Input.Email" class="form-control" />
+                <input asp-for="Input.Email" class="form-control" aria-required="true" />
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <button type="submit" class="btn btn-primary">Resend</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ResetPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ResetPassword.cshtml
@@ -14,17 +14,17 @@
             <input asp-for="Input.Code" type="hidden" />
             <div class="form-group">
                 <label asp-for="Input.Email"></label>
-                <input asp-for="Input.Email" class="form-control" autocomplete="username" />
+                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Input.Password"></label>
-                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" />
+                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" />
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Input.ConfirmPassword"></label>
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
+                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
             <button type="submit" class="btn btn-primary">Reset</button>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/25867

Adds aria-required attribute so screen readers will announce inputs as required.

Note: this requires a matching PR in scaffolding repo