### PR TITLE
Added solution filter for Native IIS components

### DIFF
--- a/src/Servers/IIS/NativeIISIntegration.slnf
+++ b/src/Servers/IIS/NativeIISIntegration.slnf
@@ -1,0 +1,15 @@
+{
+  "solution": {
+    "path": "..\\..\\..\\AspNetCore.sln",
+    "projects": [
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\AspNetCore\\AspNetCore.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\CommonLib\\CommonLib.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\CommonLibTests\\CommonLibTests.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\gtest\\gtest.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\IISLib\\IISLib.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\InProcessRequestHandler\\InProcessRequestHandler.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\OutOfProcessRequestHandler\\OutOfProcessRequestHandler.vcxproj",
+      "src\\Servers\\IIS\\AspNetCoreModuleV2\\RequestHandlerLib\\RequestHandlerLib.vcxproj",
+    ]
+  }
+}


### PR DESCRIPTION
While working with the native IIS component, I find that there is no solution filter available in `/src/Servers/IIS` that loads the projects of the native C++ component! So this PR will create a new solution filter that will load all native components from `src/Servers/IIS/AspNetCoreModuleV2` so that it will be easier while working with multiple c++ projects! 