### PR TITLE
Fix IsAjaxRequest in CookieAuthenticationEvents

### DIFF
--- a/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
+++ b/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
@@ -101,7 +101,8 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
 
         private static bool IsAjaxRequest(HttpRequest request)
         {
-            return string.Equals(request.Query[HeaderNames.XRequestedWith], "XMLHttpRequest", StringComparison.Ordinal) ||
+            return string.Equals(request.Headers["Sec-Fetch-Mode"], "cors", StringComparison.Ordinal) ||
+                string.Equals(request.Query[HeaderNames.XRequestedWith], "XMLHttpRequest", StringComparison.Ordinal) ||
                 string.Equals(request.Headers[HeaderNames.XRequestedWith], "XMLHttpRequest", StringComparison.Ordinal);
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Fix IsAjaxRequest in CookieAuthenticationEvents

**PR Description**
Add support for `Sec-Fetch-Mode` value of `cors` to detect an XHR request.

Addresses #9039