### PR TITLE
Include .Views.dll from single file in .NET Core 3.1 apps

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -724,12 +724,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       <AllPublishItemsFullPathWithTargetPath Include="@(RazorIntermediateAssembly->'%(FullPath)')">
         <TargetPath>%(Filename)%(Extension)</TargetPath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        <!-- .Views.dll and .Views.pdb were part of the single file bundle in 3.1 apps. Lets keep this unchanged. -->
+        <ExcludeFromSingleFile Condition="'$(_TargetingNET50OrLater)' == 'true'">true</ExcludeFromSingleFile>
       </AllPublishItemsFullPathWithTargetPath>
       <AllPublishItemsFullPathWithTargetPath Include="@(_RazorDebugSymbolsIntermediatePath->'%(FullPath)')">
         <TargetPath>%(Filename)%(Extension)</TargetPath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        <ExcludeFromSingleFile Condition="'$(_TargetingNET50OrLater)' == 'true'">true</ExcludeFromSingleFile>
       </AllPublishItemsFullPathWithTargetPath>
     </ItemGroup>
 


### PR DESCRIPTION
For 5.0, we made a change to exclude .Views.dll from the single file bundle as a reaction
to changes in bundling. However the SDK change also applied to .NET 3.1 apps. This change
limits the exclusion to 5.0 and newer apps.

Adding a test for this is tricky since it requires publishing with a RID which in turn requires a restore as part of the test (something we've actively avoided due to time outs). I was able to manually test this change though.

Fixes https://github.com/dotnet/aspnetcore/issues/27831

### Summary

For 5.0, we made a change to exclude .Views.dll from the single file bundle as a reaction to changes in bundling. However the SDK change also applied to .NET 3.1 apps. This change limits the exclusion to 5.0 and newer apps. While the current change is not breaking in anyway, it was considered an annoyance that we would like to address.

### Customer impact
Using a 5.0 SDK results in additional files in 3.1 ASP.NET Core apps with single file publishing.

### Regression
Yes

### Risk
Low. It's a SDK specific change to limit the change to 5.0 or newer apps. In general, we're not aware of too many customers using single file publishing with 3.1 aspnet core apps so we expect the impact to be very limited.