### PR TITLE
[Blazor] Update router attribute to be explicitly passed as a boolean

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/App.razor
@@ -1,5 +1,5 @@
 ﻿@*#if (NoAuth)
-<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>
@@ -11,7 +11,7 @@
 </Router>
 #else
 <CascadingAuthenticationState>
-    <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+    <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
         <Found Context="routeData">
             <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         </Found>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/App.razor
@@ -1,5 +1,5 @@
 ﻿@*#if (NoAuth)
-<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>
@@ -11,7 +11,7 @@
 </Router>
 #else
 <CascadingAuthenticationState>
-    <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+    <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
         <Found Context="routeData">
             <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
                 <NotAuthorized>


### PR DESCRIPTION
#### Description

We introduced a public property as part of https://github.com/dotnet/aspnetcore/pull/27907 to enable users to opt-in. Turns out that this caused issues since we didn't update the target pack. 

As a result, the Razor compiler treats this new property as a regular HTML attribute (of type string) instead of as a boolean.

In turn this causes the template to error at runtime when the application starts.

#### Customer Impact

Customers using 5.0.1 won't be able to create and run new blazor apps out of the box. They can fix the template code by preceding the `true` value in the attribute with `@` to force the compiler to interpret it as C#. (Which is the same fix we are applying).

#### Regression?

Yes, 5.0.0. Users were able to create new blazor templates without this issue.

#### Risk

Low. We've manually validated the fix against a new project from a 5.0.1 template.