### PR TITLE
Always return an WebAssemblyJSObjectReference from DefaultWebAssembly…

### DIFF
--- a/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
+++ b/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
@@ -17,4 +17,8 @@
     <Compile Include="$(SharedSourceRoot)JSInterop\*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.WebAssembly" />
+  </ItemGroup>
+
 </Project>

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>

--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Globalization;
+using Microsoft.JSInterop;
+using Microsoft.JSInterop.Implementation;
 using Microsoft.JSInterop.Infrastructure;
 using Microsoft.JSInterop.WebAssembly;
 
@@ -17,6 +19,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Services
         {
             ElementReferenceContext = new WebElementReferenceContext(this);
             JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter(ElementReferenceContext));
+            JsonSerializerOptions.Converters.Insert(0, new JSObjectReferenceJsonConverter<IJSInProcessObjectReference, JSInProcessObjectReference>(
+                    id => new WebAssemblyJSObjectReference(this, id)));
         }
 
         #pragma warning disable IDE0051 // Remove unused private members. Invoked via Mono's JS interop mechanism (invoke_method)

--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -113,6 +113,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 ["instanceMethodOutgoingByRef"] = "1234",
                 ["jsInProcessObjectReference.identity"] = "Invoked from JSInProcessObjectReference",
                 ["jsUnmarshalledObjectReference.unmarshalledFunction"] = "True",
+                ["jsCastedUnmarshalledObjectReference.unmarshalledFunction"] = "False",
                 ["stringValueUpperSync"] = "MY STRING",
                 ["testDtoNonSerializedValueSync"] = "99999",
                 ["testDtoSync"] = "Same",

--- a/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
@@ -195,6 +195,14 @@
         var jsInProcObjectReference = inProcRuntime.Invoke<IJSInProcessObjectReference>("returnJSObjectReference");
         ReturnValues["jsInProcessObjectReference.identity"] = jsInProcObjectReference.Invoke<string>("identity", "Invoked from JSInProcessObjectReference");
 
+        // we should be able to downcast a IJSInProcessObjectReference as a IJSUnmarshalledObjectReference
+        var unmarshalledCast = (IJSUnmarshalledObjectReference)jsInProcObjectReference;
+        ReturnValues["jsCastedUnmarshalledObjectReference.unmarshalledFunction"] = unmarshalledCast.InvokeUnmarshalled<InteropStruct, bool>("unmarshalledFunction", new InteropStruct
+        {
+            Message = "Sent from .NET",
+            NumberField = 41,
+        }).ToString();
+
         var unmarshalledRuntime = (IJSUnmarshalledRuntime)JSRuntime;
         var jsUnmarshalledReference = unmarshalledRuntime.InvokeUnmarshalled<IJSUnmarshalledObjectReference>("returnJSObjectReference");
         ReturnValues["jsUnmarshalledObjectReference.unmarshalledFunction"] = jsUnmarshalledReference.InvokeUnmarshalled<InteropStruct, bool>("unmarshalledFunction", new InteropStruct

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSObjectReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSObjectReferenceJsonConverter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.JSInterop.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.WebAssembly" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…JSRuntime

Currently, the kind of IJSObjectReference returned from a WASM-based JSRuntime instance depends entirely on the callsite.
JSInprocessObjectReference.Invoke<IJSObjectReference> returns a different type compared to JSInprocessObjectReference.Invoke<IJSInProcessObjectReference>
which is different yet from JSInprocessObjectReference.Invoke<IJSUmarshalledObjectReference>.

This change consistently returns an instance of WebAssemblyJSObjectReference which satisfies all three interface contracts.

This change is intentionally made using IVTs which makes it more pliable for a 5.0. If this was 6.0 only change, there's a better way to fix this. 

Fixes https://github.com/dotnet/aspnetcore/issues/26588