### PR TITLE
!temporary! Increase dotnet-install logging

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -244,6 +244,7 @@ function InstallDotNet([string] $dotnetRoot,
   $installParameters = @{
     Version = $version
     InstallDir = $dotnetRoot
+    Verbose = $null
   }
 
   if ($architecture) { $installParameters.Architecture = $architecture }
@@ -527,7 +528,7 @@ function GetDefaultMSBuildEngine() {
 
 function GetNuGetPackageCachePath() {
   if ($env:NUGET_PACKAGES -eq $null) {
-    # Use local cache on CI to ensure deterministic build. 
+    # Use local cache on CI to ensure deterministic build.
     # Avoid using the http cache as workaround for https://github.com/NuGet/Home/issues/3116
     # use global cache in dev builds to avoid cost of downloading packages.
     # For directory normalization, see also: https://github.com/NuGet/Home/issues/7968


### PR DESCRIPTION
- changes may help figure out dotnet/core-eng#11424
- will likely go away in the next Arcade update PR
  - if not, we should revert this change after dotnet/core-eng#11424 is done for realz

FYI @MattGal I didn't find a way to add similar logging in tools.sh. Tried
- adding `chmod +x "$install_script"` in `GetDotNetInstallScript`
- changing commands to `bash "verbose=true \"$install_script\" ..."` in `InstallDotNet`

but that didn't get the `say_verbose` or `eval $invocation` bits in the script going.