### PR TITLE
Remove the regex from data protection

### DIFF
--- a/src/DataProtection/DataProtection/src/TypeForwardingActivator.cs
+++ b/src/DataProtection/DataProtection/src/TypeForwardingActivator.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.DataProtection
         {
             // Type, Assembly, Version={Version}, Culture={Culture}, PublicKeyToken={Token}
 
-            var versionStartIndex = forwardedTypeName.IndexOf("Version=");
+            var versionStartIndex = forwardedTypeName.IndexOf("Version=", StringComparison.Ordinal);
 
             if (versionStartIndex == -1)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.DataProtection
                 return forwardedTypeName;
             }
 
-            var versionEndIndex = forwardedTypeName.IndexOf(',', versionStartIndex);
+            var versionEndIndex = forwardedTypeName.IndexOf(',', versionStartIndex + "Version=".Length);
 
             if (versionEndIndex == -1)
             {

--- a/src/DataProtection/DataProtection/src/TypeForwardingActivator.cs
+++ b/src/DataProtection/DataProtection/src/TypeForwardingActivator.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -13,7 +12,6 @@ namespace Microsoft.AspNetCore.DataProtection
         private const string OldNamespace = "Microsoft.AspNet.DataProtection";
         private const string CurrentNamespace = "Microsoft.AspNetCore.DataProtection";
         private readonly ILogger _logger;
-        private static readonly Regex _versionPattern = new Regex(@",\s?Version=[0-9]+(\.[0-9]+){0,3}", RegexOptions.Compiled, TimeSpan.FromSeconds(2));
 
         public TypeForwardingActivator(IServiceProvider services)
             : this(services, NullLoggerFactory.Instance)
@@ -64,6 +62,26 @@ namespace Microsoft.AspNetCore.DataProtection
         }
 
         protected string RemoveVersionFromAssemblyName(string forwardedTypeName)
-            => _versionPattern.Replace(forwardedTypeName, "");
+        {
+            // Type, Assembly, Version={Version}, Culture={Culture}, PublicKeyToken={Token}
+
+            var versionStartIndex = forwardedTypeName.IndexOf("Version=");
+
+            if (versionStartIndex == -1)
+            {
+                // No version?
+                return forwardedTypeName;
+            }
+
+            var versionEndIndex = forwardedTypeName.IndexOf(',', versionStartIndex);
+
+            if (versionEndIndex == -1)
+            {
+                // No end index?
+                return forwardedTypeName;
+            }
+            
+            return forwardedTypeName.Substring(0, versionStartIndex) + forwardedTypeName.Substring(versionEndIndex + 1);
+        }
     }
 }


### PR DESCRIPTION
- This also affects startup time since the regex is compiled

cc @stephentoub 