### PR TITLE
Use IAssemblySymbol for tag helper discovery

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -38,13 +38,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
             var types = new List<INamedTypeSymbol>();
             var visitor = new ViewComponentTypeVisitor(vcAttribute, nonVCAttribute, types);
 
-            var targetReference = context.Items.GetTargetMetadataReference();
-            if (targetReference is not null)
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null)
             {
-                if (compilation.GetAssemblyOrModuleSymbol(targetReference) is IAssemblySymbol targetAssembly && IsTagHelperAssembly(targetAssembly))
-                {
-                    visitor.Visit(targetAssembly.GlobalNamespace);
-                }
+                visitor.Visit(targetAssembly.GlobalNamespace);
             }
             else
             {

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -101,6 +101,12 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null && !SymbolEqualityComparer.Default.Equals(targetAssembly, bindMethods.ContainingAssembly))
+            {
+                return;
+            }
+
             // Tag Helper defintion for case #1. This is the most general case.
             context.Results.Add(CreateFallbackBindTagHelper());
 

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -40,14 +40,10 @@ namespace Microsoft.CodeAnalysis.Razor
             var types = new List<INamedTypeSymbol>();
             var visitor = new ComponentTypeVisitor(symbols, types);
 
-            var targetReference = context.Items.GetTargetMetadataReference();
-            if (targetReference is not null)
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null)
             {
-                if (compilation.GetAssemblyOrModuleSymbol(targetReference) is IAssemblySymbol targetAssembly)
-                {
-                    visitor.Visit(targetAssembly.GlobalNamespace);
-                }
-
+                visitor.Visit(targetAssembly.GlobalNamespace);
             }
             else
             {

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
@@ -35,13 +35,10 @@ namespace Microsoft.CodeAnalysis.Razor
             var types = new List<INamedTypeSymbol>();
             var visitor = new TagHelperTypeVisitor(iTagHelper, types);
 
-            var targetReference = context.Items.GetTargetMetadataReference();
-            if (targetReference is not null)
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null)
             {
-                if (compilation.GetAssemblyOrModuleSymbol(targetReference) is IAssemblySymbol targetAssembly && IsTagHelperAssembly(targetAssembly))
-                {
-                    visitor.Visit(targetAssembly.GlobalNamespace);
-                }
+                visitor.Visit(targetAssembly.GlobalNamespace);
             }
             else
             {

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -47,15 +47,10 @@ namespace Microsoft.CodeAnalysis.Razor
             var types = new List<INamedTypeSymbol>();
             var visitor = new EventHandlerDataVisitor(types);
 
-
-            var targetReference = context.Items.GetTargetMetadataReference();
-            if (targetReference is not null)
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null)
             {
-                if (compilation.GetAssemblyOrModuleSymbol(targetReference) is IAssemblySymbol targetAssembly)
-                {
-                    visitor.Visit(targetAssembly.GlobalNamespace);
-                }
-
+                visitor.Visit(targetAssembly.GlobalNamespace);
             }
             else
             {

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
@@ -35,6 +35,12 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null && !SymbolEqualityComparer.Default.Equals(targetAssembly, renderTreeBuilderType.ContainingAssembly))
+            {
+                return;
+            }
+
             context.Results.Add(CreateKeyTagHelper());
         }
 

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
@@ -35,6 +35,12 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null && !SymbolEqualityComparer.Default.Equals(targetAssembly, elementReference.ContainingAssembly))
+            {
+                return;
+            }
+
             context.Results.Add(CreateRefTagHelper());
         }
 

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/SplatTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/SplatTagHelperDescriptorProvider.cs
@@ -35,6 +35,12 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null && !SymbolEqualityComparer.Default.Equals(targetAssembly, renderTreeBuilder.ContainingAssembly))
+            {
+                return;
+            }
+
             context.Results.Add(CreateSplatTagHelper());
         }
 

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/TagHelperTargetAssemblyExtensions.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/TagHelperTargetAssemblyExtensions.cs
@@ -7,23 +7,23 @@ using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
-    internal static class TagHelperTargetReferenceExtensions
+    internal static class TagHelperTargetAssemblyExtensions
     {
         private static readonly object TargetAssemblyKey = new object();
 
-        public static MetadataReference? GetTargetMetadataReference(this ItemCollection items)
+        public static IAssemblySymbol? GetTargetAssembly(this ItemCollection items)
         {
-            if (items.Count == 0 || items[TargetAssemblyKey] is not MetadataReference reference)
+            if (items.Count == 0 || items[TargetAssemblyKey] is not IAssemblySymbol symbol)
             {
                 return null;
             }
 
-            return reference;
+            return symbol;
         }
 
-        public static void SetTargetMetadataReference(this ItemCollection items, MetadataReference reference)
+        public static void SetTargetAssembly(this ItemCollection items, IAssemblySymbol symbol)
         {
-            items[TargetAssemblyKey] = reference;
+            items[TargetAssemblyKey] = symbol;
         }
     }
 }

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/test/ComponentTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/test/ComponentTagHelperDescriptorProviderTest.cs
@@ -1617,7 +1617,7 @@ namespace Test
 
             var context = TagHelperDescriptorProviderContext.Create();
             context.SetCompilation(compilation);
-            context.Items.SetTargetMetadataReference(compilation.References.Single(r => r.Display.Contains("Microsoft.CodeAnalysis.Razor.Test.dll")));
+            context.Items.SetTargetAssembly((IAssemblySymbol) compilation.GetAssemblyOrModuleSymbol(compilation.References.First(r => r.Display.Contains("Microsoft.CodeAnalysis.Razor.Test.dll"))));
             var provider = new ComponentTagHelperDescriptorProvider();
 
             // Act

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorProviderTest.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorProviderTest.cs
@@ -85,7 +85,7 @@ namespace TestAssembly
         }
 
         [Fact]
-        public void Execute_WithTargetMetadataReference_Works()
+        public void Execute_WithTargetAssembly_Works()
         {
             // Arrange
             var testTagHelper = "TestAssembly.TestTagHelper";
@@ -104,7 +104,7 @@ namespace TestAssembly
 
             var context = TagHelperDescriptorProviderContext.Create();
             context.SetCompilation(compilation);
-            context.Items.SetTargetMetadataReference(compilation.References.First(r => r.Display.Contains("Microsoft.CodeAnalysis.Razor.Test.dll")));
+            context.Items.SetTargetAssembly((IAssemblySymbol) compilation.GetAssemblyOrModuleSymbol(compilation.References.First(r => r.Display.Contains("Microsoft.CodeAnalysis.Razor.Test.dll"))));
 
             // Act
             descriptorProvider.Execute(context);


### PR DESCRIPTION
Instead of expecting a `MetadataReference` to resolve tag helpers from, we'll take an `IAssemblySymbol` because:

- It plays nicer with the type that Rosyln exposes for the current compilation
- Avoids us having to repeatedly convert a MetadataReference to an IAssemblySymbol in the tag helper providers

Also added a check for applicable tag helper providers to avoid looking for tag helpers in assemblies that are not the target assembly.