### PR TITLE
Fix Json breaking change when updating Json reference manually

### DIFF
--- a/src/SignalR/SignalR.sln
+++ b/src/SignalR/SignalR.sln
@@ -147,6 +147,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Signal
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Metadata", "..\Http\Metadata\src\Microsoft.AspNetCore.Metadata.csproj", "{2E107FBB-2387-4A9F-A2CA-EFDF2E4DD64D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SignalR.Json50.Tests", "common\SignalR.Common\test-json\Microsoft.AspNetCore.SignalR.Json50.Tests.csproj", "{BFE22265-03E2-4967-B1C8-93216324D42D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -405,6 +407,10 @@ Global
 		{2E107FBB-2387-4A9F-A2CA-EFDF2E4DD64D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E107FBB-2387-4A9F-A2CA-EFDF2E4DD64D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E107FBB-2387-4A9F-A2CA-EFDF2E4DD64D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BFE22265-03E2-4967-B1C8-93216324D42D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BFE22265-03E2-4967-B1C8-93216324D42D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BFE22265-03E2-4967-B1C8-93216324D42D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BFE22265-03E2-4967-B1C8-93216324D42D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -475,6 +481,7 @@ Global
 		{FD3A8F8D-2967-4635-86FC-CC49BAF651C1} = {EDE8E45E-A5D0-4F0E-B72C-7CC14146C60A}
 		{BB52C0FB-19FD-485A-9EBD-3FC173ECAEA0} = {9FCD621E-E710-4991-B45C-1BABC977BEEC}
 		{2E107FBB-2387-4A9F-A2CA-EFDF2E4DD64D} = {EDE8E45E-A5D0-4F0E-B72C-7CC14146C60A}
+		{BFE22265-03E2-4967-B1C8-93216324D42D} = {9FCD621E-E710-4991-B45C-1BABC977BEEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7945A4E4-ACDB-4F6E-95CA-6AC6E7C2CD59}

--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -508,7 +508,14 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             else if (message.HasResult)
             {
                 writer.WritePropertyName(ResultPropertyNameBytes);
-                JsonSerializer.Serialize(writer, message.Result, message.Result?.GetType(), _payloadSerializerOptions);
+                if (message.Result == null)
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    JsonSerializer.Serialize(writer, message.Result, message.Result.GetType(), _payloadSerializerOptions);
+                }
             }
         }
 
@@ -522,7 +529,14 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
             WriteInvocationId(message, writer);
 
             writer.WritePropertyName(ItemPropertyNameBytes);
-            JsonSerializer.Serialize(writer, message.Item, message.Item?.GetType(), _payloadSerializerOptions);
+            if (message.Item == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                JsonSerializer.Serialize(writer, message.Item, message.Item.GetType(), _payloadSerializerOptions);
+            }
         }
 
         private void WriteInvocationMessage(InvocationMessage message, Utf8JsonWriter writer)
@@ -574,7 +588,14 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
                 }
                 else
                 {
-                    JsonSerializer.Serialize(writer, argument, type, _payloadSerializerOptions);
+                    if (argument == null)
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else
+                    {
+                        JsonSerializer.Serialize(writer, argument, type, _payloadSerializerOptions);
+                    }
                 }
             }
             writer.WriteEndArray();

--- a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.csproj
+++ b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.csproj
@@ -9,6 +9,7 @@
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="System.Text.Json" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Common.Tests" Key="" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Json50.Tests" Key="" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Tests.Utils" Key="" />
   </ItemGroup>
 <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">
@@ -16,6 +17,7 @@
     <Reference Include="Microsoft.AspNetCore.Connections.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Common.Tests" Key="" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Json50.Tests" Key="" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Tests.Utils" Key="" />
   </ItemGroup>
 </Project>

--- a/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
+++ b/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Common.Tests" />
-    <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Json.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Json50.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Tests.Utils" />
   </ItemGroup>
 

--- a/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
+++ b/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Common serialiation primitives for SignalR Clients Servers</Description>
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Common.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Json.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Tests.Utils" />
   </ItemGroup>
 

--- a/src/SignalR/common/SignalR.Common/test-json/Microsoft.AspNetCore.SignalR.Json50.Tests.csproj
+++ b/src/SignalR/common/SignalR.Common/test-json/Microsoft.AspNetCore.SignalR.Json50.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <!-- Avoid CS1705 errors due to mix of assemblies brought in transitively. -->
+    <CompileUsingReferenceAssemblies>false</CompileUsingReferenceAssemblies>
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SignalRSharedSourceRoot)BinaryMessageFormatter.cs" Link="BinaryMessageFormatter.cs" />
+    <Compile Include="$(SignalRSharedSourceRoot)BinaryMessageParser.cs" Link="BinaryMessageParser.cs" />
+    <Compile Include="$(SharedSourceRoot)Buffers.Testing\**\*.cs" />
+    <Compile Include="..\test\Internal\Protocol\JsonHubProtocolTestsBase.cs" />
+    <Compile Include="..\test\Internal\Protocol\JsonHubProtocolTests.cs" />
+    <Compile Include="..\test\Internal\Protocol\HubMessageHelpers.cs" />
+    <Compile Include="..\test\Internal\Protocol\TestBinder.cs" />
+    <Compile Include="..\test\Internal\Protocol\TestHubMessageEqualityComparer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SignalRTestUtilsProject)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.SignalR.Common" />
+    <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/27519

#### Description

System.Text.Json made a breaking change on purpose in 5.0 and because it can be consumed as a package reference, users who use 3.1.x SignalR with 5.0+ System.Text.Json can hit issues with the breaking change.

#### Customer Impact

Reported in https://github.com/dotnet/aspnetcore/issues/27519.

The only workarounds include not updating System.Text.Json, and not sending null values with SignalR.
Neither is particularly good or easy to do, 3rd parties can bring in newer Json references etc.

#### Regression?

Sort of.

#### Risk

Low, simple fix, change already done in 5.0 for a few months