### PR TITLE
Fix, then reduce use of `TestPathUtilities.GetSolutionRootDirectory(...)`

### DIFF
--- a/src/Components/Analyzers/test/AnalyzerTestBase.cs
+++ b/src/Components/Analyzers/test/AnalyzerTestBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Analyzer.Testing;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Components.Analyzers
@@ -18,7 +17,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
         {
             if (!source.EndsWith(".cs", StringComparison.Ordinal))
             {
-                source = source + ".cs";
+                source += ".cs";
             }
 
             var filePath = Path.Combine(ProjectDirectory, "TestFiles", GetType().Name, source);
@@ -35,7 +34,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
         {
             if (!source.EndsWith(".cs", StringComparison.Ordinal))
             {
-                source = source + ".cs";
+                source += ".cs";
             }
 
             var read = Read(source);
@@ -49,19 +48,8 @@ namespace Microsoft.AspNetCore.Components.Analyzers
 
         private static string GetProjectDirectory()
         {
-            // On helix we use the published test files
-            if (SkipOnHelixAttribute.OnHelix())
-            {
-                return AppContext.BaseDirectory;
-            }
-
-            // This test code needs to be updated to support distributed testing.
-            // See https://github.com/dotnet/aspnetcore/issues/10422
-#pragma warning disable 0618
-            var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Components");
-#pragma warning restore 0618
-            var projectDirectory = Path.Combine(solutionDirectory, "Analyzers", "test");
-            return projectDirectory;
+            // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+            return AppContext.BaseDirectory;
         }
     }
 }

--- a/src/Components/Analyzers/test/AnalyzerTestBase.cs
+++ b/src/Components/Analyzers/test/AnalyzerTestBase.cs
@@ -11,7 +11,8 @@ namespace Microsoft.AspNetCore.Components.Analyzers
 {
     public abstract class AnalyzerTestBase
     {
-        private static readonly string ProjectDirectory = GetProjectDirectory();
+        // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+        private static readonly string ProjectDirectory = AppContext.BaseDirectory;
 
         public TestSource Read(string source)
         {
@@ -44,12 +45,6 @@ namespace Microsoft.AspNetCore.Components.Analyzers
         public Task<Compilation> CreateCompilationAsync(string source)
         {
             return CreateProject(source).GetCompilationAsync();
-        }
-
-        private static string GetProjectDirectory()
-        {
-            // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
-            return AppContext.BaseDirectory;
         }
     }
 }

--- a/src/Mvc/Mvc.Analyzers/test/Infrastructure/MvcTestSource.cs
+++ b/src/Mvc/Mvc.Analyzers/test/Infrastructure/MvcTestSource.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Mvc
 {
     public static class MvcTestSource
     {
-        private static readonly string ProjectDirectory = GetProjectDirectory();
+        // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+        private static readonly string ProjectDirectory = AppContext.BaseDirectory;
 
         public static TestSource Read(string testClassName, string testMethod)
         {
@@ -21,12 +22,6 @@ namespace Microsoft.AspNetCore.Mvc
 
             var fileContent = File.ReadAllText(filePath);
             return TestSource.Read(fileContent);
-        }
-
-        private static string GetProjectDirectory()
-        {
-            // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
-            return AppContext.BaseDirectory;
         }
     }
 }

--- a/src/Mvc/Mvc.Analyzers/test/Infrastructure/MvcTestSource.cs
+++ b/src/Mvc/Mvc.Analyzers/test/Infrastructure/MvcTestSource.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Analyzer.Testing;
-using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.Mvc
 {
@@ -26,18 +25,8 @@ namespace Microsoft.AspNetCore.Mvc
 
         private static string GetProjectDirectory()
         {
-            // On helix we use the published test files
-            if (SkipOnHelixAttribute.OnHelix())
-            {
-                return AppContext.BaseDirectory;
-            }
-
-// https://github.com/dotnet/aspnetcore/issues/9431
-#pragma warning disable 0618
-            var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Mvc");
-#pragma warning restore 0618
-            var projectDirectory = Path.Combine(solutionDirectory, "Mvc.Analyzers", "test");
-            return projectDirectory;
+            // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+            return AppContext.BaseDirectory;
         }
     }
 }

--- a/src/Mvc/Mvc.Api.Analyzers/test/Infrastructure/MvcTestSource.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/Infrastructure/MvcTestSource.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Mvc
 {
     public static class MvcTestSource
     {
-        private static readonly string ProjectDirectory = GetProjectDirectory();
+        // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+        private static readonly string ProjectDirectory = AppContext.BaseDirectory;
 
         public static TestSource Read(string testClassName, string testMethod)
         {
@@ -21,12 +22,6 @@ namespace Microsoft.AspNetCore.Mvc
 
             var fileContent = File.ReadAllText(filePath);
             return TestSource.Read(fileContent);
-        }
-
-        private static string GetProjectDirectory()
-        {
-            // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
-            return AppContext.BaseDirectory;
         }
     }
 }

--- a/src/Mvc/Mvc.Api.Analyzers/test/Infrastructure/MvcTestSource.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/Infrastructure/MvcTestSource.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Analyzer.Testing;
-using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.Mvc
 {
@@ -26,18 +25,8 @@ namespace Microsoft.AspNetCore.Mvc
 
         private static string GetProjectDirectory()
         {
-            // On helix we use the published test files
-            if (SkipOnHelixAttribute.OnHelix())
-            {
-                return AppContext.BaseDirectory;
-            }
-
-// https://github.com/dotnet/aspnetcore/issues/9431
-#pragma warning disable 0618
-            var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Mvc");
-#pragma warning restore 0618
-            var projectDirectory = Path.Combine(solutionDirectory, "Mvc.Api.Analyzers", "test");
-            return projectDirectory;
+            // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+            return AppContext.BaseDirectory;
         }
     }
 }

--- a/src/Testing/src/TestPathUtilities.cs
+++ b/src/Testing/src/TestPathUtilities.cs
@@ -22,6 +22,20 @@ namespace Microsoft.AspNetCore.Testing
                     return projectFileInfo.DirectoryName;
                 }
 
+                projectFileInfo = new FileInfo(Path.Combine(directoryInfo.FullName, "AspNetCore.sln"));
+                if (projectFileInfo.Exists)
+                {
+                    // Have reached the solution root. Work down through the src/ folder to find the solution filter.
+                    directoryInfo = new DirectoryInfo(Path.Combine(directoryInfo.FullName, "src"));
+                    foreach (var solutionFileInfo in directoryInfo.EnumerateFiles($"{solution}.slnf", SearchOption.AllDirectories))
+                    {
+                        return solutionFileInfo.DirectoryName;
+                    }
+
+                    // No luck. Exit loop and error out.
+                    break;
+                }
+
                 directoryInfo = directoryInfo.Parent;
             }
             while (directoryInfo.Parent != null);


### PR DESCRIPTION
- do not traverse up past the `$(RepoRoot)` when running tests locally
  - if `$(RepoRoot)` is reached, search down for named `*.slnf` file
  - find `*.slnf` file when `$(OutputPath)` is under artifacts/bin/
- analyzer test projects publish needed files anyhow