### PR TITLE
[wasm] Enable on demand GC again

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -426,9 +426,6 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
       timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     } catch { }
     MONO.mono_wasm_setenv("TZ", timeZone || 'UTC');
-    // Turn off full-gc to prevent browser freezing.
-    const mono_wasm_enable_on_demand_gc = cwrap('mono_wasm_enable_on_demand_gc', null, ['number']);
-    mono_wasm_enable_on_demand_gc(0);
     const load_runtime = cwrap('mono_wasm_load_runtime', null, ['string', 'number']);
     // -1 enables debugging with logging disabled. 0 disables debugging entirely.
     load_runtime(appBinDirName, hasDebuggingEnabled() ? -1 : 0);


### PR DESCRIPTION
For 5.0 we turned of on demand GC because of some issues that were discovered in the bindings.  We believe those issues have now been resolved and we would like to turn on demand gc back on for 6.0.
