### PR TITLE
HTTP/3 RequestHeadersTimeout

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -683,4 +683,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http3StreamErrorRequestEndedNoHeaders" xml:space="preserve">
     <value>Request stream ended without headers.</value>
   </data>
+  <data name="Http3ControlStreamHeaderTimeout" xml:space="preserve">
+    <value>Reading the control stream header timed out.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -14,14 +15,15 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
-    internal class Http3Connection : ITimeoutHandler
+    internal class Http3Connection : ITimeoutHandler, IHttp3StreamLifetimeHandler
     {
-        internal readonly Dictionary<long, Http3Stream> _streams = new Dictionary<long, Http3Stream>();
+        internal readonly Dictionary<long, IHttp3Stream> _streams = new Dictionary<long, IHttp3Stream>();
 
         private long _highestOpenedStreamId;
         private readonly object _sync = new object(); 
@@ -84,9 +86,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         {
             try
             {
-                // Ensure TimeoutControl._lastTimestamp is initialized before anything that could set timeouts runs.
-                _timeoutControl.Initialize(_systemClock.UtcNowTicks);
-
                 var connectionHeartbeatFeature = _context.ConnectionFeatures.Get<IConnectionHeartbeatFeature>();
                 var connectionLifetimeNotificationFeature = _context.ConnectionFeatures.Get<IConnectionLifetimeNotificationFeature>();
 
@@ -198,11 +197,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 return;
             }
 
-            // It's safe to use UtcNowUnsynchronized since Tick is called by the Heartbeat.
-            var now = _systemClock.UtcNowUnsynchronized;
-            _timeoutControl.Tick(now);
+            UpdateStartingStreams();
+        }
 
-            // TODO cancel process stream loop to update logic.
+        private void UpdateStartingStreams()
+        {
+            var now = _systemClock.UtcNow.Ticks;
+
+            lock (_streams)
+            {
+                foreach (var stream in _streams.Values)
+                {
+                    if (stream.ReceivedHeader)
+                    {
+                        continue;
+                    }
+
+                    if (stream.HeaderTimeoutTicks == default)
+                    {
+                        // On expiration overflow, use max value.
+                        var expirationTicks = now + _context.ServiceContext.ServerOptions.Limits.RequestHeadersTimeout.Ticks;
+                        stream.HeaderTimeoutTicks = expirationTicks >= 0 ? expirationTicks : long.MaxValue;
+                    }
+
+                    if (stream.HeaderTimeoutTicks < now)
+                    {
+                        if (stream.IsRequestStream)
+                        {
+                            stream.Abort(new ConnectionAbortedException(CoreStrings.BadRequest_RequestHeadersTimeout), Http3ErrorCode.RequestRejected);
+                        }
+                        else
+                        {
+                            stream.Abort(new ConnectionAbortedException(CoreStrings.Http3ControlStreamHeaderTimeout), Http3ErrorCode.StreamCreationError);
+                        }
+                    }
+                }
+            }
         }
 
         public void OnTimeout(TimeoutReason reason)
@@ -213,13 +243,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             // TODO what timeouts should we handle here? Is keep alive something we should care about?
             switch (reason)
             {
-                case TimeoutReason.KeepAlive:
-                    SendGoAway(GetHighestStreamId()).Preserve();
-                    break;
                 case TimeoutReason.TimeoutFeature:
                     SendGoAway(GetHighestStreamId()).Preserve();
                     break;
-                case TimeoutReason.RequestHeaders:
+                case TimeoutReason.RequestHeaders: // Request header timeout is handled in starting stream queue
+                case TimeoutReason.KeepAlive:  // Keep-alive is handled by msquic
                 case TimeoutReason.ReadDataRate:
                 case TimeoutReason.WriteDataRate:
                 case TimeoutReason.RequestBodyDrain:
@@ -244,8 +272,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             // TODO should we await the control stream task?
             var controlTask = CreateControlStream(application);
-
-            _timeoutControl.SetTimeout(Limits.KeepAliveTimeout.Ticks, TimeoutReason.KeepAlive);
 
             try
             {
@@ -277,29 +303,36 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                             streamContext.LocalEndPoint as IPEndPoint,
                             streamContext.RemoteEndPoint as IPEndPoint,
                             streamContext.Transport,
+                            this,
                             streamContext,
                             _serverSettings);
                         httpConnectionContext.TimeoutControl = _context.TimeoutControl;
 
+                        var streamId = streamIdFeature.StreamId;
+
                         if (!quicStreamFeature.CanWrite)
                         {
                             // Unidirectional stream
-                            var stream = new Http3ControlStream<TContext>(application, this, httpConnectionContext);
+                            var stream = new Http3ControlStream<TContext>(application, httpConnectionContext);
+                            lock (_streams)
+                            {
+                                _streams[streamId] = stream;
+                            }
+
                             ThreadPool.UnsafeQueueUserWorkItem(stream, preferLocal: false);
                         }
                         else
                         {
-                            var streamId = streamIdFeature.StreamId;
-
+                            // Request stream
                             UpdateHighestStreamId(streamId);
 
-                            var http3Stream = new Http3Stream<TContext>(application, this, httpConnectionContext);
-                            var stream = http3Stream;
+                            var stream = new Http3Stream<TContext>(application, httpConnectionContext);
                             lock (_streams)
                             {
                                 _activeRequestCount++;
-                                _streams[streamId] = http3Stream;
+                                _streams[streamId] = stream;
                             }
+
                             KestrelEventSource.Log.RequestQueuedStart(stream, AspNetCore.Http.HttpProtocol.Http3);
                             ThreadPool.UnsafeQueueUserWorkItem(stream, preferLocal: false);
                         }
@@ -363,8 +396,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     {
                         await _streamCompletionAwaitable;
                     }
-
-                    _timeoutControl.CancelTimeout();
                 }
                 catch
                 {
@@ -410,17 +441,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                         SendGoAway(GetHighestStreamId()).Preserve();
                     }
                 }
-                else
-                {
-                    // TODO should keep-alive timeout be a thing for HTTP/3? MsQuic currently tracks this for us?
-                    if (_timeoutControl.TimerReason == TimeoutReason.None)
-                    {
-                        _timeoutControl.SetTimeout(Limits.KeepAliveTimeout.Ticks, TimeoutReason.KeepAlive);
-                    }
-
-                    // Only reason should be keep-alive.
-                    Debug.Assert(_timeoutControl.TimerReason == TimeoutReason.KeepAlive);
-                }
             }
         }
 
@@ -450,11 +470,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 streamContext.LocalEndPoint as IPEndPoint,
                 streamContext.RemoteEndPoint as IPEndPoint,
                 streamContext.Transport,
+                this,
                 streamContext,
                 _serverSettings);
             httpConnectionContext.TimeoutControl = _context.TimeoutControl;
 
-            return new Http3ControlStream<TContext>(application, this, httpConnectionContext);
+            return new Http3ControlStream<TContext>(application, httpConnectionContext);
         }
 
         private ValueTask<FlushResult> SendGoAway(long id)
@@ -466,33 +487,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     return OutboundControlStream.SendGoAway(id);
                 }
             }
-            return new ValueTask<FlushResult>();
+            return default;
         }
 
-        public void ApplyMaxHeaderListSize(long value)
-        {
-        }
-
-        internal void ApplyBlockedStream(long value)
-        {
-        }
-
-        internal void ApplyMaxTableCapacity(long value)
-        {
-        }
-
-        internal void RemoveStream(long streamId)
-        {
-            lock (_streams)
-            {
-                _activeRequestCount--;
-                _streams.Remove(streamId);
-            }
-
-            _streamCompletionAwaitable.Complete();
-        }
-
-        public bool SetInboundControlStream(Http3ControlStream stream)
+        public bool OnInboundControlStream(Http3ControlStream stream)
         {
             lock (_sync)
             {
@@ -505,7 +503,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
         }
 
-        public bool SetInboundEncoderStream(Http3ControlStream stream)
+        public bool OnInboundEncoderStream(Http3ControlStream stream)
         {
             lock (_sync)
             {
@@ -518,7 +516,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             }
         }
 
-        public bool SetInboundDecoderStream(Http3ControlStream stream)
+        public bool OnInboundDecoderStream(Http3ControlStream stream)
         {
             lock (_sync)
             {
@@ -528,6 +526,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     return true;
                 }
                 return false;
+            }
+        }
+
+        public void OnStreamCompleted(IHttp3Stream stream)
+        {
+            lock (_streams)
+            {
+                _activeRequestCount--;
+                _streams.Remove(stream.StreamId);
+            }
+
+            _streamCompletionAwaitable.Complete();
+        }
+
+        public void OnStreamConnectionError(Http3ConnectionErrorException ex)
+        {
+            Log.Http3ConnectionError(ConnectionId, ex);
+            Abort(new ConnectionAbortedException(ex.Message, ex), ex.ErrorCode);
+        }
+
+        public void OnInboundControlStreamSetting(Http3SettingType type, long value)
+        {
+            switch (type)
+            {
+                case Http3SettingType.QPackMaxTableCapacity:
+                    break;
+                case Http3SettingType.MaxFieldSectionSize:
+                    break;
+                case Http3SettingType.QPackBlockedStreams:
+                    break;
+                default:
+                    throw new InvalidOperationException("Unexpected setting: " + type);
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -17,32 +17,34 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
-    internal abstract class Http3ControlStream : IThreadPoolWorkItem
+    internal abstract class Http3ControlStream : IHttp3Stream, IThreadPoolWorkItem
     {
-        private const int ControlStream = 0;
-        private const int EncoderStream = 2;
-        private const int DecoderStream = 3;
+        private const int ControlStreamTypeId = 0;
+        private const int EncoderStreamTypeId = 2;
+        private const int DecoderStreamTypeId = 3;
 
         private readonly Http3FrameWriter _frameWriter;
-        private readonly Http3Connection _http3Connection;
         private readonly Http3StreamContext _context;
         private readonly Http3PeerSettings _serverPeerSettings;
         private readonly IStreamIdFeature _streamIdFeature;
-        private readonly IProtocolErrorCodeFeature _protocolErrorCodeFeature;
+        private readonly IProtocolErrorCodeFeature _errorCodeFeature;
         private readonly Http3RawFrame _incomingFrame = new Http3RawFrame();
         private volatile int _isClosed;
         private int _gracefulCloseInitiator;
+        private long _headerType;
 
         private bool _haveReceivedSettingsFrame;
 
-        public Http3ControlStream(Http3Connection http3Connection, Http3StreamContext context)
+        public long StreamId => _streamIdFeature.StreamId;
+
+        public Http3ControlStream(Http3StreamContext context)
         {
             var httpLimits = context.ServiceContext.ServerOptions.Limits;
-            _http3Connection = http3Connection;
             _context = context;
             _serverPeerSettings = context.ServerSettings;
             _streamIdFeature = context.ConnectionFeatures.Get<IStreamIdFeature>()!;
-            _protocolErrorCodeFeature = context.ConnectionFeatures.Get<IProtocolErrorCodeFeature>()!;
+            _errorCodeFeature = context.ConnectionFeatures.Get<IProtocolErrorCodeFeature>()!;
+            _headerType = -1;
 
             _frameWriter = new Http3FrameWriter(
                 context.Transport.Output,
@@ -57,27 +59,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private void OnStreamClosed()
         {
-            Abort(new ConnectionAbortedException("HTTP_CLOSED_CRITICAL_STREAM"));
+            Abort(new ConnectionAbortedException("HTTP_CLOSED_CRITICAL_STREAM"), Http3ErrorCode.InternalError);
         }
 
         public PipeReader Input => _context.Transport.Input;
         public IKestrelTrace Log => _context.ServiceContext.Log;
 
-        public void Abort(ConnectionAbortedException ex)
-        {
+        public long HeaderTimeoutTicks { get; set; }
+        public bool ReceivedHeader => _headerType >= 0;
 
-        }
+        public bool IsRequestStream => false;
 
-        public void HandleReadDataRateTimeout()
+        public void Abort(ConnectionAbortedException abortReason, Http3ErrorCode errorCode)
         {
-            //Log.RequestBodyMinimumDataRateNotSatisfied(ConnectionId, null, Limits.MinRequestBodyDataRate.BytesPerSecond);
-            Abort(new ConnectionAbortedException(CoreStrings.BadRequest_RequestBodyTimeout));
-        }
+            // TODO - Should there be a check here to track abort state to avoid
+            // running twice for a request?
 
-        public void HandleRequestHeadersTimeout()
-        {
-            //Log.ConnectionBadRequest(ConnectionId, KestrelBadHttpRequestException.GetException(RequestRejectionReason.RequestHeadersTimeout));
-            Abort(new ConnectionAbortedException(CoreStrings.BadRequest_RequestHeadersTimeout));
+            Log.Http3StreamAbort(_context.ConnectionId, errorCode, abortReason);
+
+            _errorCodeFeature.Error = (long)errorCode;
+            _frameWriter.Abort(abortReason);
+
+            Input.Complete(abortReason);
         }
 
         public void OnInputOrOutputCompleted()
@@ -111,8 +114,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             await _frameWriter.WriteSettingsAsync(_serverPeerSettings.GetNonProtocolDefaults());
         }
 
-        private async ValueTask<long> TryReadStreamIdAsync()
+        private async ValueTask<long> TryReadStreamHeaderAsync()
         {
+            // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-6.2
             while (_isClosed == 0)
             {
                 var result = await Input.ReadAsync();
@@ -149,51 +153,47 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         {
             try
             {
-                var streamType = await TryReadStreamIdAsync();
+                _headerType = await TryReadStreamHeaderAsync();
 
-                if (streamType == -1)
+                switch (_headerType)
                 {
-                    return;
-                }
+                    case -1:
+                        return;
+                    case ControlStreamTypeId:
+                        if (!_context.StreamLifetimeHandler.OnInboundControlStream(this))
+                        {
+                            // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-6.2.1
+                            throw new Http3ConnectionErrorException(CoreStrings.FormatHttp3ControlStreamErrorMultipleInboundStreams("control"), Http3ErrorCode.StreamCreationError);
+                        }
 
-                if (streamType == ControlStream)
-                {
-                    if (!_http3Connection.SetInboundControlStream(this))
-                    {
-                        // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-6.2.1
-                        throw new Http3ConnectionErrorException(CoreStrings.FormatHttp3ControlStreamErrorMultipleInboundStreams("control"), Http3ErrorCode.StreamCreationError);
-                    }
+                        await HandleControlStream();
+                        break;
+                    case EncoderStreamTypeId:
+                        if (!_context.StreamLifetimeHandler.OnInboundEncoderStream(this))
+                        {
+                            // https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#section-4.2
+                            throw new Http3ConnectionErrorException(CoreStrings.FormatHttp3ControlStreamErrorMultipleInboundStreams("encoder"), Http3ErrorCode.StreamCreationError);
+                        }
 
-                    await HandleControlStream();
-                }
-                else if (streamType == EncoderStream)
-                {
-                    if (!_http3Connection.SetInboundEncoderStream(this))
-                    {
-                        // https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#section-4.2
-                        throw new Http3ConnectionErrorException(CoreStrings.FormatHttp3ControlStreamErrorMultipleInboundStreams("encoder"), Http3ErrorCode.StreamCreationError);
-                    }
-
-                    await HandleEncodingDecodingTask();
-                }
-                else if (streamType == DecoderStream)
-                {
-                    if (!_http3Connection.SetInboundDecoderStream(this))
-                    {
-                        // https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#section-4.2
-                        throw new Http3ConnectionErrorException(CoreStrings.FormatHttp3ControlStreamErrorMultipleInboundStreams("decoder"), Http3ErrorCode.StreamCreationError);
-                    }
-                    await HandleEncodingDecodingTask();
-                }
-                else
-                {
-                    // TODO Close the control stream as it's unexpected.
+                        await HandleEncodingDecodingTask();
+                        break;
+                    case DecoderStreamTypeId:
+                        if (!_context.StreamLifetimeHandler.OnInboundDecoderStream(this))
+                        {
+                            // https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#section-4.2
+                            throw new Http3ConnectionErrorException(CoreStrings.FormatHttp3ControlStreamErrorMultipleInboundStreams("decoder"), Http3ErrorCode.StreamCreationError);
+                        }
+                        await HandleEncodingDecodingTask();
+                        break;
+                    default:
+                        // TODO Close the control stream as it's unexpected.
+                        break;
                 }
             }
             catch (Http3ConnectionErrorException ex)
             {
-                Log.Http3ConnectionError(_http3Connection.ConnectionId, ex);
-                _http3Connection.Abort(new ConnectionAbortedException(ex.Message, ex), ex.ErrorCode);
+                _errorCodeFeature.Error = (long)ex.ErrorCode;
+                _context.StreamLifetimeHandler.OnStreamConnectionError(ex);
             }
         }
 
@@ -227,10 +227,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 }
                 catch (Http3ConnectionErrorException ex)
                 {
-                    _protocolErrorCodeFeature.Error = (long)ex.ErrorCode;
-
-                    Log.Http3ConnectionError(_http3Connection.ConnectionId, ex);
-                    _http3Connection.Abort(new ConnectionAbortedException(ex.Message, ex), ex.ErrorCode);
+                    _errorCodeFeature.Error = (long)ex.ErrorCode;
+                    _context.StreamLifetimeHandler.OnStreamConnectionError(ex);
                 }
                 finally
                 {
@@ -324,13 +322,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     var message = CoreStrings.FormatHttp3ErrorControlStreamReservedSetting("0x" + id.ToString("X", CultureInfo.InvariantCulture));
                     throw new Http3ConnectionErrorException(message, Http3ErrorCode.SettingsError);
                 case (long)Http3SettingType.QPackMaxTableCapacity:
-                    _http3Connection.ApplyMaxTableCapacity(value);
-                    break;
                 case (long)Http3SettingType.MaxFieldSectionSize:
-                    _http3Connection.ApplyMaxHeaderListSize(value);
-                    break;
                 case (long)Http3SettingType.QPackBlockedStreams:
-                    _http3Connection.ApplyBlockedStream(value);
+                    _context.StreamLifetimeHandler.OnInboundControlStreamSetting((Http3SettingType)id, value);
                     break;
                 default:
                     // Ignore all unknown settings.

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStreamOfT.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
     {
         private readonly IHttpApplication<TContext> _application;
 
-        public Http3ControlStream(IHttpApplication<TContext> application, Http3Connection connection, Http3StreamContext context) : base(connection, context)
+        public Http3ControlStream(IHttpApplication<TContext> application, Http3StreamContext context) : base(context)
         {
             _application = application;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -20,7 +20,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
-    internal abstract partial class Http3Stream : HttpProtocol, IHttpHeadersHandler, IThreadPoolWorkItem, ITimeoutHandler, IRequestProcessor
+    internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpHeadersHandler, IThreadPoolWorkItem, ITimeoutHandler, IRequestProcessor
     {
         private static ReadOnlySpan<byte> AuthorityBytes => new byte[10] { (byte)':', (byte)'a', (byte)'u', (byte)'t', (byte)'h', (byte)'o', (byte)'r', (byte)'i', (byte)'t', (byte)'y' };
         private static ReadOnlySpan<byte> MethodBytes => new byte[7] { (byte)':', (byte)'m', (byte)'e', (byte)'t', (byte)'h', (byte)'o', (byte)'d' };
@@ -48,21 +48,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private int _totalParsedHeaderSize;
         private bool _isMethodConnect;
 
-        private readonly Http3Connection _http3Connection;
         private TaskCompletionSource? _appCompleted;
 
         public Pipe RequestBodyPipe { get; }
 
-        public Http3Stream(Http3Connection http3Connection, Http3StreamContext context)
+        public Http3Stream(Http3StreamContext context)
         {
             Initialize(context);
 
             InputRemaining = null;
 
-            // First, determine how we know if an Http3stream is unidirectional or bidirectional
-            var httpLimits = context.ServiceContext.ServerOptions.Limits;
-            var http3Limits = httpLimits.Http3;
-            _http3Connection = http3Connection;
             _context = context;
 
             _errorCodeFeature = _context.ConnectionFeatures.Get<IProtocolErrorCodeFeature>()!;
@@ -72,7 +67,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 context.Transport.Output,
                 context.StreamContext,
                 context.TimeoutControl,
-                httpLimits.MinResponseDataRate,
+                context.ServiceContext.ServerOptions.Limits.MinResponseDataRate,
                 context.ConnectionId,
                 context.MemoryPool,
                 context.ServiceContext.Log,
@@ -99,6 +94,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public ISystemClock SystemClock => _context.ServiceContext.SystemClock;
         public KestrelServerLimits Limits => _context.ServiceContext.ServerOptions.Limits;
+        public long StreamId => _streamIdFeature.StreamId;
+
+        public long HeaderTimeoutTicks { get; set; }
+        public bool ReceivedHeader => _appCompleted != null; // TCS is assigned once headers are received
+
+        public bool IsRequestStream => true;
 
         public void Abort(ConnectionAbortedException ex)
         {
@@ -406,10 +407,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 error = ex;
                 _errorCodeFeature.Error = (long)ex.ErrorCode;
 
-                Log.Http3ConnectionError(_http3Connection.ConnectionId, ex);
-                _http3Connection.Abort(new ConnectionAbortedException(ex.Message, ex), ex.ErrorCode);
-
-                // TODO: HTTP/3 stream will be aborted by connection. Check this is correct.
+                _context.StreamLifetimeHandler.OnStreamConnectionError(ex);
             }
             catch (Exception ex)
             {
@@ -442,7 +440,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 {
                     await _context.StreamContext.DisposeAsync();
 
-                    _http3Connection.RemoveStream(_streamIdFeature.StreamId);
+                    _context.StreamLifetimeHandler.OnStreamCompleted(this);
                 }
             }
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
     {
         private readonly IHttpApplication<TContext> _application;
 
-        public Http3Stream(IHttpApplication<TContext> application, Http3Connection connection, Http3StreamContext context) : base(connection, context)
+        public Http3Stream(IHttpApplication<TContext> application, Http3StreamContext context) : base(context)
         {
             _application = application;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/IHttp3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/IHttp3Stream.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Http;
+using Microsoft.AspNetCore.Connections;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
+{
+    internal interface IHttp3Stream
+    {
+        /// <summary>
+        /// The stream ID is set by QUIC.
+        /// </summary>
+        long StreamId { get; }
+
+        /// <summary>
+        /// Used to track the timeout between when the stream was started by the client, and getting a header.
+        /// Value is driven by <see cref="KestrelServerLimits.RequestHeadersTimeout"/>.
+        /// </summary>
+        long HeaderTimeoutTicks { get; set; }
+
+        /// <summary>
+        /// The stream has received and parsed the header frame.
+        /// - Request streams = HEADERS frame.
+        /// - Control streams = unidirectional stream header.
+        /// </summary>
+        bool ReceivedHeader { get; }
+
+        bool IsRequestStream { get; }
+
+        void Abort(ConnectionAbortedException abortReason, Http3ErrorCode errorCode);
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/IHttp3StreamLifetimeHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/IHttp3StreamLifetimeHandler.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
+{
+    internal interface IHttp3StreamLifetimeHandler
+    {
+        void OnStreamCompleted(IHttp3Stream stream);
+        void OnStreamConnectionError(Http3ConnectionErrorException ex);
+
+        bool OnInboundControlStream(Http3ControlStream stream);
+        bool OnInboundEncoderStream(Http3ControlStream stream);
+        bool OnInboundDecoderStream(Http3ControlStream stream);
+        void OnInboundControlStreamSetting(Http3SettingType type, long value);
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Http3ConnectionContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3ConnectionContext.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
 using System.Net;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal

--- a/src/Servers/Kestrel/Core/src/Internal/Http3StreamContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3StreamContext.cs
@@ -22,13 +22,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             IPEndPoint? localEndPoint,
             IPEndPoint? remoteEndPoint,
             IDuplexPipe transport,
+            IHttp3StreamLifetimeHandler streamLifetimeHandler,
             ConnectionContext streamContext,
             Http3PeerSettings settings) : base(connectionId, protocols, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint, transport)
         {
+            StreamLifetimeHandler = streamLifetimeHandler;
             StreamContext = streamContext;
             ServerSettings = settings;
         }
 
+        public IHttp3StreamLifetimeHandler StreamLifetimeHandler { get; }
         public ConnectionContext StreamContext { get; }
         public Http3PeerSettings ServerSettings { get; }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
                     default:
                         // SelectProtocol() only returns Http1, Http2 or None.
-                        throw new NotSupportedException($"{nameof(SelectProtocol)} returned something other than Http1, Http2, Http3 or None.");
+                        throw new NotSupportedException($"{nameof(SelectProtocol)} returned something other than Http1, Http2 or None.");
                 }   
 
                 _requestProcessor = requestProcessor;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ITimeoutControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ITimeoutControl.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
@@ -14,6 +15,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         void CancelTimeout();
 
         void InitializeHttp2(InputFlowControl connectionInputFlowControl);
+        void Tick(DateTimeOffset now);
+
         void StartRequestBody(MinDataRate minRate);
         void StopRequestBody();
         void StartTimingRead();

--- a/src/Servers/Kestrel/Core/test/Http3HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3HttpProtocolFeatureCollectionTests.cs
@@ -18,11 +18,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         public Http3HttpProtocolFeatureCollectionTests()
         {
-            var connection = new Http3Connection(TestContextFactory.CreateHttp3ConnectionContext());
-
             var streamContext = TestContextFactory.CreateHttp3StreamContext(transport: DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions()).Application);
 
-            var http3Stream = new TestHttp3Stream(connection, streamContext);
+            var http3Stream = new TestHttp3Stream(streamContext);
             http3Stream.Reset();
             _http3Collection = http3Stream;
         }
@@ -61,7 +59,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         private class TestHttp3Stream : Http3Stream
         {
-            public TestHttp3Stream(Http3Connection connection, Http3StreamContext context) : base(connection, context)
+            public TestHttp3Stream(Http3StreamContext context) : base(context)
             {
             }
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTimeoutControl.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTimeoutControl.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
@@ -56,6 +57,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         }
 
         public void StopTimingWrite()
+        {
+        }
+
+        public void Tick(DateTimeOffset now)
         {
         }
     }

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 
@@ -171,7 +172,8 @@ namespace Microsoft.AspNetCore.Testing
             IPEndPoint localEndPoint = null,
             IPEndPoint remoteEndPoint = null,
             IDuplexPipe transport = null,
-            ITimeoutControl timeoutControl = null)
+            ITimeoutControl timeoutControl = null,
+            IHttp3StreamLifetimeHandler streamLifetimeHandler = null)
         {
             var context = new Http3StreamContext
             (
@@ -184,6 +186,7 @@ namespace Microsoft.AspNetCore.Testing
                 localEndPoint: localEndPoint,
                 remoteEndPoint: remoteEndPoint,
                 transport: transport,
+                streamLifetimeHandler: streamLifetimeHandler,
                 streamContext: null,
                 settings: null
             );

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -432,8 +432,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         protected void CreateConnection()
         {
-            var limits = _serviceContext.ServerOptions.Limits;
-
             // Always dispatch test code back to the ThreadPool. This prevents deadlocks caused by continuing
             // Http2Connection.ProcessRequestsAsync() loop with writer locks acquired. Run product code inline to make
             // it easier to verify request frames are processed correctly immediately after sending the them.
@@ -1380,6 +1378,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             public virtual void BytesWrittenToBuffer(MinDataRate minRate, long size)
             {
                 _realTimeoutControl.BytesWrittenToBuffer(minRate, size);
+            }
+
+            public virtual void Tick(DateTimeOffset now)
+            {
+                _realTimeoutControl.Tick(now);
             }
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -1823,7 +1823,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await WaitForConnectionErrorAsync<Http3ConnectionErrorException>(
                 ignoreNonGoAwayFrames: true,
-                expectedLastStreamId: 0,
+                expectedLastStreamId: 8,
                 expectedErrorCode: Http3ErrorCode.UnexpectedFrame,
                 expectedErrorMessage: CoreStrings.FormatHttp3ErrorUnsupportedFrameOnRequestStream(frame.FormattedType));
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
+{
+    public class Http3TimeoutTests : Http3TestBase
+    {
+        [Fact]
+        public async Task HEADERS_IncompleteFrameReceivedWithinRequestHeadersTimeout_StreamError()
+        {
+            var now = _serviceContext.MockSystemClock.UtcNow;
+            var limits = _serviceContext.ServerOptions.Limits;
+
+            var requestStream = await InitializeConnectionAndStreamsAsync(_noopApplication).DefaultTimeout();
+
+            var controlStream = await GetInboundControlStream().DefaultTimeout();
+            await controlStream.ExpectSettingsAsync().DefaultTimeout();
+
+            await AssertIsTrueRetryAsync(
+                () => Connection._streams.Count == 2,
+                "Wait until streams have been created.").DefaultTimeout();
+
+            var serverRequestStream = Connection._streams[requestStream.StreamId];
+
+            await requestStream.SendHeadersPartialAsync().DefaultTimeout();
+
+            TriggerTick(now);
+            TriggerTick(now + limits.RequestHeadersTimeout);
+
+            Assert.Equal((now + limits.RequestHeadersTimeout).Ticks, serverRequestStream.HeaderTimeoutTicks);
+
+            TriggerTick(now + limits.RequestHeadersTimeout + TimeSpan.FromTicks(1));
+
+            await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.RequestRejected, CoreStrings.BadRequest_RequestHeadersTimeout);
+        }
+
+        [Fact]
+        public async Task HEADERS_HeaderFrameReceivedWithinRequestHeadersTimeout_Success()
+        {
+            var now = _serviceContext.MockSystemClock.UtcNow;
+            var limits = _serviceContext.ServerOptions.Limits;
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "Custom"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+
+            var requestStream = await InitializeConnectionAndStreamsAsync(_noopApplication).DefaultTimeout();
+
+            var controlStream = await GetInboundControlStream().DefaultTimeout();
+            await controlStream.ExpectSettingsAsync().DefaultTimeout();
+
+            await AssertIsTrueRetryAsync(
+                () => Connection._streams.Count == 2,
+                "Wait until streams have been created.").DefaultTimeout();
+
+            var serverRequestStream = Connection._streams[requestStream.StreamId];
+
+            TriggerTick(now);
+            TriggerTick(now + limits.RequestHeadersTimeout);
+
+            Assert.Equal((now + limits.RequestHeadersTimeout).Ticks, serverRequestStream.HeaderTimeoutTicks);
+
+            await requestStream.SendHeadersAsync(headers).DefaultTimeout();
+
+            await AssertIsTrueRetryAsync(
+                () => serverRequestStream.ReceivedHeader,
+                "Request stream has read headers.").DefaultTimeout();
+
+            TriggerTick(now + limits.RequestHeadersTimeout + TimeSpan.FromTicks(1));
+
+            await requestStream.SendDataAsync(Memory<byte>.Empty, endStream: true);
+
+            await requestStream.ExpectReceiveEndOfStream();
+        }
+
+        [Fact]
+        public async Task ControlStream_HeaderNotReceivedWithinRequestHeadersTimeout_StreamError()
+        {
+            var now = _serviceContext.MockSystemClock.UtcNow;
+            var limits = _serviceContext.ServerOptions.Limits;
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "Custom"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+
+            await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
+
+            var controlStream = await GetInboundControlStream().DefaultTimeout();
+            await controlStream.ExpectSettingsAsync().DefaultTimeout();
+
+            var outboundControlStream = await CreateControlStream(id: null);
+
+            await AssertIsTrueRetryAsync(
+                () => Connection._streams.Count == 1,
+                "Wait until streams have been created.").DefaultTimeout();
+
+            var serverInboundControlStream = Connection._streams[outboundControlStream.StreamId];
+
+            TriggerTick(now);
+            TriggerTick(now + limits.RequestHeadersTimeout);
+
+            Assert.Equal((now + limits.RequestHeadersTimeout).Ticks, serverInboundControlStream.HeaderTimeoutTicks);
+
+            TriggerTick(now + limits.RequestHeadersTimeout + TimeSpan.FromTicks(1));
+
+            await outboundControlStream.WaitForStreamErrorAsync(Http3ErrorCode.StreamCreationError, CoreStrings.Http3ControlStreamHeaderTimeout);
+        }
+
+        [Fact]
+        public async Task ControlStream_HeaderReceivedWithinRequestHeadersTimeout_StreamError()
+        {
+            var now = _serviceContext.MockSystemClock.UtcNow;
+            var limits = _serviceContext.ServerOptions.Limits;
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "Custom"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+
+            await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
+
+            var controlStream = await GetInboundControlStream().DefaultTimeout();
+            await controlStream.ExpectSettingsAsync().DefaultTimeout();
+
+            var outboundControlStream = await CreateControlStream(id: null);
+
+            await AssertIsTrueRetryAsync(
+                () => Connection._streams.Count == 1,
+                "Wait until streams have been created.").DefaultTimeout();
+
+            var serverInboundControlStream = Connection._streams[outboundControlStream.StreamId];
+
+            TriggerTick(now);
+            TriggerTick(now + limits.RequestHeadersTimeout);
+
+            await outboundControlStream.WriteStreamIdAsync(id: 0);
+
+            await AssertIsTrueRetryAsync(
+                () => serverInboundControlStream.ReceivedHeader,
+                "Control stream has read header.").DefaultTimeout();
+
+            TriggerTick(now + limits.RequestHeadersTimeout + TimeSpan.FromTicks(1));
+        }
+
+        [Fact]
+        public async Task ControlStream_RequestHeadersTimeoutMaxValue_ExpirationIsMaxValue()
+        {
+            var now = _serviceContext.MockSystemClock.UtcNow;
+            var limits = _serviceContext.ServerOptions.Limits;
+            limits.RequestHeadersTimeout = TimeSpan.MaxValue;
+
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "Custom"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+
+            await InitializeConnectionAsync(_noopApplication).DefaultTimeout();
+
+            var controlStream = await GetInboundControlStream().DefaultTimeout();
+            await controlStream.ExpectSettingsAsync().DefaultTimeout();
+
+            var outboundControlStream = await CreateControlStream(id: null);
+
+            await AssertIsTrueRetryAsync(
+                () => Connection._streams.Count == 1,
+                "Wait until streams have been created.").DefaultTimeout();
+
+            var serverInboundControlStream = Connection._streams[outboundControlStream.StreamId];
+
+            TriggerTick(now);
+
+            Assert.Equal(TimeSpan.MaxValue.Ticks, serverInboundControlStream.HeaderTimeoutTicks);
+        }
+
+        private static async Task AssertIsTrueRetryAsync(Func<bool> assert, string message)
+        {
+            const int Retries = 10;
+
+            for (var i = 0; i < Retries; i++)
+            {
+                if (i > 0)
+                {
+                    await Task.Delay((i + 1) * 10);
+                }
+
+                if (assert())
+                {
+                    return;
+                }
+            }
+
+            throw new Exception($"Assert failed after {Retries} retries: {message}");
+        }
+    }
+}


### PR DESCRIPTION
Adds RequestHeadersTimeout support to HTTP/3

Addresses https://github.com/dotnet/aspnetcore/issues/29702

~(this PR is still rough. Creating it early to ask questions)~

~The HTTP/3 approach doesn't use `ITimeoutControl` for this feature because multiple time controls would be required per connection, and checking them in `Tick()` would require locking the streams dictionary, foreaching over the values, and evaluating each timeout control.~

~The approach used instead is like HTTP/2's drain stream queue. New streams are added to a concurrent queue, and each tick streams are checked to see whether they have received headers and are in a "started" state.~

~I made RequestHeadersTimeout apply to both request streams and control streams. They each have the same attack vector: creating streams from the client and then never using them. Control streams use the same timeout to receive the control stream header.~

~A future possible optimization is to check whether the first read of an incoming stream completes immediately, and the first HEADERS frame or control stream frame header is immediately available. If it is then the stream can skip being added to the startingStreamsQueue.~

---

V3: On connection tick, the stream dictionary is locked and iterated over to check for streams (both request streams and inbound control streams) to see if they have received a header.

I chose not to use TimeoutControl here to avoid each stream requiring its own TimeoutControl for this one thing AND the connection having a timeout control which streams also use to track data rates.

This PR starts to unify how inbound control streams and request streams are acted on. They are both put into the `streams` dictionary so the same logic is applied to streams from the client:
* Checking a stream has started
* Aborting streams when connection aborts

@halter73 and I discussed the foreach in the lock, and while it isn't ideal:
* It happens once per second
* Little happens in it
* Default QUIC stream limit for requests is 100 so it is a bounded collection
* Compared to other locks, it will have much less contention. For example, the HTTP/2 level connection locks its framewriter multiple times per request and does much more complex work inside the lock.