### PR TITLE
Re-enable gRPC interop tests for macOS and Linux

### DIFF
--- a/src/Grpc/test/InteropTests/InteropTests.csproj
+++ b/src/Grpc/test/InteropTests/InteropTests.csproj
@@ -4,7 +4,6 @@
     <ContainsFunctionalTestAssets>true</ContainsFunctionalTestAssets>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
-    <IsWindowsOnlyTest>true</IsWindowsOnlyTest>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/27044.

Turns out there's an easy workaround for to get the interop tests working. We had to disable cross-gen when we updated to the new TFMs for 6.0 and this ensures the "windows" shared framework will work across other platforms. As such the tests should now run.