### PR TITLE
[SignalR] Remove reference to Buffer in TS client

### DIFF
--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
@@ -47,7 +47,6 @@
     "msgpack5": "^4.0.2"
   },
   "devDependencies": {
-    "@types/msgpack5": "^3.4.1",
-    "buffer": "^5.0.8"
+    "@types/msgpack5": "^3.4.1"
   }
 }

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/src/MessagePackHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/src/MessagePackHubProtocol.ts
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-import { Buffer } from "buffer";
 import * as msgpack5 from "msgpack5";
 
 import { MessagePackOptions } from "./MessagePackOptions";
@@ -51,13 +50,13 @@ export class MessagePackHubProtocol implements IHubProtocol {
 
     /** Creates an array of HubMessage objects from the specified serialized representation.
      *
-     * @param {ArrayBuffer | Buffer} input An ArrayBuffer or Buffer containing the serialized representation.
+     * @param {ArrayBuffer} input An ArrayBuffer containing the serialized representation.
      * @param {ILogger} logger A logger that will be used to log messages that occur during parsing.
      */
-    public parseMessages(input: ArrayBuffer | Buffer, logger: ILogger): HubMessage[] {
+    public parseMessages(input: ArrayBuffer, logger: ILogger): HubMessage[] {
         // The interface does allow "string" to be passed in, but this implementation does not. So let's throw a useful error.
-        if (!(input instanceof Buffer) && !(isArrayBuffer(input))) {
-            throw new Error("Invalid input for MessagePack hub protocol. Expected an ArrayBuffer or Buffer.");
+        if (!(isArrayBuffer(input))) {
+            throw new Error("Invalid input for MessagePack hub protocol. Expected an ArrayBuffer.");
         }
 
         if (logger === null) {
@@ -108,7 +107,8 @@ export class MessagePackHubProtocol implements IHubProtocol {
         }
 
         const msgpack = msgpack5(this.messagePackOptions);
-        const properties = msgpack.decode(Buffer.from(input));
+        // To avoid using the Buffer type we cast to 'any'. msgpack5 works with Uint8Array's
+        const properties = msgpack.decode(input as any);
         if (properties.length === 0 || !(properties instanceof Array)) {
             throw new Error("Invalid payload.");
         }

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/webpack.config.js
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/webpack.config.js
@@ -8,8 +8,5 @@ module.exports = baseConfig(__dirname, "signalr-protocol-msgpack", {
     externals: {
         msgpack5: "msgpack5",
         "@microsoft/signalr": "signalR"
-    },
-    alias: {
-        buffer: path.resolve(__dirname, "node_modules", "buffer", "index.js"),
-    },
+    }
 });

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/yarn.lock
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/yarn.lock
@@ -37,11 +37,6 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
-base64-js@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
-  integrity sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==
-
 bl@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
@@ -49,14 +44,6 @@ bl@^1.2.1:
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
-
-buffer@^5.0.8:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.8.tgz#84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24"
-  integrity sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -87,11 +74,6 @@ fetch-cookie@^0.7.3:
   dependencies:
     es6-denodeify "^0.1.1"
     tough-cookie "^2.3.3"
-
-ieee754@^1.1.4:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
 
 inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"

--- a/src/SignalR/clients/ts/signalr/src/HandshakeProtocol.ts
+++ b/src/SignalR/clients/ts/signalr/src/HandshakeProtocol.ts
@@ -28,7 +28,7 @@ export class HandshakeProtocol {
         let messageData: string;
         let remainingData: any;
 
-        if (isArrayBuffer(data) || (typeof Buffer !== "undefined" && data instanceof Buffer)) {
+        if (isArrayBuffer(data)) {
             // Format is binary but still need to read JSON text from handshake response
             const binaryData = new Uint8Array(data);
             const separatorIndex = binaryData.indexOf(TextMessageFormat.RecordSeparatorCode);

--- a/src/SignalR/clients/ts/signalr/src/IHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr/src/IHubProtocol.ts
@@ -157,10 +157,10 @@ export interface IHubProtocol {
      *
      * If {@link @microsoft/signalr.IHubProtocol.transferFormat} is 'Text', the `input` parameter must be a string, otherwise it must be an ArrayBuffer.
      *
-     * @param {string | ArrayBuffer | Buffer} input A string, ArrayBuffer, or Buffer containing the serialized representation.
+     * @param {string | ArrayBuffer} input A string or ArrayBuffer containing the serialized representation.
      * @param {ILogger} logger A logger that will be used to log messages that occur during parsing.
      */
-    parseMessages(input: string | ArrayBuffer | Buffer, logger: ILogger): HubMessage[];
+    parseMessages(input: string | ArrayBuffer, logger: ILogger): HubMessage[];
 
     /** Writes the specified {@link @microsoft/signalr.HubMessage} to a string or ArrayBuffer and returns it.
      *

--- a/src/SignalR/clients/ts/signalr/webpack.config.js
+++ b/src/SignalR/clients/ts/signalr/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = env => baseConfig(__dirname, "signalr", {
     target: env && env.platform ?  env.platform : undefined,
     platformDist: env && env.platform ?  env.platform : undefined,
     externals: [
-        "websocket",
+        "ws",
         "eventsource",
         "node-fetch",
         "abort-controller",


### PR DESCRIPTION
We added `Buffer` usage back when Node support was added and the `NodeHttpClient` was using `Buffer`. In 5.0 we replaced the `NodeHttpClient` with `FetchHttpClient` which allows us to cleanup our `Buffer` usage. `msgpack5` still uses `Buffer`, but the library works if you pass a `Uint8Array` (which Buffer derives from).

Fixes https://github.com/dotnet/aspnetcore/issues/13805