### PR TITLE
Fix cref for AddRazorPagesOptions

### DIFF
--- a/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcBuilderExtensions.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class MvcRazorPagesMvcBuilderExtensions
     {
         /// <summary>
-        /// Configures a set of <see cref="RazorViewEngineOptions"/> for the application.
+        /// Configures a set of <see cref="RazorPagesOptions"/> for the application.
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
-        /// <param name="setupAction">An action to configure the <see cref="RazorViewEngineOptions"/>.</param>
+        /// <param name="setupAction">An action to configure the <see cref="RazorPagesOptions"/>.</param>
         /// <returns>The <see cref="IMvcBuilder"/>.</returns>
         public static IMvcBuilder AddRazorPagesOptions(
             this IMvcBuilder builder,


### PR DESCRIPTION
`IMvcBuilder.AddRazorPagesOptions` configures an instance of `RazorPagesOptions` but the cref referenced `RazorViewEngineOptions`.