### PR TITLE
Revert "Skip AddressRegistrationTests Hostname tests on macOS (#30012)"

### DIFF
--- a/src/Servers/Kestrel/shared/test/TransportTestHelpers/HostNameIsReachableAttribute.cs
+++ b/src/Servers/Kestrel/shared/test/TransportTestHelpers/HostNameIsReachableAttribute.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class HostNameIsReachableAttribute : Attribute, ITestCondition
+    {
+        private string _hostname;
+        private string _error;
+        private bool? _isMet;
+
+        public bool IsMet
+        {
+            get
+            {
+                return _isMet ?? (_isMet = HostNameIsReachable().GetAwaiter().GetResult()).Value;
+            }
+        }
+
+        public string SkipReason => _hostname != null
+            ? $"Test cannot run when network is unreachable. Socket exception: '{_error}'"
+            : "Could not determine hostname for current test machine";
+
+        private async Task<bool> HostNameIsReachable()
+        {
+            try
+            {
+                _hostname = Dns.GetHostName();
+
+                // if the network is unreachable on macOS, throws with SocketError.NetworkUnreachable
+                // if the network device is not configured, throws with SocketError.HostNotFound
+                // if the network is reachable, throws with SocketError.ConnectionRefused or succeeds
+                var timeoutTask = Task.Delay(1000);
+                if (await Task.WhenAny(ConnectToHost(_hostname, 80), timeoutTask) == timeoutTask)
+                {
+                    _error = "Attempt to establish a connection took over a second without success or failure.";
+                    return false;
+                }
+            }
+            catch (SocketException ex) when (
+                ex.SocketErrorCode == SocketError.NetworkUnreachable
+                || ex.SocketErrorCode == SocketError.HostNotFound)
+            {
+                _error = ex.Message;
+                return false;
+            }
+            catch
+            {
+                // Swallow other errors. Allows the test to throw the failures instead
+            }
+
+            return true;
+        }
+
+        public static async Task<Socket> ConnectToHost(string hostName, int port)
+        {
+            var tcs = new TaskCompletionSource<Socket>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var socketArgs = new SocketAsyncEventArgs();
+            socketArgs.RemoteEndPoint = new DnsEndPoint(hostName, port);
+            socketArgs.Completed += (s, e) => tcs.TrySetResult(e.ConnectSocket);
+
+            // Must use static ConnectAsync(), since instance Connect() does not support DNS names on OSX/Linux.
+            if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, socketArgs))
+            {
+                await tcs.Task.ConfigureAwait(false);
+            }
+
+            var socket = socketArgs.ConnectSocket;
+
+            if (socket == null)
+            {
+                throw new SocketException((int)socketArgs.SocketError);
+            }
+            else
+            {
+                return socket;
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -20,12 +19,13 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 using Xunit.Sdk;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 {
@@ -34,7 +34,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         private const int MaxRetries = 10;
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX)] // Hostname is arbitrarily available on macOS, see https://github.com/dotnet/aspnetcore/issues/27377
+        [HostNameIsReachable]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27377")]
         public async Task RegisterAddresses_HostName_Success()
         {
             var hostName = Dns.GetHostName();
@@ -363,7 +364,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX)] // Hostname is arbitrarily available on macOS, see https://github.com/dotnet/aspnetcore/issues/27377
+        [HostNameIsReachable]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27377")]
         public async Task ListenAnyIP_HostName_Success()
         {
             var hostName = Dns.GetHostName();


### PR DESCRIPTION
This reverts commit 6dc17a44650a0056959a5cd49e7530d835ae65ec.



