### PR TITLE
Remove the thread hop from the https middleware

### DIFF
--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -133,8 +133,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
 
         public async Task OnConnectionAsync(ConnectionContext context)
         {
-            await Task.Yield();
-
             if (context.Features.Get<ITlsConnectionFeature>() != null)
             {
                 await _next(context);


### PR DESCRIPTION
It doesn't make sense to do this anymore (I'm not sure it did in the first place...)