### PR TITLE
Fixed a typo:  an errors => errors

### DIFF
--- a/src/Identity/Extensions.Core/src/IdentityResult.cs
+++ b/src/Identity/Extensions.Core/src/IdentityResult.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Identity
         public bool Succeeded { get; protected set; }
 
         /// <summary>
-        /// An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/>s containing an errors
+        /// An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/>s containing errors
         /// that occurred during the identity operation.
         /// </summary>
         /// <value>An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/>s.</value>

--- a/src/Identity/Extensions.Core/src/IdentityResult.cs
+++ b/src/Identity/Extensions.Core/src/IdentityResult.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Identity
         public bool Succeeded { get; protected set; }
 
         /// <summary>
-        /// An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/>s containing errors
+        /// An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/> instances containing errors
         /// that occurred during the identity operation.
         /// </summary>
         /// <value>An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/>s.</value>

--- a/src/Identity/Extensions.Core/src/IdentityResult.cs
+++ b/src/Identity/Extensions.Core/src/IdentityResult.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Identity
         /// An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/> instances containing errors
         /// that occurred during the identity operation.
         /// </summary>
-        /// <value>An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/>s.</value>
+        /// <value>An <see cref="IEnumerable{T}"/> of <see cref="IdentityError"/> instances.</value>
         public IEnumerable<IdentityError> Errors => _errors;
 
         /// <summary>


### PR DESCRIPTION
containing an errors => containing errors.

In addition, I'm not sure about the "s" in after the IEnumerable "IdentityError" and whether is it correct by Microsoft's standards:

"IdentityError" **s**.

Summary of the changes (Less than 80 chars)
 - Changed the typo: "an errors" to "errors".

Addresses #bugnumber (in this specific format)
