### PR TITLE
Fix jsinterop yarn install

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
@@ -5,7 +5,7 @@
   "main": "dist/Microsoft.JSInterop.js",
   "types": "dist/Microsoft.JSInterop.d.ts",
   "scripts": {
-    "preclean": "yarn install",
+    "preclean": "yarn install --mutex network",
     "clean": "node node_modules/rimraf/bin.js ./dist",
     "build": "npm run clean && npm run build:esm",
     "build:lint": "node node_modules/tslint/bin/tslint -p ./tsconfig.json",


### PR DESCRIPTION
We moved all our npm projects to `yarn install --mutex network` to fix issues with yarn running in parallel, but this project wasn't in the repo at the time and didn't get the same treatment.