### PR TITLE
Reduce allocations due to LINQ and string building.

### DIFF
--- a/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
+++ b/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
@@ -166,10 +166,7 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
             {
                 if (!distinctRegistrations.Add(registration.Name))
                 {
-                    if (builder is null)
-                    {
-                        builder = new StringBuilder("Duplicate health checks were registered with the name(s): ");
-                    }
+                    builder ??= new StringBuilder("Duplicate health checks were registered with the name(s): ");
 
                     builder.Append(registration.Name).Append(", ");
                 }


### PR DESCRIPTION
The original code:

```C#
        var duplicateNames = registrations
            .GroupBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
            .Where(g => g.Count() > 1)
            .Select(g => g.Key)
            .ToList();
```

 has one more operator than it really needs:

```C#
        var duplicateNames = registrations
            .GroupBy(c => c.Name,, c => c.Name, StringComparer.OrdinalIgnoreCase)
            .Where(g => g.Count() > 1)
            .ToList();
```

Although it's not much of a performance issue.

But it enumerates all elements in all groups to check for duplicates.

Then it builds an intermediary string (`string.Join`) before building the final string.

The whole purpose of this is to build the message string for the exception in case of duplicate registrations. There's no real need to store the registrations (or part of them) and iterate them more than once.

The proposed code maintains an hashtable of the registration names to check for duplicates and builds the exception message as it finds duplicates.