### PR TITLE
Make IncrementallyUpdatesCache and CachesResourcesAfterFirstLoad tests more robust. Hopefully fixes #20154

### DIFF
--- a/src/Components/WebAssembly/testassets/HostedInAspNet.Server/BootResourceRequestLog.cs
+++ b/src/Components/WebAssembly/testassets/HostedInAspNet.Server/BootResourceRequestLog.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 
@@ -8,10 +9,10 @@ namespace HostedInAspNet.Server
 {
     public class BootResourceRequestLog
     {
-        private List<string> _requestPaths = new List<string>();
+        private ConcurrentBag<string> _requestPaths = new ConcurrentBag<string>();
 
         public IReadOnlyCollection<string> RequestPaths => _requestPaths;
- 
+
         public void AddRequest(HttpRequest request)
         {
             _requestPaths.Add(request.Path);

--- a/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
+++ b/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
@@ -54,6 +54,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // On subsequent loads, we skip the items referenced from blazor.boot.json
             // which includes .dll files and dotnet.wasm
             Navigate("about:blank");
+            Browser.Equal(string.Empty, () => Browser.Title);
             Navigate("/");
             WaitUntilLoaded();
             var subsequentResourcesRequested = GetAndClearRequestedPaths();
@@ -87,6 +88,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // On the next load, we'll fetch only the items we need (not things already cached)
             GetAndClearRequestedPaths();
             Navigate("about:blank");
+            Browser.Equal(string.Empty, () => Browser.Title);
             Navigate("/");
             WaitUntilLoaded();
             var subsequentResourcesRequested = GetAndClearRequestedPaths();


### PR DESCRIPTION
I don't know for certain why these tests occasionally fail, because they pass ~98% of the time in CI, and 100% of the times I've tried running locally.

However I notice that the collection in which we track the requested URLs is not thread-safe, and is potentially written from multiple threads concurrently. This could explain why sometimes we don't find the expected URLs in the collection.

I've also added a second tweak to make sure that, when we navigate to `about:blank`, we wait until that navigation is completed before proceeding to re-navigate back to where we came from.