### PR TITLE
Make HttpsRedirectionMiddleware throw if there are multiple ports 

### DIFF
--- a/src/Middleware/HttpsPolicy/src/HttpsLoggingExtensions.cs
+++ b/src/Middleware/HttpsPolicy/src/HttpsLoggingExtensions.cs
@@ -11,7 +11,6 @@ namespace Microsoft.AspNetCore.HttpsPolicy
         private static readonly Action<ILogger, string, Exception?> _redirectingToHttps;
         private static readonly Action<ILogger, int, Exception?> _portLoadedFromConfig;
         private static readonly Action<ILogger, Exception?> _failedToDeterminePort;
-        private static readonly Action<ILogger, Exception?> _failedMultiplePorts;
         private static readonly Action<ILogger, int, Exception?> _portFromServer;
 
         static HttpsLoggingExtensions()
@@ -30,12 +29,6 @@ namespace Microsoft.AspNetCore.HttpsPolicy
                 LogLevel.Warning,
                 new EventId(3, "FailedToDeterminePort"),
                 "Failed to determine the https port for redirect.");
-
-            _failedMultiplePorts = LoggerMessage.Define(
-                LogLevel.Warning,
-                new EventId(4, "FailedMultiplePorts"),
-                "Cannot determine the https port from IServerAddressesFeature, multiple values were found. " +
-                "Please set the desired port explicitly on HttpsRedirectionOptions.HttpsPort.");
 
             _portFromServer = LoggerMessage.Define<int>(
                 LogLevel.Debug,
@@ -56,11 +49,6 @@ namespace Microsoft.AspNetCore.HttpsPolicy
         public static void FailedToDeterminePort(this ILogger logger)
         {
             _failedToDeterminePort(logger, null);
-        }
-
-        public static void FailedMultiplePorts(this ILogger logger)
-        {
-            _failedMultiplePorts(logger, null);
         }
 
         public static void PortFromServer(this ILogger logger, int port)

--- a/src/Middleware/HttpsPolicy/src/HttpsRedirectionMiddleware.cs
+++ b/src/Middleware/HttpsPolicy/src/HttpsRedirectionMiddleware.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy
             var httpsRedirectionOptions = options.Value;
             if (httpsRedirectionOptions.HttpsPort.HasValue)
             {
-                _httpsPort = new Lazy<int>(() => httpsRedirectionOptions.HttpsPort.Value);
+                _httpsPort = new Lazy<int>(httpsRedirectionOptions.HttpsPort.Value);
             }
             else
             {
@@ -149,8 +149,9 @@ namespace Microsoft.AspNetCore.HttpsPolicy
                     // If we find multiple different https ports specified, throw
                     if (nullablePort.HasValue && nullablePort != bindingAddress.Port)
                     {
-                        _logger.FailedMultiplePorts();
-                        return PortNotFound;
+                        throw new InvalidOperationException(
+                            "Cannot determine the https port from IServerAddressesFeature, multiple values were found. " +
+                            "Set the desired port explicitly on HttpsRedirectionOptions.HttpsPort.");
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #27951

When the HttpsRedirectionMiddleware isn't explicitly configured it will search IServerAddresses to figure out what https port it should redirect to. This doesn't work if there are A) no https address or, B) multiple https addresses with different ports.

When this feature was first designed we decided that case A should no-op to avoid breaking scenarios like development, deployment behind proxies, etc.. Case B was treated the same way, but I don't think we explored that scenario enough.

When IServerAddresses reports multiple distinct https ports it's clear that the site is using https and that the middleware should be active to protect sensitive data, but it's ambiguous which port it should redirect to. The customer feedback for this scenario is that they'd rather fail the request then let it succeed silently and risk data exposure.

#21291 is for follow-up work to let the developer resolve the port ambiguity, but this error would still be needed when that advanced config is not provided.


