### PR TITLE
[release/5.0] Target 5.0.0 shared framework in global tools

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -52,11 +52,6 @@
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == '' AND '$(IsAnalyzersProject)' == 'true'">true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(PackAsTool)' == 'true' AND '$(IsShippingPackage)' == 'true'">
-    <!-- This is a requirement for Microsoft tool packages only. -->
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.csproj' ">
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
     <IsPackable
@@ -106,7 +101,7 @@
     <IsImplementationProject Condition=" '$(IsImplementationProject)' == '' AND '$(IsAnalyzersProject)' != 'true' AND '$(IsTestAssetProject)' != 'true' AND '$(IsTestProject)' != 'true' AND '$(IsBenchmarkProject)' != 'true' AND '$(IsSampleProject)' != 'true' ">true</IsImplementationProject>
 
     <!-- This determines whether a project is available as a <Reference> to other projects in this repo. -->
-    <IsProjectReferenceProvider Condition=" '$(IsProjectReferenceProvider)' == '' AND '$(IsImplementationProject)' == 'true' AND '$(PackAsTool)' != 'true' ">true</IsProjectReferenceProvider>
+    <IsProjectReferenceProvider Condition=" '$(IsProjectReferenceProvider)' == '' AND '$(IsImplementationProject)' == 'true' ">true</IsProjectReferenceProvider>
 
     <HasReferenceAssembly
         Condition=" '$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND '$(IsAspNetCoreApp)' == 'true' ">true</HasReferenceAssembly>

--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -9,10 +9,9 @@
     <!-- Reference base shared framework at incoming dependency flow version, not bundled sdk version. -->
     <FrameworkReference
       Update="Microsoft.NETCore.App"
-      Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'"
+      Condition=" '$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND '$(TargetLatestDotNetRuntime)' != 'false' "
       RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)"
-      TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-      />
+      TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)" />
   </ItemGroup>
 
   <!--

--- a/src/Tools/Directory.Build.targets
+++ b/src/Tools/Directory.Build.targets
@@ -1,9 +1,19 @@
 <Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
-
-  <PropertyGroup>
-    <UseLatestPackageReferences Condition=" '$(PackAsTool)' == 'true' ">true</UseLatestPackageReferences>
+  <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
+    <!-- Microsoft tool packages are required to target both x64 and x86. -->
+    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' ">win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <!-- None of the tool projects are project reference providers. -->
+    <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
+    <!--
+      Target the default version of .NET Core in tool projects to maximize the compatible environments. Must be set
+      before importing root Directory.Build.targets.
+    -->
+    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' ">false</TargetLatestDotNetRuntime>
+    <!-- Tool projects publish before packing. Packages should contain the latest bits. -->
+    <UseLatestPackageReferences>true</UseLatestPackageReferences>
   </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
 
   <Target Name="CleanPublishDir" AfterTargets="CoreClean">
     <RemoveDir Directories="$(PublishDir)" />


### PR DESCRIPTION
- #19108
- ensure the packaged runtimeconfig.json file uses the 5.0.0 shared framework
  - disable `$(TargetLatestDotNetRuntime)` in tool projects
  - skip `@(FrameworkReference)` item update if `$(TargetLatestDotNetRuntime)` is disabled

nit: Move `$(PackAsTool)` settings together


----

### Description

In 3.1.x servicing, the global tools shipped from the dotnet/aspnetcore repo had an undeclared dependency on the latest shared framework. Installing, say, the 3.1.9 version of `dotnet-sql-cache` went fine. But, attempts to run it fail with the output below unless the 3.1.9 shared framework was available.

``` text
> dotnet-sql-cache
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '3.1.9' was not found.
  - The following frameworks were found:
      2.1.21 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
      3.1.7 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
      5.0.0-rc.2.20475.5 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.9&arch=x64&rid=win10-x64
```

This PR is about avoiding the same issue in 5.0.1 and later.

### Customer Impact

Customers will be able to install the latest 5.0.x global tools from dotnet/aspnetcore without also updating their installed shared frameworks.

### Regression?

Yes but from way back in 2.1.x. Those tools worked fine because, though the runtimeconfig.json files we shipped referenced the latest version of Microsoft.NETCore.App, that package could be resolved when the tool was installed.

### Risk (see taxonomy)

Incredibly small. The only possible risk would be a tool we ship from dotnet/aspnetcore depending on a fix in a serviced shared framework assembly. Such a dependency could be considered a breaking change and should be avoided.

### Original issue and/or the PR to master.

- #19108 is the (customer-reported) issue
- #27600 is the PR for master

### Packaging impact? (if a libraries change)

None