### PR TITLE
Support IAsyncDisposable for MVC

### DIFF
--- a/src/Mvc/Mvc.Core/src/Controllers/DefaultControllerActivator.cs
+++ b/src/Mvc/Mvc.Core/src/Controllers/DefaultControllerActivator.cs
@@ -73,6 +73,10 @@ namespace Microsoft.AspNetCore.Mvc.Controllers
             {
                 disposable.Dispose();
             }
+            else if (controller is IAsyncDisposable asyncDisposable)
+            {
+                asyncDisposable.DisposeAsync().AsTask().Wait()
+            }
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Controllers/DefaultControllerActivator.cs
+++ b/src/Mvc/Mvc.Core/src/Controllers/DefaultControllerActivator.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Mvc.Controllers
             }
             else if (controller is IAsyncDisposable asyncDisposable)
             {
-                asyncDisposable.DisposeAsync().AsTask().Wait()
+                asyncDisposable.DisposeAsync().AsTask().Wait();
             }
         }
     }


### PR DESCRIPTION
- Added conditional to release `IDisposableAsync` synchronously

Without this change, controllers are forced to implement `IDisposable` even if they are just `IAsyncDisposable`.

This method is not async so prefer synchronous IDisposable.

Also running `DisposeAsync` synchronously could be done better. I'm not experienced in that area.

Addresses #13150