### PR TITLE
Set all environment variables as UPPERCASE in pipeline

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -102,10 +102,10 @@ jobs:
               /p:SharedFxRID=win-x64
               /bl:artifacts/logs/SharedFx-win-x64.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build win-x64 SharedFX
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -118,10 +118,10 @@ jobs:
               /p:SharedFxRID=win-x86
               /bl:artifacts/logs/SharedFx-win-x86.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build win-x86 SharedFX
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -135,10 +135,10 @@ jobs:
               /t:DoCodeSigning
               /bl:artifacts/logs/CodeSign.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Code Sign
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -198,10 +198,10 @@ jobs:
               /p:SharedFxRID=osx-x64
               /bl:artifacts/logs/SharedFx-osx-x64.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build osx-x64 SharedFX
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
@@ -246,10 +246,10 @@ jobs:
               /p:SharedFXRid=linux-x64
               /bl:artifacts/logs/SharedFx-linux-x64.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build linux-x64 SharedFX
     - script: ./$(BuildDirectory)/build.sh
               -ci
@@ -259,10 +259,10 @@ jobs:
               /p:IsLinuxArmSupported=true
               /bl:artifacts/logs/SharedFx-linux-arm.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build linux-arm SharedFX
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
@@ -310,10 +310,10 @@ jobs:
               /p:SharedFXRid=linux-musl-x64
               /bl:artifacts/logs/SharedFx-linux-musl-x64.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build linux-musl-x64 SharedFX
     - bash: docker system prune -af
       displayName: Docker prune
@@ -386,10 +386,10 @@ jobs:
         -Config Release
         -BuildNumber $(Build.BuildId)
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Run src/Installers/Windows/build.ps1
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -443,10 +443,10 @@ jobs:
               /t:BuildFallbackArchive
               /bl:artifacts/logs/PackageArchive.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build Package Archive
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
@@ -530,10 +530,10 @@ jobs:
               /t:BuildInstallers
               /bl:artifacts/logs/SharedFx-Installers.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build SharedFX Installers
     - bash: docker system prune -af
       displayName: Docker prune
@@ -703,10 +703,10 @@ jobs:
               /p:BuildBranch=$(Build.SourceBranchName)
               /bl:artifacts/logs/Publish.binlog
       env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
+        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+        PB_ASSETROOTURL: $(PB_AssetRootUrl)
+        PB_RESTORESOURCE: $(PB_RestoreSource)
+        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Publish
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes


### PR DESCRIPTION
`run.sh` looks for these vars in all UPPERCASE: https://github.com/dotnet/aspnetcore/blob/3d0f8db69463c72278dd15efbe629b0b98e2ac9a/run.sh#L23-L24. Since Unix is case-sensitive, this means that official builds weren't getting the value of these vars, and were therefore not restoring from the live-built feeds.