### PR TITLE
Removes unnecessary object array allocation

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -642,9 +642,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
             return channel;
         }
 
-#if NETCOREAPP
-        [SkipLocalsInit]
-#endif
         private Dictionary<string, object> PackageStreamingParams(ConnectionState connectionState, ref object[] args, out List<string> streamIds)
         {
             Dictionary<string, object> readers = null;
@@ -676,10 +673,6 @@ namespace Microsoft.AspNetCore.SignalR.Client
                     streamIds.Add(id);
 
                     Log.StartingStream(_logger, id);
-                }
-                else
-                {
-                    isStreaming[i] = false;
                 }
             }
 

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -646,14 +646,14 @@ namespace Microsoft.AspNetCore.SignalR.Client
         {
             Dictionary<string, object> readers = null;
             streamIds = null;
-            int newArgsCount = args.Length;
+            var newArgsCount = args.Length;
             const int MaxStackSize = 256;
             Span<bool> isStreaming = args.Length <= MaxStackSize
                 ? stackalloc bool[MaxStackSize].Slice(0, args.Length)
                 : new bool[args.Length];
             for (var i = 0; i < args.Length; i++)
             {
-                object arg = args[i];
+                var arg = args[i];
                 if (arg is not null && ReflectionHelper.IsStreamingType(arg.GetType()))
                 {
                     isStreaming[i] = true;
@@ -681,7 +681,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
                 return null;
             }
 
-            object[] newArgs = newArgsCount > 0
+            var newArgs = newArgsCount > 0
                 ? new object[newArgsCount]
                 : Array.Empty<object>();
             int newArgsIndex = 0;
@@ -690,7 +690,8 @@ namespace Microsoft.AspNetCore.SignalR.Client
             {
                 if (!isStreaming[i])
                 {
-                    newArgs[newArgsIndex++] = args[i];
+                    newArgs[newArgsIndex] = args[i];
+                    newArgsIndex++;
                 }
             }
 

--- a/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -4,6 +4,7 @@
     <Description>Client for ASP.NET Core SignalR</Description>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework);netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Microsoft.AspNetCore.SignalR.Client</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -4,7 +4,6 @@
     <Description>Client for ASP.NET Core SignalR</Description>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework);netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Microsoft.AspNetCore.SignalR.Client</RootNamespace>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist 
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/master/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Updates `HubConnection.PackageStreamingParams` remove allocations when sending non-streaming arguments.

**PR Description**
* Only allocate an object array if one of the args ends up being removed (due to an argument being streaming)
* Reuses the input array if no streaming type args are sent
* Uses array empty if all args are streaming type args

Addresses #29399
