### PR TITLE
Update appSettings.json to have a comment for org auth cases

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/appsettings.json
@@ -19,7 +19,7 @@
 ///*
 The following identity settings need to be configured
 before the project can be successfully executed.
-For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+For more info see https:////aka.ms/dotnet-template-ms-identity-platform 
 //*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/appsettings.json
@@ -16,6 +16,11 @@
 //    "EditProfilePolicyId": "MyEditProfilePolicyId"
 //  },
 ////#elseif (OrganizationalAuth)
+///*
+The following identity settings need to be configured
+before the project can be successfully executed.
+For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+//*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",
 //#if (MultiOrgAuth)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/appsettings.json
@@ -16,7 +16,7 @@
   ///*
   The following identity settings need to be configured
   before the project can be successfully executed.
-  For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+  For more info see https:////aka.ms/dotnet-template-ms-identity-platform 
   //*/
   //"AzureAd": {
   //  "Authority": "https:////login.microsoftonline.com/22222222-2222-2222-2222-222222222222",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/appsettings.json
@@ -13,6 +13,11 @@
   //}
   ////#endif
   ////#if (OrganizationalAuth)
+  ///*
+  The following identity settings need to be configured
+  before the project can be successfully executed.
+  For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+  //*/
   //"AzureAd": {
   //  "Authority": "https:////login.microsoftonline.com/22222222-2222-2222-2222-222222222222",
   //  "ClientId": "33333333-3333-3333-33333333333333333",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/appsettings.json
@@ -23,7 +23,7 @@
 ///*
 The following identity settings need to be configured
 before the project can be successfully executed.
-For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+For more info see https:////aka.ms/dotnet-template-ms-identity-platform 
 //*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/appsettings.json
@@ -20,6 +20,11 @@
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
 //  },
 ////#elseif (OrganizationalAuth)
+///*
+The following identity settings need to be configured
+before the project can be successfully executed.
+For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+//*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",
 //#if (!SingleOrgAuth)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/appsettings.json
@@ -19,7 +19,7 @@
 ///*
 The following identity settings need to be configured
 before the project can be successfully executed.
-For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+For more info see https:////aka.ms/dotnet-template-ms-identity-platform 
 //*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/appsettings.json
@@ -16,6 +16,11 @@
 //    "EditProfilePolicyId": "MyEditProfilePolicyId"
 //  },
 ////#elseif (OrganizationalAuth)
+///*
+The following identity settings need to be configured
+before the project can be successfully executed.
+For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+//*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",
 //#if (MultiOrgAuth)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/appsettings.json
@@ -19,7 +19,7 @@
 ///*
 The following identity settings need to be configured
 before the project can be successfully executed.
-For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+For more info see https:////aka.ms/dotnet-template-ms-identity-platform 
 //*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/appsettings.json
@@ -16,6 +16,11 @@
 //    "CallbackPath": "/signin-oidc"
 //  },
 ////#elseif (OrganizationalAuth)
+///*
+The following identity settings need to be configured
+before the project can be successfully executed.
+For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+//*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",
 //#if (MultiOrgAuth)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/appsettings.json
@@ -15,7 +15,7 @@
 ///*
 The following identity settings need to be configured
 before the project can be successfully executed.
-For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+For more info see https:////aka.ms/dotnet-template-ms-identity-platform 
 //*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/appsettings.json
@@ -12,6 +12,11 @@
 //    "SignUpSignInPolicyId": "MySignUpSignInPolicyId"
 //  },
 ////#elseif (OrganizationalAuth)
+///*
+The following identity settings need to be configured
+before the project can be successfully executed.
+For more info see https://aka.ms/dotnet-template-ms-identity-platform 
+//*/
 //  "AzureAd": {
 //    "Instance": "https:////login.microsoftonline.com/",
 //#if (!SingleOrgAuth)


### PR DESCRIPTION
I have modified the `appSettings.json` to have a comment that will help users configure Azure settings that are needed for org auth scenarios.

Note: the FWLink that the comment points to will be updated before these are released.

Before merging we will need to test the nuget packages that come out of the build. @phenning and @vijayrkn will assist in testing.

Replaces PR at https://github.com/dotnet/aspnetcore/pull/29604

## Description
This includes a new comments in appSettings.json for asp.net core projects that have been created with Microsoft identity platform as the auth method.
In 16.9, the user will need to create some objects in Azure, and then specify the values in the appSettings.json.
This change includes an FWLink that will point to some docs that the user can follow to complete the process. I'm still working on that doc, so the
link is currently pointing to a general doc about Microsoft identity platform and asp.net core.
Later in 16.10, Visual Studio will do the work to provision the Azure objects and populate appSettings.json, but this comment will still be helpful
for users that create projects with `dotnet new`

## Customer Impact
Helps users complete configuration of asp.net core projects created with Microsoft identity platform as the auth method.

## Regression?
- [ ] Yes
- [X] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [X] Low

Pretty low risk, the change just includes a comment in the `appSettings.json` files for asp.net core projects that support Microsoft identity platform auth.

[Justify the selection above]

## Verification
- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A
Not sure what this question is asking here.

Addresses [issue number]
No issue tracking this currently