### PR TITLE
[Blazor] Unquarantine PreventDefaultCanBlockKeyStrokes

### DIFF
--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -164,7 +164,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23757")]
         public void PreventDefaultCanBlockKeystrokes()
         {
             // By default, the textbox accepts keystrokes


### PR DESCRIPTION
Test hasn't failed in the last 30 days

Fixes #23757