### PR TITLE
Bring back working DevServer packaging setup

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -11,10 +11,22 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Set this to false because assemblies should not reference this assembly directly, (except for tests, of course). -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
+
+    <!--
+      This project compiles against Microsoft.AspNetCore.App from the SDK.
+      This ensures that it's packaging output is correct and does not include local artifacts.
+    -->
+    <UseAspNetCoreSharedRuntime>true</UseAspNetCoreSharedRuntime>
+    <DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp>true</DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.AspNetCore" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference
+      Include="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
+      PrivateAssets="All"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <Compile Include="$(SharedSourceRoot)CommandLineUtils\**\*.cs" />
   </ItemGroup>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -11,22 +11,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Set this to false because assemblies should not reference this assembly directly, (except for tests, of course). -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
-
-    <!--
-      This project compiles against Microsoft.AspNetCore.App from the SDK.
-      This ensures that it's packaging output is correct and does not include local artifacts.
-    -->
-    <UseAspNetCoreSharedRuntime>true</UseAspNetCoreSharedRuntime>
-    <DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp>true</DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp>
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <ProjectReference
-      Include="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-      PrivateAssets="All"
-      ReferenceOutputAssembly="false"
-      SkipGetTargetFrameworkProperties="true" />
+    <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <Compile Include="$(SharedSourceRoot)CommandLineUtils\**\*.cs" />
   </ItemGroup>

--- a/src/Components/WebAssembly/DevServer/src/runtimeconfig.template.json
+++ b/src/Components/WebAssembly/DevServer/src/runtimeconfig.template.json
@@ -1,3 +1,7 @@
 {
+  "framework": {
+    "name": "Microsoft.AspNetCore.App",
+    "version": "6.0.0-preview.3.21167.1"
+  },
   "rollForwardOnNoCandidateFx": 2
 }


### PR DESCRIPTION
Bring back the changes introduced in https://github.com/dotnet/aspnetcore/pull/24816 to fix https://github.com/dotnet/aspnetcore/issues/30917.

```
cat blazor-devserver.runtimeconfig.json
{
  "runtimeOptions": {
    "tfm": "net6.0",
    "framework": {
      "name": "Microsoft.AspNetCore.App",
      "version": "6.0.0-preview.3.21158.2"
    },
    "rollForwardOnNoCandidateFx": 2
  }
}
```