### PR TITLE
Avoid ActivatorUtilities for IIS and HttpSys auth handlers 

### DIFF
--- a/src/Servers/HttpSys/src/WebHostBuilderHttpSysExtensions.cs
+++ b/src/Servers/HttpSys/src/WebHostBuilderHttpSysExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             return hostBuilder.ConfigureServices(services => {
                 services.AddSingleton<IServer, MessagePump>();
+                services.AddTransient<AuthenticationHandler>();
                 services.AddSingleton<IServerIntegratedAuth>(services =>
                 {
                     var options = services.GetRequiredService<IOptions<HttpSysOptions>>().Value;

--- a/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
+++ b/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.Hosting
                     services => {
                         services.AddSingleton(new IISNativeApplication(new NativeSafeHandle(iisConfigData.pNativeApplication)));
                         services.AddSingleton<IServer, IISHttpServer>();
+                        services.AddTransient<IISServerAuthenticationHandlerInternal>();
                         services.AddSingleton<IStartupFilter>(new IISServerSetupFilter(iisConfigData.pwzVirtualApplicationPath));
                         services.AddAuthenticationCore();
                         services.AddSingleton<IServerIntegratedAuth>(_ => new ServerIntegratedAuth()


### PR DESCRIPTION
#24150 is trying to improve or remove the use of ActivatorUtilities when creating auth handler instances per request. In testing we realized that IIS and HttpSys were using this pattern which is much slower than the DI activated pattern. This fixes the issue by registering each of their auth handler types in the DI container.
