### PR TITLE
Do not trigger CI builds for changes to doc files

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -14,6 +14,7 @@ trigger:
     exclude:
     - .github/*
     - .vscode/*
+    # Exclude only a few specific Markdown files because some of them ship.
     - docs/*
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
@@ -32,7 +33,7 @@ pr:
     exclude:
     - .github/*
     - .vscode/*
-    - docs/*
+    - '**/*.md'
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
     - LICENSE.TXT

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -7,10 +7,20 @@ trigger:
   batch: true
   branches:
     include:
-    - blazor-wasm
     - master
     - release/*
     - internal/release/*
+  paths:
+    exclude:
+    - .github/*
+    - .vscode/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - README.md
+    - SECURITY.md
+    # Do not ignore the THIRD-PARTY-NOTICES.TXT file because it ships.
 
 # Run PR validation on all branches
 pr:
@@ -18,6 +28,17 @@ pr:
   branches:
     include:
     - '*'
+  paths:
+    exclude:
+    - .github/*
+    - .vscode/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
 
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -1,9 +1,45 @@
-# We want to run quarantined tests on master as well as on PRs
+#
+# See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details on this file.
+#
+
+# Configure which branches trigger builds
+# We want to run quarantined tests on release/5.0 and master as well as on PRs
 trigger:
   batch: true
   branches:
     include:
     - master
+    - release/5.0
+  paths:
+    exclude:
+    - .github/*
+    - .vscode/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - README.md
+    - SECURITY.md
+    # Do not ignore the THIRD-PARTY-NOTICES.TXT file because it ships.
+
+# Run PR validation on branches that include Helix tests
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - release/5.0
+    - master
+  paths:
+    exclude:
+    - .github/*
+    - .vscode/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
 
 schedules:
 - cron: "0 */4 * * *"

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -14,6 +14,7 @@ trigger:
     exclude:
     - .github/*
     - .vscode/*
+    # Exclude only a few specific Markdown files because some of them ship.
     - docs/*
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
@@ -33,7 +34,7 @@ pr:
     exclude:
     - .github/*
     - .vscode/*
-    - docs/*
+    - '**/*.md'
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
     - LICENSE.TXT


### PR DESCRIPTION
- changes to these files cannot break the build!
- inspired by similar rules in the dotnet/runtime repo

also avoid starting the quarantined-pr pipeline for 2.1 and 3.1 PRs