### PR TITLE
Don't log a stack trace for AddressInUseException

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Threading;
@@ -207,7 +208,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
             catch (Exception ex)
             {
-                Trace.LogCritical(0, ex, "Unable to start Kestrel.");
+                // Do not log stack trace for known errors #29801
+                if (ex is IOException && ex.InnerException is AddressInUseException)
+                {
+                    Trace.LogCritical(0, "Unable to start Kestrel. {Message}", ex.Message);
+                }
+                else
+                {
+                    Trace.LogCritical(0, ex, "Unable to start Kestrel.");
+                }
+
                 Dispose();
                 throw;
             }

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -208,7 +208,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
             catch (Exception ex)
             {
-                // Do not log stack trace for known errors #29801
+                // Do not log stack trace for known errors https://github.com/dotnet/aspnetcore/issues/29801
                 if (ex is IOException && ex.InnerException is AddressInUseException)
                 {
                     Trace.LogCritical(0, "Unable to start Kestrel. {Message}", ex.Message);

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -209,11 +209,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             catch (Exception ex)
             {
                 // Do not log stack trace for known errors https://github.com/dotnet/aspnetcore/issues/29801
-                if (ex is IOException && ex.InnerException is AddressInUseException)
-                {
-                    Trace.LogCritical(0, "Unable to start Kestrel. {Message}", ex.Message);
-                }
-                else
+                if (ex is not IOException && ex.InnerException is not AddressInUseException)
                 {
                     Trace.LogCritical(0, ex, "Unable to start Kestrel.");
                 }

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Threading;
@@ -206,14 +205,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
                 await BindAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch
             {
-                // Do not log stack trace for known errors https://github.com/dotnet/aspnetcore/issues/29801
-                if (ex is not IOException && ex.InnerException is not AddressInUseException)
-                {
-                    Trace.LogCritical(0, ex, "Unable to start Kestrel.");
-                }
-
+                // Don't log the error https://github.com/dotnet/aspnetcore/issues/29801
                 Dispose();
                 throw;
             }

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 var exception = Assert.Throws<FormatException>(() => StartDummyApplication(server));
 
                 Assert.Contains("Invalid url", exception.Message);
-                Assert.Equal(1, testLogger.CriticalErrorsLogged);
+                Assert.Equal(0, testLogger.CriticalErrorsLogged);
             }
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.Equal(
                     $"A path base can only be configured using {nameof(IApplicationBuilder)}.UsePathBase().",
                     exception.Message);
-                Assert.Equal(1, testLogger.CriticalErrorsLogged);
+                Assert.Equal(0, testLogger.CriticalErrorsLogged);
             }
         }
 
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.Equal(
                     CoreStrings.FormatMaxRequestBufferSmallerThanRequestLineBuffer(maxRequestBufferSize, maxRequestLineSize),
                     exception.Message);
-                Assert.Equal(1, testLogger.CriticalErrorsLogged);
+                Assert.Equal(0, testLogger.CriticalErrorsLogged);
             }
         }
 
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.Equal(
                     CoreStrings.FormatMaxRequestBufferSmallerThanRequestHeaderBuffer(maxRequestBufferSize, maxRequestHeadersTotalSize),
                     exception.Message);
-                Assert.Equal(1, testLogger.CriticalErrorsLogged);
+                Assert.Equal(0, testLogger.CriticalErrorsLogged);
             }
         }
 

--- a/src/Servers/Kestrel/shared/test/TestApplicationErrorLoggerLoggedTest.cs
+++ b/src/Servers/Kestrel/shared/test/TestApplicationErrorLoggerLoggedTest.cs
@@ -17,6 +17,12 @@ namespace Microsoft.AspNetCore.Testing
 
         public ConcurrentQueue<LogMessage> LogMessages => TestApplicationErrorLogger.Messages;
 
+        public bool ThrowOnCriticalErrors
+        {
+            get => TestApplicationErrorLogger.ThrowOnCriticalErrors;
+            set => TestApplicationErrorLogger.ThrowOnCriticalErrors = value;
+        }
+
         public bool ThrowOnUngracefulShutdown
         {
             get => TestApplicationErrorLogger.ThrowOnUngracefulShutdown;

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -549,6 +549,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [Fact]
         public async Task ThrowsWhenBindingToIPv4AddressInUse()
         {
+            ThrowOnCriticalErrors = false;
+
             using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
@@ -562,13 +564,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                             .UseKestrel()
                             .UseUrls($"http://127.0.0.1:{port}")
                             .Configure(ConfigureEchoAddress);
-                    });
+                    })
+                    .ConfigureServices(AddTestLogging);
 
                 using (var host = hostBuilder.Build())
                 {
                     var exception = Assert.Throws<IOException>(() => host.Start());
-                    Assert.Equal(CoreStrings.FormatEndpointAlreadyInUse($"http://127.0.0.1:{port}"), exception.Message);
-
+                    var expectedMessage = CoreStrings.FormatEndpointAlreadyInUse($"http://127.0.0.1:{port}");
+                    Assert.Equal(expectedMessage, exception.Message);
+                    Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Critical &&
+                        log.Exception is null &&
+                        log.Message.EndsWith(expectedMessage, StringComparison.Ordinal));
                     await host.StopAsync();
                 }
             }
@@ -578,7 +584,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         [IPv6SupportedCondition]
         public async Task ThrowsWhenBindingToIPv6AddressInUse()
         {
-            IgnoredCriticalLogExceptions.Add(typeof(IOException));
+            ThrowOnCriticalErrors = false;
 
             using (var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
             {
@@ -599,7 +605,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                 using (var host = hostBuilder.Build())
                 {
                     var exception = Assert.Throws<IOException>(() => host.Start());
-                    Assert.Equal(CoreStrings.FormatEndpointAlreadyInUse($"http://[::1]:{port}"), exception.Message);
+                    var expectedMessage = CoreStrings.FormatEndpointAlreadyInUse($"http://[::1]:{port}");
+                    Assert.Equal(expectedMessage, exception.Message);
+                    Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Critical &&
+                        log.Exception is null &&
+                        log.Message.EndsWith(expectedMessage, StringComparison.Ordinal));
 
                     await host.StopAsync();
                 }
@@ -931,7 +941,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         private void ThrowsWhenBindingLocalhostToAddressInUse(AddressFamily addressFamily)
         {
-            IgnoredCriticalLogExceptions.Add(typeof(IOException));
+            ThrowOnCriticalErrors = false;
 
             var addressInUseCount = 0;
             var wrongMessageCount = 0;
@@ -990,6 +1000,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         }
 
                         Assert.Equal(CoreStrings.FormatEndpointAlreadyInUse(thisAddressString), exception.Message);
+                        Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Critical &&
+                            log.Exception is null &&
+                            log.Message.EndsWith(CoreStrings.FormatEndpointAlreadyInUse(thisAddressString), StringComparison.Ordinal));
                         break;
                     }
                 }

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -572,9 +572,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     var exception = Assert.Throws<IOException>(() => host.Start());
                     var expectedMessage = CoreStrings.FormatEndpointAlreadyInUse($"http://127.0.0.1:{port}");
                     Assert.Equal(expectedMessage, exception.Message);
-                    Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Critical &&
+                    Assert.Equal(0, LogMessages.Count(log => log.LogLevel == LogLevel.Critical &&
                         log.Exception is null &&
-                        log.Message.EndsWith(expectedMessage, StringComparison.Ordinal));
+                        log.Message.EndsWith(expectedMessage, StringComparison.Ordinal)));
                     await host.StopAsync();
                 }
             }
@@ -607,9 +607,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                     var exception = Assert.Throws<IOException>(() => host.Start());
                     var expectedMessage = CoreStrings.FormatEndpointAlreadyInUse($"http://[::1]:{port}");
                     Assert.Equal(expectedMessage, exception.Message);
-                    Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Critical &&
+                    Assert.Equal(0, LogMessages.Count(log => log.LogLevel == LogLevel.Critical &&
                         log.Exception is null &&
-                        log.Message.EndsWith(expectedMessage, StringComparison.Ordinal));
+                        log.Message.EndsWith(expectedMessage, StringComparison.Ordinal)));
 
                     await host.StopAsync();
                 }
@@ -1000,9 +1000,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                         }
 
                         Assert.Equal(CoreStrings.FormatEndpointAlreadyInUse(thisAddressString), exception.Message);
-                        Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Critical &&
+                        Assert.Equal(0, LogMessages.Count(log => log.LogLevel == LogLevel.Critical &&
                             log.Exception is null &&
-                            log.Message.EndsWith(CoreStrings.FormatEndpointAlreadyInUse(thisAddressString), StringComparison.Ordinal));
+                            log.Message.EndsWith(CoreStrings.FormatEndpointAlreadyInUse(thisAddressString), StringComparison.Ordinal)));
                         break;
                     }
                 }


### PR DESCRIPTION
In case of AddressInUseException do not log the exception
**AddressInUseException:**
![image](https://user-images.githubusercontent.com/1640125/108605996-51256700-736c-11eb-8b15-cfb3067c6fc2.png)
![image](https://user-images.githubusercontent.com/1640125/108606003-54b8ee00-736c-11eb-8a9e-c88a1642e6c5.png)

**Other exceptions:**
![image](https://user-images.githubusercontent.com/1640125/108606015-5d112900-736c-11eb-96ec-f867c7b81130.png)

Addresses #29801
