### PR TITLE
Avoid capturing the ExecutionContext in the DisconnectListener

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/DisconnectListener.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/DisconnectListener.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Threading;
 using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.Extensions.Logging;
@@ -13,8 +12,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 {
     internal class DisconnectListener
     {
-        private readonly ConcurrentDictionary<ulong, ConnectionCancellation> _connectionCancellationTokens
-            = new ConcurrentDictionary<ulong, ConnectionCancellation>();
+        private readonly ConcurrentDictionary<ulong, ConnectionCancellation> _connectionCancellationTokens = new();
 
         private readonly RequestQueue _requestQueue;
         private readonly ILogger _logger;
@@ -42,8 +40,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private CancellationToken GetOrCreateDisconnectToken(ulong connectionId)
         {
             // Read case is performance sensitive 
-            ConnectionCancellation cancellation;
-            if (!_connectionCancellationTokens.TryGetValue(connectionId, out cancellation))
+            if (!_connectionCancellationTokens.TryGetValue(connectionId, out var cancellation))
             {
                 cancellation = GetCreatedConnectionCancellation(connectionId);
             }
@@ -59,35 +56,39 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         private unsafe CancellationToken CreateDisconnectToken(ulong connectionId)
         {
-            _logger.LogDebug(LoggerEventIds.RegisterDisconnectListener, "CreateDisconnectToken; Registering connection for disconnect for connection ID: {0}" , connectionId);
+            _logger.LogDebug(LoggerEventIds.RegisterDisconnectListener, "CreateDisconnectToken; Registering connection for disconnect for connection ID: {0}", connectionId);
 
             // Create a nativeOverlapped callback so we can register for disconnect callback
             var cts = new CancellationTokenSource();
             var returnToken = cts.Token;
 
-            SafeNativeOverlapped nativeOverlapped = null;
-            var boundHandle = _requestQueue.BoundHandle;
-            nativeOverlapped = new SafeNativeOverlapped(boundHandle, boundHandle.AllocateNativeOverlapped(
-                (errorCode, numBytes, overlappedPtr) =>
+            var overlapped = new Overlapped
+            {
+                OffsetHigh = 0,
+                OffsetLow = 0
+            };
+
+            // We're not using boundHandle.AllocateNativeOverlapped here because we want to avoid capturing the ExecutionContext (see https://github.com/dotnet/runtime/issues/42549)
+            // Instead, we're going to use lower level APIs to get access to UnsafePack (which avoids the capture)
+            var nativeOverlapped = overlapped.UnsafePack((errorCode, numBytes, pOverlapped) =>
+            {
+                _logger.LogDebug(LoggerEventIds.DisconnectTriggered, "CreateDisconnectToken; http.sys disconnect callback fired for connection ID: {0}", connectionId);
+
+                // Free the overlapped
+                Overlapped.Free(pOverlapped);
+
+                // Pull the token out of the list and Cancel it.
+                _connectionCancellationTokens.TryRemove(connectionId, out _);
+                try
                 {
-                    _logger.LogDebug(LoggerEventIds.DisconnectTriggered, "CreateDisconnectToken; http.sys disconnect callback fired for connection ID: {0}" , connectionId);
-
-                    // Free the overlapped
-                    nativeOverlapped.Dispose();
-
-                    // Pull the token out of the list and Cancel it.
-                    ConnectionCancellation token;
-                    _connectionCancellationTokens.TryRemove(connectionId, out token);
-                    try
-                    {
-                        cts.Cancel();
-                    }
-                    catch (AggregateException exception)
-                    {
-                        _logger.LogError(LoggerEventIds.DisconnectHandlerError, exception, "CreateDisconnectToken Callback");
-                    }
-                },
-                null, null));
+                    cts.Cancel();
+                }
+                catch (AggregateException exception)
+                {
+                    _logger.LogError(LoggerEventIds.DisconnectHandlerError, exception, "CreateDisconnectToken Callback");
+                }
+            },
+            null);
 
             uint statusCode;
             try
@@ -105,9 +106,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
             {
                 // We got an unknown result, assume the connection has been closed.
-                nativeOverlapped.Dispose();
-                ConnectionCancellation ignored;
-                _connectionCancellationTokens.TryRemove(connectionId, out ignored);
+                Overlapped.Free(nativeOverlapped);
+                _connectionCancellationTokens.TryRemove(connectionId, out _);
                 _logger.LogDebug(LoggerEventIds.UnknownDisconnectError, new Win32Exception((int)statusCode), "HttpWaitForDisconnectEx");
                 cts.Cancel();
             }
@@ -115,9 +115,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             if (statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS && HttpSysListener.SkipIOCPCallbackOnSuccess)
             {
                 // IO operation completed synchronously - callback won't be called to signal completion
-                nativeOverlapped.Dispose();
-                ConnectionCancellation ignored;
-                _connectionCancellationTokens.TryRemove(connectionId, out ignored);
+                Overlapped.Free(nativeOverlapped);
+                _connectionCancellationTokens.TryRemove(connectionId, out _);
                 cts.Cancel();
             }
 

--- a/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         internal static extern uint HttpCancelHttpRequest(SafeHandle requestQueueHandle, ulong requestId, IntPtr pOverlapped);
 
         [DllImport(HTTPAPI, ExactSpelling = true, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
-        internal static extern uint HttpWaitForDisconnectEx(SafeHandle requestQueueHandle, ulong connectionId, uint reserved, SafeNativeOverlapped overlapped);
+        internal static extern uint HttpWaitForDisconnectEx(SafeHandle requestQueueHandle, ulong connectionId, uint reserved, NativeOverlapped* overlapped);
 
         [DllImport(HTTPAPI, ExactSpelling = true, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         internal static extern uint HttpCreateServerSession(HTTPAPI_VERSION version, ulong* serverSessionId, uint reserved);


### PR DESCRIPTION
- The execution context is captured today when register for disconnect notifications. This can result in running logic that accesses async locals related to the request after the request has ended. We drop to use lower level APIs instead of the ThreadPoolBoundHandle in this case to avoid the capture (this usually affects logging that tries to capture request information). There's no need to capture the execution context here since the cancellation token already handles it.

Fixes #26128

