### PR TITLE
React to runtimes master->main branch change

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -28,7 +28,7 @@ jobs:
         # Test this script using changes in a fork
         repository: 'dotnet/runtime'
         path: runtime
-        ref: master
+        ref: main
     - name: Copy
       shell: cmd
       working-directory: .\runtime\src\libraries\Common\src\System\Net\Http\aspnetcore\


### PR DESCRIPTION
The runtime repo renamed their master branch to main.