### PR TITLE
[Java] Don't call onClose when WebSocket connection is not open

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -109,6 +109,9 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
             } finally {
                 stateLock.unlock();
             }
+
+            logger.info("WebSocket closing with status code '{}' and reason '{}'.", code, reason);
+
             // Only call onClose if connection is open
             if (isOpen) {
                 onClose.invoke(code, reason);
@@ -126,7 +129,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
 
         @Override
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
-            logger.error("WebSocket closed from an error: {}.", t.getMessage());
+            logger.error("WebSocket closed from an error.", t);
 
             boolean isOpen = false;
             try {

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -30,7 +30,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
     private WebSocketOnClosedCallback onClose;
     private CompletableSubject startSubject = CompletableSubject.create();
     private CompletableSubject closeSubject = CompletableSubject.create();
-    private final ReentrantLock closeLock = new ReentrantLock();
+    private final ReentrantLock stateLock = new ReentrantLock();
 
     private final Logger logger = LoggerFactory.getLogger(OkHttpWebSocketWrapper.class);
 
@@ -82,7 +82,12 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
     private class SignalRWebSocketListener extends WebSocketListener {
         @Override
         public void onOpen(WebSocket webSocket, Response response) {
-            startSubject.onComplete();
+            stateLock.lock();
+            try {
+                startSubject.onComplete();
+            } finally {
+                stateLock.unlock();
+            }
         }
 
         @Override
@@ -97,39 +102,66 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
 
         @Override
         public void onClosing(WebSocket webSocket, int code, String reason) {
-            onClose.invoke(code, reason);
+            boolean isOpen = false;
+            stateLock.lock();
             try {
-                closeLock.lock();
+                isOpen = startSubject.hasComplete();
+            } finally {
+                stateLock.unlock();
+            }
+            // Only call onClose if connection is open
+            if (isOpen) {
+                onClose.invoke(code, reason);
+            }
+
+            try {
+                stateLock.lock();
                 closeSubject.onComplete();
             }
             finally {
-                closeLock.unlock();
+                stateLock.unlock();
             }
-            checkStartFailure();
+            checkStartFailure(null);
         }
 
         @Override
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
             logger.error("WebSocket closed from an error: {}.", t.getMessage());
 
+            boolean isOpen = false;
             try {
-                closeLock.lock();
+                stateLock.lock();
                 if (!closeSubject.hasComplete()) {
                     closeSubject.onError(new RuntimeException(t));
                 }
+
+                isOpen = startSubject.hasComplete();
             }
             finally {
-                closeLock.unlock();
+                stateLock.unlock();
             }
-            onClose.invoke(null, t.getMessage());
-            checkStartFailure();
+            // Only call onClose if connection is open
+            if (isOpen) {
+                onClose.invoke(null, t.getMessage());
+            }
+            checkStartFailure(t);
         }
 
-        private void checkStartFailure() {
-            // If the start task hasn't completed yet, then we need to complete it
-            // exceptionally.
-            if (!startSubject.hasComplete()) {
-                startSubject.onError(new RuntimeException("There was an error starting the WebSocket transport."));
+        private void checkStartFailure(Throwable t) {
+            stateLock.lock();
+            try {
+                // If the start task hasn't completed yet, then we need to complete it
+                // exceptionally.
+                if (!startSubject.hasComplete()) {
+                    String errorMessage = "There was an error starting the WebSocket transport. ";
+                    if (t != null) {
+                        startSubject.onError(new RuntimeException(errorMessage + t.getMessage()));
+                    } else {
+                        startSubject.onError(new RuntimeException(errorMessage));
+                    }
+                }
+            } finally {
+                stateLock.unlock();
             }
         }
     }

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -153,12 +153,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
                 // If the start task hasn't completed yet, then we need to complete it
                 // exceptionally.
                 if (!startSubject.hasComplete()) {
-                    String errorMessage = "There was an error starting the WebSocket transport. ";
-                    if (t != null) {
-                        startSubject.onError(new RuntimeException(errorMessage + t.getMessage()));
-                    } else {
-                        startSubject.onError(new RuntimeException(errorMessage));
-                    }
+                    startSubject.onError(new RuntimeException("There was an error starting the WebSocket transport.", t));
                 }
             } finally {
                 stateLock.unlock();

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/WebSocketTransport.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/WebSocketTransport.java
@@ -86,8 +86,6 @@ class WebSocketTransport implements Transport {
     }
 
     void onClose(Integer code, String reason) {
-        logger.info("WebSocket connection stopping with " +
-                "code {} and reason '{}'.", code, reason);
         if (code == null || code != 1000) {
             onClose.invoke(reason);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/27438

#### Description

If an endpoint doesn't support WebSockets or some kind of connection issue occurs then the WebSockets `onFailure` method will be called which will call `onClose`. The `onClose` callback is only expected to be called when a connection is already connected and will fail when in this state, this results in `hubConnection.start()` never completing or in some environments, the client crashes due to an unhandled exception.

#### Customer Impact

Bug reported in https://github.com/dotnet/aspnetcore/issues/27438 as well as an internal partner.
The bug will cause `hubConnection.start()` to not finish or client crashes.
A workaround is to only use LongPolling for the client, WebSockets is the best transport so this isn't a great workaround.

#### Regression?

Yes, regressed from 3.1 to 5.0

#### Risk

Low.
Issue is easy to repro and we have prior art with a similar change https://github.com/dotnet/aspnetcore/pull/14114