### PR TITLE
Fix can not set result on JwtBearer authentication event

### DIFF
--- a/src/Security/Authentication/JwtBearer/src/AuthenticationFailedContext.cs
+++ b/src/Security/Authentication/JwtBearer/src/AuthenticationFailedContext.cs
@@ -25,5 +25,10 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         /// Gets or sets the exception associated with the authentication failure.
         /// </summary>
         public Exception Exception { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="AuthenticateResult"/> result.
+        /// </summary>
+        public new AuthenticateResult Result { get; set; }
     }
 }

--- a/src/Security/Authentication/JwtBearer/src/MessageReceivedContext.cs
+++ b/src/Security/Authentication/JwtBearer/src/MessageReceivedContext.cs
@@ -24,5 +24,10 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         /// Bearer Token. This will give the application an opportunity to retrieve a token from an alternative location.
         /// </summary>
         public string Token { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="AuthenticateResult"/> result.
+        /// </summary>
+        public new AuthenticateResult Result { get;  set; }
     }
 }

--- a/src/Security/Authentication/JwtBearer/src/TokenValidatedContext.cs
+++ b/src/Security/Authentication/JwtBearer/src/TokenValidatedContext.cs
@@ -25,5 +25,10 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
         /// Gets or sets the validated security token.
         /// </summary>
         public SecurityToken SecurityToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="AuthenticateResult"/> result.
+        /// </summary>
+        public new AuthenticateResult Result { get; set; }
     }
 }


### PR DESCRIPTION
In [JwtBearerHandler.cs](https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs) , I found that the conditional of four lines of code will never be true:

- [JwtBearerHandler.cs#L63](https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs#L63)
- [JwtBearerHandler.cs#L147](https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs#L147)
- [JwtBearerHandler.cs#L173](https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs#L173)
- [JwtBearerHandler.cs#L193](https://github.com/dotnet/aspnetcore/blob/master/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs#L193)

Because the `context.Result` property has no `set accessor`, inherit from `ResultContext`, so I added set accessors for these three Context objects.