### PR TITLE
[release/5.0] Fix null ref in UrlGroup.Dispose due to logger not set

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         {
             try
             {
-                UrlGroup = new UrlGroup(this, UrlPrefix.Create(urlPrefix));
+                UrlGroup = new UrlGroup(this, UrlPrefix.Create(urlPrefix), logger);
             }
             catch
             {

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -38,8 +38,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             Id = urlGroupId;
         }
 
-        internal unsafe UrlGroup(RequestQueue requestQueue, UrlPrefix url)
+        internal unsafe UrlGroup(RequestQueue requestQueue, UrlPrefix url, ILogger logger)
         {
+            _logger = logger;
+
             ulong urlGroupId = 0;
             var statusCode = HttpApi.HttpFindUrlGroupId(
                 url.FullPrefix, requestQueue.Handle, &urlGroupId);

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -16,8 +16,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private static readonly int RequestPropertyInfoSize =
             Marshal.SizeOf<HttpApiTypes.HTTP_BINDING_INFO>();
 
+        private readonly ILogger _logger;
+
         private ServerSession _serverSession;
-        private ILogger _logger;
         private bool _disposed;
 
         internal unsafe UrlGroup(ServerSession serverSession, ILogger logger)

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -326,6 +326,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal unsafe void Delegate(DelegationRule destination)
         {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
             if (Request.HasRequestBodyStarted)
             {
                 throw new InvalidOperationException("This request cannot be delegated, the request body has already started.");


### PR DESCRIPTION
Backporting https://github.com/dotnet/aspnetcore/pull/26983 to 5.0

### Description

When disposing a DelegationRule, if the call to HttpCloseUrlGroup within UrlGroup.Dispose() fails then a NullReferenceException happens because _logger is not initialized in the constructor used by the HttpSysRequestDelegationFeature.

This could happen if the delegatee process crashes.

### Customer impact

Customer needs to guard against the null ref with a try...catch.
Backport requested by @NGloreous. Has been validated (and submitted by him 😄)

### Regression

No. This is a new feature introduced in 5.0

### Risk

Very low. 