### PR TITLE
Use short name for DebianArm64

### DIFF
--- a/src/Testing/src/xunit/HelixConstants.cs
+++ b/src/Testing/src/xunit/HelixConstants.cs
@@ -6,6 +6,6 @@ namespace Microsoft.AspNetCore.Testing
     public static class HelixConstants
     {
         public const string Windows10Arm64 = "Windows.10.Arm64v8.Open;";
-        public const string DebianArm64 = "(Debian.9.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-9-helix-arm64v8-a12566d-20190807161036;";
+        public const string DebianArm64 = "Debian.9.Arm64.Open;";
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/pull/28093 added skips for tests that aren't supported on ARM, but the skips aren't working. @BrennanConroy did some digging and it looks like we need to use the short name here because that's what's passed into the test runner.