### PR TITLE
HTTP/3: Add CompleteAsync tests and fix various bugs

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -650,4 +650,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http3StreamResetByApplication" xml:space="preserve">
     <value>The HTTP/3 stream was reset by the application with error code {errorCode}.</value>
   </data>
+  <data name="Http3StreamErrorAfterHeaders" xml:space="preserve">
+    <value>An error occurred after the response headers were sent, a reset is being sent.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -77,12 +77,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         void IHttpOutputAborter.Abort(ConnectionAbortedException abortReason)
         {
-            _stream.Abort(abortReason, Http3ErrorCode.InternalError);
+            _stream.ResetAndAbort(abortReason, Http3ErrorCode.InternalError);
         }
 
         void IHttpOutputAborter.OnInputOrOutputCompleted()
         {
-            _stream.Abort(new ConnectionAbortedException($"{nameof(Http3OutputProducer)}.{nameof(ProcessDataWrites)} has completed."), Http3ErrorCode.InternalError);
+            _stream.ResetAndAbort(new ConnectionAbortedException($"{nameof(Http3OutputProducer)}.{nameof(ProcessDataWrites)} has completed."), Http3ErrorCode.InternalError);
         }
 
         public void Advance(int bytes)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -77,12 +77,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         void IHttpOutputAborter.Abort(ConnectionAbortedException abortReason)
         {
-            _stream.ResetAndAbort(abortReason, Http3ErrorCode.InternalError);
+            _stream.Abort(abortReason, Http3ErrorCode.InternalError);
         }
 
         void IHttpOutputAborter.OnInputOrOutputCompleted()
         {
-            _stream.ResetAndAbort(new ConnectionAbortedException($"{nameof(Http3OutputProducer)}.{nameof(ProcessDataWrites)} has completed."), Http3ErrorCode.InternalError);
+            _stream.Abort(new ConnectionAbortedException($"{nameof(Http3OutputProducer)}.{nameof(ProcessDataWrites)} has completed."), Http3ErrorCode.InternalError);
         }
 
         public void Advance(int bytes)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -98,15 +98,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public void Abort(ConnectionAbortedException ex)
         {
-            Abort(ex, Http3ErrorCode.InternalError);
+            AbortCore(ex, Http3ErrorCode.InternalError);
         }
 
         public void Abort(ConnectionAbortedException ex, Http3ErrorCode errorCode)
         {
+            AbortCore(ex, errorCode);
+        }
+
+        private void AbortCore(ConnectionAbortedException abortReason, Http3ErrorCode errorCode)
+        {
             _errorCodeFeature.Error = (long)errorCode;
-            // TODO replace with IKestrelTrace log.
-            Log.LogWarning(ex, ex.Message);
-            _frameWriter.Abort(ex);
+            _frameWriter.Abort(abortReason);
+
+            // Call _http3Output.Stop() prior to poisoning the request body stream or pipe to
+            // ensure that an app that completes early due to the abort doesn't result in header frames being sent.
+            _http3Output.Stop();
+
+            CancelRequestAbortedToken();
+
+            // Unblock the request body.
+            PoisonBody(abortReason);
+            RequestBodyPipe.Writer.Complete(abortReason);
+        }
+
+        protected override void OnErrorAfterResponseStarted()
+        {
+            // We can no longer change the response, send a Reset instead.
+            var abortReason = new ConnectionAbortedException(CoreStrings.Http3StreamErrorAfterHeaders);
+            Abort(abortReason, Http3ErrorCode.InternalError);
         }
 
         public void OnHeadersComplete(bool endStream)
@@ -377,8 +397,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
                 await Input.CompleteAsync();
 
-                await RequestBodyPipe.Writer.CompleteAsync();
-
                 // Make sure application func is completed before completing writer.
                 if (_appCompleted != null)
                 {
@@ -514,7 +532,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private void ApplicationAbort(ConnectionAbortedException abortReason, Http3ErrorCode error)
         {
-            Abort(abortReason, error);
+            Log.Http3StreamResetAbort(TraceIdentifier, error, abortReason);
+
+            AbortCore(abortReason, error);
         }
 
         protected override string CreateRequestId()

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
@@ -86,5 +87,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId);
 
+        void Http3StreamResetAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -87,6 +87,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId);
 
-        void Http3StreamResetAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason);
+        void Http3StreamAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
@@ -132,6 +133,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private static readonly Action<ILogger, string, long, Exception?> _http3ConnectionClosed =
             LoggerMessage.Define<string, long>(LogLevel.Debug, new EventId(44, "Http3ConnectionClosed"),
                 @"Connection id ""{ConnectionId}"" is closed. The last processed stream ID was {HighestOpenedStreamId}.");
+
+        private static readonly Action<ILogger, string, Http3ErrorCode, Exception> _http3StreamResetError =
+            LoggerMessage.Define<string, Http3ErrorCode>(LogLevel.Debug, new EventId(45, "Http3StreamResetAbort"),
+                @"Trace id ""{TraceIdentifier}"": HTTP/3 stream error ""{error}"". A Reset is being sent to the stream.");
 
         protected readonly ILogger _logger;
 
@@ -329,6 +334,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId)
         {
             _http3ConnectionClosed(_logger, connectionId, highestOpenedStreamId, null);
+        }
+
+        public void Http3StreamResetAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason)
+        {
+            _http3StreamResetError(_logger, traceIdentifier, error, abortReason);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private static readonly Action<ILogger, string, string, Exception?> _applicationAbortedConnection =
             LoggerMessage.Define<string, string>(LogLevel.Information, new EventId(34, "RequestBodyDrainTimedOut"), @"Connection id ""{ConnectionId}"", Request id ""{TraceIdentifier}"": the application aborted the connection.");
 
-        private static readonly Action<ILogger, string, Http2ErrorCode, Exception> _http2StreamResetError =
+        private static readonly Action<ILogger, string, Http2ErrorCode, Exception> _http2StreamResetAbort =
             LoggerMessage.Define<string, Http2ErrorCode>(LogLevel.Debug, new EventId(35, "Http2StreamResetAbort"),
                 @"Trace id ""{TraceIdentifier}"": HTTP/2 stream error ""{error}"". A Reset is being sent to the stream.");
 
@@ -134,9 +134,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             LoggerMessage.Define<string, long>(LogLevel.Debug, new EventId(44, "Http3ConnectionClosed"),
                 @"Connection id ""{ConnectionId}"" is closed. The last processed stream ID was {HighestOpenedStreamId}.");
 
-        private static readonly Action<ILogger, string, Http3ErrorCode, Exception> _http3StreamResetError =
-            LoggerMessage.Define<string, Http3ErrorCode>(LogLevel.Debug, new EventId(45, "Http3StreamResetAbort"),
-                @"Trace id ""{TraceIdentifier}"": HTTP/3 stream error ""{error}"". A Reset is being sent to the stream.");
+        private static readonly Action<ILogger, string, Http3ErrorCode, Exception> _http3StreamAbort =
+            LoggerMessage.Define<string, Http3ErrorCode>(LogLevel.Debug, new EventId(45, "Http3StreamAbort"),
+                @"Trace id ""{TraceIdentifier}"": HTTP/3 stream error ""{error}"". An abort is being sent to the stream.");
 
         protected readonly ILogger _logger;
 
@@ -282,7 +282,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         public void Http2StreamResetAbort(string traceIdentifier, Http2ErrorCode error, ConnectionAbortedException abortReason)
         {
-            _http2StreamResetError(_logger, traceIdentifier, error, abortReason);
+            _http2StreamResetAbort(_logger, traceIdentifier, error, abortReason);
         }
 
         public virtual void HPackDecodingError(string connectionId, int streamId, HPackDecodingException ex)
@@ -336,9 +336,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             _http3ConnectionClosed(_logger, connectionId, highestOpenedStreamId, null);
         }
 
-        public void Http3StreamResetAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason)
+        public void Http3StreamAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason)
         {
-            _http3StreamResetError(_logger, traceIdentifier, error, abortReason);
+            _http3StreamAbort(_logger, traceIdentifier, error, abortReason);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockTrace.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
@@ -62,5 +63,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public void Http3ConnectionError(string connectionId, Http3ConnectionException ex) { }
         public void Http3ConnectionClosing(string connectionId) { }
         public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId) { }
+        public void Http3StreamResetAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason) { }
     }
 }

--- a/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Kestrel.Performance/Mocks/MockTrace.cs
@@ -63,6 +63,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Performance
         public void Http3ConnectionError(string connectionId, Http3ConnectionException ex) { }
         public void Http3ConnectionClosing(string connectionId) { }
         public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId) { }
-        public void Http3StreamResetAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason) { }
+        public void Http3StreamAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason) { }
     }
 }

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -260,6 +261,12 @@ namespace Microsoft.AspNetCore.Testing
         {
             _trace1.Http3ConnectionClosed(connectionId, highestOpenedStreamId);
             _trace2.Http3ConnectionClosed(connectionId, highestOpenedStreamId);
+        }
+
+        public void Http3StreamResetAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason)
+        {
+            _trace1.Http3StreamResetAbort(traceIdentifier, error, abortReason);
+            _trace2.Http3StreamResetAbort(traceIdentifier, error, abortReason);
         }
     }
 }

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -263,10 +263,10 @@ namespace Microsoft.AspNetCore.Testing
             _trace2.Http3ConnectionClosed(connectionId, highestOpenedStreamId);
         }
 
-        public void Http3StreamResetAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason)
+        public void Http3StreamAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason)
         {
-            _trace1.Http3StreamResetAbort(traceIdentifier, error, abortReason);
-            _trace2.Http3StreamResetAbort(traceIdentifier, error, abortReason);
+            _trace1.Http3StreamAbort(traceIdentifier, error, abortReason);
+            _trace2.Http3StreamAbort(traceIdentifier, error, abortReason);
         }
     }
 }

--- a/src/Shared/runtime/Http3/QPack/QPackEncoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackEncoder.cs
@@ -477,9 +477,8 @@ namespace System.Net.Http.QPack
                 case 400:
                 case 404:
                 case 500:
-                    // TODO this isn't safe, some index can be larger than 64. Encoded here!
-                    buffer[0] = (byte)(0xC0 | H3StaticTable.StatusIndex[statusCode]);
-                    return 1;
+                    EncodeStaticIndexedHeaderField(H3StaticTable.StatusIndex[statusCode], buffer, out var bytesWritten);
+                    return bytesWritten;
                 default:
                     // Send as Literal Header Field Without Indexing - Indexed Name
                     buffer[0] = 0x08;


### PR DESCRIPTION
* Replicate HTTP/2 CompleteAsync unit tests for HTTP/3
* Fix writing wrong header for status code 500
* Fix various errors related to aborting