### PR TITLE
[release/5.0] Enable MUSL ARM support

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -525,6 +525,40 @@ stages:
       parameters:
         inputName: Linux_musl_x64
 
+  # Build Linux Musl ARM
+  - template: jobs/default-build.yml
+    parameters:
+      jobName: Linux_musl_arm_build
+      jobDisplayName: "Build: Linux Musl ARM"
+      agentOs: Linux
+      useHostedUbuntu: false
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20200827125937-14441ae
+      buildScript: ./build.sh
+      buildArgs:
+        --arch arm
+        --os-name linux-musl
+        --pack
+        --all
+        --no-build-nodejs
+        --no-build-java
+        -p:OnlyPackPlatformSpecificPackages=true
+        -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
+        $(_BuildArgs)
+        $(_PublishArgs)
+        $(_InternalRuntimeDownloadArgs)
+      installNodeJs: false
+      installJdk: false
+      artifacts:
+      - name: Linux_musl_arm_Logs
+        path: artifacts/log/
+        publishOnError: true
+        includeForks: true
+      - name: Linux_musl_arm_Packages
+        path: artifacts/packages/
+  - template: jobs/codesign-xplat.yml
+    parameters:
+      inputName: Linux_musl_arm
+
   # Build Linux Musl ARM64
   - template: jobs/default-build.yml
     parameters:
@@ -758,6 +792,7 @@ stages:
             - CodeSign_Xplat_Linux_arm
             - CodeSign_Xplat_Linux_arm64
             - CodeSign_Xplat_Linux_musl_x64
+            - CodeSign_Xplat_Linux_musl_arm
             - CodeSign_Xplat_Linux_musl_arm64
           # In addition to the dependencies above, ensure the build was successful overall.
           - Source_Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -162,6 +162,7 @@
       win-arm64;
       osx-x64;
       linux-musl-x64;
+      linux-musl-arm;
       linux-musl-arm64;
       linux-x64;
       linux-arm;

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -94,6 +94,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-musl-x64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-musl-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Runtime.linux-musl-arm64" />
   </ItemGroup>
 

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -92,7 +92,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <PathSeparator Condition="'$(PathSeparator)' == ''">:</PathSeparator>
     <PathSeparator Condition=" '$(TargetOsName)' == 'win' ">%3B</PathSeparator>
 
-    <CrossCompileDirectory Condition=" '$(TargetRuntimeIdentifier)' == 'linux-arm' ">x64_arm</CrossCompileDirectory>
+    <CrossCompileDirectory Condition=" '$(TargetRuntimeIdentifier)' == 'linux-arm' OR '$(TargetRuntimeIdentifier)' == 'linux-musl-arm'">x64_arm</CrossCompileDirectory>
     <CrossCompileDirectory Condition=" '$(TargetArchitecture)' == 'arm64' AND '$(BuildArchitecture)' != 'arm64' ">x64_arm64</CrossCompileDirectory>
     <CrossCompileDirectory Condition=" '$(TargetRuntimeIdentifier)' == 'win-arm' ">x86_arm</CrossCompileDirectory>
 


### PR DESCRIPTION
Port of #26281

#### Description
This change adds support for building MUSL ARM packages of ASP.NET Core. 

Runtime repo has support for MUSL ARM in the 5.0 GA release, but this repo was missing it by accident. That prevent us from creating Linux Alpine ARM docker images for .NET 5.0.

#### Customer Impact
The change enables customers to use .NET Core in very small memory footprint Alpine ARM32 container.

#### Regression?
No

#### Risk
Low, this is a new platform enabling and changes are not influencing existing platforms.
