### PR TITLE
[Java] Fix skip negotiate null ref

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -69,7 +69,7 @@ public class HttpHubConnectionBuilder {
 
     /**
      * Indicates to the {@link HubConnection} that it should skip the negotiate process.
-     * Note: This option only works with the {@link TransportEnum.WEBSOCKETS} transport selected via {@link HttpHubConnectionBuilder.withTransport},
+     * Note: This option only works with the {@link TransportEnum#WEBSOCKETS} transport selected via {@link #withTransport(TransportEnum) withTransport},
      * additionally the Azure SignalR Service requires the negotiate step so this will fail when using the Azure SignalR Service.
      *
      * @param skipNegotiate Boolean indicating if the {@link HubConnection} should skip the negotiate step.

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -69,7 +69,8 @@ public class HttpHubConnectionBuilder {
 
     /**
      * Indicates to the {@link HubConnection} that it should skip the negotiate process.
-     * Note: This option only works with the Websockets transport and the Azure SignalR Service require the negotiate step.
+     * Note: This option only works with the {@link TransportEnum.WEBSOCKETS} transport selected via {@link HttpHubConnectionBuilder.withTransport},
+     * additionally the Azure SignalR Service requires the negotiate step so this will fail when using the Azure SignalR Service.
      *
      * @param skipNegotiate Boolean indicating if the {@link HubConnection} should skip the negotiate step.
      * @return This instance of the HttpHubConnectionBuilder.

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HttpHubConnectionBuilder.java
@@ -69,8 +69,7 @@ public class HttpHubConnectionBuilder {
 
     /**
      * Indicates to the {@link HubConnection} that it should skip the negotiate process.
-     * Note: This option only works with the {@link TransportEnum#WEBSOCKETS} transport selected via {@link #withTransport(TransportEnum) withTransport},
-     * additionally the Azure SignalR Service requires the negotiate step so this will fail when using the Azure SignalR Service.
+     * Note: This option only works with the Websockets transport and the Azure SignalR Service require the negotiate step.
      *
      * @param skipNegotiate Boolean indicating if the {@link HubConnection} should skip the negotiate step.
      * @return This instance of the HttpHubConnectionBuilder.

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -264,7 +264,16 @@ public class HubConnection implements AutoCloseable {
                 Transport transport = customTransport;
                 if (transport == null) {
                     Single<String> tokenProvider = negotiateResponse.getAccessToken() != null ? Single.just(negotiateResponse.getAccessToken()) : accessTokenProvider;
-                    switch (negotiateResponse.getChosenTransport()) {
+                    TransportEnum chosenTransport;
+                    if (this.skipNegotiate) {
+                        if (this.transportEnum != TransportEnum.WEBSOCKETS) {
+                            throw new RuntimeException("Negotiation can only be skipped when using the WebSocket transport directly.");
+                        }
+                        chosenTransport = this.transportEnum;
+                    } else {
+                        chosenTransport = negotiateResponse.getChosenTransport();
+                    }
+                    switch (chosenTransport) {
                         case LONG_POLLING:
                             transport = new LongPollingTransport(localHeaders, httpClient, tokenProvider);
                             break;

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -266,9 +266,6 @@ public class HubConnection implements AutoCloseable {
                     Single<String> tokenProvider = negotiateResponse.getAccessToken() != null ? Single.just(negotiateResponse.getAccessToken()) : accessTokenProvider;
                     TransportEnum chosenTransport;
                     if (this.skipNegotiate) {
-                        if (this.transportEnum != TransportEnum.WEBSOCKETS) {
-                            throw new RuntimeException("Negotiation can only be skipped when using the WebSocket transport directly.");
-                        }
                         chosenTransport = this.transportEnum;
                     } else {
                         chosenTransport = negotiateResponse.getChosenTransport();

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -2775,32 +2775,6 @@ class HubConnectionTest {
     }
 
     @Test
-    public void ThrowsIfSkipNegotiationSetAndTransportIsNotWebSockets() {
-        AtomicBoolean negotiateCalled = new AtomicBoolean(false);
-        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
-                (req) -> {
-                    negotiateCalled.set(true);
-                    return Single.just(new HttpResponse(200, "",
-                        TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
-                                + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
-                });
-
-        HubConnection hubConnection = HubConnectionBuilder
-                .create("http://example")
-                .shouldSkipNegotiate(true)
-                .withHttpClient(client)
-                .build();
-
-        try {
-            hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
-        } catch (Exception e) {
-            assertEquals("Negotiation can only be skipped when using the WebSocket transport directly.", e.getMessage());
-        }
-        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
-        assertFalse(negotiateCalled.get());
-    }
-
-    @Test
     public void connectionIdIsAvailableAfterStart() {
         TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -2744,6 +2744,63 @@ class HubConnectionTest {
     }
 
     @Test
+    public void SkippingNegotiateDoesNotNegotiate() {
+        try (TestLogger logger = new TestLogger(WebSocketTransport.class.getName())) {
+            AtomicBoolean negotiateCalled = new AtomicBoolean(false);
+            TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                    (req) -> {
+                        negotiateCalled.set(true);
+                        return Single.just(new HttpResponse(200, "",
+                            TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                    + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+                    });
+
+            HubConnection hubConnection = HubConnectionBuilder
+                    .create("http://example")
+                    .withTransport(TransportEnum.WEBSOCKETS)
+                    .shouldSkipNegotiate(true)
+                    .withHttpClient(client)
+                    .build();
+
+            try {
+                hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+            } catch (Exception e) {
+                assertEquals("WebSockets isn't supported in testing currently.", e.getMessage());
+            }
+            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+            assertFalse(negotiateCalled.get());
+
+            logger.assertLog("Starting Websocket connection.");
+        }
+    }
+
+    @Test
+    public void ThrowsIfSkipNegotiationSetAndTransportIsNotWebSockets() {
+        AtomicBoolean negotiateCalled = new AtomicBoolean(false);
+        TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                (req) -> {
+                    negotiateCalled.set(true);
+                    return Single.just(new HttpResponse(200, "",
+                        TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}")));
+                });
+
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example")
+                .shouldSkipNegotiate(true)
+                .withHttpClient(client)
+                .build();
+
+        try {
+            hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        } catch (Exception e) {
+            assertEquals("Negotiation can only be skipped when using the WebSocket transport directly.", e.getMessage());
+        }
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        assertFalse(negotiateCalled.get());
+    }
+
+    @Test
     public void connectionIdIsAvailableAfterStart() {
         TestHttpClient client = new TestHttpClient().on("POST", "http://example.com/negotiate?negotiateVersion=1",
                 (req) -> Single.just(new HttpResponse(200, "",


### PR DESCRIPTION
## Description

Using `.shouldSkipNegotiate(true)` with the SignalR Java client will null ref.

## Customer Impact

Can't use the skip negotiate feature, useful for environments where you can't/wont enable sticky sessions, and/or always know WebSockets will be used.

## Regression?
- [x] Yes
- [ ] No

Regressed from 3.1

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The issue is very obvious, the reason it wasn't found during the 5.0 release is because of an unfortunate piece of the testing that hid the issue. Fixed by writing a new test.

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/29765