### PR TITLE
Run SetupPrivateFeedCredentials in win-arm64 job

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -258,6 +258,15 @@ stages:
       installNodeJs: false
       installJdk: false
       steps:
+      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        - task: PowerShell@2
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+          env:
+            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+            
       - script: ./build.cmd
                 -ci
                 -arch arm64


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/pull/30463 changed the win-arm64 job so that it uses custom steps, which means now we have to call SetupPrivateFeedCredentials manually so that internal builds have access to private feeds.