### PR TITLE
Move artifacts block to bottom of win-arm64 leg

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -296,6 +296,16 @@ stages:
                 $(_InternalRuntimeDownloadArgs)
                 /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
         displayName: Build Arm64 Installers
+        
+      # A few files must also go to the VS package feed.
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - task: NuGetCommand@2
+          displayName: Push Visual Studio packages
+          inputs:
+            command: push
+            packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
+            nuGetFeedType: external
+            publishFeedCredentials: 'DevDiv - VS package feed'
 
       artifacts:
       - name: Windows_arm64_Logs
@@ -306,16 +316,6 @@ stages:
         path: artifacts/packages/
       - name: Windows_arm64_Installers
         path: artifacts/installers/
-
-      # A few files must also go to the VS package feed.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        - task: NuGetCommand@2
-          displayName: Push Visual Studio packages
-          inputs:
-            command: push
-            packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
-            nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
 
 
   # Build MacOS


### PR DESCRIPTION
Because of the current state, the whole `NuGetCommand` gets passed as an artifact parameter to default-build.yml, which causes it to upload the whole build directory as an artifact (and skip the `Push Visual Studio packages` step entirely)