### PR TITLE
Remove redundant DefineConstants from Bundles

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/Product.props
+++ b/src/Installers/Windows/SharedFrameworkBundle/Product.props
@@ -27,7 +27,5 @@
       <DefineConstants>$(DefineConstants);BundleRegManufacturer=$(BundleRegManufacturer)</DefineConstants>
       <DefineConstants>$(DefineConstants);BundleRegFamily=$(BundleRegFamily)</DefineConstants>
       <DefineConstants>$(DefineConstants);BundleRegName=$(BundleRegName)</DefineConstants>
-      <DefineConstants>$(DefineConstants);MajorVersion=$(AspNetCoreMajorVersion)</DefineConstants>
-      <DefineConstants>$(DefineConstants);MinorVersion=$(AspNetCoreMinorVersion)</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/src/Installers/Windows/WindowsHostingBundle/Product.props
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.props
@@ -27,7 +27,5 @@
     <DefineConstants>$(DefineConstants);BundleRegManufacturer=$(BundleRegManufacturer)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleRegFamily=$(BundleRegFamily)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleRegName=$(BundleRegName)</DefineConstants>
-    <DefineConstants>$(DefineConstants);MajorVersion=$(AspNetCoreMajorVersion)</DefineConstants>
-    <DefineConstants>$(DefineConstants);MinorVersion=$(AspNetCoreMinorVersion)</DefineConstants>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
These are already set here: https://github.com/dotnet/aspnetcore/blob/592cc06f1f7cca202ccefdbcdd2e764d3a5dc1d7/src/Installers/Windows/Wix.props#L32-L33