### PR TITLE
Port duplication of productVersion.txt to release/5.0

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -8,7 +8,9 @@
 
     <_UploadPathRoot>aspnetcore</_UploadPathRoot>
     <ProductVersionFileName>productVersion.txt</ProductVersionFileName>
+    <RepoProductVersionFileName>$(_UploadPathRoot)-$(ProductVersionFileName)</RepoProductVersionFileName>
     <ProductVersionFileLocation>$(ArtifactsShippingPackagesDir)$(ProductVersionFileName)</ProductVersionFileLocation>
+    <RepoProductVersionFileLocation>$(ArtifactsShippingPackagesDir)$(RepoProductVersionFileName)</RepoProductVersionFileLocation>
   </PropertyGroup>
 
   <!-- $(InstallersOutputPath), $(SymbolsOutputPath), and $(ChecksumExtensions) are not defined. Root Directory.Build.props is not imported. -->
@@ -33,7 +35,7 @@
     <_ChecksumsToPublish Include="$(ArtifactsDir)**\*.sha512" />
   </ItemGroup>
 
-  <Target 
+  <Target
     Name="_PublishInstallersAndChecksumsAndProductVersion"
     DependsOnTargets="_WriteProductVersionFile">
     <!--
@@ -78,10 +80,15 @@
         <PublishFlatContainer>true</PublishFlatContainer>
         <RelativeBlobPath>$(_UploadPathRoot)/Runtime/$(_PackageVersion)/$(ProductVersionFileName)</RelativeBlobPath>
       </ItemsToPushToBlobFeed>
+
+      <ItemsToPushToBlobFeed Include="$(RepoProductVersionFileLocation)" Condition=" '$(PublishInstallerBaseVersion)' == 'true'">
+        <PublishFlatContainer>true</PublishFlatContainer>
+        <RelativeBlobPath>$(_UploadPathRoot)/Runtime/$(_PackageVersion)/$(RepoProductVersionFileName)</RelativeBlobPath>
+      </ItemsToPushToBlobFeed>
     </ItemGroup>
   </Target>
 
-  <Target 
+  <Target
     Name="_WriteProductVersionFile"
     Condition=" '$(PublishInstallerBaseVersion)' == 'true'">
     <!--
@@ -103,6 +110,11 @@
     <!-- Generate productVersion.txt containing the value of $(PackageVersion) -->
     <WriteLinesToFile
       File="$(ProductVersionFileLocation)"
+      Lines="$(_ProductVersion)"
+      Overwrite="true"
+      Encoding="ASCII" />
+    <WriteLinesToFile
+      File="$(RepoProductVersionFileLocation)"
       Lines="$(_ProductVersion)"
       Overwrite="true"
       Encoding="ASCII" />


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Port duplication of productVersion.txt to release/5.0

**PR Description**
In our efforts to unify the build access story using aka.ms links, we have found that there are certain files that share the same name in multiple different repositories, most importantly, productVersion.txt. As part of the work to move to aka.ms links, we will be flattening the short link paths, so rather than having a runtime-specific, aspnetcore-specific, etc. full path to the files generated by each of the repos, they will all go to the same short link location. This means that the path to productVersion.txt will collide in the aka.ms links (the backing locations are not changing and will be unaffected). To combat this, we will add a duplicate of each of the product repos productVersion.txt, renamed to indicate which product repo it came from, in this case aspnetcore-productVersion.txt. The original will remane so that we do not break existing scenarios that do not use the aka.ms links.

Addresses https://github.com/dotnet/arcade/issues/6862
