### PR TITLE
Replace File.ReadAllLines and LINQ.Reverse with less allocating alternatives

### DIFF
--- a/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs
+++ b/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Microsoft.AspNetCore.DataProtection.Internal
 {
@@ -101,9 +102,18 @@ namespace Microsoft.AspNetCore.DataProtection.Internal
                 return false;
             }
 
-            var lines = File.ReadAllLines(procFile);
-            // typically the last line in the file is "1:name=openrc:/docker"
-            return lines.Reverse().Any(l => l.EndsWith("name=openrc:/docker", StringComparison.Ordinal));
+            using (StreamReader sr = new StreamReader(procFile, Encoding.UTF8))
+            {
+                while (sr.ReadLine() is string line)
+                {
+                    if (line.EndsWith("name=openrc:/docker", StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private static bool GetBooleanEnvVar(string envVarName)


### PR DESCRIPTION
`File.ReadAllLines(procFile)`:

1. Allocates a `List<string>`
2. Reads all lines into `string`s.
   1. List will grow (with array allocations and copy) 4, 8, 16, ...
3. Allocates array for all read lines.

`lines.Reverse().Any(l => l.EndsWith("name=openrc:/docker", StringComparison.Ordinal))`:
1. Allocates and enumerator and enumerates it to fill an array with all lines (again)
2. Allocates an enumerable to iterate lines in revers order.
3. Invokes a delegate for each line until the condition is met.

The propose change:

1. Does not allocate any memory to hold all lines.
2. Exits as soon as the condition is met.
