### PR TITLE
Remove WebView dependency to AspNetCore.App

### DIFF
--- a/src/Components/WebView/WebView/src/FileExtensionContentTypeProvider.cs
+++ b/src/Components/WebView/WebView/src/FileExtensionContentTypeProvider.cs
@@ -1,0 +1,473 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// NOTE: This file is copied from src/Middleware/StaticFiles/src/IContentTypeProvider.cs
+// and made internal with a namespace change.
+// It can't be referenced directly from the StaticFiles package because that would cause this package to require
+// Microsoft.AspNetCore.App, thus preventing it from being used anywhere ASP.NET Core isn't supported (such as
+// various platforms that .NET MAUI runs on, such as Android and iOS).
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+    /// <summary>
+    /// Provides a mapping between file extensions and MIME types.
+    /// </summary>
+    internal class FileExtensionContentTypeProvider : IContentTypeProvider
+    {
+        // Notes:
+        // - This table was initially copied from IIS and has many legacy entries we will maintain for backwards compatibility.
+        // - We only plan to add new entries where we expect them to be applicable to a majority of developers such as being
+        // used in the project templates.
+        #region Extension mapping table
+        /// <summary>
+        /// Creates a new provider with a set of default mappings.
+        /// </summary>
+        public FileExtensionContentTypeProvider()
+            : this(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { ".323", "text/h323" },
+                { ".3g2", "video/3gpp2" },
+                { ".3gp2", "video/3gpp2" },
+                { ".3gp", "video/3gpp" },
+                { ".3gpp", "video/3gpp" },
+                { ".aac", "audio/aac" },
+                { ".aaf", "application/octet-stream" },
+                { ".aca", "application/octet-stream" },
+                { ".accdb", "application/msaccess" },
+                { ".accde", "application/msaccess" },
+                { ".accdt", "application/msaccess" },
+                { ".acx", "application/internet-property-stream" },
+                { ".adt", "audio/vnd.dlna.adts" },
+                { ".adts", "audio/vnd.dlna.adts" },
+                { ".afm", "application/octet-stream" },
+                { ".ai", "application/postscript" },
+                { ".aif", "audio/x-aiff" },
+                { ".aifc", "audio/aiff" },
+                { ".aiff", "audio/aiff" },
+                { ".appcache", "text/cache-manifest" },
+                { ".application", "application/x-ms-application" },
+                { ".art", "image/x-jg" },
+                { ".asd", "application/octet-stream" },
+                { ".asf", "video/x-ms-asf" },
+                { ".asi", "application/octet-stream" },
+                { ".asm", "text/plain" },
+                { ".asr", "video/x-ms-asf" },
+                { ".asx", "video/x-ms-asf" },
+                { ".atom", "application/atom+xml" },
+                { ".au", "audio/basic" },
+                { ".avi", "video/x-msvideo" },
+                { ".axs", "application/olescript" },
+                { ".bas", "text/plain" },
+                { ".bcpio", "application/x-bcpio" },
+                { ".bin", "application/octet-stream" },
+                { ".bmp", "image/bmp" },
+                { ".c", "text/plain" },
+                { ".cab", "application/vnd.ms-cab-compressed" },
+                { ".calx", "application/vnd.ms-office.calx" },
+                { ".cat", "application/vnd.ms-pki.seccat" },
+                { ".cdf", "application/x-cdf" },
+                { ".chm", "application/octet-stream" },
+                { ".class", "application/x-java-applet" },
+                { ".clp", "application/x-msclip" },
+                { ".cmx", "image/x-cmx" },
+                { ".cnf", "text/plain" },
+                { ".cod", "image/cis-cod" },
+                { ".cpio", "application/x-cpio" },
+                { ".cpp", "text/plain" },
+                { ".crd", "application/x-mscardfile" },
+                { ".crl", "application/pkix-crl" },
+                { ".crt", "application/x-x509-ca-cert" },
+                { ".csh", "application/x-csh" },
+                { ".css", "text/css" },
+                { ".csv", "text/csv" }, // https://tools.ietf.org/html/rfc7111#section-5.1
+                { ".cur", "application/octet-stream" },
+                { ".dcr", "application/x-director" },
+                { ".deploy", "application/octet-stream" },
+                { ".der", "application/x-x509-ca-cert" },
+                { ".dib", "image/bmp" },
+                { ".dir", "application/x-director" },
+                { ".disco", "text/xml" },
+                { ".dlm", "text/dlm" },
+                { ".doc", "application/msword" },
+                { ".docm", "application/vnd.ms-word.document.macroEnabled.12" },
+                { ".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
+                { ".dot", "application/msword" },
+                { ".dotm", "application/vnd.ms-word.template.macroEnabled.12" },
+                { ".dotx", "application/vnd.openxmlformats-officedocument.wordprocessingml.template" },
+                { ".dsp", "application/octet-stream" },
+                { ".dtd", "text/xml" },
+                { ".dvi", "application/x-dvi" },
+                { ".dvr-ms", "video/x-ms-dvr" },
+                { ".dwf", "drawing/x-dwf" },
+                { ".dwp", "application/octet-stream" },
+                { ".dxr", "application/x-director" },
+                { ".eml", "message/rfc822" },
+                { ".emz", "application/octet-stream" },
+                { ".eot", "application/vnd.ms-fontobject" },
+                { ".eps", "application/postscript" },
+                { ".etx", "text/x-setext" },
+                { ".evy", "application/envoy" },
+                { ".exe", "application/vnd.microsoft.portable-executable" }, // https://www.iana.org/assignments/media-types/application/vnd.microsoft.portable-executable
+                { ".fdf", "application/vnd.fdf" },
+                { ".fif", "application/fractals" },
+                { ".fla", "application/octet-stream" },
+                { ".flr", "x-world/x-vrml" },
+                { ".flv", "video/x-flv" },
+                { ".gif", "image/gif" },
+                { ".gtar", "application/x-gtar" },
+                { ".gz", "application/x-gzip" },
+                { ".h", "text/plain" },
+                { ".hdf", "application/x-hdf" },
+                { ".hdml", "text/x-hdml" },
+                { ".hhc", "application/x-oleobject" },
+                { ".hhk", "application/octet-stream" },
+                { ".hhp", "application/octet-stream" },
+                { ".hlp", "application/winhlp" },
+                { ".hqx", "application/mac-binhex40" },
+                { ".hta", "application/hta" },
+                { ".htc", "text/x-component" },
+                { ".htm", "text/html" },
+                { ".html", "text/html" },
+                { ".htt", "text/webviewhtml" },
+                { ".hxt", "text/html" },
+                { ".ical", "text/calendar" },
+                { ".icalendar", "text/calendar" },
+                { ".ico", "image/x-icon" },
+                { ".ics", "text/calendar" },
+                { ".ief", "image/ief" },
+                { ".ifb", "text/calendar" },
+                { ".iii", "application/x-iphone" },
+                { ".inf", "application/octet-stream" },
+                { ".ins", "application/x-internet-signup" },
+                { ".isp", "application/x-internet-signup" },
+                { ".IVF", "video/x-ivf" },
+                { ".jar", "application/java-archive" },
+                { ".java", "application/octet-stream" },
+                { ".jck", "application/liquidmotion" },
+                { ".jcz", "application/liquidmotion" },
+                { ".jfif", "image/pjpeg" },
+                { ".jpb", "application/octet-stream" },
+                { ".jpe", "image/jpeg" },
+                { ".jpeg", "image/jpeg" },
+                { ".jpg", "image/jpeg" },
+                { ".js", "application/javascript" },
+                { ".json", "application/json" },
+                { ".jsx", "text/jscript" },
+                { ".latex", "application/x-latex" },
+                { ".lit", "application/x-ms-reader" },
+                { ".lpk", "application/octet-stream" },
+                { ".lsf", "video/x-la-asf" },
+                { ".lsx", "video/x-la-asf" },
+                { ".lzh", "application/octet-stream" },
+                { ".m13", "application/x-msmediaview" },
+                { ".m14", "application/x-msmediaview" },
+                { ".m1v", "video/mpeg" },
+                { ".m2ts", "video/vnd.dlna.mpeg-tts" },
+                { ".m3u", "audio/x-mpegurl" },
+                { ".m4a", "audio/mp4" },
+                { ".m4v", "video/mp4" },
+                { ".man", "application/x-troff-man" },
+                { ".manifest", "application/x-ms-manifest" },
+                { ".map", "text/plain" },
+                { ".markdown", "text/markdown" },
+                { ".md", "text/markdown" },
+                { ".mdb", "application/x-msaccess" },
+                { ".mdp", "application/octet-stream" },
+                { ".me", "application/x-troff-me" },
+                { ".mht", "message/rfc822" },
+                { ".mhtml", "message/rfc822" },
+                { ".mid", "audio/mid" },
+                { ".midi", "audio/mid" },
+                { ".mix", "application/octet-stream" },
+                { ".mmf", "application/x-smaf" },
+                { ".mno", "text/xml" },
+                { ".mny", "application/x-msmoney" },
+                { ".mov", "video/quicktime" },
+                { ".movie", "video/x-sgi-movie" },
+                { ".mp2", "video/mpeg" },
+                { ".mp3", "audio/mpeg" },
+                { ".mp4", "video/mp4" },
+                { ".mp4v", "video/mp4" },
+                { ".mpa", "video/mpeg" },
+                { ".mpe", "video/mpeg" },
+                { ".mpeg", "video/mpeg" },
+                { ".mpg", "video/mpeg" },
+                { ".mpp", "application/vnd.ms-project" },
+                { ".mpv2", "video/mpeg" },
+                { ".ms", "application/x-troff-ms" },
+                { ".msi", "application/octet-stream" },
+                { ".mso", "application/octet-stream" },
+                { ".mvb", "application/x-msmediaview" },
+                { ".mvc", "application/x-miva-compiled" },
+                { ".nc", "application/x-netcdf" },
+                { ".nsc", "video/x-ms-asf" },
+                { ".nws", "message/rfc822" },
+                { ".ocx", "application/octet-stream" },
+                { ".oda", "application/oda" },
+                { ".odc", "text/x-ms-odc" },
+                { ".ods", "application/oleobject" },
+                { ".oga", "audio/ogg" },
+                { ".ogg", "video/ogg" },
+                { ".ogv", "video/ogg" },
+                { ".ogx", "application/ogg" },
+                { ".one", "application/onenote" },
+                { ".onea", "application/onenote" },
+                { ".onetoc", "application/onenote" },
+                { ".onetoc2", "application/onenote" },
+                { ".onetmp", "application/onenote" },
+                { ".onepkg", "application/onenote" },
+                { ".osdx", "application/opensearchdescription+xml" },
+                { ".otf", "font/otf" },
+                { ".p10", "application/pkcs10" },
+                { ".p12", "application/x-pkcs12" },
+                { ".p7b", "application/x-pkcs7-certificates" },
+                { ".p7c", "application/pkcs7-mime" },
+                { ".p7m", "application/pkcs7-mime" },
+                { ".p7r", "application/x-pkcs7-certreqresp" },
+                { ".p7s", "application/pkcs7-signature" },
+                { ".pbm", "image/x-portable-bitmap" },
+                { ".pcx", "application/octet-stream" },
+                { ".pcz", "application/octet-stream" },
+                { ".pdf", "application/pdf" },
+                { ".pfb", "application/octet-stream" },
+                { ".pfm", "application/octet-stream" },
+                { ".pfx", "application/x-pkcs12" },
+                { ".pgm", "image/x-portable-graymap" },
+                { ".pko", "application/vnd.ms-pki.pko" },
+                { ".pma", "application/x-perfmon" },
+                { ".pmc", "application/x-perfmon" },
+                { ".pml", "application/x-perfmon" },
+                { ".pmr", "application/x-perfmon" },
+                { ".pmw", "application/x-perfmon" },
+                { ".png", "image/png" },
+                { ".pnm", "image/x-portable-anymap" },
+                { ".pnz", "image/png" },
+                { ".pot", "application/vnd.ms-powerpoint" },
+                { ".potm", "application/vnd.ms-powerpoint.template.macroEnabled.12" },
+                { ".potx", "application/vnd.openxmlformats-officedocument.presentationml.template" },
+                { ".ppam", "application/vnd.ms-powerpoint.addin.macroEnabled.12" },
+                { ".ppm", "image/x-portable-pixmap" },
+                { ".pps", "application/vnd.ms-powerpoint" },
+                { ".ppsm", "application/vnd.ms-powerpoint.slideshow.macroEnabled.12" },
+                { ".ppsx", "application/vnd.openxmlformats-officedocument.presentationml.slideshow" },
+                { ".ppt", "application/vnd.ms-powerpoint" },
+                { ".pptm", "application/vnd.ms-powerpoint.presentation.macroEnabled.12" },
+                { ".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation" },
+                { ".prf", "application/pics-rules" },
+                { ".prm", "application/octet-stream" },
+                { ".prx", "application/octet-stream" },
+                { ".ps", "application/postscript" },
+                { ".psd", "application/octet-stream" },
+                { ".psm", "application/octet-stream" },
+                { ".psp", "application/octet-stream" },
+                { ".pub", "application/x-mspublisher" },
+                { ".qt", "video/quicktime" },
+                { ".qtl", "application/x-quicktimeplayer" },
+                { ".qxd", "application/octet-stream" },
+                { ".ra", "audio/x-pn-realaudio" },
+                { ".ram", "audio/x-pn-realaudio" },
+                { ".rar", "application/octet-stream" },
+                { ".ras", "image/x-cmu-raster" },
+                { ".rf", "image/vnd.rn-realflash" },
+                { ".rgb", "image/x-rgb" },
+                { ".rm", "application/vnd.rn-realmedia" },
+                { ".rmi", "audio/mid" },
+                { ".roff", "application/x-troff" },
+                { ".rpm", "audio/x-pn-realaudio-plugin" },
+                { ".rtf", "application/rtf" },
+                { ".rtx", "text/richtext" },
+                { ".scd", "application/x-msschedule" },
+                { ".sct", "text/scriptlet" },
+                { ".sea", "application/octet-stream" },
+                { ".setpay", "application/set-payment-initiation" },
+                { ".setreg", "application/set-registration-initiation" },
+                { ".sgml", "text/sgml" },
+                { ".sh", "application/x-sh" },
+                { ".shar", "application/x-shar" },
+                { ".sit", "application/x-stuffit" },
+                { ".sldm", "application/vnd.ms-powerpoint.slide.macroEnabled.12" },
+                { ".sldx", "application/vnd.openxmlformats-officedocument.presentationml.slide" },
+                { ".smd", "audio/x-smd" },
+                { ".smi", "application/octet-stream" },
+                { ".smx", "audio/x-smd" },
+                { ".smz", "audio/x-smd" },
+                { ".snd", "audio/basic" },
+                { ".snp", "application/octet-stream" },
+                { ".spc", "application/x-pkcs7-certificates" },
+                { ".spl", "application/futuresplash" },
+                { ".spx", "audio/ogg" },
+                { ".src", "application/x-wais-source" },
+                { ".ssm", "application/streamingmedia" },
+                { ".sst", "application/vnd.ms-pki.certstore" },
+                { ".stl", "application/vnd.ms-pki.stl" },
+                { ".sv4cpio", "application/x-sv4cpio" },
+                { ".sv4crc", "application/x-sv4crc" },
+                { ".svg", "image/svg+xml" },
+                { ".svgz", "image/svg+xml" },
+                { ".swf", "application/x-shockwave-flash" },
+                { ".t", "application/x-troff" },
+                { ".tar", "application/x-tar" },
+                { ".tcl", "application/x-tcl" },
+                { ".tex", "application/x-tex" },
+                { ".texi", "application/x-texinfo" },
+                { ".texinfo", "application/x-texinfo" },
+                { ".tgz", "application/x-compressed" },
+                { ".thmx", "application/vnd.ms-officetheme" },
+                { ".thn", "application/octet-stream" },
+                { ".tif", "image/tiff" },
+                { ".tiff", "image/tiff" },
+                { ".toc", "application/octet-stream" },
+                { ".tr", "application/x-troff" },
+                { ".trm", "application/x-msterminal" },
+                { ".ts", "video/vnd.dlna.mpeg-tts" },
+                { ".tsv", "text/tab-separated-values" },
+                { ".ttc", "application/x-font-ttf" },
+                { ".ttf", "application/x-font-ttf" },
+                { ".tts", "video/vnd.dlna.mpeg-tts" },
+                { ".txt", "text/plain" },
+                { ".u32", "application/octet-stream" },
+                { ".uls", "text/iuls" },
+                { ".ustar", "application/x-ustar" },
+                { ".vbs", "text/vbscript" },
+                { ".vcf", "text/x-vcard" },
+                { ".vcs", "text/plain" },
+                { ".vdx", "application/vnd.ms-visio.viewer" },
+                { ".vml", "text/xml" },
+                { ".vsd", "application/vnd.visio" },
+                { ".vss", "application/vnd.visio" },
+                { ".vst", "application/vnd.visio" },
+                { ".vsto", "application/x-ms-vsto" },
+                { ".vsw", "application/vnd.visio" },
+                { ".vsx", "application/vnd.visio" },
+                { ".vtx", "application/vnd.visio" },
+                { ".wasm", "application/wasm" },
+                { ".wav", "audio/wav" },
+                { ".wax", "audio/x-ms-wax" },
+                { ".wbmp", "image/vnd.wap.wbmp" },
+                { ".wcm", "application/vnd.ms-works" },
+                { ".wdb", "application/vnd.ms-works" },
+                { ".webm", "video/webm" },
+                { ".webmanifest", "application/manifest+json" }, // https://w3c.github.io/manifest/#media-type-registration
+                { ".webp", "image/webp" },
+                { ".wks", "application/vnd.ms-works" },
+                { ".wm", "video/x-ms-wm" },
+                { ".wma", "audio/x-ms-wma" },
+                { ".wmd", "application/x-ms-wmd" },
+                { ".wmf", "application/x-msmetafile" },
+                { ".wml", "text/vnd.wap.wml" },
+                { ".wmlc", "application/vnd.wap.wmlc" },
+                { ".wmls", "text/vnd.wap.wmlscript" },
+                { ".wmlsc", "application/vnd.wap.wmlscriptc" },
+                { ".wmp", "video/x-ms-wmp" },
+                { ".wmv", "video/x-ms-wmv" },
+                { ".wmx", "video/x-ms-wmx" },
+                { ".wmz", "application/x-ms-wmz" },
+                { ".woff", "application/font-woff" }, // https://www.w3.org/TR/WOFF/#appendix-b
+                { ".woff2", "font/woff2" }, // https://www.w3.org/TR/WOFF2/#IMT
+                { ".wps", "application/vnd.ms-works" },
+                { ".wri", "application/x-mswrite" },
+                { ".wrl", "x-world/x-vrml" },
+                { ".wrz", "x-world/x-vrml" },
+                { ".wsdl", "text/xml" },
+                { ".wtv", "video/x-ms-wtv" },
+                { ".wvx", "video/x-ms-wvx" },
+                { ".x", "application/directx" },
+                { ".xaf", "x-world/x-vrml" },
+                { ".xaml", "application/xaml+xml" },
+                { ".xap", "application/x-silverlight-app" },
+                { ".xbap", "application/x-ms-xbap" },
+                { ".xbm", "image/x-xbitmap" },
+                { ".xdr", "text/plain" },
+                { ".xht", "application/xhtml+xml" },
+                { ".xhtml", "application/xhtml+xml" },
+                { ".xla", "application/vnd.ms-excel" },
+                { ".xlam", "application/vnd.ms-excel.addin.macroEnabled.12" },
+                { ".xlc", "application/vnd.ms-excel" },
+                { ".xlm", "application/vnd.ms-excel" },
+                { ".xls", "application/vnd.ms-excel" },
+                { ".xlsb", "application/vnd.ms-excel.sheet.binary.macroEnabled.12" },
+                { ".xlsm", "application/vnd.ms-excel.sheet.macroEnabled.12" },
+                { ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+                { ".xlt", "application/vnd.ms-excel" },
+                { ".xltm", "application/vnd.ms-excel.template.macroEnabled.12" },
+                { ".xltx", "application/vnd.openxmlformats-officedocument.spreadsheetml.template" },
+                { ".xlw", "application/vnd.ms-excel" },
+                { ".xml", "text/xml" },
+                { ".xof", "x-world/x-vrml" },
+                { ".xpm", "image/x-xpixmap" },
+                { ".xps", "application/vnd.ms-xpsdocument" },
+                { ".xsd", "text/xml" },
+                { ".xsf", "text/xml" },
+                { ".xsl", "text/xml" },
+                { ".xslt", "text/xml" },
+                { ".xsn", "application/octet-stream" },
+                { ".xtp", "application/octet-stream" },
+                { ".xwd", "image/x-xwindowdump" },
+                { ".z", "application/x-compress" },
+                { ".zip", "application/x-zip-compressed" },
+            })
+        {
+        }
+        #endregion
+
+        /// <summary>
+        /// Creates a lookup engine using the provided mapping.
+        /// It is recommended that the IDictionary instance use StringComparer.OrdinalIgnoreCase.
+        /// </summary>
+        /// <param name="mapping"></param>
+        public FileExtensionContentTypeProvider(IDictionary<string, string> mapping)
+        {
+            if (mapping == null)
+            {
+                throw new ArgumentNullException(nameof(mapping));
+            }
+            Mappings = mapping;
+        }
+
+        /// <summary>
+        /// The cross reference table of file extensions and content-types.
+        /// </summary>
+        public IDictionary<string, string> Mappings { get; private set; }
+
+        /// <summary>
+        /// Given a file path, determine the MIME type
+        /// </summary>
+        /// <param name="subpath">A file path</param>
+        /// <param name="contentType">The resulting MIME type</param>
+        /// <returns>True if MIME type could be determined</returns>
+        public bool TryGetContentType(string subpath, [MaybeNullWhen(false)] out string contentType)
+        {
+            var extension = GetExtension(subpath);
+            if (extension == null)
+            {
+                contentType = null;
+                return false;
+            }
+            return Mappings.TryGetValue(extension, out contentType);
+        }
+
+        private static string? GetExtension(string path)
+        {
+            // Don't use Path.GetExtension as that may throw an exception if there are
+            // invalid characters in the path. Invalid characters should be handled
+            // by the FileProviders
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            int index = path.LastIndexOf('.');
+            if (index < 0)
+            {
+                return null;
+            }
+
+            return path.Substring(index);
+        }
+    }
+}

--- a/src/Components/WebView/WebView/src/IContentTypeProvider.cs
+++ b/src/Components/WebView/WebView/src/IContentTypeProvider.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// NOTE: This file is copied from src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+// and made internal with a namespace change.
+// It can't be referenced directly from the StaticFiles package because that would cause this package to require
+// Microsoft.AspNetCore.App, thus preventing it from being used anywhere ASP.NET Core isn't supported (such as
+// various platforms that .NET MAUI runs on, such as Android and iOS).
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+    /// <summary>
+    /// Used to look up MIME types given a file path
+    /// </summary>
+    internal interface IContentTypeProvider
+    {
+        /// <summary>
+        /// Given a file path, determine the MIME type
+        /// </summary>
+        /// <param name="subpath">A file path</param>
+        /// <param name="contentType">The resulting MIME type</param>
+        /// <returns>True if MIME type could be determined</returns>
+        bool TryGetContentType(string subpath, [MaybeNullWhen(false)] out string contentType);
+    }
+}

--- a/src/Components/WebView/WebView/src/Microsoft.AspNetCore.Components.WebView.csproj
+++ b/src/Components/WebView/WebView/src/Microsoft.AspNetCore.Components.WebView.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -28,7 +28,6 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components.Web" />
-    <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="Microsoft.Extensions.Configuration.Binder" />
     <Reference Include="Microsoft.Extensions.FileProviders.Embedded" />

--- a/src/Components/WebView/WebView/src/PathString.cs
+++ b/src/Components/WebView/WebView/src/PathString.cs
@@ -1,0 +1,482 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// NOTE: This file is copied from src/Http/Http.Abstractions/src/PathString.cs
+// and made internal with a namespace change.
+// It can't be referenced directly from the StaticFiles package because that would cause this package to require
+// Microsoft.AspNetCore.App, thus preventing it from being used anywhere ASP.NET Core isn't supported (such as
+// various platforms that .NET MAUI runs on, such as Android and iOS).
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+    /// <summary>
+    /// Provides correct escaping for Path and PathBase values when needed to reconstruct a request or redirect URI string
+    /// </summary>
+    [TypeConverter(typeof(PathStringConverter))]
+    internal readonly struct PathString : IEquatable<PathString>
+    {
+        /// <summary>
+        /// Represents the empty path. This field is read-only.
+        /// </summary>
+        public static readonly PathString Empty = new(string.Empty);
+
+        /// <summary>
+        /// Initialize the path string with a given value. This value must be in unescaped format. Use
+        /// PathString.FromUriComponent(value) if you have a path value which is in an escaped format.
+        /// </summary>
+        /// <param name="value">The unescaped path to be assigned to the Value property.</param>
+        public PathString(string? value)
+        {
+            if (!string.IsNullOrEmpty(value) && value[0] != '/')
+            {
+                throw new ArgumentException(Resources.FormatException_PathMustStartWithSlash(nameof(value)), nameof(value));
+            }
+            Value = value;
+        }
+
+        /// <summary>
+        /// The unescaped path value
+        /// </summary>
+        public string? Value { get; }
+
+        /// <summary>
+        /// True if the path is not empty
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(Value))]
+        public bool HasValue
+        {
+            get { return !string.IsNullOrEmpty(Value); }
+        }
+
+        /// <summary>
+        /// Provides the path string escaped in a way which is correct for combining into the URI representation.
+        /// </summary>
+        /// <returns>The escaped path value</returns>
+        public override string ToString()
+        {
+            return ToUriComponent();
+        }
+
+        /// <summary>
+        /// Provides the path string escaped in a way which is correct for combining into the URI representation.
+        /// </summary>
+        /// <returns>The escaped path value</returns>
+        public string ToUriComponent()
+        {
+            if (!HasValue)
+            {
+                return string.Empty;
+            }
+
+            var value = Value;
+            var i = 0;
+            for (; i < value.Length; i++)
+            {
+                if (!PathStringHelper.IsValidPathChar(value[i]) || PathStringHelper.IsPercentEncodedChar(value, i))
+                {
+                    break;
+                }
+            }
+
+            if (i < value.Length)
+            {
+                return ToEscapedUriComponent(value, i);
+            }
+
+            return value;
+        }
+
+        private static string ToEscapedUriComponent(string value, int i)
+        {
+            StringBuilder? buffer = null;
+
+            var start = 0;
+            var count = i;
+            var requiresEscaping = false;
+
+            while (i < value.Length)
+            {
+                var isPercentEncodedChar = PathStringHelper.IsPercentEncodedChar(value, i);
+                if (PathStringHelper.IsValidPathChar(value[i]) || isPercentEncodedChar)
+                {
+                    if (requiresEscaping)
+                    {
+                        // the current segment requires escape
+                        buffer ??= new StringBuilder(value.Length * 3);
+                        buffer.Append(Uri.EscapeDataString(value.Substring(start, count)));
+
+                        requiresEscaping = false;
+                        start = i;
+                        count = 0;
+                    }
+
+                    if (isPercentEncodedChar)
+                    {
+                        count += 3;
+                        i += 3;
+                    }
+                    else
+                    {
+                        count++;
+                        i++;
+                    }
+                }
+                else
+                {
+                    if (!requiresEscaping)
+                    {
+                        // the current segment doesn't require escape
+                        buffer ??= new StringBuilder(value.Length * 3);
+                        buffer.Append(value, start, count);
+
+                        requiresEscaping = true;
+                        start = i;
+                        count = 0;
+                    }
+
+                    count++;
+                    i++;
+                }
+            }
+
+            if (count == value.Length && !requiresEscaping)
+            {
+                return value;
+            }
+            else
+            {
+                if (count > 0)
+                {
+                    buffer ??= new StringBuilder(value.Length * 3);
+
+                    if (requiresEscaping)
+                    {
+                        buffer.Append(Uri.EscapeDataString(value.Substring(start, count)));
+                    }
+                    else
+                    {
+                        buffer.Append(value, start, count);
+                    }
+                }
+
+                return buffer?.ToString() ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Returns an PathString given the path as it is escaped in the URI format. The string MUST NOT contain any
+        /// value that is not a path.
+        /// </summary>
+        /// <param name="uriComponent">The escaped path as it appears in the URI format.</param>
+        /// <returns>The resulting PathString</returns>
+        public static PathString FromUriComponent(string uriComponent)
+        {
+            // REVIEW: what is the exactly correct thing to do?
+            return new PathString(Uri.UnescapeDataString(uriComponent));
+        }
+
+        /// <summary>
+        /// Returns an PathString given the path as from a Uri object. Relative Uri objects are not supported.
+        /// </summary>
+        /// <param name="uri">The Uri object</param>
+        /// <returns>The resulting PathString</returns>
+        public static PathString FromUriComponent(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            // REVIEW: what is the exactly correct thing to do?
+            return new PathString("/" + uri.GetComponents(UriComponents.Path, UriFormat.Unescaped));
+        }
+
+        /// <summary>
+        /// Determines whether the beginning of this <see cref="PathString"/> instance matches the specified <see cref="PathString"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="PathString"/> to compare.</param>
+        /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+        public bool StartsWithSegments(PathString other)
+        {
+            return StartsWithSegments(other, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Determines whether the beginning of this <see cref="PathString"/> instance matches the specified <see cref="PathString"/> when compared
+        /// using the specified comparison option.
+        /// </summary>
+        /// <param name="other">The <see cref="PathString"/> to compare.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how this <see cref="PathString"/> and value are compared.</param>
+        /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+        public bool StartsWithSegments(PathString other, StringComparison comparisonType)
+        {
+            var value1 = Value ?? string.Empty;
+            var value2 = other.Value ?? string.Empty;
+            if (value1.StartsWith(value2, comparisonType))
+            {
+                return value1.Length == value2.Length || value1[value2.Length] == '/';
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the beginning of this <see cref="PathString"/> instance matches the specified <see cref="PathString"/> and returns
+        /// the remaining segments.
+        /// </summary>
+        /// <param name="other">The <see cref="PathString"/> to compare.</param>
+        /// <param name="remaining">The remaining segments after the match.</param>
+        /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+        public bool StartsWithSegments(PathString other, out PathString remaining)
+        {
+            return StartsWithSegments(other, StringComparison.OrdinalIgnoreCase, out remaining);
+        }
+
+        /// <summary>
+        /// Determines whether the beginning of this <see cref="PathString"/> instance matches the specified <see cref="PathString"/> when compared
+        /// using the specified comparison option and returns the remaining segments.
+        /// </summary>
+        /// <param name="other">The <see cref="PathString"/> to compare.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how this <see cref="PathString"/> and value are compared.</param>
+        /// <param name="remaining">The remaining segments after the match.</param>
+        /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+        public bool StartsWithSegments(PathString other, StringComparison comparisonType, out PathString remaining)
+        {
+            var value1 = Value ?? string.Empty;
+            var value2 = other.Value ?? string.Empty;
+            if (value1.StartsWith(value2, comparisonType))
+            {
+                if (value1.Length == value2.Length || value1[value2.Length] == '/')
+                {
+                    remaining = new PathString(value1[value2.Length..]);
+                    return true;
+                }
+            }
+            remaining = Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the beginning of this <see cref="PathString"/> instance matches the specified <see cref="PathString"/> and returns
+        /// the matched and remaining segments.
+        /// </summary>
+        /// <param name="other">The <see cref="PathString"/> to compare.</param>
+        /// <param name="matched">The matched segments with the original casing in the source value.</param>
+        /// <param name="remaining">The remaining segments after the match.</param>
+        /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+        public bool StartsWithSegments(PathString other, out PathString matched, out PathString remaining)
+        {
+            return StartsWithSegments(other, StringComparison.OrdinalIgnoreCase, out matched, out remaining);
+        }
+
+        /// <summary>
+        /// Determines whether the beginning of this <see cref="PathString"/> instance matches the specified <see cref="PathString"/> when compared
+        /// using the specified comparison option and returns the matched and remaining segments.
+        /// </summary>
+        /// <param name="other">The <see cref="PathString"/> to compare.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how this <see cref="PathString"/> and value are compared.</param>
+        /// <param name="matched">The matched segments with the original casing in the source value.</param>
+        /// <param name="remaining">The remaining segments after the match.</param>
+        /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+        public bool StartsWithSegments(PathString other, StringComparison comparisonType, out PathString matched, out PathString remaining)
+        {
+            var value1 = Value ?? string.Empty;
+            var value2 = other.Value ?? string.Empty;
+            if (value1.StartsWith(value2, comparisonType))
+            {
+                if (value1.Length == value2.Length || value1[value2.Length] == '/')
+                {
+                    matched = new PathString(value1.Substring(0, value2.Length));
+                    remaining = new PathString(value1[value2.Length..]);
+                    return true;
+                }
+            }
+            remaining = Empty;
+            matched = Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// Adds two PathString instances into a combined PathString value.
+        /// </summary>
+        /// <returns>The combined PathString value</returns>
+        public PathString Add(PathString other)
+        {
+            if (HasValue &&
+                other.HasValue &&
+                Value[^1] == '/')
+            {
+                // If the path string has a trailing slash and the other string has a leading slash, we need
+                // to trim one of them.
+                var combined = string.Concat(Value.AsSpan(), other.Value.AsSpan(1));
+                return new PathString(combined);
+            }
+
+            return new PathString(Value + other.Value);
+        }
+
+        /// <summary>
+        /// Combines a PathString and QueryString into the joined URI formatted string value.
+        /// </summary>
+        /// <returns>The joined URI formatted string value</returns>
+        public string Add(QueryString other)
+        {
+            return ToUriComponent() + other.ToUriComponent();
+        }
+
+        /// <summary>
+        /// Compares this PathString value to another value. The default comparison is StringComparison.OrdinalIgnoreCase.
+        /// </summary>
+        /// <param name="other">The second PathString for comparison.</param>
+        /// <returns>True if both PathString values are equal</returns>
+        public bool Equals(PathString other)
+        {
+            return Equals(other, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Compares this PathString value to another value using a specific StringComparison type
+        /// </summary>
+        /// <param name="other">The second PathString for comparison</param>
+        /// <param name="comparisonType">The StringComparison type to use</param>
+        /// <returns>True if both PathString values are equal</returns>
+        public bool Equals(PathString other, StringComparison comparisonType)
+        {
+            if (!HasValue && !other.HasValue)
+            {
+                return true;
+            }
+            return string.Equals(Value, other.Value, comparisonType);
+        }
+
+        /// <summary>
+        /// Compares this PathString value to another value. The default comparison is StringComparison.OrdinalIgnoreCase.
+        /// </summary>
+        /// <param name="obj">The second PathString for comparison.</param>
+        /// <returns>True if both PathString values are equal</returns>
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+            {
+                return !HasValue;
+            }
+            return obj is PathString pathString && Equals(pathString);
+        }
+
+        /// <summary>
+        /// Returns the hash code for the PathString value. The hash code is provided by the OrdinalIgnoreCase implementation.
+        /// </summary>
+        /// <returns>The hash code</returns>
+        public override int GetHashCode()
+        {
+            return (HasValue ? StringComparer.OrdinalIgnoreCase.GetHashCode(Value) : 0);
+        }
+
+        /// <summary>
+        /// Operator call through to Equals
+        /// </summary>
+        /// <param name="left">The left parameter</param>
+        /// <param name="right">The right parameter</param>
+        /// <returns>True if both PathString values are equal</returns>
+        public static bool operator ==(PathString left, PathString right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Operator call through to Equals
+        /// </summary>
+        /// <param name="left">The left parameter</param>
+        /// <param name="right">The right parameter</param>
+        /// <returns>True if both PathString values are not equal</returns>
+        public static bool operator !=(PathString left, PathString right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="left">The left parameter</param>
+        /// <param name="right">The right parameter</param>
+        /// <returns>The ToString combination of both values</returns>
+        public static string operator +(string left, PathString right)
+        {
+            // This overload exists to prevent the implicit string<->PathString converter from
+            // trying to call the PathString+PathString operator for things that are not path strings.
+            return string.Concat(left, right.ToString());
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="left">The left parameter</param>
+        /// <param name="right">The right parameter</param>
+        /// <returns>The ToString combination of both values</returns>
+        public static string operator +(PathString left, string? right)
+        {
+            // This overload exists to prevent the implicit string<->PathString converter from
+            // trying to call the PathString+PathString operator for things that are not path strings.
+            return string.Concat(left.ToString(), right);
+        }
+
+        /// <summary>
+        /// Operator call through to Add
+        /// </summary>
+        /// <param name="left">The left parameter</param>
+        /// <param name="right">The right parameter</param>
+        /// <returns>The PathString combination of both values</returns>
+        public static PathString operator +(PathString left, PathString right)
+        {
+            return left.Add(right);
+        }
+
+        /// <summary>
+        /// Operator call through to Add
+        /// </summary>
+        /// <param name="left">The left parameter</param>
+        /// <param name="right">The right parameter</param>
+        /// <returns>The PathString combination of both values</returns>
+        public static string operator +(PathString left, QueryString right)
+        {
+            return left.Add(right);
+        }
+
+        /// <summary>
+        /// Implicitly creates a new PathString from the given string.
+        /// </summary>
+        /// <param name="s"></param>
+        public static implicit operator PathString(string? s)
+            => ConvertFromString(s);
+
+        /// <summary>
+        /// Implicitly calls ToString().
+        /// </summary>
+        /// <param name="path"></param>
+        public static implicit operator string(PathString path)
+            => path.ToString();
+
+        internal static PathString ConvertFromString(string? s)
+            => string.IsNullOrEmpty(s) ? new PathString(s) : FromUriComponent(s);
+    }
+
+    internal sealed class PathStringConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            => value is string @string
+            ? PathString.ConvertFromString(@string)
+            : base.ConvertFrom(context, culture, value);
+
+        public override object ConvertTo(ITypeDescriptorContext context,
+           CultureInfo culture, object value, Type destinationType)
+            => destinationType == typeof(string)
+            ? value.ToString() ?? string.Empty
+            : base.ConvertTo(context, culture, value, destinationType);
+    }
+}

--- a/src/Components/WebView/WebView/src/PathStringHelper.cs
+++ b/src/Components/WebView/WebView/src/PathStringHelper.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// NOTE: This file is copied from src/Http/Http.Abstractions/src/Internal/PathStringHelper.cs
+// and made internal with a namespace change.
+// It can't be referenced directly from the StaticFiles package because that would cause this package to require
+// Microsoft.AspNetCore.App, thus preventing it from being used anywhere ASP.NET Core isn't supported (such as
+// various platforms that .NET MAUI runs on, such as Android and iOS).
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+    internal static class PathStringHelper
+    {
+        // uint[] bits uses 1 cache line (Array info + 16 bytes)
+        // bool[] would use 3 cache lines (Array info + 128 bytes)
+        // So we use 128 bits rather than 128 bytes/bools
+        private static readonly uint[] ValidPathChars = {
+            0b_0000_0000__0000_0000__0000_0000__0000_0000, // 0x00 - 0x1F
+            0b_0010_1111__1111_1111__1111_1111__1101_0010, // 0x20 - 0x3F
+            0b_1000_0111__1111_1111__1111_1111__1111_1111, // 0x40 - 0x5F
+            0b_0100_0111__1111_1111__1111_1111__1111_1110, // 0x60 - 0x7F
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValidPathChar(char c)
+        {
+            // Use local array and uint .Length compare to elide the bounds check on array access
+            var validChars = ValidPathChars;
+            var i = (int)c;
+
+            // Array is in chunks of 32 bits, so get offset by dividing by 32
+            var offset = i >> 5;		// i / 32;
+            // Significant bit position is the remainder of the above calc; i % 32 => i & 31
+            var significantBit = 1u << (i & 31);
+
+            // Check offset in bounds and check if significant bit set
+            return (uint)offset < (uint)validChars.Length &&
+                ((validChars[offset] & significantBit) != 0);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPercentEncodedChar(string str, int index)
+        {
+            var len = (uint)str.Length;
+            if (str[index] == '%' && index < len - 2)
+            {
+                return AreFollowingTwoCharsHex(str, index);
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool AreFollowingTwoCharsHex(string str, int index)
+        {
+            Debug.Assert(index < str.Length - 2);
+
+            var c1 = str[index + 1];
+            var c2 = str[index + 2];
+            return IsHexadecimalChar(c1) && IsHexadecimalChar(c2);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsHexadecimalChar(char c)
+        {
+            // Between 0 - 9 or uppercased between A - F
+            return (uint)(c - '0') <= 9 || (uint)((c & ~0x20) - 'A') <= ('F' - 'A');
+        }
+    }
+}

--- a/src/Components/WebView/WebView/src/QueryString.cs
+++ b/src/Components/WebView/WebView/src/QueryString.cs
@@ -1,0 +1,304 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// NOTE: This file is copied from src/Http/Http.Abstractions/src/QueryString.cs
+// and made internal with a namespace change.
+// It can't be referenced directly from the StaticFiles package because that would cause this package to require
+// Microsoft.AspNetCore.App, thus preventing it from being used anywhere ASP.NET Core isn't supported (such as
+// various platforms that .NET MAUI runs on, such as Android and iOS).
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Components.WebView
+{
+    /// <summary>
+    /// Provides correct handling for QueryString value when needed to reconstruct a request or redirect URI string
+    /// </summary>
+    internal readonly struct QueryString : IEquatable<QueryString>
+    {
+        /// <summary>
+        /// Represents the empty query string. This field is read-only.
+        /// </summary>
+        public static readonly QueryString Empty = new QueryString(string.Empty);
+
+        /// <summary>
+        /// Initialize the query string with a given value. This value must be in escaped and delimited format with
+        /// a leading '?' character.
+        /// </summary>
+        /// <param name="value">The query string to be assigned to the Value property.</param>
+        public QueryString(string? value)
+        {
+            if (!string.IsNullOrEmpty(value) && value[0] != '?')
+            {
+                throw new ArgumentException("The leading '?' must be included for a non-empty query.", nameof(value));
+            }
+            Value = value;
+        }
+
+        /// <summary>
+        /// The escaped query string with the leading '?' character
+        /// </summary>
+        public string? Value { get; }
+
+        /// <summary>
+        /// True if the query string is not empty
+        /// </summary>
+        public bool HasValue => !string.IsNullOrEmpty(Value);
+
+        /// <summary>
+        /// Provides the query string escaped in a way which is correct for combining into the URI representation.
+        /// A leading '?' character will be included unless the Value is null or empty. Characters which are potentially
+        /// dangerous are escaped.
+        /// </summary>
+        /// <returns>The query string value</returns>
+        public override string ToString()
+        {
+            return ToUriComponent();
+        }
+
+        /// <summary>
+        /// Provides the query string escaped in a way which is correct for combining into the URI representation.
+        /// A leading '?' character will be included unless the Value is null or empty. Characters which are potentially
+        /// dangerous are escaped.
+        /// </summary>
+        /// <returns>The query string value</returns>
+        public string ToUriComponent()
+        {
+            // Escape things properly so System.Uri doesn't mis-interpret the data.
+            return !string.IsNullOrEmpty(Value) ? Value!.Replace("#", "%23") : string.Empty;
+        }
+
+        /// <summary>
+        /// Returns an QueryString given the query as it is escaped in the URI format. The string MUST NOT contain any
+        /// value that is not a query.
+        /// </summary>
+        /// <param name="uriComponent">The escaped query as it appears in the URI format.</param>
+        /// <returns>The resulting QueryString</returns>
+        public static QueryString FromUriComponent(string uriComponent)
+        {
+            if (string.IsNullOrEmpty(uriComponent))
+            {
+                return new QueryString(string.Empty);
+            }
+            return new QueryString(uriComponent);
+        }
+
+        /// <summary>
+        /// Returns an QueryString given the query as from a Uri object. Relative Uri objects are not supported.
+        /// </summary>
+        /// <param name="uri">The Uri object</param>
+        /// <returns>The resulting QueryString</returns>
+        public static QueryString FromUriComponent(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            string queryValue = uri.GetComponents(UriComponents.Query, UriFormat.UriEscaped);
+            if (!string.IsNullOrEmpty(queryValue))
+            {
+                queryValue = "?" + queryValue;
+            }
+            return new QueryString(queryValue);
+        }
+
+        /// <summary>
+        /// Create a query string with a single given parameter name and value.
+        /// </summary>
+        /// <param name="name">The un-encoded parameter name</param>
+        /// <param name="value">The un-encoded parameter value</param>
+        /// <returns>The resulting QueryString</returns>
+        public static QueryString Create(string name, string value)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (!string.IsNullOrEmpty(value))
+            {
+                value = UrlEncoder.Default.Encode(value);
+            }
+            return new QueryString($"?{UrlEncoder.Default.Encode(name)}={value}");
+        }
+
+        /// <summary>
+        /// Creates a query string composed from the given name value pairs.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns>The resulting QueryString</returns>
+        public static QueryString Create(IEnumerable<KeyValuePair<string, string?>> parameters)
+        {
+            var builder = new StringBuilder();
+            var first = true;
+            foreach (var pair in parameters)
+            {
+                AppendKeyValuePair(builder, pair.Key, pair.Value, first);
+                first = false;
+            }
+
+            return new QueryString(builder.ToString());
+        }
+
+        /// <summary>
+        /// Creates a query string composed from the given name value pairs.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns>The resulting QueryString</returns>
+        public static QueryString Create(IEnumerable<KeyValuePair<string, StringValues>> parameters)
+        {
+            var builder = new StringBuilder();
+            var first = true;
+
+            foreach (var pair in parameters)
+            {
+                // If nothing in this pair.Values, append null value and continue
+                if (StringValues.IsNullOrEmpty(pair.Value))
+                {
+                    AppendKeyValuePair(builder, pair.Key, null, first);
+                    first = false;
+                    continue;
+                }
+                // Otherwise, loop through values in pair.Value
+                foreach (var value in pair.Value)
+                {
+                    AppendKeyValuePair(builder, pair.Key, value, first);
+                    first = false;
+                }
+            }
+
+            return new QueryString(builder.ToString());
+        }
+
+        /// <summary>
+        /// Concatenates <paramref name="other"/> to the current query string.
+        /// </summary>
+        /// <param name="other">The <see cref="QueryString"/> to concatenate.</param>
+        /// <returns>The concatenated <see cref="QueryString"/>.</returns>
+        public QueryString Add(QueryString other)
+        {
+            if (!HasValue || Value!.Equals("?", StringComparison.Ordinal))
+            {
+                return other;
+            }
+            if (!other.HasValue || other.Value!.Equals("?", StringComparison.Ordinal))
+            {
+                return this;
+            }
+
+            // ?name1=value1 Add ?name2=value2 returns ?name1=value1&name2=value2
+            return new QueryString(Value + "&" + other.Value.Substring(1));
+        }
+
+        /// <summary>
+        /// Concatenates a query string with <paramref name="name"/> and <paramref name="value"/>
+        /// to the current query string.
+        /// </summary>
+        /// <param name="name">The name of the query string to concatenate.</param>
+        /// <param name="value">The value of the query string to concatenate.</param>
+        /// <returns>The concatenated <see cref="QueryString"/>.</returns>
+        public QueryString Add(string name, string value)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (!HasValue || Value!.Equals("?", StringComparison.Ordinal))
+            {
+                return Create(name, value);
+            }
+
+            var builder = new StringBuilder(Value);
+            AppendKeyValuePair(builder, name, value, first: false);
+            return new QueryString(builder.ToString());
+        }
+
+        /// <summary>
+        /// Evalutes if the current query string is equal to <paramref name="other"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="QueryString"/> to compare.</param>
+        /// <returns><see langword="true"/> if the ssquery strings are equal.</returns>
+        public bool Equals(QueryString other)
+        {
+            if (!HasValue && !other.HasValue)
+            {
+                return true;
+            }
+            return string.Equals(Value, other.Value, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Evaluates if the current query string is equal to an object <paramref name="obj"/>.
+        /// </summary>
+        /// <param name="obj">An object to compare.</param>
+        /// <returns><see langword="true" /> if the query strings are equal.</returns>
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return !HasValue;
+            }
+            return obj is QueryString && Equals((QueryString)obj);
+        }
+
+        /// <summary>
+        /// Gets a hash code for the value.
+        /// </summary>
+        /// <returns>The hash code as an <see cref="int"/>.</returns>
+        public override int GetHashCode()
+        {
+            return (HasValue ? Value!.GetHashCode() : 0);
+        }
+
+        /// <summary>
+        /// Evaluates if one query string is equal to another.
+        /// </summary>
+        /// <param name="left">A <see cref="QueryString"/> instance.</param>
+        /// <param name="right">A <see cref="QueryString"/> instance.</param>
+        /// <returns><see langword="true" /> if the query strings are equal.</returns>
+        public static bool operator ==(QueryString left, QueryString right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Evaluates if one query string is not equal to another.
+        /// </summary>
+        /// <param name="left">A <see cref="QueryString"/> instance.</param>
+        /// <param name="right">A <see cref="QueryString"/> instance.</param>
+        /// <returns><see langword="true" /> if the query strings are not equal.</returns>
+        public static bool operator !=(QueryString left, QueryString right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Concatenates <paramref name="left"/> and <paramref name="right"/> into a single query string.
+        /// </summary>
+        /// <param name="left">A <see cref="QueryString"/> instance.</param>
+        /// <param name="right">A <see cref="QueryString"/> instance.</param>
+        /// <returns>The concatenated <see cref="QueryString"/>.</returns>
+        public static QueryString operator +(QueryString left, QueryString right)
+        {
+            return left.Add(right);
+        }
+
+        private static void AppendKeyValuePair(StringBuilder builder, string key, string? value, bool first)
+        {
+            builder.Append(first ? "?" : "&");
+            builder.Append(UrlEncoder.Default.Encode(key));
+            builder.Append("=");
+            if (!string.IsNullOrEmpty(value))
+            {
+                builder.Append(UrlEncoder.Default.Encode(value));
+            }
+        }
+    }
+}

--- a/src/Components/WebView/WebView/src/Resources.resx
+++ b/src/Components/WebView/WebView/src/Resources.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Exception_PathMustStartWithSlash" xml:space="preserve">
+    <value>The path in '{0}' must start with '/'.</value>
+  </data>
+</root>

--- a/src/Components/WebView/WebView/src/StaticContentProvider.cs
+++ b/src/Components/WebView/WebView/src/StaticContentProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Text;
-using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Components.WebView

--- a/src/Components/WebView/WebView/src/StaticWebAssetsLoader.cs
+++ b/src/Components/WebView/WebView/src/StaticWebAssetsLoader.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 


### PR DESCRIPTION
The Blazor Desktop project must not depend on Microsoft.AspNetCore.App because it needs to run on almost any platform, including Android/iOS. But AspNetCore.App doesn't run on those platforms. This changes WebView to not use any packages that are part of AspNetCore.App, such as StaticFiles and Http.Abstractions. Instead, it has copies of those files.

@Tratcher - I had to "steal" some code you know a thing or two about. This change is unlikely to be a good long-term solution but this un-blocks ongoing work. As long as this change isn't too bananas I'd like to go with it and then spend time discussing better long-term solutions.

@javiercn / @pranavkm - I had to steal a bit more code because of both the MIME type file content thing, but also due to using PathString and its dependencies.

@SteveSandersonMS - this is FYI to you so we make sure we don't accidentally re-depend on Microsoft.AspNetCore.App. Eventually between various testing efforts we'll have more reliable testing, such as vendor-based testing.