### PR TITLE
Duplicate delegation rules should not fail

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -87,7 +87,16 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
             var statusCode = HttpApi.HttpSetUrlGroupProperty(Id, property, info, infosize);
 
-            if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
+            if (statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_ALREADY_EXISTS
+                && property == HttpApiTypes.HTTP_SERVER_PROPERTY.HttpServerDelegationProperty)
+            {
+                /* Swallow file already exists exception
+                 * Delegation property has been set by
+                 * another rule referencing the same UrlGroup
+                 */
+                return;
+            }
+            else if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
             {
                 var exception = new HttpSysException((int)statusCode);
                 _logger.LogError(LoggerEventIds.SetUrlPropertyError, exception, "SetUrlGroupProperty");

--- a/src/Servers/HttpSys/test/FunctionalTests/DelegateTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/DelegateTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
             using var delegator = Utilities.CreateHttpServer(out var delegatorAddress, httpContext =>
             {
                 var delegateFeature = httpContext.Features.Get<IHttpSysRequestDelegationFeature>();
-                // Let's pick the rule we set the delegation property on
+                // Let's pick the rule we didn't set the delegation property on
                 delegateFeature.DelegateRequest(destination1);
                 return Task.CompletedTask;
             });


### PR DESCRIPTION
Creating two delegation rules for the same queue name but different url prefixes no longer results in an HttpSysException.

