### PR TITLE
Remove unused variables and unnecessary method calls in Identity UserManager.cs

### DIFF
--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -1058,7 +1058,6 @@ namespace Microsoft.AspNetCore.Identity
         public virtual Task<IdentityResult> AddClaimAsync(TUser user, Claim claim)
         {
             ThrowIfDisposed();
-            var claimStore = GetClaimStore();
             if (claim == null)
             {
                 throw new ArgumentNullException(nameof(claim));

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -1139,7 +1139,6 @@ namespace Microsoft.AspNetCore.Identity
         public virtual Task<IdentityResult> RemoveClaimAsync(TUser user, Claim claim)
         {
             ThrowIfDisposed();
-            var claimStore = GetClaimStore();
             if (user == null)
             {
                 throw new ArgumentNullException(nameof(user));


### PR DESCRIPTION

The claimStore is unused.  And I think the cast and null checking in `GetClaimStore()` is unnecessary here.


![image](https://user-images.githubusercontent.com/1818225/107110238-5de09000-6881-11eb-8ba3-8e1703da7dc7.png)


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.


