### PR TITLE
Dispatch keypresses to set input contents for validation test

### DIFF
--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -207,7 +207,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Validates on edit
             Browser.Equal("valid", () => renewalDateInput.GetAttribute("class"));
-            renewalDateInput.ReplaceText("01/01/2000\t");
+            renewalDateInput.SendKeys($"{Keys.Backspace}\t{Keys.Backspace}\t{Keys.Backspace}\t");
+            renewalDateInput.SendKeys("01/01/2000\t");
             Browser.Equal("modified valid", () => renewalDateInput.GetAttribute("class"));
 
             // Can become invalid
@@ -216,12 +217,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal(new[] { "The RenewalDate field must be a date." }, messagesAccessor);
 
             // Empty is invalid, because it's not nullable
-            renewalDateInput.ReplaceText($"{Keys.Backspace}");
+            renewalDateInput.SendKeys($"{Keys.Backspace}\t{Keys.Backspace}\t{Keys.Backspace}\t");
             Browser.Equal("modified invalid", () => renewalDateInput.GetAttribute("class"));
             Browser.Equal(new[] { "The RenewalDate field must be a date." }, messagesAccessor);
 
             // Can become valid
-            renewalDateInput.ReplaceText("01/01/01");
+            renewalDateInput.SendKeys("01/01/01\t");
             Browser.Equal("modified valid", () => renewalDateInput.GetAttribute("class"));
             Browser.Empty(messagesAccessor);
         }


### PR DESCRIPTION
This test sporadically fails because it interprets valid form fields as invalid in some cases (see [this](https://dev.azure.com/dnceng/public/_build/results?buildId=901957&view=ms.vss-test-web.build-test-results-tab&runId=28804712&resultId=100083&paneView=debug)).

```
OpenQA.Selenium.BrowserAssertFailedException : Xunit.Sdk.EqualException: Assert.Equal() Failure
   Expected: modified valid
   Actual:   modified invalid
   ...
   at Microsoft.AspNetCore.Components.E2ETest.Tests.FormsTest.InputDateInteractsWithEditContext_NonNullableDateTime() in /_/src/Components/test/E2ETest/Tests/FormsTest.cs:line 211
```

This doesn't repro locally and has only occurred in a handful of cases over the past 30 days. There's some background work that was done to make these more reliable about a year ago [here](https://github.com/dotnet/aspnetcore/pull/13648).

The PR above introduces the a `ReplaceText` utility function that uses `SendKeys` to clear out replace the contents of an input by simulating `Ctrl + A` and input for a new string. This was original introduced to address similar failures in `InputDateInteractsWithEditContext_NullableDateTimeOffset` and applied to `InputDateInteractsWithEditContext_NonNullableDateTime` as well in the PR above.

The original change seems to be made in particular for inputs that hold a nullable datetime input (which this one does not) and the workaround itself is no longer in use in the `InputDateInteractsWithEditContext_NullableDateTimeOffset`  which isn't flaky.

With all this in mind, I'm taking a stab at using `SendKeys` directly for this test so that we're consistent with the other datetime and nullable form scenarios here.

Addresses https://github.com/dotnet/aspnetcore/issues/27398
