### PR TITLE
nit: Remove reference to dotnet-install-scripts/ folder

### DIFF
--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -42,11 +42,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(RepoRoot)eng\common\dotnet-install-scripts\*">
-      <TargetPath>eng\common\dotnet-install-scripts\%(Filename)%(Extension)</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </ContentWithTargetPath>
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
- folder removed in a recent Arcade update