### PR TITLE
Add HttpClient Backchannel property to JwtBearerOptions

### DIFF
--- a/src/Security/Authentication/JwtBearer/src/JwtBearerOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerOptions.cs
@@ -75,6 +75,11 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         public HttpMessageHandler BackchannelHttpHandler { get; set; }
 
         /// <summary>
+        /// The Backchannel used to retrieve metadata.
+        /// </summary>
+        public HttpClient Backchannel { get; set; } = default!;
+
+        /// <summary>
         /// Gets or sets the timeout when using the backchannel to make an http call.
         /// </summary>
         public TimeSpan BackchannelTimeout { get; set; } = TimeSpan.FromMinutes(1);

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerPostConfigureOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerPostConfigureOptions.cs
@@ -50,12 +50,16 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                         throw new InvalidOperationException("The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false.");
                     }
 
-                    var httpClient = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
-                    httpClient.Timeout = options.BackchannelTimeout;
-                    httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+                    if (options.Backchannel == null)
+                    {
+                        options.Backchannel = new HttpClient(options.BackchannelHttpHandler ?? new HttpClientHandler());
+                        options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core JwtBearer handler");
+                        options.Backchannel.Timeout = options.BackchannelTimeout;
+                        options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
+                    }
 
                     options.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(options.MetadataAddress, new OpenIdConnectConfigurationRetriever(),
-                        new HttpDocumentRetriever(httpClient) { RequireHttps = options.RequireHttpsMetadata })
+                        new HttpDocumentRetriever(options.Backchannel) { RequireHttps = options.RequireHttpsMetadata })
                     {
                         RefreshInterval = options.RefreshInterval,
                         AutomaticRefreshInterval = options.AutomaticRefreshInterval,

--- a/src/Security/Authentication/JwtBearer/src/PublicAPI.Unshipped.txt
+++ b/src/Security/Authentication/JwtBearer/src/PublicAPI.Unshipped.txt
@@ -63,6 +63,8 @@ Microsoft.Extensions.DependencyInjection.JwtBearerExtensions
 ~Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.Authority.set -> void
 ~Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.BackchannelHttpHandler.get -> System.Net.Http.HttpMessageHandler
 ~Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.BackchannelHttpHandler.set -> void
+~Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.Backchannel.get -> System.Net.Http.HttpClient
+~Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.Backchannel.set -> void
 ~Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.Challenge.get -> string
 ~Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.Challenge.set -> void
 ~Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.Configuration.get -> Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration


### PR DESCRIPTION
Changes :
 - `HttpClient Backchannel` property is added to `JwtBearerOptions`

Addresses #27426
