### PR TITLE
Fix xml comments

### DIFF
--- a/src/Identity/Extensions.Core/src/RoleValidator.cs
+++ b/src/Identity/Extensions.Core/src/RoleValidator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Identity
     public class RoleValidator<TRole> : IRoleValidator<TRole> where TRole : class
     {
         /// <summary>
-        /// Creates a new instance of <see cref="RoleValidator{TRole}"/>/
+        /// Creates a new instance of <see cref="RoleValidator{TRole}"/>.
         /// </summary>
         /// <param name="errors">The <see cref="IdentityErrorDescriber"/> used to provider error messages.</param>
         public RoleValidator(IdentityErrorDescriber errors = null)

--- a/src/Identity/Extensions.Core/src/UserValidator.cs
+++ b/src/Identity/Extensions.Core/src/UserValidator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Identity
     public class UserValidator<TUser> : IUserValidator<TUser> where TUser : class
     {
         /// <summary>
-        /// Creates a new instance of <see cref="UserValidator{TUser}"/>/
+        /// Creates a new instance of <see cref="UserValidator{TUser}"/>.
         /// </summary>
         /// <param name="errors">The <see cref="IdentityErrorDescriber"/> used to provider error messages.</param>
         public UserValidator(IdentityErrorDescriber errors = null)


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - In ```UserValidator``` and ```RoleValidator```, the constructor XML comment ends with ```/```, it should be ```.```.
