### PR TITLE
Update regex in LaunchBrowserFilter

### DIFF
--- a/src/Tools/dotnet-watch/src/LaunchBrowserFilter.cs
+++ b/src/Tools/dotnet-watch/src/LaunchBrowserFilter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Watcher.Tools
 {
     public sealed class LaunchBrowserFilter : IWatchFilter, IAsyncDisposable
     {
-        private static readonly Regex NowListeningRegex = new Regex(@"^\s*Now listening on: (?<url>.*)$", RegexOptions.None | RegexOptions.Compiled, TimeSpan.FromSeconds(10));
+        private static readonly Regex NowListeningRegex = new Regex(@"\s*Now listening on: (?<url>.*)$", RegexOptions.None | RegexOptions.Compiled, TimeSpan.FromSeconds(10));
         private readonly bool _runningInTest;
         private readonly bool _suppressLaunchBrowser;
         private readonly bool _suppressBrowserRefresh;


### PR DESCRIPTION
When using Serilog, the output is different than when using default logger.

Example output:
`[16:00:33 INF] Now listening on: http://localhost:5000`

Removing the beginning matcher (`^`) fixes the issue in this specific instance.

Addresses #28636
