### PR TITLE
Add workaround for dotnet watch in npmproj

### DIFF
--- a/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj
+++ b/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj
@@ -42,6 +42,7 @@
   <Target Name="GetTargetFramework" />
   <Target Name="GetCopyToPublishDirectoryItems" />
   <Target Name="GetTargetPath" />
+  <Target Name="_CollectWatchItems" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 


### PR DESCRIPTION
Since we include a reference to the `Microsoft.AspNetCore.Components.Web.JS.npmproj` in the `BasicTestApp`, attempting to run `dotnet watch run` there raises the following exception because it cannot resolve the correct targets in all the referenced projects.

```
watch : MSBuild output from target 'GenerateWatchList':
watch : 
watch :    Build started 2/22/2021 1:33:02 PM.
watch :         1>Project "/Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj" on node 1 (GenerateWatchList target(s)).
watch :         1>Project "/Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj" (1) is building "/Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj" (3) on node 3 (_CollectWatchItems target(s)).
watch :         3>_CheckForInvalidConfiguration:
watch :             node -v
watch :         3>/Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj : error MSB4057: The target "_CollectWatchItems" does not exist in the project.
watch :         3>Done Building Project "/Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj" (_CollectWatchItems target(s)) -- FAILED.
watch :         1>Done Building Project "/Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj" (GenerateWatchList target(s)) -- FAILED.
watch :    Build FAILED.
watch :           "/Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj" (GenerateWatchList target) (1) ->
watch :           "/Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj" (_CollectWatchItems target) (3) ->
watch :             /Users/captainsafia/github.com/dotnet/aspnetcore/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj : error MSB4057: The target "_CollectWatchItems" does not exist in the project.
watch :        0 Warning(s)
watch :        1 Error(s)
watch :    Time Elapsed 00:00:03.93
```

We workaround this by adding an empty `<Target Name="_CollectWatchItems" />` to the npmproj. Viola! `dotnet watch run` in the BasicTestApp works.