### PR TITLE
Switch to Windows.10.Arm64v8.Open Helix queue

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -26,7 +26,7 @@ jobs:
     timeoutInMinutes: 480
     steps:
     # Build the shared framework
-    - script: ./build.cmd -ci -nobl -all -pack -arch x64 /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+    - script: ./build.cmd -ci -nobl -all -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
     - script: ./build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
@@ -52,11 +52,12 @@ jobs:
     agentOs: Linux
     timeoutInMinutes: 480
     steps:
-    - script: ./restore.sh --ci --nobl --arch arm64
-      displayName: Restore
+    - script: ./build.sh --ci --nobl --pack --arch arm64
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+      displayName: Build shared Fx
     - script: ./build.sh --ci --nobl --arch arm64 --noBuildRepoTasks --no-build-nodejs --no-restore --test --all
               --projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
-              /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.sh helix arm64 target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -56,11 +56,12 @@ jobs:
     agentOs: Linux
     timeoutInMinutes: 480
     steps:
-    - script: ./restore.sh --ci --nobl --arch arm64
-      displayName: Restore
+    - script: ./build.sh --ci --nobl --pack --arch arm64
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+      displayName: Build shared Fx
     - script: ./build.sh --ci --nobl  --arch arm64 --noBuildRepoTasks --no-build-nodejs --no-restore --test --all
               --projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
-              /p:RunQuarantinedTests=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+              /p:RunQuarantinedTests=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.sh helix arm64 target
       continueOnError: true
       env:

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -45,6 +45,6 @@
     <HelixAvailableTargetQueue Include="(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036" Platform="Linux" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true'">
-    <HelixAvailableTargetQueue Include="Windows.10.Arm64.Open" Platform="Windows" />
+    <HelixAvailableTargetQueue Include="Windows.10.Arm64v8.Open" Platform="Windows" />
   </ItemGroup>
 </Project>

--- a/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
+++ b/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.DataProtection
 
         [ConditionalFact]
         [X509StoreIsAvailable(StoreName.My, StoreLocation.CurrentUser)]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/6720 and https://github.com/dotnet/aspnetcore/issues/26871", Queues = "All.OSX;Windows.10.Arm64.Open")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/6720 and https://github.com/dotnet/aspnetcore/issues/26871", Queues = "All.OSX;Windows.10.Arm64;Windows.10.Arm64.Open;Windows.10.Arm64v8;Windows.10.Arm64v8.Open")]
         public void System_UsesProvidedDirectoryAndCertificate()
         {
             var filePath = Path.Combine(GetTestFilesPath(), "TestCert.pfx");

--- a/src/Servers/Kestrel/test/Libuv.BindTests/Libuv.BindTests.csproj
+++ b/src/Servers/Kestrel/test/Libuv.BindTests/Libuv.BindTests.csproj
@@ -5,7 +5,7 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <TestGroupName>Libuv.BindTests</TestGroupName>
     <!-- https://github.com/dotnet/aspnetcore/issues/22114 -->
-    <SkipHelixQueues>Windows.10.Arm64;Windows.10.Arm64.Open</SkipHelixQueues>
+    <SkipHelixQueues>Windows.10.Arm64;Windows.10.Arm64.Open;Windows.10.Arm64v8;Windows.10.Arm64v8.Open</SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/test/Libuv.FunctionalTests/Libuv.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Libuv.FunctionalTests/Libuv.FunctionalTests.csproj
@@ -8,7 +8,7 @@
     <!-- Put this project into its own test group to avoid running parallel with other test projects. Libuv does not play nice with other test assemblies. -->
     <TestGroupName>Libuv.FunctionalTests</TestGroupName>
     <!-- https://github.com/dotnet/aspnetcore/issues/22114 -->
-    <SkipHelixQueues>Windows.10.Arm64;Windows.10.Arm64.Open</SkipHelixQueues>
+    <SkipHelixQueues>Windows.10.Arm64;Windows.10.Arm64.Open;Windows.10.Arm64v8;Windows.10.Arm64v8.Open</SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-watch/test/AppWithDepsTests.cs
+++ b/src/Tools/dotnet-watch/test/AppWithDepsTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
 
         [ConditionalFact]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23994")]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/23360", Queues = "Windows.10.Arm64;Windows.10.Arm64.Open;Debian.9.Arm64;Debian.9.Arm64.Open;(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036;(Debian.9.Arm64)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/23360", Queues = "Windows.10.Arm64;Windows.10.Arm64.Open;Debian.9.Arm64;Debian.9.Arm64.Open;(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036;(Debian.9.Arm64)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036;Windows.10.Arm64v8;Windows.10.Arm64v8.Open")]
         public async Task ChangeFileInDependency()
         {
             await _app.StartWatcherAsync();

--- a/src/Tools/dotnet-watch/test/DotNetWatcherTests.cs
+++ b/src/Tools/dotnet-watch/test/DotNetWatcherTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         }
 
         [ConditionalFact]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/24841", Queues = "Windows.10.Arm64.Open")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/24841", Queues = "Windows.10.Arm64;Windows.10.Arm64.Open;Windows.10.Arm64v8;Windows.10.Arm64v8.Open")]
         public async Task RunsWithIterationEnvVariable()
         {
             await _app.StartWatcherAsync();

--- a/src/Tools/dotnet-watch/test/NoDepsAppTests.cs
+++ b/src/Tools/dotnet-watch/test/NoDepsAppTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Watcher.Tools.FunctionalTests
         }
 
         [ConditionalFact]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/24841", Queues = "Windows.10.Arm64.Open")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/24841", Queues = "Windows.10.Arm64;Windows.10.Arm64.Open;Windows.10.Arm64v8;Windows.10.Arm64v8.Open")]
         public async Task RestartProcessThatTerminatesAfterFileChange()
         {
             await _app.StartWatcherAsync();


### PR DESCRIPTION
- this may avoid problems with empty `$env:Path` values
