### PR TITLE
Requarantine component tests

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24688")]
         public override void EventDuringBatchRendering_CanTriggerDOMEvents()
         {
             base.EventDuringBatchRendering_CanTriggerDOMEvents();

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerGlobalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerGlobalizationTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Theory]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27155")]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27556")]
         [InlineData("en-US")]
         [InlineData("fr-FR")]
         public override void CanSetCultureAndParseCultureSensitiveNumbersAndDates(string culture)

--- a/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
@@ -43,6 +43,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void CanSendAndReceiveBytes()
         {
             IssueRequest("/subdir/api/data");

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -42,6 +42,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void CanRenderTextOnlyComponent()
         {
             var appElement = Browser.MountTestComponent<TextOnlyComponent>();

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -48,6 +48,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void BubblingStandardEvent_FiredOnElementWithoutHandler()
         {
             Browser.Exists(By.Id("button-without-onclick")).Click();

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -177,6 +177,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25929")]
         public void PreventDefault_DotNotApplyByDefault()
         {
             var appElement = Browser.MountTestComponent<EventPreventDefaultComponent>();
@@ -203,6 +204,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23757")]
         public void InputEvent_RespondsOnKeystrokes_EvenIfUpdatesAreLaggy()
         {
             // This test doesn't mean much on WebAssembly - it just shows that even if the CPU is locked

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -195,6 +195,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27398")]
         public void InputDateInteractsWithEditContext_NonNullableDateTime()
         {
             var appElement = MountTypicalValidationComponent();
@@ -303,6 +304,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24850")]
         public void InputRadioGroupWithoutNameInteractsWithEditContext()
         {
             var appElement = MountTypicalValidationComponent();
@@ -342,6 +344,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24850")]
         public void InputRadioGroupsWithNamesNestedInteractWithEditContext()
         {
             var appElement = MountTypicalValidationComponent();

--- a/src/Components/test/E2ETest/Tests/InputFileTest.cs
+++ b/src/Components/test/E2ETest/Tests/InputFileTest.cs
@@ -66,6 +66,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/26331")]
         public void CanUploadSingleLargeFile()
         {
             // Create a large text file
@@ -130,6 +131,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25929")]
         public void CanUploadAndConvertImageFile()
         {
             var sourceImageId = "image-source";

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void BenchmarksRunWithoutError()
         {
             // In CI, we only verify that the benchmarks run without throwing any

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -195,6 +195,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24922")]
         public void CanUseViewportAsContainer()
         {
             Browser.MountTestComponent<VirtualizationComponent>();

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLazyLoadTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLazyLoadTest.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23856")]
         public void CanLazyLoadOnRouteChange()
         {
             // Navigate to a page without any lazy-loaded dependencies
@@ -60,6 +61,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23856")]
         public void CanLazyLoadOnFirstVisit()
         {
             // Navigate to a page with lazy loaded assemblies for the first time


### PR DESCRIPTION
Roll back the component tests that were renabled in https://github.com/dotnet/aspnetcore/commit/3f7b205c7c7316ae683e6d4386d04b685e0b9a61#diff-161948171825dc8c1b30fdc7c517d8e960d462359d1959cd30aa428ad16172f2