### PR TITLE
RazorPage: Allow IgnoreSection to specify sections that do not exist

### DIFF
--- a/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-~Microsoft.AspNetCore.Mvc.Razor.RazorPage.IgnoreSection(string sectionName, bool required) -> void

--- a/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~Microsoft.AspNetCore.Mvc.Razor.RazorPage.IgnoreSection(string sectionName, bool required) -> void

--- a/src/Mvc/Mvc.Razor/src/RazorPage.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPage.cs
@@ -215,43 +215,21 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// </summary>
         /// <param name="sectionName">The section to ignore.</param>
         public void IgnoreSection(string sectionName)
-            => IgnoreSectionCore(sectionName, true);
-
-        /// <summary>
-        /// In layout pages, ignores rendering the content of the section named <paramref name="sectionName"/>.
-        /// </summary>
-        /// <param name="sectionName">The section to ignore.</param>
-        /// <param name="required">Indicates the <paramref name="sectionName"/> section must be registered
-        /// (using <c>@section</c>) in the page.</param>
-        public void IgnoreSection(string sectionName, bool required)
-            => IgnoreSectionCore(sectionName, required);
-
-        private void IgnoreSectionCore(string sectionName, bool required)
         {
             if (sectionName == null)
             {
                 throw new ArgumentNullException(nameof(sectionName));
             }
 
-            if (!PreviousSectionWriters.ContainsKey(sectionName))
+            if (PreviousSectionWriters.ContainsKey(sectionName))
             {
-                if (required)
+                if (_ignoredSections == null)
                 {
-                    // If the section is not defined, throw an error.
-                    throw new InvalidOperationException(Resources.FormatSectionNotDefined(
-                        ViewContext.ExecutingFilePath,
-                        sectionName,
-                        ViewContext.View.Path));
+                    _ignoredSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 }
-                return;
-            }
 
-            if (_ignoredSections == null)
-            {
-                _ignoredSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                _ignoredSections.Add(sectionName);
             }
-
-            _ignoredSections.Add(sectionName);
         }
 
         /// <inheritdoc />

--- a/src/Mvc/Mvc.Razor/src/RazorPage.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPage.cs
@@ -215,6 +215,18 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// </summary>
         /// <param name="sectionName">The section to ignore.</param>
         public void IgnoreSection(string sectionName)
+            => IgnoreSectionCore(sectionName, true);
+
+        /// <summary>
+        /// In layout pages, ignores rendering the content of the section named <paramref name="sectionName"/>.
+        /// </summary>
+        /// <param name="sectionName">The section to ignore.</param>
+        /// <param name="required">Indicates the <paramref name="sectionName"/> section must be registered
+        /// (using <c>@section</c>) in the page.</param>
+        public void IgnoreSection(string sectionName, bool required)
+            => IgnoreSectionCore(sectionName, required);
+
+        private void IgnoreSectionCore(string sectionName, bool required)
         {
             if (sectionName == null)
             {
@@ -223,11 +235,15 @@ namespace Microsoft.AspNetCore.Mvc.Razor
 
             if (!PreviousSectionWriters.ContainsKey(sectionName))
             {
-                // If the section is not defined, throw an error.
-                throw new InvalidOperationException(Resources.FormatSectionNotDefined(
-                    ViewContext.ExecutingFilePath,
-                    sectionName,
-                    ViewContext.View.Path));
+                if (required)
+                {
+                    // If the section is not defined, throw an error.
+                    throw new InvalidOperationException(Resources.FormatSectionNotDefined(
+                        ViewContext.ExecutingFilePath,
+                        sectionName,
+                        ViewContext.View.Path));
+                }
+                return;
             }
 
             if (_ignoredSections == null)

--- a/src/Mvc/Mvc.Razor/test/RazorPageTest.cs
+++ b/src/Mvc/Mvc.Razor/test/RazorPageTest.cs
@@ -480,7 +480,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         }
 
         [Fact]
-        public async Task IgnoreSection_ThrowsIfSectionIsNotFound()
+        public async Task IgnoreSection_DoesNotThrowIfSectionIsNotFound()
         {
             // Arrange
             var context = CreateViewContext(viewPath: "/Views/TestPath/Test.cshtml");
@@ -496,10 +496,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             };
 
             // Act & Assert
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => page.ExecuteAsync());
-            var message = $"The layout page '/Views/Shared/_Layout.cshtml' cannot find the section 'bar'" +
-                " in the content page '/Views/TestPath/Test.cshtml'.";
-            Assert.Equal(message, ex.Message);
+            await page.ExecuteAsync();
+            // Nothing to assert, just getting here is validation enough.
         }
 
         [Fact]


### PR DESCRIPTION
Updates IgnoreSection so it doesn't throw if the section being ignored is not found.