### PR TITLE
Fix MSB4186 error referencing Microsoft.AspNetCore.Mvc.Testing

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -29,7 +29,7 @@
     </Target>
 
   <Target Name="_AddContentRootForProjectReferences" BeforeTargets="PrepareResources" DependsOnTargets="_ResolveMvcTestProjectReferences">
-    <ItemGroup>
+    <ItemGroup Condition="'@(_ContentRootProjectReferences->Count())' != 0">
       <_ManifestProjects Include="%(_ContentRootProjectReferences.FusionName)">
         <ContentRoot>$([System.IO.Path]::GetDirectoryName(%(_ContentRootProjectReferences.MSBuildSourceProjectFile)))</ContentRoot>
       </_ManifestProjects>


### PR DESCRIPTION
**PR Title**

Fix MSB4186 error from Microsoft.AspNetCore.Mvc.Testing.

**PR Description**

Fix MSB4186 error if a project references `Microsoft.AspNetCore.Mvc.Testing` that is not itself an ASP.NET project or tests, such as a helper library in a test suite.

For some reason in this scenario the `_ContentRootProjectReferences` item is empty, which then leads to an error such as this due to the arguments into the `Path.GetDirectoryName(string)` method turning into `Path.GetDirectoryName()`:

```
C:\Users\martin.costello\.nuget\packages\microsoft.aspnetcore.mvc.testing\6.0.0-preview.2.21154.6\build\net6.0\Microsoft.AspNetCore.Mvc.Testing.targets(34,9): error MSB4186: Invalid static method invocation syntax: "[System.IO.Path]::GetDirectoryName()". Method 'System.IO.Path.GetDirectoryName' not found. Static method invocation should be of the form: $([FullTypeName]::Method()), e.g. $([System.IO.Path]::Combine(`a`, `b`)). Check that all parameters are defined, are of the correct type, and are specified in the right order. [C:\Coding\MyProject\tests\MyProject.TestInfrastructure\MyProject.TestInfrastructure.csproj]
```

This change resolves that by checking for the item group being empty.

Tested locally by applying the fix to the targets file in my NuGet package cache.
