### PR TITLE
Fix race in FrameAfterTrailers_UnexpectedFrameError 

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -1685,6 +1685,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var requestStream = await InitializeConnectionAndStreamsAsync(_noopApplication);
 
             await requestStream.SendHeadersAsync(headers, endStream: false);
+
+            // The app no-ops quickly. Wait for it here so it's not a race with the error response.
+            await requestStream.ExpectHeadersAsync();
+
             await requestStream.SendDataAsync(Encoding.UTF8.GetBytes("Hello world"));
             await requestStream.SendHeadersAsync(trailers, endStream: false);
             await requestStream.SendDataAsync(Encoding.UTF8.GetBytes("This is invalid."));


### PR DESCRIPTION
Fixes #30754 This test is racy because the app no-ops and can return headers before the error is detected. This change forces the client to wait for those headers before causing and checking for the error.

The test was at a 17/128 failure rate in the quarantine runs, and it reliably failed locally before the fix.