### PR TITLE
Added PageRequestDelegateFactory

### DIFF
--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -273,9 +273,9 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<OrderedEndpointsSequenceProviderCache>();
             services.TryAddSingleton<ControllerActionEndpointDataSourceIdProvider>();
             services.TryAddSingleton<ActionEndpointFactory>();
-            services.TryAddSingleton<IRequestDelegateFactory, ControllerRequestDelegateFactory>();
             services.TryAddSingleton<DynamicControllerEndpointSelectorCache>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, DynamicControllerEndpointMatcherPolicy>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IRequestDelegateFactory, ControllerRequestDelegateFactory>());
 
             //
             // Middleware pipeline filter related

--- a/src/Mvc/Mvc.Core/test/DependencyInjection/MvcCoreServiceCollectionExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/DependencyInjection/MvcCoreServiceCollectionExtensionsTest.cs
@@ -286,6 +286,13 @@ namespace Microsoft.AspNetCore.Mvc
                         }
                     },
                     {
+                        typeof(IRequestDelegateFactory),
+                        new Type[]
+                        {
+                            typeof(ControllerRequestDelegateFactory)
+                        }
+                    },
+                    {
                         typeof(IFilterProvider),
                         new Type[]
                         {

--- a/src/Mvc/Mvc.RazorPages/src/CompiledPageActionDescriptor.cs
+++ b/src/Mvc/Mvc.RazorPages/src/CompiledPageActionDescriptor.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
@@ -14,14 +15,14 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
     public class CompiledPageActionDescriptor : PageActionDescriptor
     {
         /// <summary>
-        /// Initializes an empty <see cref="CompiledPageActionDescriptor"/>.
+        /// Initializes an empty <see cref="CompiledPageDescriptor"/>.
         /// </summary>
         public CompiledPageActionDescriptor()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CompiledPageActionDescriptor"/>
+        /// Initializes a new instance of <see cref="CompiledPageDescriptor"/>
         /// from the specified <paramref name="actionDescriptor"/> instance.
         /// </summary>
         /// <param name="actionDescriptor">The <see cref="PageActionDescriptor"/>.</param>
@@ -65,5 +66,13 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
         /// Gets or sets the associated <see cref="Endpoint"/> of this page.
         /// </summary>
         public Endpoint Endpoint { get; set; }
+
+        internal PageActionInvokerCacheEntry CacheEntry { get; set; }
+
+        internal override CompiledPageActionDescriptor CompiledPageDescriptor
+        {
+            get => this;
+            set => throw new InvalidOperationException("Setting the compiled descriptor on a compiled descriptor is not allowed.");
+        }
     }
 }

--- a/src/Mvc/Mvc.RazorPages/src/CompiledPageActionDescriptor.cs
+++ b/src/Mvc/Mvc.RazorPages/src/CompiledPageActionDescriptor.cs
@@ -15,14 +15,14 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
     public class CompiledPageActionDescriptor : PageActionDescriptor
     {
         /// <summary>
-        /// Initializes an empty <see cref="CompiledPageDescriptor"/>.
+        /// Initializes an empty <see cref="CompiledPageActionDescriptor"/>.
         /// </summary>
         public CompiledPageActionDescriptor()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of <see cref="CompiledPageDescriptor"/>
+        /// Initializes a new instance of <see cref="CompiledPageActionDescriptor"/>
         /// from the specified <paramref name="actionDescriptor"/> instance.
         /// </summary>
         /// <param name="actionDescriptor">The <see cref="PageActionDescriptor"/>.</param>

--- a/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcCoreBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -131,6 +132,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IActionInvokerProvider, PageActionInvokerProvider>());
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IRequestDelegateFactory, PageRequestDelegateFactory>());
+            services.TryAddSingleton<PageActionInvokerCache>();
 
             // Page and Page model creation and activation
             services.TryAddSingleton<IPageModelActivatorProvider, DefaultPageModelActivatorProvider>();

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvoker.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvoker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Internal;
@@ -22,7 +21,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
     {
         private readonly IPageHandlerMethodSelector _selector;
         private readonly PageContext _pageContext;
-        private readonly ParameterBinder _parameterBinder;
         private readonly ITempDataDictionaryFactory _tempDataFactory;
         private readonly HtmlHelperOptions _htmlHelperOptions;
         private readonly CompiledPageActionDescriptor _actionDescriptor;
@@ -46,7 +44,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             PageContext pageContext,
             IFilterMetadata[] filterMetadata,
             PageActionInvokerCacheEntry cacheEntry,
-            ParameterBinder parameterBinder,
             ITempDataDictionaryFactory tempDataFactory,
             HtmlHelperOptions htmlHelperOptions)
             : base(
@@ -61,7 +58,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             _selector = handlerMethodSelector;
             _pageContext = pageContext;
             CacheEntry = cacheEntry;
-            _parameterBinder = parameterBinder;
             _tempDataFactory = tempDataFactory;
             _htmlHelperOptions = htmlHelperOptions;
 

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvokerCache.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvokerCache.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvokerCache.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvokerCache.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
+{
+    internal class PageActionInvokerCache
+    {
+        private readonly IPageFactoryProvider _pageFactoryProvider;
+        private readonly IPageModelFactoryProvider _modelFactoryProvider;
+        private readonly IModelBinderFactory _modelBinderFactory;
+        private readonly IRazorPageFactoryProvider _razorPageFactoryProvider;
+        private readonly IFilterProvider[] _filterProviders;
+        private readonly ParameterBinder _parameterBinder;
+        private readonly IModelMetadataProvider _modelMetadataProvider;
+        private readonly MvcOptions _mvcOptions;
+
+        public PageActionInvokerCache(
+            IPageFactoryProvider pageFactoryProvider,
+            IPageModelFactoryProvider modelFactoryProvider,
+            IRazorPageFactoryProvider razorPageFactoryProvider,
+            IEnumerable<IFilterProvider> filterProviders,
+            ParameterBinder parameterBinder,
+            IModelMetadataProvider modelMetadataProvider,
+            IModelBinderFactory modelBinderFactory,
+            IOptions<MvcOptions> mvcOptions)
+        {
+            _pageFactoryProvider = pageFactoryProvider;
+            _modelFactoryProvider = modelFactoryProvider;
+            _modelBinderFactory = modelBinderFactory;
+            _razorPageFactoryProvider = razorPageFactoryProvider;
+            _filterProviders = filterProviders.ToArray();
+            _parameterBinder = parameterBinder;
+            _modelMetadataProvider = modelMetadataProvider;
+            _mvcOptions = mvcOptions.Value;
+        }
+
+        public (PageActionInvokerCacheEntry cacheEntry, IFilterMetadata[] filters) GetCachedResult(ActionContext actionContext)
+        {
+            var actionDescriptor = actionContext.ActionDescriptor as PageActionDescriptor;
+
+            var compiledPageActionDescriptor = actionDescriptor.CompiledPageDescriptor;
+
+            Debug.Assert(compiledPageActionDescriptor != null, "PageLoader didn't run!");
+
+            var cacheEntry = actionDescriptor.CompiledPageDescriptor.CacheEntry;
+
+            IFilterMetadata[] filters;
+            if (cacheEntry is null)
+            {
+                actionContext.ActionDescriptor = compiledPageActionDescriptor;
+                var filterFactoryResult = FilterFactory.GetAllFilters(_filterProviders, actionContext);
+                filters = filterFactoryResult.Filters;
+                cacheEntry = CreateCacheEntry(compiledPageActionDescriptor, filterFactoryResult.CacheableFilters);
+                compiledPageActionDescriptor.CacheEntry = cacheEntry;
+            }
+            else
+            {
+                filters = FilterFactory.CreateUncachedFilters(
+                    _filterProviders,
+                    actionContext,
+                    cacheEntry.CacheableFilters);
+            }
+
+            return (cacheEntry, filters);
+        }
+
+        private PageActionInvokerCacheEntry CreateCacheEntry(
+            CompiledPageActionDescriptor compiledActionDescriptor,
+            FilterItem[] cachedFilters)
+        {
+            var viewDataFactory = ViewDataDictionaryFactory.CreateFactory(compiledActionDescriptor.DeclaredModelTypeInfo);
+
+            var pageFactory = _pageFactoryProvider.CreatePageFactory(compiledActionDescriptor);
+            var pageDisposer = _pageFactoryProvider.CreatePageDisposer(compiledActionDescriptor);
+            var propertyBinder = PageBinderFactory.CreatePropertyBinder(
+                _parameterBinder,
+                _modelMetadataProvider,
+                _modelBinderFactory,
+                compiledActionDescriptor);
+
+            Func<PageContext, object> modelFactory = null;
+            Action<PageContext, object> modelReleaser = null;
+            if (compiledActionDescriptor.ModelTypeInfo != compiledActionDescriptor.PageTypeInfo)
+            {
+                modelFactory = _modelFactoryProvider.CreateModelFactory(compiledActionDescriptor);
+                modelReleaser = _modelFactoryProvider.CreateModelDisposer(compiledActionDescriptor);
+            }
+
+            var viewStartFactories = GetViewStartFactories(compiledActionDescriptor);
+
+            var handlerExecutors = GetHandlerExecutors(compiledActionDescriptor);
+            var handlerBinders = GetHandlerBinders(compiledActionDescriptor);
+
+            return new PageActionInvokerCacheEntry(
+                compiledActionDescriptor,
+                viewDataFactory,
+                pageFactory,
+                pageDisposer,
+                modelFactory,
+                modelReleaser,
+                propertyBinder,
+                handlerExecutors,
+                handlerBinders,
+                viewStartFactories,
+                cachedFilters);
+        }
+
+        // Internal for testing.
+        internal List<Func<IRazorPage>> GetViewStartFactories(CompiledPageActionDescriptor descriptor)
+        {
+            var viewStartFactories = new List<Func<IRazorPage>>();
+            // Always pick up all _ViewStarts, including the ones outside the Pages root.
+            foreach (var filePath in RazorFileHierarchy.GetViewStartPaths(descriptor.RelativePath))
+            {
+                var factoryResult = _razorPageFactoryProvider.CreateFactory(filePath);
+                if (factoryResult.Success)
+                {
+                    viewStartFactories.Insert(0, factoryResult.RazorPageFactory);
+                }
+            }
+
+            return viewStartFactories;
+        }
+
+        private static PageHandlerExecutorDelegate[] GetHandlerExecutors(CompiledPageActionDescriptor actionDescriptor)
+        {
+            if (actionDescriptor.HandlerMethods == null || actionDescriptor.HandlerMethods.Count == 0)
+            {
+                return Array.Empty<PageHandlerExecutorDelegate>();
+            }
+
+            var results = new PageHandlerExecutorDelegate[actionDescriptor.HandlerMethods.Count];
+
+            for (var i = 0; i < actionDescriptor.HandlerMethods.Count; i++)
+            {
+                results[i] = ExecutorFactory.CreateExecutor(actionDescriptor.HandlerMethods[i]);
+            }
+
+            return results;
+        }
+
+        private PageHandlerBinderDelegate[] GetHandlerBinders(CompiledPageActionDescriptor actionDescriptor)
+        {
+            if (actionDescriptor.HandlerMethods == null || actionDescriptor.HandlerMethods.Count == 0)
+            {
+                return Array.Empty<PageHandlerBinderDelegate>();
+            }
+
+            var results = new PageHandlerBinderDelegate[actionDescriptor.HandlerMethods.Count];
+
+            for (var i = 0; i < actionDescriptor.HandlerMethods.Count; i++)
+            {
+                results[i] = PageBinderFactory.CreateHandlerBinder(
+                    _parameterBinder,
+                    _modelMetadataProvider,
+                    _modelBinderFactory,
+                    actionDescriptor,
+                    actionDescriptor.HandlerMethods[i],
+                    _mvcOptions);
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvokerProvider.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvokerProvider.cs
@@ -38,34 +38,8 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             IPageHandlerMethodSelector selector,
             DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory,
-            IActionResultTypeMapper mapper)
-            : this(
-                  pageLoader,
-                  pageActionInvokerCache,
-                  modelMetadataProvider,
-                  tempDataFactory,
-                  mvcOptions,
-                  mvcViewOptions,
-                  selector,
-                  diagnosticListener,
-                  loggerFactory,
-                  mapper,
-                  actionContextAccessor: null)
-        {
-        }
-
-        public PageActionInvokerProvider(
-            PageLoader pageLoader,
-            PageActionInvokerCache pageActionInvokerCache,
-            IModelMetadataProvider modelMetadataProvider,
-            ITempDataDictionaryFactory tempDataFactory,
-            IOptions<MvcOptions> mvcOptions,
-            IOptions<MvcViewOptions> mvcViewOptions,
-            IPageHandlerMethodSelector selector,
-            DiagnosticListener diagnosticListener,
-            ILoggerFactory loggerFactory,
             IActionResultTypeMapper mapper,
-            IActionContextAccessor actionContextAccessor)
+            IActionContextAccessor actionContextAccessor = null)
         {
             _pageLoader = pageLoader;
             _pageActionInvokerCache = pageActionInvokerCache;

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageLoaderMatcherPolicy.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageLoaderMatcherPolicy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -76,6 +76,12 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 var page = endpoint.Metadata.GetMetadata<PageActionDescriptor>();
                 if (page != null)
                 {
+                    if (page.CompiledPageDescriptor != null)
+                    {
+                        candidates.ReplaceEndpoint(i, page.CompiledPageDescriptor.Endpoint, candidate.Values);
+                        continue;
+                    }
+
                     // We found an endpoint instance that has a PageActionDescriptor, but not a
                     // CompiledPageActionDescriptor. Update the CandidateSet.
                     Task<CompiledPageActionDescriptor> compiled;
@@ -90,13 +96,14 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
                     if (compiled.IsCompletedSuccessfully)
                     {
+                        page.CompiledPageDescriptor = compiled.Result;
                         candidates.ReplaceEndpoint(i, compiled.Result.Endpoint, candidate.Values);
                     }
                     else
                     {
                         // In the most common case, GetOrAddAsync will return a synchronous result.
                         // Avoid going async since this is a fairly hot path.
-                        return ApplyAsyncAwaited(candidates, compiled, i);
+                        return ApplyAsyncAwaited(page, candidates, compiled, i);
                     }
                 }
             }
@@ -104,9 +111,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             return Task.CompletedTask;
         }
 
-        private async Task ApplyAsyncAwaited(CandidateSet candidates, Task<CompiledPageActionDescriptor> actionDescriptorTask, int index)
+        private async Task ApplyAsyncAwaited(PageActionDescriptor previousPage, CandidateSet candidates, Task<CompiledPageActionDescriptor> actionDescriptorTask, int index)
         {
             var compiled = await actionDescriptorTask;
+            previousPage.CompiledPageDescriptor = compiled;
+
             candidates.ReplaceEndpoint(index, compiled.Endpoint, candidates[index].Values);
 
             for (var i = index + 1; i < candidates.Count; i++)
@@ -123,6 +132,8 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 if (page != null)
                 {
                     compiled = await _loader.LoadAsync(page);
+                    page.CompiledPageDescriptor = compiled;
+
                     candidates.ReplaceEndpoint(i, compiled.Endpoint, candidates[i].Values);
                 }
             }

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageRequestDelegateFactory.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageRequestDelegateFactory.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageRequestDelegateFactory.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageRequestDelegateFactory.cs
@@ -1,23 +1,22 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 {
-    internal class PageActionInvokerProvider : IActionInvokerProvider
+    internal class PageRequestDelegateFactory : IRequestDelegateFactory
     {
-        private readonly PageLoader _pageLoader;
-        private readonly PageActionInvokerCache _pageActionInvokerCache;
+        private readonly PageActionInvokerCache _cache;
         private readonly IReadOnlyList<IValueProviderFactory> _valueProviderFactories;
         private readonly IModelMetadataProvider _modelMetadataProvider;
         private readonly ITempDataDictionaryFactory _tempDataFactory;
@@ -27,10 +26,10 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         private readonly ILogger<PageActionInvoker> _logger;
         private readonly IActionResultTypeMapper _mapper;
         private readonly IActionContextAccessor _actionContextAccessor;
+        private readonly bool _enableActionInvokers;
 
-        public PageActionInvokerProvider(
-            PageLoader pageLoader,
-            PageActionInvokerCache pageActionInvokerCache,
+        public PageRequestDelegateFactory(
+            PageActionInvokerCache cache,
             IModelMetadataProvider modelMetadataProvider,
             ITempDataDictionaryFactory tempDataFactory,
             IOptions<MvcOptions> mvcOptions,
@@ -40,8 +39,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             ILoggerFactory loggerFactory,
             IActionResultTypeMapper mapper)
             : this(
-                  pageLoader,
-                  pageActionInvokerCache,
+                  cache,
                   modelMetadataProvider,
                   tempDataFactory,
                   mvcOptions,
@@ -54,9 +52,8 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         {
         }
 
-        public PageActionInvokerProvider(
-            PageLoader pageLoader,
-            PageActionInvokerCache pageActionInvokerCache,
+        public PageRequestDelegateFactory(
+            PageActionInvokerCache cache,
             IModelMetadataProvider modelMetadataProvider,
             ITempDataDictionaryFactory tempDataFactory,
             IOptions<MvcOptions> mvcOptions,
@@ -67,12 +64,12 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             IActionResultTypeMapper mapper,
             IActionContextAccessor actionContextAccessor)
         {
-            _pageLoader = pageLoader;
-            _pageActionInvokerCache = pageActionInvokerCache;
+            _cache = cache;
             _valueProviderFactories = mvcOptions.Value.ValueProviderFactories.ToArray();
             _modelMetadataProvider = modelMetadataProvider;
             _tempDataFactory = tempDataFactory;
             _mvcViewOptions = mvcViewOptions.Value;
+            _enableActionInvokers = mvcOptions.Value.EnableActionInvokers;
             _selector = selector;
             _diagnosticListener = diagnosticListener;
             _logger = loggerFactory.CreateLogger<PageActionInvoker>();
@@ -80,58 +77,55 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             _actionContextAccessor = actionContextAccessor ?? ActionContextAccessor.Null;
         }
 
-        // For testing
-        internal PageActionInvokerCache Cache => _pageActionInvokerCache;
-
-        public int Order { get; } = -1000;
-
-        public void OnProvidersExecuting(ActionInvokerProviderContext context)
+        public RequestDelegate CreateRequestDelegate(ActionDescriptor actionDescriptor, RouteValueDictionary dataTokens)
         {
-            if (context == null)
+            if (_enableActionInvokers || actionDescriptor is not CompiledPageActionDescriptor page)
             {
-                throw new ArgumentNullException(nameof(context));
+                return null;
             }
 
-            var actionContext = context.ActionContext;
+            // Compiled pages are the only ones that run
 
-            if (actionContext.ActionDescriptor is not PageActionDescriptor page)
+            return context =>
             {
-                return;
-            }
+                RouteData routeData = null;
 
-            if (page.CompiledPageDescriptor == null)
-            {
-                // With legacy routing, we're forced to perform a blocking call. The exceptation is that
-                // in the most common case - build time views or successsively cached runtime views - this should finish synchronously.
-                page.CompiledPageDescriptor = _pageLoader.LoadAsync(page).GetAwaiter().GetResult();
-            }
+                if (dataTokens is null or { Count: 0 })
+                {
+                    routeData = new RouteData(context.Request.RouteValues);
+                }
+                else
+                {
+                    routeData = new RouteData();
+                    routeData.PushState(router: null, context.Request.RouteValues, dataTokens);
+                }
 
-            var (cacheEntry, filters) = _pageActionInvokerCache.GetCachedResult(actionContext);
+                var actionContext = new ActionContext(context, routeData, page);
 
-            var pageContext = new PageContext(actionContext)
-            {
-                ActionDescriptor = cacheEntry.ActionDescriptor,
-                ValueProviderFactories = new CopyOnWriteList<IValueProviderFactory>(_valueProviderFactories),
-                ViewData = cacheEntry.ViewDataFactory(_modelMetadataProvider, actionContext.ModelState),
-                ViewStartFactories = cacheEntry.ViewStartFactories.ToList(),
+                var (cacheEntry, filters) = _cache.GetCachedResult(actionContext);
+
+                var pageContext = new PageContext(actionContext)
+                {
+                    ActionDescriptor = cacheEntry.ActionDescriptor,
+                    ValueProviderFactories = new CopyOnWriteList<IValueProviderFactory>(_valueProviderFactories),
+                    ViewData = cacheEntry.ViewDataFactory(_modelMetadataProvider, actionContext.ModelState),
+                    ViewStartFactories = cacheEntry.ViewStartFactories.ToList(),
+                };
+
+                var pageInvoker = new PageActionInvoker(
+                    _selector,
+                    _diagnosticListener,
+                    _logger,
+                    _actionContextAccessor,
+                    _mapper,
+                    pageContext,
+                    filters,
+                    cacheEntry,
+                    _tempDataFactory,
+                    _mvcViewOptions.HtmlHelperOptions);
+
+                return pageInvoker.InvokeAsync();
             };
-
-            context.Result = new PageActionInvoker(
-                _selector,
-                _diagnosticListener,
-                _logger,
-                _actionContextAccessor,
-                _mapper,
-                pageContext,
-                filters,
-                cacheEntry,
-                _tempDataFactory,
-                _mvcViewOptions.HtmlHelperOptions);
-        }
-
-        public void OnProvidersExecuted(ActionInvokerProviderContext context)
-        {
-
         }
     }
 }

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageRequestDelegateFactory.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageRequestDelegateFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -40,32 +39,8 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             IPageHandlerMethodSelector selector,
             DiagnosticListener diagnosticListener,
             ILoggerFactory loggerFactory,
-            IActionResultTypeMapper mapper)
-            : this(
-                  cache,
-                  modelMetadataProvider,
-                  tempDataFactory,
-                  mvcOptions,
-                  mvcViewOptions,
-                  selector,
-                  diagnosticListener,
-                  loggerFactory,
-                  mapper,
-                  actionContextAccessor: null)
-        {
-        }
-
-        public PageRequestDelegateFactory(
-            PageActionInvokerCache cache,
-            IModelMetadataProvider modelMetadataProvider,
-            ITempDataDictionaryFactory tempDataFactory,
-            IOptions<MvcOptions> mvcOptions,
-            IOptions<MvcViewOptions> mvcViewOptions,
-            IPageHandlerMethodSelector selector,
-            DiagnosticListener diagnosticListener,
-            ILoggerFactory loggerFactory,
             IActionResultTypeMapper mapper,
-            IActionContextAccessor actionContextAccessor)
+            IActionContextAccessor actionContextAccessor = null)
         {
             _cache = cache;
             _valueProviderFactories = mvcOptions.Value.ValueProviderFactories.ToArray();

--- a/src/Mvc/Mvc.RazorPages/src/PageActionDescriptor.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PageActionDescriptor.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages
 {
@@ -59,6 +61,11 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages
         /// This value will be <c>null</c> for non-area pages.
         /// </summary>
         public string AreaName { get; set; }
+
+        internal virtual CompiledPageActionDescriptor CompiledPageDescriptor { get; set; }
+
+        // This is a cache to avoid multiple compilation operations kicking off
+        internal Task<CompiledPageActionDescriptor> CompiledPageActionDescriptorTask { get; set; }
 
         /// <inheritdoc />
         public override string DisplayName

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionInvokerTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionInvokerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
@@ -1577,44 +1576,9 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 pageContext,
                 filters ?? Array.Empty<IFilterMetadata>(),
                 cacheEntry,
-                GetParameterBinder(),
                 tempDataFactory,
                 new HtmlHelperOptions());
             return invoker;
-        }
-
-        private static ParameterBinder GetParameterBinder(
-            IModelBinderFactory factory = null,
-            IModelValidatorProvider validator = null)
-        {
-            if (validator == null)
-            {
-                validator = CreateMockValidatorProvider();
-            }
-
-            if (factory == null)
-            {
-                factory = TestModelBinderFactory.CreateDefault();
-            }
-
-            var metadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
-            var mvcOptions = new MvcOptions();
-
-            return new ParameterBinder(
-                metadataProvider,
-                factory,
-                new DefaultObjectValidator(metadataProvider, new[] { validator }, mvcOptions),
-                Options.Create(mvcOptions),
-                NullLoggerFactory.Instance);
-        }
-
-        private static IModelValidatorProvider CreateMockValidatorProvider()
-        {
-            var mockValidator = new Mock<IModelValidatorProvider>(MockBehavior.Strict);
-            mockValidator
-                .Setup(o => o.CreateValidators(
-                    It.IsAny<ModelValidatorProviderContext>()));
-            return mockValidator.Object;
         }
 
         private CompiledPageActionDescriptor CreateDescriptorForSimplePage()

--- a/src/Mvc/Mvc/test/MvcServiceCollectionExtensionsTest.cs
+++ b/src/Mvc/Mvc/test/MvcServiceCollectionExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
 using Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
@@ -523,6 +524,14 @@ namespace Microsoft.AspNetCore.Mvc
                         {
                             typeof(ControllerActionInvokerProvider),
                             typeof(PageActionInvokerProvider),
+                        }
+                    },
+                    {
+                        typeof(IRequestDelegateFactory),
+                        new Type[]
+                        {
+                            typeof(PageRequestDelegateFactory),
+                            typeof(ControllerRequestDelegateFactory)
                         }
                     },
                     {

--- a/src/Mvc/samples/MvcSandbox/Startup.cs
+++ b/src/Mvc/samples/MvcSandbox/Startup.cs
@@ -55,16 +55,14 @@ namespace MvcSandbox
 
                 builder.MapGet(
                     "/graph",
-                    (httpContext) =>
+                    async (httpContext) =>
                     {
-                        using (var writer = new StreamWriter(httpContext.Response.Body, Encoding.UTF8, 1024, leaveOpen: true))
-                        {
-                            var graphWriter = httpContext.RequestServices.GetRequiredService<DfaGraphWriter>();
-                            var dataSource = httpContext.RequestServices.GetRequiredService<EndpointDataSource>();
-                            graphWriter.Write(dataSource, writer);
-                        }
+                        await using var writer = new StringWriter();
+                        var graphWriter = httpContext.RequestServices.GetRequiredService<DfaGraphWriter>();
+                        var dataSource = httpContext.RequestServices.GetRequiredService<EndpointDataSource>();
+                        graphWriter.Write(dataSource, writer);
+                        await httpContext.Response.WriteAsync(writer.ToString());
 
-                        return Task.CompletedTask;
                     }).WithDisplayName("DFA Graph");
 
                 builder.MapControllers();


### PR DESCRIPTION
- Implemented the PageRequestDelegateFactory for razor pages
- Refactored the PageActionInvokerProvider into a PageActionInvokerCache to
mimic the controller implementation and to share logic.
- Moved the cache to be part of the CompiledPageActionDescriptor itself.
This simplifies the looked and expiration as it is tied to the
CompiledPageActionDescriptor instance.
- Skip the page loader for already compiled pages

