### PR TITLE
Add support for setting error type via ProducesResponseType attribute

### DIFF
--- a/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc
     {
         /// <summary>
         /// Initializes an instance of <see cref="ProducesResponseTypeAttribute"/>.
-        /// </summary>       
+        /// </summary>
         /// <param name="statusCode">The HTTP response status code.</param>
         public ProducesResponseTypeAttribute(int statusCode)
             : this(typeof(void), statusCode)
@@ -31,6 +31,18 @@ namespace Microsoft.AspNetCore.Mvc
         {
             Type = type ?? throw new ArgumentNullException(nameof(type));
             StatusCode = statusCode;
+            OverrideDefaultErrorType = false;
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="ProducesResponseTypeAttribute"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> of object that is going to be written in the response.</param>
+        /// <param name="statusCode">The HTTP response status code.</param>
+        /// <param name="overrideDefaultErrorType">Whether or not to override default error type</param>
+        public ProducesResponseTypeAttribute(Type type, int statusCode, bool overrideDefaultErrorType) : this(type, statusCode)
+        {
+            OverrideDefaultErrorType = overrideDefaultErrorType;
         }
 
         /// <summary>
@@ -42,6 +54,19 @@ namespace Microsoft.AspNetCore.Mvc
         /// Gets or sets the HTTP status code of the response.
         /// </summary>
         public int StatusCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether or not the default error type should be used when one
+        /// is expliclty provided as a type in the <see cref="ProducesResponseTypeAttribute"/>.
+        ///
+        /// When <see langword="true"/>, the ApiExplorer will use the provided <see cref="Type"/>
+        /// as the default type for error objects.
+        ///
+        /// When <see langword="false"/>, the ApiExplorer will use the globally configured default
+        /// error type.
+        /// </summary>
+        /// <value></value>
+        public bool OverrideDefaultErrorType { get; set; }
 
         /// <inheritdoc />
         void IApiResponseMetadataProvider.SetContentTypes(MediaTypeCollection contentTypes)

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -849,6 +849,9 @@ Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.ValidationSta
 Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.ValidationVisitor(Microsoft.AspNetCore.Mvc.ActionContext! actionContext, Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IModelValidatorProvider! validatorProvider, Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidatorCache! validatorCache, Microsoft.AspNetCore.Mvc.ModelBinding.IModelMetadataProvider! metadataProvider, Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationStateDictionary? validationState) -> void
 Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidationVisitor.ValidatorProvider.get -> Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IModelValidatorProvider!
 Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ValidatorCache.GetValidators(Microsoft.AspNetCore.Mvc.ModelBinding.ModelMetadata! metadata, Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IModelValidatorProvider! validatorProvider) -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IModelValidator!>!
+~Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute.ProducesResponseTypeAttribute(System.Type type, int statusCode, bool overrideDefaultErrorType) -> void
+Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute.OverrideDefaultErrorType.get -> bool
+Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute.OverrideDefaultErrorType.set -> void
 Microsoft.AspNetCore.Mvc.Routing.DynamicRouteValueTransformer.State.get -> object?
 Microsoft.AspNetCore.Mvc.Routing.DynamicRouteValueTransformer.State.set -> void
 Microsoft.AspNetCore.Mvc.Routing.HttpMethodAttribute.HttpMethodAttribute(System.Collections.Generic.IEnumerable<string!>! httpMethods) -> void

--- a/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -1461,6 +1461,29 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 });
         }
 
+        [Theory]
+        [InlineData("ActionWithVoidTypeAndOverrideDisabled", typeof(ProblemDetails))]
+        [InlineData("ActionWithVoidType", typeof(void))]
+        public async Task ApiAction_ForActionWithVoidResponseType(string path, Type type)
+        {
+            // Act
+            var response = await Client.GetAsync($"http://localhost/ApiExplorerVoid/{path}");
+
+            var responseBody = await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<List<ApiExplorerData>>(responseBody);
+
+            // Assert
+            var description = Assert.Single(result);
+            Assert.Collection(
+                description.SupportedResponseTypes.OrderBy(r => r.StatusCode),
+                responseType =>
+                {
+                    Assert.Equal(type.FullName, responseType.ResponseType);
+                    Assert.Equal(401, responseType.StatusCode);
+                    Assert.False(responseType.IsDefaultResponse);
+                });
+        }
+
         private IEnumerable<string> GetSortedMediaTypes(ApiExplorerResponseType apiResponseType)
         {
             return apiResponseType.ResponseFormats

--- a/src/Mvc/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerSystemVoid.cs
+++ b/src/Mvc/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerSystemVoid.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace ApiExplorerWebSite
+{
+    [Route("ApiExplorerVoid/[action]")]
+    [ApiController]
+    public class ApiExplorerVoidController : Controller
+    {
+        [ProducesResponseType(typeof(void), 401, true)]
+        public IActionResult ActionWithVoidType() => Ok();
+
+        [ProducesResponseType(typeof(void), 401)]
+        public IActionResult ActionWithVoidTypeAndOverrideDisabled() => Ok();
+
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/7874.

We set the default error type depending on whether or not the user has set the `SuppressMapClientErrors` option ([ref](https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.Core/src/ApplicationModels/ApiBehaviorApplicationModelProvider.cs#L46)). When the option is not configured, we set the default to `typeof(ProblemDetails)`.

This default gets set via an implicit `ProducesErrorResponseType` attribute on all controllers ([ref](https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs#L52)) and ultimately gets consumed for APIs that produce an error type designated as a client error ([ref](https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs#L112)).

Based on the bug reports associated here, this is not the desired behavior. So to work around that I:

- Added an opt-in `OverrideDefaultErrorType` flag to the `ProducesResponseType` attribute
- Added some logic in the `ApiResponseTypeProvider` to avoid using the default error type if the above flag is set

I chose this approach because:

- I wanted to reduce the impact of the breaking change so I made the new strategy opt-in instead of opt-out
- I wanted to localize the setting to the affected attributes