### PR TITLE
Small tweaks to result execution

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
@@ -196,7 +196,12 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             }
 
             public static void BufferingAsyncEnumerable(ILogger logger, object asyncEnumerable)
-                => _bufferingAsyncEnumerable(logger, asyncEnumerable.GetType().FullName, null);
+            {
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    _bufferingAsyncEnumerable(logger, asyncEnumerable.GetType().FullName, null);
+                }
+            }
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/SystemTextJsonResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/SystemTextJsonResultExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             }
             else
             {
-                if (!(serializerSettings is JsonSerializerOptions settingsFromResult))
+                if (serializerSettings is not JsonSerializerOptions settingsFromResult)
                 {
                     throw new InvalidOperationException(Resources.FormatProperty_MustBeInstanceOfType(
                         nameof(JsonResult),
@@ -152,12 +152,20 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
 
             public static void JsonResultExecuting(ILogger logger, object value)
             {
-                var type = value == null ? "null" : value.GetType().FullName;
-                _jsonResultExecuting(logger, type, null);
+                if (logger.IsEnabled(LogLevel.Information))
+                {
+                    var type = value == null ? "null" : value.GetType().FullName;
+                    _jsonResultExecuting(logger, type, null);
+                }
             }
 
             public static void BufferingAsyncEnumerable(ILogger logger, object asyncEnumerable)
-                => _bufferingAsyncEnumerable(logger, asyncEnumerable.GetType().FullName, null);
+            {
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    _bufferingAsyncEnumerable(logger, asyncEnumerable.GetType().FullName, null);
+                }
+            }
         }
     }
 }

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonResultExecutor.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonResultExecutor.cs
@@ -196,12 +196,20 @@ namespace Microsoft.AspNetCore.Mvc.NewtonsoftJson
 
             public static void JsonResultExecuting(ILogger logger, object value)
             {
-                var type = value == null ? "null" : value.GetType().FullName;
-                _jsonResultExecuting(logger, type, null);
+                if (logger.IsEnabled(LogLevel.Information))
+                {
+                    var type = value == null ? "null" : value.GetType().FullName;
+                    _jsonResultExecuting(logger, type, null);
+                }
             }
 
             public static void BufferingAsyncEnumerable(ILogger logger, object asyncEnumerable)
-                => _bufferingAsyncEnumerable(logger, asyncEnumerable.GetType().FullName, null);
+            {
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    _bufferingAsyncEnumerable(logger, asyncEnumerable.GetType().FullName, null);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Don't allocate string for type if logging isn't on
- Use pattern matching
