### PR TITLE
Fix dotnet watch for Debian images by not depending on pgrep

### DIFF
--- a/src/Shared/Process/ProcessExtensions.cs
+++ b/src/Shared/Process/ProcessExtensions.cs
@@ -30,7 +30,86 @@ namespace Microsoft.Extensions.Internal
             }
             else
             {
+                var children = new HashSet<int>();
+                GetAllChildIdsUnix(pid, children, timeout);
+                foreach (var childId in children)
+                {
+                    KillProcessUnix(childId, timeout);
+                }
+                KillProcessUnix(pid, timeout);
+            }
+        }
+
+        public static void KillTreeNoPgrep(this Process process) => process.KillTreeNoPgrep(_defaultTimeout);
+
+        public static void KillTreeNoPgrep(this Process process, TimeSpan timeout)
+        {
+            var pid = process.Id;
+            if (_isWindows)
+            {
+                RunProcessAndWaitForExit(
+                    "taskkill",
+                    $"/T /F /PID {pid}",
+                    timeout,
+                    out var _);
+            }
+            else
+            {
                 process.Kill(entireProcessTree: true);
+            }
+        }
+
+        private static void GetAllChildIdsUnix(int parentId, ISet<int> children, TimeSpan timeout)
+        {
+            try
+            {
+                RunProcessAndWaitForExit(
+                    "pgrep",
+                    $"-P {parentId}",
+                    timeout,
+                    out var stdout);
+
+                if (!string.IsNullOrEmpty(stdout))
+                {
+                    using (var reader = new StringReader(stdout))
+                    {
+                        while (true)
+                        {
+                            var text = reader.ReadLine();
+                            if (text == null)
+                            {
+                                return;
+                            }
+
+                            if (int.TryParse(text, out var id))
+                            {
+                                children.Add(id);
+                                // Recursively get the children
+                                GetAllChildIdsUnix(id, children, timeout);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Win32Exception ex) when (ex.Message.Contains("No such file or directory"))
+            {
+                // This probably means that pgrep isn't installed. Nothing to be done?
+            }
+        }
+
+        private static void KillProcessUnix(int processId, TimeSpan timeout)
+        {
+            try
+            {
+                RunProcessAndWaitForExit(
+                    "kill",
+                    $"-TERM {processId}",
+                    timeout,
+                    out var stdout);
+            }
+            catch (Win32Exception ex) when (ex.Message.Contains("No such file or directory"))
+            {
+                // This probably means that the process is already dead
             }
         }
 

--- a/src/Shared/Process/ProcessExtensions.cs
+++ b/src/Shared/Process/ProcessExtensions.cs
@@ -30,67 +30,7 @@ namespace Microsoft.Extensions.Internal
             }
             else
             {
-                var children = new HashSet<int>();
-                GetAllChildIdsUnix(pid, children, timeout);
-                foreach (var childId in children)
-                {
-                    KillProcessUnix(childId, timeout);
-                }
-                KillProcessUnix(pid, timeout);
-            }
-        }
-
-        private static void GetAllChildIdsUnix(int parentId, ISet<int> children, TimeSpan timeout)
-        {
-            try
-            {
-                RunProcessAndWaitForExit(
-                    "pgrep",
-                    $"-P {parentId}",
-                    timeout,
-                    out var stdout);
-
-                if (!string.IsNullOrEmpty(stdout))
-                {
-                    using (var reader = new StringReader(stdout))
-                    {
-                        while (true)
-                        {
-                            var text = reader.ReadLine();
-                            if (text == null)
-                            {
-                                return;
-                            }
-
-                            if (int.TryParse(text, out var id))
-                            {
-                                children.Add(id);
-                                // Recursively get the children
-                                GetAllChildIdsUnix(id, children, timeout);
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Win32Exception ex) when (ex.Message.Contains("No such file or directory"))
-            {
-                // This probably means that pgrep isn't installed. Nothing to be done?
-            }
-        }
-
-        private static void KillProcessUnix(int processId, TimeSpan timeout)
-        {
-            try
-            {
-                RunProcessAndWaitForExit(
-                    "kill",
-                    $"-TERM {processId}",
-                    timeout,
-                    out var stdout);
-            }
-            catch (Win32Exception ex) when (ex.Message.Contains("No such file or directory"))
-            {
-                // This probably means that the process is already dead
+                process.Kill(entireProcessTree: true);
             }
         }
 

--- a/src/Tools/Microsoft.dotnet-openapi/test/ProcessEx.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/ProcessEx.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Internal
         {
             if (_process != null && !_process.HasExited)
             {
-                _process.KillTree();
+                _process.KillTreeNoPgrep();
             }
 
             _process.CancelOutputRead();

--- a/src/Tools/Microsoft.dotnet-openapi/test/ProcessEx.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/ProcessEx.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Internal
         {
             if (_process != null && !_process.HasExited)
             {
-                _process.KillTreeNoPgrep();
+                _process.KillTree();
             }
 
             _process.CancelOutputRead();

--- a/src/Tools/dotnet-watch/src/Internal/ProcessRunner.cs
+++ b/src/Tools/dotnet-watch/src/Internal/ProcessRunner.cs
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                     if (!_process.HasExited)
                     {
                         _reporter.Verbose($"Killing process {_process.Id}");
-                        _process.KillTree();
+                        _process.Kill(entireProcessTree: true);
                     }
                 }
                 catch (Exception ex)

--- a/src/Tools/dotnet-watch/src/Internal/ProcessRunner.cs
+++ b/src/Tools/dotnet-watch/src/Internal/ProcessRunner.cs
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                     if (!_process.HasExited)
                     {
                         _reporter.Verbose($"Killing process {_process.Id}");
-                        _process.KillTree();
+                        _process.KillTreeNoPgrep();
                     }
                 }
                 catch (Exception ex)

--- a/src/Tools/dotnet-watch/src/Internal/ProcessRunner.cs
+++ b/src/Tools/dotnet-watch/src/Internal/ProcessRunner.cs
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Watcher.Internal
                     if (!_process.HasExited)
                     {
                         _reporter.Verbose($"Killing process {_process.Id}");
-                        _process.Kill(entireProcessTree: true);
+                        _process.KillTree();
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/27950

#### Description
Currently on the dotnet docker images, dotnet watch depends on the procps package to kill processes (using pgrep). This dependency was removed in .NET 5, causing dotnet watch to not work on our Debian SDK images. This also would apply to the dotnet openapi tool as well if run inside of the sdk image, as it too calls KillTree.

There are a few options for fixes here to remove the dependency on procps. In .NET 5, a new overload to Process.Kill was added to take in a bool called entireProcessTree. One option is to just call this method, which should do the desired behavior. However, as this is a new API, it is inherently risky to depend on it.

Another option is to call ps instead of pgrep to find all processes for child ids. This also seems risky as it's new code for killing processes.

Currently, I went with option 1 here of calling the new Process.Kill method as it is expected to have the behavior we need.

#### Customer Impact
The change will fix a blocking issue for using dotnet watch in our Debian images.

#### Regression?
Yes, this is a regression from 3.1.

#### Risk
Medium. We are going to start using a new API which could potentially have issues. At a minimum, we need to make sure this works on Linux, macOS, WSL2, and the debian images themselves.

cc @Pilchie 