### PR TITLE
Update EndpointHttpContextExtensionsTests.cs

### DIFF
--- a/src/Http/Http.Abstractions/test/EndpointHttpContextExtensionsTests.cs
+++ b/src/Http/Http.Abstractions/test/EndpointHttpContextExtensionsTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Http.Abstractions.Tests
         }
 
         [Fact]
-        public void GetEndpoint_ContextWithFeatureAndEndpoint_ReturnsNull()
+        public void GetEndpoint_ContextWithFeatureAndEndpoint_ReturnsEndpoint()
         {
             // Arrange
             var context = new DefaultHttpContext();


### PR DESCRIPTION
Fix test name

Summary of the changes (Less than 80 chars)
 - Fixes the name of the positive case `GetEndpoint` test to indicate the correct expected outcome.


