### PR TITLE
Fix flaky test: Pass_thru_when_exception_in_logic

### DIFF
--- a/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/Helpers/TestLoggerProvider.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/Helpers/TestLoggerProvider.cs
@@ -29,14 +29,25 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.FunctionalTests.H
         {
             private List<string> _messages = new List<string>();
 
+            private object _sync = new object();
+
             public IEnumerable<string> Messages
             {
-                get { return _messages; }
+                get
+                {
+                    lock (_sync)
+                    {
+                        return new List<string>(_messages);
+                    }
+                }
             }
 
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             {
-                _messages.Add(formatter(state, exception));
+                lock (_sync)
+                {
+                    _messages.Add(formatter(state, exception));
+                }
             }
 
             public bool IsEnabled(LogLevel logLevel)


### PR DESCRIPTION
Failure here: https://dev.azure.com/dnceng/public/_build/results?buildId=938389&view=ms.vss-test-web.build-test-results-tab&runId=29665626&resultId=104752&paneView=debug
```


Error message
System.ArgumentException : Destination array was not long enough. Check the destination index, length, and the array's lower bounds. (Parameter 'destinationArray')


Stack trace
   at System.Array.Copy(Array sourceArray, Int32 sourceIndex, Array destinationArray, Int32 destinationIndex, Int32 length, Boolean reliable)
   at System.Array.Copy(Array sourceArray, Int32 sourceIndex, Array destinationArray, Int32 destinationIndex, Int32 length)
   at System.Collections.Generic.List`1.CopyTo(T[] array, Int32 arrayIndex)
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests.DatabaseErrorPageMiddlewareTest.Pass_thru_when_exception_in_logic() in /_/src/Middleware/Diagnostics.EntityFrameworkCore/test/FunctionalTests/DatabaseErrorPageMiddlewareTest.cs:line 462
--- End of stack trace from previous location ---
```
Had a [conversation with the runtime team](https://github.com/dotnet/runtime/issues/42342) and it seemed fairly clear that there was a race in our code. This adds a lock for the logger and creates a new list to return for messages.

