### PR TITLE
Use Environment.ProcessId instead of Process.GetCurrentProcess().Id

### DIFF
--- a/src/Components/WebAssembly/Sdk/tools/DebugMode.cs
+++ b/src/Components/WebAssembly/Sdk/tools/DebugMode.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NET.Sdk.BlazorWebAssembly.Tools
             {
                 args = args.Skip(1).ToArray();
 
-                Console.WriteLine("Waiting for debugger in pid: {0}", Process.GetCurrentProcess().Id);
+                Console.WriteLine("Waiting for debugger in pid: {0}", Environment.ProcessId);
                 while (!Debugger.IsAttached)
                 {
                     Thread.Sleep(TimeSpan.FromSeconds(3));

--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Builder
             var environment = serviceProvider.GetRequiredService<IWebHostEnvironment>();
             var executablePath = LocateDebugProxyExecutable(environment);
             var muxerPath = DotNetMuxer.MuxerPathOrDefault();
-            var ownerPid = Process.GetCurrentProcess().Id;
+            var ownerPid = Environment.ProcessId;
 
             var processStartInfo = new ProcessStartInfo
             {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/DebugMode.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/DebugMode.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
             {
                 args = args.Skip(1).ToArray();
 
-                Console.WriteLine("Waiting for debugger in pid: {0}", Process.GetCurrentProcess().Id);
+                Console.WriteLine("Waiting for debugger in pid: {0}", Environment.ProcessId);
                 while (!Debugger.IsAttached)
                 {
                     Thread.Sleep(TimeSpan.FromSeconds(3));

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/DefaultRequestDispatcher.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/DefaultRequestDispatcher.cs
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                     if (request.IsShutdownRequest())
                     {
                         // Reply with the PID of this process so that the client can wait for it to exit.
-                        var response = new ShutdownServerResponse(Process.GetCurrentProcess().Id);
+                        var response = new ShutdownServerResponse(Environment.ProcessId);
                         await response.WriteAsync(connection.Stream, cancellationToken);
 
                         // We can safely disconnect the client, then when this connection gets cleaned up by the event loop

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/ServerCommand.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/src/ServerCommand.cs
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
             // <pipename>
 
             const int DefaultBufferSize = 4096;
-            var processId = Process.GetCurrentProcess().Id;
+            var processId = Environment.ProcessId;
             var fileName = $"rzc-{processId}";
 
             // Make sure the directory exists.

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/ServerCommandTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/ServerCommandTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
         public void WritePidFile_WorksAsExpected()
         {
             // Arrange
-            var expectedProcessId = Process.GetCurrentProcess().Id;
+            var expectedProcessId = Environment.ProcessId;
             var expectedRzcPath = typeof(ServerCommand).Assembly.Location;
             var expectedFileName = $"rzc-{expectedProcessId}";
             var directoryPath = Path.Combine(Path.GetTempPath(), "RazorTest", Guid.NewGuid().ToString());

--- a/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/ServerLifecycleTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Tools/test/ServerLifecycleTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 .Returns(() =>
                 {
                     // Use a thread instead of Task to guarantee this code runs on a different
-                    // thread and we can validate the mutex state. 
+                    // thread and we can validate the mutex state.
                     var source = new TaskCompletionSource<bool>();
                     var thread = new Thread(_ =>
                     {
@@ -85,9 +85,9 @@ namespace Microsoft.AspNetCore.Razor.Tools
                         }
                     });
 
-                    // Synchronously wait here.  Don't returned a Task value because we need to 
-                    // ensure the above check completes before the server hits a timeout and 
-                    // releases the mutex. 
+                    // Synchronously wait here.  Don't returned a Task value because we need to
+                    // ensure the above check completes before the server hits a timeout and
+                    // releases the mutex.
                     thread.Start();
                     source.Task.Wait();
 
@@ -108,13 +108,13 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 var serverProcessId = await ServerUtilities.SendShutdown(serverData.PipeName);
 
                 // Assert
-                Assert.Equal(Process.GetCurrentProcess().Id, serverProcessId);
+                Assert.Equal(Environment.ProcessId, serverProcessId);
                 await serverData.Verify(connections: 1, completed: 1);
             }
         }
 
         /// <summary>
-        /// A shutdown request should not abort an existing compilation.  It should be allowed to run to 
+        /// A shutdown request should not abort an existing compilation.  It should be allowed to run to
         /// completion.
         /// </summary>
         [Fact]
@@ -188,7 +188,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 {
                     // The compilation is now in progress, send the shutdown.
                     var processId = await ServerUtilities.SendShutdown(serverData.PipeName);
-                    Assert.Equal(Process.GetCurrentProcess().Id, processId);
+                    Assert.Equal(Environment.ProcessId, processId);
                     Assert.False(compileTask.IsCompleted);
                 }
 
@@ -244,7 +244,7 @@ namespace Microsoft.AspNetCore.Razor.Tools
                 }
 
                 // Act
-                // Wait until all of the connections are being processed by the server. 
+                // Wait until all of the connections are being processed by the server.
                 await completionSource.Task;
 
                 // Now cancel

--- a/src/Razor/Microsoft.NET.Sdk.Razor/src/DotnetToolTask.cs
+++ b/src/Razor/Microsoft.NET.Sdk.Razor/src/DotnetToolTask.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Razor.Tasks
         {
             if (Debug)
             {
-                Log.LogMessage(MessageImportance.High, "Waiting for debugger in pid: {0}", Process.GetCurrentProcess().Id);
+                Log.LogMessage(MessageImportance.High, "Waiting for debugger in pid: {0}", Environment.ProcessId);
                 while (!Debugger.IsAttached)
                 {
                     Thread.Sleep(TimeSpan.FromSeconds(3));

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1040,7 +1040,7 @@ namespace TestSite
 
         private async Task ProcessId(HttpContext context)
         {
-            await context.Response.WriteAsync(Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture));
+            await context.Response.WriteAsync(Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
         }
 
         public async Task ANCM_HTTPS_PORT(HttpContext context)

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/ProcessTracker.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/ProcessTracker.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting.IIS
             }
 
             // Job name is optional but helps with diagnostics.  Job name must be unique if non-null.
-            _jobHandle = CreateJobObject(IntPtr.Zero, name: $"ProcessTracker{Process.GetCurrentProcess().Id}");
+            _jobHandle = CreateJobObject(IntPtr.Zero, name: $"ProcessTracker{Environment.ProcessId}");
 
             var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
             {

--- a/src/Servers/Kestrel/samples/SampleApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/SampleApp/Startup.cs
@@ -154,7 +154,7 @@ namespace SampleApp
                         .UseContentRoot(Directory.GetCurrentDirectory())
                         .UseStartup<Startup>();
 
-                    if (string.Equals(Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture), Environment.GetEnvironmentVariable("LISTEN_PID")))
+                    if (string.Equals(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), Environment.GetEnvironmentVariable("LISTEN_PID")))
                     {
                         // Use libuv if activated by systemd, since that's currently the only transport that supports being passed a socket handle.
 #pragma warning disable CS0618

--- a/src/Servers/Kestrel/samples/SystemdTestApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/SystemdTestApp/Startup.cs
@@ -73,7 +73,7 @@ namespace SystemdTestApp
                         .UseContentRoot(Directory.GetCurrentDirectory())
                         .UseStartup<Startup>();
 
-                    if (string.Equals(Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture), Environment.GetEnvironmentVariable("LISTEN_PID")))
+                    if (string.Equals(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), Environment.GetEnvironmentVariable("LISTEN_PID")))
                     {
                         // Use libuv if activated by systemd, since that's currently the only transport that supports being passed a socket handle.
 #pragma warning disable CS0618

--- a/src/SignalR/perf/benchmarkapps/Crankier/Agent.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Agent.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
         private AgentWorker CreateWorker()
         {
             var fileName = _executable;
-            var arguments = $"worker --agent {Process.GetCurrentProcess().Id}";
+            var arguments = $"worker --agent {Environment.ProcessId}";
             if (_workerWaitForDebugger)
             {
                 arguments += " --wait-for-debugger";

--- a/src/SignalR/perf/benchmarkapps/Crankier/Commands/ServerCommand.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Commands/ServerCommand.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Commands
 
         private static int Execute(LogLevel logLevel, string azureSignalRConnectionString)
         {
-            Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
+            Console.WriteLine($"Process ID: {Environment.ProcessId}");
 
             var configBuilder = new ConfigurationBuilder()
                 .AddEnvironmentVariables(prefix: "ASPNETCORE_");
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier.Commands
                 configBuilder.AddInMemoryCollection(new [] { new KeyValuePair<string, string>("Azure:SignalR:ConnectionString", azureSignalRConnectionString) });
                 Console.WriteLine("Using Azure SignalR");
             }
-            
+
             var config = configBuilder.Build();
 
             var host = new WebHostBuilder()

--- a/src/SignalR/perf/benchmarkapps/Crankier/Program.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Program.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
             if (args.Any(a => string.Equals(a, "--debug", StringComparison.Ordinal)))
             {
                 args = args.Where(a => !string.Equals(a, "--debug", StringComparison.Ordinal)).ToArray();
-                Console.WriteLine($"Waiting for debugger. Process ID: {Process.GetCurrentProcess().Id}");
+                Console.WriteLine($"Waiting for debugger. Process ID: {Environment.ProcessId}");
                 Console.WriteLine("Press ENTER to continue");
                 Console.ReadLine();
             }

--- a/src/SignalR/perf/benchmarkapps/Crankier/Worker.cs
+++ b/src/SignalR/perf/benchmarkapps/Crankier/Worker.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.SignalR.Crankier
         {
             _agentProcess = Process.GetProcessById(agentProcessId);
             _agent = new AgentSender(new StreamWriter(Console.OpenStandardOutput()));
-            _processId = Process.GetCurrentProcess().Id;
+            _processId = Environment.ProcessId;
             _clients = new ConcurrentBag<Client>();
             _sendStatusCts = new CancellationTokenSource();
         }

--- a/src/SignalR/samples/ClientSample/Program.cs
+++ b/src/SignalR/samples/ClientSample/Program.cs
@@ -14,7 +14,7 @@ namespace ClientSample
         {
             if (args.Contains("--debug"))
             {
-                Console.WriteLine($"Ready for debugger to attach. Process ID: {Process.GetCurrentProcess().Id}");
+                Console.WriteLine($"Ready for debugger to attach. Process ID: {Environment.ProcessId}");
                 Console.Write("Press ENTER to Continue");
                 Console.ReadLine();
                 args = args.Except(new[] { "--debug" }).ToArray();

--- a/src/Tools/Microsoft.dotnet-openapi/src/DebugMode.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/DebugMode.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.OpenApi
             {
                 args = args.Skip(1).ToArray();
 
-                Console.WriteLine("Waiting for debugger in pid: {0}", Process.GetCurrentProcess().Id);
+                Console.WriteLine("Waiting for debugger in pid: {0}", Environment.ProcessId);
                 while (!Debugger.IsAttached)
                 {
                     Thread.Sleep(TimeSpan.FromSeconds(3));

--- a/src/Tools/Shared/CommandLine/DebugHelper.cs
+++ b/src/Tools/Shared/CommandLine/DebugHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Tools.Internal
             {
                 args = args.Skip(1).ToArray();
                 Console.WriteLine("Waiting for debugger to attach. Press ENTER to continue");
-                Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
+                Console.WriteLine($"Process ID: {Environment.ProcessId}");
                 Console.ReadLine();
             }
         }

--- a/src/Tools/dotnet-watch/test/TestProjects/AppWithDeps/Program.cs
+++ b/src/Tools/dotnet-watch/test/TestProjects/AppWithDeps/Program.cs
@@ -9,13 +9,13 @@ namespace ConsoleApplication
 {
     public class Program
     {
-        private static readonly int processId = Process.GetCurrentProcess().Id;
+        private static readonly int processId = Environment.ProcessId;
 
         public static void Main(string[] args)
         {
             Console.WriteLine("Started");
             // Process ID is insufficient because PID's may be reused.
-            Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
+            Console.WriteLine($"Process identifier = {Environment.ProcessId}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
             Thread.Sleep(Timeout.Infinite);
         }
     }

--- a/src/Tools/dotnet-watch/test/TestProjects/GlobbingApp/Program.cs
+++ b/src/Tools/dotnet-watch/test/TestProjects/GlobbingApp/Program.cs
@@ -15,7 +15,7 @@ namespace ConsoleApplication
         {
             Console.WriteLine("Started");
             // Process ID is insufficient because PID's may be reused.
-            Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
+            Console.WriteLine($"Process identifier = {Environment.ProcessId}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
             Console.WriteLine("Defined types = " + typeof(Program).Assembly.DefinedTypes.Count());
             Thread.Sleep(Timeout.Infinite);
         }

--- a/src/Tools/dotnet-watch/test/TestProjects/KitchenSink/Program.cs
+++ b/src/Tools/dotnet-watch/test/TestProjects/KitchenSink/Program.cs
@@ -13,7 +13,7 @@ namespace KitchenSink
         {
             Console.WriteLine("Started");
             // Process ID is insufficient because PID's may be reused.
-            Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
+            Console.WriteLine($"Process identifier = {Environment.ProcessId}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
             Console.WriteLine("DOTNET_WATCH = " + Environment.GetEnvironmentVariable("DOTNET_WATCH"));
             Console.WriteLine("DOTNET_WATCH_ITERATION = " + Environment.GetEnvironmentVariable("DOTNET_WATCH_ITERATION"));
 

--- a/src/Tools/dotnet-watch/test/TestProjects/NoDepsApp/Program.cs
+++ b/src/Tools/dotnet-watch/test/TestProjects/NoDepsApp/Program.cs
@@ -13,7 +13,7 @@ namespace ConsoleApplication
         {
             Console.WriteLine("Started");
             // Process ID is insufficient because PID's may be reused.
-            Console.WriteLine($"Process identifier = {Process.GetCurrentProcess().Id}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
+            Console.WriteLine($"Process identifier = {Environment.ProcessId}, {Process.GetCurrentProcess().StartTime:hh:mm:ss.FF}");
             if (args.Length > 0 && args[0] == "--no-exit")
             {
                 Thread.Sleep(Timeout.Infinite);


### PR DESCRIPTION
React to https://github.com/dotnet/aspnetcore/pull/28946
New more efficient api in .NET 5.0 dotnet/runtime#38388
