### PR TITLE
Remove dependency on System.Console in Blazor WASM app

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyConsoleLogger.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyConsoleLogger.cs
@@ -103,7 +103,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Services
                             break;
                         default: // invalid enum values
                             Debug.Assert(logLevel != LogLevel.None, "This method is never called with LogLevel.None.");
-                            throw new ArgumentOutOfRangeException(nameof(logLevel));
+                            _jsRuntime.InvokeVoid("console.log", formattedMessage);
+                            break;
                     }
                 }
                 finally

--- a/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyConsoleLogger.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyConsoleLogger.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
@@ -102,7 +102,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Services
                             _jsRuntime.InvokeUnmarshalled<string, object>("Blazor._internal.dotNetCriticalError", formattedMessage);
                             break;
                         default: // invalid enum values
-                            throw new ArgumentException(nameof(logLevel));
+                            Debug.Assert(logLevel != LogLevel.None, "This method is never be called with LogLevel.None.");
+                            throw new ArgumentOutOfRangeException(nameof(logLevel));
                     }
                 }
                 finally

--- a/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyConsoleLogger.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyConsoleLogger.cs
@@ -101,9 +101,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Services
                         case LogLevel.Critical:
                             _jsRuntime.InvokeUnmarshalled<string, object>("Blazor._internal.dotNetCriticalError", formattedMessage);
                             break;
-                        default: // LogLevel.None or invalid enum values
-                            Console.WriteLine(formattedMessage);
-                            break;
+                        default: // invalid enum values
+                            throw new ArgumentException(nameof(logLevel));
                     }
                 }
                 finally

--- a/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyConsoleLogger.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyConsoleLogger.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Services
                             _jsRuntime.InvokeUnmarshalled<string, object>("Blazor._internal.dotNetCriticalError", formattedMessage);
                             break;
                         default: // invalid enum values
-                            Debug.Assert(logLevel != LogLevel.None, "This method is never be called with LogLevel.None.");
+                            Debug.Assert(logLevel != LogLevel.None, "This method is never called with LogLevel.None.");
                             throw new ArgumentOutOfRangeException(nameof(logLevel));
                     }
                 }


### PR DESCRIPTION
This is the first change necessary. It removes the one place that depends on `Console.WriteLine`.

This first change doesn't save much size (.br compressed):

* **Before**: 2,719,214 bytes
* **After**: 2,719,111 bytes

However, if we can also remove the last place that references `System.Console`, we should be able to trim the whole assembly (6KB .br compressed).

https://github.com/dotnet/aspnetcore/blob/dfe625fbd122557cc4dda0f3d6f3dc5c7afc8c8e/src/Components/WebAssembly/WebAssembly/src/Hosting/EntrypointInvoker.cs#L79-L83

Speaking with @lewing, we thought if we unified the startup paths between the mono runtime and Blazor, we should be able to remove this last dependency on `System.Console`. @lewing was going to log an issue to track unifying the startup code.

cc @marek-safar 