### PR TITLE
Added support for defining custom Cascading Value Components

### DIFF
--- a/src/Components/Components/src/CascadingParameterState.cs
+++ b/src/Components/Components/src/CascadingParameterState.cs
@@ -16,11 +16,13 @@ namespace Microsoft.AspNetCore.Components
             = new ConcurrentDictionary<Type, ReflectedCascadingParameterInfo[]>();
 
         public string LocalValueName { get; }
+        public Type LocalType { get; }
         public ICascadingValueComponent ValueSupplier { get; }
 
-        public CascadingParameterState(string localValueName, ICascadingValueComponent valueSupplier)
+        public CascadingParameterState(string localValueName, Type localType, ICascadingValueComponent valueSupplier)
         {
             LocalValueName = localValueName;
+            LocalType = localType;
             ValueSupplier = valueSupplier;
         }
 
@@ -52,7 +54,7 @@ namespace Microsoft.AspNetCore.Components
                         resultStates = new List<CascadingParameterState>(infos.Length - infoIndex);
                     }
 
-                    resultStates.Add(new CascadingParameterState(info.ConsumerValueName, supplier));
+                    resultStates.Add(new CascadingParameterState(info.ConsumerValueName, info.ValueType, supplier));
                 }
             }
 
@@ -64,7 +66,7 @@ namespace Microsoft.AspNetCore.Components
             do
             {
                 if (componentState.Component is ICascadingValueComponent candidateSupplier
-                    && candidateSupplier.CanSupplyValue(info.ValueType, info.SupplierValueName))
+                    && candidateSupplier.HasValue(info.ValueType, info.SupplierValueName))
                 {
                     return candidateSupplier;
                 }

--- a/src/Components/Components/src/ICascadingValueComponent.cs
+++ b/src/Components/Components/src/ICascadingValueComponent.cs
@@ -6,19 +6,46 @@ using System;
 
 namespace Microsoft.AspNetCore.Components
 {
-    internal interface ICascadingValueComponent
+    /// <summary>
+    /// Defines the interface for providing one or more cascading values from a component.
+    /// </summary>
+    public interface ICascadingValueComponent
     {
-        // This interface exists only so that CascadingParameterState has a way
-        // to work with all CascadingValue<T> types regardless of T.
+        /// <summary>
+        /// Check if this component exposes a value for the given type and optional name combination.
+        /// </summary>
+        /// <param name="valueType">The expected type of underlying value</param>
+        /// <param name="valueName">The optional name of the underlying value</param>
+        /// <returns></returns>
+        bool HasValue(Type valueType, string? valueName);
 
-        bool CanSupplyValue(Type valueType, string? valueName);
+        /// <summary>
+        /// Get the value from the component for the given type and optional name combination.
+        /// </summary>
+        /// <param name="valueType">The expected type of underlying value</param>
+        /// <param name="valueName">The optional name of the underlying value</param>
+        /// <returns></returns>
+        object? GetValue(Type valueType, string? valueName);
 
-        object? CurrentValue { get; }
+        /// <summary>
+        /// If true, indicates that the values from <see cref="GetValue"/> will not change.
+        /// This is a performance optimization that allows the framework to skip setting up
+        /// change notifications. Set this flag only if you will not change the values provded by this component.
+        /// </summary>
+        bool IsFixed { get; }
 
-        bool CurrentValueIsFixed { get; }
+        /// <summary>
+        /// When a change happens inside of the <see cref="ICascadingValueComponent"/> consuming components will
+        /// subscribe so that your component can notify all consumers of changes.
+        /// </summary>
+        /// <param name="subscriber"></param>
+        void Subscribe(IComponentState subscriber);
 
-        void Subscribe(ComponentState subscriber);
-
-        void Unsubscribe(ComponentState subscriber);
+        /// <summary>
+        /// When a component is no longer consuming values from the <see cref="ICascadingValueComponent"/> the
+        /// component will unsubscribe to changes.
+        /// </summary>
+        /// <param name="subscriber"></param>
+        void Unsubscribe(IComponentState subscriber);
     }
 }

--- a/src/Components/Components/src/ParameterView.cs
+++ b/src/Components/Components/src/ParameterView.cs
@@ -357,7 +357,7 @@ namespace Microsoft.AspNetCore.Components
                     _currentIndex = nextIndex;
 
                     var state = _cascadingParameters[_currentIndex];
-                    _current = new ParameterValue(state.LocalValueName, state.ValueSupplier.CurrentValue!, true);
+                    _current = new ParameterValue(state.LocalValueName, state.ValueSupplier.GetValue(state.LocalType, state.LocalValueName)!, true);
                     return true;
                 }
                 else

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -7,6 +7,14 @@ Microsoft.AspNetCore.Components.DynamicComponent.Parameters.set -> void
 Microsoft.AspNetCore.Components.DynamicComponent.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.DynamicComponent.Type.get -> System.Type!
 Microsoft.AspNetCore.Components.DynamicComponent.Type.set -> void
+Microsoft.AspNetCore.Components.ICascadingValueComponent
+Microsoft.AspNetCore.Components.ICascadingValueComponent.GetValue(System.Type! valueType, string? valueName) -> object?
+Microsoft.AspNetCore.Components.ICascadingValueComponent.HasValue(System.Type! valueType, string? valueName) -> bool
+Microsoft.AspNetCore.Components.ICascadingValueComponent.IsFixed.get -> bool
+Microsoft.AspNetCore.Components.ICascadingValueComponent.Subscribe(Microsoft.AspNetCore.Components.Rendering.IComponentState! subscriber) -> void
+Microsoft.AspNetCore.Components.ICascadingValueComponent.Unsubscribe(Microsoft.AspNetCore.Components.Rendering.IComponentState! subscriber) -> void
+Microsoft.AspNetCore.Components.Rendering.IComponentState
+Microsoft.AspNetCore.Components.Rendering.IComponentState.NotifyChanged(in Microsoft.AspNetCore.Components.ParameterView lifetime) -> void
 static Microsoft.AspNetCore.Components.ParameterView.FromDictionary(System.Collections.Generic.IDictionary<string!, object?>! parameters) -> Microsoft.AspNetCore.Components.ParameterView
 virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(ulong eventHandlerId, Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo? fieldInfo, System.EventArgs! eventArgs) -> System.Threading.Tasks.Task!
 *REMOVED*readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.RemovedAttributeName -> string

--- a/src/Components/Components/src/Rendering/ComponentState.cs
+++ b/src/Components/Components/src/Rendering/ComponentState.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
     /// within the context of a <see cref="Renderer"/>. This is an internal implementation
     /// detail of <see cref="Renderer"/>.
     /// </summary>
-    internal class ComponentState : IDisposable
+    internal class ComponentState : IDisposable, IComponentState
     {
         private readonly Renderer _renderer;
         private readonly IReadOnlyList<CascadingParameterState> _cascadingParameters;
@@ -177,6 +177,11 @@ namespace Microsoft.AspNetCore.Components.Rendering
             _renderer.AddToPendingTasks(task);
         }
 
+        void IComponentState.NotifyChanged(in ParameterView parameters)
+        {
+            NotifyCascadingValueChanged(parameters.Lifetime);
+        }
+
         private bool AddCascadingParameterSubscriptions()
         {
             var hasSubscription = false;
@@ -185,7 +190,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             for (var i = 0; i < numCascadingParameters; i++)
             {
                 var valueSupplier = _cascadingParameters[i].ValueSupplier;
-                if (!valueSupplier.CurrentValueIsFixed)
+                if (!valueSupplier.IsFixed)
                 {
                     valueSupplier.Subscribe(this);
                     hasSubscription = true;
@@ -201,7 +206,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
             for (var i = 0; i < numCascadingParameters; i++)
             {
                 var supplier = _cascadingParameters[i].ValueSupplier;
-                if (!supplier.CurrentValueIsFixed)
+                if (!supplier.IsFixed)
                 {
                     supplier.Unsubscribe(this);
                 }

--- a/src/Components/Components/src/Rendering/IComponentState.cs
+++ b/src/Components/Components/src/Rendering/IComponentState.cs
@@ -1,0 +1,14 @@
+namespace Microsoft.AspNetCore.Components.Rendering
+{
+    /// <summary>
+    /// The hosted state of the component
+    /// </summary>
+    public interface IComponentState
+    {
+        /// <summary>
+        /// Used to notify a component of changes.
+        /// </summary>
+        /// <param name="lifetime"></param>
+        void NotifyChanged(in ParameterView lifetime);
+    }
+}

--- a/src/Components/Components/test/CustomCascadingParameterTest.cs
+++ b/src/Components/Components/test/CustomCascadingParameterTest.cs
@@ -1,0 +1,492 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Test.Helpers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Test
+{
+    public class CustomCascadingParameterTest
+    {
+        [Fact]
+        public void PassesCascadingParametersToNestedComponents()
+        {
+            // Arrange
+            var serviceProvider = new TestServiceProvider();
+            var data = new CustomComponentData();
+            data.AddValue(typeof(string), "Hello", null);
+            serviceProvider.AddService(data);
+            var renderer = new TestRenderer(serviceProvider);
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenComponent<CustomCascadingComponent>(0);
+                builder.AddAttribute(1, "ChildContent", new RenderFragment(childBuilder =>
+                {
+                    childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
+                    childBuilder.AddAttribute(1, "RegularParameter", "Goodbye");
+                    childBuilder.CloseComponent();
+                }));
+                builder.CloseComponent();
+            });
+
+            // Act/Assert
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+            var batch = renderer.Batches.Single();
+            var nestedComponent = FindComponent<CascadingParameterConsumerComponent<string>>(batch, out var nestedComponentId);
+            var nestedComponentDiff = batch.DiffsByComponentId[nestedComponentId].Single();
+
+            // The nested component was rendered with the correct parameters
+            Assert.Collection(nestedComponentDiff.Edits,
+                edit =>
+                {
+                    Assert.Equal(RenderTreeEditType.PrependFrame, edit.Type);
+                    AssertFrame.Text(
+                        batch.ReferenceFrames[edit.ReferenceFrameIndex],
+                        "CascadingParameter=Hello; RegularParameter=Goodbye");
+                });
+            Assert.Equal(1, nestedComponent.NumRenders);
+        }
+
+        [Fact]
+        public void RetainsCascadingParametersWhenUpdatingDirectParameters()
+        {
+            // Arrange
+            var serviceProvider = new TestServiceProvider();
+            var data = new CustomComponentData();
+            data.AddValue(typeof(string), "Hello", null);
+            serviceProvider.AddService(data);
+            var renderer = new TestRenderer(serviceProvider);
+            var regularParameterValue = "Initial value";
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenComponent<CustomCascadingComponent>(0);
+                builder.AddAttribute(1, "ChildContent", new RenderFragment(childBuilder =>
+                {
+                    childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
+                    childBuilder.AddAttribute(1, "RegularParameter", regularParameterValue);
+                    childBuilder.CloseComponent();
+                }));
+                builder.CloseComponent();
+            });
+
+            // Act 1: Render in initial state
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+
+            // Capture the nested component so we can verify the update later
+            var firstBatch = renderer.Batches.Single();
+            var nestedComponent = FindComponent<CascadingParameterConsumerComponent<string>>(firstBatch, out var nestedComponentId);
+            Assert.Equal(1, nestedComponent.NumRenders);
+
+            // Act 2: Render again with updated regular parameter
+            regularParameterValue = "Changed value";
+            component.TriggerRender();
+
+            // Assert
+            Assert.Equal(2, renderer.Batches.Count);
+            var secondBatch = renderer.Batches[1];
+            var nestedComponentDiff = secondBatch.DiffsByComponentId[nestedComponentId].Single();
+
+            // The nested component was rendered with the correct parameters
+            Assert.Collection(nestedComponentDiff.Edits,
+                edit =>
+                {
+                    Assert.Equal(RenderTreeEditType.UpdateText, edit.Type);
+                    Assert.Equal(0, edit.ReferenceFrameIndex); // This is the only change
+                    AssertFrame.Text(secondBatch.ReferenceFrames[0], "CascadingParameter=Hello; RegularParameter=Changed value");
+                });
+            Assert.Equal(2, nestedComponent.NumRenders);
+        }
+
+        [Fact]
+        public void NotifiesDescendantsOfUpdatedCascadingParameterValuesAndPreservesDirectParameters()
+        {
+            // Arrange
+            var serviceProvider = new TestServiceProvider();
+            var data = new CustomComponentData();
+            data.AddValue(typeof(string), "Initial value", null);
+            serviceProvider.AddService(data);
+            var renderer = new TestRenderer(serviceProvider);
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenComponent<CustomCascadingComponent>(0);
+                builder.AddAttribute(1, "ChildContent", new RenderFragment(childBuilder =>
+                {
+                    childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
+                    childBuilder.AddAttribute(1, "RegularParameter", "Goodbye");
+                    childBuilder.CloseComponent();
+                }));
+                builder.CloseComponent();
+            });
+
+            // Act 1: Initial render; capture nested component ID
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+            var firstBatch = renderer.Batches.Single();
+            var nestedComponent = FindComponent<CascadingParameterConsumerComponent<string>>(firstBatch, out var nestedComponentId);
+            Assert.Equal(1, nestedComponent.NumRenders);
+
+            // Act 2: Re-render CascadingValue with new value
+            data.UpdateValue("Updated value");
+            component.TriggerRender();
+
+            // Assert: We re-rendered CascadingParameterConsumerComponent
+            Assert.Equal(2, renderer.Batches.Count);
+            var secondBatch = renderer.Batches[1];
+            var nestedComponentDiff = secondBatch.DiffsByComponentId[nestedComponentId].Single();
+
+            // The nested component was rendered with the correct parameters
+            Assert.Collection(nestedComponentDiff.Edits,
+                edit =>
+                {
+                    Assert.Equal(RenderTreeEditType.UpdateText, edit.Type);
+                    Assert.Equal(0, edit.ReferenceFrameIndex); // This is the only change
+                    AssertFrame.Text(secondBatch.ReferenceFrames[0], "CascadingParameter=Updated value; RegularParameter=Goodbye");
+                });
+            Assert.Equal(2, nestedComponent.NumRenders);
+        }
+
+        [Fact]
+        public void DoesNotNotifyDescendantsIfCascadingParameterValuesAreImmutableAndUnchanged()
+        {
+            // Arrange
+            var serviceProvider = new TestServiceProvider();
+            var data = new CustomComponentData();
+            data.AddValue("Unchanging value", null);
+            serviceProvider.AddService(data);
+            var renderer = new TestRenderer(serviceProvider);
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenComponent<CustomCascadingComponent>(0);
+                builder.AddAttribute(1, "ChildContent", new RenderFragment(childBuilder =>
+                {
+                    childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
+                    childBuilder.AddAttribute(1, "RegularParameter", "Goodbye");
+                    childBuilder.CloseComponent();
+                }));
+                builder.CloseComponent();
+            });
+
+            // Act 1: Initial render
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+            var firstBatch = renderer.Batches.Single();
+            var nestedComponent = FindComponent<CascadingParameterConsumerComponent<string>>(firstBatch, out _);
+            Assert.Equal(3, firstBatch.DiffsByComponentId.Count); // Root + CascadingValue + nested
+            Assert.Equal(1, nestedComponent.NumRenders);
+
+            // Act/Assert: Re-render the CascadingValue; observe nested component wasn't re-rendered
+            component.TriggerRender();
+
+            // Assert: We did not re-render CascadingParameterConsumerComponent
+            Assert.Equal(2, renderer.Batches.Count);
+            var secondBatch = renderer.Batches[1];
+            Assert.Equal(2, secondBatch.DiffsByComponentId.Count); // Root + CascadingValue, but not nested one
+            Assert.Equal(1, nestedComponent.NumRenders);
+        }
+
+        [Fact]
+        public void StopsNotifyingDescendantsIfTheyAreRemoved()
+        {
+            // Arrange
+            var displayNestedComponent = true;
+            var serviceProvider = new TestServiceProvider();
+            var data = new CustomComponentData();
+            data.AddValue("Initial value", null);
+            serviceProvider.AddService(data);
+            var renderer = new TestRenderer(serviceProvider);
+            var component = new TestComponent(builder =>
+            {
+                // At the outer level, have an unrelated fixed cascading value to show we can deal with combining both types
+                builder.OpenComponent<CascadingValue<int>>(0);
+                builder.AddAttribute(1, "Value", 123);
+                builder.AddAttribute(2, "IsFixed", true);
+                builder.AddAttribute(3, "ChildContent", new RenderFragment(builder2 =>
+                {
+                    // Then also have a non-fixed cascading value so we can show that unsubscription works
+                    builder2.OpenComponent<CustomCascadingComponent>(0);
+                    builder2.AddAttribute(1, "ChildContent", new RenderFragment(builder3 =>
+                    {
+                        if (displayNestedComponent)
+                        {
+                            builder3.OpenComponent<SecondCascadingParameterConsumerComponent<string, int>>(0);
+                            builder3.AddAttribute(1, "RegularParameter", "Goodbye");
+                            builder3.CloseComponent();
+                        }
+                    }));
+                    builder2.CloseComponent();
+                }));
+                builder.CloseComponent();
+            });
+
+            // Act 1: Initial render; capture nested component ID
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+            var firstBatch = renderer.Batches.Single();
+            var nestedComponent = FindComponent<CascadingParameterConsumerComponent<string>>(firstBatch, out var nestedComponentId);
+            Assert.Equal(1, nestedComponent.NumSetParametersCalls);
+            Assert.Equal(1, nestedComponent.NumRenders);
+
+            // Act/Assert 2: Re-render the CascadingValue; observe nested component wasn't re-rendered
+            data.UpdateValue("Updated value");
+            displayNestedComponent = false; // Remove the nested component
+            component.TriggerRender();
+
+            // Assert: We did not render the nested component now it's been removed
+            Assert.Equal(2, renderer.Batches.Count);
+            var secondBatch = renderer.Batches[1];
+            Assert.Equal(1, nestedComponent.NumRenders);
+            Assert.Equal(3, secondBatch.DiffsByComponentId.Count); // Root + CascadingValue + CascadingValue, but not nested component
+
+            // We *did* send updated params during the first render where it was removed,
+            // because the params are sent before the disposal logic runs. We could avoid
+            // this by moving the notifications into the OnAfterRender phase, but then we'd
+            // often render descendants twice (once because they are descendants and some
+            // direct parameter might have changed, then once because a cascading parameter
+            // changed). We can't have it both ways, so optimize for the case when the
+            // nested component *hasn't* just been removed.
+            Assert.Equal(2, nestedComponent.NumSetParametersCalls);
+
+            // Act 3: However, after disposal, the subscription is removed, so we won't send
+            // updated params on subsequent CascadingValue renders.
+            data.UpdateValue("Updated value 2");
+            component.TriggerRender();
+            Assert.Equal(2, nestedComponent.NumSetParametersCalls);
+        }
+
+        [Fact]
+        public void DoesNotNotifyDescendantsOfUpdatedCascadingParameterValuesWhenFixed()
+        {
+            // Arrange
+            var shouldIncludeChild = true;
+            var serviceProvider = new TestServiceProvider();
+            var data = new CustomComponentData();
+            data.AddValue("Initial value", null);
+            serviceProvider.AddService(data);
+            var renderer = new TestRenderer(serviceProvider);
+            var component = new TestComponent(builder =>
+            {
+                builder.OpenComponent<CustomCascadingComponent>(0);
+                builder.AddAttribute(1, "IsFixed", true);
+                builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+                {
+                    if (shouldIncludeChild)
+                    {
+                        childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
+                        childBuilder.AddAttribute(1, "RegularParameter", "Goodbye");
+                        childBuilder.CloseComponent();
+                    }
+                }));
+                builder.CloseComponent();
+            });
+
+            // Act 1: Initial render; capture nested component ID
+            var componentId = renderer.AssignRootComponentId(component);
+            component.TriggerRender();
+            var firstBatch = renderer.Batches.Single();
+            var nestedComponent = FindComponent<CascadingParameterConsumerComponent<string>>(firstBatch, out var nestedComponentId);
+            Assert.Equal(1, nestedComponent.NumRenders);
+
+            // Assert: Initial value is supplied to descendant
+            var nestedComponentDiff = firstBatch.DiffsByComponentId[nestedComponentId].Single();
+            Assert.Collection(nestedComponentDiff.Edits, edit =>
+            {
+                Assert.Equal(RenderTreeEditType.PrependFrame, edit.Type);
+                AssertFrame.Text(
+                    firstBatch.ReferenceFrames[edit.ReferenceFrameIndex],
+                    "CascadingParameter=Initial value; RegularParameter=Goodbye");
+            });
+
+            // Act 2: Re-render CascadingValue with new value
+            data.UpdateValue("Updated value");
+            component.TriggerRender();
+
+            // Assert: We did not re-render the descendant
+            Assert.Equal(2, renderer.Batches.Count);
+            var secondBatch = renderer.Batches[1];
+            Assert.Equal(2, secondBatch.DiffsByComponentId.Count); // Root + CascadingValue, but not nested one
+            Assert.Equal(1, nestedComponent.NumSetParametersCalls);
+            Assert.Equal(1, nestedComponent.NumRenders);
+
+            // Act 3: Dispose
+            shouldIncludeChild = false;
+            component.TriggerRender();
+
+            // Assert: Absence of an exception here implies we didn't cause a problem by
+            // trying to remove a non-existent subscription
+        }
+
+        private static T FindComponent<T>(CapturedBatch batch, out int componentId)
+        {
+            var componentFrame = batch.ReferenceFrames.Single(
+                frame => frame.FrameType == RenderTreeFrameType.Component
+                         && frame.Component is T);
+            componentId = componentFrame.ComponentId;
+            return (T)componentFrame.Component;
+        }
+
+        class CustomComponentData
+        {
+            private readonly Dictionary<(Type valueType, string valueName), object> _values =
+                new Dictionary<(Type valueType, string valueName), object>();
+
+            private bool _updated = true;
+
+            public CustomComponentData AddValue(Type valueType, object value, string valueName = null)
+            {
+                _values.Add((valueType, valueName), value);
+                _updated = true;
+                return this;
+            }
+
+            public CustomComponentData AddValue<T>(T value, string valueName = null)
+            {
+                _values.Add((typeof(T), valueName), value);
+                _updated = true;
+                return this;
+            }
+
+            public CustomComponentData UpdateValue(Type valueType, object value, string valueName = null)
+            {
+                if (!_values.TryGetValue((valueType, valueName), out value)) return this;
+                _updated = true;
+                _values[(valueType, valueName)] = value;
+                return this;
+            }
+
+            public CustomComponentData UpdateValue<T>(T value, string valueName = null)
+            {
+                if (!_values.TryGetValue((typeof(T), valueName), out var valueObject)) return this;
+                _updated = true;
+                _values[(typeof(T), valueName)] = value;
+                return this;
+            }
+
+            internal IReadOnlyDictionary<(Type valueType, string valueName), object> Values => _values;
+            internal bool IsUpdated => _updated;
+
+            public bool HasValue(Type valueType, string valueName)
+            {
+                return _values.ContainsKey((valueType, valueName)) || _values.ContainsKey((valueType, null));
+            }
+
+            public object GetValue(Type valueType, string valueName)
+            {
+                return _values.TryGetValue((valueType, valueName), out var value) ? value : _values.TryGetValue((valueType, null), out value) ? value : null;
+            }
+
+            internal void UpdateCompleted() => _updated = false;
+        }
+
+        class CustomCascadingComponent : AutoRenderComponent, ICascadingValueComponent
+        {
+            private HashSet<IComponentState> _subscribers;
+            [Parameter] public bool IsFixed { get; set; }
+
+            [Inject] public CustomComponentData Data { get; set; }
+
+            /// <summary>
+            /// The content to which the value should be provided.
+            /// </summary>
+            [Parameter] public RenderFragment ChildContent { get; set; }
+
+            public bool HasValue(Type valueType, string valueName)
+            {
+                return Data.HasValue(valueType, valueName);
+            }
+
+            public object GetValue(Type valueType, string valueName)
+            {
+                return Data.GetValue(valueType, valueName);
+            }
+
+            public void Subscribe(IComponentState subscriber)
+            {
+                _subscribers ??= new HashSet<IComponentState>();
+                _subscribers.Add(subscriber);
+            }
+
+            public void Unsubscribe(IComponentState subscriber)
+            {
+                _subscribers.Remove(subscriber);
+            }
+
+            protected void UpdateSubscribers(in ParameterView parameters)
+            {
+                if (_subscribers is null) return;
+                foreach (var subscriber in _subscribers)
+                {
+                    subscriber.NotifyChanged(parameters);
+                }
+            }
+
+            public override async Task SetParametersAsync(ParameterView parameters)
+            {
+                await base.SetParametersAsync(parameters);
+                if (Data.IsUpdated)
+                {
+                    Data.UpdateCompleted();
+                    UpdateSubscribers(parameters);
+                }
+            }
+
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+            {
+                ChildContent(builder);
+            }
+        }
+
+        class TestComponent : AutoRenderComponent
+        {
+            private readonly RenderFragment _renderFragment;
+
+            public TestComponent(RenderFragment renderFragment)
+            {
+                _renderFragment = renderFragment;
+            }
+
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+                => _renderFragment(builder);
+        }
+
+        class CascadingParameterConsumerComponent<T> : AutoRenderComponent
+        {
+            private ParameterView lastParameterView;
+
+            public int NumSetParametersCalls { get; private set; }
+            public int NumRenders { get; private set; }
+
+            [CascadingParameter] T CascadingParameter { get; set; }
+            [Parameter] public string RegularParameter { get; set; }
+
+            public override async Task SetParametersAsync(ParameterView parameters)
+            {
+                lastParameterView = parameters;
+                NumSetParametersCalls++;
+                await base.SetParametersAsync(parameters);
+            }
+
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+            {
+                NumRenders++;
+                builder.AddContent(0, $"CascadingParameter={CascadingParameter}; RegularParameter={RegularParameter}");
+            }
+
+            public void AttemptIllegalAccessToLastParameterView()
+            {
+                // You're not allowed to hold onto a ParameterView and access it later,
+                // so this should throw
+                lastParameterView.TryGetValue<object>("anything", out _);
+            }
+        }
+
+        class SecondCascadingParameterConsumerComponent<T1, T2> : CascadingParameterConsumerComponent<T1>
+        {
+            [CascadingParameter] T2 SecondCascadingParameter { get; set; }
+        }
+    }
+}

--- a/src/Components/Components/test/ParameterViewTest.Assignment.cs
+++ b/src/Components/Components/test/ParameterViewTest.Assignment.cs
@@ -680,7 +680,7 @@ namespace Microsoft.AspNetCore.Components
                 {
                     if (kvp.Cascading)
                     {
-                        cascadingParameters.Add(new CascadingParameterState(kvp.Name, new TestCascadingValueProvider(kvp.Value)));
+                        cascadingParameters.Add(new CascadingParameterState(kvp.Name, kvp.Value.GetType(), new TestCascadingValueProvider(kvp.Value)));
                     }
                 }
 
@@ -690,26 +690,28 @@ namespace Microsoft.AspNetCore.Components
 
         private class TestCascadingValueProvider : ICascadingValueComponent
         {
+            private readonly object _value;
+
             public TestCascadingValueProvider(object value)
             {
-                CurrentValue = value;
+                _value = value;
             }
 
-            public object CurrentValue { get; }
+            public object GetValue(Type valueType, string valueName) => _value;
 
-            public bool CurrentValueIsFixed => throw new NotImplementedException();
+            public bool IsFixed => throw new NotImplementedException();
 
-            public bool CanSupplyValue(Type valueType, string valueName)
+            public bool HasValue(Type valueType, string valueName)
             {
                 throw new NotImplementedException();
             }
 
-            public void Subscribe(ComponentState subscriber)
+            public void Subscribe(IComponentState subscriber)
             {
                 throw new NotImplementedException();
             }
 
-            public void Unsubscribe(ComponentState subscriber)
+            public void Unsubscribe(IComponentState subscriber)
             {
                 throw new NotImplementedException();
             }

--- a/src/Components/Components/test/ParameterViewTest.cs
+++ b/src/Components/Components/test/ParameterViewTest.cs
@@ -99,8 +99,8 @@ namespace Microsoft.AspNetCore.Components
                 RenderTreeFrame.Attribute(1, "attribute 1", attribute1Value)
             }, 0).WithCascadingParameters(new List<CascadingParameterState>
             {
-                new CascadingParameterState("attribute 2", new TestCascadingValue(attribute2Value)),
-                new CascadingParameterState("attribute 3", new TestCascadingValue(attribute3Value)),
+                new CascadingParameterState("attribute 2", typeof(object), new TestCascadingValue(attribute2Value)),
+                new CascadingParameterState("attribute 3", typeof(object), new TestCascadingValue(attribute3Value)),
             });
 
             // Assert
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Components
                 RenderTreeFrame.Attribute(1, "some other entry", new object())
             }, 0).WithCascadingParameters(new List<CascadingParameterState>
             {
-                new CascadingParameterState("another entry", new TestCascadingValue(null))
+                new CascadingParameterState("another entry", typeof(object), new TestCascadingValue(null))
             });
 
             // Act
@@ -310,9 +310,9 @@ namespace Microsoft.AspNetCore.Components
                 RenderTreeFrame.Attribute(1, "unrelated value", new object())
             }, 0).WithCascadingParameters(new List<CascadingParameterState>
             {
-                new CascadingParameterState("unrelated value 2", new TestCascadingValue(null)),
-                new CascadingParameterState("my entry", new TestCascadingValue(myEntryValue)),
-                new CascadingParameterState("unrelated value 3", new TestCascadingValue(null)),
+                new CascadingParameterState("unrelated value 2", typeof(object), new TestCascadingValue(null)),
+                new CascadingParameterState("my entry", typeof(object), new TestCascadingValue(myEntryValue)),
+                new CascadingParameterState("unrelated value 3", typeof(object), new TestCascadingValue(null)),
             });
 
             // Act
@@ -377,22 +377,25 @@ namespace Microsoft.AspNetCore.Components
 
         private class TestCascadingValue : ICascadingValueComponent
         {
+            private readonly object _value;
+
             public TestCascadingValue(object value)
             {
-                CurrentValue = value;
+                _value = value;
             }
 
-            public object CurrentValue { get; }
+            public bool IsFixed => false;
 
-            public bool CurrentValueIsFixed => false;
+            public object GetValue(Type valueType, string valueName) => _value;
+            
 
-            public bool CanSupplyValue(Type valueType, string valueName)
+            public bool HasValue(Type valueType, string valueName)
                 => throw new NotImplementedException();
 
-            public void Subscribe(ComponentState subscriber)
+            public void Subscribe(IComponentState subscriber)
                 => throw new NotImplementedException();
 
-            public void Unsubscribe(ComponentState subscriber)
+            public void Unsubscribe(IComponentState subscriber)
                 => throw new NotImplementedException();
         }
     }


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable. (think so!)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

**PR Title**
Added support for defining custom Cascading Value Components

**PR Description**
This PR is a proof of concept for changes to `ICascadingValueComponent` that will externalize the interface and allow custom components to provide multiple cascading values. This allows similar behavior to the `provide` system from Vue where any component can provide values for a child component to consume.

I'm not sure I like the existing Subscribe / Unsubscribe methods, as it puts a lot of work on the consumer (granted this is more of an advanced feature), but I left it as is to get something simple out to start a discussion. I thought about an `event`, `EventCallback` or even an `IObservable` that could then manage the subscription internally.

Note: I am sure there are changes in there that will raise from flags, I'm totally open to discussing different ways these can be handled! I did these changes in a few hours specifically so that not a lot of time was wasted to start a conversation.

Addresses #bugnumber (in this specific format)
#18743
