### PR TITLE
Fixed broken link to build from source docs in Blazor readme

### DIFF
--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -31,7 +31,7 @@ The following contains a description of each sub-directory in the `Components` d
 
 ### Build
 
-To build this specific project from source, follow the instructions [on building a subset of the code](../../BuildFromSource.md#building-a-subset-of-the-code).
+To build this specific project from source, follow the instructions [on building a subset of the code](../../docs/BuildFromSource.md#building-a-subset-of-the-code).
 
 **Note:** You also need to run the preceding `build` command in the command line before building in VS to ensure that the Web.JS dependency is built.
 


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Fixed a broken link to the Build From Source docs

Addresses #bugnumber (in this specific format)
N/A
