### PR TITLE
Handle object disposed race on shutdown in IIS

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISNativeApplication.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISNativeApplication.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
     internal class IISNativeApplication
     {
         private readonly NativeSafeHandle _nativeApplication;
-        private object _sync = new object();
+        private readonly object _sync = new object();
 
         public IISNativeApplication(NativeSafeHandle nativeApplication)
         {

--- a/src/Servers/IIS/IIS/src/Core/IISNativeApplication.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISNativeApplication.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
     internal class IISNativeApplication
     {
         private readonly NativeSafeHandle _nativeApplication;
+        private object _sync = new object();
 
         public IISNativeApplication(NativeSafeHandle nativeApplication)
         {
@@ -17,12 +18,24 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
         public void StopIncomingRequests()
         {
-            NativeMethods.HttpStopIncomingRequests(_nativeApplication);
+            lock (_sync)
+            {
+                if (!_nativeApplication.IsInvalid)
+                {
+                    NativeMethods.HttpStopIncomingRequests(_nativeApplication);
+                }
+            }
         }
 
         public void StopCallsIntoManaged()
         {
-            NativeMethods.HttpStopCallsIntoManaged(_nativeApplication);
+            lock (_sync)
+            {
+                if (!_nativeApplication.IsInvalid)
+                {
+                    NativeMethods.HttpStopCallsIntoManaged(_nativeApplication);
+                }
+            }
         }
 
         public void RegisterCallbacks(
@@ -47,10 +60,13 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
         public void Dispose()
         {
-            GC.SuppressFinalize(this);
+            lock (_sync)
+            {
+                GC.SuppressFinalize(this);
 
-            // Don't need to await here because pinvokes should never been called after disposing the safe handle.
-            _nativeApplication.Dispose();
+                // Don't need to await here because pinvokes should never been called after disposing the safe handle.
+                _nativeApplication.Dispose();
+            }
         }
 
         ~IISNativeApplication()


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/26330.

There is a race on shutdown which will call a method with a SafeHandle that has already been disposed. This is because a call from native in managed code has the potential to be called at the same time as server dispose.

There are a few potential ways to fix this:
1. Lock inside of the object to check if we have already disposed before calling into native. This slightly defeats the purpose of the safe handle though. It's what I went with here as it seemed the simplest.
2. Delay disposing if there is an active call from native into managed. This may be difficult though as we'd need to manage state on who will eventually be disposing.
3. Figure out a way to unregister the callback that would call from native into managed. This is also difficult as there may still be active calls from managed into native when doing this check, and only tightens the race.
