### PR TITLE
`dotnet watch run` shouldn't disable the browser refresh logic injection on Linux

### DIFF
--- a/src/Tools/dotnet-watch/src/LaunchBrowserFilter.cs
+++ b/src/Tools/dotnet-watch/src/LaunchBrowserFilter.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Watcher.Tools
                     }
                     catch (Exception ex)
                     {
-                        _reporter.Verbose($"Unable to launch browser: {ex}");
+                        _reporter.Verbose($"An exception occurred when attempting to launch a browser: {ex}");
                         _browserProcess = null;
                     }
 


### PR DESCRIPTION
Prior to this change, inability or failure to launch a browser would result in the browser-refresh feature from being disabled. On Linux the feature is a bit flaky so we always disabled it. This change loosens up some of the restrictions. We always attempt to launch a browser and use heuristics to determine if launching failed. Additionally, the browser refresh feature is enabled regardless of how launching the browser fared.

 - `dotnet watch run` shouldn't disable the browser refresh logic injection on Linux

Fixes dotnet/aspnetcore#27081

### Description

`dotnet watch run` relies on OS's file associations to launch the browser the first time it's launched for ASP.NET Core apps. Support for this feature is is a bit iffy on Linux. We took a conservative approach in 5.0 RTM and disabled the ability to both launch the browser and refresh it. We have improved on this and can provide a helpful message when launching a browser did not work, and instruct the user to manually launch it. More importantly, we're able to make the browser refresh feature work all the time since the two are independent.

### Customer impact

`dotnet watch` support on Linux that is more consistent with other platforms. 

### Regression
No

### Risk
Low. The changes are limited to the dotnet-watch tool. We have CTI automation to cover using this and the changes were tested manually on some popular Linux flavors.