### PR TITLE
Update branding to 5.0.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,8 @@
   <PropertyGroup Label="Version settings">
     <AspNetCoreMajorVersion>5</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>0</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>4</AspNetCorePatchVersion>
+    <AspNetCorePatchVersion>5</AspNetCorePatchVersion>
+    <ValidateBasline>false</ValidateBasline>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->

--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -1,7 +1,8 @@
 <Project>
 
   <Target Name="EnsureBaselineIsUpdated"
-          Condition=" '$(IsServicingBuild)' == 'true' AND
+          Condition=" '$(ValidateBasline)' == 'true' AND
+              '$(IsServicingBuild)' == 'true' AND
               '$(AspNetCoreBaselineVersion)' != '$(PreviousAspNetCoreReleaseVersion)' AND
               '$(MSBuildProjectName)' != 'BaselineGenerator' AND
               '$(MSBuildProjectName)' != 'RepoTasks' "


### PR DESCRIPTION
Update branding to 5.0 and disable baseline validation. On patch tuesday we'll update the SDK & Baseline, and re-enable baseline validation