### PR TITLE
Add DefaultHttpContext._active for debugging

### DIFF
--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -36,6 +36,12 @@ namespace Microsoft.AspNetCore.Http
         private DefaultConnectionInfo? _connection;
         private DefaultWebSocketManager? _websockets;
 
+        // This is field exists to make analyzing memory dumps easier.
+        // https://github.com/dotnet/aspnetcore/issues/29709
+#pragma warning disable CS0414
+        private bool _active;
+#pragma warning restore CS0414
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultHttpContext"/> class.
         /// </summary>
@@ -73,6 +79,7 @@ namespace Microsoft.AspNetCore.Http
             _response.Initialize(revision);
             _connection?.Initialize(features, revision);
             _websockets?.Initialize(features, revision);
+            _active = true;
         }
 
         /// <summary>
@@ -85,6 +92,7 @@ namespace Microsoft.AspNetCore.Http
             _response.Uninitialize();
             _connection?.Uninitialize();
             _websockets?.Uninitialize();
+            _active = false;
         }
 
         /// <summary>

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -38,9 +38,7 @@ namespace Microsoft.AspNetCore.Http
 
         // This is field exists to make analyzing memory dumps easier.
         // https://github.com/dotnet/aspnetcore/issues/29709
-#pragma warning disable CS0414
-        private bool _active;
-#pragma warning restore CS0414
+        internal bool _active;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultHttpContext"/> class.

--- a/src/Http/Http/test/DefaultHttpContextTests.cs
+++ b/src/Http/Http/test/DefaultHttpContextTests.cs
@@ -264,6 +264,22 @@ namespace Microsoft.AspNetCore.Http
             Assert.False(scope.DisposeCalled);
         }
 
+        [Fact]
+        public void InternalActiveFlagIsSetAndUnset()
+        {
+            var context = new DefaultHttpContext();
+
+            Assert.False(context._active);
+
+            context.Initialize(new FeatureCollection());
+
+            Assert.True(context._active);
+
+            context.Uninitialize();
+
+            Assert.False(context._active);
+        }
+
         void TestAllCachedFeaturesAreNull(HttpContext context, IFeatureCollection features)
         {
             TestCachedFeaturesAreNull(context, features);


### PR DESCRIPTION
Addresses #29709

You can already look at whether the `_features` is zeroed out, but that's hard to determine at a glance. Adding a boolean field makes it a lot easier to tell if a given DefaultHttpContext is active when analyzing memory dumps.

![image](https://user-images.githubusercontent.com/54385/106220417-4ffb8280-6190-11eb-8d49-eb03d3bc8676.png)
