### PR TITLE
Update TagHelperDescriptor's GetHashCode to consider metadata.

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
@@ -67,7 +67,11 @@ namespace Microsoft.AspNetCore.Razor.Language
                 }
             }
 
-            hash.Add(descriptor.Metadata.Count);
+            foreach (var metadata in descriptor.Metadata)
+            {
+                hash.Add(metadata.Key);
+                hash.Add(metadata.Value);
+            }
 
             return hash.CombinedHash;
         }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
@@ -159,6 +159,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             {
                 foreach (var kvp in descriptor.Metadata)
                 {
+                    hash.Add(kvp.Key, StringComparer.Ordinal);
                     hash.Add(kvp.Value, StringComparer.Ordinal);
                 }
             }


### PR DESCRIPTION
- Blazor's recent implementations have been increasingly relying on `TagHelper`'s `Metadata` construct for features. Because of this we need to expand the `GetHashCode` portions of the underlying TagHelper implementations so tooling can utilize them more efficiently.
- In practice this actually fixes a bug where you could get inconsistent experiences in VS/VSCode when opening a project for the first time. Usually impacted the latest type inference feature from Blazor. See associated issue for more details.

Fixes dotnet/aspnetcore#30858