### PR TITLE
Add nullablePublicOnly Roslyn Feature

### DIFF
--- a/eng/targets/CSharp.Common.props
+++ b/eng/targets/CSharp.Common.props
@@ -4,7 +4,7 @@
     <LangVersion>9.0</LangVersion>
 
     <!-- Enables Strict mode for Roslyn compiler -->
-    <Features>strict</Features>
+    <Features>strict;nullablePublicOnly</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.DataAnnotations/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test.csproj
+++ b/src/Mvc/Mvc.DataAnnotations/test/Microsoft.AspNetCore.Mvc.DataAnnotations.Test.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <UseSharedCompilation>false</UseSharedCompilation>
+    <!-- This project has tests that rely on nullability on non-public types. Undo nullablePublicOnly configured by default -->
+    <Features>$(Features.Replace('nullablePublicOnly', ''))</Features>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Mvc/test/Mvc.IntegrationTests/Microsoft.AspNetCore.Mvc.IntegrationTests.csproj
+++ b/src/Mvc/test/Mvc.IntegrationTests/Microsoft.AspNetCore.Mvc.IntegrationTests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <UseSharedCompilation>false</UseSharedCompilation>
+    <!-- This project has tests that rely on nullability on non-public types. Undo nullablePublicOnly configured by default -->
+    <Features>$(Features.Replace('nullablePublicOnly', ''))</Features>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
~This tells Roslyn to not add [AllowNull] attributes in IL to non-public APIs.~ The same feature is set for dotnet/runtime.

See https://github.com/dotnet/runtime/blob/8033217b3c9d59da81436e120b32dd5ec74a856c/Directory.Build.props#L249.

~This is causing the `AllowNullAttribute` to be in a default Blazor WASM app, and should allow for it to be trimmed.~

cc @stephentoub 