### PR TITLE
[release/5.0] Update dependencies from dnceng/internal/dotnet-runtime

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,10 +4,9 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-efcore -->
-    <add key="darc-int-dotnet-efcore-efc2924" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-efcore-efc2924e/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-efcore -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-int-dotnet-runtime-c636bbd" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-runtime-c636bbdc/nuget/v3/index.json" />
+    <add key="darc-int-dotnet-runtime-8a5d98f" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-runtime-8a5d98fb/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
@@ -20,29 +19,14 @@
   </packageSources>
   <disabledPackageSources>
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <add key="darc-int-dotnet-efcore-1ee6b62" value="true" />
-    <add key="darc-int-dotnet-runtime-cb5f173" value="true" />
-    <add key="darc-int-dotnet-efcore-8c89ec4" value="true" />
-    <add key="darc-int-dotnet-efcore-9322ea3" value="true" />
-    <add key="darc-int-dotnet-efcore-d5943e6" value="true" />
-    <add key="darc-int-dotnet-efcore-8741b87" value="true" />
-    <add key="darc-int-dotnet-efcore-ff5f100" value="true" />
-    <add key="darc-int-dotnet-runtime-f37e9a0" value="true" />
-    <add key="darc-int-dotnet-runtime-d070c3f" value="true" />
-    <add key="darc-int-dotnet-runtime-c37365f" value="true" />
-    <add key="darc-int-dotnet-runtime-75b9165" value="true" />
-    <add key="darc-int-dotnet-runtime-8552839" value="true" />
-    <add key="darc-int-dotnet-runtime-44db96a" value="true" />
-    <add key="darc-int-dotnet-runtime-fe8a2d0" value="true" />
-    <add key="darc-int-dotnet-runtime-eae88cc" value="true" />
     <!--  Begin: Package sources from dotnet-runtime -->
-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
-    <add key="darc-int-dotnet-runtime-c636bbd" value="true" />
+    <add key="darc-int-dotnet-runtime-8a5d98f" value="true" />
+    <add key="darc-int-dotnet-runtime-d1e2874" value="true" />
     <add key="darc-int-dotnet-runtime-c636bbd" value="true" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-efcore -->
     <add key="darc-int-dotnet-efcore-efc2924" value="true" />
-    <add key="darc-int-dotnet-efcore-efc2924" value="true" />
     <!--  End: Package sources from dotnet-efcore -->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
   </disabledPackageSources>
 </configuration>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -199,7 +199,7 @@
     </Dependency>
     <Dependency Name="System.Diagnostics.EventLog" Version="5.0.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>c636bbdc8a2d393d07c0e9407a4f8923ba1a21cb</Sha>
+      <Sha>d1e2874de3956c618626ee46554a093f28a330e2</Sha>
     </Dependency>
     <Dependency Name="System.DirectoryServices.Protocols" Version="5.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -207,7 +207,7 @@
     </Dependency>
     <Dependency Name="System.Drawing.Common" Version="5.0.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>c636bbdc8a2d393d07c0e9407a4f8923ba1a21cb</Sha>
+      <Sha>d1e2874de3956c618626ee46554a093f28a330e2</Sha>
     </Dependency>
     <Dependency Name="System.IO.Pipelines" Version="5.0.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -311,7 +311,7 @@
     <!-- Listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->
     <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>c636bbdc8a2d393d07c0e9407a4f8923ba1a21cb</Sha>
+      <Sha>d1e2874de3956c618626ee46554a093f28a330e2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.21109.6">
       <Uri>https://github.com/dotnet/arcade</Uri>


### PR DESCRIPTION
- cherry-pick from internal/release/5.0
- needed to get internal merges going again
- also correct confusion in NuGet.config from e9a385d