### PR TITLE
Typo (duplicate word) in documentation comment for SuppressAsyncSuffixInActionNames (MvcOptions)

### DIFF
--- a/src/Mvc/Mvc.Core/src/MvcOptions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcOptions.cs
@@ -281,7 +281,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// <c>/Products/ListProducts</c> with views looked up at <c>/Views/Products/ListProducts.cshtml</c>.
         /// </para>
         /// <para>
-        /// This option does not affect values specified using using <see cref="ActionNameAttribute"/>.
+        /// This option does not affect values specified using <see cref="ActionNameAttribute"/>.
         /// </para>
         /// </summary>
         /// <value>


### PR DESCRIPTION
Resolved a typo, where the word "using" was duplicated in the XML documentation comment for `SuppressAsyncSuffixInActionNames` in `MvcOptions`.

Addresses #28862.