### PR TITLE
Dispose X509Chain in CertificateAuthenticationHandler

### DIFF
--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Authentication.Certificate
             }
 
             var chainPolicy = BuildChainPolicy(clientCertificate);
-            var chain = new X509Chain
+            using var chain = new X509Chain
             {
                 ChainPolicy = chainPolicy
             };

--- a/src/Security/test/AuthSamples.FunctionalTests/CustomPolicyProviderTests.cs
+++ b/src/Security/test/AuthSamples.FunctionalTests/CustomPolicyProviderTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Globalization;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
@@ -47,7 +48,7 @@ namespace AuthSamples.FunctionalTests
         public async Task MinimumAge10WorksIfOldEnough()
         {
             // Arrange & Act
-            var signIn = await SignIn(Client, "Dude", DateTime.Now.Subtract(TimeSpan.FromDays(365 * 20)).ToShortDateString());
+            var signIn = await SignIn(Client, "Dude", DateTime.Now.Subtract(TimeSpan.FromDays(365 * 20)).ToString(DateTimeFormatInfo.InvariantInfo.ShortDatePattern, CultureInfo.InvariantCulture));
             Assert.Equal(HttpStatusCode.OK, signIn.StatusCode);
 
             var response = await Client.GetAsync("/Home/MinimumAge10");
@@ -63,7 +64,7 @@ namespace AuthSamples.FunctionalTests
         public async Task MinimumAge10FailsIfNotOldEnough()
         {
             // Arrange & Act
-            var signIn = await SignIn(Client, "Dude", DateTime.Now.Subtract(TimeSpan.FromDays(365 * 5)).ToShortDateString());
+            var signIn = await SignIn(Client, "Dude", DateTime.Now.Subtract(TimeSpan.FromDays(365 * 5)).ToString(DateTimeFormatInfo.InvariantInfo.ShortDatePattern, CultureInfo.InvariantCulture));
             Assert.Equal(HttpStatusCode.OK, signIn.StatusCode);
 
             var response = await Client.GetAsync("/Home/MinimumAge10");
@@ -78,7 +79,7 @@ namespace AuthSamples.FunctionalTests
         public async Task MinimumAge50WorksIfOldEnough()
         {
             // Arrange & Act
-            var signIn = await SignIn(Client, "Dude", DateTime.Now.Subtract(TimeSpan.FromDays(365 * 55)).ToShortDateString());
+            var signIn = await SignIn(Client, "Dude", DateTime.Now.Subtract(TimeSpan.FromDays(365 * 55)).ToString(DateTimeFormatInfo.InvariantInfo.ShortDatePattern, CultureInfo.InvariantCulture));
             Assert.Equal(HttpStatusCode.OK, signIn.StatusCode);
 
             var response = await Client.GetAsync("/Home/MinimumAge50");
@@ -94,7 +95,7 @@ namespace AuthSamples.FunctionalTests
         public async Task MinimumAge50FailsIfNotOldEnough()
         {
             // Arrange & Act
-            var signIn = await SignIn(Client, "Dude", DateTime.Now.Subtract(TimeSpan.FromDays(365 * 20)).ToShortDateString());
+            var signIn = await SignIn(Client, "Dude", DateTime.Now.Subtract(TimeSpan.FromDays(365 * 20)).ToString(DateTimeFormatInfo.InvariantInfo.ShortDatePattern, CultureInfo.InvariantCulture));
             Assert.Equal(HttpStatusCode.OK, signIn.StatusCode);
 
             var response = await Client.GetAsync("/Home/MinimumAge50");

--- a/src/Security/test/AuthSamples.FunctionalTests/CustomPolicyProviderTests.cs
+++ b/src/Security/test/AuthSamples.FunctionalTests/CustomPolicyProviderTests.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.Globalization;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 


### PR DESCRIPTION
**PR Description**
* Added using statement before the var deceleration of the X509Chain
* Fixed failing test that depended on the current culture

Fixes #29680
