### PR TITLE
Remove Range usage in LegacyRouteEntry

### DIFF
--- a/src/Components/Components/src/Routing/LegacyRouteMatching/LegacyRouteEntry.cs
+++ b/src/Components/Components/src/Routing/LegacyRouteMatching/LegacyRouteEntry.cs
@@ -39,7 +39,8 @@ namespace Microsoft.AspNetCore.Components.LegacyRouteMatching
             // PathSegments:    /foo/bar/one/two/three
             if (Template.ContainsCatchAllSegment && context.Segments.Length >= Template.Segments.Length)
             {
-                catchAllValue = string.Join('/', context.Segments[Range.StartAt(Template.Segments.Length - 1)]);
+                int startIndex = Template.Segments.Length - 1;
+                catchAllValue = string.Join('/', context.Segments, startIndex, context.Segments.Length - startIndex);
             }
             // If there are no optional segments on the route and the length of the route
             // and the template do not match, then there is no chance of this matching and


### PR DESCRIPTION
Remove the last usage of System.Range/Index in a Blazor WASM default app, which allows them to be trimmed.

This approach has better runtime performance as well, since it doesn't need to allocate a new array.

Not a huge size reduction, but a little over .5 KB .br compressed:

* **Before**: 2,726,848 bytes
* **After**: 2,726,216 bytes