### PR TITLE
Fix .msi names

### DIFF
--- a/eng/targets/Wix.Common.targets
+++ b/eng/targets/Wix.Common.targets
@@ -18,6 +18,14 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup Condition="'$(OutputType)' == 'package'">
+    <!-- Set package version for SharedFx & TargetingPack wixproj's -->
+    <!-- Everything built in those projects _except_ the final package & MSI are shipping assets. -->
+    <_GeneratedPackageVersion>$(PackageVersion)</_GeneratedPackageVersion>
+    <_GeneratedPackageVersion
+        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
+    <!-- Insert PackageVersion into OutputName for SharedFx & TargetingPack -->
+    <OutputName Condition="'$(OutputNamePrefix)' != '' AND '$(OutputNameSuffix)' != ''">$(OutputNamePrefix)$(_GeneratedPackageVersion)$(OutputNameSuffix)</OutputName>
+
     <EmbedCab Condition="'$(EmbedCab)' == ''">yes</EmbedCab>
     <Cabinet Condition="'$(Cabinet)' == ''">$(OutputName.Replace('-', '_')).cab</Cabinet>
     <InstallDir>$(ProductName)</InstallDir>
@@ -25,14 +33,6 @@
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);Debug</DefineConstants>
     <DefineConstants>$(DefineConstants);EmbedCab=$(EmbedCab)</DefineConstants>
     <DefineConstants>$(DefineConstants);Cabinet=$(Cabinet)</DefineConstants>
-
-    <!-- Set package version for SharedFx & TargetingPack wixproj's -->
-    <!-- Everything built in those projects _except_ the final package & MSI are shipping assets. -->
-    <_GeneratedPackageVersion>$(PackageVersion)</_GeneratedPackageVersion>
-    <_GeneratedPackageVersion
-        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
-    <!-- Insert PackageVersion into OutputName for SharedFx & TargetingPack -->
-    <OutputName Condition="'$(OutputNamePrefix)' != '' AND '$(OutputNameSuffix)' != ''">$(OutputNamePrefix)$(_GeneratedPackageVersion)$(OutputNameSuffix)$(TargetExt)</OutputName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
+++ b/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
@@ -80,7 +80,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <PackageFileName>$(OutputName)</PackageFileName>
+    <PackageFileName>$(OutputName)$(TargetExt)</PackageFileName>
     <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Shared Framework ($(Platform))</ProductName>
     <DefineConstants>$(DefineConstants);ProductName=$(ProductName)</DefineConstants>
   </PropertyGroup>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <OutputNamePrefix>$(TargetingPackInstallerBaseName)-</OutputNamePrefix>
     <OutputNameSuffix>-win-$(Platform)</OutputNameSuffix>
-    <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Targeting Pack ($(Platform))</ProductName>
     <ProductNameFolder>Microsoft ASP.NET Core Targeting Pack</ProductNameFolder>
     <ProductNameShort>AspNetCore.TargetingPack</ProductNameShort>
     <OutputType>Package</OutputType>
@@ -71,7 +70,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <PackageFileName>$(OutputName)</PackageFileName>
+    <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Targeting Pack ($(Platform))</ProductName>
+    <PackageFileName>$(OutputName)$(TargetExt)</PackageFileName>
     <DefineConstants>$(DefineConstants);ProductName=$(ProductName)</DefineConstants>
 
     <!-- Suppresses building this project completely during servicing builds. -->


### PR DESCRIPTION
- Set `OutputName` before using it it set `Cabinet`
- Append `TargetExt` to `PackageFileName` after it's been set rather than before

Should unblock https://github.com/dotnet/installer/pull/9199. Currently we aren't publishing any sharedFx/TargetingPack .msi's, because the file doesn't have an extension.