### PR TITLE
Store cache entry on the ControllerActionDescriptor

### DIFF
--- a/src/Mvc/Mvc.Core/src/Controllers/ControllerActionDescriptor.cs
+++ b/src/Mvc/Mvc.Core/src/Controllers/ControllerActionDescriptor.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.Controllers
@@ -35,6 +36,9 @@ namespace Microsoft.AspNetCore.Mvc.Controllers
         /// The <see cref="TypeInfo"/> of the controller..
         /// </summary>
         public TypeInfo ControllerTypeInfo { get; set; }
+
+        // Cache entry so we can avoid an external cache
+        internal ControllerActionInvokerCacheEntry CacheEntry { get; set; }
 
         /// <inheritdoc />
         public override string DisplayName

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ControllerActionInvokerCacheTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ControllerActionInvokerCacheTest.cs
@@ -29,7 +29,6 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                     new FilterDescriptor(filter, FilterScope.Action)
                 });
             var controllerActionInvokerCache = CreateControllerActionInvokerCache(
-                controllerContext,
                 new[] { new DefaultFilterProvider() });
 
             // Act
@@ -50,7 +49,6 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
                     new FilterDescriptor(filter, FilterScope.Action)
                 });
             var controllerActionInvokerCache = CreateControllerActionInvokerCache(
-                controllerContext,
                 new[] { new DefaultFilterProvider() });
 
             // Act
@@ -93,17 +91,13 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
         }
 
         private static ControllerActionInvokerCache CreateControllerActionInvokerCache(
-            ControllerContext controllerContext,
             IFilterProvider[] filterProviders)
         {
-            var descriptorProvider = new CustomActionDescriptorCollectionProvider(
-                new[] { controllerContext.ActionDescriptor });
             var modelMetadataProvider = new EmptyModelMetadataProvider();
             var modelBinderFactory = TestModelBinderFactory.CreateDefault();
             var mvcOptions = Options.Create(new MvcOptions());
 
             return new ControllerActionInvokerCache(
-                descriptorProvider,
                 new ParameterBinder(
                     modelMetadataProvider,
                     modelBinderFactory,


### PR DESCRIPTION
- Remove dictionary lookup and version check per request
- Simplify ControllerActionInvokerCache logic