### PR TITLE
When looking up the async entry point also look for "<Main>$"

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/EntrypointInvoker.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/EntrypointInvoker.cs
@@ -49,24 +49,28 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
 
             // For "async Task Main", the C# compiler generates a method called "<Main>"
             // that is marked as the assembly entrypoint. Detect this case, and instead of
-            // calling "<Whatever>", call the sibling "Whatever".
+            // calling "<Whatever>", call the sibling "Whatever".  Top level main methods
+            // are generated with the name "<Main>$" so also check for that "<Whatever>$".
             if (metadataEntrypointMethodBase!.IsSpecialName)
             {
                 var origName = metadataEntrypointMethodBase.Name;
                 var origNameLength = origName.Length;
                 if (origNameLength > 2)
                 {
-                    var candidateMethodName = origName.Substring(1, origNameLength - 2);
-                    var candidateMethod = metadataEntrypointMethodBase.DeclaringType!.GetMethod(
-                        candidateMethodName,
-                        BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
-                        null,
-                        metadataEntrypointMethodBase.GetParameters().Select(p => p.ParameterType).ToArray(),
-                        null);
-
-                    if (candidateMethod != null)
+                    var candidateNames = new [] { origName.Substring(1, origNameLength - 2), origName + "$" };
+                    foreach (var candidateMethodName in candidateNames)
                     {
-                        return candidateMethod;
+                        var candidateMethod = metadataEntrypointMethodBase.DeclaringType!.GetMethod(
+                            candidateMethodName,
+                            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+                            null,
+                            metadataEntrypointMethodBase.GetParameters().Select(p => p.ParameterType).ToArray(),
+                            null);
+
+                        if (candidateMethod != null)
+                        {
+                            return candidateMethod;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Look for top level style "&lt;Main&gt;$" in addition to "Main" when looking for an async entry point.

Fixes https://github.com/dotnet/runtime/issues/47404 for blazor

/cc @javiercn 