### PR TITLE
Add initial support for Apple Silicon

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -326,11 +326,43 @@ stages:
             publishFeedCredentials: 'DevDiv - VS package feed'
 
 
-  # Build MacOS
+  # Build MacOS arm64
+  - template: jobs/default-build.yml
+    parameters:
+      jobName: MacOs_arm64_build
+      jobDisplayName: "Build: macOS arm64"
+      agentOs: macOs
+      buildArgs:
+        --arch arm64
+        --pack
+        --all
+        --no-build-nodejs
+        --no-build-java
+        -p:OnlyPackPlatformSpecificPackages=true
+        -p:AssetManifestFileName=aspnetcore-MacOS_arm64.xml
+        $(_BuildArgs)
+        $(_PublishArgs)
+        $(_InternalRuntimeDownloadArgs)
+      installNodeJs: false
+      installJdk: false
+      artifacts:
+      - name: MacOS_arm64_Logs
+        path: artifacts/log/
+        publishOnError: true
+        includeForks: true
+      - name: MacOS_arm64_Packages
+        path: artifacts/packages/
+
+  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+    - template: jobs/codesign-xplat.yml
+      parameters:
+        inputName: MacOS_arm64
+
+  # Build MacOS x64
   - template: jobs/default-build.yml
     parameters:
       jobName: MacOs_x64_build
-      jobDisplayName: "Build: macOS"
+      jobDisplayName: "Build: macOS x64"
       agentOs: macOs
       buildArgs:
         --pack
@@ -787,6 +819,7 @@ stages:
           - Windows_arm_build
           - Windows_arm64_build
           - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+            - CodeSign_Xplat_MacOS_arm64
             - CodeSign_Xplat_MacOS_x64
             - CodeSign_Xplat_Linux_x64
             - CodeSign_Xplat_Linux_arm

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -92,7 +92,7 @@ jobs:
     # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md
     pool:
       ${{ if eq(parameters.agentOs, 'macOS') }}:
-        vmImage: macOS-10.14
+        vmImage: macOS-10.15
       ${{ if eq(parameters.agentOs, 'Linux') }}:
         ${{ if eq(parameters.useHostedUbuntu, true) }}:
           vmImage: ubuntu-16.04
@@ -143,6 +143,9 @@ jobs:
     - ${{ if ne(parameters.agentOs, 'Windows') }}:
       - script: df -h
         displayName: Disk size
+    - ${{ if eq(parameters.agentOs, 'macOS') }}:
+      - script: sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer
+        displayName: Use XCode 12.2
     - checkout: self
       clean: true
     - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isTestingJob, true)) }}:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -145,8 +145,8 @@
       win-x86;
       win-arm;
       win-arm64;
-      osx-arm64;
       osx-x64;
+      osx-arm64;
       linux-musl-x64;
       linux-musl-arm;
       linux-musl-arm64;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -145,6 +145,7 @@
       win-x86;
       win-arm;
       win-arm64;
+      osx-arm64;
       osx-x64;
       linux-musl-x64;
       linux-musl-arm;

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -89,6 +89,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.win-x86" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.win-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.win-arm64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.osx-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.osx-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-arm" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -89,8 +89,8 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.win-x86" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.win-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.win-arm64" />
-    <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.osx-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.osx-x64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.osx-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-arm64" />


### PR DESCRIPTION
Add initial support for Apple Silicon

- Add osx-arm64 runtime dependency
- Add osx-arm64 to supported rid identifiers
- Update vmImage to macOS-10.15
- Use XCode 12.2 for all macOS builds
- Add build and sign macos arm64 to CI scripts

This should build aspnetcore for osx-arm64, however
the native dependencies libuv and libe_sqlite3 will
need to be updated to have full functionality.  These
are provided by separate repos.

Enabling at this point unblocks effort to create the initial
osx-arm64 SDK.

Partially addresses #26821

/cc @janvorli @mangod9 
