### PR TITLE
Optimize the SocketAwaitableEventArgs class.

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
     {
         private static readonly Action _callbackCompleted = () => { };
 
+        private static readonly Action<object?> _pipeSchedulerDelegate = state => ((Action)state!)();
+
         private readonly PipeScheduler _ioScheduler;
 
         private Action? _callback;
@@ -72,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
 
             if (continuation != null)
             {
-                _ioScheduler.Schedule(state => ((Action)state!)(), continuation);
+                _ioScheduler.Schedule(_pipeSchedulerDelegate, continuation);
             }
         }
     }

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
@@ -54,13 +54,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             if (ReferenceEquals(_callback, _callbackCompleted) ||
                 ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
             {
-                Task.Run(continuation);
+                Task.CompletedTask.ConfigureAwait(false).GetAwaiter().OnCompleted(continuation);
             }
         }
 
         public void UnsafeOnCompleted(Action continuation)
         {
-            OnCompleted(continuation);
+            if (ReferenceEquals(_callback, _callbackCompleted) ||
+                ReferenceEquals(Interlocked.CompareExchange(ref _callback, continuation, null), _callbackCompleted))
+            {
+                Task.CompletedTask.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(continuation);
+            }
         }
 
         public void Complete()


### PR DESCRIPTION
This PR does two things to Kestrel's `SocketAwaitableEventArgs` class:
 - It eliminates a lambda allocation by caching the `Action` passed to the `PipeScheduler` at the overriden `OnCompleted` method (a pretty hot path).
 - It changes the `I(Critical)Completion` methods to behave like `ValueTaskAwaiter` when the operation is already completed. Most importantly, the synchronization context is explicitly not captured and the implementations of `OnCompleted` and `UnsafeOnCompleted` now actually differ.

I have some reservations about the second change. Perhaps it is made redundant by the `unsafeSuppressExecutionContextFlow` parameter at the constructor, and the longer method call adds an overhead; I am not 100% sure.