### PR TITLE
[release/5.0] Add release/5.0 pipeline runs

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -2,11 +2,17 @@
 pr: none
 trigger: none
 schedules:
+# Cron timezone is UTC.
 - cron: "0 */12 * * *"
   branches:
     include:
     - master
   always: true
+- cron: "0 9 * * *"
+  branches:
+    include:
+    - release/5.0
+  always: false
 
 variables:
 - ${{ if ne(variables['System.TeamProject'], 'internal') }}:

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -4,6 +4,14 @@ trigger:
   branches:
     include:
     - master
+    - release/5.0
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+    - release/5.0
 
 schedules:
 - cron: "0 */4 * * *"


### PR DESCRIPTION
- run aspnetcore-helix-matrix at 09:00 UTC
  - the first run of master starts at noon UTC
  - looks highly unlikely new run would take 3 hours
- add rolling builds of aspnetcore-quarantined-pr

nit: make target branches for PR builds explicit
- we don't support Helix testing of 3.1 or older