### PR TITLE
Remove Roslyn MyGet feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,9 +8,7 @@
     <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <!-- Used for the SiteExtension 3.1 bits that are included in the 5.0 build -->
     <add key="dotnet31-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
- neither of these should be needed anymore

(tried removing the main dotnet5 feed but Windows Desktop runtime is not yet in dotnet6)