### PR TITLE
[master] Target 6.0.0 shared framework in global tools in servicing

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -57,11 +57,6 @@
     <SuppressDependenciesWhenPacking Condition="'$(SuppressDependenciesWhenPacking)' == '' AND '$(IsAnalyzersProject)' == 'true'">true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(PackAsTool)' == 'true' AND '$(IsShippingPackage)' == 'true'">
-    <!-- This is a requirement for Microsoft tool packages only. -->
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.csproj' ">
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
     <IsPackable
@@ -111,7 +106,7 @@
     <IsImplementationProject Condition=" '$(IsImplementationProject)' == '' AND '$(IsAnalyzersProject)' != 'true' AND '$(IsTestAssetProject)' != 'true' AND '$(IsTestProject)' != 'true' AND '$(IsBenchmarkProject)' != 'true' AND '$(IsSampleProject)' != 'true' ">true</IsImplementationProject>
 
     <!-- This determines whether a project is available as a <Reference> to other projects in this repo. -->
-    <IsProjectReferenceProvider Condition=" '$(IsProjectReferenceProvider)' == '' AND '$(IsImplementationProject)' == 'true' AND '$(PackAsTool)' != 'true' ">true</IsProjectReferenceProvider>
+    <IsProjectReferenceProvider Condition=" '$(IsProjectReferenceProvider)' == '' AND '$(IsImplementationProject)' == 'true' ">true</IsProjectReferenceProvider>
 
     <HasReferenceAssembly
         Condition=" '$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND '$(IsAspNetCoreApp)' == 'true' ">true</HasReferenceAssembly>

--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -9,10 +9,9 @@
     <!-- Reference base shared framework at incoming dependency flow version, not bundled sdk version. -->
     <FrameworkReference
       Update="Microsoft.NETCore.App"
-      Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'"
+      Condition=" '$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' AND '$(TargetLatestDotNetRuntime)' != 'false' "
       RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)"
-      TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-      />
+      TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)" />
   </ItemGroup>
 
   <!--

--- a/src/Tools/Directory.Build.targets
+++ b/src/Tools/Directory.Build.targets
@@ -1,9 +1,19 @@
 <Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
-
-  <PropertyGroup>
-    <UseLatestPackageReferences Condition=" '$(PackAsTool)' == 'true' ">true</UseLatestPackageReferences>
+  <PropertyGroup Condition=" '$(PackAsTool)' == 'true' ">
+    <!-- Microsoft tool packages are required to target both x64 and x86. -->
+    <PackAsToolShimRuntimeIdentifiers Condition=" '$(IsShippingPackage)' == 'true' ">win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <!-- None of the tool projects are project reference providers. -->
+    <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
+    <!--
+      Target the default version of .NET Core in tool projects to maximize the compatible environments. Must be set
+      before importing root Directory.Build.targets.
+    -->
+    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' ">false</TargetLatestDotNetRuntime>
+    <!-- Tool projects publish before packing. Packages should contain the latest bits. -->
+    <UseLatestPackageReferences>true</UseLatestPackageReferences>
   </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
 
   <Target Name="CleanPublishDir" AfterTargets="CoreClean">
     <RemoveDir Directories="$(PublishDir)" />


### PR DESCRIPTION
- #19108
- ensure the packaged runtimeconfig.json file uses the 6.0.0 shared framework
  - disable `$(TargetLatestDotNetRuntime)` in tool projects
  - skip `@(FrameworkReference)` item update if `$(TargetLatestDotNetRuntime)` is disabled
- essentially a no-op until after the 6.0.0 release

nit: Move `$(PackAsTool)` settings together