### PR TITLE
Use newer method overloads in auth handlers

### DIFF
--- a/src/Security/Authentication/Core/src/AuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationHandler.cs
@@ -153,7 +153,7 @@ namespace Microsoft.AspNetCore.Authentication
             {
                 Events = Context.RequestServices.GetRequiredService(Options.EventsType);
             }
-            Events = Events ?? await CreateEventsAsync();
+            Events ??= await CreateEventsAsync();
         }
 
         /// <summary>

--- a/src/Security/Authentication/Facebook/src/FacebookHandler.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                 throw new HttpRequestException($"An error occurred when retrieving Facebook user information ({response.StatusCode}). Please check if the authentication information is correct and the corresponding Facebook Graph API is enabled.");
             }
 
-            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
+            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted)))
             {
                 var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
                 context.RunClaimActions();

--- a/src/Security/Authentication/Google/src/GoogleHandler.cs
+++ b/src/Security/Authentication/Google/src/GoogleHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
                 throw new HttpRequestException($"An error occurred when retrieving Google user information ({response.StatusCode}). Please check if the authentication information is correct.");
             }
 
-            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
+            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted)))
             {
                 var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
                 context.RunClaimActions();

--- a/src/Security/Authentication/Google/src/GoogleHandler.cs
+++ b/src/Security/Authentication/Google/src/GoogleHandler.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
             return authorizationEndpoint;
         }
 
-        private void AddQueryString<T>(
+        private static void AddQueryString<T>(
             IDictionary<string, string> queryStrings,
             AuthenticationProperties properties,
             string name,
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
             }
         }
 
-        private void AddQueryString(
+        private static void AddQueryString(
             IDictionary<string, string> queryStrings,
             AuthenticationProperties properties,
             string name,

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
@@ -243,13 +243,13 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                 {
                     builder.Append(" error=\"");
                     builder.Append(eventContext.Error);
-                    builder.Append("\"");
+                    builder.Append('\"');
                 }
                 if (!string.IsNullOrEmpty(eventContext.ErrorDescription))
                 {
                     if (!string.IsNullOrEmpty(eventContext.Error))
                     {
-                        builder.Append(",");
+                        builder.Append(',');
                     }
 
                     builder.Append(" error_description=\"");
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                     if (!string.IsNullOrEmpty(eventContext.Error) ||
                         !string.IsNullOrEmpty(eventContext.ErrorDescription))
                     {
-                        builder.Append(",");
+                        builder.Append(',');
                     }
 
                     builder.Append(" error_uri=\"");

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             return QueryHelpers.AddQueryString(Options.AuthorizationEndpoint, queryStrings!);
         }
 
-        private void AddQueryString<T>(
+        private static void AddQueryString<T>(
            Dictionary<string, string> queryStrings,
            AuthenticationProperties properties,
            string name,
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
             }
         }
 
-        private void AddQueryString(
+        private static void AddQueryString(
             Dictionary<string, string> queryStrings,
             AuthenticationProperties properties,
             string name,

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount
                 throw new HttpRequestException($"An error occurred when retrieving Microsoft user information ({response.StatusCode}). Please check if the authentication information is correct and the corresponding Microsoft Account API is enabled.");
             }
 
-            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync()))
+            using (var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted)))
             {
                 var context = new OAuthCreatingTicketContext(new ClaimsPrincipal(identity), properties, Context, Scheme, Options, Backchannel, tokens, payload.RootElement);
                 context.RunClaimActions();

--- a/src/Security/Authentication/OAuth/src/OAuthHandler.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthHandler.cs
@@ -217,7 +217,7 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
             var response = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
             if (response.IsSuccessStatusCode)
             {
-                var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+                var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
                 return OAuthTokenResponse.Success(payload);
             }
             else

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -276,7 +276,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 Response.Headers[HeaderNames.Pragma] = "no-cache";
                 Response.Headers[HeaderNames.Expires] = HeaderValueEpocDate;
 
-                await Response.Body.WriteAsync(buffer, Context.RequestAborted);
+                await Response.Body.WriteAsync(buffer);
             }
             else
             {
@@ -479,7 +479,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 Response.Headers[HeaderNames.Pragma] = "no-cache";
                 Response.Headers[HeaderNames.Expires] = HeaderValueEpocDate;
 
-                await Response.Body.WriteAsync(buffer, Context.RequestAborted);
+                await Response.Body.WriteAsync(buffer);
                 return;
             }
 

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1037,36 +1037,6 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             return null;
         }
 
-        private AuthenticationProperties GetPropertiesFromState(string state)
-        {
-            // assume a well formed query string: <a=b&>OpenIdConnectAuthenticationDefaults.AuthenticationPropertiesKey=kasjd;fljasldkjflksdj<&c=d>
-            var startIndex = 0;
-            if (string.IsNullOrEmpty(state) || (startIndex = state.IndexOf(OpenIdConnectDefaults.AuthenticationPropertiesKey, StringComparison.Ordinal)) == -1)
-            {
-                return null;
-            }
-
-            var authenticationIndex = startIndex + OpenIdConnectDefaults.AuthenticationPropertiesKey.Length;
-            if (authenticationIndex == -1 || authenticationIndex == state.Length || state[authenticationIndex] != '=')
-            {
-                return null;
-            }
-
-            // scan rest of string looking for '&'
-            authenticationIndex++;
-            var endIndex = state.Substring(authenticationIndex, state.Length - authenticationIndex).IndexOf("&", StringComparison.Ordinal);
-
-            // -1 => no other parameters are after the AuthenticationPropertiesKey
-            if (endIndex == -1)
-            {
-                return Options.StateDataFormat.Unprotect(Uri.UnescapeDataString(state.Substring(authenticationIndex).Replace('+', ' ')));
-            }
-            else
-            {
-                return Options.StateDataFormat.Unprotect(Uri.UnescapeDataString(state.Substring(authenticationIndex, endIndex).Replace('+', ' ')));
-            }
-        }
-
         private async Task<MessageReceivedContext> RunMessageReceivedEventAsync(OpenIdConnectMessage message, AuthenticationProperties properties)
         {
             Logger.MessageReceived(message.BuildRedirectUrl());

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
               && Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase)
               && Request.Body.CanRead)
             {
-                var form = await Request.ReadFormAsync();
+                var form = await Request.ReadFormAsync(Context.RequestAborted);
                 message = new OpenIdConnectMessage(form.Select(pair => new KeyValuePair<string, string[]>(pair.Key, pair.Value)));
             }
 
@@ -521,7 +521,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
               && Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase)
               && Request.Body.CanRead)
             {
-                var form = await Request.ReadFormAsync();
+                var form = await Request.ReadFormAsync(Context.RequestAborted);
                 authorizationResponse = new OpenIdConnectMessage(form.Select(pair => new KeyValuePair<string, string[]>(pair.Key, pair.Value)));
             }
 
@@ -823,7 +823,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             var requestMessage = new HttpRequestMessage(HttpMethod.Post, tokenEndpointRequest.TokenEndpoint ?? _configuration.TokenEndpoint);
             requestMessage.Content = new FormUrlEncodedContent(tokenEndpointRequest.Parameters);
             requestMessage.Version = Backchannel.DefaultRequestVersion;
-            var responseMessage = await Backchannel.SendAsync(requestMessage);
+            var responseMessage = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
 
             var contentMediaType = responseMessage.Content.Headers.ContentType?.MediaType;
             if (string.IsNullOrEmpty(contentMediaType))
@@ -842,7 +842,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             OpenIdConnectMessage message;
             try
             {
-                var responseContent = await responseMessage.Content.ReadAsStringAsync();
+                var responseContent = await responseMessage.Content.ReadAsStringAsync(Context.RequestAborted);
                 message = new OpenIdConnectMessage(responseContent);
             }
             catch (Exception ex)
@@ -886,9 +886,9 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
             var requestMessage = new HttpRequestMessage(HttpMethod.Get, userInfoEndpoint);
             requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", message.AccessToken);
             requestMessage.Version = Backchannel.DefaultRequestVersion;
-            var responseMessage = await Backchannel.SendAsync(requestMessage);
+            var responseMessage = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
             responseMessage.EnsureSuccessStatusCode();
-            var userInfoResponse = await responseMessage.Content.ReadAsStringAsync();
+            var userInfoResponse = await responseMessage.Content.ReadAsStringAsync(Context.RequestAborted);
 
             JsonDocument user;
             var contentType = responseMessage.Content.Headers.ContentType;

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -276,7 +276,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 Response.Headers[HeaderNames.Pragma] = "no-cache";
                 Response.Headers[HeaderNames.Expires] = HeaderValueEpocDate;
 
-                await Response.Body.WriteAsync(buffer, 0, buffer.Length);
+                await Response.Body.WriteAsync(buffer, Context.RequestAborted);
             }
             else
             {
@@ -479,7 +479,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 Response.Headers[HeaderNames.Pragma] = "no-cache";
                 Response.Headers[HeaderNames.Expires] = HeaderValueEpocDate;
 
-                await Response.Body.WriteAsync(buffer, 0, buffer.Length);
+                await Response.Body.WriteAsync(buffer, Context.RequestAborted);
                 return;
             }
 

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -195,7 +195,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
                 return;
             }
 
-            properties = properties ?? new AuthenticationProperties();
+            properties ??= new AuthenticationProperties();
 
             Logger.EnteringOpenIdAuthenticationHandlerHandleSignOutAsync(GetType().FullName);
 

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             JsonDocument user;
             if (Options.RetrieveUserDetails)
             {
-                user = await RetrieveUserDetailsAsync(accessToken, identity);
+                user = await RetrieveUserDetailsAsync(accessToken);
             }
             else
             {
@@ -310,7 +310,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
         }
 
         // https://dev.twitter.com/rest/reference/get/account/verify_credentials
-        private async Task<JsonDocument> RetrieveUserDetailsAsync(AccessToken accessToken, ClaimsIdentity identity)
+        private async Task<JsonDocument> RetrieveUserDetailsAsync(AccessToken accessToken)
         {
             Logger.RetrieveUserDetails();
 

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -334,7 +334,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             return Convert.ToInt64(secondsSinceUnixEpocStart.TotalSeconds).ToString(CultureInfo.InvariantCulture);
         }
 
-        private string ComputeSignature(string consumerSecret, string tokenSecret, string signatureData)
+        private static string ComputeSignature(string consumerSecret, string tokenSecret, string signatureData)
         {
             using (var algorithm = new HMACSHA1())
             {

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -223,9 +223,9 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             var canonicalizedRequestBuilder = new StringBuilder();
             canonicalizedRequestBuilder.Append(httpMethod.Method);
-            canonicalizedRequestBuilder.Append("&");
+            canonicalizedRequestBuilder.Append('&');
             canonicalizedRequestBuilder.Append(Uri.EscapeDataString(url));
-            canonicalizedRequestBuilder.Append("&");
+            canonicalizedRequestBuilder.Append('&');
             canonicalizedRequestBuilder.Append(Uri.EscapeDataString(parameterString));
 
             var signature = ComputeSignature(Options.ConsumerSecret, accessToken?.TokenSecret, canonicalizedRequestBuilder.ToString());

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
             var response = await ExecuteRequestAsync(TwitterDefaults.RequestTokenEndpoint, HttpMethod.Post, extraOAuthPairs: new Dictionary<string, string>() { { "oauth_callback", callBackUri } });
             await EnsureTwitterRequestSuccess(response);
-            var responseText = await response.Content.ReadAsStringAsync();
+            var responseText = await response.Content.ReadAsStringAsync(Context.RequestAborted);
 
             var responseParameters = new FormCollection(new FormReader(responseText).ReadForm());
             if (!string.Equals(responseParameters["oauth_callback_confirmed"], "true", StringComparison.Ordinal))
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 await EnsureTwitterRequestSuccess(response); // throw
             }
 
-            var responseText = await response.Content.ReadAsStringAsync();
+            var responseText = await response.Content.ReadAsStringAsync(Context.RequestAborted);
             var responseParameters = new FormCollection(new FormReader(responseText).ReadForm());
 
             return new AccessToken
@@ -321,7 +321,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                 Logger.LogError("Email request failed with a status code of " + response.StatusCode);
                 await EnsureTwitterRequestSuccess(response); // throw
             }
-            var responseText = await response.Content.ReadAsStringAsync();
+            var responseText = await response.Content.ReadAsStringAsync(Context.RequestAborted);
 
             var result = JsonDocument.Parse(responseText);
 
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
             try
             {
                 // Failure, attempt to parse Twitters error message
-                var errorContentStream = await response.Content.ReadAsStreamAsync();
+                var errorContentStream = await response.Content.ReadAsStreamAsync(Context.RequestAborted);
                 errorResponse = await JsonSerializer.DeserializeAsync<TwitterErrorResponse>(errorContentStream, ErrorSerializerOptions);
             }
             catch

--- a/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
+++ b/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Authentication.WsFederation
               && Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase)
               && Request.Body.CanRead)
             {
-                var form = await Request.ReadFormAsync();
+                var form = await Request.ReadFormAsync(Context.RequestAborted);
 
                 wsFederationMessage = new WsFederationMessage(form.Select(pair => new KeyValuePair<string, string[]>(pair.Key, pair.Value)));
             }

--- a/src/Security/Authentication/test/GoogleTests.cs
+++ b/src/Security/Authentication/test/GoogleTests.cs
@@ -941,7 +941,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
         }
 
         [Fact]
-        public async Task AuthenticateFacebookWhenAlreadySignedWithGoogleReturnsNull()
+        public async Task AuthenticateGoogleWhenAlreadySignedWithGoogleReturnsNull()
         {
             var stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider(NullLoggerFactory.Instance).CreateProtector("GoogleTest"));
             using var host = await CreateHost(o =>
@@ -978,7 +978,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
         }
 
         [Fact]
-        public async Task ChallengeFacebookWhenAlreadySignedWithGoogleSucceeds()
+        public async Task ChallengeGoogleWhenAlreadySignedWithGoogleSucceeds()
         {
             var stateFormat = new PropertiesDataFormat(new EphemeralDataProtectionProvider(NullLoggerFactory.Instance).CreateProtector("GoogleTest"));
             using var host = await CreateHost(o =>


### PR DESCRIPTION
**PR Title**

Use newly added overloads of already-used methods in authentication handlers.

**PR Description**

I noticed that some of the new overloads added in .NET 5.0 weren't used, so I've switched various usages within the Authentication part of the solution to use them. I also applies some minor improvements in the files I touched that Visual Studio suggested.

* Use new overloads of methods added in .NET 5.0 that accept a `CancellationToken`.
* Use `WriteAsync()` overload that accepts a span ~and a `CancellationToken`~, instead of an array and indexes.
* Use `StringBuilder.Append(char)` instead of `StringBuilder.Append(string)` when there is only a single character.
* Make some methods that don't access instance data `static`.
* Remove some unused code.
* Use compound assignment.
* Fix two incorrect test names from copy-paste.
