### PR TITLE
Removes unused EnsureSignInScheme method

### DIFF
--- a/src/Security/Authentication/Core/src/AuthenticationServiceCollectionExtensions.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationServiceCollectionExtensions.cs
@@ -65,20 +65,5 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
-        // Used to ensure that there's always a sign in scheme
-        private class EnsureSignInScheme<TOptions> : IPostConfigureOptions<TOptions> where TOptions : RemoteAuthenticationOptions
-        {
-            private readonly AuthenticationOptions _authOptions;
-
-            public EnsureSignInScheme(IOptions<AuthenticationOptions> authOptions)
-            {
-                _authOptions = authOptions.Value;
-            }
-
-            public void PostConfigure(string name, TOptions options)
-            {
-                options.SignInScheme ??= _authOptions.DefaultSignInScheme;
-            }
-        }
     }
 }


### PR DESCRIPTION
 - Removes unused code
 - This method must be left over from a refactor or something. It now exists in [AuthenticationBuilder](https://github.com/dotnet/aspnetcore/blob/f98959f630f916d74ccdb705bd02ab34b86fcf85/src/Security/Authentication/Core/src/AuthenticationBuilder.cs#L109)