### PR TITLE
Mention 'main' instead of 'master'

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -1,4 +1,4 @@
-# We only want to run full helix matrix on master
+# We only want to run full helix matrix on main
 pr: none
 trigger: none
 schedules:

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -3,7 +3,7 @@
 #
 
 # Configure which branches trigger builds
-# We want to run quarantined tests on release/5.0 and master as well as on PRs
+# We want to run quarantined tests on release/5.0 and main as well as on PRs
 trigger:
   batch: true
   branches:

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -1,4 +1,4 @@
-# We only want to run quarantined tests on master
+# We only want to run quarantined tests on main
 pr: none
 trigger: none
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 
 <!-- Thank you for submitting a pull request to our repo. -->
 
-<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist 
+<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
 below to ensure a smooth review and merge process for your PR. -->
 
-- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/master/CODE-OF-CONDUCT.md).
+- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
 - [ ] You've included unit or integration tests for your change, where applicable.
 - [ ] You've included inline docs for your change, where applicable.
 - [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -18,14 +18,14 @@ jobs:
     - name: Checkout aspnetcore
       uses: actions/checkout@v2.0.0
       with:
-        # Test this script using changes in a fork 
+        # Test this script using changes in a fork
         repository: 'dotnet/aspnetcore'
         path: aspnetcore
-        ref: master
+        ref: main
     - name: Checkout runtime
       uses: actions/checkout@v2.0.0
       with:
-        # Test this script using changes in a fork 
+        # Test this script using changes in a fork
         repository: 'dotnet/runtime'
         path: runtime
         ref: master
@@ -67,6 +67,6 @@ jobs:
         title: 'Sync shared code from runtime'
         body: 'This PR was automatically generated to sync shared code changes from runtime. Fixes #18943'
         labels: area-servers
-        base: master
+        base: main
         branch: github-action/sync-runtime
         branch-suffix: timestamp

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Follow the [Getting Started](https://docs.microsoft.com/aspnet/core/getting-star
 
 Also check out the [.NET Homepage](https://www.microsoft.com/net) for released versions of .NET, getting started guides, and learning resources.
 
-See the [Triage Process](https://github.com/dotnet/aspnetcore/blob/master/docs/TriageProcess.md) document for more information on how we handle incoming issues.
+See the [Triage Process](https://github.com/dotnet/aspnetcore/blob/main/docs/TriageProcess.md) document for more information on how we handle incoming issues.
 
 ## How to Engage, Contribute, and Give Feedback
 

--- a/build.ps1
+++ b/build.ps1
@@ -116,7 +116,7 @@ Running tests.
     build.ps1 -test
 
 .LINK
-Online version: https://github.com/dotnet/aspnetcore/blob/master/docs/BuildFromSource.md
+Online version: https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md
 #>
 [CmdletBinding(PositionalBinding = $false, DefaultParameterSetName='Groups')]
 param(
@@ -363,7 +363,7 @@ if($dotnetFormat)
 {
     Write-Host -f Magenta "dotnet format tool is already installed."
 }
-else 
+else
 {
     Write-Host -f Magenta "Installing dotnet-format tool.."
     & dotnet tool install -g dotnet-format

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -155,7 +155,7 @@ Studio because those projects are not listed in AspNetCore.sln.
 This will download the required tools and restore all projects inside the repository. At that point, you should be able
 to open the .sln file or one of the project specific .slnf files to work on the projects you care about.
 
-   > :bulb: Pro tip: you will also want to run this command after pulling large sets of changes. On the master
+   > :bulb: Pro tip: you will also want to run this command after pulling large sets of changes. On the main
    > branch, we regularly update the versions of .NET Core SDK required to build the repo.
    > You will need to restart Visual Studio every time we update the .NET Core SDK.
 

--- a/docs/Helix.md
+++ b/docs/Helix.md
@@ -18,17 +18,17 @@ This will restore, and then publish all the test project including some bootstra
 
 ## Overview of the helix usage in our pipelines
 
-- Required queues: Windows10, OSX, Ubuntu1604 
+- Required queues: Windows10, OSX, Ubuntu1604
 - Full queue matrix: Windows[7, 81, 10], Ubuntu[1604, 1804, 2004], Centos7, Debian9, Redhat7, Fedora28, Arm64 (Win10, Debian9)
-- The queues are defined in [Helix.Common.props](https://github.com/dotnet/aspnetcore/blob/master/eng/targets/Helix.Common.props)
+- The queues are defined in [Helix.Common.props](https://github.com/dotnet/aspnetcore/blob/main/eng/targets/Helix.Common.props)
 
 [aspnetcore-ci](https://dev.azure.com/dnceng/public/_build?definitionId=278) runs non quarantined tests against the required helix queues as a required PR check and all builds on all branches.
 
-[aspnetcore-helix-matrix](https://dev.azure.com/dnceng/public/_build?definitionId=837) runs non quarantined tests against all queues twice a day only on public master.
+[aspnetcore-helix-matrix](https://dev.azure.com/dnceng/public/_build?definitionId=837) runs non quarantined tests against all queues twice a day only on public main.
 
-[aspnetcore-quarantined-pr](https://dev.azure.com/dnceng/public/_build?definitionId=869) runs only quarantined tests against the required queues on PRs and on master every 4 hours.
+[aspnetcore-quarantined-pr](https://dev.azure.com/dnceng/public/_build?definitionId=869) runs only quarantined tests against the required queues on PRs and on main every 4 hours.
 
-[aspnetcore-quarantined-tests](https://dev.azure.com/dnceng/public/_build?definitionId=331) runs only quarantined tests against all queues only on public master once a day at 11 PM.
+[aspnetcore-quarantined-tests](https://dev.azure.com/dnceng/public/_build?definitionId=331) runs only quarantined tests against all queues only on public main once a day at 11 PM.
 
 You can always manually queue pipeline runs by clicking on the link to the pipeline -> Run Pipeline -> select your branch/tag and commit
 
@@ -42,7 +42,7 @@ You can always manually queue pipeline runs by clicking on the link to the pipel
 
 The easiest way to look at a test failure is via the tests tab in azdo which now should show a summary of the errors and have attachments to the relevant console logs.
 
-You can also drill down into the helix web apis if you take the HelixJobId from the Debug tab of a failing test, and the HelixWorkItemName and go to: `https://helix.dot.net/api/2019-06-17/jobs/<jobId>/workitems/<workitemname>` which will show you more urls you can drill into for more info. 
+You can also drill down into the helix web apis if you take the HelixJobId from the Debug tab of a failing test, and the HelixWorkItemName and go to: `https://helix.dot.net/api/2019-06-17/jobs/<jobId>/workitems/<workitemname>` which will show you more urls you can drill into for more info.
 
 There's also a link embedded in the build.cmd log of the Tests: Helix x64 job on Azure Pipelines, near the bottom right that will look something like this:
 

--- a/docs/ReferenceResolution.md
+++ b/docs/ReferenceResolution.md
@@ -111,7 +111,7 @@ Once `darc` is installed and set-up, it can be used to modify the subscriptions 
 Subscriptions are objects that define the ecosystem repos we are listening for updates to, the frequency we are looking for updates, and more.
 
 ```bash
-darc get-subscriptions --target-branch master --target-repo aspnetcore$ --regex
+darc get-subscriptions --target-branch main --target-repo aspnetcore$ --regex
 ```
 
 **Disable/enable a subscription**

--- a/docs/TriageProcess.md
+++ b/docs/TriageProcess.md
@@ -64,4 +64,4 @@ The following diagram summarizes the processes detailed above:
 
 
 ## References
-We rely on some automation to help us with this process. You can learn more about some of these by reading our [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/master/docs/IssueManagementPolicies.md) document.
+We rely on some automation to help us with this process. You can learn more about some of these by reading our [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) document.

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -131,7 +131,7 @@ try {
 
     foreach ($unexpectedVar in $versionVars) {
         LogError `
-            "Version variable '$unexpectedVar' does not have a matching entry in Version.Details.xml. See https://github.com/dotnet/aspnetcore/blob/master/docs/ReferenceResolution.md for instructions on how to add a new dependency." `
+            "Version variable '$unexpectedVar' does not have a matching entry in Version.Details.xml. See https://github.com/dotnet/aspnetcore/blob/main/docs/ReferenceResolution.md for instructions on how to add a new dependency." `
             -filepath "$repoRoot\eng\Versions.props"
     }
 

--- a/eng/scripts/InstallVisualStudio.ps1
+++ b/eng/scripts/InstallVisualStudio.ps1
@@ -23,7 +23,7 @@
     Run the installer without UI and wait for installation to complete.
 .LINK
     https://visualstudio.com
-    https://github.com/dotnet/aspnetcore/blob/master/docs/BuildFromSource.md
+    https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md
 .EXAMPLE
     To install VS 2019 Enterprise, run this command in PowerShell:
 

--- a/src/Components/benchmarkapps/Wasm.Performance/benchmarks.compose.json
+++ b/src/Components/benchmarkapps/Wasm.Performance/benchmarks.compose.json
@@ -11,11 +11,11 @@
     "blazorwasmbenchmark": {
       "source": {
         "repository": "https://github.com/dotnet/AspNetCore.git",
-        "branchOrCommit": "master",
+        "branchOrCommit": "main",
         "dockerfile": "src/Components/benchmarkapps/Wasm.Performance/dockerfile"
       },
       "buildArguments": [
-        "gitBranch=master"
+        "gitBranch=main"
       ],
       "waitForExit": true,
       "readyStateText": "Application started."

--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     nodejs \
     git
 
-ARG gitBranch=master
+ARG gitBranch=main
 
 WORKDIR /src
 ADD https://api.github.com/repos/dotnet/aspnetcore/git/ref/heads/${gitBranch} /aspnetcore.commit

--- a/src/Http/Routing/test/testassets/Benchmarks/benchmarks.json
+++ b/src/Http/Routing/test/testassets/Benchmarks/benchmarks.json
@@ -8,7 +8,7 @@
     },
     "Source": {
       "Repository": "https://github.com/dotnet/aspnetcore.git",
-      "BranchOrCommit": "master",
+      "BranchOrCommit": "main",
       "Project": "src/Routing/benchmarkapps/Benchmarks/Benchmarks.csproj"
     },
     "Port": 8080

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/dotnet/aspnetcore/issues"
   },
-  "homepage": "https://github.com/dotnet/aspnetcore/tree/master/src/JSInterop",
+  "homepage": "https://github.com/dotnet/aspnetcore/tree/main/src/JSInterop",
   "files": [
     "dist/**"
   ],

--- a/src/Localization/README.md
+++ b/src/Localization/README.md
@@ -3,4 +3,4 @@ Localization
 
 These projects provide abstractions for localizing resources in .NET applications.
 
-The ASP.NET Core implementation of localization can be found in https://github.com/dotnet/aspnetcore/tree/master/src/Middleware/Localization.
+The ASP.NET Core implementation of localization can be found in https://github.com/dotnet/aspnetcore/tree/main/src/Middleware/Localization.

--- a/src/Mvc/README.md
+++ b/src/Mvc/README.md
@@ -3,8 +3,6 @@ ASP.NET Core MVC
 
 **Note: For ASP.NET MVC 5.x, Web API 2.x, and Web Pages 3.x (not ASP.NET Core), see https://github.com/aspnet/AspNetWebStack**
 
-Travis:   [![Travis](https://travis-ci.org/aspnet/Mvc.svg?branch=master)](https://travis-ci.org/aspnet/Mvc)
-
 ASP.NET Core MVC gives you a powerful, patterns-based way to build dynamic websites that enables a clean separation of concerns and gives you full control over markup for enjoyable, agile development. ASP.NET Core MVC includes many features that enable fast, TDD-friendly development for creating sophisticated applications that use the latest web standards.
 
 ASP.NET Core MVC includes support for building web pages and HTTP services in a single aligned framework that can be hosted in IIS or self-hosted in your own process.

--- a/src/Mvc/benchmarkapps/BasicApi/benchmarks.json
+++ b/src/Mvc/benchmarkapps/BasicApi/benchmarks.json
@@ -8,7 +8,7 @@
     "ReadyStateText": "Application started.",
     "Source": {
       "Repository": "https://github.com/dotnet/aspnetcore.git",
-      "BranchOrCommit": "master",
+      "BranchOrCommit": "main",
       "Project": "src/Mvc/benchmarkapps/BasicApi/BasicApi.csproj"
     }
   },
@@ -19,20 +19,20 @@
   },
   "BasicApi.GetUsingQueryString": {
     "ClientProperties": {
-      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/master/src/Mvc/benchmarkapps/BasicApi/getWithToken.lua"
+      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Mvc/benchmarkapps/BasicApi/getWithToken.lua"
     },
     "Path": "/pet/findByStatus",
     "Query": "?status=available"
   },
   "BasicApi.GetUsingRouteValue": {
     "ClientProperties": {
-      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/master/src/Mvc/benchmarkapps/BasicApi/getWithToken.lua"
+      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Mvc/benchmarkapps/BasicApi/getWithToken.lua"
     },
     "Path": "/pet/-1"
   },
   "BasicApi.GetUsingRouteValueWithoutAuthorization": {
     "ClientProperties": {
-      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/master/src/Mvc/benchmarkapps/BasicApi/getWithToken.lua"
+      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Mvc/benchmarkapps/BasicApi/getWithToken.lua"
     },
     "Path": "/pet/anonymous/-1"
   },
@@ -41,14 +41,14 @@
   },
   "BasicApi.Post": {
     "ClientProperties": {
-      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/master/src/Mvc/benchmarkapps/BasicApi/postJsonWithToken.lua"
+      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Mvc/benchmarkapps/BasicApi/postJsonWithToken.lua"
     },
     "Path": "/pet"
   },
   "BasicApi.PostWithoutDb": {
     "Path": "/pet/add-pet",
     "ClientProperties": {
-      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/master/src/Mvc/benchmarkapps/BasicApi/postJsonWithToken.lua"
+      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Mvc/benchmarkapps/BasicApi/postJsonWithToken.lua"
     }
   }
 }

--- a/src/Mvc/benchmarkapps/BasicViews/benchmarks.json
+++ b/src/Mvc/benchmarkapps/BasicViews/benchmarks.json
@@ -8,7 +8,7 @@
     "ReadyStateText": "Application started.",
     "Source": {
       "Repository": "https://github.com/dotnet/aspnetcore.git",
-      "BranchOrCommit": "master",
+      "BranchOrCommit": "main",
       "Project": "src/Mvc/benchmarkapps/BasicViews/BasicViews.csproj"
     }
   },
@@ -20,19 +20,19 @@
   },
   "BasicViews.Post": {
     "ClientProperties": {
-      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/master/src/Mvc/benchmarkapps/BasicViews/postWithToken.lua"
+      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Mvc/benchmarkapps/BasicViews/postWithToken.lua"
     },
     "Path": "/Home/Index"
   },
   "BasicViews.PostIgnoringToken": {
     "ClientProperties": {
-      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/master/src/Mvc/benchmarkapps/BasicViews/postWithToken.lua"
+      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Mvc/benchmarkapps/BasicViews/postWithToken.lua"
     },
     "Path": "/Home/IndexWithoutToken"
   },
   "BasicViews.PostWithoutToken": {
     "ClientProperties": {
-      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/master/src/Mvc/benchmarkapps/BasicViews/post.lua"
+      "Scripts": "https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Mvc/benchmarkapps/BasicViews/post.lua"
     },
     "Path": "/Home/IndexWithoutToken"
   }

--- a/src/Razor/README.md
+++ b/src/Razor/README.md
@@ -1,8 +1,6 @@
 Razor
 =====
 
-Travis:   [![Travis](https://travis-ci.org/aspnet/Razor.svg?branch=dev)](https://travis-ci.org/aspnet/Razor)
-
 The Razor syntax provides a fast, terse, clean and lightweight way to combine server code with HTML to create dynamic web content. This repo contains the parser and the C# code generator for the Razor syntax.
 
 This project is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [Home](https://www.github.com/aspnet/home) repo.

--- a/src/Shared/runtime/ReadMe.SharedCode.md
+++ b/src/Shared/runtime/ReadMe.SharedCode.md
@@ -24,7 +24,7 @@ dotnet/AspNetCore code paths:
 - `PS D:\github\runtime\src\libraries\System.Net.Http\tests\UnitTests> dotnet build /t:test`
 
 ## Building dotnet/AspNetCore code:
-- https://github.com/dotnet/AspNetCore/blob/master/docs/BuildFromSource.md
+- https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md
 - Run restore in the root once: `PS D:\github\AspNetCore> .\restore.cmd`
 - Activate to use the repo local runtime: `PS D:\github\AspNetCore> . .\activate.ps1`
 - Build the individual projects:

--- a/src/SignalR/README.md
+++ b/src/SignalR/README.md
@@ -32,7 +32,7 @@ The following contains a description of the sub-directories.
 
 By default, the build script will try to build Java and Typescript projects. If you don't want to include those, you can pass "-NoBuildJava" and "-NoBuildNodeJS" respectively to the build script to skip them. Or "--no-build-java" and "--no-build-nodejs" on MacOS or Linux.
 
-To build this specific project from source, you can follow the instructions [on building a subset of the code](https://github.com/dotnet/aspnetcore/blob/master/docs/BuildFromSource.md#building-a-subset-of-the-code).
+To build this specific project from source, you can follow the instructions [on building a subset of the code](https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md#building-a-subset-of-the-code).
 
 Or for the less detailed explanation, run the following command inside this directory.
 ```powershell
@@ -49,7 +49,7 @@ $ ./build.sh
 
 This project's tests require having "java" and "npm" on your path.
 
-To run the tests for this project, you can [run the tests on the command line](https://github.com/dotnet/aspnetcore/blob/master/docs/BuildFromSource.md#running-tests-on-command-line) in this directory.
+To run the tests for this project, you can [run the tests on the command line](https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md#running-tests-on-command-line) in this directory.
 
 Or for the less detailed explanation, run the following command inside this directory.
 ```powershell

--- a/src/SignalR/clients/java/signalr/core/build.gradle
+++ b/src/SignalR/clients/java/signalr/core/build.gradle
@@ -42,7 +42,7 @@ task generatePOM {
             scm {
                 connection 'scm:git:git://github.com/dotnet/aspnetcore.git'
                 developerConnection 'scm:git:git://github.com/dotnet/aspnetcore.git'
-                url 'http://github.com/dotnet/aspnetcore/tree/master'
+                url 'http://github.com/dotnet/aspnetcore/tree/main'
             }
             developers {
                 developer {

--- a/src/SignalR/clients/java/signalr/messagepack/build.gradle
+++ b/src/SignalR/clients/java/signalr/messagepack/build.gradle
@@ -41,7 +41,7 @@ task generatePOM {
             scm {
                 connection 'scm:git:git://github.com/dotnet/aspnetcore.git'
                 developerConnection 'scm:git:git://github.com/dotnet/aspnetcore.git'
-                url 'http://github.com/dotnet/aspnetcore/tree/master'
+                url 'http://github.com/dotnet/aspnetcore/tree/main'
             }
             developers {
                 developer {

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/package.json
@@ -37,7 +37,7 @@
   "bugs": {
     "url": "https://github.com/dotnet/aspnetcore/issues"
   },
-  "homepage": "https://github.com/dotnet/aspnetcore/tree/master/src/SignalR#readme",
+  "homepage": "https://github.com/dotnet/aspnetcore/tree/main/src/SignalR#readme",
   "files": [
     "dist/**/*",
     "src/**/*"

--- a/src/SignalR/clients/ts/signalr/package.json
+++ b/src/SignalR/clients/ts/signalr/package.json
@@ -40,7 +40,7 @@
   "bugs": {
     "url": "https://github.com/dotnet/aspnetcore/issues"
   },
-  "homepage": "https://github.com/dotnet/aspnetcore/tree/master/src/SignalR#readme",
+  "homepage": "https://github.com/dotnet/aspnetcore/tree/main/src/SignalR#readme",
   "files": [
     "dist/**/*",
     "src/**/*"


### PR DESCRIPTION
- part of #29475
- primarily involves updating links to this repo

nit: Remove broken links to old Travis environments (that happen to mention 'master')