### PR TITLE
Fix special character usage in doc comments

### DIFF
--- a/src/Mvc/Mvc.Core/src/MvcOptions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcOptions.cs
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.Mvc
 
         /// <summary>
         /// Gets or sets the flag which causes content negotiation to ignore Accept header
-        /// when it contains the media type */*. <see langword="false"/> by default.
+        /// when it contains the media type <c>*/*</c>. <see langword="false"/> by default.
         /// </summary>
         public bool RespectBrowserAcceptHeader { get; set; }
 


### PR DESCRIPTION
Usage of `*/*` in code comments results in wrong interpretation by IntelliSence.
This PR wraps the usage in a `<c></c>` tag so that it shows as is.

Addresses #29114
