### PR TITLE
Only use the ILEmitTrieJumpTable if dynamic code is compiled

### DIFF
--- a/src/Http/Routing/src/Matching/JumpTableBuilder.cs
+++ b/src/Http/Routing/src/Matching/JumpTableBuilder.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 fallback = new DictionaryJumpTable(defaultDestination, exitDestination, pathEntries);
             }
 
-            // Skip the ILEmitTrieJumpTable if the IL is going to be interpreted
+            // Use the ILEmitTrieJumpTable if the IL is going to be compiled (not interpreted)
             if (RuntimeFeature.IsDynamicCodeCompiled)
             {
                 return new ILEmitTrieJumpTable(defaultDestination, exitDestination, pathEntries, vectorize: null, fallback);

--- a/src/Http/Routing/src/Matching/JumpTableBuilder.cs
+++ b/src/Http/Routing/src/Matching/JumpTableBuilder.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Routing.Matching
 {
@@ -84,7 +85,13 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 fallback = new DictionaryJumpTable(defaultDestination, exitDestination, pathEntries);
             }
 
-            return new ILEmitTrieJumpTable(defaultDestination, exitDestination, pathEntries, vectorize: null, fallback);
+            // Skip the ILEmitTrieJumpTable if the IL is going to be interpreted
+            if (RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                return new ILEmitTrieJumpTable(defaultDestination, exitDestination, pathEntries, vectorize: null, fallback);
+            }
+
+            return fallback;
         }
     }
 }


### PR DESCRIPTION
- This will avoid trying to emit runtime code on platforms that will end up interpreting the IL or ones that don't support dynamic codegen in the first place

