### PR TITLE
Removed `OfType` usage. Less allocations and much faster

### DIFF
--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             foreach(var feature in manager.FeatureProviders)
             {
-                if(feature.GetType() == typeof(ControllerFeatureProvider))
+                if(feature is ControllerFeatureProvider)
                 {
                     controllerFeaturePresent = true;
                     break;

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -65,7 +65,18 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void ConfigureDefaultFeatureProviders(ApplicationPartManager manager)
         {
-            if (!manager.FeatureProviders.OfType<ControllerFeatureProvider>().Any())
+            var controllerFeaturePresent = false;
+
+            foreach(var feature in manager.FeatureProviders)
+            {
+                if(feature.GetType() == typeof(ControllerFeatureProvider))
+                {
+                    controllerFeaturePresent = true;
+                    break;
+                }
+            }
+
+            if(!controllerFeaturePresent)
             {
                 manager.FeatureProviders.Add(new ControllerFeatureProvider());
             }


### PR DESCRIPTION
The following benchmark test shows usage of `OfType` extension method can be slower and allocates double memory as compared to good old `foreach` even on primitive types like `string` and `int`. 

This PR removes one of the usages of `OfType` in the method, which gets called by many other extension methods internally like `AddMvcCore` and `AddControllers` etc.



```csharp
    [MemoryDiagnoser]
    public class OfTypeBenchMark
    {
        private static IList<Type> types = new List<Type> { typeof(string), typeof(int) };

        [Benchmark]
        public bool WithOfTypeExtensionMethod()
        {
            return types.OfType<string>().Any();
        }

        [Benchmark]
        public bool WithoutOfType()
        {
            var result = false;

            foreach(var type in types)
            {
                if(type is string)
                {
                    result = true;
                    break;
                }
            }

            return result;
        }
    }
```

```
|                    Method |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |----------:|---------:|---------:|-------:|------:|------:|----------:|
| WithOfTypeExtensionMethod | 106.78 ns | 0.356 ns | 0.316 ns | 0.0612 |     - |     - |      96 B |
|             WithoutOfType |  41.58 ns | 0.117 ns | 0.104 ns | 0.0255 |     - |     - |      40 B |
```

Contributes to https://github.com/dotnet/runtime/issues/44598