### PR TITLE
Fix test flakiness with OnTimeout

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -439,23 +439,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                             dataLength = 0;
                         }
 
+                        if (_minResponseDataRate != null)
+                        {
+                            _timeoutControl.BytesWrittenToBuffer(_minResponseDataRate, _unflushedBytes);
+                        }
+
                         // Don't call TimeFlushUnsynchronizedAsync() since we time this write while also accounting for
                         // flow control induced backpressure below.
                         writeTask = _flusher.FlushAsync();
                     }
                     else if (firstWrite)
                     {
+                        if (_minResponseDataRate != null)
+                        {
+                            _timeoutControl.BytesWrittenToBuffer(_minResponseDataRate, _unflushedBytes);
+                        }
+
                         // If we're facing flow control induced backpressure on the first write for a given stream's response body,
                         // we make sure to flush the response headers immediately.
                         writeTask = _flusher.FlushAsync();
                     }
 
                     firstWrite = false;
-
-                    if (_minResponseDataRate != null)
-                    {
-                        _timeoutControl.BytesWrittenToBuffer(_minResponseDataRate, _unflushedBytes);
-                    }
 
                     _unflushedBytes = 0;
                 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -423,7 +423,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                         break;
                     }
 
+                    // Observe HTTP/2 backpressure
                     var actual = flowControl.AdvanceUpToAndWait(dataLength, out availabilityTask);
+
+                    var shouldFlush = false;
 
                     if (actual > 0)
                     {
@@ -439,30 +442,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                             dataLength = 0;
                         }
 
-                        if (_minResponseDataRate != null)
-                        {
-                            _timeoutControl.BytesWrittenToBuffer(_minResponseDataRate, _unflushedBytes);
-                        }
-
-                        // Don't call TimeFlushUnsynchronizedAsync() since we time this write while also accounting for
+                        // Don't call FlushAsync() with the min data rate, since we time this write while also accounting for
                         // flow control induced backpressure below.
-                        writeTask = _flusher.FlushAsync();
+                        shouldFlush = true;
                     }
                     else if (firstWrite)
                     {
+                        // If we're facing flow control induced backpressure on the first write for a given stream's response body,
+                        // we make sure to flush the response headers immediately.
+                        shouldFlush = true;
+                    }
+
+                    if (shouldFlush)
+                    {
                         if (_minResponseDataRate != null)
                         {
+                            // Call BytesWrittenToBuffer before FlushAsync() to make testing easier, otherwise the Flush can cause test code to run before the timeout
+                            // control updates and if the test checks for a timeout it can fail
                             _timeoutControl.BytesWrittenToBuffer(_minResponseDataRate, _unflushedBytes);
                         }
 
-                        // If we're facing flow control induced backpressure on the first write for a given stream's response body,
-                        // we make sure to flush the response headers immediately.
+                        _unflushedBytes = 0;
+
                         writeTask = _flusher.FlushAsync();
                     }
 
                     firstWrite = false;
-
-                    _unflushedBytes = 0;
                 }
 
                 // Avoid timing writes that are already complete. This is likely to happen during the last iteration.

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/TimingPipeFlusher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/TimingPipeFlusher.cs
@@ -52,6 +52,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
         {
             if (minRate is object)
             {
+                // Call BytesWrittenToBuffer before FlushAsync() to make testing easier, otherwise the Flush can cause test code to run before the timeout
+                // control updates and if the test checks for a timeout it can fail
                 _timeoutControl!.BytesWrittenToBuffer(minRate, count);
             }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/TimingPipeFlusher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PipeWriterHelpers/TimingPipeFlusher.cs
@@ -50,12 +50,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeW
 
         public ValueTask<FlushResult> FlushAsync(MinDataRate? minRate, long count, IHttpOutputAborter? outputAborter, CancellationToken cancellationToken)
         {
-            var pipeFlushTask = _writer.FlushAsync(cancellationToken);
-
             if (minRate is object)
             {
                 _timeoutControl!.BytesWrittenToBuffer(minRate, count);
             }
+
+            var pipeFlushTask = _writer.FlushAsync(cancellationToken);
 
             if (pipeFlushTask.IsCompletedSuccessfully)
             {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -550,7 +550,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _mockConnectionContext.VerifyNoOtherCalls();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore-internal/issues/2197")]
+        [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore-internal/issues/2197")]
         public async Task DATA_Sent_TooSlowlyDueToOutputFlowControlOnMultipleStreams_AbortsConnectionAfterAdditiveRateTimeout()
         {
             var mockSystemClock = _serviceContext.MockSystemClock;
@@ -582,7 +583,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await SendDataAsync(3, _maxData, endStream: true);
 
             await ExpectAsync(Http2FrameType.HEADERS,
-                withLength: 32,
+                withLength: 2,
                 withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
                 withStreamId: 3);
             await ExpectAsync(Http2FrameType.DATA,


### PR DESCRIPTION
Fixes part of https://github.com/dotnet/aspnetcore/issues/21520
Fixes https://github.com/dotnet/aspnetcore-internal/issues/2197

Before, if you froze the thread right after calling `_flusher.FlushAsync` and before `_timeoutControl.BytesWrittenToBuffer` on the last write before the timeout check in the tests then you could 100% of the time repro the test issue. I can't recall the exact reasons because it's been awhile since I read through the code, but after moving the `BytesWrittenToBuffer` before flushing, the test no longer fails.

This should be fine because we weren't awaiting the flush before calling the timeout controller, so we haven't really changed any behavior here.