### PR TITLE
Fix up ComponentHubReliabilityTest and IgnitorTests

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubInvalidEventTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubInvalidEventTest.cs
@@ -27,8 +27,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         protected async override Task InitializeAsync()
         {
             var rootUri = ServerFixture.RootUri;
-            Assert.True(await Client.ConnectAsync(new Uri(rootUri, "/subdir")), "Couldn't connect to the app");
-            Assert.Single(Batches);
+            await ConnectAutomaticallyAndWait(new Uri(rootUri, "/subdir"));
 
             await Client.SelectAsync("test-selector-select", "BasicTestApp.CounterComponent");
             Assert.Equal(2, Batches.Count);

--- a/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubReliabilityTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubReliabilityTest.cs
@@ -16,7 +16,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 {
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19666")]
     public class ComponentHubReliabilityTest : IgnitorTest<ServerStartup>
     {
         public ComponentHubReliabilityTest(BasicTestAppServerSiteFixture<ServerStartup> serverFixture, ITestOutputHelper output)
@@ -55,10 +54,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
             // Arrange
             var expectedError = "The circuit host '.*?' has already been initialized.";
+
             var rootUri = ServerFixture.RootUri;
             var baseUri = new Uri(rootUri, "/subdir");
-            Assert.True(await Client.ConnectAsync(baseUri), "Couldn't connect to the app");
-            Assert.Single(Batches);
+            await ConnectAutomaticallyAndWait(baseUri);
 
             var descriptors = await Client.GetPrerenderDescriptors(baseUri);
 
@@ -97,6 +96,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         // This is a hand-chosen example of something that will cause an exception in creating the circuit host.
         // We want to test this case so that we know what happens when creating the circuit host blows up.
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task StartCircuitCausesInitializationError()
         {
             // Arrange
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             // Act
             //
             // These are valid URIs by the BaseUri doesn't contain the Uri - so it fails to initialize.
-            await Client.ExpectCircuitErrorAndDisconnect(() => Client.HubConnection.SendAsync("StartCircuit", uri, "http://example.com", descriptors));
+            await Client.ExpectCircuitErrorAndDisconnect(() => Client.HubConnection.SendAsync("StartCircuit", uri, "http://example.com", descriptors), Timeout);
 
             // Assert
             var actualError = Assert.Single(Errors);
@@ -144,6 +144,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeJSInteropCallbackCompletionsBeforeInitialization()
         {
             // Arrange
@@ -158,7 +159,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "EndInvokeJSFromDotNet",
                 3,
                 true,
-                "[]"));
+                "[]"), Timeout);
 
             // Assert
             var actualError = Assert.Single(Errors);
@@ -246,8 +247,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             var rootUri = ServerFixture.RootUri;
             var baseUri = new Uri(rootUri, "/subdir");
-            Assert.True(await Client.ConnectAsync(baseUri), "Couldn't connect to the app");
-            Assert.Single(Batches);
+            await ConnectAutomaticallyAndWait(baseUri);
 
             // Act
             await Client.ExpectCircuitError(() => Client.HubConnection.SendAsync(
@@ -266,6 +266,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task OnLocationChanged_ReportsErrorForExceptionInUserCode()
         {
             // Arrange
@@ -275,8 +276,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             var rootUri = ServerFixture.RootUri;
             var baseUri = new Uri(rootUri, "/subdir");
-            Assert.True(await Client.ConnectAsync(baseUri), "Couldn't connect to the app");
-            Assert.Single(Batches);
+
+            await ConnectAutomaticallyAndWait(baseUri);
 
             await Client.SelectAsync("test-selector-select", "BasicTestApp.NavigationFailureComponent");
 
@@ -303,6 +304,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         [InlineData("render-throw")]
         [InlineData("afterrender-sync-throw")]
         [InlineData("afterrender-async-throw")]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit(string id)
         {
             if (id == "setparameters-async-throw")
@@ -320,8 +322,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             var expectedError = "Unhandled exception in circuit .*";
             var rootUri = ServerFixture.RootUri;
             var baseUri = new Uri(rootUri, "/subdir");
-            Assert.True(await Client.ConnectAsync(baseUri), "Couldn't connect to the app");
-            Assert.Single(Batches);
+            await ConnectAutomaticallyAndWait(baseUri);
 
             await Client.SelectAsync("test-selector-select", "BasicTestApp.ReliabilityComponent");
 
@@ -345,14 +346,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task ComponentDisposeMethodThrowsExceptionTerminatesTheCircuit()
         {
             // Arrange
             var expectedError = "Unhandled exception in circuit .*";
             var rootUri = ServerFixture.RootUri;
             var baseUri = new Uri(rootUri, "/subdir");
-            Assert.True(await Client.ConnectAsync(baseUri), "Couldn't connect to the app");
-            Assert.Single(Batches);
+            await ConnectAutomaticallyAndWait(baseUri);
 
             await Client.SelectAsync("test-selector-select", "BasicTestApp.ReliabilityComponent");
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/IgnitorTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/IgnitorTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Components
                 var logs = string.Join(Environment.NewLine, Logs);
                 return new Exception(error + Environment.NewLine + logs);
             };
-            
+
             _ = ServerFixture.RootUri; // This is needed for the side-effects of starting the server.
 
             if (ServerFixture is WebHostServerFixture hostFixture)
@@ -109,6 +109,13 @@ namespace Microsoft.AspNetCore.Components
             catch (Exception)
             {
             }
+        }
+
+        protected async Task ConnectAutomaticallyAndWait(Uri baseUri)
+        {
+            Assert.True(await Client.ConnectAsync(baseUri), "Couldn't connect to the app");
+            Assert.Single(Batches);
+            await Task.Delay(500);
         }
 
         [DebuggerDisplay("{LogLevel.ToString(),nq} - {Message ?? \"null\",nq} - {Exception?.Message,nq}")]

--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -30,8 +30,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         protected async override Task InitializeAsync()
         {
             var rootUri = ServerFixture.RootUri;
-            Assert.True(await Client.ConnectAsync(new Uri(rootUri, "/subdir")), "Couldn't connect to the app");
-            Assert.Single(Batches);
+            await ConnectAutomaticallyAndWait(new Uri(rootUri, "/subdir"));
 
             await Client.SelectAsync("test-selector-select", "BasicTestApp.ReliabilityComponent");
             Assert.Equal(2, Batches.Count);

--- a/src/Components/test/E2ETest/ServerExecutionTests/RemoteRendererBufferLimitTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/RemoteRendererBufferLimitTest.cs
@@ -27,8 +27,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
             // Arrange
             var baseUri = new Uri(ServerFixture.RootUri, "/subdir");
-            Assert.True(await Client.ConnectAsync(baseUri), "Couldn't connect to the app");
-            Assert.Single(Batches);
+            await ConnectAutomaticallyAndWait(baseUri);
 
             await Client.SelectAsync("test-selector-select", "BasicTestApp.LimitCounterComponent");
             Client.ConfirmRenderBatch = false;


### PR DESCRIPTION
This PR address the `ComponentHubReliabilityTest` issues in https://github.com/dotnet/aspnetcore/issues/19666. The entire test class was quarantined. After taking a look, I noticed that some tests had been passing for 30 days and unquarantined them. For the remaining tests:

- `StartCircuitCausesInitializationError` and `CannotInvokeJSInteropCallbackCompletionsBeforeInitialization` each failed once in the past 30 days due to a timeout issue in `ExpectCircuitErrorAndDisconnect`. I increased the timeout alloted here.
- Tests that connected to the circuit automatically experienced a high volume of exceptions raised [here](https://github.com/dotnet/aspnetcore/blob/master/src/Components/Ignitor/src/BlazorClient.cs#L98-L101). I was able to produce these issues locally. After taking a look, I suspect they occur because the batch associated with the `SelectAsync` call is processed immediately after the next batch has been received before the `NextBatchReceived` flag has been disposed. To work around this, I added a new `ConnectAutomaticallyAndWait` method that connects and waits a little bit before continuing forward.

The solution for #2 above isn't ideally but it helps us make progress with these test failures. IgnitorTests are currently the most "flaky" tests in the entire repo (last column is pass rate).

<img width="1011" alt="Screen Shot 2021-01-04 at 3 18 09 PM" src="https://user-images.githubusercontent.com/1857993/103796490-2077b100-4ffc-11eb-9b52-c6338327a158.png">

We should consider moving these tests to unit tests but the fixes here are low cost-high reward and should hopefully improve the pass rates. Open to other suggestions on how to improve the existing test setup to avoid these issues.

Note: The issue originally highlighted `ComponentHubReliability` tests but actually all tests that inherit from `IgnitorTests` are broken with #2 so I've addressed those as well.