### PR TITLE
Remove some indirection

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
+++ b/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
@@ -12,6 +12,7 @@
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\StringUtilities.cs" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
+++ b/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
@@ -25,6 +25,7 @@
     <Compile Include="$(SharedSourceRoot)ErrorPage\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
   </ItemGroup>
 
   <Target Name="ValidateNativeComponentsBuilt" AfterTargets="Build" >

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
   </ItemGroup>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseStream.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
         {
-            return new ValueTask(WriteAsyncInternal(source, cancellationToken));
+            return _pipeWriter.WriteAsync(source, cancellationToken).GetAsValueTask();
         }
 
         private Task WriteAsyncInternal(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseStream.cs
@@ -96,17 +96,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return WriteAsyncInternal(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
+            return _pipeWriter.WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).GetAsTask();
         }
         
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
         {
             return _pipeWriter.WriteAsync(source, cancellationToken).GetAsValueTask();
-        }
-
-        private Task WriteAsyncInternal(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
-        {
-            return _pipeWriter.WriteAsync(source, cancellationToken).GetAsTask();
         }
     }
 }

--- a/src/Servers/Kestrel/samples/http2cat/http2cat.csproj
+++ b/src/Servers/Kestrel/samples/http2cat/http2cat.csproj
@@ -14,6 +14,7 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/ServerInfrastructure/DuplexPipeStream.cs
+++ b/src/Shared/ServerInfrastructure/DuplexPipeStream.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Buffers;
+using Microsoft.AspNetCore.Internal;
 
 #nullable enable
 
@@ -90,20 +91,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
         }
 
-        public override async Task WriteAsync(byte[]? buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[]? buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (buffer != null)
-            {
-                _output.Write(new ReadOnlySpan<byte>(buffer, offset, count));
-            }
-
-            await _output.FlushAsync(cancellationToken);
+            return _output.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).GetAsTask();
         }
 
-        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
         {
-            _output.Write(source.Span);
-            await _output.FlushAsync(cancellationToken);
+            return _output.WriteAsync(source, cancellationToken).GetAsValueTask();
         }
 
         public override void Flush()
@@ -113,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
-            return WriteAsync(null, 0, 0, cancellationToken);
+            return _output.FlushAsync(cancellationToken).GetAsTask();
         }
 
         private async ValueTask<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken)

--- a/src/Shared/ValueTaskExtensions/ValueTaskExtensions.cs
+++ b/src/Shared/ValueTaskExtensions/ValueTaskExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Internal
             {
                 // Signal consumption to the IValueTaskSource
                 valueTask.GetAwaiter().GetResult();
-                return ValueTask.CompletedTask;
+                return default;
             }
             else
             {

--- a/src/Shared/ValueTaskExtensions/ValueTaskExtensions.cs
+++ b/src/Shared/ValueTaskExtensions/ValueTaskExtensions.cs
@@ -24,5 +24,21 @@ namespace Microsoft.AspNetCore.Internal
                 return valueTask.AsTask();
             }
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ValueTask GetAsValueTask(this in ValueTask<FlushResult> valueTask)
+        {
+            // Try to avoid the allocation from AsTask
+            if (valueTask.IsCompletedSuccessfully)
+            {
+                // Signal consumption to the IValueTaskSource
+                valueTask.GetAwaiter().GetResult();
+                return ValueTask.CompletedTask;
+            }
+            else
+            {
+                return new ValueTask(valueTask.AsTask());
+            }
+        }
     }
 }

--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="$(SharedSourceRoot)PropertyHelper\*.cs" Link="Shared\PropertyHelper\%(Filename)%(Extension)"/>
     <Compile Include="$(SharedSourceRoot)SecurityHelper\**\*.cs" Link="Shared\SecurityHelper\%(Filename)%(Extension)"/>
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" Link="Shared\ServerInfrastructure\%(Filename)%(Extension)"/>
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" Link="Shared\ValueTaskExtensions\%(Filename)%(Extension)" />
     <Compile Include="$(SharedSourceRoot)StackTrace\StackFrame\**\*.cs" Link="Shared\StackTrace\%(Filename)%(Extension)"/>
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\StackFrame\**\*.cs" Link="Shared\TypeNameHelper\%(Filename)%(Extension)"/>
     <Compile Include="$(SharedSourceRoot)ValueStopwatch\**\*.cs" Link="Shared\ValueStopwatch\%(Filename)%(Extension)"/>


### PR DESCRIPTION
- Call WriteAsync on the underlying PipeWriter in DuplexPipeStream
- Added GetAsValueTask helper in ValueTaskExtensions
- Cut some indirection in Stream calls

