### PR TITLE
[release/2.1] Fixup NPM package versioning

### DIFF
--- a/src/Hosting/Hosting/test/Microsoft.AspNetCore.Hosting.Tests.csproj
+++ b/src/Hosting/Hosting/test/Microsoft.AspNetCore.Hosting.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TestGroupName>Hosting.Tests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TestGroupName>Kestrel.Tests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Transport.Libuv/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.csproj
+++ b/src/Servers/Kestrel/Transport.Libuv/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <TestGroupName>Kestrel.Tests</TestGroupName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/version.props
+++ b/version.props
@@ -39,7 +39,9 @@
     <ExperimentalPackageVersion  Condition=" '$(IncludePreReleaseLabelInPackageVersion)' == 'true' ">$(ExperimentalVersionPrefix)-$(VersionSuffix)</ExperimentalPackageVersion>
 
     <VersionMetadata Condition=" '$(DotNetProductBuildId)' != '' ">pb-$(DotNetProductBuildId)</VersionMetadata>
-    <VersionSuffix Condition=" '$(VersionMetadata)' != '' ">$(VersionSuffix)+$(VersionMetadata)</VersionSuffix>
+
+    <!-- `npm` will truncate the '+' and everything after when updating project.json. Condition avoids _Pack failures. -->
+    <VersionSuffix Condition=" '$(VersionMetadata)' != '' AND '$(MSBuildProjectExtension)' != '.npmproj' ">$(VersionSuffix)+$(VersionMetadata)</VersionSuffix>
 
     <SharedFxCliBlobChannel>release/$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion)</SharedFxCliBlobChannel>
 


### PR DESCRIPTION
- `_Pack` target failing in ProdCon builds
  - fortunately problem is specific to non-`IsFinalBuild` builds
- don't add the version metadata because that's not written into package.lock
- e.g. looking for aspnet-signalr-protocol-msgpack-1.0.26-servicing-20210212.12+pb-20210212-02.tgz
  - but `npm pack` actually wrote aspnet-signalr-protocol-msgpack-1.0.26-servicing-20210212.12.tgz
- see https://dnceng.visualstudio.com/internal/_build/results?buildId=992921&view=logs&j=f31c9f97-4411-58e7-49ac-fc73f645e6b6&t=2bcaa12b-2f4b-5b1f-c519-10308f653190&l=3190