### PR TITLE
Update ControllerActionInvoker

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ControllerActionInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ControllerActionInvoker.cs
@@ -91,6 +91,10 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                             {
                                 _actionExecutingContext = new ActionExecutingContextSealed(_controllerContext, _filters, _arguments, _instance);
                             }
+							else if (_actionExecutedContext != null && _actionExecutedContext.Result != null)
+							{
+								_actionExecutingContext.Result = _actionExecutedContext.Result;
+							}
 
                             state = current.FilterAsync;
                             goto case State.ActionAsyncBegin;
@@ -101,6 +105,10 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                             {
                                 _actionExecutingContext = new ActionExecutingContextSealed(_controllerContext, _filters, _arguments, _instance);
                             }
+							else if (_actionExecutedContext != null && _actionExecutedContext.Result != null)
+							{
+								_actionExecutingContext.Result = _actionExecutedContext.Result;
+							}
 
                             state = current.Filter;
                             goto case State.ActionSyncBegin;


### PR DESCRIPTION
After the next filter is executed and the result is changed, the _actionExecutingContext.Result is still null.

Summary of the changes (Less than 80 chars)
 - Detail 1
 - Detail 2

Addresses #bugnumber (in this specific format)
