### PR TITLE
Remove double enumeration of child nodes.

### DIFF
--- a/src/FileProviders/Embedded/src/Manifest/ManifestParser.cs
+++ b/src/FileProviders/Embedded/src/Manifest/ManifestParser.cs
@@ -143,9 +143,22 @@ namespace Microsoft.Extensions.FileProviders.Embedded.Manifest
 
         private static string EnsureText(XElement element)
         {
-            if (element.Elements().Count() == 0 &&
+            var nodeCount = 0;
+            var elementCount = 0;
+
+            foreach (var node in element.Nodes())
+            {
+                nodeCount++;
+
+                if (node is XElement)
+                {
+                    elementCount++;
+                }
+            }
+
+            if (elementCount == 0 &&
                 !element.IsEmpty &&
-                element.Nodes().Count() == 1 &&
+                nodeCount == 1 &&
                 element.FirstNode.NodeType == XmlNodeType.Text)
             {
                 return element.Value;


### PR DESCRIPTION
The existing code:

```C#
if (element.Elements().Count() == 0 &&
    !element.IsEmpty &&
    element.Nodes().Count() == 1 &&
    element.FirstNode.NodeType == XmlNodeType.Text)
{
    return element.Value;
}
```

starts by enumerating all child nodes to check if there are any child elements (`element.Elements().Count() == 0`). This requires an enumerator allocation and full iteration. Even though the expectation is that there are `0` child elements, semantically, this should have been `element.Elements().Any()`

Then, there's the cheap operation `!element.IsEmpty`.

Then, all child nodes are enumerated to check if there is only one child. This requires an enumerator allocation and full iteration.

Finally, the type of the first node is checked to see if it's a text node.

If all succeeds, the value of the `Value` property if the `element` is returned. This requires traversing all child nodes and building the text.

The proposed code:

```C#
if (!element.IsEmpty &&
    element.FirstNode is XText firstnode &&
    object.ReferenceEquals(element.LastNode, firstnode))
{
    return firstnode.Value;
}
```

starts by the cheapest operation: `!element.IsEmpty`

Then checks if the first node is a text node and, if so, keeps a reference to it: `element.FirstNode is XText firstnode`

Finally, checks if the first node and the laste node are the same (`object.ReferenceEquals(element.LastNode, firstnode)`). This asserts that the `element` only has `1` child and that that child is a text node.

If all succeeds, directly returns the value of the text node without the need to traverse nodes and build a value.

No enumerations were needed!

/cc @davidfowl 