### PR TITLE
Add TestServerOptions

### DIFF
--- a/src/Hosting/TestHost/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/TestHost/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,10 @@
 #nullable enable
+Microsoft.AspNetCore.TestHost.TestServerOptions
+Microsoft.AspNetCore.TestHost.TestServerOptions.AllowSynchronousIO.get -> bool
+Microsoft.AspNetCore.TestHost.TestServerOptions.AllowSynchronousIO.set -> void
+Microsoft.AspNetCore.TestHost.TestServerOptions.PreserveExecutionContext.get -> bool
+Microsoft.AspNetCore.TestHost.TestServerOptions.PreserveExecutionContext.set -> void
+Microsoft.AspNetCore.TestHost.TestServerOptions.TestServerOptions() -> void
+static Microsoft.AspNetCore.TestHost.WebHostBuilderExtensions.UseTestServer(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! builder, System.Action<Microsoft.AspNetCore.TestHost.TestServerOptions!>! configureOptions) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
+~Microsoft.AspNetCore.TestHost.TestServer.TestServer(System.IServiceProvider! services, Microsoft.AspNetCore.Http.Features.IFeatureCollection! featureCollection, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.TestHost.TestServerOptions!>! optionsAccessor) -> void
+~Microsoft.AspNetCore.TestHost.TestServer.TestServer(System.IServiceProvider! services, Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.TestHost.TestServerOptions!>! optionsAccessor) -> void

--- a/src/Hosting/TestHost/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/TestHost/src/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@
 Microsoft.AspNetCore.TestHost.TestServerOptions
 Microsoft.AspNetCore.TestHost.TestServerOptions.AllowSynchronousIO.get -> bool
 Microsoft.AspNetCore.TestHost.TestServerOptions.AllowSynchronousIO.set -> void
+Microsoft.AspNetCore.TestHost.TestServerOptions.BaseAddress.get -> System.Uri!
+Microsoft.AspNetCore.TestHost.TestServerOptions.BaseAddress.set -> void
 Microsoft.AspNetCore.TestHost.TestServerOptions.PreserveExecutionContext.get -> bool
 Microsoft.AspNetCore.TestHost.TestServerOptions.PreserveExecutionContext.set -> void
 Microsoft.AspNetCore.TestHost.TestServerOptions.TestServerOptions() -> void

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.TestHost
 {
@@ -26,6 +26,32 @@ namespace Microsoft.AspNetCore.TestHost
         /// For use with IHostBuilder.
         /// </summary>
         /// <param name="services"></param>
+        /// <param name="optionsAccessor"></param>
+        public TestServer(IServiceProvider services, IOptions<TestServerOptions> optionsAccessor)
+            : this(services, new FeatureCollection(), optionsAccessor)
+        {
+
+        }
+
+        /// <summary>
+        /// For use with IHostBuilder.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="featureCollection"></param>
+        /// <param name="optionsAccessor"></param>
+        public TestServer(IServiceProvider services, IFeatureCollection featureCollection, IOptions<TestServerOptions> optionsAccessor)
+        {
+            Services = services ?? throw new ArgumentNullException(nameof(services));
+            Features = featureCollection ?? throw new ArgumentNullException(nameof(featureCollection));
+            var options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
+            AllowSynchronousIO = options.AllowSynchronousIO;
+            PreserveExecutionContext = options.PreserveExecutionContext;
+        }
+
+        /// <summary>
+        /// For use with IHostBuilder.
+        /// </summary>
+        /// <param name="services"></param>
         public TestServer(IServiceProvider services)
             : this(services, new FeatureCollection())
         {
@@ -37,6 +63,7 @@ namespace Microsoft.AspNetCore.TestHost
         /// <param name="services"></param>
         /// <param name="featureCollection"></param>
         public TestServer(IServiceProvider services, IFeatureCollection featureCollection)
+            : this(services, featureCollection, Options.Create(new TestServerOptions()))
         {
             Services = services ?? throw new ArgumentNullException(nameof(services));
             Features = featureCollection ?? throw new ArgumentNullException(nameof(featureCollection));

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -46,7 +46,8 @@ namespace Microsoft.AspNetCore.TestHost
             var options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
             AllowSynchronousIO = options.AllowSynchronousIO;
             PreserveExecutionContext = options.PreserveExecutionContext;
-        }
+            BaseAddress = options.BaseAddress;
+    }
 
         /// <summary>
         /// For use with IHostBuilder.

--- a/src/Hosting/TestHost/src/TestServerOptions.cs
+++ b/src/Hosting/TestHost/src/TestServerOptions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.TestHost
+{
+    /// <summary>
+    /// Options for the test server.
+    /// </summary>
+    public class TestServerOptions
+    {
+        /// <summary>
+        /// Gets or sets a value that controls whether synchronous IO is allowed for the <see cref="HttpContext.Request"/> and <see cref="HttpContext.Response"/>. The default value is <see langword="false" />.
+        /// </summary>
+        public bool AllowSynchronousIO { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that controls if <see cref="ExecutionContext"/> and <see cref="AsyncLocal{T}"/> values are preserved from the client to the server. The default value is <see langword="false" />.
+        /// </summary>
+        public bool PreserveExecutionContext { get; set; }
+    }
+}

--- a/src/Hosting/TestHost/src/TestServerOptions.cs
+++ b/src/Hosting/TestHost/src/TestServerOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using Microsoft.AspNetCore.Http;
 
@@ -20,5 +21,10 @@ namespace Microsoft.AspNetCore.TestHost
         /// Gets or sets a value that controls if <see cref="ExecutionContext"/> and <see cref="AsyncLocal{T}"/> values are preserved from the client to the server. The default value is <see langword="false" />.
         /// </summary>
         public bool PreserveExecutionContext { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base address associated with the HttpClient returned by the test server. Defaults to http://localhost/.
+        /// </summary>
+        public Uri BaseAddress { get; set; } = new Uri("http://localhost/");
     }
 }

--- a/src/Hosting/TestHost/src/WebHostBuilderExtensions.cs
+++ b/src/Hosting/TestHost/src/WebHostBuilderExtensions.cs
@@ -33,6 +33,22 @@ namespace Microsoft.AspNetCore.TestHost
         }
 
         /// <summary>
+        /// Enables the <see cref="TestServer" /> service.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebHostBuilder"/>.</param>
+        /// <param name="configureOptions">Configures test server options</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        public static IWebHostBuilder UseTestServer(this IWebHostBuilder builder, Action<TestServerOptions> configureOptions)
+        {
+            return builder.ConfigureServices(services =>
+            {
+                services.Configure(configureOptions);
+                services.AddSingleton<IHostLifetime, NoopHostLifetime>();
+                services.AddSingleton<IServer, TestServer>();
+            });
+        }
+
+        /// <summary>
         /// Retrieves the TestServer from the host services.
         /// </summary>
         /// <param name="host"></param>

--- a/src/Hosting/TestHost/test/TestServerTests.cs
+++ b/src/Hosting/TestHost/test/TestServerTests.cs
@@ -352,6 +352,7 @@ namespace Microsoft.AspNetCore.TestHost
         public async Task TestServerConstructorSetOptions()
         {
             // Arrange
+            var baseAddress = new Uri("http://localhost/test");
             using var host = await new HostBuilder()
                 .ConfigureWebHost(webBuilder =>
                 {
@@ -360,6 +361,7 @@ namespace Microsoft.AspNetCore.TestHost
                         { 
                             options.AllowSynchronousIO = true;
                             options.PreserveExecutionContext = true;
+                            options.BaseAddress = baseAddress;
                         })
                         .Configure(_ => { });
                 })
@@ -372,6 +374,7 @@ namespace Microsoft.AspNetCore.TestHost
             // Assert
             Assert.True(testServer.AllowSynchronousIO);
             Assert.True(testServer.PreserveExecutionContext);
+            Assert.Equal(baseAddress, testServer.BaseAddress);
         }
 
         public class TestService { public string Message { get; set; } }

--- a/src/Hosting/TestHost/test/TestServerTests.cs
+++ b/src/Hosting/TestHost/test/TestServerTests.cs
@@ -348,6 +348,32 @@ namespace Microsoft.AspNetCore.TestHost
             Assert.Equal(testService, testServer.Services.GetService<TestService>());
         }
 
+        [Fact]
+        public async Task TestServerConstructorSetOptions()
+        {
+            // Arrange
+            using var host = await new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder
+                        .UseTestServer(options =>
+                        { 
+                            options.AllowSynchronousIO = true;
+                            options.PreserveExecutionContext = true;
+                        })
+                        .Configure(_ => { });
+                })
+                .StartAsync();
+
+            // Act
+            // By calling GetTestServer(), a new TestServer instance will be instantiated
+            var testServer = host.GetTestServer();
+
+            // Assert
+            Assert.True(testServer.AllowSynchronousIO);
+            Assert.True(testServer.PreserveExecutionContext);
+        }
+
         public class TestService { public string Message { get; set; } }
 
         public class TestRequestServiceMiddleware


### PR DESCRIPTION
Introduce `TestServerOptions` with `AllowSynchronousIO` and `PreserveExecutionContext`.

Fixes https://github.com/dotnet/aspnetcore/issues/28983