### PR TITLE
Disable parallelism on BootResourceCachingTest

### DIFF
--- a/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
+++ b/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
@@ -18,6 +18,9 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 {
+    // Disabling parallelism for these tests because of flakiness
+    [CollectionDefinition(nameof(BootResourceCachingTest), DisableParallelization = true)]
+    [Collection(nameof(BootResourceCachingTest))]
     public class BootResourceCachingTest
         : ServerTestBase<AspNetSiteServerFixture>
     {


### PR DESCRIPTION
Tests in `BootResourceCachingTest` have been quarantined for a long time due to flakiness. Even after several attempts to fix this (#20154 and #27374), they continue to fail about 1 in 10 times. Somehow, the browser's cache occasionally doesn't include files we expect to have been cached, or it does include a file that should not yet be cached (suggesting that the test browser isn't as isolated as it should be). Maybe the browser doesn't always commit the cache updates to disk in a synchronous and blocking manner, so sometimes the expected cache updates haven't completed by the time we try to observe them.

The nuclear solutions might include:

 * Put in a retry mechanism, and agree it's good enough if the test passes either first time or N-out-of-M times
 * Or, rewrite the test using PlayWright which gives us more direct visibility into the HTTP traffic (but still doesn't guarantee anything about how the browser's caches get committed)

As one final attempt to avert those, this PR disables parallelism for those tests. It's quite possible that if the test environment isn't under heavy load at the time it runs these tests, then the browser's cache storage might behave predictably. We can see if this is reliable enough to justify unquarantining the tests.