### PR TITLE
ResponseCompression: set Content-Encoding and Vary headers for HEAD requests

### DIFF
--- a/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
@@ -59,6 +59,12 @@ namespace Microsoft.AspNetCore.ResponseCompression
             {
                 await _compressionStream.DisposeAsync();
             }
+
+            // Adds the compression headers for HEAD requests even if the body was not used.
+            if (HttpMethods.IsHead(_context.Request.Method) && !_compressionChecked)
+            {
+                InitializeCompression();
+            }
         }
 
         HttpsCompressionMode IHttpsCompressionFeature.Mode { get; set; } = HttpsCompressionMode.Default;
@@ -232,40 +238,49 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
         }
 
+        private void InitializeCompression()
+        {
+            if (_provider.ShouldCompressResponse(_context))
+            {
+                // If the MIME type indicates that the response could be compressed, caches will need to vary by the Accept-Encoding header
+                var varyValues = _context.Response.Headers.GetCommaSeparatedValues(HeaderNames.Vary);
+                var varyByAcceptEncoding = false;
+
+                for (var i = 0; i < varyValues.Length; i++)
+                {
+                    if (string.Equals(varyValues[i], HeaderNames.AcceptEncoding, StringComparison.OrdinalIgnoreCase))
+                    {
+                        varyByAcceptEncoding = true;
+                        break;
+                    }
+                }
+
+                if (!varyByAcceptEncoding)
+                {
+                    _context.Response.Headers.Append(HeaderNames.Vary, HeaderNames.AcceptEncoding);
+                }
+
+                var compressionProvider = ResolveCompressionProvider();
+                if (compressionProvider != null)
+                {
+                    _context.Response.Headers.Append(HeaderNames.ContentEncoding, compressionProvider.EncodingName);
+                    _context.Response.Headers.Remove(HeaderNames.ContentMD5); // Reset the MD5 because the content changed.
+                    _context.Response.Headers.Remove(HeaderNames.ContentLength);
+                }
+            }
+        }
+
         private void OnWrite()
         {
             if (!_compressionChecked)
             {
                 _compressionChecked = true;
-                if (_provider.ShouldCompressResponse(_context))
+
+                InitializeCompression();
+
+                if (_compressionProvider != null)
                 {
-                    // If the MIME type indicates that the response could be compressed, caches will need to vary by the Accept-Encoding header
-                    var varyValues = _context.Response.Headers.GetCommaSeparatedValues(HeaderNames.Vary);
-                    var varyByAcceptEncoding = false;
-
-                    for (var i = 0; i < varyValues.Length; i++)
-                    {
-                        if (string.Equals(varyValues[i], HeaderNames.AcceptEncoding, StringComparison.OrdinalIgnoreCase))
-                        {
-                            varyByAcceptEncoding = true;
-                            break;
-                        }
-                    }
-
-                    if (!varyByAcceptEncoding)
-                    {
-                        _context.Response.Headers.Append(HeaderNames.Vary, HeaderNames.AcceptEncoding);
-                    }
-
-                    var compressionProvider = ResolveCompressionProvider();
-                    if (compressionProvider != null)
-                    {
-                        _context.Response.Headers.Append(HeaderNames.ContentEncoding, compressionProvider.EncodingName);
-                        _context.Response.Headers.Remove(HeaderNames.ContentMD5); // Reset the MD5 because the content changed.
-                        _context.Response.Headers.Remove(HeaderNames.ContentLength);
-
-                        _compressionStream = compressionProvider.CreateStream(_innerStream);
-                    }
+                    _compressionStream = _compressionProvider.CreateStream(_innerStream);
                 }
             }
         }

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
@@ -61,9 +61,9 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
 
             // Adds the compression headers for HEAD requests even if the body was not used.
-            if (HttpMethods.IsHead(_context.Request.Method) && !_compressionChecked)
+            if (!_compressionChecked && HttpMethods.IsHead(_context.Request.Method))
             {
-                InitializeCompression();
+                InitializeCompressionHeaders();
             }
         }
 
@@ -238,7 +238,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
         }
 
-        private void InitializeCompression()
+        private void InitializeCompressionHeaders()
         {
             if (_provider.ShouldCompressResponse(_context))
             {
@@ -276,7 +276,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             {
                 _compressionChecked = true;
 
-                InitializeCompression();
+                InitializeCompressionHeaders();
 
                 if (_compressionProvider != null)
                 {


### PR DESCRIPTION
Currently the compression related headers are missing for HEAD responses that, correctly, do not include a body, as the middleware emit those headers when working on the body.

This change ensure that those headers are generated even for head request without a response body.

I've played a bit on how to extract the required functionality out of the` OnWrite` method and this looked like the cleaner approach that also limited the size of the change.

Fixes #24844

@Tratcher I've followed your suggestion on the issue on where to insert the logic

