### PR TITLE
[release/5.0] Don't call HttpCloseUrlGroup if you didn't create it

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private ServerSession _serverSession;
         private ILogger _logger;
         private bool _disposed;
-        private bool _created = false;
+        private bool _created;
 
         internal unsafe UrlGroup(ServerSession serverSession, ILogger logger)
         {
@@ -43,6 +43,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         internal unsafe UrlGroup(RequestQueue requestQueue, UrlPrefix url)
         {
             ulong urlGroupId = 0;
+            _created = false;
             var statusCode = HttpApi.HttpFindUrlGroupId(
                 url.FullPrefix, requestQueue.Handle, &urlGroupId);
 

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private ServerSession _serverSession;
         private ILogger _logger;
         private bool _disposed;
+        private bool _created = false;
 
         internal unsafe UrlGroup(ServerSession serverSession, ILogger logger)
         {
@@ -26,6 +27,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             _logger = logger;
 
             ulong urlGroupId = 0;
+            _created = true;
             var statusCode = HttpApi.HttpCreateUrlGroup(
                 _serverSession.Id.DangerousGetServerSessionId(), &urlGroupId, 0);
 
@@ -138,14 +140,20 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
             _disposed = true;
 
-            Debug.Assert(Id != 0, "HttpCloseUrlGroup called with invalid url group id");
-
-            uint statusCode = HttpApi.HttpCloseUrlGroup(Id);
-
-            if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
+            if (_created)
             {
-                _logger.LogError(LoggerEventIds.CloseUrlGroupError, "HttpCloseUrlGroup; Result: {0}" , statusCode);
+
+                Debug.Assert(Id != 0, "HttpCloseUrlGroup called with invalid url group id");
+
+                uint statusCode = HttpApi.HttpCloseUrlGroup(Id);
+
+                if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
+                {
+                    _logger.LogError(LoggerEventIds.CloseUrlGroupError, "HttpCloseUrlGroup; Result: {0}", statusCode);
+                }
+
             }
+
             Id = 0;
         }
 


### PR DESCRIPTION
Backporting https://github.com/dotnet/aspnetcore/pull/28336 to 5.0

### Description

HttpSysRequestDelegationFeature - DelegationRule.Dispose() - Call to HttpCloseUrlGroup Fails with result ERROR_INVALID_PARAMETER

### Customer impact

Backport requested by @NGloreous. Has been validated by him

Results in a null ref that the customer needs to catch if https://github.com/dotnet/aspnetcore/pull/28494 isn't merged

### Regression

No. This is a new feature introduced in 5.0

### Risk

Very low.