### PR TITLE
Mark Blazor WASM as trimmable

### DIFF
--- a/eng/targets/CSharp.Common.targets
+++ b/eng/targets/CSharp.Common.targets
@@ -61,6 +61,11 @@
         <_Parameter1>Serviceable</_Parameter1>
         <_Parameter2>True</_Parameter2>
       </AssemblyAttribute>
+
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(Trimmable)' == 'true'">
+        <_Parameter1>IsTrimmable</_Parameter1>
+        <_Parameter2>True</_Parameter2>
+      </AssemblyAttribute>
     </ItemGroup>
   </Target>
 

--- a/src/Components/Authorization/src/Microsoft.AspNetCore.Components.Authorization.csproj
+++ b/src/Components/Authorization/src/Microsoft.AspNetCore.Components.Authorization.csproj
@@ -5,6 +5,7 @@
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
     <Description>Authentication and authorization support for Blazor applications.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -6,6 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
     <Nullable>enable</Nullable>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Forms/src/Microsoft.AspNetCore.Components.Forms.csproj
+++ b/src/Components/Forms/src/Microsoft.AspNetCore.Components.Forms.csproj
@@ -6,6 +6,7 @@
     <Description>Forms and validation support for Blazor applications.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Web/src/Microsoft.AspNetCore.Components.Web.csproj
+++ b/src/Components/Web/src/Microsoft.AspNetCore.Components.Web.csproj
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Microsoft.AspNetCore.Components</RootNamespace>
     <Nullable>enable</Nullable>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
+++ b/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsShippingPackage>true</IsShippingPackage>
     <Nullable>enable</Nullable>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);BL0006</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Http/Metadata/src/Microsoft.AspNetCore.Metadata.csproj
+++ b/src/Http/Metadata/src/Microsoft.AspNetCore.Metadata.csproj
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
     <Nullable>enable</Nullable>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
 </Project>

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.csproj
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
     <Nullable>enable</Nullable>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj
+++ b/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj
@@ -11,6 +11,7 @@ Microsoft.AspNetCore.Authorization.AuthorizeAttribute</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;authorization</PackageTags>
     <Nullable>enable</Nullable>
+    <Trimmable>true</Trimmable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This covers Blazor assemblies that have been annotated for trimming and are baselined as part of the trimmer test.