### PR TITLE
Make SignalR build script consistent with repo

### DIFF
--- a/src/SignalR/build.cmd
+++ b/src/SignalR/build.cmd
@@ -1,3 +1,3 @@
 @ECHO OFF
-SET RepoRoot=%~dp0..\..\
-%RepoRoot%build.cmd -buildJava -projects %~dp0**\*.*proj %*
+SET RepoRoot=%~dp0..\..
+%RepoRoot%\eng\build.cmd -buildJava -projects %~dp0**\*.*proj %*


### PR DESCRIPTION
SignalR's build script defines the `RepoRoot` variable with a trailing slash which isn't consistent with other build scripts in the repo. Fixing that here.