### PR TITLE
Fix padding in Kestrel connection logs

### DIFF
--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/LoggingStream.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/LoggingStream.cs
@@ -150,7 +150,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             builder.Append(method);
             builder.Append("[");
             builder.Append(buffer.Length);
-            builder.AppendLine("]");
+            builder.Append("]");
+
+            if (buffer.Length > 0)
+            {
+                builder.AppendLine();
+            }
 
             var charBuilder = new StringBuilder();
 
@@ -174,7 +179,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 {
                     builder.Append("  ");
                     builder.Append(charBuilder.ToString());
-                    builder.AppendLine();
+                    if (i != buffer.Length - 1)
+                    {
+                        builder.AppendLine();
+                    }
                     charBuilder.Clear();
                 }
                 else if ((i + 1) % 8 == 0)
@@ -183,15 +191,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                     charBuilder.Append(" ");
                 }
             }
-            if (charBuilder.Length > 0)
+
+            // Different than charBuffer.Length since charBuffer contains an extra " " after the 8th byte.
+            var numBytesInLastLine = buffer.Length % 16;
+
+            if (numBytesInLastLine > 0)
             {
                 // 2 (between hex and char blocks) + num bytes left (3 per byte)
-                builder.Append(string.Empty.PadRight(2 + (3 * (16 - charBuilder.Length))));
+                var padLength = 2 + (3 * (16 - numBytesInLastLine));
                 // extra for space after 8th byte
-                if (charBuilder.Length < 8)
+                if (numBytesInLastLine < 8)
                 {
-                    builder.Append(" ");
+                    padLength++;
                 }
+
+                builder.Append(new string(' ', padLength));
                 builder.Append(charBuilder.ToString());
             }
 

--- a/src/Servers/Kestrel/Core/test/LoggingStreamTests.cs
+++ b/src/Servers/Kestrel/Core/test/LoggingStreamTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class LoggingStreamTests
+    {
+        [Theory]
+        [InlineData( 1, "00                                                 .")]
+        [InlineData( 2, "00 00                                              ..")]
+        [InlineData( 3, "00 00 00                                           ...")]
+        [InlineData( 4, "00 00 00 00                                        ....")]
+        [InlineData( 5, "00 00 00 00 00                                     .....")]
+        [InlineData( 6, "00 00 00 00 00 00                                  ......")]
+        [InlineData( 7, "00 00 00 00 00 00 00                               .......")]
+        [InlineData( 8, "00 00 00 00 00 00 00 00                            ........ ")]
+        [InlineData( 9, "00 00 00 00 00 00 00 00  00                        ........ .")]
+        [InlineData(10, "00 00 00 00 00 00 00 00  00 00                     ........ ..")]
+        [InlineData(11, "00 00 00 00 00 00 00 00  00 00 00                  ........ ...")]
+        [InlineData(12, "00 00 00 00 00 00 00 00  00 00 00 00               ........ ....")]
+        [InlineData(13, "00 00 00 00 00 00 00 00  00 00 00 00 00            ........ .....")]
+        [InlineData(14, "00 00 00 00 00 00 00 00  00 00 00 00 00 00         ........ ......")]
+        [InlineData(15, "00 00 00 00 00 00 00 00  00 00 00 00 00 00 00      ........ .......")]
+        [InlineData(16, "00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   ........ ........")]
+        public void CorrectPaddingIsUsedAfterHexValues(int bufferLength, string expectedOutput)
+        {
+            var mockLogger = new MockLogger();
+            var loggingStream = new LoggingStream(Stream.Null, mockLogger);
+
+            loggingStream.Write(new byte[bufferLength]);
+
+            Assert.Equal($"Write[{bufferLength}]{Environment.NewLine}{expectedOutput}", mockLogger.Logs);
+        }
+
+        [Fact]
+        public void ExtraNewLineIsNotLoggedGivenEmptyBuffer()
+        {
+            var mockLogger = new MockLogger();
+            var loggingStream = new LoggingStream(Stream.Null, mockLogger);
+
+            loggingStream.Write(default);
+
+            Assert.Equal($"Write[0]", mockLogger.Logs);
+        }
+
+        private class MockLogger : ILogger
+        {
+            private StringBuilder _logs = new();
+
+            public string Logs => _logs.ToString();
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                _logs.Append(formatter(state, exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Before:

```
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      ReadAsync[490]
      47 45 54 20 2F 66 61 76  69 63 6F 6E 2E 69 63 6F   GET /fav icon.ico
      20 48 54 54 50 2F 31 2E  31 0D 0A 48 6F 73 74 3A    HTTP/1. 1..Host:
...
      65 2C 20 62 72 0D 0A 41  63 63 65 70 74 2D 4C 61   e, br..A ccept-La
      6E 67 75 61 67 65 3A 20  65 6E 2D 55 53 2C 65 6E   nguage:  en-US,en
      3B 71 3D 30 2E 39 0D 0A  0D 0A                  ;q=0.9.. ..
```

After:

```
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      ReadAsync[490]
      47 45 54 20 2F 66 61 76  69 63 6F 6E 2E 69 63 6F   GET /fav icon.ico
      20 48 54 54 50 2F 31 2E  31 0D 0A 48 6F 73 74 3A    HTTP/1. 1..Host:
...
      65 2C 20 62 72 0D 0A 41  63 63 65 70 74 2D 4C 61   e, br..A ccept-La
      6E 67 75 61 67 65 3A 20  65 6E 2D 55 53 2C 65 6E   nguage:  en-US,en
      3B 71 3D 30 2E 39 0D 0A  0D 0A                     ;q=0.9.. ..
```

";q=0.9.." is misaligned in the "Before:" example.