### PR TITLE
Ensure AppLocalResolver handles package with multiple libs

### DIFF
--- a/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticProject.cs
+++ b/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticProject.cs
@@ -81,18 +81,17 @@ namespace Microsoft.AspNetCore.Analyzer.Testing
                     if (File.Exists(dll))
                     {
                         assemblies.Add(dll);
-                        return true;
+                        continue;
                     }
 
                     dll = Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileName(assembly));
                     if (File.Exists(dll))
                     {
                         assemblies.Add(dll);
-                        return true;
                     }
                 }
 
-                return false;
+                return assemblies.Count > 0;
             }
         }
     }

--- a/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticProject.cs
+++ b/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/DiagnosticProject.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Analyzer.Testing
         /// </summary>
         public static string TestProjectName = "TestProject";
 
+        private static readonly ICompilationAssemblyResolver _assemblyResolver = new AppBaseCompilationAssemblyResolver();
         private static readonly Dictionary<Assembly, Solution> _solutionCache = new Dictionary<Assembly, Solution>();
 
         public static Project Create(Assembly testAssembly, string[] sources)
@@ -41,7 +42,7 @@ namespace Microsoft.AspNetCore.Analyzer.Testing
 
                     foreach (var defaultCompileLibrary in DependencyContext.Load(testAssembly).CompileLibraries)
                     {
-                        foreach (var resolveReferencePath in defaultCompileLibrary.ResolveReferencePaths(new AppLocalResolver()))
+                        foreach (var resolveReferencePath in defaultCompileLibrary.ResolveReferencePaths(_assemblyResolver))
                         {
                             solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(resolveReferencePath));
                         }
@@ -68,31 +69,6 @@ namespace Microsoft.AspNetCore.Analyzer.Testing
             }
 
             return solution.GetProject(testProject);
-        }
-
-        // Required to resolve compilation assemblies inside unit tests
-        private class AppLocalResolver : ICompilationAssemblyResolver
-        {
-            public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
-            {
-                foreach (var assembly in library.Assemblies)
-                {
-                    var dll = Path.Combine(Directory.GetCurrentDirectory(), "refs", Path.GetFileName(assembly));
-                    if (File.Exists(dll))
-                    {
-                        assemblies.Add(dll);
-                        continue;
-                    }
-
-                    dll = Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileName(assembly));
-                    if (File.Exists(dll))
-                    {
-                        assemblies.Add(dll);
-                    }
-                }
-
-                return assemblies.Count > 0;
-            }
         }
     }
 }

--- a/src/Components/Analyzers/test/AnalyzerTestBase.cs
+++ b/src/Components/Analyzers/test/AnalyzerTestBase.cs
@@ -5,20 +5,20 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Analyzer.Testing;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Components.Analyzers
 {
     public abstract class AnalyzerTestBase
     {
-        private static readonly string ProjectDirectory = GetProjectDirectory();
+        // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+        private static readonly string ProjectDirectory = AppContext.BaseDirectory;
 
         public TestSource Read(string source)
         {
             if (!source.EndsWith(".cs"))
             {
-                source = source + ".cs";
+                source += ".cs";
             }
 
             var filePath = Path.Combine(ProjectDirectory, "TestFiles", GetType().Name, source);
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Components.Analyzers
         {
             if (!source.EndsWith(".cs"))
             {
-                source = source + ".cs";
+                source += ".cs";
             }
 
             var read = Read(source);
@@ -45,23 +45,6 @@ namespace Microsoft.AspNetCore.Components.Analyzers
         public Task<Compilation> CreateCompilationAsync(string source)
         {
             return CreateProject(source).GetCompilationAsync();
-        }
-
-        private static string GetProjectDirectory()
-        {
-            // On helix we use the published test files
-            if (SkipOnHelixAttribute.OnHelix())
-            {
-                return AppContext.BaseDirectory;
-            }
-
-            // This test code needs to be updated to support distributed testing.
-            // See https://github.com/dotnet/aspnetcore/issues/10422
-#pragma warning disable 0618
-            var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Components");
-#pragma warning restore 0618
-            var projectDirectory = Path.Combine(solutionDirectory, "Analyzers", "test");
-            return projectDirectory;
         }
     }
 }

--- a/src/Mvc/Mvc.Analyzers/test/Infrastructure/MvcTestSource.cs
+++ b/src/Mvc/Mvc.Analyzers/test/Infrastructure/MvcTestSource.cs
@@ -1,16 +1,16 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Analyzer.Testing;
-using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.Mvc
 {
     public static class MvcTestSource
     {
-        private static readonly string ProjectDirectory = GetProjectDirectory();
+        // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+        private static readonly string ProjectDirectory = AppContext.BaseDirectory;
 
         public static TestSource Read(string testClassName, string testMethod)
         {
@@ -22,22 +22,6 @@ namespace Microsoft.AspNetCore.Mvc
 
             var fileContent = File.ReadAllText(filePath);
             return TestSource.Read(fileContent);
-        }
-
-        private static string GetProjectDirectory()
-        {
-            // On helix we use the published test files
-            if (SkipOnHelixAttribute.OnHelix())
-            {
-                return AppContext.BaseDirectory;
-            }
-
-// https://github.com/dotnet/aspnetcore/issues/9431
-#pragma warning disable 0618
-            var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Mvc");
-#pragma warning restore 0618
-            var projectDirectory = Path.Combine(solutionDirectory, "Mvc.Analyzers", "test");
-            return projectDirectory;
         }
     }
 }

--- a/src/Mvc/Mvc.Api.Analyzers/test/Infrastructure/MvcTestSource.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/Infrastructure/MvcTestSource.cs
@@ -1,16 +1,16 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Analyzer.Testing;
-using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore.Mvc
 {
     public static class MvcTestSource
     {
-        private static readonly string ProjectDirectory = GetProjectDirectory();
+        // Test files are copied to both the bin/ and publish/ folders. Use BaseDirectory on or off Helix.
+        private static readonly string ProjectDirectory = AppContext.BaseDirectory;
 
         public static TestSource Read(string testClassName, string testMethod)
         {
@@ -22,22 +22,6 @@ namespace Microsoft.AspNetCore.Mvc
 
             var fileContent = File.ReadAllText(filePath);
             return TestSource.Read(fileContent);
-        }
-
-        private static string GetProjectDirectory()
-        {
-            // On helix we use the published test files
-            if (SkipOnHelixAttribute.OnHelix())
-            {
-                return AppContext.BaseDirectory;
-            }
-
-// https://github.com/dotnet/aspnetcore/issues/9431
-#pragma warning disable 0618
-            var solutionDirectory = TestPathUtilities.GetSolutionRootDirectory("Mvc");
-#pragma warning restore 0618
-            var projectDirectory = Path.Combine(solutionDirectory, "Mvc.Api.Analyzers", "test");
-            return projectDirectory;
         }
     }
 }

--- a/src/Testing/src/TestPathUtilities.cs
+++ b/src/Testing/src/TestPathUtilities.cs
@@ -22,6 +22,20 @@ namespace Microsoft.AspNetCore.Testing
                     return projectFileInfo.DirectoryName;
                 }
 
+                projectFileInfo = new FileInfo(Path.Combine(directoryInfo.FullName, "AspNetCore.sln"));
+                if (projectFileInfo.Exists)
+                {
+                    // Have reached the solution root. Work down through the src/ folder to find the solution filter.
+                    directoryInfo = new DirectoryInfo(Path.Combine(directoryInfo.FullName, "src"));
+                    foreach (var solutionFileInfo in directoryInfo.EnumerateFiles($"{solution}.slnf", SearchOption.AllDirectories))
+                    {
+                        return solutionFileInfo.DirectoryName;
+                    }
+
+                    // No luck. Exit loop and error out.
+                    break;
+                }
+
                 directoryInfo = directoryInfo.Parent;
             }
             while (directoryInfo.Parent != null);


### PR DESCRIPTION
This was failing to pass references to a package which contains more than one lib.

I debugged this failure in the 5.0-release branch and root-caused to this, which should be fixed regardless.  If you want you can port this to 5.0 as well.

Essentially a port of https://github.com/dotnet/extensions/commit/7aff1be4fc62f6c5534801b40272319334e0636a to a copy of the same type.  cc @pakrym @dougbu @eerhardt (as DependencyContext expert 😉)

