### PR TITLE
Run dotnet-format on pull request 

### DIFF
--- a/.github/workflows/dotnet-format
+++ b/.github/workflows/dotnet-format
@@ -1,0 +1,40 @@
+name: Daily code format check
+on: pull_request
+jobs:
+  dotnet-format:
+    runs-on: windows-latest
+    steps:
+      - name: Install dotnet-format
+        run: dotnet tool install -g dotnet-format
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Run dotnet format
+        id: format
+        uses: MCCshreyas/dotnet-format@v1.0.5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          action: "fix"
+          only-changed-files: true # only works for PRs
+          workspace: "AspNetCore.sln"
+    
+      - name: Commit files
+        if: steps.format.outputs.has-changes == 'true'
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -a -m 'Automated dotnet-format update'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: '[housekeeping] Automated PR to fix formatting errors'
+          body: |
+            Automated PR to fix formatting errors
+          committer: GitHub <noreply@github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          #labels: t/housekeeping ♻︎
+          branch: housekeeping/fix-codeformatting

--- a/.github/workflows/dotnet-format
+++ b/.github/workflows/dotnet-format
@@ -1,5 +1,10 @@
 name: Code format on pull request
-on: pull_request
+push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   dotnet-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-format
+++ b/.github/workflows/dotnet-format
@@ -1,40 +1,34 @@
-name: Daily code format check
+name: Code format on pull request
 on: pull_request
 jobs:
   dotnet-format:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2.2.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
       - name: Install dotnet-format
         run: dotnet tool install -g dotnet-format
 
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-
       - name: Run dotnet format
         id: format
-        uses: MCCshreyas/dotnet-format@v1.0.5
+        uses: MCCshreyas/dotnet-format@v1.0.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           action: "fix"
-          only-changed-files: true # only works for PRs
-          workspace: "AspNetCore.sln"
-    
+          only-changed-files: true
+          folder: "."
+      
       - name: Commit files
         if: steps.format.outputs.has-changes == 'true'
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -a -m 'Automated dotnet-format update'
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: EndBug/add-and-commit@v4.1.0
         with:
-          title: '[housekeeping] Automated PR to fix formatting errors'
-          body: |
-            Automated PR to fix formatting errors
-          committer: GitHub <noreply@github.com>
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          #labels: t/housekeeping ♻︎
-          branch: housekeeping/fix-codeformatting
+          author_name: Github Actions
+          author_email: actions@github.com
+          message: Automated dotnet-format update
+          ref: ${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-format
+++ b/.github/workflows/dotnet-format
@@ -1,10 +1,10 @@
 name: Code format on pull request
 push:
     branches:
-      - main
+      - patch-3
   pull_request:
     branches:
-      - main
+      - patch-3
 jobs:
   dotnet-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-format
+++ b/.github/workflows/dotnet-format
@@ -1,10 +1,10 @@
 name: Code format on pull request
 push:
     branches:
-      - patch-3
+      - main
   pull_request:
     branches:
-      - patch-3
+      - main
 jobs:
   dotnet-format:
     runs-on: ubuntu-latest

--- a/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/Assert.cs
+++ b/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/Assert.cs
@@ -16,10 +16,8 @@ namespace Microsoft.AspNetCore.Analyzer.Testing
 
             // Only check line position if there is an actual line in the real diagnostic
             if (actualLinePosition.Line > 0)
-            {
-                if (actualLinePosition.Line + 1 != expected.Line)
-                {
-                    throw new DiagnosticLocationAssertException(
+            {if (actualLinePosition.Line + 1 != expected.Line)
+                {throw new DiagnosticLocationAssertException(
                         expected,
                         actual,
                         $"Expected diagnostic to be on line \"{expected.Line}\" was actually on line \"{actualLinePosition.Line + 1}\"");
@@ -28,14 +26,14 @@ namespace Microsoft.AspNetCore.Analyzer.Testing
 
             // Only check column position if there is an actual column position in the real diagnostic
             if (actualLinePosition.Character > 0)
-            {
+                        {
                 if (actualLinePosition.Character + 1 != expected.Column)
                 {
                     throw new DiagnosticLocationAssertException(
                         expected,
                         actual,
                         $"Expected diagnostic to start at column \"{expected.Column}\" was actually on column \"{actualLinePosition.Character + 1}\"");
-                }
+      }
             }
         }
 


### PR DESCRIPTION
Instead of a pre-commit hook, we can test this GitHub workflow which will run on PR and do code formatting using `dotnet-format`. 

Regarding https://github.com/dotnet/aspnetcore/issues/27632