### PR TITLE
Set cab name for TargetingPack.wixproj

### DIFF
--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -8,6 +8,7 @@
     <ProductNameFolder>Microsoft ASP.NET Core Targeting Pack</ProductNameFolder>
     <ProductNameShort>AspNetCore.TargetingPack</ProductNameShort>
     <OutputType>Package</OutputType>
+    <Cabinet>targeting_pack_$(Platform).cab</Cabinet>
     <IsShipping>true</IsShipping>
     <SkipCopyToArtifactsDirectory Condition="'$(IsTargetingPackBuilding)' == 'false'">true</SkipCopyToArtifactsDirectory>
     <ProjectGuid>0AC34F1B-8056-4FFB-A398-E6BB7D67B48D</ProjectGuid>


### PR DESCRIPTION
I just made a similar change in 3.1 to fix errors like:

> ##[error]src\Installers\Windows\TargetingPack\Product.wxs(8,0): error CNDL0032: The Media/@Cabinet attribute's value, 'aspnetcore_targeting_pack_3.1.10_servicing.21162.7_win_arm64.cab', is 64 characters long. The name is too long for an embedded cabinet. It cannot be more than than 62 characters long.

Doing it here too for consistency. Matches what we do in the SharedFx wixproj:

https://github.com/dotnet/aspnetcore/blob/19785ccdf595772231ee7b93083471ff13bad3de/src/Installers/Windows/SharedFramework/SharedFramework.wixproj#L12