### PR TITLE
Make Ignitor test more strongly typed, and fix failure introduced with custom event args change

### DIFF
--- a/src/Components/Components/src/RenderTree/EventFieldInfo.cs
+++ b/src/Components/Components/src/RenderTree/EventFieldInfo.cs
@@ -11,7 +11,11 @@ namespace Microsoft.AspNetCore.Components.RenderTree
     // Information supplied with an event notification that can be used to update an existing
     // render tree to match the latest UI state when a form field has mutated. To determine
     // which field has been mutated, the renderer matches it based on the event handler ID.
+#if IGNITOR
+    internal class EventFieldInfo
+#else
     public class EventFieldInfo
+#endif
     {
         /// <summary>
         /// Identifies the component whose render tree contains the affected form field.

--- a/src/Components/Ignitor/src/ElementNode.cs
+++ b/src/Components/Ignitor/src/ElementNode.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.SignalR.Client;
 
 #nullable enable
@@ -73,12 +74,12 @@ namespace Ignitor
                 Value = value
             };
 
-            var webEventDescriptor = new
+            var webEventDescriptor = new WebEventDescriptor
             {
                 BrowserRendererId = 0,
                 EventHandlerId = changeEventDescriptor.EventId,
-                EventArgsType = "change",
-                EventFieldInfo = new
+                EventName = "change",
+                EventFieldInfo = new EventFieldInfo
                 {
                     ComponentId = 0,
                     FieldValue = value
@@ -100,11 +101,11 @@ namespace Ignitor
                 Type = clickEventDescriptor.EventName,
                 Detail = 1
             };
-            var webEventDescriptor = new
+            var webEventDescriptor = new WebEventDescriptor
             {
                 BrowserRendererId = 0,
                 EventHandlerId = clickEventDescriptor.EventId,
-                EventArgsType = "mouse",
+                EventName = "mouse",
             };
 
             return DispatchEventCore(connection, Serialize(webEventDescriptor), Serialize(mouseEventArgs));

--- a/src/Components/Ignitor/src/ElementNode.cs
+++ b/src/Components/Ignitor/src/ElementNode.cs
@@ -105,7 +105,7 @@ namespace Ignitor
             {
                 BrowserRendererId = 0,
                 EventHandlerId = clickEventDescriptor.EventId,
-                EventName = "mouse",
+                EventName = "click",
             };
 
             return DispatchEventCore(connection, Serialize(webEventDescriptor), Serialize(mouseEventArgs));

--- a/src/Components/Ignitor/src/Ignitor.csproj
+++ b/src/Components/Ignitor/src/Ignitor.csproj
@@ -9,6 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,12 +17,14 @@
     <Compile Include="..\..\Components\src\RenderTree\ArrayBuilderExtensions.cs" LinkBase="RenderTree" />
     <Compile Include="..\..\Components\src\RenderTree\ArrayBuilderSegment.cs" LinkBase="RenderTree" />
     <Compile Include="..\..\Components\src\RenderTree\ArrayRange.cs" LinkBase="RenderTree" />
+    <Compile Include="..\..\Components\src\RenderTree\EventFieldInfo.cs" LinkBase="RenderTree" />
     <Compile Include="..\..\Components\src\RenderTree\RenderBatch.cs" LinkBase="RenderTree" />
     <Compile Include="..\..\Components\src\RenderTree\RenderTreeDiff.cs" LinkBase="RenderTree" />
     <Compile Include="..\..\Components\src\RenderTree\RenderTreeEdit.cs" LinkBase="RenderTree" />
     <Compile Include="..\..\Components\src\RenderTree\RenderTreeEditType.cs" LinkBase="RenderTree" />
     <Compile Include="..\..\Components\src\RenderTree\RenderTreeFrame.cs" LinkBase="RenderTree" />
     <Compile Include="..\..\Components\src\RenderTree\RenderTreeFrameType.cs" LinkBase="RenderTree" />
+    <Compile Include="..\..\Web\src\WebEventDescriptor.cs" LinkBase="RenderTree" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Ignitor/src/RenderBatchReader.cs
+++ b/src/Components/Ignitor/src/RenderBatchReader.cs
@@ -80,7 +80,7 @@ namespace Ignitor
                             break;
 
                         case RenderTreeEditType.RemoveAttribute:
-                            edits[j] = RenderTreeEdit.RemoveAttribute(siblingIndex, removedAttributeName);
+                            edits[j] = RenderTreeEdit.RemoveAttribute(siblingIndex, removedAttributeName!);
                             break;
 
                         case RenderTreeEditType.PrependFrame:

--- a/src/Components/Web/src/WebEventDescriptor.cs
+++ b/src/Components/Web/src/WebEventDescriptor.cs
@@ -7,7 +7,11 @@ namespace Microsoft.AspNetCore.Components.RenderTree
     /// Types in the Microsoft.AspNetCore.Components.RenderTree are not recommended for use outside
     /// of the Blazor framework. These types will change in a future release.
     /// </summary>
+#if IGNITOR
+    internal sealed class WebEventDescriptor
+#else
     public sealed class WebEventDescriptor
+#endif
     {
         // We split the incoming event data in two, because we don't know what type
         // to use when deserializing the args until we've deserialized the descriptor.


### PR DESCRIPTION
Technically we could just fix the anonymously-typed data to match the new protocol, but this will be more resistant to similar problems in the future.