### PR TITLE
[Blazor] Skip invalid test

### DIFF
--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
@@ -341,7 +341,7 @@ namespace Templates.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/28596")]
         public async Task BlazorWasmStandaloneTemplate_IndividualAuth_Works()
         {
             // Additional arguments are needed. See: https://github.com/dotnet/aspnetcore/issues/24278


### PR DESCRIPTION
Marking the test as Skip since the current values that we are passing in don't allow the correct testing of the template instance. See https://github.com/dotnet/aspnetcore/issues/28596 for details