### PR TITLE
Update branding to 3.1.14

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,9 @@
   <PropertyGroup Label="Version settings">
     <AspNetCoreMajorVersion>3</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>1</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>13</AspNetCorePatchVersion>
+    <AspNetCorePatchVersion>14</AspNetCorePatchVersion>
+    <ValidateBasline>false</ValidateBasline>
+    
     <PreReleasePreviewNumber>0</PreReleasePreviewNumber>
     <ComponentsWebAssemblyMajorVersion>3</ComponentsWebAssemblyMajorVersion>
     <ComponentsWebAssemblyMinorVersion>2</ComponentsWebAssemblyMinorVersion>

--- a/eng/scripts/install-nginx-mac.sh
+++ b/eng/scripts/install-nginx-mac.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 brew update
-brew install openssl nginx
+brew list openssl || brew install openssl
+brew list nginx || brew install nginx

--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -1,7 +1,8 @@
 <Project>
 
   <Target Name="EnsureBaselineIsUpdated"
-          Condition=" '$(IsServicingBuild)' == 'true' AND
+          Condition=" '$(ValidateBasline)' == 'true' AND
+              '$(IsServicingBuild)' == 'true' AND
               '$(AspNetCoreBaselineVersion)' != '$(PreviousAspNetCoreReleaseVersion)' AND
               '$(MSBuildProjectName)' != 'BaselineGenerator' AND
               '$(MSBuildProjectName)' != 'RepoTasks' "


### PR DESCRIPTION
Update branding to 3.1.14 and disable baseline validation. On patch tuesday we'll update the SDK & Baseline, and re-enable baseline validation