### PR TITLE
[Java] Catch exceptions from users and change close state correctly

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -517,7 +517,14 @@ public class HubConnection implements AutoCloseable {
         RuntimeException exception = null;
         this.state.lock();
         try {
-            ConnectionState connectionState = this.state.getConnectionStateUnsynchronized(false);
+            ConnectionState connectionState = this.state.getConnectionStateUnsynchronized(true);
+
+            if (connectionState == null)
+            {
+                this.logger.error("'stopConnection' called with a null ConnectionState. This is not expected, please file a bug.");
+                return;
+            }
+
             // errorMessage gets passed in from the transport. An already existing stopError value
             // should take precedence.
             if (connectionState.stopError != null) {

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -517,25 +517,25 @@ public class HubConnection implements AutoCloseable {
         RuntimeException exception = null;
         this.state.lock();
         try {
+            ConnectionState connectionState = this.state.getConnectionStateUnsynchronized(false);
             // errorMessage gets passed in from the transport. An already existing stopError value
             // should take precedence.
-            if (this.state.getConnectionStateUnsynchronized(false).stopError != null) {
-                errorMessage = this.state.getConnectionStateUnsynchronized(false).stopError;
+            if (connectionState.stopError != null) {
+                errorMessage = connectionState.stopError;
             }
             if (errorMessage != null) {
                 exception = new RuntimeException(errorMessage);
                 logger.error("HubConnection disconnected with an error {}.", errorMessage);
             }
 
-            ConnectionState connectionState = this.state.getConnectionStateUnsynchronized(true);
-            if (connectionState != null) {
-                connectionState.cancelOutstandingInvocations(exception);
-                connectionState.close();
-                this.state.setConnectionState(null);
-            }
+            this.state.setConnectionState(null);
+            connectionState.cancelOutstandingInvocations(exception);
+            connectionState.close();
 
             logger.info("HubConnection stopped.");
-            this.state.changeState(HubConnectionState.CONNECTED, HubConnectionState.DISCONNECTED);
+            // We can be in the CONNECTING or CONNECTED state here, depending on if the handshake response was received or not.
+            // connectionState.close() above will exit the Start call with an error if it's still running
+            this.state.changeState(HubConnectionState.DISCONNECTED);
         } finally {
             this.state.unlock();
         }
@@ -543,7 +543,11 @@ public class HubConnection implements AutoCloseable {
         // Do not run these callbacks inside the hubConnectionStateLock
         if (onClosedCallbackList != null) {
             for (OnClosedCallback callback : onClosedCallbackList) {
-                callback.invoke(exception);
+                try {
+                    callback.invoke(exception);
+                } catch (Exception ex) {
+                    logger.warn("Invoking 'onClosed' method failed:", ex);
+                }
             }
         }
     }
@@ -1513,6 +1517,16 @@ public class HubConnection implements AutoCloseable {
                         from, to, this.hubConnectionState));
                 }
 
+                this.hubConnectionState = to;
+            } finally {
+                this.lock.unlock();
+            }
+        }
+
+        public void changeState(HubConnectionState to) {
+            this.lock.lock();
+            try {
+                logger.debug("The HubConnection is transitioning from the {} state to the {} state.", this.hubConnectionState, to);
                 this.hubConnectionState = to;
             } finally {
                 this.lock.unlock();

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -521,7 +521,7 @@ public class HubConnection implements AutoCloseable {
 
             if (connectionState == null)
             {
-                this.logger.error("'stopConnection' called with a null ConnectionState. This is not expected, please file a bug.");
+                this.logger.error("'stopConnection' called with a null ConnectionState. This is not expected, please file a bug. https://github.com/dotnet/aspnetcore/issues/new?assignees=&labels=&template=bug_report.md");
                 return;
             }
 

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -125,6 +125,9 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
                 stateLock.unlock();
             }
             checkStartFailure(null);
+
+            // Send the close frame response if this was a server initiated close, otherwise noops
+            webSocket.close(1000, "");
         }
 
         @Override


### PR DESCRIPTION
## Description

If an exception happens during the websockets "onClosing" method then it will call the "onFailure" method which was not expected. So some code that was meant to only run once would run twice and cause issues.

## Customer Impact

Reported by internal partner.
Client can crash if they hit this scenario.
A workaround is to only use LongPolling for the client, WebSockets is the best transport so this isn't a great workaround.

## Regression?
- [x] Yes
- [ ] No

Regressed from 3.1 behavior

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Mostly defensive code, removing risk of exceptions flowing through the code base.

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A