### PR TITLE
Make Google OAuth provider recognize avatar

### DIFF
--- a/src/Security/Authentication/Google/src/GoogleOptions.cs
+++ b/src/Security/Authentication/Google/src/GoogleOptions.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
             ClaimActions.MapJsonKey(ClaimTypes.GivenName, "given_name");
             ClaimActions.MapJsonKey(ClaimTypes.Surname, "family_name");
             ClaimActions.MapJsonKey("urn:google:profile", "link");
+            ClaimActions.MapJsonKey("urn:google:photo", "picture");
             ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
         }
 


### PR DESCRIPTION
Just simple one-line change.
Questions. 
1. I wonder about claim name that I have chosen by analogy to `urn:google:profile`. If there is some guidance/anything to choose claim names?
2. Should I include any unit tests with this change?

Addresses #29392
