### PR TITLE
Fix SignInResult with default scheme

### DIFF
--- a/src/Mvc/Mvc.Core/src/SignInResult.cs
+++ b/src/Mvc/Mvc.Core/src/SignInResult.cs
@@ -85,14 +85,6 @@ namespace Microsoft.AspNetCore.Mvc
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (AuthenticationScheme == null)
-            {
-                throw new InvalidOperationException(
-                    Resources.FormatPropertyOfTypeCannotBeNull(
-                        /* property: */ nameof(AuthenticationScheme),
-                        /* type: */ nameof(SignInResult)));
-            }
-
             var loggerFactory = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger<SignInResult>();
 

--- a/src/Mvc/Mvc.Core/test/SignInResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/SignInResultTest.cs
@@ -46,6 +46,33 @@ namespace Microsoft.AspNetCore.Mvc
         }
 
         [Fact]
+        public async Task ExecuteResultAsync_InvokesSignInAsyncOnAuthenticationManagerWithDefaultScheme()
+        {
+            // Arrange
+            var principal = new ClaimsPrincipal();
+            var httpContext = new Mock<HttpContext>();
+            var auth = new Mock<IAuthenticationService>();
+            auth
+                .Setup(c => c.SignInAsync(httpContext.Object, null, principal, null))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+            httpContext.Setup(c => c.RequestServices).Returns(CreateServices(auth.Object));
+            var result = new SignInResult(principal);
+            var routeData = new RouteData();
+
+            var actionContext = new ActionContext(
+                httpContext.Object,
+                routeData,
+                new ActionDescriptor());
+
+            // Act
+            await result.ExecuteResultAsync(actionContext);
+
+            // Assert
+            auth.Verify();
+        }
+
+        [Fact]
         public async Task ExecuteResultAsync_InvokesSignInAsyncOnConfiguredScheme()
         {
             // Arrange


### PR DESCRIPTION
#### Description

Fixes https://github.com/dotnet/aspnetcore/issues/27494

A community PR introduced new overloads to ControllerBase for SignIn.  The new overload throws due to an existing check which blocks when the scheme is null.  The fix is to remove this unnecessary check.  Note SignOutResult already had test coverage for this usage and is unaffected

#### Customer Impact

The bug was reported by a customer trying to use the new overload.  The fix enables the method to be used.

#### Regression?

No

#### Risk

Low as this is a new API, and the api was unuseable in its current form. 