### PR TITLE
Use Uri.SchemeDelimiter instead of hardcoded "://" for const of SchemeDelimiter in UriHelper

### DIFF
--- a/src/Http/Http.Extensions/src/UriHelper.cs
+++ b/src/Http/Http.Extensions/src/UriHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
         private const char ForwardSlash = '/';
         private const char Hash = '#';
         private const char QuestionMark = '?';
-        private const string SchemeDelimiter = "://";
+        private static readonly string SchemeDelimiter = Uri.SchemeDelimiter;
 
         /// <summary>
         /// Combines the given URI components into a string that is properly encoded for use in HTTP headers.

--- a/src/Http/Http/src/BindingAddress.cs
+++ b/src/Http/Http/src/BindingAddress.cs
@@ -49,11 +49,11 @@ namespace Microsoft.AspNetCore.Http
         {
             if (IsUnixPipe)
             {
-                return Scheme.ToLowerInvariant() + "://" + Host.ToLowerInvariant();
+                return Scheme.ToLowerInvariant() + Uri.SchemeDelimiter + Host.ToLowerInvariant();
             }
             else
             {
-                return Scheme.ToLowerInvariant() + "://" + Host.ToLowerInvariant() + ":" + Port.ToString(CultureInfo.InvariantCulture) + PathBase;
+                return Scheme.ToLowerInvariant() + Uri.SchemeDelimiter + Host.ToLowerInvariant() + ":" + Port.ToString(CultureInfo.InvariantCulture) + PathBase;
             }
         }
 
@@ -79,12 +79,12 @@ namespace Microsoft.AspNetCore.Http
         {
             address = address ?? string.Empty;
 
-            int schemeDelimiterStart = address.IndexOf("://", StringComparison.Ordinal);
+            int schemeDelimiterStart = address.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal);
             if (schemeDelimiterStart < 0)
             {
                 throw new FormatException($"Invalid url: '{address}'");
             }
-            int schemeDelimiterEnd = schemeDelimiterStart + "://".Length;
+            int schemeDelimiterEnd = schemeDelimiterStart + Uri.SchemeDelimiter.Length;
 
             var isUnixPipe = address.IndexOf(UnixPipeHostPrefix, schemeDelimiterEnd, StringComparison.Ordinal) == schemeDelimiterEnd;
 

--- a/src/Middleware/Rewrite/src/RedirectRule.cs
+++ b/src/Middleware/Rewrite/src/RedirectRule.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Rewrite
                     return;
                 }
 
-                if (newPath.IndexOf("://", StringComparison.Ordinal) == -1 && newPath[0] != '/')
+                if (newPath.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal) == -1 && newPath[0] != '/')
                 {
                     newPath = '/' + newPath;
                 }

--- a/src/Middleware/Rewrite/src/RewriteRule.cs
+++ b/src/Middleware/Rewrite/src/RewriteRule.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Rewrite
                     result = "/";
                 }
 
-                if (result.IndexOf("://", StringComparison.Ordinal) >= 0)
+                if (result.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal) >= 0)
                 {
                     string scheme;
                     HostString host;

--- a/src/Middleware/Rewrite/src/UrlActions/RedirectAction.cs
+++ b/src/Middleware/Rewrite/src/UrlActions/RedirectAction.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Rewrite.UrlActions
                 return;
             }
 
-            if (pattern.IndexOf("://", StringComparison.Ordinal) == -1 && pattern[0] != '/')
+            if (pattern.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal) == -1 && pattern[0] != '/')
             {
                 pattern = '/' + pattern;
             }

--- a/src/Middleware/Rewrite/src/UrlActions/RewriteAction.cs
+++ b/src/Middleware/Rewrite/src/UrlActions/RewriteAction.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Rewrite.UrlActions
 
 
             // TODO PERF, substrings, object creation, etc.
-            if (pattern.IndexOf("://", StringComparison.Ordinal) >= 0)
+            if (pattern.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal) >= 0)
             {
                 string scheme;
                 HostString host;

--- a/src/Mvc/Mvc.Core/src/Routing/UrlHelperBase.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/UrlHelperBase.cs
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                     protocol = string.IsNullOrEmpty(protocol) ? "http" : protocol;
                     builder.Append(protocol);
 
-                    builder.Append("://");
+                    builder.Append(Uri.SchemeDelimiter);
 
                     host = string.IsNullOrEmpty(host) ? ActionContext.HttpContext.Request.Host.Value : host;
                     builder.Append(host);
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Mvc.Routing
                     protocol = string.IsNullOrEmpty(protocol) ? "http" : protocol;
                     builder.Append(protocol);
 
-                    builder.Append("://");
+                    builder.Append(Uri.SchemeDelimiter);
 
                     host = string.IsNullOrEmpty(host) ? ActionContext.HttpContext.Request.Host.Value : host;
                     builder.Append(host);

--- a/src/Security/Authentication/Core/src/AuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationHandler.cs
@@ -76,12 +76,12 @@ namespace Microsoft.AspNetCore.Authentication
         protected ISystemClock Clock { get; }
 
         /// <summary>
-        /// Gets the <see cref="IOptionsMonitor{TOptions}"/> to detect changes to options. 
+        /// Gets the <see cref="IOptionsMonitor{TOptions}"/> to detect changes to options.
         /// </summary>
         protected IOptionsMonitor<TOptions> OptionsMonitor { get; }
 
         /// <summary>
-        /// The handler calls methods on the events which give the application control at certain points where processing is occurring. 
+        /// The handler calls methods on the events which give the application control at certain points where processing is occurring.
         /// If it is not provided a default instance is supplied which does nothing when the methods are called.
         /// </summary>
         protected virtual object? Events { get; set; }
@@ -99,9 +99,9 @@ namespace Microsoft.AspNetCore.Authentication
         /// </summary>
         protected string CurrentUri
         {
-            get => Request.Scheme + "://" + Request.Host + Request.PathBase + Request.Path + Request.QueryString;
+            get => Request.Scheme + Uri.SchemeDelimiter + Request.Host + Request.PathBase + Request.Path + Request.QueryString;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of <see cref="AuthenticationHandler{TOptions}"/>.
         /// </summary>
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <param name="targetPath">The path.</param>
         /// <returns>The absolute url.</returns>
         protected string BuildRedirectUri(string targetPath)
-            => Request.Scheme + "://" + Request.Host + OriginalPathBase + targetPath;
+            => Request.Scheme + Uri.SchemeDelimiter + Request.Host + OriginalPathBase + targetPath;
 
         /// <summary>
         /// Resolves the scheme that this authentication operation is forwarded to.

--- a/src/Servers/HttpSys/src/UrlPrefix.cs
+++ b/src/Servers/HttpSys/src/UrlPrefix.cs
@@ -109,12 +109,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             string path = null;
             var whole = prefix ?? string.Empty;
 
-            var schemeDelimiterEnd = whole.IndexOf("://", StringComparison.Ordinal);
+            var schemeDelimiterEnd = whole.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal);
             if (schemeDelimiterEnd < 0)
             {
                 throw new FormatException("Invalid prefix, missing scheme separator: " + prefix);
             }
-            var hostDelimiterStart = schemeDelimiterEnd + "://".Length;
+            var hostDelimiterStart = schemeDelimiterEnd + Uri.SchemeDelimiter.Length;
 
             var pathDelimiterStart = whole.IndexOf("/", hostDelimiterStart, StringComparison.Ordinal);
             if (pathDelimiterStart < 0)
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public string Path { get; }
 
         internal string PathWithoutTrailingSlash { get; }
-        
+
         /// <summary>
         /// Gets a string representation of the prefix
         /// </summary>


### PR DESCRIPTION

This PR is to update of use Uri.SchemeDelimiter instead of having hardcoded value of "://" for const value of SchemeDelimiter

Summary of the changes (Less than 80 chars)
 - set  value of SchemeDelimiter const to  Uri.SchemeDelimiter 

Addresses #bugnumber (in this specific format)? 
N/A (just minor refactor over existing code in `src/Http/Http.Extensions/src/UriHelper.cs`)
