### PR TITLE
Fix null ref in SyntaxTokenCache (#30978)

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -1,7 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
 {
@@ -9,9 +7,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
     {
         internal static SyntaxToken Token(SyntaxKind kind, string content, params RazorDiagnostic[] diagnostics)
         {
-            if (SyntaxTokenCache.CanBeCached(kind, diagnostics))
+            if (SyntaxTokenCache.Instance.CanBeCached(kind, diagnostics))
             {
-                return SyntaxTokenCache.GetCachedToken(kind, content);
+                return SyntaxTokenCache.Instance.GetCachedToken(kind, content);
             }
 
             return new SyntaxToken(kind, content, diagnostics);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Syntax/SyntaxTokenCacheTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Syntax/SyntaxTokenCacheTest.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax
+{
+    public class SyntaxTokenCacheTest
+    {
+        // Regression test for https://github.com/dotnet/aspnetcore/issues/27154
+        [Fact]
+        public void GetCachedToken_ReturnsNewEntry()
+        {
+            // Arrange
+            var cache = new SyntaxTokenCache();
+
+            // Act
+            var token = cache.GetCachedToken(SyntaxKind.Whitespace, "Hello world");
+
+            // Assert
+            Assert.Equal(SyntaxKind.Whitespace, token.Kind);
+            Assert.Equal("Hello world", token.Content);
+            Assert.Empty(token.GetDiagnostics());
+        }
+
+        [Fact]
+        public void GetCachedToken_ReturnsCachedToken()
+        {
+            // Arrange
+            var cache = new SyntaxTokenCache();
+
+            // Act
+            var token1 = cache.GetCachedToken(SyntaxKind.Whitespace, "Hello world");
+            var token2 = cache.GetCachedToken(SyntaxKind.Whitespace, "Hello world");
+
+            // Assert
+            Assert.Same(token1, token2);
+        }
+
+        [Fact]
+        public void GetCachedToken_ReturnsDifferentEntries_IfKindsAreDifferent()
+        {
+            // Arrange
+            var cache = new SyntaxTokenCache();
+
+            // Act
+            var token1 = cache.GetCachedToken(SyntaxKind.Whitespace, "Hello world");
+            var token2 = cache.GetCachedToken(SyntaxKind.Keyword, "Hello world");
+
+            // Assert
+            Assert.NotSame(token1, token2);
+            Assert.Equal(SyntaxKind.Whitespace, token1.Kind);
+            Assert.Equal("Hello world", token1.Content);
+
+            Assert.Equal(SyntaxKind.Keyword, token2.Kind);
+            Assert.Equal("Hello world", token2.Content);
+        }
+
+        [Fact]
+        public void GetCachedToken_ReturnsDifferentEntries_IfContentsAreDifferent()
+        {
+            // Arrange
+            var cache = new SyntaxTokenCache();
+
+            // Act
+            var token1 = cache.GetCachedToken(SyntaxKind.Keyword, "Text1");
+            var token2 = cache.GetCachedToken(SyntaxKind.Keyword, "Text2");
+
+            // Assert
+            Assert.NotSame(token1, token2);
+            Assert.Equal(SyntaxKind.Keyword, token1.Kind);
+            Assert.Equal("Text1", token1.Content);
+
+            Assert.Equal(SyntaxKind.Keyword, token2.Kind);
+            Assert.Equal("Text2", token2.Content);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/30979

## Description

In 5.0 we introduced a null reference bug in the Razor compiler. We first noticed it as part of our test suite. Later StackOverflow.com reported that that their builds would frequently see this null ref. This PR ports the change in master to 5.0.

## Customer Impact

Makes StackOverflow.com happy


## Regression?
- [x] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

3.1

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

The code in question is fairly isolated to exactly one use case and we've added some tests to cover the null ref code path.

## Verification
- [ ] Manual (required) - It's difficult to reproduce manually
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [x] No
- [ ] N/A
