### PR TITLE
Fixed ResponseCompression middleware nullability

### DIFF
--- a/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
@@ -270,8 +270,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
         }
 
-        [MemberNotNull(nameof(_compressionProvider))]
-        private ICompressionProvider ResolveCompressionProvider()
+        private ICompressionProvider? ResolveCompressionProvider()
         {
             if (!_providerCreated)
             {
@@ -279,7 +278,6 @@ namespace Microsoft.AspNetCore.ResponseCompression
                 _compressionProvider = _provider.GetCompressionProvider(_context);
             }
 
-            Debug.Assert(_compressionProvider != null);
             return _compressionProvider;
         }
 


### PR DESCRIPTION
The compression provider can be null, e.g. when using identity provider
https://github.com/dotnet/aspnetcore/blame/master/src/Middleware/ResponseCompression/src/ResponseCompressionProvider.cs#L140-L142

There were some tests failing the assertion, so #11632 would have help to detect those.

It's a private method and all the calling site were already handling nulls correctly. so, there was no bug, just an invalid annotation.

/cc @pranavkm