### PR TITLE
Fix nullability of TypeNameHelper.GetTypeDisplayName parameter

### DIFF
--- a/src/Shared/TypeNameHelper/TypeNameHelper.cs
+++ b/src/Shared/TypeNameHelper/TypeNameHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
@@ -33,7 +34,8 @@ namespace Microsoft.Extensions.Internal
             { typeof(ushort), "ushort" }
         };
 
-        public static string? GetTypeDisplayName(object item, bool fullName = true)
+        [return: NotNullIfNotNull("item")]
+        public static string? GetTypeDisplayName(object? item, bool fullName = true)
         {
             return item == null ? null : GetTypeDisplayName(item.GetType(), fullName);
         }


### PR DESCRIPTION
The method clearly allows nulls. Looks like an oversight. // @JamesNK 