### PR TITLE
Adding support for custom JsonConverter(s) when deserializing JSON Patch value object

### DIFF
--- a/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
+++ b/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             return ConvertTo(value, typeToConvertTo, null);
         }
 
-        public static ConversionResult ConvertTo(object value, Type typeToConvertTo, IContractResolver contractResolver)
+        internal static ConversionResult ConvertTo(object value, Type typeToConvertTo, IContractResolver contractResolver)
         {
             if (value == null)
             {

--- a/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
+++ b/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
@@ -34,12 +34,20 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             {
                 try
                 {
-                    var serializerSettings = new JsonSerializerSettings()
+                    if (contractResolver == null)
                     {
-                        ContractResolver = contractResolver
-                    };
-                    var deserialized = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), typeToConvertTo, serializerSettings);
-                    return new ConversionResult(true, deserialized);
+                        var deserialized = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), typeToConvertTo);
+                        return new ConversionResult(true, deserialized);
+                    }
+                    else
+                    {
+                        var serializerSettings = new JsonSerializerSettings()
+                        {
+                            ContractResolver = contractResolver
+                        };
+                        var deserialized = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), typeToConvertTo, serializerSettings);
+                        return new ConversionResult(true, deserialized);
+                    }
                 }
                 catch
                 {

--- a/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
+++ b/src/Features/JsonPatch/src/Internal/ConversionResultProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.AspNetCore.JsonPatch.Internal
 {
@@ -14,6 +15,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
     public static class ConversionResultProvider
     {
         public static ConversionResult ConvertTo(object value, Type typeToConvertTo)
+        {
+            return ConvertTo(value, typeToConvertTo, null);
+        }
+
+        public static ConversionResult ConvertTo(object value, Type typeToConvertTo, IContractResolver contractResolver)
         {
             if (value == null)
             {
@@ -28,7 +34,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             {
                 try
                 {
-                    var deserialized = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), typeToConvertTo);
+                    var serializerSettings = new JsonSerializerSettings()
+                    {
+                        ContractResolver = contractResolver
+                    };
+                    var deserialized = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value), typeToConvertTo, serializerSettings);
                     return new ConversionResult(true, deserialized);
                 }
                 catch

--- a/src/Features/JsonPatch/src/Internal/ListAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/ListAdapter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 return false;
             }
 
-            if (!TryConvertValue(value, typeArgument, segment, out var convertedValue, out errorMessage))
+            if (!TryConvertValue(value, typeArgument, segment, contractResolver, out var convertedValue, out errorMessage))
             {
                 return false;
             }
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 return false;
             }
 
-            if (!TryConvertValue(value, typeArgument, segment, out var convertedValue, out errorMessage))
+            if (!TryConvertValue(value, typeArgument, segment, contractResolver, out var convertedValue, out errorMessage))
             {
                 return false;
             }
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 return false;
             }
 
-            if (!TryConvertValue(value, typeArgument, segment, out var convertedValue, out errorMessage))
+            if (!TryConvertValue(value, typeArgument, segment, contractResolver, out var convertedValue, out errorMessage))
             {
                 return false;
             }
@@ -235,7 +235,24 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             out object convertedValue,
             out string errorMessage)
         {
-            var conversionResult = ConversionResultProvider.ConvertTo(originalValue, listTypeArgument);
+            return TryConvertValue(
+                originalValue,
+                listTypeArgument,
+                segment,
+                null,
+                out convertedValue,
+                out errorMessage);
+        }
+
+        protected virtual bool TryConvertValue(
+            object originalValue,
+            Type listTypeArgument,
+            string segment,
+            IContractResolver contractResolver,
+            out object convertedValue,
+            out string errorMessage)
+        {
+            var conversionResult = ConversionResultProvider.ConvertTo(originalValue, listTypeArgument, contractResolver);
             if (!conversionResult.CanBeConverted)
             {
                 convertedValue = null;

--- a/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
+++ b/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~static Microsoft.AspNetCore.JsonPatch.Internal.ConversionResultProvider.ConvertTo(object value, System.Type typeToConvertTo, Newtonsoft.Json.Serialization.IContractResolver contractResolver) -> Microsoft.AspNetCore.JsonPatch.Internal.ConversionResult
+~virtual Microsoft.AspNetCore.JsonPatch.Internal.ListAdapter.TryConvertValue(object originalValue, System.Type listTypeArgument, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object convertedValue, out string errorMessage) -> bool

--- a/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
+++ b/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
 #nullable enable
-~static Microsoft.AspNetCore.JsonPatch.Internal.ConversionResultProvider.ConvertTo(object value, System.Type typeToConvertTo, Newtonsoft.Json.Serialization.IContractResolver contractResolver) -> Microsoft.AspNetCore.JsonPatch.Internal.ConversionResult
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.ListAdapter.TryConvertValue(object originalValue, System.Type listTypeArgument, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object convertedValue, out string errorMessage) -> bool

--- a/src/Features/JsonPatch/test/IntegrationTests/HeterogenousCollectionTests.cs
+++ b/src/Features/JsonPatch/test/IntegrationTests/HeterogenousCollectionTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Microsoft.AspNetCore.JsonPatch.IntegrationTests
+{
+    public class HeterogenousCollectionTests
+    {
+        [Fact]
+        public void AddItemToList()
+        {
+            // Arrange
+            var targetObject = new Canvas()
+            {
+                Items = new List<Shape>()
+            };
+
+            var circleJObject = JObject.Parse(@"{
+              Type: 'Circle',
+              ShapeProperty: 'Shape property',
+              CircleProperty: 'Circle property'
+            }");
+
+            var patchDocument = new JsonPatchDocument
+            {
+                ContractResolver = new CanvasContractResolver()
+            };
+
+            patchDocument.Add("/Items/-", circleJObject);
+
+            // Act
+            patchDocument.ApplyTo(targetObject);
+
+            // Assert
+            var circle = targetObject.Items[0] as Circle;
+            Assert.NotNull(circle);
+            Assert.Equal("Shape property", circle.ShapeProperty);
+            Assert.Equal("Circle property", circle.CircleProperty);
+        }
+    }
+
+    public class CanvasContractResolver : DefaultContractResolver
+    {
+        protected override JsonConverter ResolveContractConverter(Type objectType)
+        {
+            if (objectType == typeof(Shape))
+            {
+                return new ShapeJsonConverter();
+            }
+
+            return base.ResolveContractConverter(objectType);
+        }
+    }
+
+    public class ShapeJsonConverter : CustomCreationConverter<Shape>
+    {
+        private const string TypeProperty = "Type";
+
+        public override bool CanRead => true;
+
+        public override Shape Create(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object existingValue,
+            JsonSerializer serializer)
+        {
+            var jObject = JObject.Load(reader);
+
+            var target = CreateShape(jObject);
+            serializer.Populate(jObject.CreateReader(), target);
+
+            return target;
+        }
+
+        private Shape CreateShape(JObject jObject)
+        {
+            var typeProperty = jObject.GetValue(TypeProperty).ToString();
+
+            switch (typeProperty)
+            {
+                case "Circle":
+                    return new Circle();
+
+                case "Rectangle":
+                    return new Rectangle();
+            }
+
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Features/JsonPatch/test/Internal/ListAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/ListAdapterTest.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using Moq;
 using Newtonsoft.Json.Serialization;
 using Xunit;
 
@@ -16,12 +15,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Patch_OnArrayObject_Fails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new[] { 20, 30 };
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "0", resolver.Object, "40", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "0", resolver, "40", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -32,14 +31,14 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Patch_OnNonGenericListObject_Fails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new ArrayList();
             targetObject.Add(20);
             targetObject.Add(30);
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, "40", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver, "40", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -50,13 +49,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_WithIndexSameAsNumberOfElements_Works()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<string>() { "James", "Mike" };
             var listAdapter = new ListAdapter();
             var position = targetObject.Count.ToString(CultureInfo.InvariantCulture);
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, "Rob", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, resolver, "Rob", out var message);
 
             // Assert
             Assert.Null(message);
@@ -72,12 +71,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_WithOutOfBoundsIndex_Fails(string position)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<string>() { "James", "Mike" };
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, "40", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, resolver, "40", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -90,12 +89,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Patch_WithInvalidPositionFormat_Fails(string position)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<string>() { "James", "Mike" };
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, "40", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, resolver, "40", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -125,11 +124,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_Appends_AtTheEnd(List<int> targetObject, List<int> expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, "20", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver, "20", out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -142,12 +141,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_NullObject_ToReferenceTypeListWorks()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var listAdapter = new ListAdapter();
             var targetObject = new List<string>() { "James", "Mike" };
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, value: null, errorMessage: out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver, value: null, errorMessage: out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -162,12 +161,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             // Arrange
             var sDto = new SimpleObject();
             var iDto = new InheritedObject();
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<SimpleObject>() { sDto };
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, iDto, out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver, iDto, out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -180,12 +179,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_NonCompatibleType_Fails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>() { 10, 20 };
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver.Object, "James", out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, "-", resolver, "James", out var message);
 
             // Assert
             Assert.False(addStatus);
@@ -231,11 +230,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_DifferentComplexTypeWorks(IList targetObject, object value, string position, IList expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, value, out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, resolver, value, out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -286,11 +285,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Add_KeepsObjectReference(IList targetObject, object value, string position, IList expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var listAdapter = new ListAdapter();
 
             // Act
-            var addStatus = listAdapter.TryAdd(targetObject, position, resolver.Object, value, out var message);
+            var addStatus = listAdapter.TryAdd(targetObject, position, resolver, value, out var message);
 
             // Assert
             Assert.True(addStatus);
@@ -306,12 +305,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Get_IndexOutOfBounds(int[] input, string position)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>(input);
             var listAdapter = new ListAdapter();
 
             // Act
-            var getStatus = listAdapter.TryGet(targetObject, position, resolver.Object, out var value, out var message);
+            var getStatus = listAdapter.TryGet(targetObject, position, resolver, out var value, out var message);
 
             // Assert
             Assert.False(getStatus);
@@ -325,12 +324,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Get(int[] input, string position, object expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>(input);
             var listAdapter = new ListAdapter();
 
             // Act
-            var getStatus = listAdapter.TryGet(targetObject, position, resolver.Object, out var value, out var message);
+            var getStatus = listAdapter.TryGet(targetObject, position, resolver, out var value, out var message);
 
             // Assert
             Assert.True(getStatus);
@@ -345,12 +344,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Remove_IndexOutOfBounds(int[] input, string position)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>(input);
             var listAdapter = new ListAdapter();
 
             // Act
-            var removeStatus = listAdapter.TryRemove(targetObject, position, resolver.Object, out var message);
+            var removeStatus = listAdapter.TryRemove(targetObject, position, resolver, out var message);
 
             // Assert
             Assert.False(removeStatus);
@@ -364,12 +363,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Remove(int[] input, string position, int[] expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>(input);
             var listAdapter = new ListAdapter();
 
             // Act
-            var removeStatus = listAdapter.TryRemove(targetObject, position, resolver.Object, out var message);
+            var removeStatus = listAdapter.TryRemove(targetObject, position, resolver, out var message);
 
             // Assert
             Assert.True(removeStatus);
@@ -380,12 +379,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Replace_NonCompatibleType_Fails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>() { 10, 20 };
             var listAdapter = new ListAdapter();
 
             // Act
-            var replaceStatus = listAdapter.TryReplace(targetObject, "-", resolver.Object, "James", out var message);
+            var replaceStatus = listAdapter.TryReplace(targetObject, "-", resolver, "James", out var message);
 
             // Assert
             Assert.False(replaceStatus);
@@ -396,12 +395,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Replace_ReplacesValue_AtTheEnd()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>() { 10, 20 };
             var listAdapter = new ListAdapter();
 
             // Act
-            var replaceStatus = listAdapter.TryReplace(targetObject, "-", resolver.Object, "30", out var message);
+            var replaceStatus = listAdapter.TryReplace(targetObject, "-", resolver, "30", out var message);
 
             // Assert
             Assert.True(replaceStatus);
@@ -432,12 +431,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Replace_ReplacesValue_AtGivenPosition(string position, List<int> expected)
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>() { 10, 20 };
             var listAdapter = new ListAdapter();
 
             // Act
-            var replaceStatus = listAdapter.TryReplace(targetObject, position, resolver.Object, "30", out var message);
+            var replaceStatus = listAdapter.TryReplace(targetObject, position, resolver, "30", out var message);
 
             // Assert
             Assert.True(replaceStatus);
@@ -449,12 +448,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Test_DoesNotThrowException_IfTestIsSuccessful()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>() { 10, 20 };
             var listAdapter = new ListAdapter();
 
             // Act
-            var testStatus = listAdapter.TryTest(targetObject, "0", resolver.Object, "10", out var message);
+            var testStatus = listAdapter.TryTest(targetObject, "0", resolver, "10", out var message);
 
             //Assert
             Assert.True(testStatus);
@@ -465,13 +464,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Test_ThrowsJsonPatchException_IfTestFails()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>() { 10, 20 };
             var listAdapter = new ListAdapter();
             var expectedErrorMessage = "The current value '20' at position '1' is not equal to the test value '10'.";
 
             // Act
-            var testStatus = listAdapter.TryTest(targetObject, "1", resolver.Object, "10", out var errorMessage);
+            var testStatus = listAdapter.TryTest(targetObject, "1", resolver, "10", out var errorMessage);
 
             //Assert
             Assert.False(testStatus);
@@ -482,13 +481,13 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         public void Test_ThrowsJsonPatchException_IfListPositionOutOfBounds()
         {
             // Arrange
-            var resolver = new Mock<IContractResolver>(MockBehavior.Strict);
+            var resolver = new DefaultContractResolver();
             var targetObject = new List<int>() { 10, 20 };
             var listAdapter = new ListAdapter();
             var expectedErrorMessage = "The index value provided by path segment '2' is out of bounds of the array size.";
 
             // Act
-            var testStatus = listAdapter.TryTest(targetObject, "2", resolver.Object, "10", out var errorMessage);
+            var testStatus = listAdapter.TryTest(targetObject, "2", resolver, "10", out var errorMessage);
 
             //Assert
             Assert.False(testStatus);

--- a/src/Features/JsonPatch/test/TestObjectModels/HeterogenousCollection.cs
+++ b/src/Features/JsonPatch/test/TestObjectModels/HeterogenousCollection.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.JsonPatch
+{
+    public abstract class Shape
+    {
+        public string ShapeProperty { get; set; }
+    }
+
+    public class Circle : Shape
+    {
+        public string CircleProperty { get; set; }
+    }
+
+    public class Rectangle : Shape
+    {
+        public string RectangleProperty { get; set; }
+    }
+
+    public class Canvas
+    {
+        public IList<Shape> Items { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Adding support for custom JsonConverter(s) when deserializing JSON Patch value object

**PR Description**
When we started using the JSON Patch library we hit an issue with heterogenous collections. To specify what type an object in a heterogenous collection is, we added a "Type" property to the JSON value object. However, regardless of what we supplied in our custom ContractResolver, nothing was getting used when the JObject was converted to a concrete object.

Once we looked at the sources we found out that the JsonPatchDocument.ContractResolver is not used at all when deserializing the value object. So we added an overload that takes an IContractResolver and wired it up for the ListAdapter.

That solved our issue as now our custom JsonConverter is used to read the "Type" property and create the correct object instance. We also added an integration unit test that covers this scenario.
