### PR TITLE
Add tests for SVG scenarios

### DIFF
--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -356,34 +356,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        public void CanRenderSvgWithCorrectNamespace()
-        {
-            var appElement = Browser.MountTestComponent<SvgComponent>();
-
-            var svgElement = appElement.FindElement(By.XPath("//*[local-name()='svg' and namespace-uri()='http://www.w3.org/2000/svg']"));
-            Assert.NotNull(svgElement);
-
-            var svgCircleElement = appElement.FindElement(By.XPath("//*[local-name()='circle' and namespace-uri()='http://www.w3.org/2000/svg']"));
-            Assert.NotNull(svgCircleElement);
-            Assert.Equal("10", svgCircleElement.GetAttribute("r"));
-
-            appElement.FindElement(By.TagName("button")).Click();
-            Browser.Equal("20", () => svgCircleElement.GetAttribute("r"));
-        }
-
-        [Fact]
-        public void CanRenderSvgChildComponentWithCorrectNamespace()
-        {
-            var appElement = Browser.MountTestComponent<SvgWithChildComponent>();
-
-            var svgElement = appElement.FindElement(By.XPath("//*[local-name()='svg' and namespace-uri()='http://www.w3.org/2000/svg']"));
-            Assert.NotNull(svgElement);
-
-            var svgCircleElement = appElement.FindElement(By.XPath("//*[local-name()='circle' and namespace-uri()='http://www.w3.org/2000/svg']"));
-            Assert.NotNull(svgCircleElement);
-        }
-
-        [Fact]
         public void LogicalElementInsertionWorksHierarchically()
         {
             var appElement = Browser.MountTestComponent<LogicalElementInsertionCases>();

--- a/src/Components/test/E2ETest/Tests/SvgTest.cs
+++ b/src/Components/test/E2ETest/Tests/SvgTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Assert.NotNull(svgCircleElement);
         }
 
-        [Fact(Skip="https://github.com/dotnet/aspnetcore/issues/18271")]
+        [Fact(Skip="Skipped because functionality is not supported. See https://github.com/dotnet/aspnetcore/issues/18271.")]
         public void CanRenderVariablesInForeignObject()
         {
             var appElement = Browser.MountTestComponent<SvgComponent>();
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 e => Assert.Equal("thestringbar", e.Text));
         }
 
-        [Fact(Skip="https://github.com/dotnet/aspnetcore/issues/18271")]
+        [Fact(Skip="Skipped because functionality is not supported. See https://github.com/dotnet/aspnetcore/issues/18271.")]
         public void CanRenderSvgWithLink()
         {
             var appElement = Browser.MountTestComponent<SvgComponent>();
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Assert.Equal("SVG", currentScenario.Text);
         }
 
-        [Fact(Skip="https://github.com/dotnet/aspnetcore/issues/18271")]
+        [Fact(Skip="Skipped because functionality is not supported. See https://github.com/dotnet/aspnetcore/issues/18271.")]
         public void CanRenderSvgWithTwoWayBinding()
         {
             var appElement = Browser.MountTestComponent<SvgComponent>();
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Assert.Equal("15", valueElement.Text);
         }
 
-        [Fact(Skip="https://github.com/dotnet/aspnetcore/issues/18271")]
+        [Fact(Skip="Skipped because functionality is not supported. See https://github.com/dotnet/aspnetcore/issues/18271.")]
         public void CanRenderSvgRenderFragment()
         {
             var appElement = Browser.MountTestComponent<SvgComponent>();

--- a/src/Components/test/E2ETest/Tests/SvgTest.cs
+++ b/src/Components/test/E2ETest/Tests/SvgTest.cs
@@ -1,0 +1,143 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using BasicTestApp;
+using BasicTestApp.RouterTest;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETest.Tests
+{
+    public class SvgTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
+    {
+        public SvgTest(
+            BrowserFixture browserFixture,
+            ToggleExecutionModeServerFixture<Program> serverFixture,
+            ITestOutputHelper output)
+            : base(browserFixture, serverFixture, output)
+        {
+        }
+
+        protected override void InitializeAsyncCore()
+        {
+            Navigate(ServerPathBase, noReload: _serverFixture.ExecutionMode == ExecutionMode.Client);
+        }
+
+        [Fact]
+        public void CanRenderSvgWithCorrectNamespace()
+        {
+            var appElement = Browser.MountTestComponent<SvgComponent>();
+
+            var svgElement = appElement.FindElement(By.Id("svg-with-callback"));
+            Assert.NotNull(svgElement);
+
+            var svgCircleElement = svgElement.FindElement(By.XPath("//*[local-name()='circle' and namespace-uri()='http://www.w3.org/2000/svg']"));
+            Assert.NotNull(svgCircleElement);
+            Assert.Equal("10", svgCircleElement.GetAttribute("r"));
+
+            appElement.FindElement(By.TagName("button")).Click();
+            Browser.Equal("20", () => svgCircleElement.GetAttribute("r"));
+        }
+
+        [Fact]
+        public void CanRenderSvgChildComponentWithCorrectNamespace()
+        {
+            var appElement = Browser.MountTestComponent<SvgComponent>();
+
+            var svgElement = appElement.FindElement(By.Id("svg-with-child-component"));
+            Assert.NotNull(svgElement);
+
+            var svgCircleElement = svgElement.FindElement(By.XPath("//*[local-name()='circle' and namespace-uri()='http://www.w3.org/2000/svg']"));
+            Assert.NotNull(svgCircleElement);
+        }
+
+        [Fact(Skip="https://github.com/dotnet/aspnetcore/issues/18271")]
+        public void CanRenderVariablesInForeignObject()
+        {
+            var appElement = Browser.MountTestComponent<SvgComponent>();
+
+            var svgElement = appElement.FindElement(By.Id("svg-with-foreign-object"));
+            Assert.NotNull(svgElement);
+
+            Func<IEnumerable<IWebElement>> strongElement =
+                () => appElement.FindElements(By.TagName("strong"));
+
+            Browser.Collection<IWebElement>(strongElement,
+                e => Assert.Equal("thestringfoo", e.Text),
+                e => Assert.Equal("thestringbar", e.Text));
+        }
+
+        [Fact(Skip="https://github.com/dotnet/aspnetcore/issues/18271")]
+        public void CanRenderSvgWithLink()
+        {
+            var appElement = Browser.MountTestComponent<SvgComponent>();
+
+            var svgElement = appElement.FindElement(By.Id("svg-with-link"));
+            Assert.NotNull(svgElement);
+
+            var svgLinkElement = svgElement.FindElement(By.Id("navlink-in-svg"));
+            Assert.NotNull(svgLinkElement);
+            svgLinkElement.Click();
+
+            var currentScenario = Browser.FindElement(By.Id("test-selector-select"));
+            Assert.Equal("SVG", currentScenario.Text);
+        }
+
+        [Fact(Skip="https://github.com/dotnet/aspnetcore/issues/18271")]
+        public void CanRenderSvgWithTwoWayBinding()
+        {
+            var appElement = Browser.MountTestComponent<SvgComponent>();
+
+            var svgElement = appElement.FindElement(By.Id("svg-with-two-way-binding"));
+            Assert.NotNull(svgElement);
+
+            var valueElement = appElement.FindElement(By.Id("svg-with-two-way-binding-value"));
+            Assert.Equal("10", valueElement.Text);
+
+            var svgInputElement = svgElement.FindElement(By.TagName("input"));
+            Assert.NotNull(svgInputElement);
+
+            svgInputElement.SendKeys("15");
+            Assert.Equal("15", valueElement.Text);
+        }
+
+        [Fact(Skip="https://github.com/dotnet/aspnetcore/issues/18271")]
+        public void CanRenderSvgRenderFragment()
+        {
+            var appElement = Browser.MountTestComponent<SvgComponent>();
+
+            var svgElement = appElement.FindElement(By.Id("svg-with-render-fragment"));
+            Assert.NotNull(svgElement);
+
+            var svgForeignObjectElement = svgElement.FindElement(By.TagName("foreignObject"));
+            Assert.NotNull(svgForeignObjectElement);
+
+            Assert.Contains("Hello", svgForeignObjectElement.Text);
+        }
+
+        [Fact]
+        public void CanRenderSvgWithScopedCSS()
+        {
+            var appElement = Browser.MountTestComponent<SvgComponent>();
+
+            var svgElement = appElement.FindElement(By.Id("svg-with-css-scope"));
+            Assert.NotNull(svgElement);
+
+            var svgCircleElement = svgElement.FindElement(By.TagName("circle"));
+            Assert.NotNull(svgCircleElement);
+
+            Assert.Equal("rgb(0, 128, 0)", svgCircleElement.GetCssValue("fill"));
+
+        }
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -87,7 +87,6 @@
         <option value="BasicTestApp.SignalRClientComponent">SignalR client</option>
         <option value="BasicTestApp.StringComparisonComponent">StringComparison</option>
         <option value="BasicTestApp.SvgComponent">SVG</option>
-        <option value="BasicTestApp.SvgWithChildComponent">SVG with child component</option>
         <option value="BasicTestApp.TextOnlyComponent">Plain text</option>
         <option value="BasicTestApp.ToggleEventComponent">Toggle Event</option>
         <option value="BasicTestApp.TouchEventComponent">Touch events</option>

--- a/src/Components/test/testassets/BasicTestApp/SvgComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/SvgComponent.razor
@@ -1,9 +1,63 @@
-﻿<svg height="250" width=250>
+﻿@using Microsoft.AspNetCore.Components.Routing
+
+<h3>SVG with Callback</h3>
+<svg height="250" width="250" id="svg-with-callback">
     <circle cx="125" cy="125" r=@radius fill="red" stroke="black" stroke-width="3" />
 </svg>
 
 <button @onclick=@(() => { radius *= 2; })>Click me</button>
 
+<h3>SVG with Child Component</h3>
+<svg height="250" width="250" id="svg-with-child-component">
+    <SvgCircleComponent />
+</svg>
+
+<h3>SVG with Foreign Object</h3>
+<svg width="100" height="100" id="svg-with-foreign-object">
+    <foreignObject x="0" y="0" width="100" height="100">
+        <strong>thestringfoo</strong>
+        <strong>@bar</strong>
+    </foreignObject>
+</svg>
+
+<h3>SVG with link</h3>
+<svg id="svg-with-link">
+    <NavLink href="counter" id="navlink-in-svg">
+        <circle cx="100" cy="100" r="10"></circle>
+    </NavLink>
+</svg>
+
+<h3>SVG with input element and two-way binding</h3>
+<svg id="svg-with-two-way-binding">
+    <foreignobject style="overflow:visible">
+        <input @bind="value" @bind:event="oninput" type="number"/> SVG Two way bind
+    </foreignobject>
+</svg>
+<p id="svg-with-two-way-binding-value">@value</p>
+
+
+<h3>SVG with render fragment</h3>
+<svg id="svg-with-render-fragment">
+    <foreignObject width="100" height="100">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <div>
+                @rf
+            </div>
+        </div>
+    </foreignObject>
+</svg>
+
+<h3>SVG with scoped CSS</h3>
+<svg id="svg-with-css-scope">
+    <circle cx="125" cy="125" r=@radius stroke-width="3" />
+</svg>
+
 @code {
     int radius = 10;
+    string bar = "thestringbar";
+
+    int value = 10;
+
+    RenderFragment rf = @<text><i>Hello</i></text>;
+
 }

--- a/src/Components/test/testassets/BasicTestApp/SvgComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/SvgComponent.razor
@@ -1,5 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
 
+<strong>Note all features implemented here are currently supported. See https://github.com/dotnet/aspnetcore/issues/18271 and SvgTest for more info.</strong>
+
 <h3>SVG with Callback</h3>
 <svg height="250" width="250" id="svg-with-callback">
     <circle cx="125" cy="125" r=@radius fill="red" stroke="black" stroke-width="3" />

--- a/src/Components/test/testassets/BasicTestApp/SvgComponent.razor.css
+++ b/src/Components/test/testassets/BasicTestApp/SvgComponent.razor.css
@@ -1,0 +1,3 @@
+#svg-with-css-scope circle {
+    fill: rgb(0, 128, 0);
+}

--- a/src/Components/test/testassets/BasicTestApp/SvgWithChildComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/SvgWithChildComponent.razor
@@ -1,5 +1,0 @@
-﻿<h1>SVG with Child Component</h1>
-
-<svg height="250" width="250">
-    <SvgCircleComponent />
-</svg>

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/images/circle.svg
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/images/circle.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <symbol id="icon" fill="currentColor" viewBox="0 0 100 100">
+        <ellipse cx="0" cy="0" rx="100" ry="50" style="fill:yellow;stroke:purple;stroke-width:2"/>
+    </symbol>
+</svg>


### PR DESCRIPTION
I went through the issues reported/duped to the SVG item and created test cases for the ones that needed them.

For some issue reports, I wasn't able to reproduce the bug, I've included test cases for these. For others, I've added tests that are skipped for now until we resolve the underlying issues. A fair amount of those are under the general category of "Blazor inside SVGs."

Addresses #30299.