### PR TITLE
Respect user set Type for client errors via ProducesResponseType

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
@@ -101,9 +101,6 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
                     if (apiResponseType.Type == typeof(void))
                     {
-                        // Determine whether or not the type was provided by the user. If so, favor it over the default
-                        // error type.
-                        var setByDefault = metadataAttribute is ProducesResponseTypeAttribute { IsResponseTypeSetByDefault: true };
                         if (type != null && (statusCode == StatusCodes.Status200OK || statusCode == StatusCodes.Status201Created))
                         {
                             // ProducesResponseTypeAttribute's constructor defaults to setting "Type" to void when no value is specified.
@@ -112,9 +109,15 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                             // from the return type.
                             apiResponseType.Type = type;
                         }
-                        else if (setByDefault && ((IsClientError(statusCode) || apiResponseType.IsDefaultResponse)))
+                        else if (IsClientError(statusCode))
                         {
-                            // Use the default error type for "default" responses or 4xx client errors if no response type is specified.
+                            // Determine whether or not the type was provided by the user. If so, favor it over the default
+                            // error type for 4xx client errors if no response type is specified..
+                            var setByDefault = metadataAttribute is ProducesResponseTypeAttribute { IsResponseTypeSetByDefault: true };
+                            apiResponseType.Type = setByDefault ? defaultErrorType : apiResponseType.Type;
+                        }
+                        else if (apiResponseType.IsDefaultResponse)
+                        {
                             apiResponseType.Type = defaultErrorType;
                         }
                     }

--- a/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
@@ -101,7 +101,9 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
                     if (apiResponseType.Type == typeof(void))
                     {
-                        var setByDefault = metadataAttribute is ProducesResponseTypeAttribute attribute && attribute.SetByDefault;
+                        // Determine whether or not the type was provided by the user. If so, favor it over the default
+                        // error type.
+                        var setByDefault = metadataAttribute is ProducesResponseTypeAttribute { SetByDefault: true };
                         if (type != null && (statusCode == StatusCodes.Status200OK || statusCode == StatusCodes.Status201Created))
                         {
                             // ProducesResponseTypeAttribute's constructor defaults to setting "Type" to void when no value is specified.

--- a/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     {
                         // Determine whether or not the type was provided by the user. If so, favor it over the default
                         // error type.
-                        var setByDefault = metadataAttribute is ProducesResponseTypeAttribute { SetByDefault: true };
+                        var setByDefault = metadataAttribute is ProducesResponseTypeAttribute { IsResponseTypeSetByDefault: true };
                         if (type != null && (statusCode == StatusCodes.Status200OK || statusCode == StatusCodes.Status201Created))
                         {
                             // ProducesResponseTypeAttribute's constructor defaults to setting "Type" to void when no value is specified.

--- a/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs
@@ -101,6 +101,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
                     if (apiResponseType.Type == typeof(void))
                     {
+                        var setByDefault = metadataAttribute is ProducesResponseTypeAttribute attribute && attribute.SetByDefault;
                         if (type != null && (statusCode == StatusCodes.Status200OK || statusCode == StatusCodes.Status201Created))
                         {
                             // ProducesResponseTypeAttribute's constructor defaults to setting "Type" to void when no value is specified.
@@ -109,7 +110,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                             // from the return type.
                             apiResponseType.Type = type;
                         }
-                        else if (IsClientError(statusCode) || apiResponseType.IsDefaultResponse)
+                        else if (setByDefault && ((IsClientError(statusCode) || apiResponseType.IsDefaultResponse)))
                         {
                             // Use the default error type for "default" responses or 4xx client errors if no response type is specified.
                             apiResponseType.Type = defaultErrorType;

--- a/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Mvc
         public ProducesResponseTypeAttribute(int statusCode)
             : this(typeof(void), statusCode)
         {
-            SetByDefault = true;
+            IsResponseTypeSetByDefault = true;
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             Type = type ?? throw new ArgumentNullException(nameof(type));
             StatusCode = statusCode;
-            SetByDefault = false;
+            IsResponseTypeSetByDefault = false;
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Mvc
         /// default in the constructor
         /// </summary>
         /// <value></value>
-        internal bool SetByDefault { get; }
+        internal bool IsResponseTypeSetByDefault { get; }
 
         /// <inheritdoc />
         void IApiResponseMetadataProvider.SetContentTypes(MediaTypeCollection contentTypes)

--- a/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
@@ -45,7 +45,17 @@ namespace Microsoft.AspNetCore.Mvc
         /// </summary>
         public int StatusCode { get; set; }
 
-        internal bool SetByDefault { get; private set; }
+        /// <summary>
+        /// Used to distinguish a `Type` set by default in the constructor versus
+        /// one provided by the user.
+        ///
+        /// When <see langword="false"/>, then <see cref="Type"/> is set by user.
+        ///
+        /// When <see langword="true"/>, then <see cref="Type"/> is set by by
+        /// default in the constructor
+        /// </summary>
+        /// <value></value>
+        internal bool SetByDefault { get; }
 
         /// <inheritdoc />
         void IApiResponseMetadataProvider.SetContentTypes(MediaTypeCollection contentTypes)

--- a/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesResponseTypeAttribute.cs
@@ -15,11 +15,12 @@ namespace Microsoft.AspNetCore.Mvc
     {
         /// <summary>
         /// Initializes an instance of <see cref="ProducesResponseTypeAttribute"/>.
-        /// </summary>       
+        /// </summary>
         /// <param name="statusCode">The HTTP response status code.</param>
         public ProducesResponseTypeAttribute(int statusCode)
             : this(typeof(void), statusCode)
         {
+            SetByDefault = true;
         }
 
         /// <summary>
@@ -31,6 +32,7 @@ namespace Microsoft.AspNetCore.Mvc
         {
             Type = type ?? throw new ArgumentNullException(nameof(type));
             StatusCode = statusCode;
+            SetByDefault = false;
         }
 
         /// <summary>
@@ -42,6 +44,8 @@ namespace Microsoft.AspNetCore.Mvc
         /// Gets or sets the HTTP status code of the response.
         /// </summary>
         public int StatusCode { get; set; }
+
+        internal bool SetByDefault { get; private set; }
 
         /// <inheritdoc />
         void IApiResponseMetadataProvider.SetContentTypes(MediaTypeCollection contentTypes)

--- a/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ApiExplorerTest.cs
@@ -1461,6 +1461,29 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 });
         }
 
+        [Theory]
+        [InlineData("ActionWithNoExplicitType", typeof(ProblemDetails))]
+        [InlineData("ActionWithVoidType", typeof(void))]
+        public async Task ApiAction_ForActionWithVoidResponseType(string path, Type type)
+        {
+            // Act
+            var response = await Client.GetAsync($"http://localhost/ApiExplorerVoid/{path}");
+
+            var responseBody = await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<List<ApiExplorerData>>(responseBody);
+
+            // Assert
+            var description = Assert.Single(result);
+            Assert.Collection(
+                description.SupportedResponseTypes.OrderBy(r => r.StatusCode),
+                responseType =>
+                {
+                    Assert.Equal(type.FullName, responseType.ResponseType);
+                    Assert.Equal(401, responseType.StatusCode);
+                    Assert.False(responseType.IsDefaultResponse);
+                });
+        }
+
         private IEnumerable<string> GetSortedMediaTypes(ApiExplorerResponseType apiResponseType)
         {
             return apiResponseType.ResponseFormats

--- a/src/Mvc/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerSystemVoid.cs
+++ b/src/Mvc/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerSystemVoid.cs
@@ -1,0 +1,20 @@
+
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace ApiExplorerWebSite
+{
+    [Route("ApiExplorerVoid/[action]")]
+    [ApiController]
+    public class ApiExplorerVoidController : Controller
+    {
+        [ProducesResponseType(typeof(void), 401)]
+        public IActionResult ActionWithVoidType() => Ok();
+
+        [ProducesResponseType(401)]
+        public IActionResult ActionWithNoExplicitType() => Ok();
+
+    }
+}


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/7874.

Follow-up to https://github.com/dotnet/aspnetcore/pull/30236.