### PR TITLE
SignalR: Give IHubContext more flexibility to deal with generics

### DIFF
--- a/src/SignalR/server/Core/src/IHubContext.cs
+++ b/src/SignalR/server/Core/src/IHubContext.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.AspNetCore.SignalR
 {
     /// <summary>
-    /// A context abstraction for a hub.
+    /// A context abstraction.
     /// </summary>
-    public interface IHubContext<THub> where THub : Hub
+    public interface IHubContext
     {
         /// <summary>
         /// Gets a <see cref="IHubClients"/> that can be used to invoke methods on clients connected to the hub.
@@ -18,4 +18,9 @@ namespace Microsoft.AspNetCore.SignalR
         /// </summary>
         IGroupManager Groups { get; }
     }
+
+    /// <summary>
+    /// A context abstraction for a hub.
+    /// </summary>
+    public interface IHubContext<THub> : IHubContext where THub : Hub { }
 }

--- a/src/SignalR/server/Core/src/PublicAPI.Shipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Shipped.txt
@@ -144,6 +144,7 @@ Microsoft.AspNetCore.SignalR.IHubClients<T>.Users(System.Collections.Generic.IRe
 Microsoft.AspNetCore.SignalR.IHubContext<THub, T>.Clients.get -> Microsoft.AspNetCore.SignalR.IHubClients<T!>!
 Microsoft.AspNetCore.SignalR.IHubContext<THub, T>.Groups.get -> Microsoft.AspNetCore.SignalR.IGroupManager!
 ~Microsoft.AspNetCore.SignalR.IHubContext<THub>
+~Microsoft.AspNetCore.SignalR.IHubContext
 Microsoft.AspNetCore.SignalR.IHubContext<THub>.Clients.get -> Microsoft.AspNetCore.SignalR.IHubClients!
 Microsoft.AspNetCore.SignalR.IHubContext<THub>.Groups.get -> Microsoft.AspNetCore.SignalR.IGroupManager!
 Microsoft.AspNetCore.SignalR.IHubFilter

--- a/src/SignalR/server/Core/src/PublicAPI.Shipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Shipped.txt
@@ -145,8 +145,8 @@ Microsoft.AspNetCore.SignalR.IHubContext<THub, T>.Clients.get -> Microsoft.AspNe
 Microsoft.AspNetCore.SignalR.IHubContext<THub, T>.Groups.get -> Microsoft.AspNetCore.SignalR.IGroupManager!
 ~Microsoft.AspNetCore.SignalR.IHubContext<THub>
 ~Microsoft.AspNetCore.SignalR.IHubContext
-Microsoft.AspNetCore.SignalR.IHubContext<THub>.Clients.get -> Microsoft.AspNetCore.SignalR.IHubClients!
-Microsoft.AspNetCore.SignalR.IHubContext<THub>.Groups.get -> Microsoft.AspNetCore.SignalR.IGroupManager!
+Microsoft.AspNetCore.SignalR.IHubContext.Clients.get -> Microsoft.AspNetCore.SignalR.IHubClients!
+Microsoft.AspNetCore.SignalR.IHubContext.Groups.get -> Microsoft.AspNetCore.SignalR.IGroupManager!
 Microsoft.AspNetCore.SignalR.IHubFilter
 Microsoft.AspNetCore.SignalR.IHubFilter.InvokeMethodAsync(Microsoft.AspNetCore.SignalR.HubInvocationContext! invocationContext, System.Func<Microsoft.AspNetCore.SignalR.HubInvocationContext!, System.Threading.Tasks.ValueTask<object?>>! next) -> System.Threading.Tasks.ValueTask<object?>
 Microsoft.AspNetCore.SignalR.IHubFilter.OnConnectedAsync(Microsoft.AspNetCore.SignalR.HubLifetimeContext! context, System.Func<Microsoft.AspNetCore.SignalR.HubLifetimeContext!, System.Threading.Tasks.Task!>! next) -> System.Threading.Tasks.Task!


### PR DESCRIPTION
Since Clients and Groups do not require the generic type we can abstract the IHubContext even further. This change gives the flexibility needed to perform generic casting from some IHubContext<SomeHub> to IHubContext while being able to use the Clients and/or Groups properties.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Abstract Clients and Groups to a non-generic IHubContext to be implemented by IHubContext<>.

**PR Description**
Right now, it is only possible to inject generic-type IHubContext objects. Since Clients and Groups do not require the generic type we can abstract the IHubContext even further so that IHubContext<> and IHubContext<,> implement IHubContext (with no generic type).  Can this be considered for a later major update? It includes a change in the public API definition.

Addresses #30167 (in this specific format)
