### PR TITLE
Use cached verbs strings

### DIFF
--- a/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
+++ b/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.HttpSys.Internal
 {
@@ -389,14 +390,14 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 null,
                 "Unknown",
                 "Invalid",
-                "OPTIONS",
-                "GET",
-                "HEAD",
-                "POST",
-                "PUT",
-                "DELETE",
-                "TRACE",
-                "CONNECT",
+                HttpMethods.Options,
+                HttpMethods.Get,
+                HttpMethods.Head,
+                HttpMethods.Post,
+                HttpMethods.Put,
+                HttpMethods.Delete,
+                HttpMethods.Trace,
+                HttpMethods.Connect,
                 "TRACK",
                 "MOVE",
                 "COPY",

--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Security.Principal.Windows" />
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
+    <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 


### PR DESCRIPTION
- Makes for faster comparison further in the ASP.NET Core pipeline

