### PR TITLE
Webassembly Auth: changed lifetime registration of IPostConfigureOptions<> from Singleton to Scoped

### DIFF
--- a/src/Components/WebAssembly/Authentication.Msal/src/MsalWebAssemblyServiceCollectionExtensions.cs
+++ b/src/Components/WebAssembly/Authentication.Msal/src/MsalWebAssemblyServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TAccount : RemoteUserAccount
         {
             services.AddRemoteAuthentication<TRemoteAuthenticationState, TAccount, MsalProviderOptions>(configure);
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<RemoteAuthenticationOptions<MsalProviderOptions>>, MsalDefaultOptionsConfiguration>());
+            services.TryAddEnumerable(ServiceDescriptor.Scoped<IPostConfigureOptions<RemoteAuthenticationOptions<MsalProviderOptions>>, MsalDefaultOptionsConfiguration>());
 
             return new MsalRemoteAuthenticationBuilder<TRemoteAuthenticationState, TAccount>(services);
         }

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/PublicAPI.Shipped.txt
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/PublicAPI.Shipped.txt
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken
 Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.AccessToken() -> void
 Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken.Expires.get -> System.DateTimeOffset
@@ -133,7 +133,6 @@ virtual Microsoft.AspNetCore.Components.WebAssembly.Authentication.SignOutSessio
 ~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.JsRuntime.get -> Microsoft.JSInterop.IJSRuntime
 ~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.Navigation.get -> Microsoft.AspNetCore.Components.NavigationManager
 ~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.Options.get -> Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TProviderOptions>
-~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.RemoteAuthenticationService(Microsoft.JSInterop.IJSRuntime jsRuntime, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TProviderOptions>> options, Microsoft.AspNetCore.Components.NavigationManager navigation, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccountClaimsPrincipalFactory<TAccount> accountClaimsPrincipalFactory) -> void
 ~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState.ReturnUrl.get -> string
 ~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState.ReturnUrl.set -> void
 ~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationUserOptions.AuthenticationType.get -> string

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 ~Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions.AdditionalProviderParameters.get -> System.Collections.Generic.IDictionary<string, string>
+~Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService<TRemoteAuthenticationState, TAccount, TProviderOptions>.RemoteAuthenticationService(Microsoft.JSInterop.IJSRuntime jsRuntime, Microsoft.Extensions.Options.IOptionsSnapshot<Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<TProviderOptions>> options, Microsoft.AspNetCore.Components.NavigationManager navigation, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccountClaimsPrincipalFactory<TAccount> accountClaimsPrincipalFactory) -> void

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/DefaultRemoteApplicationPathsProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/DefaultRemoteApplicationPathsProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
     {
         private readonly IOptions<RemoteAuthenticationOptions<TProviderOptions>> _options;
 
-        public DefaultRemoteApplicationPathsProvider(IOptions<RemoteAuthenticationOptions<TProviderOptions>> options)
+        public DefaultRemoteApplicationPathsProvider(IOptionsSnapshot<RemoteAuthenticationOptions<TProviderOptions>> options)
         {
             _options = options;
         }

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/RemoteAuthenticationService.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/RemoteAuthenticationService.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
         /// <param name="accountClaimsPrincipalFactory">The <see cref="AccountClaimsPrincipalFactory{TAccount}"/> used to generate the <see cref="ClaimsPrincipal"/> for the user.</param>
         public RemoteAuthenticationService(
             IJSRuntime jsRuntime,
-            IOptions<RemoteAuthenticationOptions<TProviderOptions>> options,
+            IOptionsSnapshot<RemoteAuthenticationOptions<TProviderOptions>> options,
             NavigationManager navigation,
             AccountClaimsPrincipalFactory<TAccount> accountClaimsPrincipalFactory)
         {

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/WebAssemblyAuthenticationServiceCollectionExtensions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/WebAssemblyAuthenticationServiceCollectionExtensions.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TRemoteAuthenticationState : RemoteAuthenticationState, new()
             where TAccount : RemoteUserAccount
         {
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<RemoteAuthenticationOptions<OidcProviderOptions>>, DefaultOidcOptionsConfiguration>());
+            services.TryAddEnumerable(ServiceDescriptor.Scoped<IPostConfigureOptions<RemoteAuthenticationOptions<OidcProviderOptions>>, DefaultOidcOptionsConfiguration>());
 
             return AddRemoteAuthentication<TRemoteAuthenticationState, TAccount, OidcProviderOptions>(services, configure);
         }
@@ -203,7 +203,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TAccount : RemoteUserAccount
         {
             services.TryAddEnumerable(
-                ServiceDescriptor.Singleton<IPostConfigureOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>, DefaultApiAuthorizationOptionsConfiguration>(_ =>
+                ServiceDescriptor.Scoped<IPostConfigureOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>, DefaultApiAuthorizationOptionsConfiguration>(_ =>
                 new DefaultApiAuthorizationOptionsConfiguration(inferredClientId)));
 
             services.AddRemoteAuthentication<TRemoteAuthenticationState, TAccount, ApiAuthorizationProviderOptions>(configure);

--- a/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticationServiceTests.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticationServiceTests.cs
@@ -479,7 +479,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
             Assert.Empty(result.FindAll("scope"));
         }
 
-        private static IOptions<RemoteAuthenticationOptions<OidcProviderOptions>> CreateOptions(string scopeClaim = null)
+        private static IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>> CreateOptions(string scopeClaim = null)
         {
             var options = new RemoteAuthenticationOptions<OidcProviderOptions>();
 
@@ -504,7 +504,11 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
             options.ProviderOptions.RedirectUri = "https://www.example.com/base/custom-login";
             options.ProviderOptions.PostLogoutRedirectUri = "https://www.example.com/base/custom-logout";
 
-            return Options.Create(options);
+            var iOptions = Options.Create(options);
+
+            var mock = new Mock<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>();
+            mock.Setup(m => m.Value).Returns(options);
+            return mock.Object;
         }
 
         private class TestJsRuntime : IJSRuntime

--- a/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticatorCoreTests.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/test/RemoteAuthenticatorCoreTests.cs
@@ -656,7 +656,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
             var jsRuntime = new TestJsRuntime();
             var authenticationServiceMock = new TestRemoteAuthenticationService(
                 jsRuntime,
-                Mock.Of<IOptions<RemoteAuthenticationOptions<OidcProviderOptions>>>(),
+                Mock.Of<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>(),
                 navigationManager);
 
             remoteAuthenticator.SignOutManager = new TestSignOutSessionStateManager();
@@ -740,7 +740,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
         {
             public TestRemoteAuthenticationService(
                 IJSRuntime jsRuntime,
-                IOptions<RemoteAuthenticationOptions<OidcProviderOptions>> options,
+                IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>> options,
                 TestNavigationManager navigationManager) :
                 base(jsRuntime, options, navigationManager, new AccountClaimsPrincipalFactory<RemoteUserAccount>(Mock.Of<IAccessTokenProviderAccessor>()))
             {

--- a/src/Components/WebAssembly/WebAssembly.Authentication/test/WebAssemblyAuthenticationServiceCollectionExtensionsTests.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/test/WebAssemblyAuthenticationServiceCollectionExtensionsTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
             builder.Services.AddApiAuthorization();
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
 
             var paths = options.Value.AuthenticationPaths;
 
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
 
             var user = options.Value.UserOptions;
             Assert.Equal("Microsoft.AspNetCore.Components.WebAssembly.Authentication.Tests", user.AuthenticationType);
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
 
             var user = options.Value.UserOptions;
             // Make sure that the defaults are applied on this overload
@@ -132,7 +132,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
 
             var user = options.Value.UserOptions;
             // Make sure that the defaults are applied on this overload
@@ -156,7 +156,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
 
             var user = options.Value.UserOptions;
             // Make sure that the defaults are applied on this overload
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
 
             var user = options.Value.UserOptions;
             // Make sure that the defaults are applied on this overload
@@ -222,7 +222,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>>>();
 
             var paths = options.Value.AuthenticationPaths;
 
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
             builder.Services.AddOidcAuthentication(options => { });
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<OidcProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>();
 
             var paths = options.Value.AuthenticationPaths;
 
@@ -317,7 +317,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<OidcProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>();
 
             var paths = options.Value.AuthenticationPaths;
 
@@ -359,7 +359,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<OidcProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>();
             Assert.Equal("name", options.Value.UserOptions.NameClaim);
 
             Assert.Equal(1, calls);
@@ -376,7 +376,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<OidcProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>();
             // Make sure options are applied
             Assert.Equal("name", options.Value.UserOptions.NameClaim);
 
@@ -398,7 +398,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 
             var host = builder.Build();
 
-            var options = host.Services.GetRequiredService<IOptions<RemoteAuthenticationOptions<OidcProviderOptions>>>();
+            var options = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>();
             // Make sure options are applied
             Assert.Equal("name", options.Value.UserOptions.NameClaim);
 
@@ -407,6 +407,34 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
             var authenticationService = host.Services.GetService<IRemoteAuthenticationService<TestAuthenticationState>>();
             Assert.NotNull(authenticationService);
             Assert.IsType<RemoteAuthenticationService<TestAuthenticationState, TestAccount, OidcProviderOptions>>(authenticationService);
+        }
+
+        [Fact]
+        public void OidcProviderOptionsAndDependencies_NotResolvedFromRootScope()
+        {
+            var builder = new WebAssemblyHostBuilder(new TestJSUnmarshalledRuntime());
+
+            var calls = 0;
+
+            builder.Services.AddOidcAuthentication<TestAuthenticationState, TestAccount>(options => { });
+            builder.Services.Replace(ServiceDescriptor.Scoped(typeof(NavigationManager), _ =>
+            {
+                calls++;
+                return new TestNavigationManager();
+            }));
+
+            var host = builder.Build();
+
+            using var scope = host.Services.CreateScope();
+
+            // from the root scope.
+            var rootOptions = host.Services.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>();
+
+            // from the created scope
+            var scopedOptions = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>();
+
+            // we should have 2 navigation managers. One in the root scope, and one in the created scope.
+            Assert.Equal(2, calls);
         }
 
         private class TestNavigationManager : NavigationManager


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Changed lifetime registration of IPostConfigureOptions<> from Singleton to Scoped
 - Added unit test.
 - Changed existing tests (some were failing).

Addresses #27937 (in this specific format)

Please note that the public API changes a little because of this change.
