### PR TITLE
Allow user specific PasswordValidator options

### DIFF
--- a/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-virtual Microsoft.AspNetCore.Identity.PasswordValidator<TUser>.GetOptions(Microsoft.AspNetCore.Identity.UserManager<TUser> manager, TUser user) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Identity.PasswordOptions>
+~virtual Microsoft.AspNetCore.Identity.PasswordValidator<TUser>.GetOptions(Microsoft.AspNetCore.Identity.UserManager<TUser> manager, TUser user) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Identity.PasswordOptions>

--- a/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+virtual Microsoft.AspNetCore.Identity.PasswordValidator<TUser>.GetOptions(Microsoft.AspNetCore.Identity.UserManager<TUser> manager, TUser user) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Identity.PasswordOptions>


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Add virtual method `PasswordValidator.GetOptions` to get `PasswordOptions`
