### PR TITLE
Update runtime-sync.yml

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Send PR
       if: steps.check.outputs.changed == 'true'
       # https://github.com/marketplace/actions/create-pull-request
-      uses: peter-evans/create-pull-request@v2
+      uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: .\aspnetcore


### PR DESCRIPTION
Updating the create-pull-request tool to address new github infrastructure warnings like `Error: The ``set-env`` command is disabled.` See https://github.com/dotnet/aspnetcore/runs/1429482573?check_suite_focus=true

I'll admit I haven't tested the new version, but I'm willing to test it in production 😁. 

Relevant docs:
https://github.com/peter-evans/create-pull-request/blob/master/docs/updating.md

Reviewers: Sorry, the whole build team is out so you got picked randomly.