### PR TITLE
Use docker image with cert fix

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
 
 ENV StressRunDuration=0
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The 3.1 docker image runs in to NuGet restore failure - https://github.com/NuGet/Announcements/issues/49. We use the base imageto bootstrap all the pre-reqs for the dotnet-sdk that allows us to build the aspnetcore repo so this version shouldn't really matter a whole lot.



