### PR TITLE
Reuse the state machines for http/2 streams

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -431,6 +431,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
         }
 
+        protected virtual bool EndRequestProcessing()
+        {
+            return !_keepAlive;
+        }
+
         protected virtual void OnErrorAfterResponseStarted()
         {
         }
@@ -609,7 +614,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private async Task ProcessRequests<TContext>(IHttpApplication<TContext> application) where TContext : notnull
         {
-            while (_keepAlive)
+            while (true)
             {
                 if (_context.InitialExecutionContext is null)
                 {
@@ -749,6 +754,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (HasStartedConsumingRequestBody)
                 {
                     await messageBody.StopAsync();
+                }
+
+                if (EndRequestProcessing())
+                {
+                    break;
                 }
             }
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -122,6 +122,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             CompleteStream(errored: false);
         }
 
+        protected override bool EndRequestProcessing()
+        {
+            CompleteStream(errored: false);
+            return true;
+        }
+
         public void CompleteStream(bool errored)
         {
             try
@@ -612,7 +618,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         /// </summary>
         public abstract void Execute();
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             _http2Output.Dispose();
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Abstractions;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
@@ -9,22 +13,61 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
     internal sealed class Http2Stream<TContext> : Http2Stream, IHostContextContainer<TContext> where TContext : notnull
     {
-        private readonly IHttpApplication<TContext> _application;
+        private readonly Task _executingTask;
 
-        public Http2Stream(IHttpApplication<TContext> application, Http2StreamContext context) 
+        private readonly Channel<ReadResult> _requestQueue = Channel.CreateUnbounded<ReadResult>(new UnboundedChannelOptions
+        {
+            // We want to run continuations inline
+            SingleReader = true,
+            SingleWriter = true,
+            AllowSynchronousContinuations = true
+        });
+
+        public Http2Stream(IHttpApplication<TContext> application, Http2StreamContext context)
         {
             Initialize(context);
-            _application = application;
+
+            _executingTask = ProcessRequestsAsync(application);
         }
 
         public override void Execute()
         {
             KestrelEventSource.Log.RequestQueuedStop(this, AspNetCore.Http.HttpProtocol.Http2);
-            // REVIEW: Should we store this in a field for easy debugging?
-            _ = ProcessRequestsAsync(_application);
+
+            _requestQueue.Writer.TryWrite(new ReadResult(default, isCanceled: false, isCompleted: false));
         }
 
         // Pooled Host context
         TContext? IHostContextContainer<TContext>.HostContext { get; set; }
+
+        protected override bool BeginRead(out ValueTask<ReadResult> awaitable)
+        {
+            awaitable = _requestQueue.Reader.ReadAsync();
+            return true;
+        }
+
+        protected override bool TryParseRequest(ReadResult result, out bool endConnection)
+        {
+            if (result.IsCompleted)
+            {
+                endConnection = true;
+                return true;
+            }
+
+            return base.TryParseRequest(result, out endConnection);
+        }
+
+        protected override bool EndRequestProcessing()
+        {
+            base.EndRequestProcessing();
+            return _requestQueue.Reader.Completion.IsCompleted;
+        }
+
+        public override void Dispose()
+        {
+            _requestQueue.Writer.TryWrite(new ReadResult(default, isCanceled: false, isCompleted: true));
+            _requestQueue.Writer.TryComplete();
+            base.Dispose();
+        }
     }
 }


### PR DESCRIPTION
- Use a channel to reuse the state machine for http/2 streams.

This is just a prototype at the moment. 