### PR TITLE
Fix doc comment typo in ControllerModel.cs

### DIFF
--- a/src/Mvc/Mvc.Core/src/ApplicationModels/ControllerModel.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/ControllerModel.cs
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
         public IDictionary<object, object> Properties { get; }
 
         /// <summary>
-        /// The selector models of this controller..
+        /// The selector models of this controller.
         /// </summary>
         public IList<SelectorModel> Selectors { get; }
 


### PR DESCRIPTION
The XML doc comment for the `Selectors` property has an extra period that should be removed:

> The selector models of this controller..