### PR TITLE
Use string.Create to build absolute URI

### DIFF
--- a/src/Http/Http.Extensions/test/UriHelperTests.cs
+++ b/src/Http/Http.Extensions/test/UriHelperTests.cs
@@ -42,6 +42,46 @@ namespace Microsoft.AspNetCore.Http.Extensions
             Assert.Equal("http://my.xn--host-cpd:80/un%3Fescaped/base/un%3Fescaped?name=val%23ue#my%20value", result);
         }
 
+        [Theory]
+        [InlineData("http", "example.com", "", "", "", "", "http://example.com/")]
+        [InlineData("https", "example.com", "", "", "", "", "https://example.com/")]
+        [InlineData("http", "example.com", "", "/foo/bar", "", "", "http://example.com/foo/bar")]
+        [InlineData("http", "example.com", "", "/foo/bar", "?baz=1", "", "http://example.com/foo/bar?baz=1")]
+        [InlineData("http", "example.com", "", "/foo", "", "#col=2", "http://example.com/foo#col=2")]
+        [InlineData("http", "example.com", "", "/foo", "?bar=1", "#col=2", "http://example.com/foo?bar=1#col=2")]
+        [InlineData("http", "example.com", "/base", "/foo", "?bar=1", "#col=2", "http://example.com/base/foo?bar=1#col=2")]
+        [InlineData("http", "example.com", "/base/", "/foo", "?bar=1", "#col=2", "http://example.com/base/foo?bar=1#col=2")]
+        [InlineData("http", "example.com", "", "", "?bar=1", "#col=2", "http://example.com/?bar=1#col=2")]
+        [InlineData("http", "example.com", "", "", "", "#frag?stillfrag/stillfrag", "http://example.com/#frag?stillfrag/stillfrag")]
+        [InlineData("http", "example.com", "", "", "?q/stillq", "#frag?stillfrag/stillfrag", "http://example.com/?q/stillq#frag?stillfrag/stillfrag")]
+        [InlineData("http", "example.com", "", "/fo#o", "", "#col=2", "http://example.com/fo%23o#col=2")]
+        [InlineData("http", "example.com", "", "/fo?o", "", "#col=2", "http://example.com/fo%3Fo#col=2")]
+        [InlineData("ftp", "example.com", "", "/", "", "", "ftp://example.com/")]
+        [InlineData("ftp", "example.com", "/", "/", "", "", "ftp://example.com/")]
+        [InlineData("https", "127.0.0.0:80", "", "/bar", "", "", "https://127.0.0.0:80/bar")]
+        [InlineData("http", "[1080:0:0:0:8:800:200C:417A]", "", "/index.html", "", "", "http://[1080:0:0:0:8:800:200C:417A]/index.html")]
+        [InlineData("http", "example.com", "", "///", "", "", "http://example.com///")]
+        [InlineData("http", "example.com", "///", "///", "", "", "http://example.com/////")]
+        public void BuildAbsoluteGenerationChecks(
+            string scheme,
+            string host,
+            string pathBase,
+            string path,
+            string query,
+            string fragment,
+            string expectedUri)
+        {
+            var uri = UriHelper.BuildAbsolute(
+                scheme,
+                new HostString(host),
+                new PathString(pathBase),
+                new PathString(path),
+                new QueryString(query),
+                new FragmentString(fragment));
+
+            Assert.Equal(expectedUri, uri);
+        }
+
         [Fact]
         public void GetEncodedUrlFromRequest()
         {


### PR DESCRIPTION
**PR Title**

Use string.Creat to build absolute URI.

**PR Description**

`UriHelper.BuildAbsolute` creates an intermediary string for the combined path that is used only for concatenating with the other components to create the final URL.

It also uses a non-pooled `StringBuilder` that is instantiated on every invocation. Although optimized in size, it is a heap allocation with an intermediary buffer.

Using `string.Create` will bring a significant performance improvement.

Fixes #28905
