### PR TITLE
Start connections on a fresh ExecutionContext

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         private CancellationTokenSource _connectionClosedTokenSource;
 
         // No need to RunContinuationsAsynchronously since we're at the tail of a threadpool thread
-        private TaskCompletionSource _connectionDelegateTcs = new TaskCompletionSource();
+        private readonly TaskCompletionSource _connectionDelegateTcs = new ();
         private ConnectionDelegate _connectionDelegate;
 
         private CancellationTokenSource _sendCts;


### PR DESCRIPTION
- This change removes the `ExecutionContext` from new connections, this removes the possibility of capturing request scoped async locals and flowing them to the hub. This will ensure that the `IHttpContextAccessor` and `Activity` for hub invocations is always null and aren't carried over from the incoming request.
- This will break the ability to pass state to the hub via an async local from middleware but I'm OK with that.

Related to #29846

This breaks the localization middleware for SignalR and for Blazor scenarios https://github.com/dotnet/aspnetcore/blob/c925f99cddac0df90ed0bc4a07ecda6b054a0b02/src/Components/test/testassets/TestServer/InternationalizationStartup.cs#L42

PS: I need to write a test but nothing works in visual studio...

cc @stephentoub you were asking about https://github.com/dotnet/runtime/issues/47998, this is the change.