### PR TITLE
Produce correct blazor.boot.json when using StaticWebAssetBasePath

### DIFF
--- a/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
+++ b/src/Components/WebAssembly/Sdk/src/targets/Microsoft.NET.Sdk.BlazorWebAssembly.Current.targets
@@ -509,7 +509,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <_BlazorPublishBootResource
         Include="@(ResolvedFileToPublish)"
-        Condition="$([System.String]::Copy('%(RelativePath)').Replace('\','/').StartsWith('wwwroot/_framework')) AND '%(Extension)' != '.a'" />
+        Condition="$([System.String]::Copy('%(RelativePath)').Replace('\','/').StartsWith($(_BlazorFrameworkPublishPath.Replace('\', '/')))) AND '%(Extension)' != '.a'" />
     </ItemGroup>
 
     <GetFileHash Files="@(_BlazorPublishBootResource)" Algorithm="SHA256" HashEncoding="base64">

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/App.razor
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/App.razor
@@ -1,0 +1,1 @@
+<h1>@typeof(BlazorMultipleApps.FirstClient.Program)</h1>

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/BlazorMultipleApps.FirstClient.csproj
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/BlazorMultipleApps.FirstClient.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <StaticWebAssetBasePath>FirstApp</StaticWebAssetBasePath>
+    <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
+    <BlazorWebAssemblySdkDirectoryRoot>$(BlazorWebAssemblySdkArtifactsDirectory)$(Configuration)\sdk-output\</BlazorWebAssemblySdkDirectoryRoot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(BinariesRoot)'==''">
+    <!-- In test scenarios $(BinariesRoot) is defined in a generated Directory.Build.props file -->
+    <BinariesRoot>$(RepoRoot)artifacts\bin\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib\$(Configuration)\netstandard2.0\</BinariesRoot>
+  </PropertyGroup>
+
+  <!-- DO NOT add addition references here. This is meant to simulate a non-MVC library -->
+  <ItemGroup Condition="'$(BinariesRoot)'!=''">
+    <Reference Include="$(BinariesRoot)\Microsoft.AspNetCore.Razor.Test.ComponentShim.dll"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/Program.cs
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/Program.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Text;
+
+namespace BlazorMultipleApps.FirstClient
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            GC.KeepAlive(typeof(System.Text.Json.JsonSerializer));
+        }
+    }
+}

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/wwwroot/css/app.css
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/wwwroot/css/app.css
@@ -1,0 +1,1 @@
+﻿/* First app.css */

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/wwwroot/index.html
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.FirstClient/wwwroot/index.html
@@ -1,0 +1,14 @@
+﻿<!DOCTYPE html>
+<html>
+
+<head>
+    <title>BlazorMultipleApps</title>
+    <base href="/FirstApp/" />
+    <link href="css/app.css" rel="stylesheet" />
+</head>
+
+<body>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/App.razor
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/App.razor
@@ -1,0 +1,1 @@
+<h1>@typeof(BlazorMultipleApps.SecondClient.Program)</h1>

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/BlazorMultipleApps.SecondClient.csproj
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/BlazorMultipleApps.SecondClient.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <StaticWebAssetBasePath>SecondApp</StaticWebAssetBasePath>
+    <RazorSdkDirectoryRoot>$(RazorSdkArtifactsDirectory)$(Configuration)\sdk-output\</RazorSdkDirectoryRoot>
+    <BlazorWebAssemblySdkDirectoryRoot>$(BlazorWebAssemblySdkArtifactsDirectory)$(Configuration)\sdk-output\</BlazorWebAssemblySdkDirectoryRoot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(BinariesRoot)'==''">
+    <!-- In test scenarios $(BinariesRoot) is defined in a generated Directory.Build.props file -->
+    <BinariesRoot>$(RepoRoot)artifacts\bin\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib\$(Configuration)\netstandard2.0\</BinariesRoot>
+  </PropertyGroup>
+
+  <!-- DO NOT add addition references here. This is meant to simulate a non-MVC library -->
+  <ItemGroup Condition="'$(BinariesRoot)'!=''">
+    <Reference Include="$(BinariesRoot)\Microsoft.AspNetCore.Razor.Test.ComponentShim.dll"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/Program.cs
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/Program.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace BlazorMultipleApps.SecondClient
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/wwwroot/css/app.css
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/wwwroot/css/app.css
@@ -1,0 +1,1 @@
+﻿/* Second app.css */

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/wwwroot/index.html
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.SecondClient/wwwroot/index.html
@@ -1,0 +1,14 @@
+﻿<!DOCTYPE html>
+<html>
+
+<head>
+    <title>SecondBlazorApp</title>
+    <base href="/SecondApp/" />
+    <link href="css/app.css" rel="stylesheet" />
+</head>
+
+<body>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+
+</html>

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.Server/BlazorMultipleApps.Server.csproj
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.Server/BlazorMultipleApps.Server.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorMultipleApps.SecondClient\BlazorMultipleApps.SecondClient.csproj" />
+    <ProjectReference Include="..\BlazorMultipleApps.FirstClient\BlazorMultipleApps.FirstClient.csproj" />
+    <ProjectReference Include="..\BlazorMultipleApps.Shared\BlazorMultipleApps.Shared.csproj" />
+  </ItemGroup>
+
+
+</Project>

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.Server/Program.cs
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.Server/Program.cs
@@ -1,0 +1,10 @@
+﻿namespace BlazorMultipleApps.Server
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            
+        }
+    }
+}

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.Shared/BlazorMultipleApps.Shared.csproj
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.Shared/BlazorMultipleApps.Shared.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.Shared/WeatherForecast.cs
+++ b/src/Components/WebAssembly/Sdk/testassets/BlazorMultipleApps.Shared/WeatherForecast.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlazorMultipleApps.Shared
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public string Summary { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    }
+}

--- a/src/Components/WebAssembly/Sdk/testassets/RestoreBlazorWasmTestProjects/RestoreBlazorWasmTestProjects.csproj
+++ b/src/Components/WebAssembly/Sdk/testassets/RestoreBlazorWasmTestProjects/RestoreBlazorWasmTestProjects.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\blazorwasm\blazorwasm.csproj" />
     <ProjectReference Include="..\blazorwasm-minimal\blazorwasm-minimal.csproj" />
     <ProjectReference Include="..\blazorwasm-fxref\blazorwasm-fxref.csproj" />
+    <ProjectReference Include="..\BlazorMultipleApps.Server\BlazorMultipleApps.Server.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description

This is a follow up to an issue that was patched in 5.0.2. Blazor WASM allows publishing files to a subdirectory by configuring the `StaticWebAssetBasePath`. In an earlier fix, we resolved issues around `dotnet run` but missed verifying `dotnet publish` scenarios where the blazor.boot.json (Blazor WASM's equivalent to  `deps.json`) is incorrect. This change addresses the issue.

### Regression
Yes, compared to Blazor WASM 3.2

### Customer impact

Customers with `StaticWebAssetBasePath` configured in their apps are unable to run the app once it's published.

### Risk

Low. We should have much more confidence in the change, including SDK tests that verify publising, integration tests that verfy dotnet run, and CTI scenarios to capture the end-to-end worklows.

### Validation
- [ ] Manual
  - [ ] CTI (Scenario added,next build will be validated
  - [x] Engineers
- [x] Automated

Fixes https://github.com/dotnet/aspnetcore/issues/29264