### PR TITLE
Make parameter for ParseQuery and ParseNullableQuery nullable

### DIFF
--- a/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
+++ b/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*static Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseNullableQuery(string! queryString) -> System.Collections.Generic.Dictionary<string!, Microsoft.Extensions.Primitives.StringValues>?
+static Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseNullableQuery(string? queryString) -> System.Collections.Generic.Dictionary<string!, Microsoft.Extensions.Primitives.StringValues>?
+*REMOVED*static Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(string! queryString) -> System.Collections.Generic.Dictionary<string!, Microsoft.Extensions.Primitives.StringValues>!
+static Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(string? queryString) -> System.Collections.Generic.Dictionary<string!, Microsoft.Extensions.Primitives.StringValues>!

--- a/src/Http/WebUtilities/src/QueryHelpers.cs
+++ b/src/Http/WebUtilities/src/QueryHelpers.cs
@@ -152,7 +152,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         /// </summary>
         /// <param name="queryString">The raw query string value, with or without the leading '?'.</param>
         /// <returns>A collection of parsed keys and values.</returns>
-        public static Dictionary<string, StringValues> ParseQuery(string queryString)
+        public static Dictionary<string, StringValues> ParseQuery(string? queryString)
         {
             var result = ParseNullableQuery(queryString);
 
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.WebUtilities
         /// </summary>
         /// <param name="queryString">The raw query string value, with or without the leading '?'.</param>
         /// <returns>A collection of parsed keys and values, null if there are no entries.</returns>
-        public static Dictionary<string, StringValues>? ParseNullableQuery(string queryString)
+        public static Dictionary<string, StringValues>? ParseNullableQuery(string? queryString)
         {
             var accumulator = new KeyValueAccumulator();
 

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -55,6 +55,16 @@ namespace Microsoft.AspNetCore.WebUtilities
             Assert.Equal(new[] { "value1", "" }, collection[""]);
         }
 
+        [Theory]
+        [InlineData("?")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ParseEmptyOrNullQueryWorks(string? queryString)
+        {
+            var collection = QueryHelpers.ParseQuery(queryString);
+            Assert.Empty(collection);
+        }
+
         [Fact]
         public void AddQueryStringWithNullValueThrows()
         {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Make parameter for ParseQuery and ParseNullableQuery in QueryHelpers nullable

**PR Description**
Addresses #30413
