### PR TITLE
[release/5.0] DelegationRule.Dispose() unsets delegation property on the queue

### DIFF
--- a/src/Servers/HttpSys/src/DelegationRule.cs
+++ b/src/Servers/HttpSys/src/DelegationRule.cs
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
     public class DelegationRule : IDisposable
     {
         private readonly ILogger _logger;
+        private readonly UrlGroup _sourceQueueUrlGroup;
         /// <summary>
         /// The name of the Http.Sys request queue
         /// </summary>
@@ -23,8 +24,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         public string UrlPrefix { get; }
         internal RequestQueue Queue { get; }
 
-        internal DelegationRule(string queueName, string urlPrefix, ILogger logger)
+        internal DelegationRule(UrlGroup sourceQueueUrlGroup, string queueName, string urlPrefix, ILogger logger)
         {
+            _sourceQueueUrlGroup = sourceQueueUrlGroup;
             _logger = logger;
             QueueName = queueName;
             UrlPrefix = urlPrefix;
@@ -34,6 +36,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <inheritdoc />
         public void Dispose()
         {
+            _sourceQueueUrlGroup.UnSetDelegationProperty(Queue, throwOnError: false);
             Queue.UrlGroup?.Dispose();
             Queue?.Dispose();
         }

--- a/src/Servers/HttpSys/src/DelegationRule.cs
+++ b/src/Servers/HttpSys/src/DelegationRule.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
     {
         private readonly ILogger _logger;
         private readonly UrlGroup _sourceQueueUrlGroup;
+        private bool _disposed;
         /// <summary>
         /// The name of the Http.Sys request queue
         /// </summary>
@@ -36,9 +37,20 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <inheritdoc />
         public void Dispose()
         {
-            _sourceQueueUrlGroup.UnSetDelegationProperty(Queue, throwOnError: false);
-            Queue.UrlGroup?.Dispose();
-            Queue?.Dispose();
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            try
+            {
+                _sourceQueueUrlGroup.UnSetDelegationProperty(Queue, throwOnError: false);
+            }
+            catch (ObjectDisposedException) { /* Server may have been shutdown */ }
+            Queue.UrlGroup.Dispose();
+            Queue.Dispose();
         }
     }
 }

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -77,6 +77,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             SetProperty(HttpApiTypes.HTTP_SERVER_PROPERTY.HttpServerDelegationProperty, new IntPtr(&propertyInfo), (uint)RequestPropertyInfoSize);
         }
 
+        internal unsafe void UnSetDelegationProperty(RequestQueue destination, bool throwOnError = true)
+        {
+            var propertyInfo = new HttpApiTypes.HTTP_BINDING_INFO();
+            propertyInfo.Flags = HttpApiTypes.HTTP_FLAGS.NONE;
+            propertyInfo.RequestQueueHandle = destination.Handle.DangerousGetHandle();
+
+            SetProperty(HttpApiTypes.HTTP_SERVER_PROPERTY.HttpServerDelegationProperty, new IntPtr(&propertyInfo), (uint)RequestPropertyInfoSize, throwOnError);
+        }
+
         internal void SetProperty(HttpApiTypes.HTTP_SERVER_PROPERTY property, IntPtr info, uint infosize, bool throwOnError = true)
         {
             Debug.Assert(info != IntPtr.Zero, "SetUrlGroupProperty called with invalid pointer");

--- a/src/Servers/HttpSys/src/ServerDelegationPropertyFeature.cs
+++ b/src/Servers/HttpSys/src/ServerDelegationPropertyFeature.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         public DelegationRule CreateDelegationRule(string queueName, string uri)
         {
-            var rule = new DelegationRule(queueName, uri, _logger);
+            var rule = new DelegationRule(_queue.UrlGroup, queueName, uri, _logger);
             _queue.UrlGroup.SetDelegationProperty(rule.Queue);
             return rule;
         }


### PR DESCRIPTION
Backporting https://github.com/dotnet/aspnetcore/pull/28342 to 5.0

### Description

When a new DelegationRule is created, SetDelegationProperty gets called to add a HttpServerDelegationProperty property flag to the RequestQueue owned/created by the process (i.e. not the RequestQueue the delegator is trying to delegate to). When a DelegationRule is disposed, this property flag is not unset. This keeps the delegator process linked to destination queue and prevents a new DelegationRule rule for the same from being created later on.

### Customer impact

Backport requested by @NGloreous. Has been validated (and submitted) by him

> Ideally as a consumer of this feature I want to be able to dynamically add/remove rules in production via config without the need to restart the process and this bug blocks this ability.

### Regression

No. This is a new feature introduced in 5.0

### Risk

Very low.