### PR TITLE
Remove obsolete StaticFileResponseContext constructor 

### DIFF
--- a/src/Middleware/StaticFiles/src/PublicAPI.Shipped.txt
+++ b/src/Middleware/StaticFiles/src/PublicAPI.Shipped.txt
@@ -40,7 +40,6 @@ Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptionsBase.RequestPath.ge
 Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptionsBase.RequestPath.set -> void
 Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware
 Microsoft.AspNetCore.StaticFiles.StaticFileResponseContext
-Microsoft.AspNetCore.StaticFiles.StaticFileResponseContext.StaticFileResponseContext() -> void
 Microsoft.Extensions.DependencyInjection.DirectoryBrowserServiceExtensions
 ~Microsoft.AspNetCore.Builder.DefaultFilesOptions.DefaultFileNames.get -> System.Collections.Generic.IList<string>
 ~Microsoft.AspNetCore.Builder.DefaultFilesOptions.DefaultFileNames.set -> void

--- a/src/Middleware/StaticFiles/src/StaticFileResponseContext.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileResponseContext.cs
@@ -15,30 +15,12 @@ namespace Microsoft.AspNetCore.StaticFiles
         /// <summary>
         /// Constructs the <see cref="StaticFileResponseContext"/>.
         /// </summary>
-        [Obsolete("Use the constructor that passes in the HttpContext and IFileInfo parameters: StaticFileResponseContext(HttpContext context, IFileInfo file)", false)]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public StaticFileResponseContext()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-        }
-
-        /// <summary>
-        /// Constructs the <see cref="StaticFileResponseContext"/>.
-        /// </summary>
         /// <param name="context">The request and response information.</param>
         /// <param name="file">The file to be served.</param>
         public StaticFileResponseContext(HttpContext context, IFileInfo file)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-            Context = context;
-            File = file;
+            Context = context ?? throw new ArgumentNullException(nameof(context));
+            File = file ?? throw new ArgumentNullException(nameof(file));
         }
 
         /// <summary>


### PR DESCRIPTION
#27529

Obsolete APIs in Middleware:
- StaticFileResponseContext.ctor(): Obsolete since 3.0, and wasn't usable before that because all of the properties had internal setters. Replaced by a new constructor with parameters. Removed.
