### PR TITLE
Re-disable IsWindowsOnlyTest on ARM

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -45,7 +45,7 @@
     <HelixAvailableTargetQueue Include="(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036" Platform="Linux" />
   </ItemGroup>
   <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on it's setup scripts. -->
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true' AND Condition="'$(IsWindowsOnlyTest)' != 'true'">
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailableTargetQueue Include="Windows.10.Arm64v8.Open" Platform="Windows" />
   </ItemGroup>
 </Project>

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -44,7 +44,8 @@
   <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailableTargetQueue Include="(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036" Platform="Linux" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true'">
+  <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on it's setup scripts. -->
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true' AND Condition="'$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailableTargetQueue Include="Windows.10.Arm64v8.Open" Platform="Windows" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
All work items that depend on the IIS Express setup script don't work on ARM because IIS Express isn't supported/installed.
https://dev.azure.com/dnceng/public/_build/results?buildId=902748&view=ms.vss-test-web.build-test-results-tab&runId=28825126&paneView=debug&resultId=122844

Whatever I'd done as part of #27838 to verify this scenario in the PR clearly didn't work.