### PR TITLE
Remove dotnet-format from dotnet-tools

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,12 +8,6 @@
         "dotnet-serve"
       ]
     },
-    "dotnet-format": {
-      "version": "5.0.210401",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "playwright-sharp-tool": {
       "version": "0.170.2",
       "commands": [


### PR DESCRIPTION
Restore.cmd is failing because it can't find this tool on our feeds. The version it's looking for isn't even on nuget.org. https://www.nuget.org/packages/dotnet-format/

We're not using this tool right now so I'm removing it.

