### PR TITLE
Enable verbose logging for install scripts

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -244,6 +244,7 @@ function InstallDotNet([string] $dotnetRoot,
   $installParameters = @{
     Version = $version
     InstallDir = $dotnetRoot
+    Verbose = $null
   }
 
   if ($architecture) { $installParameters.Architecture = $architecture }
@@ -542,7 +543,7 @@ function GetDefaultMSBuildEngine() {
 
 function GetNuGetPackageCachePath() {
   if ($env:NUGET_PACKAGES -eq $null) {
-    # Use local cache on CI to ensure deterministic build. 
+    # Use local cache on CI to ensure deterministic build.
     # Avoid using the http cache as workaround for https://github.com/NuGet/Home/issues/3116
     # use global cache in dev builds to avoid cost of downloading packages.
     # For directory normalization, see also: https://github.com/NuGet/Home/issues/7968

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -200,7 +200,7 @@ function InstallDotNet {
   if [[ "$#" -ge "5" ]] && [[ "$5" != 'false' ]]; then
     skipNonVersionedFilesArg="--skip-non-versioned-files"
   fi
-  bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg || {
+  bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg --verbose || {
     local exit_code=$?
     echo "Failed to install dotnet SDK from public location (exit code '$exit_code')."
 
@@ -223,7 +223,7 @@ function InstallDotNet {
     fi
 
     if [[ -n "$runtimeSourceFeed" || -n "$runtimeSourceFeedKey" ]]; then
-      bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey || {
+      bash "$install_script" --version $version --install-dir "$root" $archArg $runtimeArg $skipNonVersionedFilesArg $runtimeSourceFeed $runtimeSourceFeedKey --verbose || {
         local exit_code=$?
         Write-PipelineTelemetryError -category 'InitializeToolset' "Failed to install dotnet SDK from custom location '$runtimeSourceFeed' (exit code '$exit_code')."
         ExitWithExitCode $exit_code


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspnetcore/pull/27972 and an attempt to get this logging working for Shell scripts as well.

We need this in order to investigate the hangs that are happening on the ARM Helix machines.