### PR TITLE
Point to correct documentation link

### DIFF
--- a/src/HttpClientFactory/README.md
+++ b/src/HttpClientFactory/README.md
@@ -1,6 +1,6 @@
 # HttpClient Factory
 
-Contains an opinionated factory for creating HttpClient instances. See documentation at https://docs.microsoft.com/en-us/aspnet/core/performance/caching/distributed.
+Contains an opinionated factory for creating HttpClient instances. See documentation at https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests.
 
 ## Description
 


### PR DESCRIPTION
The HttpClientFactory README.md points to documentation about distributed caching, I think linking to [this URL](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-5.0) is more useful. 😄