### PR TITLE
Fix #if for full framework SignalR client

### DIFF
--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             {
                 // Full Framework will throw when trying to set the User-Agent header
                 // So avoid setting it in netstandard2.0 and only set it in netstandard2.1 and higher
-#if !NETSTANDARD2_0
+#if !NETSTANDARD2_0 && !NET461
                 _webSocket.Options.SetRequestHeader("User-Agent", Constants.UserAgentHeader.ToString());
 #else
                 // Set an alternative user agent header on Full framework


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/27878

#### Description

In 5.0 we added a net461 target to our packages that targeted netstandard2.0 for  better experience with full framework programs. Because of fixes and additions after netstandard2.0, `#if netstandard2_0` was used in some places with the assumption that that would be the "lowest tfm" supported. With the addition of the net461 TFM, some `#if`s weren't correct and caused code to run that shouldn't.

#### Customer Impact

Customer reported bug https://github.com/dotnet/aspnetcore/issues/27878

Only workaround is to not use WebSockets which is not an acceptable workaround.

#### Testing

We don't have net461 testing, I'll file an issue to get some net461 tests added.

#### Regression?

Yes, regressed in 5.0 when net461 was added as a TFM to the SignalR client. Before, net461 users would get the netstandard2.0 version which worked.

#### Risk

Low, only a couple places we used `netstandard2_0` to detect supported code paths, and they have been audited/fixed for net461 now.