### PR TITLE
Refactor how we capture the IHttpApplication

### DIFF
--- a/src/Servers/HttpSys/src/ApplicationRequestContextFactory.cs
+++ b/src/Servers/HttpSys/src/ApplicationRequestContextFactory.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Hosting.Server;
+
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    internal class ApplicationRequestContextFactory<TContext> : IRequestContextFactory
+    {
+        private readonly IHttpApplication<TContext> _application;
+        private readonly MessagePump _messagePump;
+
+        public ApplicationRequestContextFactory(IHttpApplication<TContext> application, MessagePump messagePump)
+        {
+            _application = application;
+            _messagePump = messagePump;
+        }
+
+        public RequestContext CreateRequestContext(uint? bufferSize, ulong requestId)
+        {
+            return new RequestContext<TContext>(_application, _messagePump, _messagePump.Listener, bufferSize, requestId);
+        }
+    }
+}

--- a/src/Servers/HttpSys/src/AsyncAcceptContext.cs
+++ b/src/Servers/HttpSys/src/AsyncAcceptContext.cs
@@ -24,10 +24,12 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         };
 
         private RequestContext _requestContext;
+        private readonly IRequestContextFactory _requestContextFactory;
 
-        internal AsyncAcceptContext(HttpSysListener server)
+        internal AsyncAcceptContext(HttpSysListener server, IRequestContextFactory requestContextFactory)
         {
             Server = server;
+            _requestContextFactory = requestContextFactory;
             _preallocatedOverlapped = new(IOCallback, state: this, pinData: null);
         }
 
@@ -193,7 +195,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 boundHandle.FreeNativeOverlapped(_overlapped);
             }
 
-            _requestContext = new RequestContext(Server, size, requestId);
+            _requestContext = _requestContextFactory.CreateRequestContext(size, requestId);
             _overlapped = boundHandle.AllocateNativeOverlapped(_preallocatedOverlapped);
         }
 

--- a/src/Servers/HttpSys/src/IRequestContextFactory.cs
+++ b/src/Servers/HttpSys/src/IRequestContextFactory.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    internal interface IRequestContextFactory
+    {
+        RequestContext CreateRequestContext(uint? bufferSize, ulong requestId);
+    }
+}

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.HttpSys
+{
+    internal sealed class RequestContext<TContext> : RequestContext
+    {
+        private readonly IHttpApplication<TContext> _application;
+        private readonly MessagePump _messagePump;
+
+        public RequestContext(IHttpApplication<TContext> application, MessagePump messagePump, HttpSysListener server, uint? bufferSize, ulong requestId)
+            : base(server, bufferSize, requestId)
+        {
+            _application = application;
+            _messagePump = messagePump;
+        }
+
+        protected override async Task ExecuteAsync()
+        {
+            var messagePump = _messagePump;
+            var application = _application;
+
+            try
+            {
+                if (messagePump.Stopping)
+                {
+                    SetFatalResponse(503);
+                    return;
+                }
+
+                TContext context = default;
+                messagePump.IncrementOutstandingRequest();
+                try
+                {
+                    context = application.CreateContext(Features);
+                    try
+                    {
+                        await application.ProcessRequestAsync(context);
+                        await CompleteAsync();
+                    }
+                    finally
+                    {
+                        await OnCompleted();
+                    }
+                    application.DisposeContext(context, null);
+                    Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(LoggerEventIds.RequestProcessError, ex, "ProcessRequestAsync");
+                    application.DisposeContext(context, ex);
+                    if (Response.HasStarted)
+                    {
+                        // HTTP/2 INTERNAL_ERROR = 0x2 https://tools.ietf.org/html/rfc7540#section-7
+                        // Otherwise the default is Cancel = 0x8.
+                        SetResetCode(2);
+                        Abort();
+                    }
+                    else
+                    {
+                        // We haven't sent a response yet, try to send a 500 Internal Server Error
+                        Response.Headers.IsReadOnly = false;
+                        Response.Trailers.IsReadOnly = false;
+                        Response.Headers.Clear();
+                        Response.Trailers.Clear();
+
+                        if (ex is BadHttpRequestException badHttpRequestException)
+                        {
+                            SetFatalResponse(badHttpRequestException.StatusCode);
+                        }
+                        else
+                        {
+                            SetFatalResponse(StatusCodes.Status500InternalServerError);
+                        }
+                    }
+                }
+                finally
+                {
+                    if (messagePump.DecrementOutstandingRequest() == 0 && messagePump.Stopping)
+                    {
+                        Logger.LogInformation(LoggerEventIds.RequestsDrained, "All requests drained.");
+                        messagePump.SetShutdownSignal();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(LoggerEventIds.RequestError, ex, "ProcessRequestAsync");
+                Abort();
+            }
+        }
+    }
+
+}

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -113,7 +113,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
         /// </summary>
         internal static async Task<RequestContext> AcceptAsync(this HttpSysListener server, TimeSpan timeout)
         {
-            var acceptContext = new AsyncAcceptContext(server);
+            var factory = new TestRequestContextFactory(server);
+            var acceptContext = new AsyncAcceptContext(server, factory);
             var acceptTask = server.AcceptAsync(acceptContext).AsTask();
             var completedTask = await Task.WhenAny(acceptTask, Task.Delay(timeout));
 
@@ -141,6 +142,21 @@ namespace Microsoft.AspNetCore.Server.HttpSys.Listener
             {
                 var response = await responseTask;
                 throw new InvalidOperationException("The response completed prematurely: " + response.ToString());
+            }
+        }
+
+        private class TestRequestContextFactory : IRequestContextFactory
+        {
+            private readonly HttpSysListener _server;
+
+            public TestRequestContextFactory(HttpSysListener server)
+            {
+                _server = server;
+            }
+
+            public RequestContext CreateRequestContext(uint? bufferSize, ulong requestId)
+            {
+                return new RequestContext(_server, bufferSize, requestId);
             }
         }
     }


### PR DESCRIPTION
- Use a similar technique to capture the generic IHttpApplication that we do in IIS and Kestrel. Now the AsyncAcceptContext takes an IRequestContextFactory to delegate RequestContext creation to pull the request from the HTTP.sys queue.

