### PR TITLE
Build break: Shorten Windows targeting pack CAB name

### DIFF
--- a/eng/targets/Wix.Common.targets
+++ b/eng/targets/Wix.Common.targets
@@ -27,12 +27,15 @@
     <OutputName Condition="'$(OutputNamePrefix)' != '' AND '$(OutputNameSuffix)' != ''">$(OutputNamePrefix)$(_GeneratedPackageVersion)$(OutputNameSuffix)</OutputName>
 
     <EmbedCab Condition="'$(EmbedCab)' == ''">yes</EmbedCab>
-    <Cabinet Condition="'$(Cabinet)' == ''">$(OutputName.Replace('-', '_')).cab</Cabinet>
     <InstallDir>$(ProductName)</InstallDir>
 
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);Debug</DefineConstants>
     <DefineConstants>$(DefineConstants);EmbedCab=$(EmbedCab)</DefineConstants>
-    <DefineConstants>$(DefineConstants);Cabinet=$(Cabinet)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(OutputType)' == 'package' AND '$(Cabinet)' == '' ">
+    <Cabinet>$(OutputName.Replace('-', '_')).cab</Cabinet>
+    <Cabinet Condition=" '$(EmbedCab)' != 'yes' ">$(OutputName.Replace('_win', '')).cab</Cabinet>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -40,6 +43,8 @@
     <Cultures Condition=" '$(Cultures)' == '' ">$(Culture)</Cultures>
     <InstallerPlatform>$(Platform)</InstallerPlatform>
     <OutDir Condition=" '$(OutDir)' == '' ">$(OutputPath)</OutDir>
+
+    <DefineConstants>$(DefineConstants);Cabinet=$(Cabinet)</DefineConstants>
     <DefineConstants>$(DefineConstants);BinPath=$(OutputPath)$(Culture)\</DefineConstants>
     <DefineConstants>$(WixVariables);$(DefineConstants)</DefineConstants>
   </PropertyGroup>

--- a/src/Installers/Windows/TargetingPack/Product.wxs
+++ b/src/Installers/Windows/TargetingPack/Product.wxs
@@ -5,7 +5,13 @@
         <Package InstallerVersion="$(var.InstallerVersion)" Compressed="yes" InstallScope="perMachine" />
 
         <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." Schedule="afterInstallFinalize" />
-        <Media Id="1" Cabinet="$(var.Cabinet)" CompressionLevel="high" EmbedCab="$(var.EmbedCab)" />
+
+        <?if $(var.EmbedCab)=yes?>
+            <!-- Ignore var.Cabinet This element should choose an appropriate name for the embedded CAB. -->
+            <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
+        <?else?>
+            <Media Id="1" Cabinet="$(var.Cabinet)" CompressionLevel="high" EmbedCab="no" />
+        <?endif?>
 
         <WixVariable Id="WixUILicenseRtf" Value="$(var.files)\eula.rtf" />
         <UIRef Id="WixUI_Minimal" />


### PR DESCRIPTION
- use `<MediaTemplate>` and auto-generated name when embedding
- otherwise, stick with `<Media>` but remove `_win` from the CAB name