### PR TITLE
Add connection logging for multiplexed connections

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -417,6 +417,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 }
                 finally
                 {
+                    await _context.StreamContext.DisposeAsync();
+
                     _http3Connection.RemoveStream(_streamIdFeature.StreamId);
                 }
             }

--- a/src/Servers/Kestrel/Core/src/Middleware/ListenOptionsConnectionLoggingExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/ListenOptionsConnectionLoggingExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Connections.Experimental;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,7 +35,12 @@ namespace Microsoft.AspNetCore.Hosting
         {
             var loggerFactory = listenOptions.KestrelServerOptions.ApplicationServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerName == null ? loggerFactory.CreateLogger<LoggingConnectionMiddleware>() : loggerFactory.CreateLogger(loggerName);
+
             listenOptions.Use(next => new LoggingConnectionMiddleware(next, logger).OnConnectionAsync);
+
+            IMultiplexedConnectionBuilder multiplexedConnectionBuilder = listenOptions;
+            multiplexedConnectionBuilder.Use(next => new LoggingMultiplexedConnectionMiddleware(next, logger).OnConnectionAsync);
+
             return listenOptions;
         }
     }

--- a/src/Servers/Kestrel/Core/src/Middleware/LoggingConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/LoggingConnectionMiddleware.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO.Pipelines;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
@@ -36,14 +36,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             finally
             {
                 context.Transport = oldTransport;
-            }
-        }
-
-        private class LoggingDuplexPipe : DuplexPipeStreamAdapter<LoggingStream>
-        {
-            public LoggingDuplexPipe(IDuplexPipe transport, ILogger logger) :
-                base(transport, stream => new LoggingStream(stream, logger))
-            {
             }
         }
     }

--- a/src/Servers/Kestrel/Core/src/Middleware/LoggingDuplexPipe.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/LoggingDuplexPipe.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO.Pipelines;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
+{
+    internal class LoggingDuplexPipe : DuplexPipeStreamAdapter<LoggingStream>
+    {
+        public LoggingDuplexPipe(IDuplexPipe transport, ILogger logger) :
+            base(transport, stream => new LoggingStream(stream, logger))
+        {
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Middleware/LoggingMultiplexedConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/LoggingMultiplexedConnectionMiddleware.cs
@@ -1,0 +1,137 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Experimental;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
+{
+    internal class LoggingMultiplexedConnectionMiddleware
+    {
+        private readonly MultiplexedConnectionDelegate _multiplexedNext;
+        private readonly ILogger _logger;
+
+        public LoggingMultiplexedConnectionMiddleware(MultiplexedConnectionDelegate multiplexedNext, ILogger logger)
+        {
+            _multiplexedNext = multiplexedNext ?? throw new ArgumentNullException(nameof(multiplexedNext));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task OnConnectionAsync(MultiplexedConnectionContext context)
+        {
+            return _multiplexedNext(new LoggingMultiplexedConnectionContext(context, _logger));
+        }
+
+        /// <summary>
+        /// Wrap the initial <see cref="MultiplexedConnectionContext"/>.
+        /// ConnectionContext's returned from ConnectAsync and AcceptAsync will then be wrapped.
+        /// </summary>
+        private class LoggingMultiplexedConnectionContext : MultiplexedConnectionContext
+        {
+            private readonly MultiplexedConnectionContext _inner;
+            private readonly ILogger _logger;
+
+            public LoggingMultiplexedConnectionContext(MultiplexedConnectionContext inner, ILogger logger)
+            {
+                _inner = inner;
+                _logger = logger;
+            }
+
+            public override string ConnectionId { get => _inner.ConnectionId; set => _inner.ConnectionId = value; }
+            public override IFeatureCollection Features => _inner.Features;
+            public override IDictionary<object, object?> Items { get => _inner.Items; set => _inner.Items = value; }
+
+            public override void Abort()
+            {
+                _inner.Abort();
+            }
+
+            public override void Abort(ConnectionAbortedException abortReason)
+            {
+                _inner.Abort(abortReason);
+            }
+
+            public override async ValueTask<ConnectionContext?> AcceptAsync(CancellationToken cancellationToken = default)
+            {
+                var context = await _inner.AcceptAsync(cancellationToken);
+                if (context != null)
+                {
+                    context = new LoggingConnectionContext(context, _logger);
+                }
+                return context;
+            }
+
+            public override async ValueTask<ConnectionContext> ConnectAsync(IFeatureCollection? features = null, CancellationToken cancellationToken = default)
+            {
+                var context = await _inner.ConnectAsync(features, cancellationToken);
+                context = new LoggingConnectionContext(context, _logger);
+                return context;
+            }
+
+            public override CancellationToken ConnectionClosed { get => _inner.ConnectionClosed; set => _inner.ConnectionClosed = value; }
+            public override ValueTask DisposeAsync()
+            {
+                return _inner.DisposeAsync();
+            }
+            public override EndPoint? LocalEndPoint { get => _inner.LocalEndPoint; set => _inner.LocalEndPoint = value; }
+            public override EndPoint? RemoteEndPoint { get => _inner.RemoteEndPoint; set => _inner.RemoteEndPoint = value; }
+        }
+
+        /// <summary>
+        /// Wraps transport with <see cref="LoggingDuplexPipe"/>.
+        /// </summary>
+        private class LoggingConnectionContext : ConnectionContext
+        {
+            private readonly ConnectionContext _inner;
+            private readonly ILogger _logger;
+            private readonly LoggingDuplexPipe _loggingPipe;
+
+            public LoggingConnectionContext(ConnectionContext inner, ILogger logger)
+            {
+                _inner = inner;
+                _logger = logger;
+
+                _loggingPipe = new LoggingDuplexPipe(_inner.Transport, _logger);
+
+                Transport = _loggingPipe;
+            }
+
+            public override void Abort()
+            {
+                _inner.Abort();
+            }
+            public override void Abort(ConnectionAbortedException abortReason)
+            {
+                _inner.Abort(abortReason);
+            }
+
+            public override CancellationToken ConnectionClosed { get => _inner.ConnectionClosed; set => _inner.ConnectionClosed = value; }
+
+            public override string ConnectionId { get => _inner.ConnectionId; set => _inner.ConnectionId = value; }
+
+            public override async ValueTask DisposeAsync()
+            {
+                await _loggingPipe.DisposeAsync();
+                await _inner.DisposeAsync();
+            }
+
+            public override IFeatureCollection Features => _inner.Features;
+
+            public override IDictionary<object, object?> Items { get => _inner.Items; set => _inner.Items = value; }
+
+            public override EndPoint? LocalEndPoint { get => _inner.LocalEndPoint; set => _inner.LocalEndPoint = value; }
+            public override EndPoint? RemoteEndPoint { get => _inner.RemoteEndPoint; set => _inner.RemoteEndPoint = value; }
+
+            public override IDuplexPipe Transport { get => _inner.Transport; set => _inner.Transport = value; }
+        }
+    }
+}

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -42,6 +42,7 @@ namespace Http3SampleApp
                             {
                                 httpsOptions.ServerCertificate = cert;
                             });
+                            listenOptions.UseConnectionLogging();
                             listenOptions.Protocols = HttpProtocols.Http3;
                         });
                     })


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/29436

Output:

```
dbug: Microsoft.Extensions.Hosting.Internal.Host[1]
      Hosting starting
warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'https://localhost:5001, http://localhost:5000'. Binding to endpoints defined via IConfiguration and/or UseKestrel() instead.
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: https://0.0.0.0:5557
dbug: Microsoft.AspNetCore.Hosting.Diagnostics[0]
      Loaded hosting startup assembly Http3SampleApp
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: C:\Development\Source\AspNetCore\artifacts\bin\Http3SampleApp\Debug\net6.0\
dbug: Microsoft.Extensions.Hosting.Internal.Host[2]
      Hosting started
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
dbug: Microsoft.Extensions.Hosting.Internal.Host[3]
      Hosting stopping
dbug: Microsoft.AspNetCore.Server.Kestrel.Transport.MsQuic[0]
      Listener has aborted with exception: Operation aborted.
dbug: Microsoft.Extensions.Hosting.Internal.Host[4]
      Hosting stopped
(AspNetCore) C:\Development\Source\AspNetCore\src\Servers\Kestrel\samples\Http3SampleApp [jamesnk/http3-connectionlogging ≡ +1 ~2 -0 !]> dotnet run
dbug: Microsoft.Extensions.Hosting.Internal.Host[1]
      Hosting starting
warn: Microsoft.AspNetCore.Server.Kestrel[0]
      Overriding address(es) 'https://localhost:5001, http://localhost:5000'. Binding to endpoints defined via IConfiguration and/or UseKestrel() instead.
info: Microsoft.Hosting.Lifetime[0]
      Now listening on: https://0.0.0.0:5557
dbug: Microsoft.AspNetCore.Hosting.Diagnostics[0]
      Loaded hosting startup assembly Http3SampleApp
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: C:\Development\Source\AspNetCore\artifacts\bin\Http3SampleApp\Debug\net6.0\
dbug: Microsoft.Extensions.Hosting.Internal.Host[2]
      Hosting started
dbug: Microsoft.AspNetCore.Server.Kestrel.Transport.MsQuic[1]
      Connection id "0HM633MU3AAQ7" accepted.
dbug: Microsoft.AspNetCore.Server.Kestrel[39]
      Connection id "0HM633MU3AAQ7" accepted.
dbug: Microsoft.AspNetCore.Server.Kestrel[1]
      Connection id "0HM633MU3AAQ7" started.
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      WriteAsync[1]
      00                                                 .
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      WriteAsync[5]
      04 03 06 60 00                                     ...`.
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      ReadAsync[8]
      00 04 05 06 80 01 00 00                            ........
trce: Microsoft.AspNetCore.Server.Kestrel[46]
      Connection id "0HM633MU3AAQ7:2" received Settings frame for stream ID 2 with length 5.
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      ReadAsync[65]
      01 32 00 00 D1 D7 50 0E  6C 6F 63 61 6C 68 6F 73   .2..Ñ×P. localhos
      74 3A 35 35 35 37 C1 37  01 61 6C 74 2D 75 73 65   t:5557Á7 .alt-use
      64 0E 6C 6F 63 61 6C 68  6F 73 74 3A 35 35 35 37   d.localh ost:5557
      74 02 31 31 00 0B 48 65  6C 6C 6F 20 77 6F 72 6C   t.11..He llo worl
      64                                                 d
trce: Microsoft.AspNetCore.Server.Kestrel[46]
      Connection id "0HM633MU3AAQ7:0" received Headers frame for stream ID 0 with length 50.
trce: Microsoft.AspNetCore.Server.Kestrel[46]
      Connection id "0HM633MU3AAQ7:0" received Data frame for stream ID 0 with length 11.
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      ReadAsync[0]
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/3 GET https://localhost:5557/ - 11
dbug: Microsoft.AspNetCore.Server.Kestrel[25]
      Connection id "0HM633MU3AAQ7:0", Request id "0HM633MU3AAQ7:0": started reading request body.
dbug: Microsoft.AspNetCore.Server.Kestrel[26]
      Connection id "0HM633MU3AAQ7:0", Request id "0HM633MU3AAQ7:0": done reading request body.
trce: Microsoft.AspNetCore.Server.Kestrel[47]
      Connection id "0HM633MU3AAQ7:0" sending Headers frame for stream ID 0 with length 62.
trce: Microsoft.AspNetCore.Server.Kestrel[47]
      Connection id "0HM633MU3AAQ7:0" sending Data frame for stream ID 0 with length 19.
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      WriteAsync[85]
      01 3E 00 00 D9 34 64 61  74 65 1D 57 65 64 2C 20   .>..Ù4da te.Wed,
      32 37 20 4A 61 6E 20 32  30 32 31 20 32 33 3A 34   27 Jan 2 021 23:4
      36 3A 31 34 20 47 4D 54  36 73 65 72 76 65 72 07   6:14 GMT 6server.
      4B 65 73 74 72 65 6C 34  74 65 73 74 03 66 6F 6F   Kestrel4 test.foo
      00 13 48 65 6C 6C 6F 20  57 6F 72 6C 64 21 20 48   ..Hello  World! H
      54 54 50 2F 33                                     TTP/3
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/3 GET https://localhost:5557/ - 11 - 200 - - 53.9519ms
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      ReadAsync[0]
dbug: Microsoft.AspNetCore.Server.Kestrel[44]
      Connection id "0HM633MU3AAQ7" is closed. The last processed stream ID was 0.
trce: Microsoft.AspNetCore.Server.Kestrel[47]
      Connection id "(null)" sending GoAway frame for stream ID 3 with length 1.
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      WriteAsync[3]
      07 01 00                                           ...
dbug: Microsoft.AspNetCore.Server.Kestrel.Transport.MsQuic[7]
      Stream id "0HM633MU3AAQ7:3" shutting down writes because: "Could not send data to peer. Error Code: INVALID_STATE".
dbug: Microsoft.AspNetCore.Server.Kestrel[2]
      Connection id "0HM633MU3AAQ7" stopped.
```

~There is a hang of 10 seconds here:~

```
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/3 GET https://localhost:5557/ - 11 - 200 - - 53.9519ms
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware[0]
      ReadAsync[0]
```

~Something about the SDK at the moment has broken debugging for me so I'm waiting until it is fixed before finding the exact cause. I'm guessing a close/end event is not being propagated.~

~Dispose is never called on the debug transport streams set by the multiplexed connection.~