### PR TITLE
Limit CallStopAsyncOnRequestThread_DoesNotHangIndefinitely

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         [ConditionalTheory]
         [InlineData("/ShutdownStopAsync")]
         [InlineData("/ShutdownStopAsyncWithCancelledToken")]
+        [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "Shutdown hangs https://github.com/dotnet/aspnetcore/issues/30149")]
         public async Task CallStopAsyncOnRequestThread_DoesNotHangIndefinitely(string path)
         {
             // Canceled token doesn't affect shutdown, in-proc doesn't handle ungraceful shutdown


### PR DESCRIPTION
RE: #30149 #25107

Here's another test that struggles to shut down on the Win10 preview queue. I'm skipping the test on that queue for now.