### PR TITLE
Remove SignCheck package version override

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -218,7 +218,6 @@
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>3.0.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftDataODataPackageVersion>5.8.4</MicrosoftDataODataPackageVersion>
     <MicrosoftDataServicesClientPackageVersion>5.8.4</MicrosoftDataServicesClientPackageVersion>
-    <MicrosoftDotNetSignCheckVersion>1.0.0-beta.20569.8</MicrosoftDotNetSignCheckVersion>
     <MicrosoftIdentityModelClientsActiveDirectoryPackageVersion>3.19.8</MicrosoftIdentityModelClientsActiveDirectoryPackageVersion>
     <MicrosoftIdentityModelLoggingPackageVersion>5.5.0</MicrosoftIdentityModelLoggingPackageVersion>
     <MicrosoftIdentityModelProtocolsOpenIdConnectPackageVersion>5.5.0</MicrosoftIdentityModelProtocolsOpenIdConnectPackageVersion>


### PR DESCRIPTION
This override was added during the 3.1.11 build, we can remove it now that we've gotten an Arcade update with a newer version