### PR TITLE
Quarantine E2E Test DownloadFileFromAnchor

### DIFF
--- a/src/Components/test/E2ETest/Tests/DownloadAnchorTest.cs
+++ b/src/Components/test/E2ETest/Tests/DownloadAnchorTest.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/29739")]
         public void DownloadFileFromAnchor()
         {
             // Arrange

--- a/src/Components/test/E2ETest/Tests/DownloadAnchorTest.cs
+++ b/src/Components/test/E2ETest/Tests/DownloadAnchorTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using OpenQA.Selenium;
 using Xunit;


### PR DESCRIPTION
Extension of tests quarantined in #29652 / #29698.

Failure: https://dev.azure.com/dnceng/public/_build/results?buildId=970420&view=ms.vss-test-web.build-test-results-tab&runId=30490800&resultId=100005&paneView=debug
