### PR TITLE
Fix typos in MvcOptions.cs

### DIFF
--- a/src/Mvc/Mvc.Core/src/MvcOptions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcOptions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Mvc
 
         /// <summary>
         /// Gets or sets a value that detemines if the inference of <see cref="RequiredAttribute"/> for
-        /// for properties and parameters of non-nullable reference types is suppressed. If <c>false</c>
+        /// properties and parameters of non-nullable reference types is suppressed. If <c>false</c>
         /// (the default), then all non-nullable reference types will behave as-if <c>[Required]</c> has
         /// been applied. If <c>true</c>, this behavior will be suppressed; nullable reference types and
         /// non-nullable reference types will behave the same for the purposes of validation.

--- a/src/Mvc/Mvc.Core/src/MvcOptions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcOptions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc
         public FormatterCollection<IInputFormatter> InputFormatters { get; }
 
         /// <summary>
-        /// Gets or sets a value that detemines if the inference of <see cref="RequiredAttribute"/> for
+        /// Gets or sets a value that determines if the inference of <see cref="RequiredAttribute"/> for
         /// properties and parameters of non-nullable reference types is suppressed. If <c>false</c>
         /// (the default), then all non-nullable reference types will behave as-if <c>[Required]</c> has
         /// been applied. If <c>true</c>, this behavior will be suppressed; nullable reference types and


### PR DESCRIPTION
Change `detemines` to `determines` and remove duplicated `for` word in XML docs for `SuppressImplicitRequiredAttributeForNonNullableReferenceTypes`
