### PR TITLE
Enable post-build signing

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -611,9 +611,11 @@ stages:
         includeForks: true
       - name: Linux_musl_arm_Packages
         path: artifacts/packages/
-  - template: jobs/codesign-xplat.yml
-    parameters:
-      inputName: Linux_musl_arm
+
+  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+    - template: jobs/codesign-xplat.yml
+      parameters:
+        inputName: Linux_musl_arm
 
   # Build Linux Musl ARM64
   - template: jobs/default-build.yml

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -55,7 +55,7 @@ variables:
 - name: _DotNetValidationArtifactsCategory
   value: .NETCORE
 - name: PostBuildSign
-  value: false
+  value: true
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)


### PR DESCRIPTION
Enables post build signing. This repo will discontinue signing in-build and instead the entire product will sign all at once in the staging pipelines.