### PR TITLE
[release/5.0] Don't push to VS feed when post build sign == true

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -316,7 +316,7 @@ stages:
         displayName: Build Arm64 Installers
 
       # A few files must also go to the VS package feed.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
         - task: NuGetCommand@2
           displayName: Push Visual Studio packages
           inputs:


### PR DESCRIPTION
Avoid pushing to the VS package feed when post build sign == true since these assets would be unsigned. They will be pushed in the staging pipeline after being signed.