### PR TITLE
Fix issue with cert being finalized in data protection test

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -1,9 +1,6 @@
 # We only want to run full helix matrix on master
-pr:
-  autoCancel: true
-  branches:
-    include:
-    - '*'
+pr: none
+trigger: none
 schedules:
 # Cron timezone is UTC.
 - cron: "0 */12 * * *"

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -1,6 +1,9 @@
 # We only want to run full helix matrix on master
-pr: none
-trigger: none
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - '*'
 schedules:
 # Cron timezone is UTC.
 - cron: "0 */12 * * *"

--- a/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
+++ b/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
@@ -22,16 +22,6 @@ namespace Microsoft.AspNetCore.DataProtection
     public class DataProtectionProviderTests
     {
         [Fact]
-        public void VerifyX509StoreWorks()
-        {
-            using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
-            {
-                store.Open(OpenFlags.ReadWrite);
-                Assert.True(true);
-            }
-        }
-        
-        [Fact]
         public void System_UsesProvidedDirectory()
         {
             WithUniqueTempDirectory(directory =>
@@ -129,48 +119,51 @@ namespace Microsoft.AspNetCore.DataProtection
         public void System_UsesProvidedDirectoryAndCertificate()
         {
             var filePath = Path.Combine(GetTestFilesPath(), "TestCert.pfx");
-            using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (var imported = new X509Certificate2(filePath, "password", X509KeyStorageFlags.Exportable))
             {
-                store.Open(OpenFlags.ReadWrite);
-                store.Add(new X509Certificate2(filePath, "password", X509KeyStorageFlags.Exportable));
-                store.Close();
+                using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+                {
+                    store.Open(OpenFlags.ReadWrite);
+                    store.Add(imported);
+                    store.Close();
+                }
+
+                WithUniqueTempDirectory(directory =>
+                {
+                    var certificateStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+                    certificateStore.Open(OpenFlags.ReadWrite);
+                    var certificate = certificateStore.Certificates.Find(X509FindType.FindBySubjectName, "TestCert", false)[0];
+                    Assert.True(certificate.HasPrivateKey, "Cert should have a private key");
+                    try
+                    {
+                        // Step 1: directory should be completely empty
+                        directory.Create();
+                        Assert.Empty(directory.GetFiles());
+
+                        // Step 2: instantiate the system and round-trip a payload
+                        var protector = DataProtectionProvider.Create(directory, certificate).CreateProtector("purpose");
+                        var data = protector.Protect("payload");
+
+                        // add a cert without the private key to ensure the decryption will still fallback to the cert store
+                        var certWithoutKey = new X509Certificate2(Path.Combine(GetTestFilesPath(), "TestCertWithoutPrivateKey.pfx"), "password");
+                        var unprotector = DataProtectionProvider.Create(directory, o => o.UnprotectKeysWithAnyCertificate(certWithoutKey)).CreateProtector("purpose");
+                        Assert.Equal("payload", unprotector.Unprotect(data));
+
+                        // Step 3: validate that there's now a single key in the directory and that it's is protected using the certificate
+                        var allFiles = directory.GetFiles();
+                        Assert.Single(allFiles);
+                        Assert.StartsWith("key-", allFiles[0].Name, StringComparison.OrdinalIgnoreCase);
+                        string fileText = File.ReadAllText(allFiles[0].FullName);
+                        Assert.DoesNotContain("Warning: the key below is in an unencrypted form.", fileText, StringComparison.Ordinal);
+                        Assert.Contains("X509Certificate", fileText, StringComparison.Ordinal);
+                    }
+                    finally
+                    {
+                        certificateStore.Remove(certificate);
+                        certificateStore.Close();
+                    }
+                });
             }
-
-            WithUniqueTempDirectory(directory =>
-            {
-                var certificateStore = new X509Store(StoreName.My, StoreLocation.CurrentUser);
-                certificateStore.Open(OpenFlags.ReadWrite);
-                var certificate = certificateStore.Certificates.Find(X509FindType.FindBySubjectName, "TestCert", false)[0];
-                Assert.True(certificate.HasPrivateKey, "Cert should have a private key");
-                try
-                {
-                    // Step 1: directory should be completely empty
-                    directory.Create();
-                    Assert.Empty(directory.GetFiles());
-
-                    // Step 2: instantiate the system and round-trip a payload
-                    var protector = DataProtectionProvider.Create(directory, certificate).CreateProtector("purpose");
-                    var data = protector.Protect("payload");
-
-                    // add a cert without the private key to ensure the decryption will still fallback to the cert store
-                    var certWithoutKey = new X509Certificate2(Path.Combine(GetTestFilesPath(), "TestCertWithoutPrivateKey.pfx"), "password");
-                    var unprotector = DataProtectionProvider.Create(directory, o => o.UnprotectKeysWithAnyCertificate(certWithoutKey)).CreateProtector("purpose");
-                    Assert.Equal("payload", unprotector.Unprotect(data));
-
-                    // Step 3: validate that there's now a single key in the directory and that it's is protected using the certificate
-                    var allFiles = directory.GetFiles();
-                    Assert.Single(allFiles);
-                    Assert.StartsWith("key-", allFiles[0].Name, StringComparison.OrdinalIgnoreCase);
-                    string fileText = File.ReadAllText(allFiles[0].FullName);
-                    Assert.DoesNotContain("Warning: the key below is in an unencrypted form.", fileText, StringComparison.Ordinal);
-                    Assert.Contains("X509Certificate", fileText, StringComparison.Ordinal);
-                }
-                finally
-                {
-                    certificateStore.Remove(certificate);
-                    certificateStore.Close();
-                }
-            });
         }
 
         [ConditionalFact]

--- a/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
+++ b/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.DataProtection
 
         [ConditionalFact]
         [X509StoreIsAvailable(StoreName.My, StoreLocation.CurrentUser)]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/6720 and https://github.com/dotnet/aspnetcore/issues/26871", Queues = "All.OSX;Windows.10.Arm64;Windows.10.Arm64.Open;Windows.10.Arm64v8;Windows.10.Arm64v8.Open")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/6720 and https://github.com/dotnet/aspnetcore/issues/26871", Queues = "All.OSX")]
         public void System_UsesProvidedDirectoryAndCertificate()
         {
             var filePath = Path.Combine(GetTestFilesPath(), "TestCert.pfx");

--- a/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
+++ b/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
@@ -22,6 +22,16 @@ namespace Microsoft.AspNetCore.DataProtection
     public class DataProtectionProviderTests
     {
         [Fact]
+        public void VerifyX509StoreWorks()
+        {
+            using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            {
+                store.Open(OpenFlags.ReadWrite);
+                Assert.True(true);
+            }
+        }
+        
+        [Fact]
         public void System_UsesProvidedDirectory()
         {
             WithUniqueTempDirectory(directory =>

--- a/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
+++ b/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.AspNetCore.DataProtection
 
         [ConditionalFact]
         [X509StoreIsAvailable(StoreName.My, StoreLocation.CurrentUser)]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/6720 and https://github.com/dotnet/aspnetcore/issues/26871", Queues = "All.OSX")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/6720", Queues = "All.OSX")]
         public void System_UsesProvidedDirectoryAndCertificate()
         {
             var filePath = Path.Combine(GetTestFilesPath(), "TestCert.pfx");


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/26871

Root cause appears to be Arm64 having less memory so the cert was getting finalized, see https://github.com/dotnet/aspnetcore/issues/26871#issuecomment-756320161 for more details