### PR TITLE
[SignalR] Follow HTTP redirects TS client

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -150,6 +150,20 @@ namespace FunctionalTests
 
             app.Use((context, next) =>
             {
+                if (context.Request.Path.StartsWithSegments("/echoredirect"))
+                {
+                    var url = context.Request.Path.ToString();
+                    url = url.Replace("echoredirect", "echo");
+                    url += context.Request.QueryString.ToString();
+                    context.Response.Redirect(url, false, true);
+                    return Task.CompletedTask;
+                }
+
+                return next.Invoke();
+            });
+
+            app.Use((context, next) =>
+            {
                 if (context.Request.Path.StartsWithSegments("/redirect"))
                 {
                     var newUrl = context.Request.Query["baseUrl"] + "/testHub?numRedirects=" + Interlocked.Increment(ref _numRedirects);

--- a/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
@@ -91,7 +91,7 @@ export class FetchHttpClient extends HttpClient {
                 },
                 method: request.method!,
                 mode: "cors",
-                redirect: "manual",
+                redirect: "follow",
                 signal: abortController.signal,
             });
         } catch (e) {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/27068

Side-note: WebSockets will fail to connect and fallback because the browser doesn't follow redirects for websocket requests.