### PR TITLE
Add an application part factory for an assembly that contains controllers and views.

### DIFF
--- a/src/Mvc/Mvc.Razor/src/ApplicationParts/ConsolidatedAssemblyApplicationPartFactory.cs
+++ b/src/Mvc/Mvc.Razor/src/ApplicationParts/ConsolidatedAssemblyApplicationPartFactory.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Mvc.ApplicationParts
+{
+    /// <summary>
+    /// Configures an <see cref="ApplicationPart" /> that contains controllers, as well as Razor views and Pages.
+    /// <para>
+    /// Combines the results of <see cref="DefaultApplicationPartFactory.GetApplicationParts(Assembly)"/> and
+    /// <see cref="CompiledRazorAssemblyApplicationPartFactory.GetApplicationParts(Assembly)"/>. This part factory
+    /// may be used if Razor views or Razor Pages are compiled in to with other types including controllers.
+    /// </para>
+    /// </summary>
+    public sealed class ConsolidatedAssemblyApplicationPartFactory : ApplicationPartFactory
+    {
+        /// <inheritdoc />
+        public override IEnumerable<ApplicationPart> GetApplicationParts(Assembly assembly)
+        {
+            return Enumerable.Concat(
+                DefaultApplicationPartFactory.GetDefaultApplicationParts(assembly),
+                CompiledRazorAssemblyApplicationPartFactory.GetDefaultApplicationParts(assembly));
+        }
+    }
+}

--- a/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Microsoft.AspNetCore.Mvc.ApplicationParts.ConsolidatedAssemblyApplicationPartFactory
+Microsoft.AspNetCore.Mvc.ApplicationParts.ConsolidatedAssemblyApplicationPartFactory.ConsolidatedAssemblyApplicationPartFactory() -> void
+~override Microsoft.AspNetCore.Mvc.ApplicationParts.ConsolidatedAssemblyApplicationPartFactory.GetApplicationParts(System.Reflection.Assembly assembly) -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApplicationParts.ApplicationPart>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/29862.

MVC has infrastructure for providing where assets such as controllers or views come from by means of an ApplicationPartFactory. By default, MyApp.Views.dll is stamped with an `CompiledRazorAssemblyApplicationPartFactory` that can provided Razor Pages and views. This application part combines the behavior of the default part factory (so that it can provide things like controllers) and the views one (so that it can provide views) from the same assembly. 

Assemblies in .net6 that are compiled with views and controllers in the same assembly will use this part factory.