### PR TITLE
Use Msquic nuget package for HTTP/3

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,6 +8,7 @@
     <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
+    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <!-- Used for the SiteExtension 3.1 bits that are included in the 5.0 build -->
     <add key="dotnet31-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -132,6 +132,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.Web.Xdt" />
     <LatestPackageReference Include="NETStandard.Library" />
     <LatestPackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <LatestPackageReference Include="System.Net.Experimental.MsQuic" />
     <LatestPackageReference Include="System.Net.Http.WinHttpHandler" />
     <LatestPackageReference Include="System.Net.WebSockets.WebSocketProtocol" />
     <LatestPackageReference Include="System.ServiceProcess.ServiceController" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -208,7 +208,7 @@
     <MicrosoftWebXdtVersion>1.4.0</MicrosoftWebXdtVersion>
     <SystemIdentityModelTokensJwtVersion>6.7.1</SystemIdentityModelTokensJwtVersion>
     <NuGetVersioningVersion>5.7.0</NuGetVersioningVersion>
-    <SystemNetExperimentalMsQuic>5.0.0-alpha.20560.6</SystemNetExperimentalMsQuic>
+    <SystemNetExperimentalMsQuicVersion>5.0.0-alpha.20560.6</SystemNetExperimentalMsQuicVersion>
     <!-- Packages from 2.1, 3.1, and 5.0 branches used for site extension build. -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22Version>2.2.0</MicrosoftAspNetCoreAzureAppServicesSiteExtension22Version>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -208,7 +208,7 @@
     <MicrosoftWebXdtVersion>1.4.0</MicrosoftWebXdtVersion>
     <SystemIdentityModelTokensJwtVersion>6.7.1</SystemIdentityModelTokensJwtVersion>
     <NuGetVersioningVersion>5.7.0</NuGetVersioningVersion>
-    <SystemNetExperimentalMsQuic>5.0.0-alpha</SystemNetExperimentalMsQuic>
+    <SystemNetExperimentalMsQuic>5.0.0-alpha.20560.6</SystemNetExperimentalMsQuic>
     <!-- Packages from 2.1, 3.1, and 5.0 branches used for site extension build. -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22Version>2.2.0</MicrosoftAspNetCoreAzureAppServicesSiteExtension22Version>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -208,6 +208,7 @@
     <MicrosoftWebXdtVersion>1.4.0</MicrosoftWebXdtVersion>
     <SystemIdentityModelTokensJwtVersion>6.7.1</SystemIdentityModelTokensJwtVersion>
     <NuGetVersioningVersion>5.7.0</NuGetVersioningVersion>
+    <SystemNetExperimentalMsQuic>5.0.0-alpha</SystemNetExperimentalMsQuic>
     <!-- Packages from 2.1, 3.1, and 5.0 branches used for site extension build. -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension22Version>2.2.0</MicrosoftAspNetCoreAzureAppServicesSiteExtension22Version>

--- a/src/Servers/Kestrel/Transport.Quic/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.csproj
@@ -27,6 +27,7 @@
     <Reference Include="Microsoft.AspNetCore.Connections.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="System.Net.Experimental.MsQuic" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
@@ -10,10 +10,4 @@
     <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="msquic.dll" Condition="Exists('msquic.dll')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This way, we don't need to build msquic each time we want to use the HTTP/3 samples!

Follow ups:
- [ ] Build msquic as stub tls for functional tests on windows and *nix.
- [ ] Write functional tests with msquic.