### PR TITLE
Don't close connection with user-settable Pipes

### DIFF
--- a/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/src/Internal/LibuvConnection.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             (handle, suggestedSize, state) => AllocCallback(handle, suggestedSize, state);
 
         private readonly UvStreamHandle _socket;
+        private readonly IDuplexPipe _originalTransport;
         private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
 
         private volatile ConnectionAbortedException _abortReason;
@@ -62,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
             var pair = DuplexPipe.CreateConnectionPair(inputOptions, outputOptions);
 
             // Set the transport and connection id
-            Transport = pair.Transport;
+            Transport = _originalTransport = pair.Transport;
             Application = pair.Application;
         }
 
@@ -162,8 +163,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Internal
 
         public override async ValueTask DisposeAsync()
         {
-            Transport.Input.Complete();
-            Transport.Output.Complete();
+            _originalTransport.Input.Complete();
+            _originalTransport.Output.Complete();
 
             if (_processingTask != null)
             {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
         private readonly QuicStream _stream;
         private readonly QuicConnectionContext _connection;
         private readonly QuicTransportContext _context;
+        private readonly IDuplexPipe _originalTransport;
         private readonly CancellationTokenSource _streamClosedTokenSource = new CancellationTokenSource();
         private readonly IQuicTrace _log;
         private string? _connectionId;
@@ -58,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
             CanRead = stream.CanRead;
             CanWrite = stream.CanWrite;
 
-            Transport = pair.Transport;
+            Transport = _originalTransport = pair.Transport;
             Application = pair.Application;
         }
 
@@ -342,8 +343,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.Intern
 
         public override async ValueTask DisposeAsync()
         {
-            Transport.Input.Complete();
-            Transport.Output.Complete();
+            _originalTransport.Input.Complete();
+            _originalTransport.Output.Complete();
 
             await _processingTask;
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         private readonly ISocketsTrace _trace;
         private readonly SocketReceiver _receiver;
         private readonly SocketSender _sender;
+        private readonly IDuplexPipe _originalTransport;
         private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
 
         private readonly object _shutdownLock = new object();
@@ -79,7 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
             var pair = DuplexPipe.CreateConnectionPair(inputOptions, outputOptions);
 
             // Set the transport and connection id
-            Transport = pair.Transport;
+            Transport = _originalTransport = pair.Transport;
             Application = pair.Application;
         }
 
@@ -127,8 +128,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
         // Only called after connection middleware is complete which means the ConnectionClosed token has fired.
         public override async ValueTask DisposeAsync()
         {
-            Transport.Input.Complete();
-            Transport.Output.Complete();
+            _originalTransport.Input.Complete();
+            _originalTransport.Output.Complete();
 
             if (_processingTask != null)
             {

--- a/src/Servers/Kestrel/test/FunctionalTests/ConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ConnectionMiddlewareTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
+using System.IO.Pipelines;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
@@ -40,6 +42,127 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
                             await Task.Delay(5);
                         }
                     });
+                }
+            }
+        }
+
+        [Fact]
+        public async Task DisposeAsyncAfterReplacingTransportClosesConnection()
+        {
+            var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0));
+
+            var connectionCloseTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockDuplexPipe = new MockDuplexPipe();
+
+            listenOptions.Use(next =>
+            {
+                return async context =>
+                {
+                    context.Transport = mockDuplexPipe;
+                    await context.DisposeAsync();
+                    await connectionCloseTcs.Task;
+                };
+            });
+
+            var serviceContext = new TestServiceContext(LoggerFactory);
+
+            await using (var server = new TestServer(TestApp.EmptyApp, serviceContext, listenOptions))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.WaitForConnectionClose();
+                    connectionCloseTcs.SetResult();
+                }
+            }
+
+            Assert.False(mockDuplexPipe.WasCompleted);
+        }
+
+        private class MockDuplexPipe : IDuplexPipe
+        {
+            public bool WasCompleted { get; private set; }
+
+            public PipeReader Input => new MockPipeReader(this);
+
+            public PipeWriter Output => new MockPipeWriter(this);
+
+            private class MockPipeReader : PipeReader
+            {
+                private readonly MockDuplexPipe _duplexPipe;
+
+                public MockPipeReader(MockDuplexPipe duplexPipe)
+                {
+                    _duplexPipe = duplexPipe;
+                }
+
+                public override void AdvanceTo(SequencePosition consumed)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override void CancelPendingRead()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override void Complete(Exception exception = null)
+                {
+                    _duplexPipe.WasCompleted = true;
+                }
+
+                public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override bool TryRead(out ReadResult result)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            private class MockPipeWriter : PipeWriter
+            {
+                private readonly MockDuplexPipe _duplexPipe;
+
+                public MockPipeWriter(MockDuplexPipe duplexPipe)
+                {
+                    _duplexPipe = duplexPipe;
+                }
+
+                public override void Advance(int bytes)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override void CancelPendingFlush()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override void Complete(Exception exception = null)
+                {
+                    _duplexPipe.WasCompleted = true;
+                }
+
+                public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override Memory<byte> GetMemory(int sizeHint = 0)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override Span<byte> GetSpan(int sizeHint = 0)
+                {
+                    throw new NotImplementedException();
                 }
             }
         }


### PR DESCRIPTION
When looking at https://github.com/dotnet/aspnetcore/pull/29704 with @JamesNK we noticed that Kestrel uses user-settable Pipes to complete connections in its various ConnectionContext.DisposeAsync() implementations. I think ConnectionContext.DisposeAsync() should always and only complete the original Pipes.