### PR TITLE
Use better check for detecting UTF7 encoding.

### DIFF
--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -297,6 +297,7 @@ namespace Microsoft.AspNetCore.Http.Features
         private static Encoding FilterEncoding(Encoding? encoding)
         {
             // UTF-7 is insecure and should not be honored. UTF-8 will succeed for most cases.
+            // https://docs.microsoft.com/en-us/dotnet/core/compatibility/syslib-warnings/syslib0001
             if (encoding == null || encoding.CodePage == 65000)
             {
                 return Encoding.UTF8;

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -297,9 +297,7 @@ namespace Microsoft.AspNetCore.Http.Features
         private static Encoding FilterEncoding(Encoding? encoding)
         {
             // UTF-7 is insecure and should not be honored. UTF-8 will succeed for most cases.
-#pragma warning disable CS0618, SYSLIB0001 // Type or member is obsolete
-            if (encoding == null || Encoding.UTF7.Equals(encoding))
-#pragma warning restore CS0618, SYSLIB0001 // Type or member is obsolete
+            if (encoding == null || encoding.CodePage == 65000)
             {
                 return Encoding.UTF8;
             }

--- a/src/Http/WebUtilities/src/FormPipeReader.cs
+++ b/src/Http/WebUtilities/src/FormPipeReader.cs
@@ -47,6 +47,7 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         public FormPipeReader(PipeReader pipeReader, Encoding encoding)
         {
+            // https://docs.microsoft.com/en-us/dotnet/core/compatibility/syslib-warnings/syslib0001
             if (encoding is Encoding { CodePage: 65000 })
             {
                 throw new ArgumentException("UTF7 is unsupported and insecure. Please select a different encoding.");

--- a/src/Http/WebUtilities/src/FormPipeReader.cs
+++ b/src/Http/WebUtilities/src/FormPipeReader.cs
@@ -47,10 +47,8 @@ namespace Microsoft.AspNetCore.WebUtilities
 
         public FormPipeReader(PipeReader pipeReader, Encoding encoding)
         {
-#pragma warning disable CS0618, SYSLIB0001 // Type or member is obsolete
-            if (encoding == Encoding.UTF7)
+            if (encoding is Encoding { CodePage: 65000 })
             {
-#pragma warning restore CS0618, SYSLIB0001 // Type or member is obsolete
                 throw new ArgumentException("UTF7 is unsupported and insecure. Please select a different encoding.");
             }
 

--- a/src/Http/WebUtilities/src/MultipartSectionStreamExtensions.cs
+++ b/src/Http/WebUtilities/src/MultipartSectionStreamExtensions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             MediaTypeHeaderValue.TryParse(section.ContentType, out var sectionMediaType);
 
             var streamEncoding = sectionMediaType?.Encoding;
+            // https://docs.microsoft.com/en-us/dotnet/core/compatibility/syslib-warnings/syslib0001
             if (streamEncoding == null || streamEncoding.CodePage == 65000)
             {
                 streamEncoding = Encoding.UTF8;

--- a/src/Http/WebUtilities/src/MultipartSectionStreamExtensions.cs
+++ b/src/Http/WebUtilities/src/MultipartSectionStreamExtensions.cs
@@ -34,9 +34,7 @@ namespace Microsoft.AspNetCore.WebUtilities
             MediaTypeHeaderValue.TryParse(section.ContentType, out var sectionMediaType);
 
             var streamEncoding = sectionMediaType?.Encoding;
-#pragma warning disable CS0618, SYSLIB0001 // Type or member is obsolete
-            if (streamEncoding == null || streamEncoding == Encoding.UTF7)
-#pragma warning restore CS0618, SYSLIB0001 // Type or member is obsolete
+            if (streamEncoding == null || streamEncoding.CodePage == 65000)
             {
                 streamEncoding = Encoding.UTF8;
             }


### PR DESCRIPTION
As described in the documentation: https://docs.microsoft.com/en-us/dotnet/core/compatibility/syslib-warnings/syslib0001#workarounds