### PR TITLE
Typo in class documentation

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/src/Events/OpenIdConnectEvents.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/OpenIdConnectEvents.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
 {
     /// <summary>
-    /// Specifies events which the <see cref="OpenIdConnectHandler" />invokes to enable developer control over the authentication process.
+    /// Specifies events which the <see cref="OpenIdConnectHandler" /> invokes to enable developer control over the authentication process.
     /// </summary>
     public class OpenIdConnectEvents : RemoteAuthenticationEvents
     {


### PR DESCRIPTION
Added missing space in class documentation.
