### PR TITLE
Remove unnecessary NuGet.config file

### DIFF
--- a/src/Servers/Kestrel/NuGet.config
+++ b/src/Servers/Kestrel/NuGet.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <add key="general-testing" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
- historical artifact from early QUIC days