### PR TITLE
Caching Redis: Add option to register profiling session

### DIFF
--- a/src/Caching/StackExchangeRedis/src/PublicAPI.Unshipped.txt
+++ b/src/Caching/StackExchangeRedis/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-~Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.ProfilingSession.get -> Func<ProfilingSession>
+~Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.ProfilingSession.get -> System.Func<StackExchange.Redis.Profiling.ProfilingSession>
 ~Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.ProfilingSession.set -> void

--- a/src/Caching/StackExchangeRedis/src/PublicAPI.Unshipped.txt
+++ b/src/Caching/StackExchangeRedis/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.ProfilingSession.get -> Func<ProfilingSession>
+~Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.ProfilingSession.set -> void

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -194,10 +194,12 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
                     if (_options.ConfigurationOptions != null)
                     {
                         _connection = ConnectionMultiplexer.Connect(_options.ConfigurationOptions);
+                        _connection.RegisterProfiler(_options.ProfilingSession);
                     }
                     else
                     {
                         _connection = ConnectionMultiplexer.Connect(_options.Configuration);
+                        _connection.RegisterProfiler(_options.ProfilingSession);
                     }
                     _cache = _connection.GetDatabase();
                 }
@@ -226,10 +228,12 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
                     if (_options.ConfigurationOptions != null)
                     {
                         _connection = await ConnectionMultiplexer.ConnectAsync(_options.ConfigurationOptions).ConfigureAwait(false);
+                        _connection.RegisterProfiler(_options.ProfilingSession);
                     }
                     else
                     {
                         _connection = await ConnectionMultiplexer.ConnectAsync(_options.Configuration).ConfigureAwait(false);
+                        _connection.RegisterProfiler(_options.ProfilingSession);
                     }
 
                     _cache = _connection.GetDatabase();

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -194,13 +194,13 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
                     if (_options.ConfigurationOptions != null)
                     {
                         _connection = ConnectionMultiplexer.Connect(_options.ConfigurationOptions);
-                        _connection.RegisterProfiler(_options.ProfilingSession);
                     }
                     else
                     {
                         _connection = ConnectionMultiplexer.Connect(_options.Configuration);
-                        _connection.RegisterProfiler(_options.ProfilingSession);
                     }
+
+                    TryRegisterProfiler();
                     _cache = _connection.GetDatabase();
                 }
             }
@@ -228,20 +228,27 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
                     if (_options.ConfigurationOptions != null)
                     {
                         _connection = await ConnectionMultiplexer.ConnectAsync(_options.ConfigurationOptions).ConfigureAwait(false);
-                        _connection.RegisterProfiler(_options.ProfilingSession);
                     }
                     else
                     {
                         _connection = await ConnectionMultiplexer.ConnectAsync(_options.Configuration).ConfigureAwait(false);
-                        _connection.RegisterProfiler(_options.ProfilingSession);
                     }
 
+                    TryRegisterProfiler();
                     _cache = _connection.GetDatabase();
                 }
             }
             finally
             {
                 _connectionLock.Release();
+            }
+        }
+
+        private void TryRegisterProfiler()
+        {
+            if (_connection != null && _options.ProfilingSession != null)
+            {
+                _connection.RegisterProfiler(_options.ProfilingSession);
             }
         }
 

--- a/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheOptions.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
+using StackExchange.Redis.Profiling;
 
 namespace Microsoft.Extensions.Caching.StackExchangeRedis
 {
@@ -27,6 +29,11 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         /// The Redis instance name.
         /// </summary>
         public string InstanceName { get; set; }
+
+        /// <summary>
+        /// The Redis profiling session
+        /// </summary>
+        public Func<ProfilingSession> ProfilingSession { get; set; }
 
         RedisCacheOptions IOptions<RedisCacheOptions>.Value
         {


### PR DESCRIPTION
This PR adds possibility to register a profiling session on the `ConnectionMultiplexer`. 
This is very useful to add `Redis` to the application tracing.

```csharp
services
    .AddStackExchangeRedisCache(o =>
    {
        o.Configuration = "localhost";
        o.ProfilingSession = () => new ProfilingSession();
    })
```