### PR TITLE
Check for downloaded file in requests and disk

### DIFF
--- a/src/Components/test/E2ETest/Tests/DownloadAnchorTest.cs
+++ b/src/Components/test/E2ETest/Tests/DownloadAnchorTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using BasicTestApp;
@@ -45,9 +46,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // URL should still be same as before click
             Assert.Equal(initialUrl, Browser.Url);
 
-            // File should be requested
+            // File should be requested or downloaded to to disk
             var requestedPaths = GetAndClearRequestedPaths();
-            Assert.NotEmpty(requestedPaths.Where(path => path.EndsWith("blazor_logo_1000x.png", StringComparison.InvariantCultureIgnoreCase)));
+            var downloadPath = Path.Combine(BrowserFixture.UserProfileDir, "Downloads", "blazor_logo_1000x.png");
+            var fileExists = File.Exists(downloadPath);
+            var requestSent = requestedPaths.Any(path => path.EndsWith("blazor_logo_1000x.png", StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(fileExists || requestSent);
         }
 
         protected IWebElement MountAndNavigateToRouterTest()

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -33,6 +33,8 @@ namespace Microsoft.AspNetCore.E2ETesting
 
         public IMessageSink DiagnosticsMessageSink { get; }
 
+        public string UserProfileDir { get; private set; }
+
         public static void EnforceSupportedConfigurations()
         {
             // Do not change the current platform support without explicit approval.
@@ -168,6 +170,7 @@ namespace Microsoft.AspNetCore.E2ETesting
             {
                 Directory.CreateDirectory(userProfileDirectory);
                 opts.AddArgument($"--user-data-dir={userProfileDirectory}");
+                opts.AddUserProfilePreference("download.default_directory", Path.Combine(userProfileDirectory, "Downloads"));
             }
 
             var instance = await SeleniumStandaloneServer.GetInstanceAsync(output);

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -166,6 +166,7 @@ namespace Microsoft.AspNetCore.E2ETesting
             }
 
             var userProfileDirectory = UserProfileDirectory(context);
+            UserProfileDir = userProfileDirectory;
             if (!string.IsNullOrEmpty(userProfileDirectory))
             {
                 Directory.CreateDirectory(userProfileDirectory);


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/29739.

Note: ideally, once we migrate to Playwright, we can flaky-proof this test by using Playwright's download listener APIs but trying this as a stop-gap.