### PR TITLE
Allow RazorTagHelper task to be invoked by MSBuild targets that do not specify ToolExe

### DIFF
--- a/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/MvcBuildIntegrationTest22.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/integrationtests/MvcBuildIntegrationTest22.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
+
+namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
+{
+    public class MvcBuildIntegrationTest22 : MvcBuildIntegrationTestLegacy
+    {
+        public MvcBuildIntegrationTest22(LegacyBuildServerTestFixture buildServer)
+            : base(buildServer)
+        {
+        }
+
+        public override string TestProjectName => "SimpleMvc22";
+        public override string TargetFramework => "netcoreapp2.2";
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        public async Task BuildProject_UsingDesktopMSBuild()
+        {
+            using var _ = CreateTestProject();
+
+            // Build
+            // This is a regression test for https://github.com/dotnet/aspnetcore/issues/28333. We're trying to ensure
+            // building in Desktop when DOTNET_HOST_PATH is not configured continues to work.
+            // Explicitly unset it to verify a value is not being picked up as an ambient value.
+            var result = await DotnetMSBuild("Build", args: "/p:DOTNET_HOST_PATH=", msBuildProcessKind: MSBuildProcessKind.Desktop);
+
+            Assert.BuildPassed(result);
+            Assert.FileExists(result, OutputPath, OutputFileName);
+            Assert.FileExists(result, OutputPath, $"{TestProjectName}.pdb");
+            Assert.FileExists(result, OutputPath, $"{TestProjectName}.Views.dll");
+            Assert.FileExists(result, OutputPath, $"{TestProjectName}.Views.pdb");
+
+            // Verify RazorTagHelper works
+            Assert.FileExists(result, IntermediateOutputPath, $"{TestProjectName}.TagHelpers.input.cache");
+            Assert.FileExists(result, IntermediateOutputPath, $"{TestProjectName}.TagHelpers.output.cache");
+            Assert.FileContains(
+                result,
+                Path.Combine(IntermediateOutputPath, $"{TestProjectName}.TagHelpers.output.cache"),
+                @"""Name"":""SimpleMvc.SimpleTagHelper""");
+        }
+    }
+}

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/DotnetToolTask.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/DotnetToolTask.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Microsoft.AspNetCore.Razor.Tools;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.Extensions.CommandLineUtils;
 
 namespace Microsoft.AspNetCore.Razor.Tasks
 {
@@ -40,7 +41,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
 
         public string PipeName { get; set; }
 
-        protected override string ToolName => Path.GetDirectoryName(DotNetPath);
+        protected override string ToolName => "dotnet";
 
         // If we're debugging then make all of the stdout gets logged in MSBuild
         protected override MessageImportance StandardOutputLoggingImportance => DebugTool ? MessageImportance.High : base.StandardOutputLoggingImportance;
@@ -60,11 +61,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
                     return _dotnetPath;
                 }
 
-                _dotnetPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
-                if (string.IsNullOrEmpty(_dotnetPath))
-                {
-                    throw new InvalidOperationException("DOTNET_HOST_PATH is not set");
-                }
+                _dotnetPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? ToolExe;
 
                 return _dotnetPath;
             }

--- a/src/Razor/test/testassets/RestoreTestProjects/RestoreTestProjects.csproj
+++ b/src/Razor/test/testassets/RestoreTestProjects/RestoreTestProjects.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SimpleMvc21\SimpleMvc21.csproj" />
+    <ProjectReference Include="..\SimpleMvc22\SimpleMvc22.csproj" />
     <ProjectReference Include="..\SimpleMvc31\SimpleMvc31.csproj" />
     <ProjectReference Include="..\blazor31\blazor31.csproj" />
     <ProjectReference Include="..\ClassLibraryMvc21\ClassLibraryMvc21.csproj" />

--- a/src/Razor/test/testassets/SimpleMvc22/Program.cs
+++ b/src/Razor/test/testassets/SimpleMvc22/Program.cs
@@ -1,0 +1,13 @@
+﻿
+namespace SimpleMvc
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            // Just make sure we have a reference to MVC
+            var t = typeof(Microsoft.AspNetCore.Mvc.IActionResult);
+            System.Console.WriteLine(t.FullName);
+        }
+    }
+}

--- a/src/Razor/test/testassets/SimpleMvc22/SimpleMvc22.csproj
+++ b/src/Razor/test/testassets/SimpleMvc22/SimpleMvc22.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <!--
+    This project references a shipped version of MVC and should not reference local builds of
+    the CodeGeneration targets, rzc, or any of the test shims.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
+  </PropertyGroup>
+
+  <!-- Test Placeholder -->
+
+  <PropertyGroup Condition="'$(RunningAsTest)' == ''">
+    <!-- We don't want to run build server when not running as tests. -->
+    <UseRazorBuildServer>false</UseRazorBuildServer>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App">
+      <!-- Avoid exporting types from real MVC that will conflict with the test shim -->
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+
+     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0">
+      <!-- Avoid exporting types from real MVC that will conflict with the test shim -->
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/Razor/test/testassets/SimpleMvc22/SimpleTagHelper.cs
+++ b/src/Razor/test/testassets/SimpleMvc22/SimpleTagHelper.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace SimpleMvc
+{
+    public class SimpleTagHelper : TagHelper
+    {
+    }
+}

--- a/src/Razor/test/testassets/SimpleMvc22/Views/Home/Index.cshtml
+++ b/src/Razor/test/testassets/SimpleMvc22/Views/Home/Index.cshtml
@@ -1,0 +1,10 @@
+﻿@{
+    ViewData["Title"] = "Home Page";
+}
+
+<h2>
+    Learn how to build ASP.NET apps that can run anywhere.
+    <a class="btn btn-default" href="https://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
+        Learn More
+    </a>
+</h2>

--- a/src/Razor/test/testassets/SimpleMvc22/Views/Shared/_Layout.cshtml
+++ b/src/Razor/test/testassets/SimpleMvc22/Views/Shared/_Layout.cshtml
@@ -1,0 +1,25 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - SimpleMvc</title>
+
+    <environment exclude="Development">
+        <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css"
+              asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
+              asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
+        <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
+    </environment>
+</head>
+<body>
+    <nav class="navbar navbar-inverse navbar-fixed-top">
+        <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">SimpleMvc</a>
+    </nav>
+    <div class="container body-content">
+        @RenderBody()
+    </div>
+
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/src/Razor/test/testassets/SimpleMvc22/Views/_ViewImports.cshtml
+++ b/src/Razor/test/testassets/SimpleMvc22/Views/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+﻿@using SimpleMvc
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@namespace SimpleMvc21
+@inject DateTime TheTime

--- a/src/Razor/test/testassets/SimpleMvc22/Views/_ViewStart.cshtml
+++ b/src/Razor/test/testassets/SimpleMvc22/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}


### PR DESCRIPTION
### Description

The RazorTagHelper task in the SDK is invoked by targets outside the SDK.
Consequently, any new requirements on the tasks need to be compatible with these versions.

In 5.0, we changed the task to expect the path to be passed in by the ToolExe property. This changes allows
using dotnet.exe from the ambient PATH to be used instead (the previous behavior)

### Customer impact

Makes the RazorTagHelper task backwards compatibile

### Regression

Yes. Introduced as part of 5.0.0

### Risk

Low. We have some integration testing for this code path. I manually tested a few key scenarios


