### PR TITLE
QUIC transport logging clean up

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
         void StreamError(string streamId, Exception ex);
         void StreamPause(string streamId);
         void StreamResume(string streamId);
-        void StreamShutdownWrite(string streamId, Exception? ex);
+        void StreamShutdownWrite(string streamId, string reason);
         void StreamAbort(string streamId, Exception ex);
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
         void StreamError(string streamId, Exception ex);
         void StreamPause(string streamId);
         void StreamResume(string streamId);
-        void StreamShutdownWrite(string streamId, Exception ex);
+        void StreamShutdownWrite(string streamId, Exception? ex);
         void StreamAbort(string streamId, Exception ex);
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
@@ -8,13 +8,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 {
     internal interface IQuicTrace : ILogger
     {
-        void NewConnection(string connectionId);
-        void NewStream(string streamId);
+        void AcceptedConnection(string connectionId);
+        void AcceptedStream(string streamId);
         void ConnectionError(string connectionId, Exception ex);
         void StreamError(string streamId, Exception ex);
         void StreamPause(string streamId);
         void StreamResume(string streamId);
         void StreamShutdownWrite(string streamId, string reason);
-        void StreamAbort(string streamId, Exception ex);
+        void StreamAbort(string streamId, string reason);
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             Features.Set<ITlsConnectionFeature>(new FakeTlsConnectionFeature());
             Features.Set<IProtocolErrorCodeFeature>(this);
 
-            _log.NewConnection(ConnectionId);
+            _log.AcceptedConnection(ConnectionId);
         }
 
         public ValueTask<ConnectionContext> StartUnidirectionalStreamAsync()

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -324,7 +324,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             {
                 lock (_shutdownLock)
                 {
-                    _shutdownReason = shutdownReason ?? new ConnectionAbortedException("The Quic transport's send loop completed gracefully.");
+                    _shutdownReason = shutdownReason;
 
                     _log.StreamShutdownWrite(ConnectionId, _shutdownReason);
                     _stream.Shutdown();

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 
             _aborted = true;
 
-            _log.StreamAbort(ConnectionId, abortReason);
+            _log.StreamAbort(ConnectionId, abortReason.Message);
 
             lock (_shutdownLock)
             {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -324,9 +324,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             {
                 lock (_shutdownLock)
                 {
-                    _shutdownReason = shutdownReason;
+                    // TODO: Exception is always allocated. Consider only allocating if receive hasn't completed.
+                    _shutdownReason = shutdownReason ?? new ConnectionAbortedException("The Quic transport's send loop completed gracefully.");
 
-                    _log.StreamShutdownWrite(ConnectionId, _shutdownReason);
+                    _log.StreamShutdownWrite(ConnectionId, _shutdownReason.Message);
                     _stream.Shutdown();
                 }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -9,21 +9,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
     internal class QuicTrace : IQuicTrace
     {
         private static readonly Action<ILogger, string, Exception?> _acceptedConnection =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(1, nameof(NewConnection)), @"Connection id ""{ConnectionId}"" accepted.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(1, "AcceptedConnection"), @"Connection id ""{ConnectionId}"" accepted.");
         private static readonly Action<ILogger, string, Exception?> _acceptedStream =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(2, nameof(NewStream)), @"Stream id ""{ConnectionId}"" accepted.");
-        private static readonly Action<ILogger, string, string, Exception?> _connectionError =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(3, nameof(ConnectionError)), @"Connection id ""{ConnectionId}"" hit an exception: ""{Reason}"".");
-        private static readonly Action<ILogger, string, string, Exception?> _streamError =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(4, nameof(StreamError)), @"Connection id ""{ConnectionId}"" hit an exception: ""{Reason}"".");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(2, "AcceptedStream"), @"Stream id ""{ConnectionId}"" accepted.");
+        private static readonly Action<ILogger, string, Exception?> _connectionError =
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(3, "ConnectionError"), @"Connection id ""{ConnectionId}"" unexpected error.");
+        private static readonly Action<ILogger, string, Exception?> _streamError =
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, "StreamError"), @"Stream id ""{ConnectionId}"" unexpected error.");
         private static readonly Action<ILogger, string, Exception?> _streamPause =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, nameof(StreamPause)), @"Stream id ""{ConnectionId}"" paused.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, "StreamPause"), @"Stream id ""{ConnectionId}"" paused.");
         private static readonly Action<ILogger, string, Exception?> _streamResume =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, nameof(StreamResume)), @"Stream id ""{ConnectionId}"" resumed.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, "StreamResume"), @"Stream id ""{ConnectionId}"" resumed.");
         private static readonly Action<ILogger, string, string, Exception?> _streamShutdownWrite =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(7, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" shutting down writes because: ""{Reason}"".");
+            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(7, "StreamShutdownWrite"), @"Stream id ""{ConnectionId}"" shutting down writes because: ""{Reason}"".");
         private static readonly Action<ILogger, string, string, Exception?> _streamAborted =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(8, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" aborted by application, exception: ""{Reason}"".");
+            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(8, "StreamAbort"), @"Stream id ""{ConnectionId}"" aborted by application because: ""{Reason}"".");
 
         private ILogger _logger;
 
@@ -39,24 +39,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
             => _logger.Log(logLevel, eventId, state, exception, formatter);
 
-        public void NewConnection(string connectionId)
+        public void AcceptedConnection(string connectionId)
         {
             _acceptedConnection(_logger, connectionId, null);
         }
 
-        public void NewStream(string streamId)
+        public void AcceptedStream(string streamId)
         {
             _acceptedStream(_logger, streamId, null);
         }
 
         public void ConnectionError(string connectionId, Exception ex)
         {
-            _connectionError(_logger, connectionId, ex.Message, ex);
+            _connectionError(_logger, connectionId, ex);
         }
 
         public void StreamError(string streamId, Exception ex)
         {
-            _streamError(_logger, streamId, ex.Message, ex);
+            _streamError(_logger, streamId, ex);
         }
 
         public void StreamPause(string streamId)
@@ -74,9 +74,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             _streamShutdownWrite(_logger, streamId, reason, null);
         }
 
-        public void StreamAbort(string streamId, Exception ex)
+        public void StreamAbort(string streamId, string reason)
         {
-            _streamAborted(_logger, streamId, ex.Message, ex);
+            _streamAborted(_logger, streamId, reason, null);
         }
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -9,21 +9,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
     internal class QuicTrace : IQuicTrace
     {
         private static readonly Action<ILogger, string, Exception?> _acceptedConnection =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, nameof(NewConnection)), @"Connection id ""{ConnectionId}"" accepted.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(1, nameof(NewConnection)), @"Connection id ""{ConnectionId}"" accepted.");
         private static readonly Action<ILogger, string, Exception?> _acceptedStream =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, nameof(NewStream)), @"Stream id ""{ConnectionId}"" accepted.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(2, nameof(NewStream)), @"Stream id ""{ConnectionId}"" accepted.");
         private static readonly Action<ILogger, string, string, Exception?> _connectionError =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(6, nameof(ConnectionError)), @"Connection id ""{ConnectionId}"" hit an exception: ""{Reason}"".");
+            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(3, nameof(ConnectionError)), @"Connection id ""{ConnectionId}"" hit an exception: ""{Reason}"".");
         private static readonly Action<ILogger, string, string, Exception?> _streamError =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(7, nameof(StreamError)), @"Connection id ""{ConnectionId}"" hit an exception: ""{Reason}"".");
+            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(4, nameof(StreamError)), @"Connection id ""{ConnectionId}"" hit an exception: ""{Reason}"".");
         private static readonly Action<ILogger, string, Exception?> _streamPause =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(7, nameof(StreamPause)), @"Stream id ""{ConnectionId}"" paused.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, nameof(StreamPause)), @"Stream id ""{ConnectionId}"" paused.");
         private static readonly Action<ILogger, string, Exception?> _streamResume =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(7, nameof(StreamResume)), @"Stream id ""{ConnectionId}"" resumed.");
-        private static readonly Action<ILogger, string, string, Exception?> _streamShutdownWrite =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(7, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" shutting down writes, exception: ""{Reason}"".");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, nameof(StreamResume)), @"Stream id ""{ConnectionId}"" resumed.");
+        private static readonly Action<ILogger, string, Exception?> _streamShutdownWrite =
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(7, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" shutting down writes.");
         private static readonly Action<ILogger, string, string, Exception?> _streamAborted =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(7, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" aborted by application, exception: ""{Reason}"".");
+            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(8, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" aborted by application, exception: ""{Reason}"".");
 
         private ILogger _logger;
 
@@ -69,9 +69,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             _streamResume(_logger, streamId, null);
         }
 
-        public void StreamShutdownWrite(string streamId, Exception ex)
+        public void StreamShutdownWrite(string streamId, Exception? ex)
         {
-            _streamShutdownWrite(_logger, streamId, ex.Message, ex);
+            _streamShutdownWrite(_logger, streamId, ex);
         }
 
         public void StreamAbort(string streamId, Exception ex)

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -20,8 +20,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, nameof(StreamPause)), @"Stream id ""{ConnectionId}"" paused.");
         private static readonly Action<ILogger, string, Exception?> _streamResume =
             LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, nameof(StreamResume)), @"Stream id ""{ConnectionId}"" resumed.");
-        private static readonly Action<ILogger, string, Exception?> _streamShutdownWrite =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(7, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" shutting down writes.");
+        private static readonly Action<ILogger, string, string, Exception?> _streamShutdownWrite =
+            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(7, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" shutting down writes because: ""{Reason}"".");
         private static readonly Action<ILogger, string, string, Exception?> _streamAborted =
             LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(8, nameof(StreamShutdownWrite)), @"Stream id ""{ConnectionId}"" aborted by application, exception: ""{Reason}"".");
 
@@ -69,9 +69,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             _streamResume(_logger, streamId, null);
         }
 
-        public void StreamShutdownWrite(string streamId, Exception? ex)
+        public void StreamShutdownWrite(string streamId, string reason)
         {
-            _streamShutdownWrite(_logger, streamId, ex);
+            _streamShutdownWrite(_logger, streamId, reason, null);
         }
 
         public void StreamAbort(string streamId, Exception ex)

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketsTrace.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketsTrace.cs
@@ -11,26 +11,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         // ConnectionRead: Reserved: 3
 
         private static readonly Action<ILogger, string, Exception?> _connectionPause =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, nameof(ConnectionPause)), @"Connection id ""{ConnectionId}"" paused.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, "ConnectionPause"), @"Connection id ""{ConnectionId}"" paused.");
 
         private static readonly Action<ILogger, string, Exception?> _connectionResume =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, nameof(ConnectionResume)), @"Connection id ""{ConnectionId}"" resumed.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, "ConnectionResume"), @"Connection id ""{ConnectionId}"" resumed.");
 
         private static readonly Action<ILogger, string, Exception?> _connectionReadFin =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, nameof(ConnectionReadFin)), @"Connection id ""{ConnectionId}"" received FIN.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, "ConnectionReadFin"), @"Connection id ""{ConnectionId}"" received FIN.");
 
         private static readonly Action<ILogger, string, string, Exception?> _connectionWriteFin =
-            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(7, nameof(ConnectionWriteFin)), @"Connection id ""{ConnectionId}"" sending FIN because: ""{Reason}""");
+            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(7, "ConnectionWriteFin"), @"Connection id ""{ConnectionId}"" sending FIN because: ""{Reason}""");
 
         // ConnectionWrite: Reserved: 11
 
         // ConnectionWriteCallback: Reserved: 12
 
         private static readonly Action<ILogger, string, Exception?> _connectionError =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(14, nameof(ConnectionError)), @"Connection id ""{ConnectionId}"" communication error.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(14, "ConnectionError"), @"Connection id ""{ConnectionId}"" communication error.");
 
         private static readonly Action<ILogger, string, Exception?> _connectionReset =
-            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(19, nameof(ConnectionReset)), @"Connection id ""{ConnectionId}"" reset.");
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(19, "ConnectionReset"), @"Connection id ""{ConnectionId}"" reset.");
 
         private readonly ILogger _logger;
 


### PR DESCRIPTION
* Fix logging IDs
* Don't always include exception with `StreamShutdownWrite`