### PR TITLE
Adds test and lets us test against empty strings

### DIFF
--- a/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
+++ b/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             var currentValue = dictionary[convertedKey];
 
             // The target segment does not have an assigned value to compare the test value with
-            if (currentValue == null || string.IsNullOrEmpty(currentValue.ToString()))
+            if (currentValue == null)
             {
                 errorMessage = Resources.FormatValueForTargetSegmentCannotBeNullOrEmpty(segment);
                 return false;

--- a/src/Features/JsonPatch/test/IntegrationTests/ExpandoObjectIntegrationTest.cs
+++ b/src/Features/JsonPatch/test/IntegrationTests/ExpandoObjectIntegrationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -117,6 +117,41 @@ namespace Microsoft.AspNetCore.JsonPatch.IntegrationTests
 
             // Act & Assert
             patchDocument.ApplyTo(targetObject);
+        }
+
+        [Fact]
+        public void TestEmptyProperty_IsSuccessful()
+        {
+            // Arrange
+            dynamic targetObject = new ExpandoObject();
+            targetObject.Test = "";
+
+            var patchDocument = new JsonPatchDocument();
+            patchDocument.Test("Test", "");
+
+            // Act & Assert
+            patchDocument.ApplyTo(targetObject);
+        }
+
+        [Fact]
+        public void TestValueAgainstEmptyProperty_ThrowsJsonPatchException_IsSuccessful()
+        {
+            // Arrange
+            dynamic targetObject = new ExpandoObject();
+            targetObject.Test = "";
+
+            var patchDocument = new JsonPatchDocument();
+            patchDocument.Test("Test", "TestValue");
+
+            // Act
+            var exception = Assert.Throws<JsonPatchException>(() =>
+            {
+                patchDocument.ApplyTo(targetObject);
+            });
+
+            // Assert
+            Assert.Equal("The current value '' at path 'Test' is not equal to the test value 'TestValue'.",
+                exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - When using JsonPatch.Test, this removes check for current value being null or empty. 

Addresses #28019 

This makes it compliant with [RFC6902 4.6](https://tools.ietf.org/html/rfc6902#section-4.6) saying 
```
Here, "equal" means that the value at the target location and the
   value conveyed by "value" are of the same JSON type, and that they
   are considered equal by the following rules for that type:

   o  strings: are considered equal if they contain the same number of
      Unicode characters and their code points are byte-by-byte equal.
```

Two empty strings should be `equal`.

Might also want to remove the null check on current value completely, seeing as RFC6902 specifies that `literals (false, true, and null): are considered equal if they are the same`. Testing a null value against a null value would now fail. As I read the spec, they should be considered equal. 