### PR TITLE
Remove baseline suppressions from 5.0

### DIFF
--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -153,7 +153,7 @@
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Metadata" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
@@ -167,7 +167,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[5.0.0, )" />
   </ItemGroup>
@@ -190,7 +190,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Authorization' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[5.0.4, )" />
   </ItemGroup>
@@ -198,14 +198,14 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Forms' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[5.0.4, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Components.Web-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.Web' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.JSInterop" Version="[5.0.4, )" />
@@ -216,7 +216,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.WebAssembly.Authentication' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.WebAssembly.Authentication' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.WebAssembly.Authentication' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Web" Version="[5.0.4, )" />
   </ItemGroup>
@@ -232,7 +232,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.WebAssembly' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.WebAssembly' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components.WebAssembly' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.JSInterop.WebAssembly" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Web" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[5.0.0, )" />
@@ -243,7 +243,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Components' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[5.0.4, )" />
   </ItemGroup>
@@ -263,7 +263,7 @@
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[1.0.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[5.0.4, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
@@ -284,7 +284,7 @@
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND '$(TargetFramework)' == 'net461' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[5.0.4, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[5.0.4, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND '$(TargetFramework)' == 'netstandard2.0' ">
@@ -310,7 +310,7 @@
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[5.0.1, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[5.0.1, )" />
   </ItemGroup>
@@ -345,7 +345,7 @@
     <BaselinePackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="[4.3.0, )" />
     <BaselinePackageReference Include="System.Security.Cryptography.Xml" Version="[5.0.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0, )" />
@@ -417,7 +417,7 @@
     <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[5.0.4, )" />
     <BaselinePackageReference Include="System.Text.Json" Version="[5.0.1, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[5.0.4, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND '$(TargetFramework)' == 'netstandard2.0' ">
@@ -432,7 +432,7 @@
     <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[5.0.0, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[5.0.1, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[5.0.0, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[5.0.1, )" />
   </ItemGroup>
@@ -444,7 +444,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[5.0.4, )" />
   </ItemGroup>
@@ -592,7 +592,7 @@
     <BaselinePackageReference Include="System.Net.Sockets" Version="[4.3.0, )" />
     <BaselinePackageReference Include="System.Text.Json" Version="[5.0.1, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
   </ItemGroup>
@@ -608,7 +608,7 @@
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'net461' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[5.0.4, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[5.0.4, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'netstandard2.0' ">
@@ -677,7 +677,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Authentication.WebAssembly.Msal' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Authentication.WebAssembly.Msal' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Authentication.WebAssembly.Msal' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[5.0.4, )" />
   </ItemGroup>
   <!-- Package: Microsoft.CodeAnalysis.Razor-->
@@ -725,7 +725,7 @@
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[5.0.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Configuration.KeyPerFile' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Configuration.KeyPerFile' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[5.0.0, )" />
   </ItemGroup>
@@ -756,7 +756,7 @@
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Diagnostics.HealthChecks' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Diagnostics.HealthChecks' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5.0.0, )" />
@@ -772,7 +772,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.FileProviders.Embedded' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.FileProviders.Embedded' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.FileProviders.Embedded' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="[5.0.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.FileProviders.Embedded' AND '$(TargetFramework)' == 'netstandard2.0' ">
@@ -788,7 +788,7 @@
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
     <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[5.0.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
@@ -808,7 +808,7 @@
     <BaselinePackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[5.0.0, )" />
@@ -832,7 +832,7 @@
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Localization' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Localization' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="[5.0.4, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[5.0.0, )" />
@@ -878,7 +878,7 @@
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
     <BaselinePackageReference Include="System.Text.Encodings.Web" Version="[5.0.1, )" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.WebEncoders' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.WebEncoders' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[5.0.0, )" />
   </ItemGroup>
@@ -891,7 +891,7 @@
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.JSInterop.WebAssembly' ">
     <BaselinePackageVersion>5.0.4</BaselinePackageVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.JSInterop.WebAssembly' AND '$(TargetFramework)' == 'net50' ">
+  <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.JSInterop.WebAssembly' AND ('$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)' OR '$(TargetFramework)' == 'net5.0') ">
     <BaselinePackageReference Include="Microsoft.JSInterop" Version="[5.0.4, )" />
   </ItemGroup>
   <!-- Package: Microsoft.JSInterop-->

--- a/eng/tools/BaselineGenerator/BaselineGenerator.csproj
+++ b/eng/tools/BaselineGenerator/BaselineGenerator.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)CommandLineUtils\**\*.cs" />
-    <PackageReference Include="NuGet.Protocol" Version="4.8.2" />
+    <PackageReference Include="NuGet.Protocol" Version="5.8.1" />
   </ItemGroup>
 
 </Project>

--- a/eng/tools/BaselineGenerator/BaselineGenerator.csproj
+++ b/eng/tools/BaselineGenerator/BaselineGenerator.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)CommandLineUtils\**\*.cs" />
-    <PackageReference Include="NuGet.Protocol" Version="5.8.1" />
+    <PackageReference Include="NuGet.Protocol" Version="4.8.2" />
   </ItemGroup>
 
 </Project>

--- a/eng/tools/BaselineGenerator/Program.cs
+++ b/eng/tools/BaselineGenerator/Program.cs
@@ -100,12 +100,9 @@ namespace PackageBaselineGenerator
             var baselineVersion = input.Root.Attribute("Version").Value;
 
             // Baseline and .NET Core versions always align in non-preview releases.
-            // But, NuspecReader reports netcoreapp5.0 or net50 instead of net5.0. We use net5.0 in Baseline.Designer.props.
             var parsedVersion = Version.Parse(baselineVersion);
             var defaultTarget = ((parsedVersion.Major < 5) ? "netcoreapp" : "net") +
                 $"{parsedVersion.Major}.{parsedVersion.Minor}";
-            var netcoreappTarget = $"netcoreapp{parsedVersion.Major}.{parsedVersion.Minor}";
-            var netTarget = $"net{parsedVersion.Major}{parsedVersion.Minor}";
 
             var doc = new XDocument(
                 new XComment(" Auto generated. Do not edit manually, use eng/tools/BaselineGenerator/ to recreate. "),
@@ -180,10 +177,7 @@ namespace PackageBaselineGenerator
                         var targetCondition = $"'$(TargetFramework)' == '{group.TargetFramework.GetShortFolderName()}'";
                         if (string.Equals(
                             group.TargetFramework.GetShortFolderName(),
-                            netcoreappTarget,
-                            StringComparison.OrdinalIgnoreCase) || string.Equals(
-                            group.TargetFramework.GetShortFolderName(),
-                            netTarget,
+                            defaultTarget,
                             StringComparison.OrdinalIgnoreCase))
                         {
                             targetCondition =

--- a/eng/tools/BaselineGenerator/Program.cs
+++ b/eng/tools/BaselineGenerator/Program.cs
@@ -100,11 +100,12 @@ namespace PackageBaselineGenerator
             var baselineVersion = input.Root.Attribute("Version").Value;
 
             // Baseline and .NET Core versions always align in non-preview releases.
-            // But, NuspecReader reports netcoreapp5.0 instead of net5.0. We use net5.0 in Baseline.Designer.props.
+            // But, NuspecReader reports netcoreapp5.0 or net50 instead of net5.0. We use net5.0 in Baseline.Designer.props.
             var parsedVersion = Version.Parse(baselineVersion);
             var defaultTarget = ((parsedVersion.Major < 5) ? "netcoreapp" : "net") +
                 $"{parsedVersion.Major}.{parsedVersion.Minor}";
-            var matchTarget = $"netcoreapp{parsedVersion.Major}.{parsedVersion.Minor}";
+            var netcoreappTarget = $"netcoreapp{parsedVersion.Major}.{parsedVersion.Minor}";
+            var netTarget = $"net{parsedVersion.Major}{parsedVersion.Minor}";
 
             var doc = new XDocument(
                 new XComment(" Auto generated. Do not edit manually, use eng/tools/BaselineGenerator/ to recreate. "),
@@ -179,7 +180,10 @@ namespace PackageBaselineGenerator
                         var targetCondition = $"'$(TargetFramework)' == '{group.TargetFramework.GetShortFolderName()}'";
                         if (string.Equals(
                             group.TargetFramework.GetShortFolderName(),
-                            matchTarget,
+                            netcoreappTarget,
+                            StringComparison.OrdinalIgnoreCase) || string.Equals(
+                            group.TargetFramework.GetShortFolderName(),
+                            netTarget,
                             StringComparison.OrdinalIgnoreCase))
                         {
                             targetCondition =

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -20,19 +20,6 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
-  <!--
-    These references exist only in the .nuspec files and baseline checks are not aware of them. Keep suppressions
-    in sync with the two .nuspec files:
-    - Anytime a reference is added to this project file, remove its suppression.
-    - Remove InNuspecFile attributes of references removed from the .nuspec files. Make suppression conditional on
-      Major.Minor during previews. After RTM (and baseline updates), remove suppressions entirely.
-  -->
-  <ItemGroup>
-    <SuppressBaselineReference Include="Microsoft.AspNetCore.Components.Analyzers" InNuspecFile="true" />
-    <SuppressBaselineReference Include="Microsoft.AspNetCore.Authorization" InNuspecFile="true" />
-    <SuppressBaselineReference Include="Microsoft.JSInterop" Condition=" '$(AspNetCoreMajorMinorVersion)' == '6.0' " />
-  </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Properties\ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
   </ItemGroup>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -20,6 +20,19 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
+  <!--
+    These references exist only in the .nuspec files and baseline checks are not aware of them. Keep suppressions
+    in sync with the two .nuspec files:
+    - Anytime a reference is added to this project file, remove its suppression.
+    - Remove InNuspecFile attributes of references removed from the .nuspec files. Make suppression conditional on
+      Major.Minor during previews. After RTM (and baseline updates), remove suppressions entirely.
+  -->
+  <ItemGroup>
+    <SuppressBaselineReference Include="Microsoft.AspNetCore.Components.Analyzers" InNuspecFile="true" />
+    <SuppressBaselineReference Include="Microsoft.AspNetCore.Authorization" InNuspecFile="true" />
+    <SuppressBaselineReference Include="Microsoft.JSInterop" Condition=" '$(AspNetCoreMajorMinorVersion)' == '6.0' " />
+  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Properties\ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
   </ItemGroup>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -28,7 +28,8 @@
       Major.Minor during previews. After RTM (and baseline updates), remove suppressions entirely.
   -->
   <ItemGroup>
-    <SuppressBaselineReference Include="Microsoft.JSInterop" Condition=" '$(AspNetCoreMajorMinorVersion)' == '6.0' " />
+    <SuppressBaselineReference Include="Microsoft.AspNetCore.Components.Analyzers" InNuspecFile="true" />
+    <SuppressBaselineReference Include="Microsoft.AspNetCore.Authorization" InNuspecFile="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -28,8 +28,6 @@
       Major.Minor during previews. After RTM (and baseline updates), remove suppressions entirely.
   -->
   <ItemGroup>
-    <SuppressBaselineReference Include="Microsoft.AspNetCore.Components.Analyzers" InNuspecFile="true" />
-    <SuppressBaselineReference Include="Microsoft.AspNetCore.Authorization" InNuspecFile="true" />
     <SuppressBaselineReference Include="Microsoft.JSInterop" Condition=" '$(AspNetCoreMajorMinorVersion)' == '6.0' " />
   </ItemGroup>
 

--- a/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
+++ b/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
@@ -36,11 +36,6 @@
     <Reference Include="Microsoft.Extensions.Identity.Stores" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(AspNetCoreMajorMinorVersion)' == '6.0' ">
-    <!-- This dependency was removed in 5.0. The suppression can be removed after 5.0 RTM is released. -->
-    <SuppressBaselineReference Include="Newtonsoft.Json" />
-  </ItemGroup>
-
   <Target Name="SetupRazorInputs" BeforeTargets="ResolveRazorGenerateInputs">
     <ItemGroup>
       <_RazorGenerate Include="Areas\Identity\Pages\V4\**\*.cshtml" />

--- a/src/Middleware/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
+++ b/src/Middleware/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
@@ -16,11 +16,5 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCode.SpaServices.Extensions.Tests" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(AspNetCoreMajorMinorVersion)' == '6.0' ">
-    <!--
-      Dependency was removed in 5.0. Suppression can be removed after 5.0 RTM is released.
-    -->
-    <SuppressBaselineReference Include="Microsoft.AspNetCore.SpaServices" />
-  </ItemGroup>
+  
 </Project>

--- a/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
+++ b/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
@@ -22,13 +22,5 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(DefaultNetFxTargetFramework)'">
     <Reference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(AspNetCoreMajorMinorVersion)' == '6.0' ">
-    <!--
-      Dependency (a transitive reference) was removed in 5.0. Suppression can be
-      removed after 5.0 RTM is released.
-    -->
-    <SuppressBaselineReference Include="System.IO.Pipelines" />
-  </ItemGroup>
-
+  
 </Project>

--- a/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -30,11 +30,6 @@
     <Reference Include="System.Threading.Channels" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(AspNetCoreMajorMinorVersion)' == '6.0' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <!-- Dependency (a transitive ref) was removed in 5.0. Suppression can be removed after 5.0 RTM is released. -->
-    <SuppressBaselineReference Include="Microsoft.Bcl.AsyncInterfaces" />
-  </ItemGroup>
-
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Client.FunctionalTests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Client.Tests" />


### PR DESCRIPTION
In the spirit of https://github.com/dotnet/aspnetcore/issues/9473

Note - when we rebranded to 6.0, the global find/replace 5.0 -> 6.0 changed the conditions on a lot of these so that they applied to 6.0 instead of 5.0 - we should keep this in mind next time we update the major version