### PR TITLE
[release/3.1] Make sure SharedFx & TargetingPack msi names match

### DIFF
--- a/eng/targets/Wix.Common.targets
+++ b/eng/targets/Wix.Common.targets
@@ -18,6 +18,14 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup Condition="'$(OutputType)' == 'package'">
+    <!-- Set package version for SharedFx & TargetingPack wixproj's -->
+    <!-- Everything built in those projects _except_ the final package & MSI are shipping assets. -->
+    <_GeneratedPackageVersion>$(PackageVersion)</_GeneratedPackageVersion>
+    <_GeneratedPackageVersion
+        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
+    <!-- Insert PackageVersion into OutputName for SharedFx & TargetingPack -->
+    <OutputName Condition="'$(OutputNamePrefix)' != '' AND '$(OutputNameSuffix)' != ''">$(OutputNamePrefix)$(_GeneratedPackageVersion)$(OutputNameSuffix)</OutputName>
+
     <EmbedCab Condition="'$(EmbedCab)' == ''">yes</EmbedCab>
     <Cabinet Condition="'$(Cabinet)' == ''">$(OutputName.Replace('-', '_')).cab</Cabinet>
     <InstallDir>$(ProductName)</InstallDir>
@@ -25,14 +33,6 @@
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);Debug</DefineConstants>
     <DefineConstants>$(DefineConstants);EmbedCab=$(EmbedCab)</DefineConstants>
     <DefineConstants>$(DefineConstants);Cabinet=$(Cabinet)</DefineConstants>
-
-    <!-- Set package version for SharedFx & TargetingPack wixproj's -->
-    <!-- Everything built in those projects _except_ the final package & MSI are shipping assets. -->
-    <_GeneratedPackageVersion>$(PackageVersion)</_GeneratedPackageVersion>
-    <_GeneratedPackageVersion
-        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
-    <!-- Insert PackageVersion into OutputName for SharedFx & TargetingPack -->
-    <OutputName Condition="'$(OutputNamePrefix)' != '' AND '$(OutputNameSuffix)' != ''">$(OutputNamePrefix)$(_GeneratedPackageVersion)$(OutputNameSuffix)$(TargetExt)</OutputName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/targets/Wix.Common.targets
+++ b/eng/targets/Wix.Common.targets
@@ -25,6 +25,14 @@
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);Debug</DefineConstants>
     <DefineConstants>$(DefineConstants);EmbedCab=$(EmbedCab)</DefineConstants>
     <DefineConstants>$(DefineConstants);Cabinet=$(Cabinet)</DefineConstants>
+
+    <!-- Set package version for SharedFx & TargetingPack wixproj's -->
+    <!-- Everything built in those projects _except_ the final package & MSI are shipping assets. -->
+    <_GeneratedPackageVersion>$(PackageVersion)</_GeneratedPackageVersion>
+    <_GeneratedPackageVersion
+        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
+    <!-- Insert PackageVersion into OutputName for SharedFx & TargetingPack -->
+    <OutputName Condition="'$(OutputNamePrefix)' != '' AND '$(OutputNameSuffix)' != ''">$(OutputNamePrefix)$(_GeneratedPackageVersion)$(OutputNameSuffix)$(TargetExt)</OutputName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
+++ b/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
@@ -3,10 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <OutputNamePrefix>$(RuntimeInstallerBaseName)-</OutputNamePrefix>
+    <OutputNameSuffix>-win-$(Platform)</OutputNameSuffix>
     <ProductNameFolder>Microsoft ASP.NET Core Shared Framework</ProductNameFolder>
     <ProductNameShort>AspNetCore.SharedFramework</ProductNameShort>
-    <Name>AspNetCoreSharedFramework</Name>
-    <OutputName>$(Name)-$(Platform)</OutputName>
     <OutputType>Package</OutputType>
     <EmbedCab>yes</EmbedCab>
     <Cabinet>sfx_$(Platform).cab</Cabinet>
@@ -76,11 +76,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <!-- Everything built in this project _except_ the final package & MSI are shipping assets. -->
-    <_GeneratedPackageVersion>$(PackageVersion)</_GeneratedPackageVersion>
-    <_GeneratedPackageVersion
-        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
-    <PackageFileName>$(RuntimeInstallerBaseName)-$(_GeneratedPackageVersion)-win-$(Platform)$(TargetExt)</PackageFileName>
+    <PackageFileName>$(OutputName)</PackageFileName>
     <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Shared Framework ($(Platform))</ProductName>
     <DefineConstants>$(DefineConstants);ProductName=$(ProductName)</DefineConstants>
   </PropertyGroup>

--- a/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
+++ b/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
@@ -76,7 +76,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <PackageFileName>$(OutputName)</PackageFileName>
+    <PackageFileName>$(OutputName)$(TargetExt)</PackageFileName>
     <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Shared Framework ($(Platform))</ProductName>
     <DefineConstants>$(DefineConstants);ProductName=$(ProductName)</DefineConstants>
   </PropertyGroup>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <OutputNamePrefix>$(TargetingPackInstallerBaseName)-</OutputNamePrefix>
     <OutputNameSuffix>-win-$(Platform)</OutputNameSuffix>
-    <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Targeting Pack ($(Platform))</ProductName>
     <ProductNameFolder>Microsoft ASP.NET Core Targeting Pack</ProductNameFolder>
     <ProductNameShort>AspNetCore.TargetingPack</ProductNameShort>
     <OutputType>Package</OutputType>
@@ -71,7 +70,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <PackageFileName>$(OutputName)</PackageFileName>
+    <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Targeting Pack ($(Platform))</ProductName>
+    <PackageFileName>$(OutputName)$(TargetExt)</PackageFileName>
     <DefineConstants>$(DefineConstants);ProductName=$(ProductName)</DefineConstants>
 
     <!-- Suppresses building this project completely during servicing builds. -->

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -3,10 +3,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <OutputNamePrefix>$(TargetingPackInstallerBaseName)-</OutputNamePrefix>
+    <OutputNameSuffix>-win-$(Platform)</OutputNameSuffix>
+    <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Targeting Pack ($(Platform))</ProductName>
     <ProductNameFolder>Microsoft ASP.NET Core Targeting Pack</ProductNameFolder>
     <ProductNameShort>AspNetCore.TargetingPack</ProductNameShort>
-    <Name>AspNetCoreTargetingPack</Name>
-    <OutputName>$(Name)-$(Platform)</OutputName>
     <OutputType>Package</OutputType>
     <IsShipping>true</IsShipping>
     <SkipCopyToArtifactsDirectory Condition="'$(IsTargetingPackBuilding)' == 'false'">true</SkipCopyToArtifactsDirectory>
@@ -70,12 +71,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
   <PropertyGroup>
-    <!-- Everything built in this project _except_ the final package are shipping assets. -->
-    <_GeneratedPackageVersion>$(PackageVersion)</_GeneratedPackageVersion>
-    <_GeneratedPackageVersion
-        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
-    <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Targeting Pack ($(Platform))</ProductName>
-    <PackageFileName>$(TargetingPackInstallerBaseName)-$(_GeneratedPackageVersion)-win-$(Platform)$(TargetExt)</PackageFileName>
+    <PackageFileName>$(OutputName)</PackageFileName>
     <DefineConstants>$(DefineConstants);ProductName=$(ProductName)</DefineConstants>
 
     <!-- Suppresses building this project completely during servicing builds. -->


### PR DESCRIPTION
3.1 port of https://github.com/dotnet/aspnetcore/pull/28298 and https://github.com/dotnet/aspnetcore/pull/28572. Should fix customer reports of being unable to upgrade/repair 3.1 Asp.Net bits via the .msi's. More context in https://github.com/dotnet/aspnetcore/issues/28029

> The name of the standalone .msi's here weren't matching what gets into VS, meaning that you can't repair a VS installation with the standalone bundle. The solution is to make sure the names match in both places (the .msi should be versioned)