### PR TITLE
Add ARM64 to TestMatrix logic

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -44,7 +44,7 @@
   <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailableTargetQueue Include="(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036" Platform="Linux" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true' AND '$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true'">
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true'">
     <HelixAvailableTargetQueue Include="Windows.10.Arm64v8.Open" Platform="Windows" />
   </ItemGroup>
 </Project>

--- a/src/Hosting/Server.IntegrationTesting/src/TestMatrix.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/TestMatrix.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -124,9 +124,11 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
             {
                 switch (RuntimeInformation.OSArchitecture)
                 {
+                    case Architecture.Arm:
                     case Architecture.X86:
                         Architectures.Add(RuntimeArchitecture.x86);
                         break;
+                    case Architecture.Arm64:
                     case Architecture.X64:
                         Architectures.Add(RuntimeArchitecture.x64);
                         break;


### PR DESCRIPTION
Fixes #26872 by adding ARM architecture checks to TestMatrix.

I'd temporarily enabled the helix arm tests on this PR and didn't see any additional issues. 