### PR TITLE
Update helix installation retry logic

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -1,5 +1,9 @@
 # We only want to run full helix matrix on main
-pr: none
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - '*'
 trigger: none
 schedules:
 # Cron timezone is UTC.

--- a/eng/helix/content/runtests.ps1
+++ b/eng/helix/content/runtests.ps1
@@ -42,7 +42,7 @@ function InvokeInstallDotnet([string]$command) {
     return $false
 }
 
-function InstallDotnetSDKAndRuntime([string]$Feed, [string]$FeedCred) {
+function InstallDotnetSDKAndRuntime([string]$Feed, [string]$FeedCredParam) {
     foreach ($i in 1..5) {
         $random = Get-Random -Maximum 1024
         $env:DOTNET_HOME = Join-Path $currentDirectory "sdk$random"
@@ -52,14 +52,14 @@ function InstallDotnetSDKAndRuntime([string]$Feed, [string]$FeedCred) {
 
         Write-Host "Set PATH to: $env:PATH"
 
-        $success = InvokeInstallDotnet ". eng\common\tools.ps1; InstallDotNet $env:DOTNET_ROOT $SdkVersion $Arch `'`' `$true `'$Feed`' `'$FeedCred`' `$true"
+        $success = InvokeInstallDotnet ". eng\common\tools.ps1; InstallDotNet $env:DOTNET_ROOT $SdkVersion $Arch `'`' `$true `'$Feed`' `'$FeedCredParam`' `$true"
 
         if (!$success) {
             Write-Host "Retrying..."
             continue
         }
 
-        $success = InvokeInstallDotnet ". eng\common\tools.ps1; InstallDotNet $env:DOTNET_ROOT $SdkVersion $Arch dotnet `$true `'$Feed`' `'$FeedCred`' `$true"
+        $success = InvokeInstallDotnet ". eng\common\tools.ps1; InstallDotNet $env:DOTNET_ROOT $SdkVersion $Arch dotnet `$true `'$Feed`' `'$FeedCredParam`' `$true"
 
         if (!$success) {
             Write-Host "Retrying..."
@@ -73,7 +73,7 @@ function InstallDotnetSDKAndRuntime([string]$Feed, [string]$FeedCred) {
     exit 1
 }
 
-if ($FeedCred -eq $null) {
+if ([string]::IsNullOrEmpty($FeedCred)) {
     InstallDotnetSDKAndRuntime
 } else {
     InstallDotnetSDKAndRuntime "https://dotnetclimsrc.blob.core.windows.net/dotnet" $FeedCred

--- a/eng/helix/content/runtests.ps1
+++ b/eng/helix/content/runtests.ps1
@@ -59,7 +59,7 @@ function InstallDotnetSDKAndRuntime([string]$Feed, [string]$FeedCredParam) {
             continue
         }
 
-        $success = InvokeInstallDotnet ". eng\common\tools.ps1; InstallDotNet $env:DOTNET_ROOT $SdkVersion $Arch dotnet `$true `'$Feed`' `'$FeedCredParam`' `$true"
+        $success = InvokeInstallDotnet ". eng\common\tools.ps1; InstallDotNet $env:DOTNET_ROOT $RuntimeVersion $Arch dotnet `$true `'$Feed`' `'$FeedCredParam`' `$true"
 
         if (!$success) {
             Write-Host "Retrying..."


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspnetcore/pull/29842 to fix partial installation issues.

The problem was that if the process timed out when the SDK was partially installed, upon retry, the dotnet-install script will see the partial installation and consider the SDK already installed and exit with success. This PR changes it so that upon failure (timeout or non-zero exit code) of either SDK or runtime installation, both will be re-installed as part of the retry.