### PR TITLE
Handle duplicate extensible directives properly in the Razor parser

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpCodeParser.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpCodeParser.cs
@@ -959,10 +959,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
         }
 
-        protected void MapDirectives(Action<SyntaxListBuilder<RazorSyntaxNode>, CSharpTransitionSyntax> handler, params string[] directives)
+        // Internal for testing.
+        internal void MapDirectives(Action<SyntaxListBuilder<RazorSyntaxNode>, CSharpTransitionSyntax> handler, params string[] directives)
         {
             foreach (var directive in directives)
             {
+                if (_directiveParserMap.ContainsKey(directive))
+                {
+                    // It is possible for the list to contain duplicates in cases when the project is misconfigured.
+                    // In those cases, we shouldn't register multiple handlers per keyword.
+                    continue;
+                }
+
                 _directiveParserMap.Add(directive, (builder, transition) =>
                 {
                     handler(builder, transition);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpCodeParserTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpCodeParserTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -210,6 +210,20 @@ namespace Microsoft.AspNetCore.Razor.Language.Test.Legacy
             var chunkGenerator = Assert.IsType<TagHelperPrefixDirectiveChunkGenerator>(erroredNode.GetSpanContext().ChunkGenerator);
             var diagnostic = Assert.Single(chunkGenerator.Diagnostics);
             Assert.Equal(expectedDiagnostic, diagnostic);
+        }
+
+        [Fact]
+        public void MapDirectives_HandlesDuplicates()
+        {
+            // Arrange
+            var source = TestRazorSourceDocument.Create();
+            var options = RazorParserOptions.CreateDefault();
+            var context = new ParserContext(source, options);
+            var parser = new CSharpCodeParser(context);
+
+            // Act & Assert (Does not throw)
+            parser.MapDirectives((b, t) => { }, "test");
+            parser.MapDirectives((b, t) => { }, "test");
         }
     }
 }


### PR DESCRIPTION
Fixes  [937161](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/937161/)

