### PR TITLE
Move APIs added in 5.0.1 patch to Unshipped

### DIFF
--- a/src/Components/Components/src/PublicAPI.Shipped.txt
+++ b/src/Components/Components/src/PublicAPI.Shipped.txt
@@ -429,5 +429,3 @@ virtual Microsoft.AspNetCore.Components.RouteView.Render(Microsoft.AspNetCore.Co
 ~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.MarkupContent.get -> string
 ~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.TextContent.get -> string
 ~override Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ToString() -> string
-Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.get -> bool
-Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.set -> void

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 *REMOVED*static Microsoft.AspNetCore.Components.ParameterView.FromDictionary(System.Collections.Generic.IDictionary<string!, object!>! parameters) -> Microsoft.AspNetCore.Components.ParameterView
 *REMOVED*virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(ulong eventHandlerId, Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo! fieldInfo, System.EventArgs! eventArgs) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.get -> bool
+Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.set -> void
 Microsoft.AspNetCore.Components.DynamicComponent
 Microsoft.AspNetCore.Components.DynamicComponent.Attach(Microsoft.AspNetCore.Components.RenderHandle renderHandle) -> void
 Microsoft.AspNetCore.Components.DynamicComponent.DynamicComponent() -> void


### PR DESCRIPTION
Following up to a concern in https://github.com/dotnet/aspnetcore/pull/28253.

Note that there's no action needed on the ProtectedBrowserStorage/src/PublicAPI.*Shipped.txt files since those were moved in 5.0 to Components/Servers but the API files were left in ProtectedBrowserStorage/src accidentally. These files were removed in https://github.com/dotnet/aspnetcore/pull/29901 hence the diff between release/5.0 and main branches.