### PR TITLE
Implement IHttpUpgradeFeature.IsUpgradableRequest in IIS 

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -250,7 +250,10 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
             await _writeBodyTask;
         }
 
-        bool IHttpUpgradeFeature.IsUpgradableRequest => true;
+        // Http/2 does not support the upgrade mechanic.
+        // Http/1.x upgrade requests may have a request body, but that's not allowed in our main scenario (WebSockets) and much
+        // more complicated to support. See https://tools.ietf.org/html/rfc7230#section-6.7, https://tools.ietf.org/html/rfc7540#section-3.2
+        bool IHttpUpgradeFeature.IsUpgradableRequest => !RequestCanHaveBody && HttpVersion < System.Net.HttpVersion.Version20;
 
         bool IFeatureCollection.IsReadOnly => false;
 

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.WebSockets.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.WebSockets.cs
@@ -21,16 +21,27 @@ namespace TestSite
 {
     public partial class Startup
     {
-
-        private void WebsocketRequest(IApplicationBuilder app)
+        private void WebSocketNotUpgradable(IApplicationBuilder app)
         {
-            app.Run(async context =>
-            {
-                await context.Response.WriteAsync("test");
+            app.Run(context => {
+
+                var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
+                Assert.False(upgradeFeature.IsUpgradableRequest);
+                return Task.CompletedTask;
             });
         }
 
-        private void WebReadBeforeUpgrade(IApplicationBuilder app)
+        private void WebSocketUpgradable(IApplicationBuilder app)
+        {
+            app.Run(context => {
+
+                var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
+                Assert.True(upgradeFeature.IsUpgradableRequest);
+                return Task.CompletedTask;
+            });
+        }
+
+        private void WebSocketReadBeforeUpgrade(IApplicationBuilder app)
         {
             app.Run(async context => {
 

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1488,6 +1488,8 @@ namespace TestSite
             Assert.Equal("HTTP/2", httpContext.Request.Protocol);
 #if !FORWARDCOMPAT
             Assert.False(httpContext.Request.CanHaveBody());
+            var feature = httpContext.Features.Get<IHttpUpgradeFeature>();
+            Assert.False(feature.IsUpgradableRequest);
 #endif
             Assert.Null(httpContext.Request.ContentLength);
             Assert.False(httpContext.Request.Headers.ContainsKey(HeaderNames.TransferEncoding));


### PR DESCRIPTION
#23172 IHttpUpgradeFeature.IsUpgradableRequest was not implemented before, it always returned true. This was confusing for proxy scenarios like YARP that aren't checking for more protocol specific headers like those required for WebSockets.

IIS/Http.Sys have fairly loose requirements for what can be upgraded:
- The request must be Http/1.x
- There must not be a request body.
- The response must have an `Upgrade: WebSocket` header.

We may consider backporting this to 5.0 and 3.1 for YARP.