### PR TITLE
Correct System.Diagnostics.EventLog.Messages workaround for servicing

### DIFF
--- a/eng/SharedFramework.External.props
+++ b/eng/SharedFramework.External.props
@@ -60,7 +60,6 @@
       three do not. This is likely about our public APIs i.e. external compilation requirements.
     -->
     <_TransitiveExternalAspNetCoreAppReference Include="System.Diagnostics.EventLog"                        Version="$(SystemDiagnosticsEventLogVersion)" />
-    <_TransitiveExternalAspNetCoreAppReference Include="System.Diagnostics.EventLog.Messages"               Version="$(SystemDiagnosticsEventLogVersion)" />
     <_TransitiveExternalAspNetCoreAppReference Include="System.Security.Permissions"                        Version="$(SystemSecurityPermissionsVersion)" />
     <_TransitiveExternalAspNetCoreAppReference Include="System.Windows.Extensions"                          Version="$(SystemWindowsExtensionsVersion)" />
   </ItemGroup>

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -12,7 +12,15 @@
     <!-- Ignore aspnetcorev2_inprocess because tests expect only managed assemblies in this item group. -->
     <_SharedFrameworkBinariesFromRepo Include="@(AspNetCoreAppReference);@(AspNetCoreAppReferenceAndPackage)" />
 
-    <_ExpectedSharedFrameworkBinaries Include="@(_SharedFrameworkBinariesFromRepo);@(ExternalAspNetCoreAppReference);@(_TransitiveExternalAspNetCoreAppReference)" />
+    <!--
+      Special-case System.Diagnostics.EventLog.Messages.dll because that assembly name does _not_ match a
+      package. Can't mention it in @(ExternalAspNetCoreAppReference) or underlying
+      @(_TransitiveExternalAspNetCoreAppReference) without thoroughly confusing eng/targets/ResolveReferences.targets.
+    -->
+    <_ExpectedSharedFrameworkBinaries Include="@(_SharedFrameworkBinariesFromRepo);
+        @(ExternalAspNetCoreAppReference);
+        @(_TransitiveExternalAspNetCoreAppReference);
+        System.Diagnostics.EventLog.Messages" />
     <_ExpectedSharedFrameworkBinaries Condition="'$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' != 'arm'" Include="aspnetcorev2_inprocess" />
 
     <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">


### PR DESCRIPTION
- previous workaround didn't handle `'$(IsServicingBuild)' == 'true'` case