### PR TITLE
Working to resolve issue 27111, AuthenticationSchemeOptions.ForwardDefaultSelector should allow for null.

### DIFF
--- a/src/Security/Authentication/Core/src/AuthenticationSchemeOptions.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationSchemeOptions.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// setting first, followed by checking the ForwardDefaultSelector, followed by ForwardDefault. The first non null result
         /// will be used as the target scheme to forward to.
         /// </summary>
-        public Func<HttpContext, string>? ForwardDefaultSelector { get; set; }
+        public Func<HttpContext, string?>? ForwardDefaultSelector { get; set; }
 
     }
 }

--- a/src/Security/Authentication/Core/src/PublicAPI.Shipped.txt
+++ b/src/Security/Authentication/Core/src/PublicAPI.Shipped.txt
@@ -51,7 +51,6 @@ Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardChallenge
 Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardChallenge.set -> void
 Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardDefault.get -> string?
 Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardDefault.set -> void
-Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardDefaultSelector.get -> System.Func<Microsoft.AspNetCore.Http.HttpContext!, string!>?
 Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardDefaultSelector.set -> void
 Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardForbid.get -> string?
 Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardForbid.set -> void

--- a/src/Security/Authentication/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Security/Authentication/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Authentication.AuthenticationSchemeOptions.ForwardDefaultSelector.get -> System.Func<Microsoft.AspNetCore.Http.HttpContext!, string?>?


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Added the `?` character to the ForwardDefaultSelector property Func return type as requested in this bug/issue here: [Issue #27111 ](https://github.com/dotnet/aspnetcore/issues/27111)

Addresses #27111
