### PR TITLE
Add IHttpMinRequestBodyDataRateFeature to Http3Stream

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -554,8 +554,8 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http2ErrorStreamAborted" xml:space="preserve">
     <value>A frame of type {frameType} was received after stream {streamId} was reset or aborted.</value>
   </data>
-  <data name="Http2MinDataRateNotSupported" xml:space="preserve">
-    <value>This feature is not supported for HTTP/2 requests except to disable it entirely by setting the rate to null.</value>
+  <data name="HttpMinDataRateNotSupported" xml:space="preserve">
+    <value>This feature is not supported for HTTP/2 and HTTP/3 requests except to disable it entirely by setting the rate to null.</value>
   </data>
   <data name="RequestTrailersNotAvailable" xml:space="preserve">
     <value>The request trailers are not available yet. They may not be available until the full request body is read.</value>

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.FeatureCollection.cs
@@ -48,12 +48,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         MinDataRate? IHttpMinRequestBodyDataRateFeature.MinDataRate
         {
-            get => throw new NotSupportedException(CoreStrings.Http2MinDataRateNotSupported);
+            get => throw new NotSupportedException(CoreStrings.HttpMinDataRateNotSupported);
             set 
             {
                 if (value != null)
                 {
-                    throw new NotSupportedException(CoreStrings.Http2MinDataRateNotSupported);
+                    throw new NotSupportedException(CoreStrings.HttpMinDataRateNotSupported);
                 }
 
                 MinRequestBodyDataRate = value;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.FeatureCollection.cs
@@ -6,11 +6,13 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
     internal partial class Http3Stream : IHttpResetFeature,
+                                         IHttpMinRequestBodyDataRateFeature,
                                          IHttpResponseTrailersFeature
     {
         private IHeaderDictionary? _userTrailers;
@@ -37,6 +39,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 }
 
                 _userTrailers = value;
+            }
+        }
+
+        MinDataRate? IHttpMinRequestBodyDataRateFeature.MinDataRate
+        {
+            get => throw new NotSupportedException(CoreStrings.HttpMinDataRateNotSupported);
+            set
+            {
+                if (value != null)
+                {
+                    throw new NotSupportedException(CoreStrings.HttpMinDataRateNotSupported);
+                }
+
+                MinRequestBodyDataRate = value;
             }
         }
 

--- a/src/Servers/Kestrel/Core/test/Http3HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3HttpProtocolFeatureCollectionTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Experimental;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class Http3HttpProtocolFeatureCollectionTests
+    {
+        private readonly IFeatureCollection _http3Collection;
+
+        public Http3HttpProtocolFeatureCollectionTests()
+        {
+            var connection = new Http3Connection(TestContextFactory.CreateHttp3ConnectionContext());
+
+            var streamContext = TestContextFactory.CreateHttp3StreamContext();
+
+            var http3Stream = new TestHttp3Stream(connection, streamContext);
+            http3Stream.Reset();
+            _http3Collection = http3Stream;
+        }
+
+        [Fact]
+        public void Http3StreamFeatureCollectionDoesNotIncludeIHttpMinResponseDataRateFeature()
+        {
+            Assert.Null(_http3Collection.Get<IHttpMinResponseDataRateFeature>());
+        }
+
+        [Fact]
+        public void Http3StreamFeatureCollectionDoesIncludeUpgradeFeature()
+        {
+            var upgradeFeature = _http3Collection.Get<IHttpUpgradeFeature>();
+
+            Assert.NotNull(upgradeFeature);
+            Assert.False(upgradeFeature.IsUpgradableRequest);
+        }
+
+        [Fact]
+        public void Http3StreamFeatureCollectionDoesIncludeIHttpMinRequestBodyDataRateFeature()
+        {
+            var minRateFeature = _http3Collection.Get<IHttpMinRequestBodyDataRateFeature>();
+
+            Assert.NotNull(minRateFeature);
+
+            Assert.Throws<NotSupportedException>(() => minRateFeature.MinDataRate);
+            Assert.Throws<NotSupportedException>(() => minRateFeature.MinDataRate = new MinDataRate(1, TimeSpan.FromSeconds(2)));
+
+            // You can set the MinDataRate to null though.
+            minRateFeature.MinDataRate = null;
+
+            // But you still cannot read the property;
+            Assert.Throws<NotSupportedException>(() => minRateFeature.MinDataRate);
+        }
+
+        private class TestHttp3Stream : Http3Stream
+        {
+            public TestHttp3Stream(Http3Connection connection, Http3StreamContext context) : base(connection, context)
+            {
+            }
+
+            public override void Execute()
+            {
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/test/Http3HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3HttpProtocolFeatureCollectionTests.cs
@@ -2,13 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Buffers;
-using System.Collections.Generic;
 using System.IO.Pipelines;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Connections.Experimental;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
@@ -26,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             var connection = new Http3Connection(TestContextFactory.CreateHttp3ConnectionContext());
 
-            var streamContext = TestContextFactory.CreateHttp3StreamContext();
+            var streamContext = TestContextFactory.CreateHttp3StreamContext(transport: DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions()).Application);
 
             var http3Stream = new TestHttp3Stream(connection, streamContext);
             http3Stream.Reset();

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Testing
                 memoryPool: memoryPool ?? MemoryPool<byte>.Shared,
                 localEndPoint: localEndPoint,
                 remoteEndPoint: remoteEndPoint,
-                transport: transport ?? DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions()).Application,
+                transport: transport,
                 streamContext: null,
                 settings: null
             );

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Experimental;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
@@ -70,6 +73,28 @@ namespace Microsoft.AspNetCore.Testing
             return context;
         }
 
+        public static Http3ConnectionContext CreateHttp3ConnectionContext(
+            MultiplexedConnectionContext connectionContext = null,
+            ServiceContext serviceContext = null,
+            IFeatureCollection connectionFeatures = null,
+            MemoryPool<byte> memoryPool = null,
+            IPEndPoint localEndPoint = null,
+            IPEndPoint remoteEndPoint = null,
+            ITimeoutControl timeoutControl = null)
+        {
+            var http3ConnectionContext = new Http3ConnectionContext(
+                "TestConnectionId",
+                connectionContext ?? new TestMultiplexedConnectionContext(),
+                serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
+                connectionFeatures ?? new FeatureCollection(),
+                memoryPool ?? SlabMemoryPoolFactory.Create(),
+                localEndPoint,
+                remoteEndPoint);
+            http3ConnectionContext.TimeoutControl = timeoutControl;
+
+            return http3ConnectionContext;
+        }
+
         public static AddressBindContext CreateAddressBindContext(
             ServerAddressesFeature serverAddressesFeature,
             KestrelServerOptions serverOptions,
@@ -121,6 +146,61 @@ namespace Microsoft.AspNetCore.Testing
             context.TimeoutControl = timeoutControl;
 
             return context;
+        }
+
+        public static Http3StreamContext CreateHttp3StreamContext(
+            string connectionId = null,
+            ConnectionContext connectionContext = null,
+            ServiceContext serviceContext = null,
+            IFeatureCollection connectionFeatures = null,
+            MemoryPool<byte> memoryPool = null,
+            IPEndPoint localEndPoint = null,
+            IPEndPoint remoteEndPoint = null,
+            IDuplexPipe transport = null,
+            ITimeoutControl timeoutControl = null)
+        {
+            var context = new Http3StreamContext
+            (
+                connectionId: connectionId ?? "TestConnectionId",
+                protocols: HttpProtocols.Http3,
+                connectionContext: connectionContext,
+                serviceContext: serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
+                connectionFeatures: connectionFeatures ?? new FeatureCollection(),
+                memoryPool: memoryPool ?? MemoryPool<byte>.Shared,
+                localEndPoint: localEndPoint,
+                remoteEndPoint: remoteEndPoint,
+                transport: transport ?? DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions()).Application,
+                streamContext: null,
+                settings: null
+            );
+            context.TimeoutControl = timeoutControl;
+
+            return context;
+        }
+
+        private class TestMultiplexedConnectionContext : MultiplexedConnectionContext
+        {
+            public override string ConnectionId { get; set; }
+            public override IFeatureCollection Features { get; }
+            public override IDictionary<object, object> Items { get; set; }
+
+            public override void Abort()
+            {
+            }
+
+            public override void Abort(ConnectionAbortedException abortReason)
+            {
+            }
+
+            public override ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
+            {
+                return default;
+            }
+
+            public override ValueTask<ConnectionContext> ConnectAsync(IFeatureCollection features = null, CancellationToken cancellationToken = default)
+            {
+                return default;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/29615

I don't see any tests for request body data rate with HTTP/3. I presume that HTTP/3 should have equivilent functionality here to HTTP/2?