### PR TITLE
Bump Selenium dependency versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -243,10 +243,10 @@
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <NewtonsoftJsonVersion>12.0.2</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
-    <SeleniumSupportVersion>4.0.0-alpha05</SeleniumSupportVersion>
+    <SeleniumSupportVersion>4.0.0-alpha07</SeleniumSupportVersion>
     <SeleniumWebDriverMicrosoftDriverVersion>17.17134.0</SeleniumWebDriverMicrosoftDriverVersion>
-    <SeleniumWebDriverChromeDriverVersion>86.0.4240.2200-beta</SeleniumWebDriverChromeDriverVersion>
-    <SeleniumWebDriverVersion>4.0.0-alpha05</SeleniumWebDriverVersion>
+    <SeleniumWebDriverChromeDriverVersion>87.0.4280.2000-beta</SeleniumWebDriverChromeDriverVersion>
+    <SeleniumWebDriverVersion>4.0.0-alpha07</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.0.593</StackExchangeRedisVersion>

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23015")]
         public async Task ClosingTheBrowserWindow_GracefullyDisconnects_TheCurrentCircuit()
         {
             // Arrange & Act

--- a/src/Shared/E2ETesting/WaitAssert.cs
+++ b/src/Shared/E2ETesting/WaitAssert.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using OpenQA.Selenium;
-using OpenQA.Selenium.DevTools.Page;
+using OpenQA.Selenium.DevTools;
 using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Support.UI;
 using Xunit;

--- a/src/Shared/E2ETesting/selenium-config.json
+++ b/src/Shared/E2ETesting/selenium-config.json
@@ -1,7 +1,7 @@
 {
   "drivers": {
     "chrome": {
-      "version" : "85.0.4183.87"
+      "version" : "87.0.4280.20"
     }
   },
   "ignoreExtraDrivers": true


### PR DESCRIPTION
These changes are made to resolve some instability we've been seeing with Selenium tests in the CI.

- Bump to the latest version of Seleniums 4.x package versions
- Bump to a supported version of the Chrome drivers
- Quarantine a Blazor tests that performs unreliably in newer versions of Chrome