### PR TITLE
Fix Http2_MethodsRequestWithoutData_Success on IIS

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         public IISTestSiteFixture Fixture { get; }
 
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/26060")]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/28265")]
         [ConditionalTheory]
         [InlineData("GET")]
         [InlineData("HEAD")]

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1489,7 +1489,9 @@ namespace TestSite
 #if !FORWARDCOMPAT
             Assert.False(httpContext.Request.CanHaveBody());
             var feature = httpContext.Features.Get<IHttpUpgradeFeature>();
-            Assert.False(feature.IsUpgradableRequest);
+            // The upgrade feature won't be present if WebSockets aren't enabled in IIS.
+            // IsUpgradableRequest should always return false for HTTP/2.
+            Assert.False(feature?.IsUpgradableRequest ?? false);
 #endif
             Assert.Null(httpContext.Request.ContentLength);
             Assert.False(httpContext.Request.Headers.ContainsKey(HeaderNames.TransferEncoding));


### PR DESCRIPTION
Fixes #28265
I added a check to this test back in:
https://github.com/dotnet/aspnetcore/pull/28121/files#diff-5569f952a9bd8a7d71d30f47c79c8419604210508dca41b86c3d867b322d08eb

It worked on IIS Express but failed on full IIS because the IHttpUpgradeFeature is removed if WebSockets aren't enabled in IIS.

It looks like we don't have any WebSocket tests for full IIS, only Express, likely because we don't control if WebSockets are installed. I've changed the test here to allow for the missing upgrade feature.