### PR TITLE
Fixes flaky HTTP/3 test

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -277,7 +277,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>(HeaderNames.Path, "/"),
                 new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
             };
-            await InitializeConnectionAsync(_noopApplication);
 
             var requestStream = await InitializeConnectionAndStreamsAsync(_noopApplication);
 


### PR DESCRIPTION
Will eventually resolve https://github.com/dotnet/aspnetcore/issues/21520.

I believe this was flaky due to the connection being initialize twice. I tried running this locally and hit debug fails each time when running in debug. After removing, the test passed.

Going to keep in quarantine for 30 days still though as it could still be flaky on CI.