### PR TITLE
[release/5.0] Update gRPC packages to 2.34.0 to fix MacOS tooling issue

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -244,11 +244,11 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <CommandLineParserPackageVersion>2.3.0</CommandLineParserPackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
-    <GoogleProtobufPackageVersion>3.13.0</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>2.32.0</GrpcAspNetCorePackageVersion>
-    <GrpcAuthPackageVersion>2.32.0</GrpcAuthPackageVersion>
-    <GrpcNetClientPackageVersion>2.32.0</GrpcNetClientPackageVersion>
-    <GrpcToolsPackageVersion>2.32.0</GrpcToolsPackageVersion>
+    <GoogleProtobufPackageVersion>3.14.0</GoogleProtobufPackageVersion>
+    <GrpcAspNetCorePackageVersion>2.34.0</GrpcAspNetCorePackageVersion>
+    <GrpcAuthPackageVersion>2.34.0</GrpcAuthPackageVersion>
+    <GrpcNetClientPackageVersion>2.34.0</GrpcNetClientPackageVersion>
+    <GrpcToolsPackageVersion>2.34.0</GrpcToolsPackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>4.1.0</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>4.1.0</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>4.1.0</IdentityServer4PackageVersion>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/28538

~Note: 2.34.0 (non-preview) isn't on NuGet yet. PR won't be merged until it is published and the template tests pass.~ 2.34.0 published

### Description

There is a [bug in Grpc.Tools for MacOS Big Sur](https://github.com/grpc/grpc/issues/24529) that prevents gRPC tooling working. This is fixed in an update of Grpc.Tools. This PR updates the templates to use a fixed gRPC version.

### Customer impact

gRPC template is broken on MacOS Big Sur. Customers can update their NuGet package versions to fix.

### Regression

No.

### Risk

Low. Only updates package versions in templates.