### PR TITLE
Some post build signing fixups

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -61,6 +61,7 @@ variables:
     value: /p:TeamName=$(_TeamName)
            /p:OfficialBuildId=$(Build.BuildNumber)
            /p:SkipTestBuild=true
+           /p:PostBuildSign=$(PostBuildSign)
   # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
   # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
   - group: DotNet-Blob-Feed
@@ -89,7 +90,7 @@ variables:
     value: -ExcludeCIBinaryLog
 - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
-    value: '/p:SkipTestBuild=true'
+    value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
   - name: _PublishArgs
     value: ''
   # Write binary logs for all main Windows build steps except the x86 one in public and PR builds.
@@ -431,7 +432,6 @@ stages:
             -p:OnlyPackPlatformSpecificPackages=true
             -p:AssetManifestFileName=aspnetcore-Linux_x64.xml
             $(_BuildArgs)
-            $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
         displayName: Run build.sh
       - script: |
@@ -461,7 +461,7 @@ stages:
             -p:OnlyPackPlatformSpecificPackages=true \
             -p:BuildRuntimeArchive=false \
             -p:LinuxInstallerType=rpm \
-            -p:AssetManifestFileName=aspnetcore-Linux_x64-installers.xml \
+            -p:AssetManifestFileName=aspnetcore-Linux_x64.xml \
             $(_BuildArgs) \
             $(_PublishArgs) \
             $(_InternalRuntimeDownloadArgs)

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -54,10 +54,6 @@
            Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
            the nupkgs pushed. -->
       <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true'" />
-      <!-- Linux x64 is built in 3 stages: Build the base packages, layout, and archive. Then build deb and rpm installers.
-           The first and last segments will both publish the layout (they share artifacts). Only publish this during the first pass. -->
-      <_InstallersToPublish Remove="$(ArtifactsDir)installers\**\*.tar.gz" Condition="'$(BuildRuntimeArchive)' == 'false'" />
-      <_ChecksumsToPublish Remove="$(ArtifactsDir)installers\**\*.tar.gz.sha512" Condition="'$(BuildRuntimeArchive)' == 'false'" />
 
       <ItemsToPushToBlobFeed Include="@(_ChecksumsToPublish)">
         <PublishFlatContainer>true</PublishFlatContainer>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,6 +5,7 @@
   <ItemGroup>
     <!-- Reset Arcade's defaults. -->
     <ItemsToSign Remove="@(ItemsToSign)" />
+    <ItemsToSignPostBuild Remove="@(ItemsToSignPostBuild)" />
     <FileExtensionSignInfo Remove="@(FileExtensionSignInfo)" />
   </ItemGroup>
 


### PR DESCRIPTION
Some error checking in arcade was tightened up a bit, leading to failures in the push to bar and publishing steps for aspnet. The two errors were:
- Conflicting certificate entries for the .msi extension, because the PostBuildSign variable wasn't being passed to the rpm/deb docker builds. Fixed by making it a build parameter.
- Duplicated items to publish entries in the same leg. This is just because the deb/rpm and archive/package build steps share output directories. So artifacts produced in the first get picked up in the last leg. Instead, only do publishing in the last build step once everything is built.