### PR TITLE
[release/5.0] Change bundle branding from '.Net Core' to '.Net'

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
+++ b/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
@@ -75,7 +75,7 @@
 
     <!-- Registration -->
     <BundleRegManufacturer>Microsoft</BundleRegManufacturer>
-    <BundleRegFamily>.NET Core</BundleRegFamily>
+    <BundleRegFamily>.NET</BundleRegFamily>
 
     <DefineConstants>$(DefineConstants);BundleNameShort=$(BundleNameShort)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleName=$(BundleName)</DefineConstants>

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -76,7 +76,7 @@
   <PropertyGroup>
     <PackageFileName>dotnet-hosting-$(PackageVersion)-win$(TargetExt)</PackageFileName>
 
-    <BundleNameShort>Microsoft .NET Core $(PackageBrandingVersion)</BundleNameShort>
+    <BundleNameShort>Microsoft .NET $(PackageBrandingVersion)</BundleNameShort>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -88,8 +88,8 @@
 
     <!-- Registration -->
     <BundleRegManufacturer>Microsoft</BundleRegManufacturer>
-    <BundleRegFamily>.NET Core</BundleRegFamily>
-    <BundleRegName>Microsoft .NET Core $(PackageBrandingVersion) - Windows Server Hosting</BundleRegName>
+    <BundleRegFamily>.NET</BundleRegFamily>
+    <BundleRegName>Microsoft .NET $(PackageBrandingVersion) - Windows Server Hosting</BundleRegName>
     <BundleRegName>$(BundleNameFull)</BundleRegName>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/28658

@joeloff the only instances of the string `BundleRegFamily` I found in the dotnet org are in this repo - will changing it from `.Net Core` to `.Net` affect any downstream repos?