### PR TITLE
Update launchSettings to indicate hotReload is to be used

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Properties/launchSettings.json
@@ -28,6 +28,7 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,
+      "hotReloadProfile": "aspnetcore",
       //#if(RequiresHttps)
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#else

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Properties/launchSettings.json
@@ -29,6 +29,7 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,
+      "hotReloadProfile": "blazorwasm",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       //#if(RequiresHttps)
       "applicationUrl": "https://localhost:5001;http://localhost:5000",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
@@ -28,6 +28,7 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,
+      "hotReloadProfile": "aspnetcore",
       //#if(NoHttps)
       "applicationUrl": "http://localhost:5000",
       //#else

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
@@ -33,6 +33,7 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,
+      "hotReloadProfile": "aspnetcore",
       //#if(RequiresHttps)
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#else

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
@@ -34,6 +34,7 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,
+      "hotReloadProfile": "aspnetcore",
       //#if(EnableOpenAPI)
       "launchUrl": "swagger",
       //#else


### PR DESCRIPTION
Haven't enabled it for BlazorWasm Hosted (#30815), Grpc, F#, or Worker templates