### PR TITLE
Add JWT and OpendId only if they are needed

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -9,8 +9,8 @@
   <!--#if (OrganizationalAuth || IndividualB2CAuth || EnableOpenAPI) -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="${MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion}" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="${MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion}" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="${MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="${MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" />
     <PackageReference Include="Microsoft.Identity.Web" Version="${MicrosoftIdentityWebPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'"/>
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="${MicrosoftIdentityWebMicrosoftGraphPackageVersion}" Condition=" '$(GenerateGraph)' == 'True' " />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="${SwashbuckleAspNetCorePackageVersion}" Condition="'$(EnableOpenAPI)' == 'True'" />


### PR DESCRIPTION
Remove MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion and MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion if there are not need eg. user wants only OpenApi.

Summary of the changes
 - Excluded MicrosoftAspNetCoreAuthenticationJwtBearer when running without Auth but with OpenApi
 - Excluded MicrosoftAspNetCoreAuthenticationOpenIdConnect when running without Auth but with OpenApi
Addresses #27714 

### Description
WebAPI project template adds unnecessary package references when not required. This was a template authoring bug.

### Customer impact
Newly created projects without auth will not have these packages referenced out of the box.

### Regression
Yes. This was regressed in a 5.0-RC release.

### Risk
Low. There's automation tests to verify project templates work. I was also able to verify the project templates scenarios manually.

