### PR TITLE
Migrate to ActivitySource

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -319,7 +319,10 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 StopActivity(activity, httpContext);
             }
-            activity.Stop();
+            else
+            {
+                activity.Stop();
+            }
         }
 
         // These are versions of DiagnosticSource.Start/StopActivity that don't allocate strings per call (see https://github.com/dotnet/corefx/issues/37055)
@@ -339,6 +342,7 @@ namespace Microsoft.AspNetCore.Hosting
                 activity.SetEndTime(DateTime.UtcNow);
             }
             _diagnosticListener.Write(ActivityStopKey, httpContext);
+            activity.Stop();    // Resets Activity.Current (we want this after the Write)
         }
     }
 }

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -465,7 +465,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         }
 
         [Fact]
-        public void ActivityOnExportHookIsCalled()
+        public void ActivityOnImportHookIsCalled()
         {
             var diagnosticListener = new DiagnosticListener("DummySource");
             var hostingApplication = CreateApplication(out var features, diagnosticListener: diagnosticListener);
@@ -477,7 +477,9 @@ namespace Microsoft.AspNetCore.Hosting.Tests
                 onActivityImport: (activity, context) =>
                 {
                     onActivityImportCalled = true;
-                    Assert.Null(Activity.Current);
+                    // Review: Breaking change
+                    // Since we fire OnActivityImport after Activity.Start(), it will no longer be not null
+                    //Assert.Null(Activity.Current);
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", activity.OperationName);
                     Assert.NotNull(context);
                     Assert.IsAssignableFrom<HttpContext>(context);

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -506,8 +506,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
                 ActivityStarted = activity =>
                 {
                     Assert.Equal("0123456789abcdef", Activity.Current.ParentSpanId.ToHexString());
-                },
-                //ActivityStopped = activity => Assert..
+                }
             };
 
             ActivitySource.AddActivityListener(listener);

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -478,9 +478,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
                 onActivityImport: (activity, context) =>
                 {
                     onActivityImportCalled = true;
-                    // Review: Breaking change
-                    // Since we fire OnActivityImport after Activity.Start(), it will no longer be not null
-                    //Assert.Null(Activity.Current);
+                    Assert.Null(Activity.Current);
                     Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", activity.OperationName);
                     Assert.NotNull(context);
                     Assert.IsAssignableFrom<HttpContext>(context);


### PR DESCRIPTION
Current behavior:

1. if (loggingEnabled || diagnosticsListenerEnabled), new up Activity
2. activity.SetParentId(headers["traceparent"] or headers["request-id"])
3. activity Add Baggage from headers["baggage"] or headers["Correlation-Context"]
4. _diagnosticsListener.OnActivityImport(activity, httpContext)
4. activity.Start()
5. _diagnosticsListener.Write(ActivityStartKey, httpContext)

New behavior:

1. if (loggingEnabled || diagnosticsListenerEnabled), new up a dummyListener
2. Defer creation of Activity to ActivitySource

if (activity is not null)
{

  3. Add baggage
  4. _diagnosticsListener.OnActivityImport(activity, httpContext)
  5. _diagnosticListener.Write(ActivityStartKey, httpContext);

}


Questions:
1. Baggage isn't present on Activity before starting
2. Is it okay if we don't fire diagnosticsListener.OnActivityImport? Is ordering important? Can I do it after Activity.Start()?