### PR TITLE
Upload Windows Installers from builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -260,6 +260,8 @@ stages:
         includeForks: true
       - name: Windows_Packages
         path: artifacts/packages/
+      - name: Windows_Installers
+        path: artifacts/installers/
 
   # Build Windows ARM
   - template: jobs/default-build.yml


### PR DESCRIPTION
We upload the arm64 installers, but not the x64/x86 ones: https://github.com/dotnet/aspnetcore/blob/19c492ffca19dd25ace7290cf6cf0a0cebff5be2/.azure/pipelines/ci.yml#L309-L310