### PR TITLE
[Blazor] Unquarantine CanRenderMarkupBlocks

### DIFF
--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -537,7 +537,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27375")]
         public void CanRenderMarkupBlocks()
         {
             var appElement = Browser.MountTestComponent<MarkupBlockComponent>();
@@ -734,6 +733,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             var log = Browser.Manage().Logs.GetLog(LogType.Browser);
             Assert.DoesNotContain(log, entry => entry.Level == LogLevel.Severe);
             Browser.Equal("", () => input.Text);
-        } 
+        }
     }
 }


### PR DESCRIPTION
Test has been passing for the past 30 days.

Fixes #27375