### PR TITLE
Alway skip failing UseSpa tests on Alpine

### DIFF
--- a/src/Middleware/SpaServices.Extensions/test/SpaServicesExtensionsTests.cs
+++ b/src/Middleware/SpaServices.Extensions/test/SpaServicesExtensionsTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Tests
         }
 
         [ConditionalFact]
-        [SkipOnHelix("Flaky on Alpine", Queues = "(Alpine.312.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673")]
+        [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/29549")]
         public async Task UseSpa_KillsRds_WhenAppIsStopped()
         {
             var serviceProvider = GetServiceProvider(s => s.RootPath = "/");
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Tests
         }
 
         [ConditionalFact]
-        [SkipOnHelix("Flaky on Alpine", Queues = "(Alpine.312.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673")]
+        [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/29549")]
         public async Task UseSpa_KillsAngularCli_WhenAppIsStopped()
         {
             var serviceProvider = GetServiceProvider(s => s.RootPath = "/");

--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -106,28 +106,5 @@ namespace Templates.Test
                 }
             }
         }
-
-        /// <summary>
-        /// Skip test if running on Alpine Linux (which uses musl instead of glibc)
-        /// </summary>
-        private class SkipOnAlpineAttribute : Attribute, ITestCondition
-        {
-            public SkipOnAlpineAttribute(string issueUrl = "")
-            {
-                IssueUrl = issueUrl;
-            }
-
-            public string IssueUrl { get; }
-
-            public bool IsMet { get; } = !IsAlpine;
-
-            public string SkipReason => "Test cannot run on Alpine Linux.";
-
-            // This logic is borrowed from https://github.com/dotnet/runtime/blob/6a5a78bec9a6e14b4aa52cd5ac558f6cf5c6a211/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
-            private static bool IsAlpine { get; } =
-                RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/etc/os-release") &&
-                File.ReadAllLines("/etc/os-release").Any(line =>
-                    line.StartsWith("ID=", StringComparison.Ordinal) && line.Substring(3).Trim('"', '\'') == "alpine");
-        }
     }
 }

--- a/src/Testing/src/xunit/SkipOnAlpineAttribute.cs
+++ b/src/Testing/src/xunit/SkipOnAlpineAttribute.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Testing
+{
+    /// <summary>
+    /// Skip test if running on Alpine Linux (which uses musl instead of glibc)
+    /// </summary>
+    public class SkipOnAlpineAttribute : Attribute, ITestCondition
+    {
+        public SkipOnAlpineAttribute(string issueUrl = "")
+        {
+            IssueUrl = issueUrl;
+        }
+
+        public string IssueUrl { get; }
+
+        public bool IsMet { get; } = !IsAlpine;
+
+        public string SkipReason => "Test cannot run on Alpine Linux.";
+
+        // This logic is borrowed from https://github.com/dotnet/runtime/blob/6a5a78bec9a6e14b4aa52cd5ac558f6cf5c6a211/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+        private static bool IsAlpine { get; } =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/etc/os-release") &&
+            File.ReadAllLines("/etc/os-release").Any(line =>
+                line.StartsWith("ID=", StringComparison.Ordinal) && line.Substring(3).Trim('"', '\'') == "alpine");
+    }
+}


### PR DESCRIPTION
It looks like merely skipping the helix queue didn't prevent the test from running on Alpine as part of aspnetcore-helix-matrix. It started failing consistently after https://github.com/dotnet/aspnetcore/pull/29247 was merged yesterday.

https://dev.azure.com/dnceng/public/_build/results?buildId=961017&view=ms.vss-test-web.build-test-results-tab

I'm not sure why the previous SkipOnHelix attributes didn't prevent this since the name seems correct, but as with the GrpcTemplate test, it's better just to read `/etc/os-release` to see if we're running on Alpine because this works outside of helix anyway. See https://github.com/dotnet/aspnetcore/pull/27262 for some previous discussion about this.