### PR TITLE
Remove use of Any, Single, and LastOrDefault from JSInterop

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -384,12 +384,18 @@ namespace Microsoft.JSInterop.Infrastructure
             // set of already-loaded assemblies.
             // In some edge cases this might force developers to explicitly call something on the
             // target assembly (from .NET) before they can invoke its allowed methods from JS.
-            var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-            // Using LastOrDefault to workaround for https://github.com/dotnet/arcade/issues/2816.
+            // Using the last to workaround https://github.com/dotnet/arcade/issues/2816.
             // In most ordinary scenarios, we wouldn't have two instances of the same Assembly in the AppDomain
             // so this doesn't change the outcome.
-            var assembly = loadedAssemblies.LastOrDefault(a => new AssemblyKey(a).Equals(assemblyKey));
+            Assembly? assembly = null;
+            foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (new AssemblyKey(a).Equals(assemblyKey))
+                {
+                    assembly = a;
+                }
+            }
 
             return assembly
                 ?? throw new ArgumentException($"There is no loaded assembly with the name '{assemblyKey.AssemblyName}'.");

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/TaskGenericsUtil.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/TaskGenericsUtil.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.JSInterop.Infrastructure
@@ -51,7 +50,7 @@ namespace Microsoft.JSInterop.Infrastructure
             }
 
             return taskType.IsGenericType
-                ? taskType.GetGenericArguments().Single()
+                ? taskType.GetGenericArguments()[0]
                 : null;
         }
 
@@ -108,7 +107,7 @@ namespace Microsoft.JSInterop.Infrastructure
         {
             return _cachedResultSetters.GetOrAdd(taskCompletionSource.GetType(), tcsType =>
             {
-                var resultType = tcsType.GetGenericArguments().Single();
+                var resultType = tcsType.GetGenericArguments()[0];
                 return (ITcsResultSetter)Activator.CreateInstance(
                     typeof(TcsResultSetter<>).MakeGenericType(resultType))!;
             });

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -120,7 +119,7 @@ namespace Microsoft.JSInterop
                     return new ValueTask<TValue>(tcs.Task);
                 }
 
-                var argsJson = args?.Any() == true ?
+                var argsJson = args is not null && args.Length != 0 ?
                     JsonSerializer.Serialize(args, JsonSerializerOptions) :
                     null;
                 var resultType = JSCallResultTypeHelper.FromGeneric<TValue>();


### PR DESCRIPTION
These uses are keeping these APIs from being trimmed out of a default Blazor wasm app.

cc: @pranavkm, @eerhardt 