### PR TITLE
Enable ARM64 installers build. (#25579)

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -47,6 +47,11 @@ variables:
     value: /bl:artifacts/log/Release/Build.arm64.binlog
   - name: WindowsArm64InstallersLogArgs
     value: /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: WindowsArm64LogArgs
+    value: ''
+  - name: WindowsArm64InstallersLogArgs
+    value: ''
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-MSRC-Storage
   - name: _InternalRuntimeDownloadArgs
@@ -57,10 +62,6 @@ variables:
   - name: _InternalRuntimeDownloadCodeSignArgs
     value: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
-    - name: WindowsArm64LogArgs
-      value: -ExcludeCIBinaryLog
-    - name: WindowsArm64InstallersLogArgs
-      value: -ExcludeCIBinaryLog
     # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     - group: DotNet-Blob-Feed

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -42,16 +42,6 @@ variables:
     value: ''
   - name: _InternalRuntimeDownloadCodeSignArgs
     value: ''
-- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-  - name: WindowsArm64LogArgs
-    value: /bl:artifacts/log/Release/Build.arm64.binlog
-  - name: WindowsArm64InstallersLogArgs
-    value: /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - name: WindowsArm64LogArgs
-    value: ''
-  - name: WindowsArm64InstallersLogArgs
-    value: ''
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-MSRC-Storage
   - name: _InternalRuntimeDownloadArgs
@@ -267,15 +257,6 @@ stages:
       agentOs: Windows
       installNodeJs: false
       installJdk: false
-      artifacts:
-      - name: Windows_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_arm64_Packages
-        path: artifacts/packages/
-      - name: Windows_arm64_Installers
-        path: artifacts/installers/
       steps:
       - script: ./build.cmd
                 -ci
@@ -288,7 +269,7 @@ stages:
                 /p:OnlyPackPlatformSpecificPackages=true
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
-                $(WindowsArm64LogArgs)
+                /bl:artifacts/log/Release/Build.arm64.binlog
         displayName: Build ARM64
 
       # Windows installers bundle for arm64
@@ -304,8 +285,18 @@ stages:
                 $(_BuildArgs)
                 $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
-                $(WindowsArm64InstallersLogArgs)
+                /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
         displayName: Build Arm64 Installers
+
+      artifacts:
+      - name: Windows_arm64_Logs
+        path: artifacts/log/
+        publishOnError: true
+        includeForks: true
+      - name: Windows_arm64_Packages
+        path: artifacts/packages/
+      - name: Windows_arm64_Installers
+        path: artifacts/installers/
 
       # A few files must also go to the VS package feed.
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -42,6 +42,11 @@ variables:
     value: ''
   - name: _InternalRuntimeDownloadCodeSignArgs
     value: ''
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: WindowsArm64LogArgs
+    value: /bl:artifacts/log/Release/Build.arm64.binlog
+  - name: WindowsArm64InstallersLogArgs
+    value: /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-MSRC-Storage
   - name: _InternalRuntimeDownloadArgs
@@ -52,6 +57,10 @@ variables:
   - name: _InternalRuntimeDownloadCodeSignArgs
     value: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - name: WindowsArm64LogArgs
+      value: -ExcludeCIBinaryLog
+    - name: WindowsArm64InstallersLogArgs
+      value: -ExcludeCIBinaryLog
     # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     - group: DotNet-Blob-Feed
@@ -255,19 +264,6 @@ stages:
       jobName: Windows_64_build
       jobDisplayName: "Build: Windows ARM64"
       agentOs: Windows
-      buildArgs:
-        -arch arm64
-        -sign
-        -pack
-        -noBuildNodeJS
-        -noBuildJava
-        /bl:artifacts/log/build.win-arm64.binlog
-        /p:DotNetSignType=$(_SignType)
-        /p:OnlyPackPlatformSpecificPackages=true
-        /p:AssetManifestFileName=aspnetcore-win-arm64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
       installNodeJs: false
       installJdk: false
       artifacts:
@@ -279,6 +275,47 @@ stages:
         path: artifacts/packages/
       - name: Windows_arm64_Installers
         path: artifacts/installers/
+      steps:
+      - script: ./build.cmd
+                -ci
+                -arch arm64
+                -sign
+                -pack
+                -noBuildJava
+                -noBuildNative
+                /p:DotNetSignType=$(_SignType)
+                /p:OnlyPackPlatformSpecificPackages=true
+                $(_BuildArgs)
+                $(_InternalRuntimeDownloadArgs)
+                $(WindowsArm64LogArgs)
+        displayName: Build ARM64
+
+      # Windows installers bundle for arm64
+      - script: ./build.cmd
+                -ci
+                -noBuildRepoTasks
+                -arch arm64
+                -sign
+                -buildInstallers
+                -noBuildNative
+                /p:DotNetSignType=$(_SignType)
+                /p:AssetManifestFileName=aspnetcore-win-arm64.xml
+                $(_BuildArgs)
+                $(_PublishArgs)
+                $(_InternalRuntimeDownloadArgs)
+                $(WindowsArm64InstallersLogArgs)
+        displayName: Build Arm64 Installers
+
+      # A few files must also go to the VS package feed.
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - task: NuGetCommand@2
+          displayName: Push Visual Studio packages
+          inputs:
+            command: push
+            packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
+            nuGetFeedType: external
+            publishFeedCredentials: 'DevDiv - VS package feed'
+
 
   # Build MacOS
   - template: jobs/default-build.yml

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -84,7 +84,8 @@
     <RuntimeInstallerBaseName>aspnetcore-runtime</RuntimeInstallerBaseName>
     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>
 
-    <!-- Produce targeting pack installers/packages once per major.minor except in extraordinary cases i.e. 3.1.10. -->
+    <!-- Produce targeting pack installers/packages once per major.minor except in extraordinary cases i.e. 3.1.13 win-arm64. -->
+    <IsTargetingPackBuilding Condition=" '$(AspNetCorePatchVersion)' == '13' AND '$(TargetArchitecture)' == 'arm64' AND $([MSBuild]::IsOSPlatform('Windows')) ">true</IsTargetingPackBuilding>
     <IsTargetingPackBuilding Condition=" '$(DotNetBuildFromSource)' == 'true' ">false</IsTargetingPackBuilding>
     <IsTargetingPackBuilding
         Condition=" '$(IsTargetingPackBuilding)' == '' AND '$(AspNetCorePatchVersion)' != '10' ">false</IsTargetingPackBuilding>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -84,8 +84,8 @@
     <RuntimeInstallerBaseName>aspnetcore-runtime</RuntimeInstallerBaseName>
     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>
 
-    <!-- Produce targeting pack installers/packages once per major.minor except in extraordinary cases i.e. 3.1.13 win-arm64. -->
-    <IsTargetingPackBuilding Condition=" '$(AspNetCorePatchVersion)' == '13' AND '$(TargetArchitecture)' == 'arm64' AND $([MSBuild]::IsOSPlatform('Windows')) ">true</IsTargetingPackBuilding>
+    <!-- Produce targeting pack installers/packages once per major.minor except in extraordinary cases i.e. 3.1.14 win-arm64. -->
+    <IsTargetingPackBuilding Condition=" '$(AspNetCorePatchVersion)' == '14' AND '$(TargetArchitecture)' == 'arm64' AND $([MSBuild]::IsOSPlatform('Windows')) ">true</IsTargetingPackBuilding>
     <IsTargetingPackBuilding Condition=" '$(DotNetBuildFromSource)' == 'true' ">false</IsTargetingPackBuilding>
     <IsTargetingPackBuilding
         Condition=" '$(IsTargetingPackBuilding)' == '' AND '$(AspNetCorePatchVersion)' != '10' ">false</IsTargetingPackBuilding>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -57,7 +57,8 @@
   <PropertyGroup>
     <!-- When OnlyPackPlatformSpecificPackages is set, only produce packages for projects which set RuntimeIdentifier. -->
     <!-- Keep this below where we set "IsPackageInThisPatch" -->
-    <IsPackable Condition=" '$(OnlyPackPlatformSpecificPackages)' == 'true' AND '$(RuntimeIdentifier)' == '' ">false</IsPackable>
+    <!-- Do not apply this logic to App.Ref, it's packability is determined by IsTargetingPackBuilding -->
+    <IsPackable Condition=" '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Ref' AND '$(OnlyPackPlatformSpecificPackages)' == 'true' AND '$(RuntimeIdentifier)' == '' ">false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -57,8 +57,8 @@
   <PropertyGroup>
     <!-- When OnlyPackPlatformSpecificPackages is set, only produce packages for projects which set RuntimeIdentifier. -->
     <!-- Keep this below where we set "IsPackageInThisPatch" -->
-    <!-- Do not apply this logic to App.Ref, it's packability is determined by IsTargetingPackBuilding -->
-    <IsPackable Condition=" '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Ref' AND '$(OnlyPackPlatformSpecificPackages)' == 'true' AND '$(RuntimeIdentifier)' == '' ">false</IsPackable>
+    <!-- Do not apply this logic to App.Ref and App.Ref.Internal, it's packability is determined by IsTargetingPackBuilding -->
+    <IsPackable Condition=" '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Ref' AND '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Ref.Internal' AND '$(OnlyPackPlatformSpecificPackages)' == 'true' AND '$(RuntimeIdentifier)' == '' ">false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -60,7 +60,7 @@
       </ItemGroup>
     </When>
     <Otherwise>
-      <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' ">
+      <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64')  ">
         <!-- Build the ANCM custom action -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=x64" />
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=Win32" />
@@ -74,6 +74,10 @@
         <!-- Build the targeting pack installers -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=x64" />
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=x86" />
+        <!-- This really shouldn't be here, but instead of harvesting from the intermediate/output directories, the targetting pack installer logic
+        harvests from a zip of the reference assemblies. Producing it in each leg ends up with multiple targeting packs
+        getting produced and the BAR will reject the build. Centralize building the targeting pack in the x86/x64 leg. -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=arm64" />
 
         <!-- Build the SharedFramework installers -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" AdditionalProperties="Platform=x64" />
@@ -85,6 +89,14 @@
 
         <!-- Windows hosting bundled -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\WindowsHostingBundle\WindowsHostingBundle.wixproj" AdditionalProperties="Platform=x86" />
+      </ItemGroup>
+
+      <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'arm64' ">
+        <!-- We don't build the bundle here because we'd have to bundle the x86 installer which gets built in a different leg.
+        Instead we only provide the ARM64 MSI-->
+
+        <!-- Build the SharedFramework wixlib -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=arm64" />
       </ItemGroup>
 
       <ItemGroup Condition="'$(BuildInstallers)' == 'true' AND '$(TargetRuntimeIdentifier)' == 'linux-x64'">

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -95,6 +95,9 @@
         <!-- We don't build the bundle here because we'd have to bundle the x86 installer which gets built in a different leg.
         Instead we only provide the ARM64 MSI-->
 
+        <!-- Build the targeting pack installers -->
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\TargetingPack\TargetingPack.wixproj" AdditionalProperties="Platform=arm64" />
+
         <!-- Build the SharedFramework wixlib -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=arm64" />
       </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,7 +35,7 @@
     <!-- TargetingPackVersionPrefix is used by projects, like .deb and .rpm, which use slightly different version formats. -->
     <TargetingPackVersionPrefix>$(VersionPrefix)</TargetingPackVersionPrefix>
     <!-- Targeting packs do not produce patch versions in servicing builds. No API changes are allowed in patches. -->
-    <TargetingPackVersionPrefix Condition="'$(IsTargetingPackBuilding)' != 'true'">$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).10</TargetingPackVersionPrefix>
+    <TargetingPackVersionPrefix Condition="'$(IsTargetingPackBuilding)' != 'true'">$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).13</TargetingPackVersionPrefix>
     <ExperimentalVersionPrefix>0.3.$(AspNetCorePatchVersion)</ExperimentalVersionPrefix>
     <!-- ANCM versioning is intentionally 10 + AspNetCoreMajorVersion because earlier versions of ANCM shipped as 8.x. -->
     <AspNetCoreModuleVersionMajor>$([MSBuild]::Add(10, $(AspNetCoreMajorVersion)))</AspNetCoreModuleVersionMajor>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,7 +35,7 @@
     <!-- TargetingPackVersionPrefix is used by projects, like .deb and .rpm, which use slightly different version formats. -->
     <TargetingPackVersionPrefix>$(VersionPrefix)</TargetingPackVersionPrefix>
     <!-- Targeting packs do not produce patch versions in servicing builds. No API changes are allowed in patches. -->
-    <TargetingPackVersionPrefix Condition="'$(IsTargetingPackBuilding)' != 'true'">$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).14</TargetingPackVersionPrefix>
+    <TargetingPackVersionPrefix Condition="'$(IsTargetingPackBuilding)' != 'true'">$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).10</TargetingPackVersionPrefix>
     <ExperimentalVersionPrefix>0.3.$(AspNetCorePatchVersion)</ExperimentalVersionPrefix>
     <!-- ANCM versioning is intentionally 10 + AspNetCoreMajorVersion because earlier versions of ANCM shipped as 8.x. -->
     <AspNetCoreModuleVersionMajor>$([MSBuild]::Add(10, $(AspNetCoreMajorVersion)))</AspNetCoreModuleVersionMajor>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     <AspNetCoreMinorVersion>1</AspNetCoreMinorVersion>
     <AspNetCorePatchVersion>14</AspNetCorePatchVersion>
     <ValidateBasline>false</ValidateBasline>
-    
+
     <PreReleasePreviewNumber>0</PreReleasePreviewNumber>
     <ComponentsWebAssemblyMajorVersion>3</ComponentsWebAssemblyMajorVersion>
     <ComponentsWebAssemblyMinorVersion>2</ComponentsWebAssemblyMinorVersion>
@@ -35,7 +35,7 @@
     <!-- TargetingPackVersionPrefix is used by projects, like .deb and .rpm, which use slightly different version formats. -->
     <TargetingPackVersionPrefix>$(VersionPrefix)</TargetingPackVersionPrefix>
     <!-- Targeting packs do not produce patch versions in servicing builds. No API changes are allowed in patches. -->
-    <TargetingPackVersionPrefix Condition="'$(IsTargetingPackBuilding)' != 'true'">$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).13</TargetingPackVersionPrefix>
+    <TargetingPackVersionPrefix Condition="'$(IsTargetingPackBuilding)' != 'true'">$(AspNetCoreMajorVersion).$(AspNetCoreMinorVersion).14</TargetingPackVersionPrefix>
     <ExperimentalVersionPrefix>0.3.$(AspNetCorePatchVersion)</ExperimentalVersionPrefix>
     <!-- ANCM versioning is intentionally 10 + AspNetCoreMajorVersion because earlier versions of ANCM shipped as 8.x. -->
     <AspNetCoreModuleVersionMajor>$([MSBuild]::Add(10, $(AspNetCoreMajorVersion)))</AspNetCoreModuleVersionMajor>

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="$(var.ProductCode)" Name="$(var.ProductName)" Language="1033" Version="$(var.Version)"
              Manufacturer="Microsoft Corporation" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+        <Package InstallerVersion="$(var.InstallerVersion)" Compressed="yes" InstallScope="perMachine" />
 
         <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." Schedule="afterInstallFinalize" />
         <Media Id="1" Cabinet="$(var.Cabinet)" CompressionLevel="high" EmbedCab="$(var.EmbedCab)" />
@@ -21,7 +21,7 @@
 
     <?if $(var.Platform)=x86?>
     <?define PFilesFolder=ProgramFilesFolder?>
-    <?elseif $(var.Platform)=x64?>
+    <?elseif $(var.Platform)=x64 or $(var.Platform)=arm64?>
     <?define PFilesFolder=ProgramFiles64Folder?>
     <?else?>
     <?error Invalid Platform ($(var.Platform))?>

--- a/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
+++ b/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
@@ -61,12 +61,16 @@
   <!-- TODO: https://github.com/aspnet/AspNetCore/issues/6304. Harvest shared frameworks from a project reference -->
   <Target Name="ExtractIntermediateSharedFx" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
+      <SharedFrameworkArm64HarvestRootPath Condition="'$(SharedFrameworkArm64HarvestRootPath)' == ''">$(InstallersOutputPath)</SharedFrameworkArm64HarvestRootPath>
       <SharedFrameworkX64HarvestRootPath Condition="'$(SharedFrameworkX64HarvestRootPath)' == ''">$(InstallersOutputPath)</SharedFrameworkX64HarvestRootPath>
       <SharedFrameworkX86HarvestRootPath Condition="'$(SharedFrameworkX86HarvestRootPath)' == ''">$(InstallersOutputPath)</SharedFrameworkX86HarvestRootPath>
+      <IntermediateArm64SharedFxZip>$(SharedFrameworkArm64HarvestRootPath)aspnetcore-runtime-internal-$(PackageVersion)-win-arm64.zip</IntermediateArm64SharedFxZip>
       <IntermediateX64SharedFxZip>$(SharedFrameworkX64HarvestRootPath)aspnetcore-runtime-internal-$(PackageVersion)-win-x64.zip</IntermediateX64SharedFxZip>
       <IntermediateX86SharedFxZip>$(SharedFrameworkX86HarvestRootPath)aspnetcore-runtime-internal-$(PackageVersion)-win-x86.zip</IntermediateX86SharedFxZip>
     </PropertyGroup>
 
+    <Unzip Condition="'$(Platform)' == 'arm64'"
+           SourceFiles="$(IntermediateArm64SharedFxZip)" DestinationFolder="$(HarvestSource)" />
     <Unzip Condition="'$(Platform)' == 'x64'"
            SourceFiles="$(IntermediateX64SharedFxZip)" DestinationFolder="$(HarvestSource)" />
     <Unzip Condition="'$(Platform)' == 'x86'"

--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -93,6 +93,8 @@
             <PackageGroupRef Id="PG_AspNetCoreSharedFramework_x86"/>
             <?elseif $(var.Platform)=x64?>
             <PackageGroupRef Id="PG_AspNetCoreSharedFramework_x64"/>
+            <?elseif $(var.Platform)=arm64?>
+            <PackageGroupRef Id="PG_AspNetCoreSharedFramework_arm64"/>
             <?endif?>
         </Chain>
     </Bundle>

--- a/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
+++ b/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
@@ -29,20 +29,35 @@
     <Content Include="thm.xml" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj" SetPlatform="Platform=x86">
-      <Name>SharedFrameworkLib</Name>
-      <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
-      <Private>True</Private>
-      <DoNotHarvest>True</DoNotHarvest>
-    </ProjectReference>
-    <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj" SetPlatform="Platform=x64">
-      <Name>SharedFrameworkLib</Name>
-      <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
-      <Private>True</Private>
-      <DoNotHarvest>True</DoNotHarvest>
-    </ProjectReference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(Platform)' == 'arm64'">
+      <ItemGroup>
+        <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj" SetPlatform="Platform=arm64">
+          <Name>SharedFrameworkLib</Name>
+          <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
+          <Private>True</Private>
+          <DoNotHarvest>True</DoNotHarvest>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj" SetPlatform="Platform=x86">
+          <Name>SharedFrameworkLib</Name>
+          <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
+          <Private>True</Private>
+          <DoNotHarvest>True</DoNotHarvest>
+        </ProjectReference>
+        <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj" SetPlatform="Platform=x64">
+          <Name>SharedFrameworkLib</Name>
+          <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
+          <Private>True</Private>
+          <DoNotHarvest>True</DoNotHarvest>
+        </ProjectReference>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 

--- a/src/Installers/Windows/SharedFrameworkLib/Library.wxs
+++ b/src/Installers/Windows/SharedFrameworkLib/Library.wxs
@@ -16,6 +16,9 @@
             <?elseif $(var.Platform)=x64?>
             <?define SharedFrameworkInstallCondition=VersionNT64 AND (NOT OPT_NO_SHAREDFX)?>
             <?define DotNetHome=DOTNETHOME_X64?>
+            <?elseif $(var.Platform)=arm64?>
+            <?define SharedFrameworkInstallCondition=VersionNT64 AND (NOT OPT_NO_SHAREDFX)?>
+            <?define DotNetHome=DOTNETHOME_ARM64?>
             <?endif?>
 
             <MsiPackage Id="AspNetCoreSharedFramework_$(var.Platform)"

--- a/src/Installers/Windows/TargetingPack/Product.wxs
+++ b/src/Installers/Windows/TargetingPack/Product.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="$(var.ProductCode)" Name="$(var.ProductName)" Language="1033" Version="$(var.Version)"
              Manufacturer="Microsoft Corporation" UpgradeCode="$(var.UpgradeCode)">
-        <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+        <Package InstallerVersion="$(var.InstallerVersion)" Compressed="yes" InstallScope="perMachine" />
 
         <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." Schedule="afterInstallFinalize" />
         <Media Id="1" Cabinet="$(var.Cabinet)" CompressionLevel="high" EmbedCab="$(var.EmbedCab)" />
@@ -21,7 +21,7 @@
 
     <?if $(var.Platform)=x86?>
     <?define PFilesFolder=ProgramFilesFolder?>
-    <?elseif $(var.Platform)=x64?>
+    <?elseif $(var.Platform)=x64 or $(var.Platform)=arm64?>
     <?define PFilesFolder=ProgramFiles64Folder?>
     <?else?>
     <?error Invalid Platform ($(var.Platform))?>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -21,6 +21,8 @@
     <NamespaceGuid>DDBB771F-963F-47D3-8510-9ABD04DBE1D1</NamespaceGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <ToolsetInstallerNuspecFile>$(RepoRoot)\src\Installers\Windows\TargetingPack\TargetingPackPackage.nuspec</ToolsetInstallerNuspecFile>
+    <PackageVersion>$(TargetingPackVersionPrefix)</PackageVersion>
+    <BundleVersion>$(TargetingPackVersionPrefix)</BundleVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -61,7 +61,7 @@
   <Target Name="ExtractIntermediateTargetingPack" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <TargetingPackHarvestRoot Condition="'$(TargetingPackHarvestRoot)' == ''">$(InstallersOutputPath)</TargetingPackHarvestRoot>
-      <IntermediateTargetingPackZip>$(TargetingPackHarvestRoot)aspnetcore-targeting-pack-$(PackageVersion).zip</IntermediateTargetingPackZip>
+      <IntermediateTargetingPackZip>$(TargetingPackHarvestRoot)aspnetcore-targeting-pack-$(TargetingPackVersionPrefix).zip</IntermediateTargetingPackZip>
     </PropertyGroup>
 
     <Unzip SourceFiles="$(IntermediateTargetingPackZip)" DestinationFolder="$(HarvestSource)" />

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -4,7 +4,8 @@
     <!-- Actual upgrade code used in bundles to ensure upgrades withing a version band, e.g. 3.0.0.xxx -->
     <_FileRevisionVersion>$(VersionSuffixDateStamp)</_FileRevisionVersion>
     <_FileRevisionVersion Condition=" '$(_FileRevisionVersion)' == '' ">42424</_FileRevisionVersion>
-    <BundleVersion>$(AspNetCoreMajorMinorVersion).$(AspNetCorePatchVersion).$(_FileRevisionVersion)</BundleVersion>
+    <BundleVersion Condition="'$(BundleVersion)' != ''" >$(BundleVersion).$(_FileRevisionVersion)</BundleVersion>
+    <BundleVersion Condition="'$(BundleVersion)' == ''" >$(AspNetCoreMajorMinorVersion).$(AspNetCorePatchVersion).$(_FileRevisionVersion)</BundleVersion>
     <!-- Used for generating stable upgrade codes for bundles -->
     <Version>$(BundleVersion)</Version>
 

--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -8,6 +8,11 @@
     <!-- Used for generating stable upgrade codes for bundles -->
     <Version>$(BundleVersion)</Version>
 
+    <!-- ARM64 MSIs require the installer version to be at least 500. -->
+    <!-- See: https://docs.microsoft.com/en-us/windows/win32/msi/64-bit-windows-installer-packages -->
+    <DefineConstants Condition=" '$(Platform)' == 'arm64' ">$(DefineConstants);InstallerVersion=500</DefineConstants>
+    <DefineConstants Condition=" '$(Platform)' != 'arm64' ">$(DefineConstants);InstallerVersion=200</DefineConstants>
+
     <DefineConstants>$(DefineConstants);MajorVersion=$(AspNetCoreMajorVersion)</DefineConstants>
     <DefineConstants>$(DefineConstants);MinorVersion=$(AspNetCoreMinorVersion)</DefineConstants>
     <DefineConstants>$(DefineConstants);Version=$(Version)</DefineConstants>


### PR DESCRIPTION
Backporting https://github.com/dotnet/aspnetcore/commit/dda1d33f7bea9e85e6abcd5dab2642f22e9a8093 to release/3.1

Changes WiX toolset used to 3.14 to support ARM64
Generates targeting pack from the x86/x64 leg, as it gets produced using a zip that gets generated there.
The ARM64 leg now produces all the necessary msi's, exe, and wixlib needed for the installer to generate a bundle.

This change is required in addition to https://github.com/dotnet/core-setup/pull/9124 to add support for win-arm64 for the SDK.