### PR TITLE
Avoid capturing allocations in TagHelperMatchingConventions.SatisfiesAttributes

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/IReadOnlyListExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/IReadOnlyListExtensions.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language.Extensions
+{
+    internal static class IReadOnlyListExtensions
+    {
+        public static bool Any<T, TArg>(this IReadOnlyList<T> list, Func<T, TArg, bool> predicate, TArg arg)
+        {
+            if (list is null)
+            {
+                throw new ArgumentNullException(nameof(list));
+            }
+
+            if (predicate is null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (predicate(list[i], arg))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool All<T, TArg>(this IReadOnlyList<T> list, Func<T, TArg, bool> predicate, TArg arg)
+        {
+            if (list is null)
+            {
+                throw new ArgumentNullException(nameof(list));
+            }
+
+            if (predicate is null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (!predicate(list[i], arg))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperMatchingConventions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperMatchingConventions.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Security.Cryptography;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public static bool SatisfiesRule(
             string tagNameWithoutPrefix,
             string parentTagNameWithoutPrefix,
-            IEnumerable<KeyValuePair<string, string>> tagAttributes,
+            IReadOnlyList<KeyValuePair<string, string>> tagAttributes,
             TagMatchingRuleDescriptor rule)
         {
             if (tagNameWithoutPrefix == null)
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             return true;
         }
 
-        public static bool SatisfiesAttributes(IEnumerable<KeyValuePair<string, string>> tagAttributes, TagMatchingRuleDescriptor rule)
+        public static bool SatisfiesAttributes(IReadOnlyList<KeyValuePair<string, string>> tagAttributes, TagMatchingRuleDescriptor rule)
         {
             if (tagAttributes == null)
             {
@@ -118,8 +118,10 @@ namespace Microsoft.AspNetCore.Razor.Language
             }
 
             if (!rule.Attributes.All(
-                requiredAttribute => tagAttributes.Any(
-                    attribute => SatisfiesRequiredAttribute(attribute.Key, attribute.Value, requiredAttribute))))
+                static (requiredAttribute, tagAttributes) => tagAttributes.Any(
+                    static (attribute, requiredAttribute) => SatisfiesRequiredAttribute(attribute.Key, attribute.Value, requiredAttribute),
+                    requiredAttribute),
+                tagAttributes))
             {
                 return false;
             }


### PR DESCRIPTION
This change addresses 50% of the remaining allocations observed in a performance trace by @ryanbrandenburg.