### PR TITLE
Don't call HttpCloseUrlGroup if you didn't create it

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private ServerSession _serverSession;
         private bool _disposed;
+        private bool _created = false;
 
         internal unsafe UrlGroup(ServerSession serverSession, ILogger logger)
         {
@@ -27,6 +28,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             _logger = logger;
 
             ulong urlGroupId = 0;
+            _created = true;
             var statusCode = HttpApi.HttpCreateUrlGroup(
                 _serverSession.Id.DangerousGetServerSessionId(), &urlGroupId, 0);
 
@@ -141,14 +143,20 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
             _disposed = true;
 
-            Debug.Assert(Id != 0, "HttpCloseUrlGroup called with invalid url group id");
-
-            uint statusCode = HttpApi.HttpCloseUrlGroup(Id);
-
-            if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
+            if (_created)
             {
-                _logger.LogError(LoggerEventIds.CloseUrlGroupError, "HttpCloseUrlGroup; Result: {0}" , statusCode);
+
+                Debug.Assert(Id != 0, "HttpCloseUrlGroup called with invalid url group id");
+
+                uint statusCode = HttpApi.HttpCloseUrlGroup(Id);
+
+                if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
+                {
+                    _logger.LogError(LoggerEventIds.CloseUrlGroupError, "HttpCloseUrlGroup; Result: {0}", statusCode);
+                }
+
             }
+
             Id = 0;
         }
 

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private ServerSession _serverSession;
         private bool _disposed;
-        private bool _created = false;
+        private bool _created;
 
         internal unsafe UrlGroup(ServerSession serverSession, ILogger logger)
         {
@@ -46,6 +46,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             _logger = logger;
 
             ulong urlGroupId = 0;
+            _created = false;
             var statusCode = HttpApi.HttpFindUrlGroupId(
                 url.FullPrefix, requestQueue.Handle, &urlGroupId);
 


### PR DESCRIPTION
Added a `_created` bool to track whether we created or attached to the UrlGroup