### PR TITLE
Ship the Identity.Specification.Tests package again

### DIFF
--- a/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity;membership</PackageTags>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/27873

### Description

This package is a collection of tests which we have shipped which allows customers who have implemented their own identity stores to verify that their stores behave as expected.  Our quarantine process introduced some internal dependencies to this package during 5.0, which resulted in us no longer shipping this package.

### Customer impact

Customers were relying on using this library to ensure that their implementations worked against our identity manager implementations.

### Regression

Yes. Regression from 3.2

### Risk
Low. We currently run our CI tests against this package, this just allows customers to once again be able to run our tests on their CI builds.