### PR TITLE
Automatically assign `Servicing-consider` label to servicing PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/servicing.md
+++ b/.github/PULL_REQUEST_TEMPLATE/servicing.md
@@ -1,3 +1,9 @@
+---
+name: Servicing PR
+labels: Servicing-consider
+---
+
+
 ## Description
 
 


### PR DESCRIPTION
This is one step in the larger process of simplifying and unifying the servicing process.
I've build up a small guide to help with the template as well as help with finding all the information necessary for that.
Everything is linked from: https://aka.ms/aspnet/links
The servicing related items: https://aka.ms/aspnet/servicing