### PR TITLE
Consistently produce an instance of WebAssemblyJSObjectReference from WebAssemblyJSRuntime

### DIFF
--- a/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
+++ b/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)JSInterop\JSCallResultTypeHelper.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)JSInterop\JSObjectReferenceJsonWorker.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
+++ b/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
@@ -14,7 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(SharedSourceRoot)JSInterop\*.cs" />
+    <Compile Include="$(SharedSourceRoot)JSInterop\JSCallResultTypeHelper.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)JSInterop\JSObjectReferenceJsonWorker.cs" LinkBase="Shared" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.WebAssembly.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/WebAssembly/JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/JSInterop/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 override Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.BeginInvokeJS(long asyncHandle, string! identifier, string? argsJson, Microsoft.JSInterop.JSCallResultType resultType, long targetInstanceId) -> void
 Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.InvokeUnmarshalled<T0, T1, T2, TResult>(string! identifier, T0 arg0, T1 arg1, T2 arg2) -> TResult
 Microsoft.JSInterop.WebAssembly.WebAssemblyJSRuntime.InvokeUnmarshalled<T0, T1, TResult>(string! identifier, T0 arg0, T1 arg1) -> TResult

--- a/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSObjectReference.cs
+++ b/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSObjectReference.cs
@@ -15,8 +15,6 @@ namespace Microsoft.JSInterop.WebAssembly
             _jsRuntime = jsRuntime;
         }
 
-        internal new long Id => base.Id;
-
         public TResult InvokeUnmarshalled<TResult>(string identifier)
         {
             ThrowIfDisposed();

--- a/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSObjectReference.cs
+++ b/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSObjectReference.cs
@@ -9,10 +9,13 @@ namespace Microsoft.JSInterop.WebAssembly
     {
         private readonly WebAssemblyJSRuntime _jsRuntime;
 
-        public WebAssemblyJSObjectReference(WebAssemblyJSRuntime jsRuntime, long id) : base(jsRuntime, id)
+        public WebAssemblyJSObjectReference(WebAssemblyJSRuntime jsRuntime, long id)
+            : base(jsRuntime, id)
         {
             _jsRuntime = jsRuntime;
         }
+
+        internal new long Id => base.Id;
 
         public TResult InvokeUnmarshalled<TResult>(string identifier)
         {

--- a/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSObjectReferenceJsonConverter.cs
+++ b/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSObjectReferenceJsonConverter.cs
@@ -22,19 +22,18 @@ namespace Microsoft.JSInterop.WebAssembly
             return typeToConvert == typeof(WebAssemblyJSObjectReference) ||
                 typeToConvert == typeof(IJSObjectReference) ||
                 typeToConvert == typeof(IJSInProcessObjectReference) ||
-                typeToConvert == typeof(IJSUnmarshalledObjectReference) ||
-                typeToConvert == typeof(JSObjectReference);
+                typeToConvert == typeof(IJSUnmarshalledObjectReference);
         }
 
         public override IJSObjectReference? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var id = JSObjectReferenceJsonWorker.ReadIdentifier(ref reader);
+            var id = JSObjectReferenceJsonWorker.ReadJSObjectReferenceIdentifier(ref reader);
             return new WebAssemblyJSObjectReference(_jsRuntime, id);
         }
 
         public override void Write(Utf8JsonWriter writer, IJSObjectReference value, JsonSerializerOptions options)
         {
-            JSObjectReferenceJsonWorker.Write(writer, ((WebAssemblyJSObjectReference)value).Id);
+            JSObjectReferenceJsonWorker.WriteJSObjectReference(writer, (JSObjectReference)value);
         }
     }
 }

--- a/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSObjectReferenceJsonConverter.cs
+++ b/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSObjectReferenceJsonConverter.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.JSInterop.Implementation;
+
+namespace Microsoft.JSInterop.WebAssembly
+{
+    internal sealed class WebAssemblyJSObjectReferenceJsonConverter : JsonConverter<IJSObjectReference>
+    {
+        private readonly WebAssemblyJSRuntime _jsRuntime;
+
+        public WebAssemblyJSObjectReferenceJsonConverter(WebAssemblyJSRuntime jsRuntime)
+        {
+            _jsRuntime = jsRuntime;
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(WebAssemblyJSObjectReference) ||
+                typeToConvert == typeof(IJSObjectReference) ||
+                typeToConvert == typeof(IJSInProcessObjectReference) ||
+                typeToConvert == typeof(IJSUnmarshalledObjectReference) ||
+                typeToConvert == typeof(JSObjectReference);
+        }
+
+        public override IJSObjectReference? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var id = JSObjectReferenceJsonWorker.ReadIdentifier(ref reader);
+            return new WebAssemblyJSObjectReference(_jsRuntime, id);
+        }
+
+        public override void Write(Utf8JsonWriter writer, IJSObjectReference value, JsonSerializerOptions options)
+        {
+            JSObjectReferenceJsonWorker.Write(writer, ((WebAssemblyJSObjectReference)value).Id);
+        }
+    }
+}

--- a/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/JSInterop/src/WebAssemblyJSRuntime.cs
@@ -14,6 +14,14 @@ namespace Microsoft.JSInterop.WebAssembly
     /// </summary>
     public abstract class WebAssemblyJSRuntime : JSInProcessRuntime, IJSUnmarshalledRuntime
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="WebAssemblyJSRuntime"/>.
+        /// </summary>
+        protected WebAssemblyJSRuntime()
+        {
+            JsonSerializerOptions.Converters.Insert(0, new WebAssemblyJSObjectReferenceJsonConverter(this));
+        }
+
         /// <inheritdoc />
         protected override string InvokeJS(string identifier, string? argsJson, JSCallResultType resultType, long targetInstanceId)
         {

--- a/src/Components/WebAssembly/WebAssembly/test/JSObjectReferenceJsonConverterTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/JSObjectReferenceJsonConverterTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using Microsoft.JSInterop;
+using Microsoft.JSInterop.Implementation;
+using Microsoft.JSInterop.WebAssembly;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.WebAssembly.Services
+{
+    public class JSObjectReferenceJsonConverterTest
+    {
+        private readonly JsonSerializerOptions JsonSerializerOptions;
+
+        public JSObjectReferenceJsonConverterTest()
+        {
+            JsonSerializerOptions = DefaultWebAssemblyJSRuntime.Instance.JsonSerializerOptions;
+        }
+
+        [Fact]
+        public void Read_ReadsJson_IJSInProcessObjectReference()
+        {
+            // Arrange
+            var expectedId = 3;
+            var json = $"{{\"__jsObjectId\":{expectedId}}}";
+
+            // Act
+            var deserialized = (JSInProcessObjectReference)JsonSerializer.Deserialize<IJSInProcessObjectReference>(json, JsonSerializerOptions)!;
+
+            // Assert
+            Assert.Equal(expectedId, deserialized?.Id);
+        }
+
+        [Fact]
+        public void Read_ReadsJson_IJSUnmarshalledObjectReference()
+        {
+            // Arrange
+            var expectedId = 3;
+            var json = $"{{\"__jsObjectId\":{expectedId}}}";
+
+            // Act
+            var deserialized = (WebAssemblyJSObjectReference)JsonSerializer.Deserialize<IJSUnmarshalledObjectReference>(json, JsonSerializerOptions)!;
+
+            // Assert
+            Assert.Equal(expectedId, deserialized?.Id);
+        }
+    }
+}

--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -112,6 +112,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 ["instanceMethodOutgoingByRef"] = "1234",
                 ["jsInProcessObjectReference.identity"] = "Invoked from JSInProcessObjectReference",
                 ["jsUnmarshalledObjectReference.unmarshalledFunction"] = "True",
+                ["jsCastedUnmarshalledObjectReference.unmarshalledFunction"] = "False",
                 ["stringValueUpperSync"] = "MY STRING",
                 ["testDtoNonSerializedValueSync"] = "99999",
                 ["testDtoSync"] = "Same",

--- a/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
@@ -195,6 +195,15 @@
         var jsInProcObjectReference = inProcRuntime.Invoke<IJSInProcessObjectReference>("returnJSObjectReference");
         ReturnValues["jsInProcessObjectReference.identity"] = jsInProcObjectReference.Invoke<string>("identity", "Invoked from JSInProcessObjectReference");
 
+        // we should be able to downcast a IJSInProcessObjectReference as a IJSUnmarshalledObjectReference
+        var unmarshalledCast = (IJSUnmarshalledObjectReference)jsInProcObjectReference;
+        ReturnValues["jsCastedUnmarshalledObjectReference.unmarshalledFunction"] = unmarshalledCast.InvokeUnmarshalled<InteropStruct, bool>("unmarshalledFunction", new InteropStruct
+        {
+            Message = "Sent from .NET",
+            NumberField = 41,
+        }).ToString();
+
+
         var unmarshalledRuntime = (IJSUnmarshalledRuntime)JSRuntime;
         var jsUnmarshalledReference = unmarshalledRuntime.InvokeUnmarshalled<IJSUnmarshalledObjectReference>("returnJSObjectReference");
         ReturnValues["jsUnmarshalledObjectReference.unmarshalledFunction"] = jsUnmarshalledReference.InvokeUnmarshalled<InteropStruct, bool>("unmarshalledFunction", new InteropStruct

--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSInProcessObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSInProcessObjectReference.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.JSInterop.Implementation
 {
     /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSObjectReferenceJsonWorker.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSObjectReferenceJsonWorker.cs
@@ -3,16 +3,24 @@
 
 using System.Text.Json;
 
-namespace Microsoft.JSInterop
+namespace Microsoft.JSInterop.Implementation
 {
     /// <summary>
     /// Used by JsonConverters to read or write a IJSObjectReference instance.
+    /// <para>
+    /// This type is part of ASP.NET Core's internal infrastructure and is not recommended for use by external code.
+    /// </para>
     /// </summary>
-    internal static class JSObjectReferenceJsonWorker
+    public static class JSObjectReferenceJsonWorker
     {
         private static readonly JsonEncodedText _idKey = JsonEncodedText.Encode("__jsObjectId");
 
-        public static long ReadIdentifier(ref Utf8JsonReader reader)
+        /// <summary>
+        /// Reads the id for a <see cref="JSObjectReference"/> instance.
+        /// </summary>
+        /// <param name="reader">The <see cref="Utf8JsonReader"/></param>
+        /// <returns></returns>
+        public static long ReadJSObjectReferenceIdentifier(ref Utf8JsonReader reader)
         {
             long id = -1;
 
@@ -44,10 +52,15 @@ namespace Microsoft.JSInterop
             return id;
         }
 
-        public static void Write(Utf8JsonWriter writer, long identifier)
+        /// <summary>
+        /// Writes a <see cref="JSObjectReference"/> to the <paramref name="objectReference"/>.
+        /// </summary>
+        /// <param name="writer">The <see cref="Utf8JsonWriter"/>.</param>
+        /// <param name="objectReference">The <see cref="JSObjectReference"/> to write.</param>
+        public static void WriteJSObjectReference(Utf8JsonWriter writer, JSObjectReference objectReference)
         {
             writer.WriteStartObject();
-            writer.WriteNumber(_idKey, identifier);
+            writer.WriteNumber(_idKey, objectReference.Id);
             writer.WriteEndObject();
         }
     }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSObjectReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSObjectReferenceJsonConverter.cs
@@ -8,59 +8,27 @@ using Microsoft.JSInterop.Implementation;
 
 namespace Microsoft.JSInterop.Infrastructure
 {
-    internal sealed class JSObjectReferenceJsonConverter<TInterface, TImplementation> : JsonConverter<TInterface>
-        where TInterface : class, IJSObjectReference
-        where TImplementation : JSObjectReference, TInterface
+    internal sealed class JSObjectReferenceJsonConverter : JsonConverter<IJSObjectReference>
     {
-        private static readonly JsonEncodedText _idKey = JsonEncodedText.Encode("__jsObjectId");
+        private readonly JSRuntime _jsRuntime;
 
-        private readonly Func<long, TImplementation> _jsObjectReferenceFactory;
-
-        public JSObjectReferenceJsonConverter(Func<long, TImplementation> jsObjectReferenceFactory)
+        public JSObjectReferenceJsonConverter(JSRuntime jsRuntime)
         {
-            _jsObjectReferenceFactory = jsObjectReferenceFactory;
+            _jsRuntime = jsRuntime;
         }
 
         public override bool CanConvert(Type typeToConvert)
-            => typeToConvert == typeof(TInterface) || typeToConvert == typeof(TImplementation);
+            => typeToConvert == typeof(IJSObjectReference) || typeToConvert == typeof(JSObjectReference);
 
-        public override TInterface? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override IJSObjectReference? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            long id = -1;
-
-            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
-            {
-                if (reader.TokenType == JsonTokenType.PropertyName)
-                {
-                    if (id == -1 && reader.ValueTextEquals(_idKey.EncodedUtf8Bytes))
-                    {
-                        reader.Read();
-                        id = reader.GetInt64();
-                    }
-                    else
-                    {
-                        throw new JsonException($"Unexcepted JSON property {reader.GetString()}.");
-                    }
-                }
-                else
-                {
-                    throw new JsonException($"Unexcepted JSON token {reader.TokenType}");
-                }
-            }
-
-            if (id == -1)
-            {
-                throw new JsonException($"Required property {_idKey} not found.");
-            }
-
-            return _jsObjectReferenceFactory(id);
+            var id = JSObjectReferenceJsonWorker.ReadIdentifier(ref reader);
+            return new JSObjectReference(_jsRuntime, id);
         }
 
-        public override void Write(Utf8JsonWriter writer, TInterface value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, IJSObjectReference value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            writer.WriteNumber(_idKey, ((TImplementation)value).Id);
-            writer.WriteEndObject();
+            JSObjectReferenceJsonWorker.Write(writer, ((JSObjectReference)value).Id);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSObjectReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSObjectReferenceJsonConverter.cs
@@ -22,13 +22,13 @@ namespace Microsoft.JSInterop.Infrastructure
 
         public override IJSObjectReference? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var id = JSObjectReferenceJsonWorker.ReadIdentifier(ref reader);
+            var id = JSObjectReferenceJsonWorker.ReadJSObjectReferenceIdentifier(ref reader);
             return new JSObjectReference(_jsRuntime, id);
         }
 
         public override void Write(Utf8JsonWriter writer, IJSObjectReference value, JsonSerializerOptions options)
         {
-            JSObjectReferenceJsonWorker.Write(writer, ((JSObjectReference)value).Id);
+            JSObjectReferenceJsonWorker.WriteJSObjectReference(writer, (JSObjectReference)value);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/JSInProcessRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSInProcessRuntime.cs
@@ -1,10 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using Microsoft.JSInterop.Implementation;
-using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop
 {
@@ -13,16 +10,6 @@ namespace Microsoft.JSInterop
     /// </summary>
     public abstract class JSInProcessRuntime : JSRuntime, IJSInProcessRuntime
     {
-        /// <summary>
-        /// Initializes a new instance of <see cref="JSInProcessRuntime"/>.
-        /// </summary>
-        protected JSInProcessRuntime()
-        {
-            JsonSerializerOptions.Converters.Add(
-                new JSObjectReferenceJsonConverter<IJSInProcessObjectReference, JSInProcessObjectReference>(
-                    id => new JSInProcessObjectReference(this, id)));
-        }
-
         internal TValue Invoke<TValue>(string identifier, long targetInstanceId, params object?[]? args)
         {
             var resultJson = InvokeJS(

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.JSInterop.Implementation;
 using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop
@@ -38,8 +37,7 @@ namespace Microsoft.JSInterop
                 Converters =
                 {
                     new DotNetObjectReferenceJsonConverterFactory(this),
-                    new JSObjectReferenceJsonConverter<IJSObjectReference, JSObjectReference>(
-                        id => new JSObjectReference(this, id)),
+                    new JSObjectReferenceJsonConverter(this),
                 }
             };
         }

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)JSInterop\JSCallResultTypeHelper.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)JSInterop\JSObjectReferenceJsonWorker.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
@@ -14,11 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(SharedSourceRoot)JSInterop\*.cs" />
+    <Compile Include="$(SharedSourceRoot)JSInterop\JSCallResultTypeHelper.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)JSInterop\JSObjectReferenceJsonWorker.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.JSInterop.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Components.WebAssembly.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Microsoft.JSInterop.Implementation.JSObjectReferenceJsonWorker
+static Microsoft.JSInterop.Implementation.JSObjectReferenceJsonWorker.ReadJSObjectReferenceIdentifier(ref System.Text.Json.Utf8JsonReader reader) -> long
+static Microsoft.JSInterop.Implementation.JSObjectReferenceJsonWorker.WriteJSObjectReference(System.Text.Json.Utf8JsonWriter! writer, Microsoft.JSInterop.Implementation.JSObjectReference! objectReference) -> void

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/JSObjectReferenceJsonConverterTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/JSObjectReferenceJsonConverterTest.cs
@@ -16,10 +16,7 @@ namespace Microsoft.JSInterop.Infrastructure
         public JSObjectReferenceJsonConverterTest()
         {
             JsonSerializerOptions = JSRuntime.JsonSerializerOptions;
-            JsonSerializerOptions.Converters.Add(new JSObjectReferenceJsonConverter<IJSInProcessObjectReference, JSInProcessObjectReference>(
-                id => new JSInProcessObjectReference(default!, id)));
-            JsonSerializerOptions.Converters.Add(new JSObjectReferenceJsonConverter<IJSUnmarshalledObjectReference, TestJSUnmarshalledObjectReference>(
-                id => new TestJSUnmarshalledObjectReference(id)));
+            JsonSerializerOptions.Converters.Add(new JSObjectReferenceJsonConverter(JSRuntime));
         }
 
         [Fact]
@@ -75,34 +72,6 @@ namespace Microsoft.JSInterop.Infrastructure
 
             // Act
             var deserialized = (JSObjectReference)JsonSerializer.Deserialize<IJSObjectReference>(json, JsonSerializerOptions)!;
-
-            // Assert
-            Assert.Equal(expectedId, deserialized?.Id);
-        }
-
-        [Fact]
-        public void Read_ReadsJson_IJSInProcessObjectReference()
-        {
-            // Arrange
-            var expectedId = 3;
-            var json = $"{{\"__jsObjectId\":{expectedId}}}";
-
-            // Act
-            var deserialized = (JSInProcessObjectReference)JsonSerializer.Deserialize<IJSInProcessObjectReference>(json, JsonSerializerOptions)!;
-
-            // Assert
-            Assert.Equal(expectedId, deserialized?.Id);
-        }
-
-        [Fact]
-        public void Read_ReadsJson_IJSUnmarshalledObjectReference()
-        {
-            // Arrange
-            var expectedId = 3;
-            var json = $"{{\"__jsObjectId\":{expectedId}}}";
-
-            // Act
-            var deserialized = (TestJSUnmarshalledObjectReference)JsonSerializer.Deserialize<IJSUnmarshalledObjectReference>(json, JsonSerializerOptions)!;
 
             // Assert
             Assert.Equal(expectedId, deserialized?.Id);

--- a/src/Shared/JSInterop/JSObjectReferenceJsonWorker.cs
+++ b/src/Shared/JSInterop/JSObjectReferenceJsonWorker.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json;
+
+namespace Microsoft.JSInterop
+{
+    /// <summary>
+    /// Used by JsonConverters to read or write a IJSObjectReference instance.
+    /// </summary>
+    internal static class JSObjectReferenceJsonWorker
+    {
+        private static readonly JsonEncodedText _idKey = JsonEncodedText.Encode("__jsObjectId");
+
+        public static long ReadIdentifier(ref Utf8JsonReader reader)
+        {
+            long id = -1;
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (id == -1 && reader.ValueTextEquals(_idKey.EncodedUtf8Bytes))
+                    {
+                        reader.Read();
+                        id = reader.GetInt64();
+                    }
+                    else
+                    {
+                        throw new JsonException($"Unexcepted JSON property {reader.GetString()}.");
+                    }
+                }
+                else
+                {
+                    throw new JsonException($"Unexcepted JSON token {reader.TokenType}");
+                }
+            }
+
+            if (id == -1)
+            {
+                throw new JsonException($"Required property {_idKey} not found.");
+            }
+
+            return id;
+        }
+
+        public static void Write(Utf8JsonWriter writer, long identifier)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber(_idKey, identifier);
+            writer.WriteEndObject();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/26588

---- API review:


```C#
namespace Microsoft.JSInterop.Implementation
{
  public static class JSObjectReferenceJsonWorker
  {
     static long ReadJSObjectReferenceIdentifier(ref System.Text.Json.Utf8JsonReader reader);
     static void WriteJSObjectReference(Utf8JsonWriter writer, JSObjectReference! objectReference);
  }
}
```
