### PR TITLE
Reduce overheads in KestrelEventSource

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             Interlocked.Increment(ref _totalConnections);
             Interlocked.Increment(ref _currentConnections);
 
-            if (IsEnabled())
+            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 ConnectionStart(
                     connection.ConnectionId,
@@ -67,23 +67,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(1, Level = EventLevel.Informational)]
-        private void ConnectionStart(string connectionId,
-            string? localEndPoint,
-            string? remoteEndPoint)
+        private void ConnectionStart(string connectionId, string? localEndPoint, string? remoteEndPoint)
         {
-            WriteEvent(
-                1,
-                connectionId,
-                localEndPoint,
-                remoteEndPoint
-            );
+            WriteEvent(1, connectionId, localEndPoint, remoteEndPoint);
         }
 
         [NonEvent]
         public void ConnectionStop(BaseConnectionContext connection)
         {
             Interlocked.Decrement(ref _currentConnections);
-            if (IsEnabled())
+
+            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 ConnectionStop(connection.ConnectionId);
             }
@@ -99,14 +93,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [NonEvent]
         public void RequestStart(HttpProtocol httpProtocol)
         {
-            // avoid allocating the trace identifier unless logging is enabled
             if (IsEnabled())
             {
-                RequestStart(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpProtocol.HttpVersion, httpProtocol.Path!, httpProtocol.MethodText);
+                Core(httpProtocol);
+            }
+
+            [NonEvent]
+            void Core(HttpProtocol httpProtocol)
+            {
+                // avoid allocating the trace identifier unless logging is enabled
+                if (IsEnabled(EventLevel.Informational, EventKeywords.None))
+                {
+                    RequestStart(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpProtocol.HttpVersion, httpProtocol.Path!, httpProtocol.MethodText);
+                }
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(3, Level = EventLevel.Informational)]
         private void RequestStart(string connectionId, string requestId, string httpVersion, string path, string method)
         {
@@ -116,14 +118,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [NonEvent]
         public void RequestStop(HttpProtocol httpProtocol)
         {
-            // avoid allocating the trace identifier unless logging is enabled
             if (IsEnabled())
             {
-                RequestStop(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpProtocol.HttpVersion, httpProtocol.Path!, httpProtocol.MethodText);
+                Core(httpProtocol);
+            }
+
+            [NonEvent]
+            void Core(HttpProtocol httpProtocol)
+            {
+                // avoid allocating the trace identifier unless logging is enabled
+                if (IsEnabled(EventLevel.Informational, EventKeywords.None))
+                {
+                    RequestStop(httpProtocol.ConnectionIdFeature, httpProtocol.TraceIdentifier, httpProtocol.HttpVersion, httpProtocol.Path!, httpProtocol.MethodText);
+                }
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         [Event(4, Level = EventLevel.Informational)]
         private void RequestStop(string connectionId, string requestId, string httpVersion, string path, string method)
         {
@@ -134,7 +144,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [Event(5, Level = EventLevel.Informational)]
         public void ConnectionRejected(string connectionId)
         {
-            if (IsEnabled())
+            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 WriteEvent(5, connectionId);
             }
@@ -157,7 +167,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         {
             Interlocked.Increment(ref _currentTlsHandshakes);
             Interlocked.Increment(ref _totalTlsHandshakes);
-            if (IsEnabled())
+
+            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 TlsHandshakeStart(connectionContext.ConnectionId, sslOptions.EnabledSslProtocols.ToString());
             }
@@ -174,7 +185,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public void TlsHandshakeStop(BaseConnectionContext connectionContext, TlsConnectionFeature? feature)
         {
             Interlocked.Decrement(ref _currentTlsHandshakes);
-            if (IsEnabled())
+
+            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 // TODO: Write this without a string allocation using WriteEventData
                 var applicationProtocol = feature == null ? string.Empty : Encoding.UTF8.GetString(feature.ApplicationProtocol.Span);
@@ -196,7 +208,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public void TlsHandshakeFailed(string connectionId)
         {
             Interlocked.Increment(ref _failedTlsHandshakes);
-            WriteEvent(10, connectionId);
+
+            if (IsEnabled(EventLevel.Error, EventKeywords.None))
+            {
+                WriteEvent(10, connectionId);
+            }
         }
 
         [NonEvent]
@@ -281,6 +297,55 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 {
                     DisplayName = "Current Upgraded Requests (WebSockets)"
                 };
+            }
+        }
+
+        [NonEvent]
+        private unsafe void WriteEvent(int eventId, string? arg1, string? arg2, string? arg3, string? arg4, string? arg5)
+        {
+            const int EventDataCount = 5;
+
+            arg1 ??= string.Empty;
+            arg2 ??= string.Empty;
+            arg3 ??= string.Empty;
+            arg4 ??= string.Empty;
+            arg5 ??= string.Empty;
+
+            fixed (char* arg1Ptr = arg1)
+            fixed (char* arg2Ptr = arg2)
+            fixed (char* arg3Ptr = arg3)
+            fixed (char* arg4Ptr = arg4)
+            fixed (char* arg5Ptr = arg5)
+            {
+                EventData* data = stackalloc EventData[EventDataCount];
+
+                data[0] = new EventData
+                {
+                    DataPointer = (IntPtr)arg1Ptr,
+                    Size = (arg1.Length + 1) * sizeof(char)
+                };
+                data[1] = new EventData
+                {
+                    DataPointer = (IntPtr)arg2Ptr,
+                    Size = (arg2.Length + 1) * sizeof(char)
+                };
+                data[2] = new EventData
+                {
+                    DataPointer = (IntPtr)arg3Ptr,
+                    Size = (arg3.Length + 1) * sizeof(char)
+                };
+                data[3] = new EventData
+                {
+                    DataPointer = (IntPtr)arg4Ptr,
+                    Size = (arg4.Length + 1) * sizeof(char)
+                };
+                data[4] = new EventData
+                {
+                    DataPointer = (IntPtr)arg5Ptr,
+                    Size = (arg5.Length + 1) * sizeof(char)
+                };
+
+                WriteEventCore(eventId, EventDataCount, data);
             }
         }
     }


### PR DESCRIPTION
- Added a `WriteEvent(int, string, string, string, string, string)` overload to avoid allocating the `params object[]` on every `RequestStart/Stop`
- Added `IsEnabled(EventLevel)` checks to avoid the overhead of computing arguments when only counters are enabled (so when the `EventLevel` is higher than `Informational`)


As a side note, I'm not sure how much you care about the Interlocked cost on some of these paths, but it can be improved (putting it behind an IsEnabled check / going from 3 Interlocked operations for Start/Stop to 2)

Fixes #30159