### PR TITLE
Include `area-blazor` in API Review process

### DIFF
--- a/docs/APIReviewProcess.md
+++ b/docs/APIReviewProcess.md
@@ -4,6 +4,7 @@ Starting in 5.0, certain areas within the dotnet/aspnetcore and dotnet/extension
 API changes to the following areas are required to go follow this process:
 
 * area-azure
+* area-blazor
 * area-hosting
 * area-installers
 * area-middleware


### PR DESCRIPTION
We've been treating `blazor` as a quickly evolving area and were initially not taking all the API changes through this process.
That changed since approximately 5.0-preview8 and many API changes have been going through this process.
I'm formalizing this now to require it officially.