### PR TITLE
Mostly revert "Do not trigger CI builds for changes to doc files (#27484)"

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -10,18 +10,6 @@ trigger:
     - master
     - release/*
     - internal/release/*
-  paths:
-    exclude:
-    - .github/*
-    - .vscode/*
-    # Exclude only a few specific Markdown files because some of them ship.
-    - docs/*
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - README.md
-    - SECURITY.md
-    # Do not ignore the THIRD-PARTY-NOTICES.TXT file because it ships.
 
 # Run PR validation on all branches
 pr:
@@ -29,17 +17,6 @@ pr:
   branches:
     include:
     - '*'
-  paths:
-    exclude:
-    - .github/*
-    - .vscode/*
-    - '**/*.md'
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - README.md
-    - SECURITY.md
-    - THIRD-PARTY-NOTICES.TXT
 
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -10,18 +10,6 @@ trigger:
     include:
     - master
     - release/5.0
-  paths:
-    exclude:
-    - .github/*
-    - .vscode/*
-    # Exclude only a few specific Markdown files because some of them ship.
-    - docs/*
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - README.md
-    - SECURITY.md
-    # Do not ignore the THIRD-PARTY-NOTICES.TXT file because it ships.
 
 # Run PR validation on branches that include Helix tests
 pr:
@@ -30,17 +18,6 @@ pr:
     include:
     - master
     - release/5.0
-  paths:
-    exclude:
-    - .github/*
-    - .vscode/*
-    - '**/*.md'
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - README.md
-    - SECURITY.md
-    - THIRD-PARTY-NOTICES.TXT
 
 schedules:
 - cron: "0 */4 * * *"

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -18,6 +18,17 @@ pr:
     include:
     - master
     - release/5.0
+  paths:
+    exclude:
+    - .github/*
+    - .vscode/*
+    - '**/*.md'
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
 
 schedules:
 - cron: "0 */4 * * *"


### PR DESCRIPTION
- remove `paths` for PRs and triggers
- maintain the explicit opt-in of quarantined runs in PRs et cetera

This reverts most of commit f55bcd840f9405808d0daa210933a425b584b95c.