### PR TITLE
Avoid expensive work for CertificateManager logging when not enabled

### DIFF
--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -56,7 +56,10 @@ namespace Microsoft.AspNetCore.Certificates.Generation
             try
             {
                 ExportCertificate(publicCertificate, tmpFile, includePrivateKey: false, password: null, CertificateKeyExportFormat.Pfx);
-                Log.MacOSTrustCommandStart($"{MacOSTrustCertificateCommandLine} {MacOSTrustCertificateCommandLineArguments}{tmpFile}");
+                if (Log.IsEnabled())
+                {
+                    Log.MacOSTrustCommandStart($"{MacOSTrustCertificateCommandLine} {MacOSTrustCertificateCommandLineArguments}{tmpFile}");
+                }
                 using (var process = Process.Start(MacOSTrustCertificateCommandLine, MacOSTrustCertificateCommandLineArguments + tmpFile))
                 {
                     process.WaitForExit();
@@ -238,7 +241,11 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                 RedirectStandardError = true
             };
 
-            Log.MacOSRemoveCertificateFromKeyChainStart(keyChain, GetDescription(certificate));
+            if (Log.IsEnabled())
+            {
+                Log.MacOSRemoveCertificateFromKeyChainStart(keyChain, GetDescription(certificate));
+            }
+
             using (var process = Process.Start(processInfo))
             {
                 var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
@@ -282,7 +289,11 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                 RedirectStandardError = true
             };
 
-            Log.MacOSAddCertificateToKeyChainStart(MacOSUserKeyChain, GetDescription(certificate));
+            if (Log.IsEnabled())
+            {
+                Log.MacOSAddCertificateToKeyChainStart(MacOSUserKeyChain, GetDescription(certificate));
+            }
+
             using (var process = Process.Start(processInfo))
             {
                 var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();


### PR DESCRIPTION
A bunch of calls to CertificateManager.Log.SomeEvent are made but with computed arguments that are relatively expensive.  These should all be guarded behind IsEnabled checks to only do that work if the logging is likely to happen.

Related to https://github.com/dotnet/runtime/issues/44598