### PR TITLE
Respect default value for TextAreaTagHelper

### DIFF
--- a/src/Mvc/Mvc.TagHelpers/src/PublicAPI.Shipped.txt
+++ b/src/Mvc/Mvc.TagHelpers/src/PublicAPI.Shipped.txt
@@ -357,7 +357,7 @@ static readonly Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelperBase.DefaultEx
 ~override Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper.Process(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) -> void
 ~override Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper.Init(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context) -> void
 ~override Microsoft.AspNetCore.Mvc.TagHelpers.SelectTagHelper.Process(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) -> void
-~override Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper.Process(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) -> void
+~override Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper.ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) -> System.Threading.Tasks.Task
 ~override Microsoft.AspNetCore.Mvc.TagHelpers.ValidationMessageTagHelper.ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) -> System.Threading.Tasks.Task
 ~override Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper.Process(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) -> void
 ~static Microsoft.AspNetCore.Mvc.TagHelpers.TagHelperOutputExtensions.AddClass(this Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput tagHelperOutput, string classValue, System.Text.Encodings.Web.HtmlEncoder htmlEncoder) -> void

--- a/src/Mvc/Mvc.TagHelpers/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.TagHelpers/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-~override Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper.ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) -> System.Threading.Tasks.Task

--- a/src/Mvc/Mvc.TagHelpers/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.TagHelpers/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~override Microsoft.AspNetCore.Mvc.TagHelpers.TextAreaTagHelper.ProcessAsync(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext context, Microsoft.AspNetCore.Razor.TagHelpers.TagHelperOutput output) -> System.Threading.Tasks.Task

--- a/src/Mvc/Mvc.TagHelpers/src/TextAreaTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/TextAreaTagHelper.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 if (tagBuilder.HasInnerHtml)
                 {
                     // Overwrite current Content to ensure expression result round-trips correctly.
-                    output.Content.SetHtmlContent(tagBuilder.InnerHtml);
+                    output.Content.SetHtmlContent(output.GetChildContentAsync().Result.GetContent());
                 }
             }
         }

--- a/src/Mvc/Mvc.TagHelpers/src/TextAreaTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/TextAreaTagHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -58,7 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
 
         /// <inheritdoc />
         /// <remarks>Does nothing if <see cref="For"/> is <c>null</c>.</remarks>
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (context == null)
             {
@@ -103,7 +104,8 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers
                 if (tagBuilder.HasInnerHtml)
                 {
                     // Overwrite current Content to ensure expression result round-trips correctly.
-                    output.Content.SetHtmlContent(output.GetChildContentAsync().Result.GetContent());
+                    var content = await output.GetChildContentAsync();
+                    output.Content.SetHtmlContent(content.GetContent());
                 }
             }
         }


### PR DESCRIPTION
### Points considered while making changes
There are different ways to solve this issue, but I choose the non-breaking change to public APIs for compatibility! 
1. In current PR, I'm grabbing `innerText` synchronously and setting content of `<textarea>` before rendering. 
2. Another approach would be to introduce a new property in `TextAreaTagHelper` which will hold the default value for `<textarea>` and will set for the user. (Breaking Change to `TextAreaTagHelper` and also against RFC https://www.w3.org/TR/html52/sec-forms.html#the-textarea-element) 
![image](https://user-images.githubusercontent.com/17148381/105162429-9de10c80-5b38-11eb-8794-63ec80bf3572.png)

Fixes https://github.com/dotnet/aspnetcore/issues/4824

