### PR TITLE
Fix darc publish branch

### DIFF
--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -60,7 +60,7 @@ try {
   --id $buildId `
   --publishing-infra-version $PublishingInfraVersion `
   --default-channels `
-  --source-branch internal/release-publishing `
+  --source-branch master `
   --azdev-pat $AzdoToken `
   --bar-uri $MaestroApiEndPoint `
   --password $MaestroToken `


### PR DESCRIPTION
aspnetcore-ci-official has been failing since yesterday with the following error:

https://dev.azure.com/dnceng/internal/_build/results?buildId=950865&view=logs&j=226748d0-f812-5437-d3f0-2dd291f5666e&t=bad11196-972e-5d03-45a8-9db526506073&l=33
```
A '400 - BadRequest' status was returned for a HTTP request. We'll set the retries amount to 0. Error details: {"$id":"1","innerException":null,"message":"Unable to resolve the reference 'refs/heads/internal/release-publishing' to a specific version. Verify the reference exists in the source repository.","typeName":"Microsoft.Azure.Pipelines.WebApi.PipelineValidationException, Microsoft.Azure.Pipelines.WebApi","typeKey":"PipelineValidationException","errorCode":0,"eventId":3000} 
```

This recommended fix is to revert a change that looks like it was supposed to be temporary and only in the 5.0.x branch. 
https://github.com/dotnet/aspnetcore/commit/5b92756c41a80ec0f09d901b2b7472945b1527ff

