### PR TITLE
Enable all Globalization analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -44,6 +44,4 @@ end_of_line = lf
 charset = utf-8-bom
 
 [*.cs]
-dotnet_diagnostic.CA1304.severity = error
-dotnet_diagnostic.CA1305.severity = error
-dotnet_diagnostic.CA1310.severity = error
+dotnet_analyzer_diagnostic.category-Globalization.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -45,3 +45,4 @@ charset = utf-8-bom
 
 [*.cs]
 dotnet_analyzer_diagnostic.category-Globalization.severity = error
+dotnet_diagnostic.CA1309.severity = suggestion


### PR DESCRIPTION
The three enabled rules are all Globalization rules, which shows interest in this category.

This PR enables all Globalization rules. I'm going to wait for CI to see how many violations are there, and depending on that I'll see how this can move forward.