### PR TITLE
[release/3.1] Add Custom UI strings for en-us bundle

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/1033/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1033/thm.wxl
@@ -58,4 +58,7 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
+
+  <String Id="Welcome">Welcome to the [WixBundle] Setup.</String>
+  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
@@ -58,4 +58,12 @@
   <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications. A reboot will be required.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
+
+  <!-- Custom UI strings -->
+  <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
+  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>


### PR DESCRIPTION
Fixes customer report of 3.1.12/5.0.3 Asp.net bundle installers showing placeholder strings for en-us. These have been missing from the 1033 thm.wxl files, but didn't show up until last month when we added 1033 to the list of loc files for the bundles.