### PR TITLE
Log as Information when failing to bind on localhost for Kestrel.

### DIFF
--- a/src/Servers/Kestrel/Core/src/LocalhostListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/LocalhostListenOptions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
             catch (Exception ex) when (!(ex is IOException))
             {
-                context.Logger.LogWarning(0, CoreStrings.NetworkInterfaceBindingFailed, GetDisplayName(), "IPv4 loopback", ex.Message);
+                context.Logger.LogInformation(0, CoreStrings.NetworkInterfaceBindingFailed, GetDisplayName(), "IPv4 loopback", ex.Message);
                 exceptions.Add(ex);
             }
 
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
             catch (Exception ex) when (!(ex is IOException))
             {
-                context.Logger.LogWarning(0, CoreStrings.NetworkInterfaceBindingFailed, GetDisplayName(), "IPv6 loopback", ex.Message);
+                context.Logger.LogInformation(0, CoreStrings.NetworkInterfaceBindingFailed, GetDisplayName(), "IPv6 loopback", ex.Message);
                 exceptions.Add(ex);
             }
 


### PR DESCRIPTION
**Log as Information when failing to bind on localhost for Kestrel.**
Log as Information instead of Warning when Kestrel fails to bind to the IPv4 or IPv6 loopback address


Addresses #29928
