### PR TITLE
Make sure DataTokens are set on the RouteContext for IActionConstraints

### DIFF
--- a/src/Mvc/Mvc.Core/src/Routing/ActionConstraintMatcherPolicy.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ActionConstraintMatcherPolicy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -222,11 +222,23 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                         {
                             foundMatchingConstraint = true;
 
+                            ref var candidate = ref candidateSet[item.index];
+
+                            var routeData = new RouteData(candidate.Values);
+
+                            var dataTokens = candidate.Endpoint.Metadata.GetMetadata<IDataTokensMetadata>()?.DataTokens;
+
+                            if (dataTokens != null)
+                            {
+                                // Set the data tokens if there are any for this candidate
+                                routeData.PushState(router: null, values: null, dataTokens: new RouteValueDictionary(dataTokens));
+                            }
+
                             // Before we run the constraint, we need to initialize the route values.
                             // In endpoint routing, the route values are per-endpoint.
                             constraintContext.RouteContext = new RouteContext(httpContext)
                             {
-                                RouteData = new RouteData(candidateSet[item.index].Values),
+                                RouteData = routeData,
                             };
                             if (!constraint.Accept(constraintContext))
                             {


### PR DESCRIPTION
- When using endpoint routing, IActionConstraints are run before endpoints are selected on the HttpContext via a MatcherPolicy.

Fixes #20904
