### PR TITLE
Revert "Automatically assign `Servicing-consider` label to servicing …

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/servicing.md
+++ b/.github/PULL_REQUEST_TEMPLATE/servicing.md
@@ -1,9 +1,3 @@
----
-name: Servicing PR
-labels: Servicing-consider
----
-
-
 ## Description
 
 


### PR DESCRIPTION
…PRs (#29071)"

This reverts commit 689cef0e72f92ebe7c9f0a3c667b421474be5242.

Turns out that the labels aren't supported for PR templates.
