### PR TITLE
Creates script command for sql-cache-tool

### DIFF
--- a/src/Tools/dotnet-sql-cache/src/Program.cs
+++ b/src/Tools/dotnet-sql-cache/src/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Data;
+using System.IO;
 using System.Reflection;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.CommandLineUtils;
@@ -15,6 +16,9 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
         private string _connectionString = null;
         private string _schemaName = null;
         private string _tableName = null;
+        private string _outputPath = null;
+        private bool _idempotent;
+
         private readonly IConsole _console;
 
         public Program(IConsole console)
@@ -49,7 +53,7 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
 
                 app.Command("create", command =>
                 {
-                    command.Description = app.Description;
+                    command.Description = "Adds table and indexes to the database.";
 
                     var connectionStringArg = command.Argument(
                         "[connectionString]", "The connection string to connect to the database.");
@@ -70,7 +74,7 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
                             || string.IsNullOrEmpty(tableNameArg.Value))
                         {
                             reporter.Error("Invalid input");
-                            app.ShowHelp();
+                            command.ShowHelp();
                             return 2;
                         }
 
@@ -79,6 +83,51 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
                         _tableName = tableNameArg.Value;
 
                         return CreateTableAndIndexes(reporter);
+                    });
+                });
+
+                app.Command("script", command =>
+                {
+                    command.Description = "Generates a SQL script for the table and indexes.";
+
+                    var schemaNameArg = command.Argument(
+                        "[schemaName]", "Name of the table schema.");
+
+                    var tableNameArg = command.Argument(
+                        "[tableName]", "Name of the table to be created.");
+
+                    var outputOption = command.Option(
+                        "-o|--output",
+                        "The file to write the result to.",
+                        CommandOptionType.SingleValue);
+
+                    var idempontentOption = command.Option(
+                        "-i|--idempotent",
+                        "Generates a script that can be used on a database that already has the table.",
+                        CommandOptionType.NoValue);
+
+                    command.HelpOption();
+
+                    command.OnExecute(() =>
+                    {
+                        var reporter = CreateReporter(verbose.HasValue());
+                        if (string.IsNullOrEmpty(schemaNameArg.Value)
+                            || string.IsNullOrEmpty(tableNameArg.Value))
+                        {
+                            reporter.Error("Invalid input");
+                            command.ShowHelp();
+                            return 2;
+                        }
+
+                        _schemaName = schemaNameArg.Value;
+                        _tableName = tableNameArg.Value;
+                        _idempotent = idempontentOption.HasValue();
+                        if (outputOption.HasValue())
+                        {
+                            _outputPath = outputOption.Value();
+                        }
+
+                        return ScriptTableAndIndexes(reporter);
                     });
                 });
 
@@ -100,6 +149,57 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
 
         private IReporter CreateReporter(bool verbose)
             => new ConsoleReporter(_console, verbose, quiet: false);
+
+        private SqlQueries CreateSqlQueries()
+            => new SqlQueries(_schemaName, _tableName);
+
+        private int ScriptTableAndIndexes(IReporter reporter)
+        {
+            Action<string> writer = reporter.Output;
+            StreamWriter streamWriter = default;
+
+            try
+            {
+                if (_outputPath is not null)
+                {
+                    streamWriter = new StreamWriter(_outputPath);
+                    writer = streamWriter.WriteLine;
+                }
+
+                var sqlQueries = CreateSqlQueries();
+
+                if (_idempotent)
+                {
+                    writer("IF NOT EXISTS (");
+                    writer("\t" + sqlQueries.TableInfo);
+                    writer(")");
+                    writer("BEGIN");
+                }
+
+                var prefix = _idempotent ? "\t" : "";
+                writer(prefix + sqlQueries.CreateTable);
+                writer(prefix + sqlQueries.CreateNonClusteredIndexOnExpirationTime);
+
+                if (_idempotent)
+                {
+                    writer("END");
+                }
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                reporter.Error(
+                    $"An error occurred while trying to script the table and index. {ex.Message}");
+
+                return 1;
+            }
+            finally
+            {
+                streamWriter?.Dispose();
+            }
+        }
+
         private int CreateTableAndIndexes(IReporter reporter)
         {
             ValidateConnectionString();
@@ -108,7 +208,7 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
             {
                 connection.Open();
 
-                var sqlQueries = new SqlQueries(_schemaName, _tableName);
+                var sqlQueries = CreateSqlQueries();
                 var command = new SqlCommand(sqlQueries.TableInfo, connection);
 
                 using (var reader = command.ExecuteReader(CommandBehavior.SingleRow))

--- a/src/Tools/dotnet-sql-cache/src/Program.cs
+++ b/src/Tools/dotnet-sql-cache/src/Program.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
                         "The file to write the result to.",
                         CommandOptionType.SingleValue);
 
-                    var idempontentOption = command.Option(
+                    var idempotentOption = command.Option(
                         "-i|--idempotent",
                         "Generates a script that can be used on a database that already has the table.",
                         CommandOptionType.NoValue);
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Caching.SqlConfig.Tools
 
                         _schemaName = schemaNameArg.Value;
                         _tableName = tableNameArg.Value;
-                        _idempotent = idempontentOption.HasValue();
+                        _idempotent = idempotentOption.HasValue();
                         if (outputOption.HasValue())
                         {
                             _outputPath = outputOption.Value();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Creates a new command for sql-cache-tool, which outputs the SQL Script needed.

**PR Description**
* Adds new `script` command to create SQL Script
* Includes the ability to output directly to a file
* Includes the ability to make the output script idempotent
* Minor fix to `create` command to produce the command's help on validation error

Addresses #24635
