### PR TITLE
Remove unnecessary calls to GetTypeInfo

### DIFF
--- a/src/Components/Server/src/BlazorPack/SequenceOfT.cs
+++ b/src/Components/Server/src/BlazorPack/SequenceOfT.cs
@@ -299,7 +299,7 @@ namespace Nerdbank.Streams
             /// <summary>
             /// A value indicating whether the element is a value type.
             /// </summary>
-            private static readonly bool IsValueTypeElement = typeof(T).GetTypeInfo().IsValueType;
+            private static readonly bool IsValueTypeElement = typeof(T).IsValueType;
 
             /// <summary>
             /// Gets the backing array, when using an <see cref="ArrayPool{T}"/> instead of a <see cref="MemoryPool{T}"/>.

--- a/src/Components/WebAssembly/Sdk/tools/Application.cs
+++ b/src/Components/WebAssembly/Sdk/tools/Application.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -71,7 +71,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tools
 
         private string GetInformationalVersion()
         {
-            var assembly = typeof(Application).GetTypeInfo().Assembly;
+            var assembly = typeof(Application).Assembly;
             var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             return attribute.InformationalVersion;
         }

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/EntrypointInvokerTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/EntrypointInvokerTest.cs
@@ -137,7 +137,7 @@ namespace SomeApp
             var compilation = CSharpCompilation.Create(
                 $"TestAssembly-{Guid.NewGuid().ToString("D")}",
                 new[] { syntaxTree },
-                new[] { MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.Location) },
+                new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
                 new CSharpCompilationOptions(OutputKind.ConsoleApplication));
             using var ms = new MemoryStream();
             var compilationResult = compilation.Emit(ms);

--- a/src/DataProtection/DataProtection/test/TypeForwardingActivatorTests.cs
+++ b/src/DataProtection/DataProtection/test/TypeForwardingActivatorTests.cs
@@ -110,14 +110,14 @@ namespace Microsoft.AspNetCore.DataProtection
         {
             var activator = new TypeForwardingActivator(null);
 
-            var typeInfo = typeof(ClassWithParameterlessCtor).GetTypeInfo();
-            var typeName = typeInfo.FullName;
-            var assemblyName = typeInfo.Assembly.GetName();
+            var type = typeof(ClassWithParameterlessCtor);
+            var typeName = type.FullName;
+            var assemblyName = type.Assembly.GetName();
 
             assemblyName.Version = newVersion;
             var newName = $"{typeName}, {assemblyName}";
 
-            Assert.NotEqual(typeInfo.AssemblyQualifiedName, newName);
+            Assert.NotEqual(type.AssemblyQualifiedName, newName);
             Assert.IsType<ClassWithParameterlessCtor>(activator.CreateInstance(typeof(object), newName, out var forwarded));
             Assert.True(forwarded, "Should have forwarded this type to new version or namespace");
         }

--- a/src/DefaultBuilder/src/WebHost.cs
+++ b/src/DefaultBuilder/src/WebHost.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore
         /// <returns>A started <see cref="IWebHost"/> that hosts the application.</returns>
         public static IWebHost Start(string url, RequestDelegate app)
         {
-            var startupAssemblyName = app.GetMethodInfo().DeclaringType!.GetTypeInfo().Assembly.GetName().Name;
+            var startupAssemblyName = app.GetMethodInfo().DeclaringType!.Assembly.GetName().Name;
             return StartWith(url: url, configureServices: null, app: appBuilder => appBuilder.Run(app), applicationName: startupAssemblyName);
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore
         /// <returns>A started <see cref="IWebHost"/> that hosts the application.</returns>
         public static IWebHost Start(string url, Action<IRouteBuilder> routeBuilder)
         {
-            var startupAssemblyName = routeBuilder.GetMethodInfo().DeclaringType!.GetTypeInfo().Assembly.GetName().Name;
+            var startupAssemblyName = routeBuilder.GetMethodInfo().DeclaringType!.Assembly.GetName().Name;
             return StartWith(url, services => services.AddRouting(), appBuilder => appBuilder.UseRouter(routeBuilder), applicationName: startupAssemblyName);
         }
 

--- a/src/Features/JsonPatch/src/Converters/TypedJsonPatchDocumentConverter.cs
+++ b/src/Features/JsonPatch/src/Converters/TypedJsonPatchDocumentConverter.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
                     return null;
                 }
 
-                var genericType = objectType.GetTypeInfo().GenericTypeArguments[0];
+                var genericType = objectType.GenericTypeArguments[0];
 
                 // load jObject
                 var jObject = JArray.Load(reader);

--- a/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
+++ b/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -63,11 +63,10 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
 
         private static bool IsNullableType(Type type)
         {
-            var typeInfo = type.GetTypeInfo();
-            if (typeInfo.IsValueType)
+            if (type.IsValueType)
             {
                 // value types are only nullable if they are Nullable<T>
-                return typeInfo.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+                return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
             }
             else
             {

--- a/src/Features/JsonPatch/src/Internal/DynamicObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/DynamicObjectAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Setting the value to "null" will use the default value in case of value types, and
             // null in case of reference types
             object value = null;
-            if (property.GetType().GetTypeInfo().IsValueType
+            if (property.GetType().IsValueType
                 && Nullable.GetUnderlyingType(property.GetType()) == null)
             {
                 value = Activator.CreateInstance(property.GetType());

--- a/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Setting the value to "null" will use the default value in case of value types, and
             // null in case of reference types
             object value = null;
-            if (jsonProperty.PropertyType.GetTypeInfo().IsValueType
+            if (jsonProperty.PropertyType.IsValueType
                 && Nullable.GetUnderlyingType(jsonProperty.PropertyType) == null)
             {
                 value = Activator.CreateInstance(jsonProperty.PropertyType);

--- a/src/FileProviders/Embedded/test/EmbeddedFileProviderTests.cs
+++ b/src/FileProviders/Embedded/test/EmbeddedFileProviderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsNotFoundFileInfo_IfFileDoesNotExist()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
+            var provider = new EmbeddedFileProvider(GetType().Assembly);
 
             // Act
             var fileInfo = provider.GetFileInfo("DoesNotExist.Txt");
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsFilesAtRoot(string filePath)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
+            var provider = new EmbeddedFileProvider(GetType().Assembly);
             var expectedFileLength = 8;
 
             // Act
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsNotFoundFileInfo_IfFileDoesNotExistUnderSpecifiedNamespace()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".SubNamespace");
+            var provider = new EmbeddedFileProvider(GetType().Assembly, Namespace + ".SubNamespace");
 
             // Act
             var fileInfo = provider.GetFileInfo("File.txt");
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_ReturnsNotFoundIfPathStartsWithBackSlash()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
+            var provider = new EmbeddedFileProvider(GetType().Assembly);
 
             // Act
             var fileInfo = provider.GetFileInfo("\\File.txt");
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_LocatesFilesUnderSpecifiedNamespace(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".Resources");
+            var provider = new EmbeddedFileProvider(GetType().Assembly, Namespace + ".Resources");
 
             // Act
             var fileInfo = provider.GetFileInfo(path);
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetFileInfo_LocatesFilesUnderSubDirectories(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
+            var provider = new EmbeddedFileProvider(GetType().Assembly);
 
             // Act
             var fileInfo = provider.GetFileInfo(path);
@@ -165,7 +165,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetDirectoryContents_ReturnsAllFilesInFileSystem(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, Namespace + ".Resources");
+            var provider = new EmbeddedFileProvider(GetType().Assembly, Namespace + ".Resources");
 
             // Act
             var files = provider.GetDirectoryContents(path);
@@ -185,7 +185,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetDirectoryContents_ReturnsEmptySequence_IfResourcesDoNotExistUnderNamespace()
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly, "Unknown.Namespace");
+            var provider = new EmbeddedFileProvider(GetType().Assembly, "Unknown.Namespace");
 
             // Act
             var files = provider.GetDirectoryContents(string.Empty);
@@ -202,7 +202,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void GetDirectoryContents_ReturnsNotFoundDirectoryContents_IfHierarchicalPathIsSpecified(string path)
         {
             // Arrange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
+            var provider = new EmbeddedFileProvider(GetType().Assembly);
 
             // Act
             var files = provider.GetDirectoryContents(path);
@@ -217,7 +217,7 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Tests
         public void Watch_ReturnsNoOpTrigger()
         {
             // Arange
-            var provider = new EmbeddedFileProvider(GetType().GetTypeInfo().Assembly);
+            var provider = new EmbeddedFileProvider(GetType().Assembly);
 
             // Act
             var token = provider.Watch("Resources/File.txt");

--- a/src/Grpc/test/testassets/InteropClient/Program.cs
+++ b/src/Grpc/test/testassets/InteropClient/Program.cs
@@ -27,7 +27,7 @@ namespace InteropTestsClient
         {
             Console.WriteLine("Application started.");
 
-            var runtimeVersion = typeof(object).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
+            var runtimeVersion = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
             Console.WriteLine($"NetCoreAppVersion: {runtimeVersion}");
 
             InteropClient.Run(args);

--- a/src/Grpc/test/testassets/InteropWebsite/Startup.cs
+++ b/src/Grpc/test/testassets/InteropWebsite/Startup.cs
@@ -43,9 +43,9 @@ namespace InteropTestsWebsite
             {
                 Console.WriteLine("Application started.");
 
-                var runtimeVersion = typeof(object).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
+                var runtimeVersion = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
                 Console.WriteLine($"NetCoreAppVersion: {runtimeVersion}");
-                var aspNetCoreVersion = typeof(HeaderNames).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
+                var aspNetCoreVersion = typeof(HeaderNames).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "Unknown";
                 Console.WriteLine($"AspNetCoreAppVersion: {aspNetCoreVersion}");
             });
 

--- a/src/Hosting/Abstractions/src/HostingStartupAttribute.cs
+++ b/src/Hosting/Abstractions/src/HostingStartupAttribute.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Hosting
                 throw new ArgumentNullException(nameof(hostingStartupType));
             }
 
-            if (!typeof(IHostingStartup).GetTypeInfo().IsAssignableFrom(hostingStartupType.GetTypeInfo()))
+            if (!typeof(IHostingStartup).IsAssignableFrom(hostingStartupType))
             {
                 throw new ArgumentException($@"""{hostingStartupType}"" does not implement {typeof(IHostingStartup)}.", nameof(hostingStartupType));
             }

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -157,11 +157,11 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 RuntimeDisplayName = RuntimeInformation.FrameworkDescription
             };
-            var systemRuntimeAssembly = typeof(System.ComponentModel.DefaultValueAttribute).GetTypeInfo().Assembly;
+            var systemRuntimeAssembly = typeof(System.ComponentModel.DefaultValueAttribute).Assembly;
             var assemblyVersion = new AssemblyName(systemRuntimeAssembly.FullName).Version.ToString();
             var clrVersion = assemblyVersion;
             model.RuntimeArchitecture = RuntimeInformation.ProcessArchitecture.ToString();
-            var currentAssembly = typeof(ErrorPage).GetTypeInfo().Assembly;
+            var currentAssembly = typeof(ErrorPage).Assembly;
             model.CurrentAssemblyVesion = currentAssembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 .InformationalVersion;

--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -254,11 +254,11 @@ namespace Microsoft.AspNetCore.Hosting
                 {
                     RuntimeDisplayName = RuntimeInformation.FrameworkDescription
                 };
-                var systemRuntimeAssembly = typeof(System.ComponentModel.DefaultValueAttribute).GetTypeInfo().Assembly;
+                var systemRuntimeAssembly = typeof(System.ComponentModel.DefaultValueAttribute).Assembly;
                 var assemblyVersion = new AssemblyName(systemRuntimeAssembly.FullName).Version.ToString();
                 var clrVersion = assemblyVersion;
                 model.RuntimeArchitecture = RuntimeInformation.ProcessArchitecture.ToString();
-                var currentAssembly = typeof(ErrorPage).GetTypeInfo().Assembly;
+                var currentAssembly = typeof(ErrorPage).Assembly;
                 model.CurrentAssemblyVesion = currentAssembly
                     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                     .InformationalVersion;

--- a/src/Hosting/Hosting/src/WebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilder.cs
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Hosting
                 {
                     var startupType = StartupLoader.FindStartupType(_options.StartupAssembly, _hostingEnvironment.EnvironmentName);
 
-                    if (typeof(IStartup).GetTypeInfo().IsAssignableFrom(startupType.GetTypeInfo()))
+                    if (typeof(IStartup).IsAssignableFrom(startupType))
                     {
                         services.AddSingleton(typeof(IStartup), startupType);
                     }

--- a/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         public static IWebHostBuilder Configure(this IWebHostBuilder hostBuilder, Action<IApplicationBuilder> configureApp)
         {
-            return hostBuilder.Configure((_, app) => configureApp(app), configureApp.GetMethodInfo().DeclaringType!.GetTypeInfo().Assembly.GetName().Name!);
+            return hostBuilder.Configure((_, app) => configureApp(app), configureApp.GetMethodInfo().DeclaringType!.Assembly.GetName().Name!);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Hosting
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         public static IWebHostBuilder Configure(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, IApplicationBuilder> configureApp)
         {
-            return hostBuilder.Configure(configureApp, configureApp.GetMethodInfo().DeclaringType!.GetTypeInfo().Assembly.GetName().Name!);
+            return hostBuilder.Configure(configureApp, configureApp.GetMethodInfo().DeclaringType!.Assembly.GetName().Name!);
         }
 
         private static IWebHostBuilder Configure(this IWebHostBuilder hostBuilder, Action<WebHostBuilderContext, IApplicationBuilder> configureApp, string startupAssemblyName)
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Hosting
                 throw new ArgumentNullException(nameof(startupFactory));
             }
 
-            var startupAssemblyName = startupFactory.GetMethodInfo().DeclaringType!.GetTypeInfo().Assembly.GetName().Name;
+            var startupAssemblyName = startupFactory.GetMethodInfo().DeclaringType!.Assembly.GetName().Name;
 
             hostBuilder.UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName);
 
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Hosting
                 throw new ArgumentNullException(nameof(startupType));
             }
 
-            var startupAssemblyName = startupType.GetTypeInfo().Assembly.GetName().Name;
+            var startupAssemblyName = startupType.Assembly.GetName().Name;
 
             hostBuilder.UseSetting(WebHostDefaults.ApplicationKey, startupAssemblyName);
 
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Hosting
             return hostBuilder
                 .ConfigureServices(services =>
                 {
-                    if (typeof(IStartup).GetTypeInfo().IsAssignableFrom(startupType.GetTypeInfo()))
+                    if (typeof(IStartup).IsAssignableFrom(startupType))
                     {
                         services.AddSingleton(typeof(IStartup), startupType);
                     }

--- a/src/Http/Http.Abstractions/src/Extensions/UseMiddlewareExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UseMiddlewareExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
         public static IApplicationBuilder UseMiddleware(this IApplicationBuilder app, [DynamicallyAccessedMembers(MiddlewareAccessibility)] Type middleware, params object?[] args)
         {
-            if (typeof(IMiddleware).GetTypeInfo().IsAssignableFrom(middleware.GetTypeInfo()))
+            if (typeof(IMiddleware).IsAssignableFrom(middleware))
             {
                 // IMiddleware doesn't support passing args directly since it's
                 // activated from the container

--- a/src/Http/Owin/src/OwinFeatureCollection.cs
+++ b/src/Http/Owin/src/OwinFeatureCollection.cs
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.Owin
         private bool SupportsInterface(Type key)
         {
             // Does this type implement the requested interface?
-            if (key.GetTypeInfo().IsAssignableFrom(GetType().GetTypeInfo()))
+            if (key.IsAssignableFrom(GetType()))
             {
                 // Check for conditional features
                 if (key == typeof(ITlsConnectionFeature))

--- a/src/Identity/Core/src/IdentityBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityBuilderExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Identity
             builder.AddSignInManagerDeps();
             var managerType = typeof(SignInManager<>).MakeGenericType(builder.UserType);
             var customType = typeof(TSignInManager);
-            if (!managerType.GetTypeInfo().IsAssignableFrom(customType.GetTypeInfo()))
+            if (!managerType.IsAssignableFrom(customType))
             {
                 throw new InvalidOperationException(Resources.FormatInvalidManagerType(customType.Name, "SignInManager", builder.UserType.Name));
             }

--- a/src/Identity/EntityFrameworkCore/src/IdentityEntityFrameworkBuilderExtensions.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityEntityFrameworkBuilderExtensions.cs
@@ -94,16 +94,15 @@ namespace Microsoft.Extensions.DependencyInjection
 
         }
 
-        private static TypeInfo FindGenericBaseType(Type currentType, Type genericBaseType)
+        private static Type FindGenericBaseType(Type currentType, Type genericBaseType)
         {
             var type = currentType;
             while (type != null)
             {
-                var typeInfo = type.GetTypeInfo();
                 var genericType = type.IsGenericType ? type.GetGenericTypeDefinition() : null;
                 if (genericType != null && genericType == genericBaseType)
                 {
-                    return typeInfo;
+                    return type;
                 }
                 type = type.BaseType;
             }

--- a/src/Identity/Extensions.Core/src/IdentityBuilder.cs
+++ b/src/Identity/Extensions.Core/src/IdentityBuilder.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Identity
         /// <returns>The current <see cref="IdentityBuilder"/> instance.</returns>
         public virtual IdentityBuilder AddTokenProvider(string providerName, Type provider)
         {
-            if (!typeof(IUserTwoFactorTokenProvider<>).MakeGenericType(UserType).GetTypeInfo().IsAssignableFrom(provider.GetTypeInfo()))
+            if (!typeof(IUserTwoFactorTokenProvider<>).MakeGenericType(UserType).IsAssignableFrom(provider))
             {
                 throw new InvalidOperationException(Resources.FormatInvalidManagerType(provider.Name, "IUserTwoFactorTokenProvider", UserType.Name));
             }
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Identity
         {
             var userManagerType = typeof(UserManager<>).MakeGenericType(UserType);
             var customType = typeof(TUserManager);
-            if (!userManagerType.GetTypeInfo().IsAssignableFrom(customType.GetTypeInfo()))
+            if (!userManagerType.IsAssignableFrom(customType))
             {
                 throw new InvalidOperationException(Resources.FormatInvalidManagerType(customType.Name, "UserManager", UserType.Name));
             }
@@ -228,7 +228,7 @@ namespace Microsoft.AspNetCore.Identity
             }
             var managerType = typeof(RoleManager<>).MakeGenericType(RoleType);
             var customType = typeof(TRoleManager);
-            if (!managerType.GetTypeInfo().IsAssignableFrom(customType.GetTypeInfo()))
+            if (!managerType.IsAssignableFrom(customType))
             {
                 throw new InvalidOperationException(Resources.FormatInvalidManagerType(customType.Name, "RoleManager", RoleType.Name));
             }

--- a/src/Identity/test/Identity.Test/ApiConsistencyTest.cs
+++ b/src/Identity/test/Identity.Test/ApiConsistencyTest.cs
@@ -8,6 +8,6 @@ namespace Microsoft.AspNetCore.Identity.Test
 {
     public class ApiConsistencyTest : ApiConsistencyTestBase
     {
-        protected override Assembly TargetAssembly => typeof(IdentityOptions).GetTypeInfo().Assembly;
+        protected override Assembly TargetAssembly => typeof(IdentityOptions).Assembly;
     }
 }

--- a/src/Identity/test/Shared/ApiConsistencyTestBase.cs
+++ b/src/Identity/test/Shared/ApiConsistencyTestBase.cs
@@ -84,14 +84,14 @@ namespace Microsoft.AspNetCore.Identity.Test
             }
         }
 
-        protected TypeInfo GetBasestTypeInAssembly(Type type)
+        protected Type GetBasestTypeInAssembly(Type type)
         {
-            while (type.GetTypeInfo()?.BaseType?.GetTypeInfo()?.Assembly == type.GetTypeInfo().Assembly)
+            while (type.BaseType?.Assembly == type.Assembly)
             {
-                type = type.GetTypeInfo().BaseType;
+                type = type.BaseType;
             }
 
-            return type.GetTypeInfo();
+            return type;
         }
     }
 }

--- a/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests/ResourceManagerStringLocalizerFactoryTest.cs
+++ b/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests/ResourceManagerStringLocalizerFactoryTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.Localization.Tests
                 rootNamespaceAttribute: null,
                 loggerFactory: loggerFactory);
             var type = typeof(ResourceManagerStringLocalizerFactoryTest);
-            var assemblyName = new AssemblyName(type.GetTypeInfo().Assembly.FullName);
+            var assemblyName = new AssemblyName(type.Assembly.FullName);
 
             // Act
             typeFactory.Create(type);
@@ -212,7 +212,7 @@ namespace Microsoft.Extensions.Localization.Tests
             options.Setup(o => o.Value).Returns(locOptions);
             var loggerFactory = NullLoggerFactory.Instance;
             var factory = new ResourceManagerStringLocalizerFactory(localizationOptions: options.Object, loggerFactory: loggerFactory);
-            var location = typeof(ResourceManagerStringLocalizer).GetTypeInfo().Assembly.FullName;
+            var location = typeof(ResourceManagerStringLocalizer).Assembly.FullName;
 
             // Act
             var result1 = factory.Create("baseName", location);
@@ -231,7 +231,7 @@ namespace Microsoft.Extensions.Localization.Tests
             options.Setup(o => o.Value).Returns(locOptions);
             var loggerFactory = NullLoggerFactory.Instance;
             var factory = new ResourceManagerStringLocalizerFactory(localizationOptions: options.Object, loggerFactory: loggerFactory);
-            var location = typeof(ResourceManagerStringLocalizer).GetTypeInfo().Assembly.FullName;
+            var location = typeof(ResourceManagerStringLocalizer).Assembly.FullName;
 
             // Act
             var result1 = factory.Create("baseName1", location);
@@ -250,8 +250,8 @@ namespace Microsoft.Extensions.Localization.Tests
             options.Setup(o => o.Value).Returns(locOptions);
             var loggerFactory = NullLoggerFactory.Instance;
             var factory = new ResourceManagerStringLocalizerFactory(localizationOptions: options.Object, loggerFactory: loggerFactory);
-            var location1 = new AssemblyName(typeof(ResourceManagerStringLocalizer).GetTypeInfo().Assembly.FullName).Name;
-            var location2 = new AssemblyName(typeof(ResourceManagerStringLocalizerFactoryTest).GetTypeInfo().Assembly.FullName).Name;
+            var location1 = new AssemblyName(typeof(ResourceManagerStringLocalizer).Assembly.FullName).Name;
+            var location2 = new AssemblyName(typeof(ResourceManagerStringLocalizerFactoryTest).Assembly.FullName).Name;
 
             // Act
             var result1 = factory.Create("baseName", location1);

--- a/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests/ResourceManagerStringLocalizerTest.cs
+++ b/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests/ResourceManagerStringLocalizerTest.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Extensions.Localization
             }
 
             public TestAssemblyWrapper(Type type)
-                : base(type.GetTypeInfo().Assembly)
+                : base(type.Assembly)
             {
             }
 

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/Helpers/StringHelpers.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/Helpers/StringHelpers.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests.H
     {
         public static string GetResourceString(string stringName, params object[] parameters)
         {
-            var strings = typeof(DatabaseErrorPageMiddleware).GetTypeInfo().Assembly.GetType("Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Strings").GetTypeInfo();
+            var strings = typeof(DatabaseErrorPageMiddleware).Assembly.GetType("Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Strings").GetTypeInfo();
 
             if (parameters.Length > 0)
             {

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/test/UnitTests/Helpers/StringHelpers.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/test/UnitTests/Helpers/StringHelpers.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests.Helpers
     {
         public static string GetResourceString(string stringName, params object[] parameters)
         {
-            var strings = typeof(DatabaseErrorPageMiddleware).GetTypeInfo().Assembly.GetType("Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Strings").GetTypeInfo();
+            var strings = typeof(DatabaseErrorPageMiddleware).Assembly.GetType("Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Strings").GetTypeInfo();
             var method = strings.GetDeclaredMethods(stringName).SingleOrDefault();
             if (method != null)
             {

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionDetailsProviderTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionDetailsProviderTest.cs
@@ -113,8 +113,8 @@ namespace Microsoft.Extensions.Internal
         {
             // Arrange
             var provider = new EmbeddedFileProvider(
-                GetType().GetTypeInfo().Assembly,
-                baseNamespace: $"{typeof(ExceptionDetailsProviderTest).GetTypeInfo().Assembly.GetName().Name}.Resources");
+                GetType().Assembly,
+                baseNamespace: $"{typeof(ExceptionDetailsProviderTest).Assembly.GetName().Name}.Resources");
 
             // Act
             var exceptionDetailProvider = new ExceptionDetailsProvider(provider, logger: null, sourceCodeLineCount: 6);

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -605,7 +605,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
 
             IsComplexType = !TypeDescriptor.GetConverter(ModelType).CanConvertFrom(typeof(string));
             IsNullableValueType = Nullable.GetUnderlyingType(ModelType) != null;
-            IsReferenceOrNullableType = !ModelType.GetTypeInfo().IsValueType || IsNullableValueType;
+            IsReferenceOrNullableType = !ModelType.IsValueType || IsNullableValueType;
             UnderlyingOrModelType = Nullable.GetUnderlyingType(ModelType) ?? ModelType;
 
             var collectionType = ClosedGenericMatcher.ExtractGenericInterface(ModelType, typeof(ICollection<>));

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs
@@ -682,11 +682,11 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 
             // Find where the method was originally declared
             var baseMethodInfo = methodInfo.GetBaseDefinition();
-            var declaringTypeInfo = baseMethodInfo.DeclaringType.GetTypeInfo();
+            var declaringType = baseMethodInfo.DeclaringType;
 
             return
-                (typeof(IDisposable).GetTypeInfo().IsAssignableFrom(declaringTypeInfo) &&
-                 declaringTypeInfo.GetRuntimeInterfaceMap(typeof(IDisposable)).TargetMethods[0] == baseMethodInfo);
+                (typeof(IDisposable).IsAssignableFrom(declaringType) &&
+                 declaringType.GetInterfaceMap(typeof(IDisposable)).TargetMethods[0] == baseMethodInfo);
         }
 
         private bool IsSilentRouteAttribute(IRouteTemplateProvider routeTemplateProvider)

--- a/src/Mvc/Mvc.Core/src/Filters/MiddlewareFilterConfigurationProvider.cs
+++ b/src/Mvc/Mvc.Core/src/Filters/MiddlewareFilterConfigurationProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
                 throw new ArgumentNullException(nameof(configurationType));
             }
 
-            if (!HasParameterlessConstructor(configurationType.GetTypeInfo()))
+            if (!HasParameterlessConstructor(configurationType))
             {
                 throw new InvalidOperationException(
                     Resources.FormatMiddlewareFilterConfigurationProvider_CreateConfigureDelegate_CannotCreateType(configurationType, nameof(configurationType)));
@@ -72,9 +72,9 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             return methodInfo;
         }
 
-        private static bool HasParameterlessConstructor(TypeInfo modelTypeInfo)
+        private static bool HasParameterlessConstructor(Type modelType)
         {
-            return !modelTypeInfo.IsAbstract && modelTypeInfo.GetConstructor(Type.EmptyTypes) != null;
+            return !modelType.IsAbstract && modelType.GetConstructor(Type.EmptyTypes) != null;
         }
 
         private class ConfigureBuilder

--- a/src/Mvc/Mvc.Core/src/Formatters/InputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/InputFormatter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 throw new ArgumentNullException(nameof(modelType));
             }
 
-            if (modelType.GetTypeInfo().IsValueType)
+            if (modelType.IsValueType)
             {
                 return Activator.CreateInstance(modelType);
             }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
@@ -203,8 +203,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 return true;
             }
 
-            return targetType.GetTypeInfo().IsClass &&
-                !targetType.GetTypeInfo().IsAbstract &&
+            return targetType.IsClass &&
+                !targetType.IsAbstract &&
                 typeof(ICollection<TElement>).IsAssignableFrom(targetType);
         }
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinderProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
             if (enumerableType != null)
             {
                 var listType = typeof(List<>).MakeGenericType(enumerableType.GenericTypeArguments);
-                if (modelType.GetTypeInfo().IsAssignableFrom(listType.GetTypeInfo()))
+                if (modelType.IsAssignableFrom(listType))
                 {
                     return CreateInstance(context, listType);
                 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
@@ -194,8 +194,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 // reflection does not provide information about the implicit parameterless constructor for a struct.
                 // This binder would eventually fail to construct an instance of the struct as the Linq's NewExpression
                 // compile fails to construct it.
-                var modelTypeInfo = bindingContext.ModelType.GetTypeInfo();
-                if (modelTypeInfo.IsAbstract || modelTypeInfo.GetConstructor(Type.EmptyTypes) == null)
+                var modelType = bindingContext.ModelType;
+                if (modelType.IsAbstract || modelType.GetConstructor(Type.EmptyTypes) == null)
                 {
                     var metadata = bindingContext.ModelMetadata;
                     switch (metadata.MetadataKind)
@@ -203,18 +203,18 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                         case ModelMetadataKind.Parameter:
                             throw new InvalidOperationException(
                                 Resources.FormatComplexObjectModelBinder_NoSuitableConstructor_ForParameter(
-                                    modelTypeInfo.FullName,
+                                    modelType.FullName,
                                     metadata.ParameterName));
                         case ModelMetadataKind.Property:
                             throw new InvalidOperationException(
                                 Resources.FormatComplexObjectModelBinder_NoSuitableConstructor_ForProperty(
-                                    modelTypeInfo.FullName,
+                                    modelType.FullName,
                                     metadata.PropertyName,
                                     bindingContext.ModelMetadata.ContainerType.FullName));
                         case ModelMetadataKind.Type:
                             throw new InvalidOperationException(
                                 Resources.FormatComplexObjectModelBinder_NoSuitableConstructor_ForType(
-                                    modelTypeInfo.FullName));
+                                    modelType.FullName));
                     }
                 }
 
@@ -666,7 +666,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             // Value types have copy-by-value semantics, which prevents us from updating
             // properties that are marked readonly.
-            if (propertyType.GetTypeInfo().IsValueType)
+            if (propertyType.IsValueType)
             {
                 return false;
             }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
@@ -440,7 +440,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
         {
             // Value types have copy-by-value semantics, which prevents us from updating
             // properties that are marked readonly.
-            if (propertyType.GetTypeInfo().IsValueType)
+            if (propertyType.IsValueType)
             {
                 return false;
             }
@@ -482,8 +482,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 // reflection does not provide information about the implicit parameterless constructor for a struct.
                 // This binder would eventually fail to construct an instance of the struct as the Linq's NewExpression
                 // compile fails to construct it.
-                var modelTypeInfo = bindingContext.ModelType.GetTypeInfo();
-                if (modelTypeInfo.IsAbstract || modelTypeInfo.GetConstructor(Type.EmptyTypes) == null)
+                var modelType = bindingContext.ModelType;
+                if (modelType.IsAbstract || modelType.GetConstructor(Type.EmptyTypes) == null)
                 {
                     var metadata = bindingContext.ModelMetadata;
                     switch (metadata.MetadataKind)
@@ -491,18 +491,18 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                         case ModelMetadataKind.Parameter:
                             throw new InvalidOperationException(
                                 Resources.FormatComplexTypeModelBinder_NoParameterlessConstructor_ForParameter(
-                                    modelTypeInfo.FullName,
+                                    modelType.FullName,
                                     metadata.ParameterName));
                         case ModelMetadataKind.Property:
                             throw new InvalidOperationException(
                                 Resources.FormatComplexTypeModelBinder_NoParameterlessConstructor_ForProperty(
-                                    modelTypeInfo.FullName,
+                                    modelType.FullName,
                                     metadata.PropertyName,
                                     bindingContext.ModelMetadata.ContainerType.FullName));
                         case ModelMetadataKind.Type:
                             throw new InvalidOperationException(
                                 Resources.FormatComplexTypeModelBinder_NoParameterlessConstructor_ForType(
-                                    modelTypeInfo.FullName));
+                                    modelType.FullName));
                     }
                 }
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FormCollectionModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FormCollectionModelBinderProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
 
             var modelType = context.Metadata.ModelType;
 
-            if (typeof(FormCollection).GetTypeInfo().IsAssignableFrom(modelType))
+            if (typeof(FormCollection).IsAssignableFrom(modelType))
             {
                 throw new InvalidOperationException(
                     Resources.FormatFormCollectionModelBinder_CannotBindToFormCollection(

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/KeyValuePairModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/KeyValuePairModelBinderProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -22,11 +22,11 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var modelTypeInfo = context.Metadata.ModelType.GetTypeInfo();
-            if (modelTypeInfo.IsGenericType &&
-                modelTypeInfo.GetGenericTypeDefinition().GetTypeInfo() == typeof(KeyValuePair<,>).GetTypeInfo())
+            var modelType = context.Metadata.ModelType;
+            if (modelType.IsGenericType &&
+                modelType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
             {
-                var typeArguments = modelTypeInfo.GenericTypeArguments;
+                var typeArguments = modelType.GenericTypeArguments;
 
                 var keyMetadata = context.MetadataProvider.GetMetadataForType(typeArguments[0]);
                 var keyBinder = context.CreateBinder(keyMetadata);

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultBindingMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultBindingMetadataProvider.cs
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
                     // attributes on the Property Type.
                     var matchingAttributes = context.PropertyAttributes.OfType<BindingBehaviorAttribute>();
                     return matchingAttributes.FirstOrDefault()
-                        ?? context.Key.ContainerType.GetTypeInfo()
+                        ?? context.Key.ContainerType
                             .GetCustomAttributes(typeof(BindingBehaviorAttribute), inherit: true)
                             .OfType<BindingBehaviorAttribute>()
                             .FirstOrDefault();

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultValidationMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/DefaultValidationMetadataProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
                 {
                     // No IPropertyValidationFilter attributes on the property.
                     // Check if container has such an attribute.
-                    validationFilter = context.Key.ContainerType.GetTypeInfo()
+                    validationFilter = context.Key.ContainerType
                         .GetCustomAttributes(inherit: true)
                         .OfType<IPropertyValidationFilter>()
                         .FirstOrDefault();

--- a/src/Mvc/Mvc.Core/src/ModelBinding/ModelBindingHelper.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/ModelBindingHelper.cs
@@ -551,8 +551,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             }
 
             // Will we be able to activate an instance and use that?
-            return modelType.GetTypeInfo().IsClass &&
-                !modelType.GetTypeInfo().IsAbstract &&
+            return modelType.IsClass &&
+                !modelType.IsAbstract &&
                 typeof(ICollection<T>).IsAssignableFrom(modelType);
         }
 
@@ -673,7 +673,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             if (value == null)
             {
                 // For value types, treat null values as though they were the default value for the type.
-                return type.GetTypeInfo().IsValueType ? Activator.CreateInstance(type) : null;
+                return type.IsValueType ? Activator.CreateInstance(type) : null;
             }
 
             if (type.IsAssignableFrom(value.GetType()))
@@ -756,7 +756,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
             if (!(canConvertFrom || converter.CanConvertTo(destinationType)))
             {
                 // EnumConverter cannot convert integer, so we verify manually
-                if (destinationType.GetTypeInfo().IsEnum &&
+                if (destinationType.IsEnum &&
                     (value is int ||
                     value is uint ||
                     value is long ||

--- a/src/Mvc/Mvc.Core/src/ModelBinding/SuppressChildValidationMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/SuppressChildValidationMetadataProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding
                 return true;
             }
 
-            return IsMatchingName(type.GetTypeInfo().BaseType);
+            return IsMatchingName(type.BaseType);
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/MvcCoreLoggerExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcCoreLoggerExtensions.cs
@@ -1569,7 +1569,7 @@ namespace Microsoft.AspNetCore.Mvc
             if (enumerableType != null)
             {
                 var elementType = enumerableType.GenericTypeArguments[0];
-                if (elementType.IsGenericType && elementType.GetGenericTypeDefinition().GetTypeInfo() == typeof(KeyValuePair<,>).GetTypeInfo())
+                if (elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
                 {
                     _attemptingToBindCollectionOfKeyValuePair(logger, modelName, modelName, modelName, modelName, modelName, modelName, null);
                     return;

--- a/src/Mvc/Mvc.Core/test/ApplicationModels/ActionModelTest.cs
+++ b/src/Mvc/Mvc.Core/test/ApplicationModels/ActionModelTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                     // Ensure non-default value
                     Assert.NotEmpty((IDictionary<object, object>)value1);
                 }
-                else if (property.PropertyType.GetTypeInfo().IsValueType ||
+                else if (property.PropertyType.IsValueType ||
                     Nullable.GetUnderlyingType(property.PropertyType) != null)
                 {
                     Assert.Equal(value1, value2);

--- a/src/Mvc/Mvc.Core/test/ApplicationModels/AttributeRouteModelTests.cs
+++ b/src/Mvc/Mvc.Core/test/ApplicationModels/AttributeRouteModelTests.cs
@@ -33,14 +33,14 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                 var value1 = property.GetValue(route);
                 var value2 = property.GetValue(route2);
 
-                if (typeof(IEnumerable<object>).GetTypeInfo().IsAssignableFrom(property.PropertyType.GetTypeInfo()))
+                if (typeof(IEnumerable<object>).IsAssignableFrom(property.PropertyType))
                 {
                     Assert.Equal<object>((IEnumerable<object>)value1, (IEnumerable<object>)value2);
 
                     // Ensure non-default value
                     Assert.NotEmpty((IEnumerable<object>)value1);
                 }
-                else if (property.PropertyType.GetTypeInfo().IsValueType ||
+                else if (property.PropertyType.IsValueType ||
                     Nullable.GetUnderlyingType(property.PropertyType) != null)
                 {
                     Assert.Equal(value1, value2);

--- a/src/Mvc/Mvc.Core/test/ApplicationModels/ControllerModelTest.cs
+++ b/src/Mvc/Mvc.Core/test/ApplicationModels/ControllerModelTest.cs
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
                     // Ensure non-default value
                     Assert.NotEmpty((IDictionary<object, object>)value1);
                 }
-                else if (property.PropertyType.GetTypeInfo().IsValueType ||
+                else if (property.PropertyType.IsValueType ||
                     Nullable.GetUnderlyingType(property.PropertyType) != null)
                 {
                     Assert.Equal(value1, value2);

--- a/src/Mvc/Mvc.Core/test/ApplicationParts/AssemblyPartTest.cs
+++ b/src/Mvc/Mvc.Core/test/ApplicationParts/AssemblyPartTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         public void AssemblyPart_Name_ReturnsAssemblyName()
         {
             // Arrange
-            var part = new AssemblyPart(typeof(AssemblyPartTest).GetTypeInfo().Assembly);
+            var part = new AssemblyPart(typeof(AssemblyPartTest).Assembly);
 
             // Act
             var name = part.Name;
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         public void AssemblyPart_Types_ReturnsDefinedTypes()
         {
             // Arrange
-            var assembly = typeof(AssemblyPartTest).GetTypeInfo().Assembly;
+            var assembly = typeof(AssemblyPartTest).Assembly;
             var part = new AssemblyPart(assembly);
 
             // Act
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         public void AssemblyPart_Assembly_ReturnsAssembly()
         {
             // Arrange
-            var assembly = typeof(AssemblyPartTest).GetTypeInfo().Assembly;
+            var assembly = typeof(AssemblyPartTest).Assembly;
             var part = new AssemblyPart(assembly);
 
             // Act & Assert

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/MvcBuilderExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/MvcBuilderExtensionsTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc
             var manager = new ApplicationPartManager();
             var builder = new MvcBuilder(Mock.Of<IServiceCollection>(), manager);
 
-            var assembly = typeof(MvcBuilder).GetTypeInfo().Assembly;
+            var assembly = typeof(MvcBuilder).Assembly;
 
             // Act
             var result = builder.AddApplicationPart(assembly);

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/MvcCoreBuilderExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/MvcCoreBuilderExtensionsTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.DependencyInjection
             // Arrange
             var manager = new ApplicationPartManager();
             var builder = new MvcCoreBuilder(Mock.Of<IServiceCollection>(), manager);
-            var assembly = typeof(MvcCoreBuilder).GetTypeInfo().Assembly;
+            var assembly = typeof(MvcCoreBuilder).Assembly;
 
             // Act
             var result = builder.AddApplicationPart(assembly);

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/MvcCoreServiceCollectionExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/MvcCoreServiceCollectionExtensionsTest.cs
@@ -197,7 +197,7 @@ namespace Microsoft.AspNetCore.Mvc
             // Arrange
             var services = new ServiceCollection();
             var environment = new Mock<IWebHostEnvironment>(MockBehavior.Strict);
-            var assemblyName = typeof(MvcCoreServiceCollectionExtensionsTest).GetTypeInfo().Assembly.GetName();
+            var assemblyName = typeof(MvcCoreServiceCollectionExtensionsTest).Assembly.GetName();
             var applicationName = assemblyName.FullName;
             environment.SetupGet(e => e.ApplicationName).Returns(applicationName).Verifiable();
             services.AddSingleton<IWebHostEnvironment>(environment.Object);

--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -183,15 +183,14 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
 
             // IsEnum et cetera
             var underlyingType = Nullable.GetUnderlyingType(context.Key.ModelType) ?? context.Key.ModelType;
-            var underlyingTypeInfo = underlyingType.GetTypeInfo();
 
-            if (underlyingTypeInfo.IsEnum)
+            if (underlyingType.IsEnum)
             {
                 // IsEnum
                 displayMetadata.IsEnum = true;
 
                 // IsFlagsEnum
-                displayMetadata.IsFlagsEnum = underlyingTypeInfo.IsDefined(typeof(FlagsAttribute), inherit: false);
+                displayMetadata.IsFlagsEnum = underlyingType.IsDefined(typeof(FlagsAttribute), inherit: false);
 
                 // EnumDisplayNamesAndValues and EnumNamesAndValues
                 //

--- a/src/Mvc/Mvc.Formatters.Xml/src/EnumerableWrapperProvider.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/EnumerableWrapperProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             var enumerableOfT = ClosedGenericMatcher.ExtractGenericInterface(
                 sourceEnumerableOfT,
                 typeof(IEnumerable<>));
-            if (!sourceEnumerableOfT.GetTypeInfo().IsInterface || enumerableOfT == null)
+            if (!sourceEnumerableOfT.IsInterface || enumerableOfT == null)
             {
                 throw new ArgumentException(
                     Resources.FormatEnumerableWrapperProvider_InvalidSourceEnumerableOfT(typeof(IEnumerable<>).Name),

--- a/src/Mvc/Mvc.Formatters.Xml/src/EnumerableWrapperProviderFactory.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/EnumerableWrapperProviderFactory.cs
@@ -48,11 +48,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters.Xml
             {
                 // Example: IEnumerable<SerializableError>
                 var declaredType = context.DeclaredType;
-                var declaredTypeInfo = declaredType.GetTypeInfo();
 
                 // We only wrap interfaces types(ex: IEnumerable<T>, IQueryable<T>, IList<T> etc.) and not
                 // concrete types like List<T>, Collection<T> which implement IEnumerable<T>.
-                if (declaredType != null && declaredTypeInfo.IsInterface && declaredTypeInfo.IsGenericType)
+                if (declaredType != null && declaredType.IsInterface && declaredType.IsGenericType)
                 {
                     var enumerableOfT = ClosedGenericMatcher.ExtractGenericInterface(
                         declaredType,

--- a/src/Mvc/Mvc.Formatters.Xml/src/ModelBinding/DataMemberRequiredBindingMetadataProvider.cs
+++ b/src/Mvc/Mvc.Formatters.Xml/src/ModelBinding/DataMemberRequiredBindingMetadataProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
             }
 
             // isDataContract == true iff the container type has at least one DataContractAttribute
-            var containerType = context.Key.ContainerType.GetTypeInfo();
+            var containerType = context.Key.ContainerType;
             var isDataContract = containerType.IsDefined(typeof(DataContractAttribute));
             if (isDataContract)
             {

--- a/src/Mvc/Mvc.NewtonsoftJson/src/BsonTempDataSerializer.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/BsonTempDataSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
             {
                 actualType = typeToSerialize.GetElementType();
             }
-            else if (typeToSerialize.GetTypeInfo().IsGenericType)
+            else if (typeToSerialize.IsGenericType)
             {
                 if (ClosedGenericMatcher.ExtractGenericInterface(typeToSerialize, typeof(IList<>)) != null)
                 {
@@ -240,10 +240,8 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
 
         private static bool IsSimpleType(Type type)
         {
-            var typeInfo = type.GetTypeInfo();
-
-            return typeInfo.IsPrimitive ||
-                typeInfo.IsEnum ||
+            return type.IsPrimitive ||
+                type.IsEnum ||
                 type.Equals(typeof(decimal)) ||
                 type.Equals(typeof(string)) ||
                 type.Equals(typeof(DateTime)) ||

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonPatchInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonPatchInputFormatter.cs
@@ -96,9 +96,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var modelTypeInfo = context.ModelType.GetTypeInfo();
-            if (!typeof(IJsonPatchDocument).GetTypeInfo().IsAssignableFrom(modelTypeInfo) ||
-                !modelTypeInfo.IsGenericType)
+            var modelType = context.ModelType;
+            if (!typeof(IJsonPatchDocument).IsAssignableFrom(modelType) ||
+                !modelType.IsGenericType)
             {
                 return false;
             }

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/test/AssemblyPartExtensionTest.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/test/AssemblyPartExtensionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         public void GetReferencePaths_ReturnsReferencesFromDependencyContext_IfPreserveCompilationContextIsSet()
         {
             // Arrange
-            var assembly = GetType().GetTypeInfo().Assembly;
+            var assembly = GetType().Assembly;
             var part = new AssemblyPart(assembly);
 
             // Act
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
             // Assert
             Assert.Contains(assembly.Location, references);
             Assert.Contains(
-                typeof(AssemblyPart).GetTypeInfo().Assembly.GetName().Name,
+                typeof(AssemblyPart).Assembly.GetName().Name,
                 references.Select(Path.GetFileNameWithoutExtension));
         }
 
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationParts
         {
             // Arrange
             // src projects do not have preserveCompilationContext specified.
-            var assembly = typeof(AssemblyPart).GetTypeInfo().Assembly;
+            var assembly = typeof(AssemblyPart).Assembly;
             var part = new AssemblyPart(assembly);
 
             // Act

--- a/src/Mvc/Mvc.Razor/src/Compilation/DefaultRazorPageFactoryProvider.cs
+++ b/src/Mvc/Mvc.Razor/src/Compilation/DefaultRazorPageFactoryProvider.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
             if (viewType != null)
             {
                 var newExpression = Expression.New(viewType);
-                var pathProperty = viewType.GetTypeInfo().GetProperty(nameof(IRazorPage.Path));
+                var pathProperty = viewType.GetProperty(nameof(IRazorPage.Path));
 
                 // Generate: page.Path = relativePath;
                 // Use the normalized path specified from the result.

--- a/src/Mvc/Mvc.Razor/src/RazorPagePropertyActivator.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPagePropertyActivator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -36,8 +36,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             if (viewDataDictionaryModelType != null)
             {
                 _viewDataDictionaryType = typeof(ViewDataDictionary<>).MakeGenericType(viewDataDictionaryModelType);
-                _rootFactory = ViewDataDictionaryFactory.CreateFactory(viewDataDictionaryModelType.GetTypeInfo());
-                _nestedFactory = ViewDataDictionaryFactory.CreateNestedFactory(viewDataDictionaryModelType.GetTypeInfo());
+                _rootFactory = ViewDataDictionaryFactory.CreateFactory(viewDataDictionaryModelType);
+                _nestedFactory = ViewDataDictionaryFactory.CreateNestedFactory(viewDataDictionaryModelType);
             }
 
             _propertyActivators = PropertyActivator<ViewContext>.GetPropertiesToActivate(

--- a/src/Mvc/Mvc.Razor/src/TagHelpers/UrlResolutionTagHelper.cs
+++ b/src/Mvc/Mvc.Razor/src/TagHelpers/UrlResolutionTagHelper.cs
@@ -285,7 +285,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
                         nameof(IUrlHelper.Content),
                         "removeTagHelper",
                         typeof(UrlResolutionTagHelper).FullName,
-                        typeof(UrlResolutionTagHelper).GetTypeInfo().Assembly.GetName().Name));
+                        typeof(UrlResolutionTagHelper).Assembly.GetName().Name));
             }
 
             resolvedUrl = new EncodeFirstSegmentContent(

--- a/src/Mvc/Mvc.Razor/test/RazorPageCreateTagHelperTest.cs
+++ b/src/Mvc/Mvc.Razor/test/RazorPageCreateTagHelperTest.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             serviceProvider.Setup(mock => mock.GetService(typeof(ITypeActivatorCache)))
                            .Returns(typeActivator);
             serviceProvider.Setup(mock => mock.GetService(It.Is<Type>(serviceType =>
-                serviceType.GetTypeInfo().IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))))
+                serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))))
                 .Returns<Type>(serviceType =>
                 {
                     var enumerableType = serviceType.GetGenericArguments().First();

--- a/src/Mvc/Mvc.Razor/test/TagHelpers/UrlResolutionTagHelperTest.cs
+++ b/src/Mvc/Mvc.Razor/test/TagHelpers/UrlResolutionTagHelperTest.cs
@@ -313,7 +313,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.TagHelpers
                 nameof(IUrlHelper.Content),
                 "removeTagHelper",
                 typeof(UrlResolutionTagHelper).FullName,
-                typeof(UrlResolutionTagHelper).GetTypeInfo().Assembly.GetName().Name);
+                typeof(UrlResolutionTagHelper).Assembly.GetName().Name);
             var tagHelperOutput = new TagHelperOutput(
                 tagName: "a",
                 attributes: new TagHelperAttributeList

--- a/src/Mvc/Mvc.TagHelpers/src/JavaScriptResources.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/JavaScriptResources.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
     /// </summary>
     internal static class JavaScriptResources
     {
-        private static readonly Assembly ResourcesAssembly = typeof(JavaScriptResources).GetTypeInfo().Assembly;
+        private static readonly Assembly ResourcesAssembly = typeof(JavaScriptResources).Assembly;
 
         private static readonly ConcurrentDictionary<string, string> Cache =
             new ConcurrentDictionary<string, string>(StringComparer.Ordinal);

--- a/src/Mvc/Mvc.ViewFeatures/src/ExpressionHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ExpressionHelper.cs
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             // Check whether GetDefaultMembers() (if present in CoreCLR) would return a member of this type. Compiler
             // names the indexer property, if any, in a generated [DefaultMember] attribute for the containing type.
             var declaringType = methodExpression.Method.DeclaringType;
-            var defaultMember = declaringType.GetTypeInfo().GetCustomAttribute<DefaultMemberAttribute>(inherit: true);
+            var defaultMember = declaringType.GetCustomAttribute<DefaultMemberAttribute>(inherit: true);
             if (defaultMember == null)
             {
                 return false;

--- a/src/Mvc/Mvc.ViewFeatures/src/TemplateRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/TemplateRenderer.cs
@@ -188,7 +188,6 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         {
             // Not returning type name here for IEnumerable<IFormFile> since we will be returning
             // a more specific name, IEnumerableOfIFormFileName.
-            var fieldTypeInfo = fieldType.GetTypeInfo();
 
             if (typeof(IEnumerable<IFormFile>) != fieldType)
             {
@@ -203,7 +202,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
             else if (!modelMetadata.IsComplexType)
             {
                 // IsEnum is false for the Enum class itself
-                if (fieldTypeInfo.IsEnum)
+                if (fieldType.IsEnum)
                 {
                     // Same as fieldType.BaseType.Name in this case
                     yield return "Enum";
@@ -216,12 +215,12 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 yield return "String";
                 yield break;
             }
-            else if (!fieldTypeInfo.IsInterface)
+            else if (!fieldType.IsInterface)
             {
                 var type = fieldType;
                 while (true)
                 {
-                    type = type.GetTypeInfo().BaseType;
+                    type = type.BaseType;
                     if (type == null || type == typeof(object))
                     {
                         break;

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewComponents/DefaultViewComponentDescriptorProvider.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewComponents/DefaultViewComponentDescriptorProvider.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewComponents
             var selectedMethod = methods[0];
             if (string.Equals(selectedMethod.Name, AsyncMethodName, StringComparison.Ordinal))
             {
-                if (!selectedMethod.ReturnType.GetTypeInfo().IsGenericType ||
+                if (!selectedMethod.ReturnType.IsGenericType ||
                     selectedMethod.ReturnType.GetGenericTypeDefinition() != typeof(Task<>))
                 {
                     throw new InvalidOperationException(Resources.FormatViewComponent_AsyncMethod_ShouldReturnTask(

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionaryFactory.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionaryFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
     internal static class ViewDataDictionaryFactory
     {
-        public static Func<IModelMetadataProvider, ModelStateDictionary, ViewDataDictionary> CreateFactory(TypeInfo modelType)
+        public static Func<IModelMetadataProvider, ModelStateDictionary, ViewDataDictionary> CreateFactory(Type modelType)
         {
             if (modelType == null)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
                 .Compile();
         }
 
-        public static Func<ViewDataDictionary, ViewDataDictionary> CreateNestedFactory(TypeInfo modelType)
+        public static Func<ViewDataDictionary, ViewDataDictionary> CreateNestedFactory(Type modelType)
         {
             if (modelType == null)
             {

--- a/src/Mvc/Mvc/src/MvcServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc/src/MvcServiceCollectionExtensions.cs
@@ -326,13 +326,13 @@ namespace Microsoft.Extensions.DependencyInjection
 
         internal static void AddTagHelpersFrameworkParts(ApplicationPartManager partManager)
         {
-            var mvcTagHelpersAssembly = typeof(InputTagHelper).GetTypeInfo().Assembly;
+            var mvcTagHelpersAssembly = typeof(InputTagHelper).Assembly;
             if (!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcTagHelpersAssembly))
             {
                 partManager.ApplicationParts.Add(new FrameworkAssemblyPart(mvcTagHelpersAssembly));
             }
 
-            var mvcRazorAssembly = typeof(UrlResolutionTagHelper).GetTypeInfo().Assembly;
+            var mvcRazorAssembly = typeof(UrlResolutionTagHelper).Assembly;
             if (!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcRazorAssembly))
             {
                 partManager.ApplicationParts.Add(new FrameworkAssemblyPart(mvcRazorAssembly));

--- a/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
+++ b/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
@@ -286,7 +286,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             var hostingEnvironment = new Mock<IWebHostEnvironment>();
             hostingEnvironment.SetupGet(e => e.ApplicationName)
-                .Returns(typeof(MvcOptionsSetupTest).GetTypeInfo().Assembly.GetName().Name);
+                .Returns(typeof(MvcOptionsSetupTest).Assembly.GetName().Name);
 
             hostingEnvironment.SetupGet(e => e.ContentRootFileProvider)
                 .Returns(Mock.Of<IFileProvider>());

--- a/src/Mvc/Mvc/test/MvcServiceCollectionExtensionsTest.cs
+++ b/src/Mvc/Mvc/test/MvcServiceCollectionExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Mvc
                     // 'single-registration' services should only have one implementation registered.
                     AssertServiceCountEquals(services, service.ServiceType, 1);
                 }
-                else if (service.ImplementationType != null && !service.ImplementationType.GetTypeInfo().Assembly.FullName.Contains("Mvc"))
+                else if (service.ImplementationType != null && !service.ImplementationType.Assembly.FullName.Contains("Mvc"))
                 {
                     // Ignore types that don't come from MVC
                 }
@@ -277,8 +277,8 @@ namespace Microsoft.AspNetCore.Mvc
         public void AddMvc_AddsAssemblyPartsForFrameworkTagHelpers()
         {
             // Arrange
-            var mvcRazorAssembly = typeof(UrlResolutionTagHelper).GetTypeInfo().Assembly;
-            var mvcTagHelpersAssembly = typeof(InputTagHelper).GetTypeInfo().Assembly;
+            var mvcRazorAssembly = typeof(UrlResolutionTagHelper).Assembly;
+            var mvcTagHelpersAssembly = typeof(InputTagHelper).Assembly;
             var services = new ServiceCollection();
             var providers = new IApplicationFeatureProvider[]
             {
@@ -304,8 +304,8 @@ namespace Microsoft.AspNetCore.Mvc
         public void AddMvcTwice_DoesNotAddDuplicateFrameworkParts()
         {
             // Arrange
-            var mvcRazorAssembly = typeof(UrlResolutionTagHelper).GetTypeInfo().Assembly;
-            var mvcTagHelpersAssembly = typeof(InputTagHelper).GetTypeInfo().Assembly;
+            var mvcRazorAssembly = typeof(UrlResolutionTagHelper).Assembly;
+            var mvcTagHelpersAssembly = typeof(InputTagHelper).Assembly;
             var services = new ServiceCollection();
             var providers = new IApplicationFeatureProvider[]
             {
@@ -395,7 +395,7 @@ namespace Microsoft.AspNetCore.Mvc
             // Act & Assert
             using (var scope = scopeFactory.CreateScope())
             {
-                foreach (var serviceType in services.Select(d => d.ServiceType).Where(t => !t.GetTypeInfo().IsGenericTypeDefinition).Distinct())
+                foreach (var serviceType in services.Select(d => d.ServiceType).Where(t => !t.IsGenericTypeDefinition).Distinct())
                 {
                     // This will throw if something is invalid.
                     scope.ServiceProvider.GetService(typeof(IEnumerable<>).MakeGenericType(serviceType));
@@ -443,7 +443,7 @@ namespace Microsoft.AspNetCore.Mvc
                 var multiRegistrationServiceTypes = MultiRegistrationServiceTypes;
                 return services
                     .Where(sd => !multiRegistrationServiceTypes.Keys.Contains(sd.ServiceType))
-                    .Where(sd => sd.ServiceType.GetTypeInfo().Assembly.FullName.Contains("Mvc"))
+                    .Where(sd => sd.ServiceType.Assembly.FullName.Contains("Mvc"))
                     .Select(sd => sd.ServiceType);
             }
         }
@@ -627,7 +627,7 @@ namespace Microsoft.AspNetCore.Mvc
             var environment = new Mock<IWebHostEnvironment>();
             environment
                 .Setup(e => e.ApplicationName)
-                .Returns(typeof(MvcServiceCollectionExtensionsTest).GetTypeInfo().Assembly.GetName().Name);
+                .Returns(typeof(MvcServiceCollectionExtensionsTest).Assembly.GetName().Name);
 
             return environment.Object;
         }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/Application.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/Application.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
 
         private string GetInformationalVersion()
         {
-            var assembly = typeof(Application).GetTypeInfo().Assembly;
+            var assembly = typeof(Application).Assembly;
             var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             return attribute.InformationalVersion;
         }

--- a/src/Razor/tools/RazorSyntaxGenerator/Program.cs
+++ b/src/Razor/tools/RazorSyntaxGenerator/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -79,7 +79,7 @@ namespace RazorSyntaxGenerator
         private static void WriteUsage()
         {
             Console.WriteLine("Invalid usage");
-            Console.WriteLine(typeof(Program).GetTypeInfo().Assembly.ManifestModule.Name + " input-file output-file [/write-test]");
+            Console.WriteLine(typeof(Program).Assembly.ManifestModule.Name + " input-file output-file [/write-test]");
         }
 
         private static void WriteToFile(Tree tree, Action<TextWriter, Tree> writeAction, string outputFile)

--- a/src/Security/Authentication/WsFederation/samples/WsFedSample/Program.cs
+++ b/src/Security/Authentication/WsFederation/samples/WsFedSample/Program.cs
@@ -45,7 +45,7 @@ namespace WsFedSample
 
         private static X509Certificate2 LoadCertificate()
         {
-            var assembly = typeof(Startup).GetTypeInfo().Assembly;
+            var assembly = typeof(Startup).Assembly;
             var embeddedFileProvider = new EmbeddedFileProvider(assembly, "WsFedSample");
             var certificateFileInfo = embeddedFileProvider.GetFileInfo("compiler/resources/cert.pfx");
             using (var certificateStream = certificateFileInfo.CreateReadStream())

--- a/src/Servers/IIS/IIS/src/StartupHook.cs
+++ b/src/Servers/IIS/IIS/src/StartupHook.cs
@@ -68,11 +68,11 @@ internal class StartupHook
                 RuntimeDisplayName = RuntimeInformation.FrameworkDescription
             };
 
-            var systemRuntimeAssembly = typeof(System.ComponentModel.DefaultValueAttribute).GetTypeInfo().Assembly;
+            var systemRuntimeAssembly = typeof(System.ComponentModel.DefaultValueAttribute).Assembly;
             var assemblyVersion = new AssemblyName(systemRuntimeAssembly.FullName).Version.ToString();
             var clrVersion = assemblyVersion;
             model.RuntimeArchitecture = RuntimeInformation.ProcessArchitecture.ToString();
-            var currentAssembly = typeof(ErrorPage).GetTypeInfo().Assembly;
+            var currentAssembly = typeof(ErrorPage).Assembly;
             model.CurrentAssemblyVesion = currentAssembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 .InformationalVersion;

--- a/src/Servers/Kestrel/Core/test/KestrelEventSourceTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelEventSourceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void ExistsWithCorrectId()
         {
-            var esType = typeof(KestrelServer).GetTypeInfo().Assembly.GetType(
+            var esType = typeof(KestrelServer).Assembly.GetType(
                 "Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.KestrelEventSource",
                 throwOnError: true,
                 ignoreCase: false

--- a/src/Servers/Kestrel/shared/test/TransportTestHelpers/TestServer.cs
+++ b/src/Servers/Kestrel/shared/test/TransportTestHelpers/TestServer.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                             });
                             configureServices(services);
                         })
-                        .UseSetting(WebHostDefaults.ApplicationKey, typeof(TestServer).GetTypeInfo().Assembly.FullName)
+                        .UseSetting(WebHostDefaults.ApplicationKey, typeof(TestServer).Assembly.FullName)
                         .UseSetting(WebHostDefaults.ShutdownTimeoutKey, TestConstants.DefaultTimeout.TotalSeconds.ToString(CultureInfo.InvariantCulture))
                         .Configure(app => { app.Run(_app); });
                 })

--- a/src/Shared/ActivatorUtilities/ActivatorUtilities.cs
+++ b/src/Shared/ActivatorUtilities/ActivatorUtilities.cs
@@ -47,13 +47,11 @@ namespace Microsoft.Extensions.Internal
 
             ConstructorMatcher bestMatcher = default;
 
-            if (!instanceType.GetTypeInfo().IsAbstract)
+            if (!instanceType.IsAbstract)
             {
-                foreach (var constructor in instanceType
-                    .GetTypeInfo()
-                    .DeclaredConstructors)
+                foreach (var constructor in instanceType.GetConstructors())
                 {
-                    if (!constructor.IsStatic && constructor.IsPublic)
+                    if (!constructor.IsStatic)
                     {
                         var matcher = new ConstructorMatcher(constructor);
                         var isPreferred = constructor.IsDefined(typeof(ActivatorUtilitiesConstructorAttribute), false);
@@ -237,9 +235,9 @@ namespace Microsoft.Extensions.Internal
             ref ConstructorInfo matchingConstructor,
             ref int?[] parameterMap)
         {
-            foreach (var constructor in instanceType.GetTypeInfo().DeclaredConstructors)
+            foreach (var constructor in instanceType.GetConstructors())
             {
-                if (constructor.IsStatic || !constructor.IsPublic)
+                if (constructor.IsStatic)
                 {
                     continue;
                 }
@@ -267,9 +265,9 @@ namespace Microsoft.Extensions.Internal
             ref int?[] parameterMap)
         {
             var seenPreferred = false;
-            foreach (var constructor in instanceType.GetTypeInfo().DeclaredConstructors)
+            foreach (var constructor in instanceType.GetConstructors())
             {
-                if (constructor.IsStatic || !constructor.IsPublic)
+                if (constructor.IsStatic)
                 {
                     continue;
                 }
@@ -304,7 +302,7 @@ namespace Microsoft.Extensions.Internal
             for (var i = 0; i < argumentTypes.Length; i++)
             {
                 var foundMatch = false;
-                var givenParameter = argumentTypes[i].GetTypeInfo();
+                var givenParameter = argumentTypes[i];
 
                 for (var j = 0; j < constructorParameters.Length; j++)
                 {
@@ -314,7 +312,7 @@ namespace Microsoft.Extensions.Internal
                         continue;
                     }
 
-                    if (constructorParameters[j].ParameterType.GetTypeInfo().IsAssignableFrom(givenParameter))
+                    if (constructorParameters[j].ParameterType.IsAssignableFrom(givenParameter))
                     {
                         foundMatch = true;
                         parameterMap[j] = i;
@@ -350,13 +348,13 @@ namespace Microsoft.Extensions.Internal
                 var applyExactLength = 0;
                 for (var givenIndex = 0; givenIndex != givenParameters.Length; givenIndex++)
                 {
-                    var givenType = givenParameters[givenIndex]?.GetType().GetTypeInfo();
+                    var givenType = givenParameters[givenIndex]?.GetType();
                     var givenMatched = false;
 
                     for (var applyIndex = applyIndexStart; givenMatched == false && applyIndex != _parameters.Length; ++applyIndex)
                     {
                         if (_parameterValues[applyIndex] == null &&
-                            _parameters[applyIndex].ParameterType.GetTypeInfo().IsAssignableFrom(givenType))
+                            _parameters[applyIndex].ParameterType.IsAssignableFrom(givenType))
                         {
                             givenMatched = true;
                             _parameterValues[applyIndex] = givenParameters[givenIndex];

--- a/src/Shared/BenchmarkRunner/Program.cs
+++ b/src/Shared/BenchmarkRunner/Program.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.BenchmarkDotNet.Runner
             BeforeMain(args);
 
             AssignConfiguration(ref args);
-            var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly)
+            var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
                 .Run(args, GetConfig());
 
             foreach (var summary in summaries)

--- a/src/Shared/ClosedGenericMatcher/ClosedGenericMatcher.cs
+++ b/src/Shared/ClosedGenericMatcher/ClosedGenericMatcher.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.Internal
         private static bool IsGenericInstantiation(Type candidate, Type interfaceType)
         {
             return
-                candidate.GetTypeInfo().IsGenericType &&
+                candidate.IsGenericType &&
                 candidate.GetGenericTypeDefinition() == interfaceType;
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.Extensions.Internal
             }
 
             // BaseType will be null for object and interfaces, which means we've reached 'bottom'.
-            var baseType = queryType?.GetTypeInfo().BaseType;
+            var baseType = queryType?.BaseType;
             if (baseType == null)
             {
                 return null;

--- a/src/Shared/ObjectMethodExecutor/ObjectMethodExecutorFSharpSupport.cs
+++ b/src/Shared/ObjectMethodExecutor/ObjectMethodExecutorFSharpSupport.cs
@@ -111,14 +111,12 @@ namespace Microsoft.Extensions.Internal
             var fsharpOptionOfTaskCreationOptionsType = fsharpOptionType
                 .MakeGenericType(typeof(TaskCreationOptions));
             _fsharpOptionOfTaskCreationOptionsNoneProperty = fsharpOptionOfTaskCreationOptionsType
-                .GetTypeInfo()
                 .GetRuntimeProperty("None");
 
             // Get a reference to FSharpOption<CancellationToken>.None
             var fsharpOptionOfCancellationTokenType = fsharpOptionType
                 .MakeGenericType(typeof(CancellationToken));
             _fsharpOptionOfCancellationTokenNoneProperty = fsharpOptionOfCancellationTokenType
-                .GetTypeInfo()
                 .GetRuntimeProperty("None");
 
             // Get a reference to FSharpAsync.StartAsTask<>

--- a/src/SignalR/server/Core/src/Internal/HubReflectionHelper.cs
+++ b/src/SignalR/server/Core/src/Internal/HubReflectionHelper.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
                 return false;
             }
 
-            var baseType = baseDefinition.GetTypeInfo().IsGenericType ? baseDefinition.GetGenericTypeDefinition() : baseDefinition;
+            var baseType = baseDefinition.IsGenericType ? baseDefinition.GetGenericTypeDefinition() : baseDefinition;
             return typeof(Hub) != baseType;
         }
     }

--- a/src/Tools/Microsoft.dotnet-openapi/src/Application.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Application.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.OpenApi
 
         private string GetInformationalVersion()
         {
-            var assembly = typeof(Application).GetTypeInfo().Assembly;
+            var assembly = typeof(Application).Assembly;
             var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             return attribute.InformationalVersion;
         }

--- a/src/Tools/dotnet-sql-cache/src/Program.cs
+++ b/src/Tools/dotnet-sql-cache/src/Program.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
                 };
 
                 app.HelpOption();
-                app.VersionOptionFromAssemblyAttributes(typeof(Program).GetTypeInfo().Assembly);
+                app.VersionOptionFromAssemblyAttributes(typeof(Program).Assembly);
                 var verbose = app.VerboseOption();
 
                 app.Command("create", command =>

--- a/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
+++ b/src/Tools/dotnet-user-secrets/src/CommandLineOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.SecretManager.Tools
             };
 
             app.HelpOption();
-            app.VersionOptionFromAssemblyAttributes(typeof(Program).GetTypeInfo().Assembly);
+            app.VersionOptionFromAssemblyAttributes(typeof(Program).Assembly);
 
             var optionVerbose = app.VerboseOption();
 

--- a/src/Tools/dotnet-watch/src/CommandLineOptions.cs
+++ b/src/Tools/dotnet-watch/src/CommandLineOptions.cs
@@ -88,7 +88,7 @@ Examples:
             var optList = app.Option("--list", "Lists all discovered files without starting the watcher",
                 CommandOptionType.NoValue);
 
-            app.VersionOptionFromAssemblyAttributes(typeof(Program).GetTypeInfo().Assembly);
+            app.VersionOptionFromAssemblyAttributes(typeof(Program).Assembly);
 
             if (app.Execute(args) != 0)
             {

--- a/src/Tools/dotnet-watch/test/TestProjects/GlobbingApp/Program.cs
+++ b/src/Tools/dotnet-watch/test/TestProjects/GlobbingApp/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,7 +16,7 @@ namespace ConsoleApplication
             Console.WriteLine("Started");
             // Process ID is insufficient because PID's may be reused.
             Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
-            Console.WriteLine("Defined types = " + typeof(Program).GetTypeInfo().Assembly.DefinedTypes.Count());
+            Console.WriteLine("Defined types = " + typeof(Program).Assembly.DefinedTypes.Count());
             Thread.Sleep(Timeout.Infinite);
         }
     }


### PR DESCRIPTION
GetTypeInfo() calls are no longer necessary just to use Reflection APIs. And typically they [allocate a small `TypeDelegator` object](https://github.com/dotnet/runtime/blob/88ecbab85beead9c7d9406ee2f3ea468b1d4cd1e/src/libraries/System.Private.CoreLib/src/System/Reflection/IntrospectionExtensions.cs#L16) when used, so they should be avoided when not necessary.

I removed the obvious cases from the product, and a few occurrences in `test` code. However, I didn't tackle every place `test` code was calling it as there is a diminishing return.

Similar work is done in dotnet/runtime:

* https://github.com/dotnet/runtime/pull/44414
* https://github.com/dotnet/runtime/pull/44891
