### PR TITLE
Remove Skip Windows.10.Amd64.Server20H1.Open Helix Queue

### DIFF
--- a/src/Middleware/Diagnostics/test/FunctionalTests/Diagnostics.FunctionalTests.csproj
+++ b/src/Middleware/Diagnostics/test/FunctionalTests/Diagnostics.FunctionalTests.csproj
@@ -5,7 +5,6 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyName>Diagnostics.FunctionalTests</AssemblyName>
     <TestDependsOnMssql>true</TestDependsOnMssql>
-    <SkipHelixQueues>Windows.10.Amd64.Server20H1.Open</SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As discussed in https://github.com/dotnet/aspnetcore/issues/25768#issuecomment-768680237, un-skipping the Windows.10.Amd64.Server20H1.Open Helix Queue.