### PR TITLE
Fix PreferExactMatches in test assets and samples

### DIFF
--- a/src/Components/Samples/BlazorServerApp/App.razor
+++ b/src/Components/Samples/BlazorServerApp/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/src/Components/WebAssembly/Sdk/testassets/blazorwasm-minimal/App.razor
+++ b/src/Components/WebAssembly/Sdk/testassets/blazorwasm-minimal/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData"/>
     </Found>

--- a/src/Components/WebAssembly/Sdk/testassets/blazorwasm/App.razor
+++ b/src/Components/WebAssembly/Sdk/testassets/blazorwasm/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData"/>
     </Found>

--- a/src/Components/WebAssembly/testassets/StandaloneApp/App.razor
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(StandaloneApp.Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(StandaloneApp.Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/src/Components/WebAssembly/testassets/Wasm.Authentication.Client/App.razor
+++ b/src/Components/WebAssembly/testassets/Wasm.Authentication.Client/App.razor
@@ -1,5 +1,5 @@
 ﻿<CascadingAuthenticationState>
-    <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+    <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
         <Found Context="routeData">
             <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
                 <NotAuthorized>

--- a/src/Components/benchmarkapps/BlazingPizza.Server/App.razor
+++ b/src/Components/benchmarkapps/BlazingPizza.Server/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="typeof(Program).Assembly" PreferExactMatches="@true">
     <NotFound>Page not found</NotFound>
     <Found Context="routeData">
         <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)"></RouteView>

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/App.razor
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" />
     </Found>

--- a/src/Components/test/testassets/BasicTestApp/AuthTest/AuthRouter.razor
+++ b/src/Components/test/testassets/BasicTestApp/AuthTest/AuthRouter.razor
@@ -9,7 +9,7 @@
     and @page authorization rules.
 *@
 
-<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" PreferExactMatches="true">
+<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(AuthRouterLayout)">
             <Authorizing>Authorizing...</Authorizing>

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouter.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouter.razor
@@ -1,5 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
-<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" PreferExactMatches="true">
+<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" />
     </Found>

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithAdditionalAssembly.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithAdditionalAssembly.razor
@@ -1,5 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
-<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" AdditionalAssemblies="@(new[] { typeof(TestContentPackage.RouteableComponentFromPackage).Assembly, })" PreferExactMatches="true">
+<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" AdditionalAssemblies="@(new[] { typeof(TestContentPackage.RouteableComponentFromPackage).Assembly, })" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" />
     </Found>

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithLazyAssembly.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithLazyAssembly.razor
@@ -4,7 +4,7 @@
 
 @inject LazyAssemblyLoader lazyLoader
 
-<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" AdditionalAssemblies="@lazyLoadedAssemblies" OnNavigateAsync="@OnNavigateAsync" PreferExactMatches="true">
+<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" AdditionalAssemblies="@lazyLoadedAssemblies" OnNavigateAsync="@OnNavigateAsync" PreferExactMatches="@true">
     <Navigating>
         <div style="padding: 20px;background-color:blue;color:white;" id="loading-banner">
             <p>Loading the requested page...</p>

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/TestRouterWithOnNavigate.razor
@@ -4,7 +4,7 @@
 
 <button @onclick="TriggerRerender" id="trigger-rerender">Trigger Rerender</button>
 
-<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" OnNavigateAsync="@OnNavigateAsync" PreferExactMatches="true">
+<Router AppAssembly="@typeof(BasicTestApp.Program).Assembly" OnNavigateAsync="@OnNavigateAsync" PreferExactMatches="@true">
     <Navigating>
         <div style="padding: 20px;background-color:blue;color:white;" id="loading-banner">
             <p>Loading the requested page...</p>

--- a/src/Components/test/testassets/ComponentsApp.App/App.razor
+++ b/src/Components/test/testassets/ComponentsApp.App/App.razor
@@ -1,6 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Components;
 <CascadingValue Value="Name" Name="Name" IsFixed=true>
-    <Router AppAssembly="@typeof(ComponentsApp.App.App).Assembly" PreferExactMatches="true">
+    <Router AppAssembly="@typeof(ComponentsApp.App.App).Assembly" PreferExactMatches="@true">
         <Found Context="routeData">
             <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         </Found>


### PR DESCRIPTION
Noticed a couple of testapps were still incorrectly setting the `PreferExactMatches` property as a string instead of a boolean. Fixing this to resolve some of the test failures that are occurring because of this.