### PR TITLE
Prevent LayoutComponentBase properties from being trimmed.

### DIFF
--- a/src/Components/Components/src/LayoutComponentBase.cs
+++ b/src/Components/Components/src/LayoutComponentBase.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
+
 namespace Microsoft.AspNetCore.Components
 {
     /// <summary>
@@ -17,5 +21,12 @@ namespace Microsoft.AspNetCore.Components
         /// </summary>
         [Parameter]
         public RenderFragment? Body { get; set; }
+
+        /// <inheritdoc />
+        // Derived instances of LayoutComponentBase do not appear in any statically analyzable
+        // calls of OpenComponent<T> where T is well-known. Consequently we have to explicitly provide a hint to the trimmer to preserve
+        // properties.
+        [DynamicDependency(Component, typeof(LayoutComponentBase))]
+        public override Task SetParametersAsync(ParameterView parameters) => base.SetParametersAsync(parameters);
     }
 }

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -31,6 +31,7 @@ Microsoft.AspNetCore.Components.CascadingTypeParameterAttribute
 Microsoft.AspNetCore.Components.CascadingTypeParameterAttribute.CascadingTypeParameterAttribute(string! name) -> void
 Microsoft.AspNetCore.Components.CascadingTypeParameterAttribute.Name.get -> string!
 Microsoft.AspNetCore.Components.RenderTree.Renderer.GetEventArgsType(ulong eventHandlerId) -> System.Type!
+override Microsoft.AspNetCore.Components.LayoutComponentBase.SetParametersAsync(Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
 static Microsoft.AspNetCore.Components.ParameterView.FromDictionary(System.Collections.Generic.IDictionary<string!, object?>! parameters) -> Microsoft.AspNetCore.Components.ParameterView
 virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(ulong eventHandlerId, Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo? fieldInfo, System.EventArgs! eventArgs) -> System.Threading.Tasks.Task!
 *REMOVED*readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.RemovedAttributeName -> string


### PR DESCRIPTION
Note that this SDK is busted for Blazor apps. We'll need to pick up another SDK, but the source changes should be the same.