### PR TITLE
Make interface `IComponentRenderer` public

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.ViewFeatures/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Mvc.ViewFeatures.IComponentRenderer
+Microsoft.AspNetCore.Mvc.ViewFeatures.IComponentRenderer.RenderComponentAsync(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext, System.Type componentType, Microsoft.AspNetCore.Mvc.Rendering.RenderMode renderMode, System.Object parameters) -> System.Threading.Tasks.Task<IHtmlContent>

--- a/src/Mvc/Mvc.ViewFeatures/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.ViewFeatures/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
 Microsoft.AspNetCore.Mvc.ViewFeatures.IComponentRenderer
-Microsoft.AspNetCore.Mvc.ViewFeatures.IComponentRenderer.RenderComponentAsync(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext, System.Type componentType, Microsoft.AspNetCore.Mvc.Rendering.RenderMode renderMode, System.Object parameters) -> System.Threading.Tasks.Task<IHtmlContent>
+Microsoft.AspNetCore.Mvc.ViewFeatures.IComponentRenderer.RenderComponentAsync(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext, System.Type componentType, Microsoft.AspNetCore.Mvc.Rendering.RenderMode renderMode, System.Object parameters) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Html.IHtmlContent>

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/IComponentRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/IComponentRenderer.cs
@@ -8,8 +8,20 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
+    /// <summary>
+    /// IComponentRenderer which can be used to render a component.
+    /// </summary>
     public interface IComponentRenderer
     {
+        /// <summary>
+        /// Renders a <paramref name="componentType"/> with <paramref name="parameters"/>
+        /// and returns <see cref="IHtmlContent"/>. 
+        /// </summary>
+        /// <param name="viewContext">The <see cref="ViewContext"/> in which the component is rendered</param>
+        /// <param name="componentType">The <see cref="Type"/> of the component to render</param>
+        /// <param name="renderMode">The <see cref="RenderMode"/></param>
+        /// <param name="parameters">The component parameters</param>
+        /// <returns></returns>
         Task<IHtmlContent> RenderComponentAsync(
             ViewContext viewContext,
             Type componentType,

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/IComponentRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/IComponentRenderer.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures
 {
-    internal interface IComponentRenderer
+    public interface IComponentRenderer
     {
         Task<IHtmlContent> RenderComponentAsync(
             ViewContext viewContext,


### PR DESCRIPTION
Make interface `IComponentRenderer` public so components can be rendered in normal C#/F# code without razor. This seems to be currently impossible without calling into internal types via reflection.

Summary of the changes (Less than 80 chars)
 - Change access modifier of `IComponentRenderer` from `internal` to `public`

Addresses #29120
