### PR TITLE
Enable 2.1 official builds in AzDO

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -101,6 +101,11 @@ jobs:
               $(SharedFxArgs)
               /p:SharedFxRID=win-x64
               /bl:artifacts/logs/SharedFx-win-x64.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Build win-x64 SharedFX
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -112,6 +117,11 @@ jobs:
               $(SharedFxArgs)
               /p:SharedFxRID=win-x86
               /bl:artifacts/logs/SharedFx-win-x86.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Build win-x86 SharedFX
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -124,6 +134,11 @@ jobs:
               /p:DisableSignCheck=true
               /t:DoCodeSigning
               /bl:artifacts/logs/CodeSign.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Code Sign
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -182,6 +197,11 @@ jobs:
               $(SharedFxArgs)
               /p:SharedFxRID=osx-x64
               /bl:artifacts/logs/SharedFx-osx-x64.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Build osx-x64 SharedFX
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
@@ -225,6 +245,11 @@ jobs:
               $(SharedFxArgs)
               /p:SharedFXRid=linux-x64
               /bl:artifacts/logs/SharedFx-linux-x64.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Build linux-x64 SharedFX
     - script: ./$(BuildDirectory)/build.sh
               -ci
@@ -233,6 +258,11 @@ jobs:
               /p:SharedFXRid=linux-arm
               /p:IsLinuxArmSupported=true
               /bl:artifacts/logs/SharedFx-linux-arm.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Build linux-arm SharedFX
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
@@ -279,6 +309,11 @@ jobs:
               /t:BuildSharedFx
               /p:SharedFXRid=linux-musl-x64
               /bl:artifacts/logs/SharedFx-linux-musl-x64.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Build linux-musl-x64 SharedFX
     - bash: docker system prune -af
       displayName: Docker prune
@@ -350,6 +385,11 @@ jobs:
     - powershell: src/Installers/Windows/build.ps1
         -Config Release
         -BuildNumber $(Build.BuildId)
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Run src/Installers/Windows/build.ps1
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -402,6 +442,11 @@ jobs:
               /p:SignType=$(_SignType)
               /t:BuildFallbackArchive
               /bl:artifacts/logs/PackageArchive.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Build Package Archive
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -484,6 +529,11 @@ jobs:
               $(BuildScriptArgs)
               /t:BuildInstallers
               /bl:artifacts/logs/SharedFx-Installers.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Build SharedFX Installers
     - bash: docker system prune -af
       displayName: Docker prune
@@ -652,6 +702,11 @@ jobs:
               /t:Publish
               /p:BuildBranch=$(Build.SourceBranchName)
               /bl:artifacts/logs/Publish.binlog
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Publish
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -7,22 +7,661 @@ pr:
     include:
     - '*'
 
+variables:
+- name: ASPNETCORE_TEST_LOG_MAXPATH
+  value: "200" # Keep test log file name length low enough for artifact zipping
+- name: DOTNET_HOME
+  value: $(Agent.BuildDirectory)/.dotnet
+- name: TeamName
+  value: AspNetCore
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - name: BuildScriptArgs
+    value: ''
+- ${{ if ne(variables['System.TeamProject'], 'public') }}:
+  - name: BuildScriptArgs
+    value: '/p:BuildNumber=$(Build.BuildId)'
+  - name: SharedFxArgs
+    value: '/t:Prepare
+            /t:Restore
+            /t:GeneratePropsFiles
+            /t:BuildSharedFx'
+
 jobs:
 - template: jobs/default-build.yml
   parameters:
     jobName: Windows_Build
     jobDisplayName: "Build and test: Windows"
     agentOs: Windows
+    codeSign: true
     beforeBuild:
     - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1"
       displayName: Setup IISExpress test certificates
-- template: jobs/default-build.yml
-  parameters:
-    jobName: macOs_Build
-    jobDisplayName: "Build and test : macOS"
-    agentOs: macOS
-- template: jobs/default-build.yml
-  parameters:
-    jobName: Linux_Build
-    jobDisplayName: "Build and test : Linux"
-    agentOs: Linux
+# Unix test jobs only run on public CI builds
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - template: jobs/default-build.yml
+    parameters:
+      jobName: MacOs_Build
+      jobDisplayName: "Build and test : MacOS"
+      agentOs: MacOS
+  - template: jobs/default-build.yml
+    parameters:
+      jobName: Linux_Build
+      jobDisplayName: "Build and test : Linux"
+      agentOs: Linux
+
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - job: Windows_SharedFx
+    displayName: Build Windows x64/x86 SharedFx
+    dependsOn: Windows_Build
+    timeoutInMinutes: 90
+    workspace:
+      clean: all
+    pool:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2017
+    variables:
+      _SignType: real
+      JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+    steps:
+    - checkout: self
+      clean: true
+    - task: NodeTool@0
+      displayName: Install Node 10.x
+      inputs:
+        versionSpec: 10.x
+    - powershell: ./eng/scripts/InstallJdk.ps1 '11.0.1'
+      displayName: Install JDK 11
+    - task: NuGetCommand@2
+      displayName: 'Clear NuGet caches'
+      condition: succeeded()
+      inputs:
+        command: custom
+        arguments: 'locals all -clear'
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild Signing plugin
+      inputs:
+        signType: $(_SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifacts
+      inputs:
+        artifactName: artifacts-Windows-Release
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: CopyFiles@2
+      displayName: Copy artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/
+    - script: .\build.cmd
+              -ci
+              /p:SignType=$(_SignType)
+              $(BuildScriptArgs)
+              $(SharedFxArgs)
+              /p:SharedFxRID=win-x64
+              /bl:artifacts/logs/SharedFx-win-x64.binlog
+      displayName: Build win-x64 SharedFX
+    - powershell: eng\scripts\KillProcesses.ps1
+      displayName: Kill processes
+      condition: always()
+    - script: .\build.cmd
+              -ci
+              /p:SignType=$(_SignType)
+              $(BuildScriptArgs)
+              $(SharedFxArgs)
+              /p:SharedFxRID=win-x86
+              /bl:artifacts/logs/SharedFx-win-x86.binlog
+      displayName: Build win-x86 SharedFX
+    - powershell: eng\scripts\KillProcesses.ps1
+      displayName: Kill processes
+      condition: always()
+    - script: .\build.cmd
+              -ci
+              /p:SignType=$(_SignType)
+              $(BuildScriptArgs)
+              /p:SkipArtifactInfoTargets=true
+              /p:DisableSignCheck=true
+              /t:DoCodeSigning
+              /bl:artifacts/logs/CodeSign.binlog
+      displayName: Code Sign
+    - powershell: eng\scripts\KillProcesses.ps1
+      displayName: Kill processes
+      condition: always()
+    - task: MicroBuildCleanup@1
+      displayName: Cleanup MicroBuild tasks
+      condition: always()
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/
+        artifactName: artifacts-Windows-SharedFx
+        artifactType: Container
+        parallel: true
+    - task: PublishBuildArtifacts@1
+      displayName: Upload dependencies.g.props
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: .deps/dependencies.g.props
+        artifactName: artifacts-dependencies-props
+        artifactType: Container
+        parallel: true
+
+  - job: MacOs_SharedFx
+    displayName: Build Osx-x64 SharedFx
+    dependsOn: Windows_Build
+    timeoutInMinutes: 90
+    workspace:
+      clean: all
+    pool:
+      vmImage: macOS-10.14
+    steps:
+    - checkout: self
+      clean: true
+    - task: NodeTool@0
+      displayName: Install Node 10.x
+      inputs:
+        versionSpec: 10.x
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifacts
+      inputs:
+        artifactName: artifacts-Windows-Release
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: CopyFiles@2
+      displayName: Copy artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/
+    - script: ./$(BuildDirectory)/build.sh
+              -ci
+              $(BuildScriptArgs)
+              $(SharedFxArgs)
+              /p:SharedFxRID=osx-x64
+              /bl:artifacts/logs/SharedFx-osx-x64.binlog
+      displayName: Build osx-x64 SharedFX
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/
+        artifactName: artifacts-MacOs-SharedFx
+        artifactType: Container
+        parallel: true
+
+  - job: Linux_SharedFx
+    displayName: Build Linux x64/arm SharedFx
+    dependsOn: Windows_Build
+    timeoutInMinutes: 90
+    workspace:
+      clean: all
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+    - checkout: self
+      clean: true
+    - task: NodeTool@0
+      displayName: Install Node 10.x
+      inputs:
+        versionSpec: 10.x
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifacts
+      inputs:
+        artifactName: artifacts-Windows-Release
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: CopyFiles@2
+      displayName: Copy artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/
+    - script: ./$(BuildDirectory)/build.sh
+              -ci
+              $(BuildScriptArgs)
+              $(SharedFxArgs)
+              /p:SharedFXRid=linux-x64
+              /bl:artifacts/logs/SharedFx-linux-x64.binlog
+      displayName: Build linux-x64 SharedFX
+    - script: ./$(BuildDirectory)/build.sh
+              -ci
+              $(BuildScriptArgs)
+              $(SharedFxArgs)
+              /p:SharedFXRid=linux-arm
+              /p:IsLinuxArmSupported=true
+              /bl:artifacts/logs/SharedFx-linux-arm.binlog
+      displayName: Build linux-arm SharedFX
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/
+        artifactName: artifacts-Linux-SharedFx
+        artifactType: Container
+        parallel: true
+
+  - job: Linux_Musl_SharedFx
+    displayName: Build Linux-musl-x64 SharedFx
+    dependsOn: Windows_Build
+    timeoutInMinutes: 90
+    workspace:
+      clean: all
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+    - checkout: self
+      clean: true
+    - task: NodeTool@0
+      displayName: Install Node 10.x
+      inputs:
+        versionSpec: 10.x
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifacts
+      inputs:
+        artifactName: artifacts-Windows-Release
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: CopyFiles@2
+      displayName: Copy artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/
+    - script: ./$(BuildDirectory)/dockerbuild.sh
+              alpine
+              -ci
+              $(BuildScriptArgs)
+              /t:Prepare
+              /t:GeneratePropsFiles
+              /t:BuildSharedFx
+              /p:SharedFXRid=linux-musl-x64
+              /bl:artifacts/logs/SharedFx-linux-musl-x64.binlog
+      displayName: Build linux-musl-x64 SharedFX
+    - bash: docker system prune -af
+      displayName: Docker prune
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/
+        artifactName: artifacts-Linux-Musl-SharedFx
+        artifactType: Container
+        parallel: true
+
+  - job: Windows_Installers
+    displayName: Build Windows Installers
+    dependsOn: Windows_SharedFx
+    timeoutInMinutes: 90
+    workspace:
+      clean: all
+    pool:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2017
+    variables:
+      _SignType: real
+      JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+    steps:
+    - checkout: self
+      clean: true
+    - task: NuGetCommand@2
+      displayName: 'Clear NuGet caches'
+      condition: succeeded()
+      inputs:
+        command: custom
+        arguments: 'locals all -clear'
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild Signing plugin
+      inputs:
+        signType: $(_SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifacts
+      inputs:
+        artifactName: artifacts-Windows-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download dependencies.g.props
+      inputs:
+        artifactName: artifacts-dependencies-props
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: CopyFiles@2
+      displayName: Copy SharedFx artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/SharedFX/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/fx/
+    - task: CopyFiles@2
+      displayName: Copy SharedFx artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/packages/
+        contents: 'Microsoft.AspNetCore.AspNetCoreModule*.nupkg'
+        targetFolder: $(Build.SourcesDirectory)/.deps/ANCM/
+    - task: CopyFiles@2
+      displayName: Copy dependencies.g.props to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-dependencies-props/
+        contents: 'dependencies.g.props'
+        targetFolder: $(Build.SourcesDirectory)/.deps/
+    - powershell: src/Installers/Windows/build.ps1
+        -Config Release
+        -BuildNumber $(Build.BuildId)
+      displayName: Run src/Installers/Windows/build.ps1
+    - powershell: eng\scripts\KillProcesses.ps1
+      displayName: Kill processes
+      condition: always()
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/
+        artifactName: artifacts-Windows-Installers
+        artifactType: Container
+        parallel: true
+
+  - job: Package_Archive
+    displayName: Build Package Archive
+    dependsOn: Windows_SharedFx
+    timeoutInMinutes: 90
+    workspace:
+      clean: all
+    pool:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2017
+    variables:
+      _SignType: real
+      JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+    steps:
+    - checkout: self
+      clean: true
+    - task: NuGetCommand@2
+      displayName: 'Clear NuGet caches'
+      condition: succeeded()
+      inputs:
+        command: custom
+        arguments: 'locals all -clear'
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifacts
+      inputs:
+        artifactName: artifacts-Windows-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: CopyFiles@2
+      displayName: Copy artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/Signed/
+    - script: .\build.cmd
+              -ci
+              $(BuildScriptArgs)
+              /p:SignType=$(_SignType)
+              /t:BuildFallbackArchive
+              /bl:artifacts/logs/PackageArchive.binlog
+      displayName: Build Package Archive
+    - powershell: eng\scripts\KillProcesses.ps1
+      displayName: Kill processes
+      condition: always()
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/
+        artifactName: artifacts-Package-Archive
+        artifactType: Container
+        parallel: true
+
+  - job: SharedFX_Installers
+    displayName: Build SharedFX Installers
+    dependsOn: 
+      - Linux_SharedFx
+      - Linux_Musl_SharedFx
+      - MacOs_SharedFx
+      - Windows_SharedFx
+    timeoutInMinutes: 90
+    workspace:
+      clean: all
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+    - checkout: self
+      clean: true
+    - task: NodeTool@0
+      displayName: Install Node 10.x
+      inputs:
+        versionSpec: 10.x
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Linux SharedFx artifacts
+      inputs:
+        artifactName: artifacts-Linux-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Linux Musl SharedFx artifacts
+      inputs:
+        artifactName: artifacts-Linux-Musl-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download MacOs SharedFx artifacts
+      inputs:
+        artifactName: artifacts-MacOs-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Windows SharedFx artifacts
+      inputs:
+        artifactName: artifacts-Windows-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: CopyFiles@2
+      displayName: Copy Linux artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Linux-SharedFx/runtime/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/Signed/SharedFx/
+    - task: CopyFiles@2
+      displayName: Copy Linux-Musl artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Linux-Musl-SharedFx/runtime/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/Signed/SharedFx/
+    - task: CopyFiles@2
+      displayName: Copy MacOS artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-MacOs-SharedFx/runtime/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/Signed/SharedFx/
+    - task: CopyFiles@2
+      displayName: Copy Windows SharedFx artifacts to .deps/
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/Signed/
+    - script: ./$(BuildDirectory)/build.sh
+              -ci
+              $(BuildScriptArgs)
+              /t:BuildInstallers
+              /bl:artifacts/logs/SharedFx-Installers.binlog
+      displayName: Build SharedFX Installers
+    - bash: docker system prune -af
+      displayName: Docker prune
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/
+        artifactName: artifacts-SharedFx-Installers
+        artifactType: Container
+        parallel: true
+
+  - job: Publish
+    displayName: Publish
+    dependsOn: 
+      - Windows_Installers
+      - SharedFX_Installers
+      - Package_Archive
+    timeoutInMinutes: 90
+    workspace:
+      clean: all
+    pool:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2017
+    variables:
+      _SignType: real
+      JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+    steps:
+    - checkout: self
+      clean: true
+    - task: NuGetCommand@2
+      displayName: 'Clear NuGet caches'
+      condition: succeeded()
+      inputs:
+        command: custom
+        arguments: 'locals all -clear'
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Windows artifacts
+      inputs:
+        artifactName: artifacts-Windows-Release
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Linux SharedFx artifacts
+      inputs:
+        artifactName: artifacts-Linux-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Linux Musl SharedFx artifacts
+      inputs:
+        artifactName: artifacts-Linux-Musl-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download MacOs SharedFx artifacts
+      inputs:
+        artifactName: artifacts-MacOs-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Windows SharedFx artifacts
+      inputs:
+        artifactName: artifacts-Windows-SharedFx
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Package Archive artifacts
+      inputs:
+        artifactName: artifacts-Package-Archive
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download SharedFx installer artifacts
+      inputs:
+        artifactName: artifacts-SharedFx-Installers
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Windows installer artifacts
+      inputs:
+        artifactName: artifacts-Windows-Installers
+        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+    - task: CopyFiles@2
+      displayName: Copy Windows artifacts to .deps/assets
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/build/
+        contents: '**/*.tgz'
+        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+        flattenFolders: true
+    - task: CopyFiles@2
+      displayName: Copy Linux SharedFx artifacts to .deps/assets
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Linux-SharedFx/runtime/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+    - task: CopyFiles@2
+      displayName: Copy Linux Musl SharedFx artifacts to .deps/assets
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Linux-Musl-SharedFx/runtime/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+    - task: CopyFiles@2
+      displayName: Copy MacOs SharedFx artifacts to .deps/assets
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-MacOs-SharedFx/runtime/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+    - task: CopyFiles@2
+      displayName: Copy Windows SharedFx artifacts to .deps/assets
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
+        contents: |
+          SharedFx/**
+          OobArchives/**
+        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+        flattenFolders: true
+    - task: CopyFiles@2
+      displayName: Copy Package Archive artifacts to .deps/assets
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Package-Archive/lzma/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+    - task: CopyFiles@2
+      displayName: Copy SharedFx Installer artifacts to .deps/assets
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-SharedFx-Installers/installers/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+    - task: CopyFiles@2
+      displayName: Copy Windows Installer artifacts to .deps/assets
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Installers/bin/Release/installers/
+        contents: |
+          en-US/*.msi
+          **/*.exe
+          **/*.wixlib
+          **/*.nupkg
+        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+        flattenFolders: true
+    - task: CopyFiles@2
+      displayName: Copy Linux SharedFx artifacts to .deps/packages
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Linux-SharedFx/symbols/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/packages/
+    - task: CopyFiles@2
+      displayName: Copy Linux Musl SharedFx artifacts to .deps/packages
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Linux-Musl-SharedFx/symbols/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/packages/
+    - task: CopyFiles@2
+      displayName: Copy MacOs SharedFx artifacts to .deps/packages
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-MacOs-SharedFx/symbols/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/packages/
+    - task: CopyFiles@2
+      displayName: Copy Windows SharedFx artifacts to .deps/packages
+      inputs:
+        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/Packages/
+        contents: '**'
+        targetFolder: $(Build.SourcesDirectory)/.deps/packages/
+    - task: DeleteFiles@1
+      displayName: Delete korebuild.json
+      inputs:
+        contents: korebuild.json
+    - script: .\build.cmd
+              -ci
+              $(BuildScriptArgs)
+              /t:Publish
+              /p:BuildBranch=$(Build.SourceBranchName)
+              /bl:artifacts/logs/Publish.binlog
+      displayName: Publish
+    - powershell: eng\scripts\KillProcesses.ps1
+      displayName: Kill processes
+      condition: always()
+    - task: PublishBuildArtifacts@1
+      displayName: Upload logs
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      continueOnError: true
+      inputs:
+        pathtoPublish: artifacts/logs
+        artifactName: artifacts-Publish
+        artifactType: Container
+        parallel: true

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -95,6 +95,11 @@ jobs:
     ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       _SignType: real
     ${{ insert }}: ${{ parameters.variables }}
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      PB_PackageVersionPropsUrl: ''
+      PB_AssetRootUrl: ''
+      PB_RestoreSource: ''
+      PB_PublishBlobFeedKey: ''
   steps:
   - checkout: self
     clean: true

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -128,6 +128,11 @@ jobs:
               /p:DisableSignCheck=true
               $(BuildScriptArgs)
               $(BinlogArg)
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Run build.cmd
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -138,6 +143,11 @@ jobs:
               -p:Configuration=$(BuildConfiguration)
               $(BuildScriptArgs)
               $(BinlogArg)
+      env:
+        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
+        PB_AssetRootUrl: $(PB_AssetRootUrl)
+        PB_RestoreSource: $(PB_RestoreSource)
+        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Run build.sh
     - script: eng/scripts/KillProcesses.sh
       displayName: Kill processes

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -56,7 +56,7 @@ parameters:
   buildDirectory: ''
 
 jobs:
-- job: ${{ parameters.jobName }}
+- job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
   displayName: ${{ coalesce(parameters.jobDisplayName, parameters.agentOs) }}
   dependsOn: ${{ parameters.dependsOn }}
   timeoutInMinutes: 90

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -8,7 +8,7 @@
 #   poolName: string
 #       The name of the Azure DevOps agent pool to use.
 #   agentOs: string
-#       Used in templates to define variables which are OS specific. Typically from the set { Windows, Linux, macOS }
+#       Used in templates to define variables which are OS specific. Typically from the set { Windows, Linux, MacOS }
 #   buildArgs: string
 #       Additional arguments to pass to the build.sh/cmd script.
 #       Note: -ci is always passed
@@ -41,7 +41,6 @@
 parameters:
   agentOs: 'Windows'
   poolName: ''
-  buildArgs: ''
   configuration: 'Release'
   beforeBuild: []
   afterBuild: []
@@ -57,7 +56,7 @@ parameters:
   buildDirectory: ''
 
 jobs:
-- job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
+- job: ${{ parameters.jobName }}
   displayName: ${{ coalesce(parameters.jobDisplayName, parameters.agentOs) }}
   dependsOn: ${{ parameters.dependsOn }}
   timeoutInMinutes: 90
@@ -72,7 +71,7 @@ jobs:
   pool:
     ${{ if ne(parameters.poolName, '') }}:
       name: ${{ parameters.poolName }}
-    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
+    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'MacOS')) }}:
       vmImage: macOS-10.14
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
       vmImage: ubuntu-16.04
@@ -85,13 +84,10 @@ jobs:
         queue: BuildPool.Server.Amd64.VS2017
   variables:
     AgentOsName: ${{ parameters.agentOs }}
-    ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping
-    DOTNET_HOME: $(Agent.BuildDirectory)/.dotnet
     BuildScript: ${{ parameters.buildScript }}
-    BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
     BuildDirectory: ${{ parameters.buildDirectory }}
-    TeamName: AspNetCore
+    BinlogArg: /bl:artifacts/logs/${{ parameters.agentOs }}.binlog
     ${{ if eq(parameters.agentOs, 'Windows') }}:
       JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
     ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -116,7 +112,7 @@ jobs:
         command: custom
         arguments: 'locals all -clear'
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.agentOs, 'Windows'), eq(parameters.codeSign, 'true')) }}:
-    - task: MicroBuildSigningPlugin@1
+    - task: MicroBuildSigningPlugin@2
       displayName: Install MicroBuild Signing plugin
       condition: and(succeeded(), in(variables['_SignType'], 'test', 'real'))
       inputs:
@@ -125,13 +121,23 @@ jobs:
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
   - ${{ parameters.beforeBuild }}
   - ${{ if eq(parameters.agentOs, 'Windows') }}:
-    - script: .\$(BuildDirectory)\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+    - script: .\$(BuildDirectory)\build.cmd
+              -ci
+              /p:SignType=$(_SignType)
+              /p:Configuration=$(BuildConfiguration)
+              /p:DisableSignCheck=true
+              $(BuildScriptArgs)
+              $(BinlogArg)
       displayName: Run build.cmd
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
       condition: always()
   - ${{ if ne(parameters.agentOs, 'Windows') }}:
-    - script: ./$(BuildDirectory)/build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+    - script: ./$(BuildDirectory)/build.sh
+              -ci
+              -p:Configuration=$(BuildConfiguration)
+              $(BuildScriptArgs)
+              $(BinlogArg)
       displayName: Run build.sh
     - script: eng/scripts/KillProcesses.sh
       displayName: Kill processes

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,6 @@
     <!-- MicrosoftNETCoreApp21PackageVersion is assigned at the bottom so it can automatically pick up MicrosoftNETCoreAppPackageVersion in an orchestrated build. -->
     <MicrosoftNETCoreAppPackageVersion>2.1.23</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetAppHostPackageVersion>2.1.23</MicrosoftNETCoreDotNetAppHostPackageVersion>
-    <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>2.1.1</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
@@ -31,6 +30,7 @@
     <MicrosoftExtensionsCachingSqlServerPackageVersion>2.1.2</MicrosoftExtensionsCachingSqlServerPackageVersion>
     <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.1.1</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.1</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>2.1.1</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
     <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.10</MicrosoftExtensionsConfigurationBinderPackageVersion>
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.1.1</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.1</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,7 +16,7 @@
     <!-- Determined by build tools -->
     <InternalAspNetCoreSdkPackageVersion>$(KoreBuildVersion)</InternalAspNetCoreSdkPackageVersion>
     <InternalAspNetCoreSiteExtensionSdkPackageVersion>$(KoreBuildVersion)</InternalAspNetCoreSiteExtensionSdkPackageVersion>
-    <InternalAspNetCoreSdkPackageVersion Condition=" '$(KoreBuildVersion)' == '' ">2.1.7-build-20201119.1</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion Condition=" '$(KoreBuildVersion)' == '' ">2.1.7-build-20201218.2</InternalAspNetCoreSdkPackageVersion>
   </PropertyGroup>
 
   <!-- These are package versions that should not be overridden or updated by automation. -->

--- a/build/repo.props
+++ b/build/repo.props
@@ -20,7 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <SharedSourceDirectories Include="$(SharedSourcesFolder)Hosting.WebHostBuilderFactory\" />
+    <!-- Don't populate SharedSourceDirectories while doing Code Signing, otherwise we'll try to sign this nonexistant package -->
+    <SharedSourceDirectories Include="$(SharedSourcesFolder)Hosting.WebHostBuilderFactory\" Condition="'$(SkipArtifactInfoTargets)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -21,9 +21,9 @@
     <PackageDependsOn Condition="'$(TestOnly)' != 'true' AND '$(_ProjectsOnly)' != 'true'">$(PackageDependsOn);BuildMetapackages;BuildSiteExtension;CheckExpectedPackagesExist</PackageDependsOn>
     <TestDependsOn>$(TestDependsOn);TestProjects</TestDependsOn>
     <TestDependsOn Condition="'$(_ProjectsOnly)' != 'true'">$(TestDependsOn);_TestRepositories</TestDependsOn>
-    <GetArtifactInfoDependsOn>$(GetArtifactInfoDependsOn);GetProjectArtifactInfo</GetArtifactInfoDependsOn>
-    <GetArtifactInfoDependsOn>$(GetArtifactInfoDependsOn);ResolveSharedSourcesPackageInfo</GetArtifactInfoDependsOn>
-    <GetArtifactInfoDependsOn  Condition="'$(_ProjectsOnly)' != 'true'">$(GetArtifactInfoDependsOn);ResolveRepoInfo</GetArtifactInfoDependsOn>
+    <GetArtifactInfoDependsOn Condition="'$(SkipArtifactInfoTargets)' != 'true'">$(GetArtifactInfoDependsOn);GetProjectArtifactInfo</GetArtifactInfoDependsOn>
+    <GetArtifactInfoDependsOn Condition="'$(SkipArtifactInfoTargets)' != 'true'">$(GetArtifactInfoDependsOn);ResolveSharedSourcesPackageInfo</GetArtifactInfoDependsOn>
+    <GetArtifactInfoDependsOn Condition="'$(SkipArtifactInfoTargets)' != 'true' AND '$(_ProjectsOnly)' != 'true'">$(GetArtifactInfoDependsOn);ResolveRepoInfo</GetArtifactInfoDependsOn>
   </PropertyGroup>
 
   <Target Name="PrepareOutputPaths">
@@ -272,6 +272,65 @@
   <Target Name="VerifyAllReposHaveNuGetPackageVerifier" DependsOnTargets="_PrepareRepositories">
     <Error Condition="'%(Repository.Identity)' != '' AND !Exists('%(Repository.RootPath)NuGetPackageVerifier.json')"
            Text="Repository %(Repository.Identity) is missing NuGetPackageVerifier.json. Expected file to exist in %(Repository.RootPath)NuGetPackageVerifier.json" />
+  </Target>
+
+  <Target Name="DoCodeSigning" DependsOnTargets="_SetupCodeSign;CodeSign;_CopySignedFilesToArtifacts" />
+
+  <Target Name="_SetupCodeSign">
+    <PropertyGroup>
+      <!-- Make sure we're not disabling code signing -->
+      <DisableCodeSigning>false</DisableCodeSigning>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- We're passing a custom list of files - clear out the exclusion list so it doesn't interfere -->
+      <FilesToExcludeFromSigning Remove="@(FilesToExcludeFromSigning)" />
+
+      <!-- Make sure 3rd party binaries get 3rd party certificate -->
+      <CustomFileSignInfo Include="MsgPack.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="MessagePack.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="Newtonsoft.Json.Bson.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="Remotion.Linq.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="SQLitePCLRaw.batteries_green.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="SQLitePCLRaw.batteries_v2.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="SQLitePCLRaw.core.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="SQLitePCLRaw.provider.e_sqlite3.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="e_sqlite3.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="StackExchange.Redis.StrongName.dll" CertificateName="3PartySHA2" />
+      <CustomFileSignInfo Include="System.Interactive.Async.dll" CertificateName="3PartySHA2" />
+      <!--
+      Map file extensions to a code-sign cert.
+      "None" means don't sign the file itself, but still scan the contents for signable files.
+      -->
+      <CustomFileExtensionSignInfo Include=".ps1;.psd1;.psm1;.psc1" CertificateName="Microsoft400" />
+      <CustomFileExtensionSignInfo Include=".dll;.exe" CertificateName="MicrosoftSHA2" />
+      <CustomFileExtensionSignInfo Include=".cab" CertificateName="None" />
+      <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
+      <CustomFileExtensionSignInfo Include=".js" CertificateName="None" />
+      <!-- We don't produce font files. We rebundle some for using the web brower, so they do not need to be signed. -->
+      <CustomFileExtensionSignInfo Include=".otf" CertificateName="None" />
+      <CustomFileExtensionSignInfo Include=".ttf" CertificateName="None" />
+      <!-- This is a text file which doesn't need to be code signed, even though some .mof files can be signed. -->
+      <CustomFileSignInfo Include="ancm.mof" CertificateName="None" />
+      <!-- Exclude the apphost because this is expected to be code-signed by customers after the SDK modifies it. -->
+      <CustomFileSignInfo Include="apphost.exe" CertificateName="None" />
+
+      <FilesToSign Include="$(DependencyPackageDir)**\*.nupkg" Certificate="NuGet" />
+      <FilesToSign Include="$(DependencyPackageDir)**\*.mpack" Certificate="None" />
+      <FilesToSign Include="$(DependencyPackageDir)**\*.vsix" Certificate="VsixSHA2" />
+      <FilesToSign Include="$(DependencyPackageDir)**\*.jar" Certificate="MicrosoftJARSHA2" />
+      <FilesToSign Include="$(ArtifactsDir)symbols\**\*.nupkg" Certificate="NuGet" />
+      <FilesToSign Include="$(SharedFxOutputPath)**\*.zip" Certificate="None" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CopySignedFilesToArtifacts">
+    <Copy SourceFiles="%(FilesToSign.Identity)" DestinationFiles="$(ArtifactsDir)Signed\MPacks\%(FilesToSign.Filename)%(FilesToSign.Extension)" Condition="'%(FilesToSign.Extension)' == '.mpack'" />
+    <Copy SourceFiles="%(FilesToSign.Identity)" DestinationFiles="$(ArtifactsDir)Signed\Packages\%(FilesToSign.Filename)%(FilesToSign.Extension)" Condition="'%(FilesToSign.Extension)' == '.nupkg'" />
+    <Copy SourceFiles="%(FilesToSign.Identity)" DestinationFiles="$(ArtifactsDir)Signed\Packages\%(FilesToSign.Filename)%(FilesToSign.Extension)" Condition="'%(FilesToSign.Extension)' == '.jar'" />
+    <Copy SourceFiles="%(FilesToSign.Identity)" DestinationFiles="$(ArtifactsDir)Signed\VSIX\%(FilesToSign.Filename)%(FilesToSign.Extension)" Condition="'%(FilesToSign.Extension)' == '.vsix'" />
+    <Copy SourceFiles="%(FilesToSign.Identity)" DestinationFiles="$(ArtifactsDir)Signed\SharedFx\%(FilesToSign.Filename)%(FilesToSign.Extension)" Condition="'%(FilesToSign.Extension)' == '.zip'" />
   </Target>
 
 </Project>

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -104,6 +104,15 @@ docker run \
     -e TEAMCITY_VERSION \
     -e DOTNET_CLI_TELEMETRY_OPTOUT \
     -e Configuration \
+    -e PB_RESTORESOURCE \
+    -e PB_PUBLISHBLOBFEEDURL \
+    -e PB_PUBLISHTYPE \
+    -e PB_SKIPTESTS \
+    -e PB_ISFINALBUILD \
+    -e PB_ACCESSTOKENSUFFIX \
+    -e PB_PACKAGEVERSIONPROPSURL\
+    -e PB_ASSETROOTURL \
+    -e PRODUCTBUILDID \
     -v "$DIR:/code/build" \
     ${docker_args[@]+"${docker_args[@]}"} \
     $tagname \

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.7-build-20201119.1
-commithash:8212674c2abff7b51f99422c9bdb1a81b90d9dc1
+version:2.1.7-build-20201218.2
+commithash:26d5fca2ed53577d072f0c7a00c188a2fe826f7f

--- a/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
@@ -16,8 +16,8 @@
     <IisOobWinSdkVersion Condition="'$(IisOobWinSdkVersion)' == ''">10.0.17134.0</IisOobWinSdkVersion>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(IisOobWinSdkVersion)</WindowsTargetPlatformVersion>
     <CharacterSet>Unicode</CharacterSet>
-    <OutDir>bin\$(Configuration)\$(PlatformShortname)\</OutDir>
-    <IntDir>obj\$(Configuration)\$(PlatformShortname)\</IntDir>
+    <OutDir Condition=" '$(OutDir)' == '' ">bin\$(Configuration)\$(PlatformShortname)\</OutDir>
+    <IntDir Condition=" '$(IntDir)' == '' ">obj\$(Configuration)\$(PlatformShortname)\</IntDir>
   </PropertyGroup>
 
   <!--

--- a/src/Installers/Windows/WindowsInstallers.proj
+++ b/src/Installers/Windows/WindowsInstallers.proj
@@ -19,7 +19,7 @@
 
   </ItemGroup>
 
-  <Target Name="Build">
+  <Target Name="Build" DependsOnTargets="UnzipSharedFx">
     <MSBuild Projects="@(InstallerProject)" Targets="Build" />
   </Target>
 
@@ -30,6 +30,30 @@
   <Target Name="Restore">
     <MSBuild Projects="AspNetCoreModule-Setup/ANCMPackageResolver/ANCMPackageResolver.csproj" Targets="Restore" />
     <MSBuild Projects="@(InstallerProject)" Targets="Restore" />
+  </Target>
+
+  <Target Name="UnzipSharedFx">
+    <Message Text="Unzipping x64 SharedFx to $(SharedFrameworkHarvestRootPath)x64" Importance="High" />
+
+    <ItemGroup>
+      <x64Archive Include="$(SharedFxDepsRoot)aspnetcore-runtime-internal-*-win-x64.zip" />
+      <x86Archive Include="$(SharedFxDepsRoot)aspnetcore-runtime-internal-*-win-x86.zip" />
+    </ItemGroup>
+
+    <!-- We don't import version files here, so unzip whatever internal archives are in the .deps folder -->
+    <Unzip
+      SourceFiles="@(x64Archive)"
+      DestinationFolder="$(SharedFrameworkHarvestRootPath)x64"
+      Condition="!Exists('$(SharedFrameworkHarvestRootPath)x64/shared/')"
+    />
+
+    <Message Text="Unzipping x86 SharedFx to $(SharedFrameworkHarvestRootPath)x86" Importance="High" />
+
+    <Unzip
+      SourceFiles="@(x86Archive)"
+      DestinationFolder="$(SharedFrameworkHarvestRootPath)x86"
+      Condition="!Exists('$(SharedFrameworkHarvestRootPath)x86/shared/')"
+    />
   </Target>
 
 </Project>

--- a/src/Installers/Windows/Wix.props
+++ b/src/Installers/Windows/Wix.props
@@ -1,7 +1,13 @@
 <Project>
 
   <PropertyGroup>
-    <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(BuildNumber)</Version>
+    <!-- Ugly hack - Wix doesn't accept build numbers larger than 65535, and AzDo's BuildIds are larger than that.
+         The largest we ever got on TeamCity was 31363, so we want to be in the range of 31364 - 65535. To achieve this we take the
+         AzDO build number modulo 34172 (65545 - 31363 = 34172), and add 31364 to that to give us a number in the desired range. -->
+    <InstallerBuildNumber>$(BuildNumber)</InstallerBuildNumber>
+    <InstallerBuildNumberModulo Condition="'$(BuildNumber)' != 't000'">$([MSBuild]::Modulo($(BuildNumber), 34172))</InstallerBuildNumberModulo>
+    <InstallerBuildNumber Condition="'$(BuildNumber)' != 't000'">$([MSBuild]::Add($(InstallerBuildNumberModulo), 31364))</InstallerBuildNumber>
+    <Version>$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).$(AspNetCorePatchVersion).$(InstallerBuildNumber)</Version>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Lang Condition="'$(Lang)' == ''">ENU</Lang>


### PR DESCRIPTION
Migrates our TeamCity build infrastructure for release/2.1 official builds to Azure DevOps. 

Notes:

- Pipebuild PR to point the new definition: [here](https://devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline/pullrequest/294879)
- Pipebuild PR I'll need to merge once I'm done testing end-to-end builds: [here](https://devdiv.visualstudio.com/DevDiv/_git/DotNet-BuildPipeline/pullrequest/294881)
- Aspnet/Buildtools PR to allow customization of inputs to the SignFiles target: [here](https://github.com/aspnet/BuildTools/pull/989), [here](https://github.com/aspnet/BuildTools/pull/990)
- I removed usage of the `aspnet-internal-tools` repo entirely, opting instead to use microbuild to do signing at the end of the Windows-SharedFx job (instead of a separate code signing job that checked out and built aspnet-internal-tools)
- Green test build ran in isolation: [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=930251&view=results)
- Test build with pipebuild inputs, still running: [here](https://dev.azure.com/dnceng/internal/_build/results?buildId=930884&view=results)

Also called out some relevant things in comments on the file changes, and I still have some general cleanup to do, so this is still a WIP.

CC @Pilchie 