### PR TITLE
Provide a better error message if a blazorwasm app references ASP.NET Core

### DIFF
--- a/src/Components/WebAssembly/Sdk/integrationtests/WasmBuildIntegrationTest.cs
+++ b/src/Components/WebAssembly/Sdk/integrationtests/WasmBuildIntegrationTest.cs
@@ -335,6 +335,16 @@ namespace Microsoft.AspNetCore.Razor.Design.IntegrationTests
             Assert.BuildPassed(result);
         }
 
+        [Fact]
+        public async Task Build_WithAspNetCoreFrameworkReference_Fails()
+        {
+            // Arrange
+            using var project = ProjectDirectory.Create("blazorwasm-fxref");
+
+            var result = await MSBuildProcessManager.DotnetMSBuild(project);
+            Assert.BuildError(result, "BLAZORSDK1001");
+        }
+
         private static BootJsonData ReadBootJsonData(MSBuildResult result, string path)
         {
             return JsonSerializer.Deserialize<BootJsonData>(

--- a/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -631,6 +631,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
+  <Target Name="_FailIfReferencingAspNetCoreApp" BeforeTargets="ResolveRuntimePackAssets">
+    <Error
+      Code="BLAZORSDK1001"
+      Text="The project references the ASP.NET Core shared framework, which is not supported by Blazor WebAssembly apps. Remove the framework reference if directly referenced, or the package reference that adds the framework reference."
+      Condition="'@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->Count())' != '0'" />
+  </Target>
+
   <!--
     This is a hook to import a set of targets after the Blazor WebAssembly targets. By default this is unused.
   -->

--- a/src/Components/WebAssembly/Sdk/testassets/RestoreBlazorWasmTestProjects/RestoreBlazorWasmTestProjects.csproj
+++ b/src/Components/WebAssembly/Sdk/testassets/RestoreBlazorWasmTestProjects/RestoreBlazorWasmTestProjects.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\blazorhosted-rid\blazorhosted-rid.csproj" />
     <ProjectReference Include="..\blazorwasm\blazorwasm.csproj" />
     <ProjectReference Include="..\blazorwasm-minimal\blazorwasm-minimal.csproj" />
+    <ProjectReference Include="..\blazorwasm-fxref\blazorwasm-fxref.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/WebAssembly/Sdk/testassets/blazorwasm-fxref/App.razor
+++ b/src/Components/WebAssembly/Sdk/testassets/blazorwasm-fxref/App.razor
@@ -1,0 +1,1 @@
+﻿Hello from App

--- a/src/Components/WebAssembly/Sdk/testassets/blazorwasm-fxref/Program.cs
+++ b/src/Components/WebAssembly/Sdk/testassets/blazorwasm-fxref/Program.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace standalone
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/Components/WebAssembly/Sdk/testassets/blazorwasm-fxref/blazorwasm-fxref.csproj
+++ b/src/Components/WebAssembly/Sdk/testassets/blazorwasm-fxref/blazorwasm-fxref.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
+    <BlazorWebAssemblySdkDirectoryRoot>$(BlazorWebAssemblySdkArtifactsDirectory)$(Configuration)\sdk-output\</BlazorWebAssemblySdkDirectoryRoot>
+  </PropertyGroup>
+
+  <!-- Test Placeholder -->
+
+  <PropertyGroup Condition="'$(RunningAsTest)' == ''">
+    <!-- We don't want to run build server when not running as tests. -->
+    <UseRazorBuildServer>false</UseRazorBuildServer>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(BinariesRoot)'==''">
+    <!-- In test scenarios $(BinariesRoot) is defined in a generated Directory.Build.props file -->
+    <BinariesRoot>$(RepoRoot)artifacts\bin\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib\$(Configuration)\netstandard2.0\</BinariesRoot>
+  </PropertyGroup>
+
+  <!-- DO NOT add addition references here. This is meant to simulate a non-MVC library -->
+  <ItemGroup Condition="'$(BinariesRoot)'!=''">
+    <Reference Include="$(BinariesRoot)\Microsoft.AspNetCore.Razor.Test.ComponentShim.dll"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/28478

### Description

We've seen a few incidents of Blazor WASM users accidentally referencing the ASP.NET Core shared framework typically from a transitive package reference. This results in a cryptic error about being unable to resolve a runtime pack. We want to provide a clearer message in this case.

### Customer impact
Better error experience for an unsupported scenario.

### Regression
No

### Risk
Low. The change is in the Blazor SDK (no runtime impact), and throws a build error. We're producing a more recognizable build error. There's an integration test and this was also verified manually.

