### PR TITLE
[SignalR] Remove obsolete APIs

### DIFF
--- a/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
@@ -258,16 +258,6 @@ namespace Microsoft.AspNetCore.Http.Connections
             }
         }
 
-        /// <summary>
-        /// <para>
-        ///     This method is obsolete and will be removed in a future version.
-        ///     The recommended alternative is <see cref="ParseResponse(ReadOnlySpan{byte})" />.
-        /// </para>
-        /// </summary>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is ParseResponse(ReadOnlySpan{byte}).")]
-        public static NegotiationResponse ParseResponse(Stream content) =>
-            throw new NotSupportedException("This method is obsolete and will be removed in a future version. The recommended alternative is ParseResponse(ReadOnlySpan{byte}).");
-
         private static AvailableTransport ParseAvailableTransport(ref Utf8JsonReader reader)
         {
             var availableTransport = new AvailableTransport();

--- a/src/SignalR/common/Http.Connections.Common/src/PublicAPI.Shipped.txt
+++ b/src/SignalR/common/Http.Connections.Common/src/PublicAPI.Shipped.txt
@@ -29,6 +29,5 @@ static readonly Microsoft.AspNetCore.Http.Connections.HttpTransports.All -> Micr
 ~Microsoft.AspNetCore.Http.Connections.NegotiationResponse.Error.set -> void
 ~Microsoft.AspNetCore.Http.Connections.NegotiationResponse.Url.get -> string
 ~Microsoft.AspNetCore.Http.Connections.NegotiationResponse.Url.set -> void
-~static Microsoft.AspNetCore.Http.Connections.NegotiateProtocol.ParseResponse(System.IO.Stream content) -> Microsoft.AspNetCore.Http.Connections.NegotiationResponse
 ~static Microsoft.AspNetCore.Http.Connections.NegotiateProtocol.ParseResponse(System.ReadOnlySpan<byte> content) -> Microsoft.AspNetCore.Http.Connections.NegotiationResponse
 ~static Microsoft.AspNetCore.Http.Connections.NegotiateProtocol.WriteResponse(Microsoft.AspNetCore.Http.Connections.NegotiationResponse response, System.Buffers.IBufferWriter<byte> output) -> void

--- a/src/SignalR/server/Core/src/HubInvocationContext.cs
+++ b/src/SignalR/server/Core/src/HubInvocationContext.cs
@@ -33,18 +33,6 @@ namespace Microsoft.AspNetCore.SignalR
             Context = context;
         }
 
-        /// <summary>
-        /// Instantiates a new instance of the <see cref="HubInvocationContext"/> class.
-        /// </summary>
-        /// <param name="context">Context for the active Hub connection and caller.</param>
-        /// <param name="hubMethodName">The name of the Hub method being invoked.</param>
-        /// <param name="hubMethodArguments">The arguments provided by the client.</param>
-        [Obsolete("This constructor is obsolete and will be removed in a future version. The recommended alternative is to use the other constructor.")]
-        public HubInvocationContext(HubCallerContext context, string hubMethodName, object?[] hubMethodArguments)
-        {
-            throw new NotSupportedException("This constructor no longer works. Use the other constructor.");
-        }
-
         internal HubInvocationContext(ObjectMethodExecutor objectMethodExecutor, HubCallerContext context, IServiceProvider serviceProvider, Hub hub, object?[] hubMethodArguments)
             : this(context, serviceProvider, hub, objectMethodExecutor.MethodInfo, hubMethodArguments)
         {

--- a/src/SignalR/server/Core/src/PublicAPI.Shipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Shipped.txt
@@ -72,7 +72,6 @@ Microsoft.AspNetCore.SignalR.HubInvocationContext
 Microsoft.AspNetCore.SignalR.HubInvocationContext.Context.get -> Microsoft.AspNetCore.SignalR.HubCallerContext!
 Microsoft.AspNetCore.SignalR.HubInvocationContext.Hub.get -> Microsoft.AspNetCore.SignalR.Hub!
 Microsoft.AspNetCore.SignalR.HubInvocationContext.HubInvocationContext(Microsoft.AspNetCore.SignalR.HubCallerContext! context, System.IServiceProvider! serviceProvider, Microsoft.AspNetCore.SignalR.Hub! hub, System.Reflection.MethodInfo! hubMethod, System.Collections.Generic.IReadOnlyList<object?>! hubMethodArguments) -> void
-Microsoft.AspNetCore.SignalR.HubInvocationContext.HubInvocationContext(Microsoft.AspNetCore.SignalR.HubCallerContext! context, string! hubMethodName, object?[]! hubMethodArguments) -> void
 Microsoft.AspNetCore.SignalR.HubInvocationContext.HubMethod.get -> System.Reflection.MethodInfo!
 Microsoft.AspNetCore.SignalR.HubInvocationContext.HubMethodArguments.get -> System.Collections.Generic.IReadOnlyList<object?>!
 Microsoft.AspNetCore.SignalR.HubInvocationContext.HubMethodName.get -> string!


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/27529

Both APIs already throw when used. The `ParseResponse` method was obsoleted in 3.1, `HubInvocationContext.ctor` was obsoleted in 5.0.

I have seen no evidence of anyone using `HubInvocationContext.ctor` and there wasn't a good reason to use it before 5.0 (Hub filters).

I have seen one place using `ParseResponse`, but the newest version of the package uses the non-obsolete method.