### PR TITLE
Added `WebAssembly` capability to Blazor WebAssembly projects

### DIFF
--- a/src/Components/WebAssembly/Sdk/src/Sdk/Sdk.targets
+++ b/src/Components/WebAssembly/Sdk/src/Sdk/Sdk.targets
@@ -15,6 +15,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_BlazorWebAssemblyTargetsFile Condition="'$(_BlazorWebAssemblyTargetsFile)' == ''">$(MSBuildThisFileDirectory)..\targets\Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets</_BlazorWebAssemblyTargetsFile>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectCapability Include="WebAssembly" />
+  </ItemGroup>
+  
   <Import Project="$(_BlazorWebAssemblyTargetsFile)" />
 
 </Project>


### PR DESCRIPTION
## Description

VS has a feature of adding gRPC service reference to a project using UI. Currently that experience has no easy way to differentiate between Blazor Server and Blazor WebAssembly projects. As a result, adding gRPC reference using VS feature adds the wrong gRPC package (Grpc.AspNetCore), instead of adding `Grpc.Net.Client` and `Grpc.Net.Client.Web`, per our documentation. The package which is wrong adds framework reference transitively, which is not supported on WebAssembly.

This change adds a unique WebAssembly capability to all Blazor WebAssembly projects (through the SDK) so VS can build unique experiences those projects and also address that bug.

## Customer Impact
This particular change has no customer impact, but it will enable VS to fix their experience tracked by [this AzDO issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1242008)

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

## Verification
- [ ] Manual (required)
- [ ] Automated

Not applicable as this change has no functional impact. The follow-up change is on the VS side to utilize this change and differentiate projects.

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/28716
