### PR TITLE
Use a single request object

### DIFF
--- a/src/Servers/HttpSys/HttpSysServer.slnf
+++ b/src/Servers/HttpSys/HttpSysServer.slnf
@@ -23,7 +23,8 @@
       "src\\Servers\\HttpSys\\src\\Microsoft.AspNetCore.Server.HttpSys.csproj",
       "src\\Servers\\HttpSys\\test\\FunctionalTests\\Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj",
       "src\\Servers\\HttpSys\\test\\Tests\\Microsoft.AspNetCore.Server.HttpSys.Tests.csproj",
-      "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj"
+      "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj",
+      "src\\Testing\\src\\Microsoft.AspNetCore.Testing.csproj"
     ]
   }
 }

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -20,8 +20,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 {
     internal sealed class Request
     {
-        private NativeRequestContext _nativeRequestContext;
-
         private X509Certificate2 _clientCert;
         // TODO: https://github.com/aspnet/HttpSysServer/issues/231
         // private byte[] _providedTokenBindingId;
@@ -39,26 +37,25 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private bool _isDisposed = false;
 
-        internal Request(RequestContext requestContext, NativeRequestContext nativeRequestContext)
+        internal Request(RequestContext requestContext)
         {
             // TODO: Verbose log
             RequestContext = requestContext;
-            _nativeRequestContext = nativeRequestContext;
             _contentBoundaryType = BoundaryType.None;
 
-            RequestId = nativeRequestContext.RequestId;
-            UConnectionId = nativeRequestContext.ConnectionId;
-            SslStatus = nativeRequestContext.SslStatus;
+            RequestId = requestContext.RequestId;
+            UConnectionId = requestContext.ConnectionId;
+            SslStatus = requestContext.SslStatus;
 
-            KnownMethod = nativeRequestContext.VerbId;
-            Method = _nativeRequestContext.GetVerb();
+            KnownMethod = requestContext.VerbId;
+            Method = requestContext.GetVerb();
 
-            RawUrl = nativeRequestContext.GetRawUrl();
+            RawUrl = requestContext.GetRawUrl();
 
-            var cookedUrl = nativeRequestContext.GetCookedUrl();
+            var cookedUrl = requestContext.GetCookedUrl();
             QueryString = cookedUrl.GetQueryString() ?? string.Empty;
 
-            var rawUrlInBytes = _nativeRequestContext.GetRawUrlInBytes();
+            var rawUrlInBytes = requestContext.GetRawUrlInBytes();
             var originalPath = RequestUriBuilder.DecodeAndUnescapePath(rawUrlInBytes);
 
             PathBase = string.Empty;
@@ -72,7 +69,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
             else
             {
-                var prefix = requestContext.Server.Options.UrlPrefixes.GetPrefix((int)nativeRequestContext.UrlContext);
+                var prefix = requestContext.Server.Options.UrlPrefixes.GetPrefix((int)requestContext.UrlContext);
                 // Prefix may be null if the requested has been transfered to our queue
                 if (!(prefix is null))
                 {
@@ -97,11 +94,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 }
             }
 
-            ProtocolVersion = _nativeRequestContext.GetVersion();
+            ProtocolVersion = RequestContext.GetVersion();
 
-            Headers = new RequestHeaders(_nativeRequestContext);
+            Headers = new RequestHeaders(RequestContext);
 
-            User = _nativeRequestContext.GetUser();
+            User = RequestContext.GetUser();
 
             if (IsHttps)
             {
@@ -111,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             // GetTlsTokenBindingInfo(); TODO: https://github.com/aspnet/HttpSysServer/issues/231
 
             // Finished directly accessing the HTTP_REQUEST structure.
-            _nativeRequestContext.ReleasePins();
+            RequestContext.ReleasePins();
             // TODO: Verbose log parameters
         }
 
@@ -222,7 +219,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 if (_remoteEndPoint == null)
                 {
-                    _remoteEndPoint = _nativeRequestContext.GetRemoteEndPoint();
+                    _remoteEndPoint = RequestContext.GetRemoteEndPoint();
                 }
 
                 return _remoteEndPoint;
@@ -235,7 +232,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 if (_localEndPoint == null)
                 {
-                    _localEndPoint = _nativeRequestContext.GetLocalEndPoint();
+                    _localEndPoint = RequestContext.GetLocalEndPoint();
                 }
 
                 return _localEndPoint;
@@ -278,7 +275,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 if (_requestInfo == null)
                 {
-                    _requestInfo = _nativeRequestContext.GetRequestInfo();
+                    _requestInfo = RequestContext.GetRequestInfo();
                 }
                 return _requestInfo;
             }
@@ -286,7 +283,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private void GetTlsHandshakeResults()
         {
-            var handshake = _nativeRequestContext.GetTlsHandshake();
+            var handshake = RequestContext.GetTlsHandshake();
 
             Protocol = handshake.Protocol;
             // The OS considers client and server TLS as different enum values. SslProtocols choose to combine those for some reason.
@@ -332,7 +329,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 {
                     try
                     {
-                        _clientCert = _nativeRequestContext.GetClientCertificate();
+                        _clientCert = RequestContext.GetClientCertificate();
                     }
                     catch (CryptographicException ce)
                     {
@@ -426,27 +423,19 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         */
         internal uint GetChunks(ref int dataChunkIndex, ref uint dataChunkOffset, byte[] buffer, int offset, int size)
         {
-            return _nativeRequestContext.GetChunks(ref dataChunkIndex, ref dataChunkOffset, buffer, offset, size);
+            return RequestContext.GetChunks(ref dataChunkIndex, ref dataChunkOffset, buffer, offset, size);
         }
 
         // should only be called from RequestContext
         internal void Dispose()
         {
-            // TODO: Verbose log
-            _isDisposed = true;
-            _nativeRequestContext.Dispose();
-            (User?.Identity as WindowsIdentity)?.Dispose();
-            if (_nativeStream != null)
+            if (!_isDisposed)
             {
-                _nativeStream.Dispose();
-            }
-        }
-
-        private void CheckDisposed()
-        {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(this.GetType().FullName);
+                // TODO: Verbose log
+                _isDisposed = true;
+                RequestContext.Dispose();
+                (User?.Identity as WindowsIdentity)?.Dispose();
+                _nativeStream?.Dispose();
             }
         }
 

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Principal;
 using System.Threading;
@@ -16,21 +14,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.HttpSys
 {
-    internal sealed class RequestContext : IDisposable, IThreadPoolWorkItem
+    internal sealed partial class RequestContext : NativeRequestContext, IThreadPoolWorkItem
     {
         private static readonly Action<object> AbortDelegate = Abort;
-        private NativeRequestContext _memoryBlob;
         private CancellationTokenSource _requestAbortSource;
         private CancellationToken? _disconnectToken;
         private bool _disposed;
+        private bool _initialized;
 
-        internal RequestContext(HttpSysListener server, NativeRequestContext memoryBlob)
+        public RequestContext(HttpSysListener server, uint? bufferSize, ulong requestId)
+            : base(server.MemoryPool, bufferSize, requestId)
         {
-            // TODO: Verbose log
             Server = server;
-            _memoryBlob = memoryBlob;
-            Request = new Request(this, _memoryBlob);
-            Response = new Response(this);
             AllowSynchronousIO = server.Options.AllowSynchronousIO;
         }
 
@@ -40,9 +35,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal ILogger Logger => Server.Logger;
 
-        public Request Request { get; }
+        public Request Request { get; private set; }
 
-        public Response Response { get; }
+        public Response Response { get; private set; }
 
         public WindowsPrincipal User => Request.User;
 
@@ -132,31 +127,38 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             return value != null;
         }
 
+
         /// <summary>
         /// Flushes and completes the response.
         /// </summary>
-        public void Dispose()
+        public override void Dispose()
         {
             if (_disposed)
             {
                 return;
             }
+
             _disposed = true;
 
-            // TODO: Verbose log
-            try
+            if (_initialized)
             {
-                _requestAbortSource?.Dispose();
-                Response.Dispose();
+                // TODO: Verbose log
+                try
+                {
+                    _requestAbortSource?.Dispose();
+                    Response.Dispose();
+                }
+                catch
+                {
+                    Abort();
+                }
+                finally
+                {
+                    Request.Dispose();
+                }
             }
-            catch
-            {
-                Abort();
-            }
-            finally
-            {
-                Request.Dispose();
-            }
+
+            base.Dispose();
         }
 
         /// <summary>
@@ -258,16 +260,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 messagePump.IncrementOutstandingRequest();
                 try
                 {
-                    var featureContext = new FeatureContext(this);
-                    context = application.CreateContext(featureContext.Features);
+                    context = application.CreateContext(Features);
                     try
                     {
                         await application.ProcessRequestAsync(context);
-                        await featureContext.CompleteAsync();
+                        await CompleteAsync();
                     }
                     finally
                     {
-                        await featureContext.OnCompleted();
+                        await OnCompleted();
                     }
                     application.DisposeContext(context, null);
                     Dispose();

--- a/src/Servers/HttpSys/src/StandardFeatureCollection.cs
+++ b/src/Servers/HttpSys/src/StandardFeatureCollection.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 {
     internal sealed class StandardFeatureCollection : IFeatureCollection
     {
-        private static readonly Func<FeatureContext, object> _identityFunc = ReturnIdentity;
-        private static readonly Dictionary<Type, Func<FeatureContext, object>> _featureFuncLookup = new Dictionary<Type, Func<FeatureContext, object>>()
+        private static readonly Func<RequestContext, object> _identityFunc = ReturnIdentity;
+        private static readonly Dictionary<Type, Func<RequestContext, object>> _featureFuncLookup = new()
         {
             { typeof(IHttpRequestFeature), _identityFunc },
             { typeof(IHttpRequestBodyDetectionFeature), _identityFunc },
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             { typeof(IHttpRequestLifetimeFeature), _identityFunc },
             { typeof(IHttpAuthenticationFeature), _identityFunc },
             { typeof(IHttpRequestIdentifierFeature), _identityFunc },
-            { typeof(RequestContext), ctx => ctx.RequestContext },
+            { typeof(RequestContext), ctx => ctx },
             { typeof(IHttpMaxRequestBodySizeFeature), _identityFunc },
             { typeof(IHttpBodyControlFeature), _identityFunc },
             { typeof(IHttpSysRequestInfoFeature), _identityFunc },
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             { typeof(IHttpResetFeature), ctx => ctx.GetResetFeature() },
         };
 
-        private readonly FeatureContext _featureContext;
+        private readonly RequestContext _featureContext;
 
         static StandardFeatureCollection()
         {
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
-        public StandardFeatureCollection(FeatureContext featureContext)
+        public StandardFeatureCollection(RequestContext featureContext)
         {
             _featureContext = featureContext;
         }
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             get
             {
-                Func<FeatureContext, object> lookupFunc;
+                Func<RequestContext, object> lookupFunc;
                 _featureFuncLookup.TryGetValue(key, out lookupFunc);
                 return lookupFunc?.Invoke(_featureContext);
             }
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
-        private static object ReturnIdentity(FeatureContext featureContext)
+        private static object ReturnIdentity(RequestContext featureContext)
         {
             return featureContext;
         }


### PR DESCRIPTION
- Merged NativeRequestContext, RequestContext and FeatureContext into a single object.
    - RequestContext derives from NativeRequestContext

Contributes to #22022