### PR TITLE
HttpSys Http/2 requests should not be upgradable

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public string Scheme => IsHttps ? Constants.HttpsScheme : Constants.HttpScheme;
 
         // HTTP.Sys allows you to upgrade anything to opaque unless content-length > 0 or chunked are specified.
-        internal bool IsUpgradable => !HasEntityBody && ComNetOS.IsWin8orLater;
+        internal bool IsUpgradable => ProtocolVersion < HttpVersion.Version20 && !HasEntityBody && ComNetOS.IsWin8orLater;
 
         internal WindowsPrincipal User { get; }
 

--- a/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
@@ -29,8 +29,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
         {
             using var server = Utilities.CreateDynamicHttpsServer(out var address, httpContext =>
             {
-                // Default 200
+                var feature = httpContext.Features.Get<IHttpUpgradeFeature>();
+                Assert.False(feature.IsUpgradableRequest);
                 Assert.False(httpContext.Request.CanHaveBody());
+                // Default 200
                 return Task.CompletedTask;
             });
 

--- a/src/Servers/HttpSys/test/FunctionalTests/OpaqueUpgradeTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/OpaqueUpgradeTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 }
                 catch (Exception ex)
                 {
+                    httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
                     return httpContext.Response.WriteAsync(ex.ToString());
                 }
                 return Task.FromResult(0);
@@ -267,7 +268,37 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 }
             }))
             {
-                await Assert.ThrowsAsync<InvalidOperationException>(async () => await SendOpaqueRequestAsync(method, address, extraHeader));
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await SendOpaqueRequestAsync(method, address, extraHeader));
+                Assert.Equal("The response status code was incorrect: HTTP/1.1 200 OK", ex.Message);
+            }
+        }
+
+        [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8)]
+        // Http.Sys returns a 411 Length Required if PUT or POST does not specify content-length or chunked.
+        public async Task OpaqueUpgrade_PostWithBodyAndUpgradeHeaders_Accepted()
+        {
+            using (Utilities.CreateHttpServer(out string address, async httpContext =>
+            {
+                try
+                {
+                    var opaqueFeature = httpContext.Features.Get<IHttpUpgradeFeature>();
+                    Assert.NotNull(opaqueFeature);
+                    Assert.False(opaqueFeature.IsUpgradableRequest);
+                }
+                catch (Exception ex)
+                {
+                    await httpContext.Response.WriteAsync(ex.ToString());
+                }
+            }))
+            {
+                using var client = new HttpClient();
+
+                var request = new HttpRequestMessage(HttpMethod.Post, address);
+                request.Headers.Connection.Add("upgrade");
+                request.Content = new StringContent("Hello World");
+                var response = await client.SendAsync(request);
+                response.EnsureSuccessStatusCode();
             }
         }
 

--- a/src/Servers/HttpSys/test/FunctionalTests/OpaqueUpgradeTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/OpaqueUpgradeTests.cs
@@ -275,7 +275,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         [ConditionalFact]
         [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8)]
-        // Http.Sys returns a 411 Length Required if PUT or POST does not specify content-length or chunked.
         public async Task OpaqueUpgrade_PostWithBodyAndUpgradeHeaders_Accepted()
         {
             using (Utilities.CreateHttpServer(out string address, async httpContext =>


### PR DESCRIPTION
Related to #23172, #27921. When comparing the behavior of upgrades across the server implementations I noticed that HttpSys does not check the request protocol version. Upgrade is not supported on HTTP/2 and later. This isn't a big problem because WebSockets checks for other headers before attempting an upgrade.

Http.Sys's requirements for upgrades are:
1. There's no request body
2. It's HTTP/1.1
3. The response includes `Upgrade: WebSockets`.
4. It's Win8+

Http.Sys allows/ignores the Upgrade header if there's a request body.

IIS should have the same requirements, but that's tracked by #23172.