### PR TITLE
Get rid of 2 pass razor pages logic in the default case

### DIFF
--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/DefaultPageLoader.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/DefaultPageLoader.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             _globalFilters = mvcOptions.Value.Filters;
         }
 
-        private IViewCompiler Compiler => _viewCompilerProvider.GetCompiler();
+        internal IViewCompiler Compiler => _viewCompilerProvider.GetCompiler();
 
         public override Task<CompiledPageActionDescriptor> LoadAsync(PageActionDescriptor actionDescriptor)
             => LoadAsync(actionDescriptor, EndpointMetadataCollection.Empty);

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/DefaultPageLoader.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/DefaultPageLoader.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             return actionDescriptor.CompiledPageActionDescriptorTask = LoadAsyncCore(actionDescriptor, endpointMetadata);
         }
 
-        private async Task<CompiledPageActionDescriptor> LoadAsyncCore(PageActionDescriptor actionDescriptor, EndpointMetadataCollection endpointMetadata)
+        internal async Task<CompiledPageActionDescriptor> LoadWithoutEndpoint(PageActionDescriptor actionDescriptor)
         {
             var viewDescriptor = await Compiler.CompileAsync(actionDescriptor.RelativePath);
             var context = new PageApplicationModelProviderContext(actionDescriptor, viewDescriptor.Type.GetTypeInfo());
@@ -80,7 +80,12 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
             ApplyConventions(_conventions, context.PageApplicationModel);
 
-            var compiled = CompiledPageActionDescriptorBuilder.Build(context.PageApplicationModel, _globalFilters);
+            return CompiledPageActionDescriptorBuilder.Build(context.PageApplicationModel, _globalFilters);
+        }
+
+        private async Task<CompiledPageActionDescriptor> LoadAsyncCore(PageActionDescriptor actionDescriptor, EndpointMetadataCollection endpointMetadata)
+        {
+            var compiled = await LoadWithoutEndpoint(actionDescriptor);
 
             // We need to create an endpoint for routing to use and attach it to the CompiledPageActionDescriptor...
             // routing for pages is two-phase. First we perform routing using the route info - we can do this without

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSource.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSource.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                         // The default view compiler does a dictionary lookup so we can rely on that always completing synchronously
                         // this lets us avoid lots of per-request work as the compiled page is already available at
                         // startup for this page so we can base the endpoint on that directly.
-                        var compiledTask = _pageLoader.LoadAsync(action);
+                        var compiledTask = _pageLoader.LoadWithoutEndpoint(action);
 
                         // This should always complete synchronously
                         Debug.Assert(compiledTask.IsCompleted);

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSourceFactory.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionEndpointDataSourceFactory.cs
@@ -11,20 +11,23 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
         private readonly PageActionEndpointDataSourceIdProvider _dataSourceIdProvider;
         private readonly IActionDescriptorCollectionProvider _actions;
         private readonly ActionEndpointFactory _endpointFactory;
+        private readonly PageLoader _pageLoader;
 
         public PageActionEndpointDataSourceFactory(
             PageActionEndpointDataSourceIdProvider dataSourceIdProvider,
             IActionDescriptorCollectionProvider actions,
+            PageLoader pageLoader,
             ActionEndpointFactory endpointFactory)
         {
             _dataSourceIdProvider = dataSourceIdProvider;
             _actions = actions;
+            _pageLoader = pageLoader;
             _endpointFactory = endpointFactory;
         }
 
         public PageActionEndpointDataSource Create(OrderedEndpointsSequenceProvider orderProvider)
         {
-            return new PageActionEndpointDataSource(_dataSourceIdProvider, _actions, _endpointFactory, orderProvider);
+            return new PageActionEndpointDataSource(_dataSourceIdProvider, _actions, _endpointFactory, _pageLoader, orderProvider);
         }
     }
 }

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageLoaderMatcherPolicy.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageLoaderMatcherPolicy.cs
@@ -41,9 +41,9 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
             for (var i = 0; i < endpoints.Count; i++)
             {
                 var page = endpoints[i].Metadata.GetMetadata<PageActionDescriptor>();
-                if (page != null)
+                if (page is not null and not CompiledPageActionDescriptor)
                 {
-                    // Found a page
+                    // Found an uncompiled page
                     return true;
                 }
             }

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionEndpointDataSourceTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/PageActionEndpointDataSourceTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
         private protected override ActionEndpointDataSourceBase CreateDataSource(IActionDescriptorCollectionProvider actions, ActionEndpointFactory endpointFactory)
         {
-            return new PageActionEndpointDataSource(new PageActionEndpointDataSourceIdProvider(), actions, endpointFactory, new OrderedEndpointsSequenceProvider());
+            return new PageActionEndpointDataSource(new PageActionEndpointDataSourceIdProvider(), actions, endpointFactory, Mock.Of<PageLoader>(), new OrderedEndpointsSequenceProvider());
         }
 
         protected override ActionDescriptor CreateActionDescriptor(


### PR DESCRIPTION
- Today RazorPages uses a 2 pass model where initially pages are discovered but not "compiled" up front. Then a matcher policy is used to build the compiled page action descriptor with the type information. This requires running logic per request that determines if we need to compile the page. By default, runtime compilation is off and the compiled page information is available via a dictionary lookup. We can use the page loader at startup time to avoid doing lazy lookup of this information and a dynamic swap in the endpoint system. Instead we can build the endpoint for the compiled page descriptor directly.

