### PR TITLE
Reduce delegate invocations and enumeration.

### DIFF
--- a/src/Http/Routing/src/EndpointNameAddressScheme.cs
+++ b/src/Http/Routing/src/EndpointNameAddressScheme.cs
@@ -73,8 +73,7 @@ namespace Microsoft.AspNetCore.Routing
             // OK we need to report some duplicates.
             var duplicates = endpoints
                 .GroupBy(e => GetEndpointName(e))
-                .Where(g => g.Key != null)
-                .Where(g => g.Count() > 1);
+                .Where(g => g.Key != null && g.Count() > 1);
 
             var builder = new StringBuilder();
             builder.AppendLine(Resources.DuplicateEndpointNameHeader);


### PR DESCRIPTION
The existing code is using 2 delegate invocations when, as it is, only one is needed.

```C#
var duplicates = endpoints
                .GroupBy(e => GetEndpointName(e))
                .Where(g => g.Key != null && g.Count() > 1);
```

The grouping of `null` endpoints could be avoided, but the overall cost could be highier:

```C#
var duplicates = endpoints
    .Select(e => (endpoint: e, key: GetEndpointName(e)))
    .Where(i => i.key is not null)
    .GroupBy(i => i.Key, i => i.endpoint)
    .Where(g => g.Count() > 1);
```