### PR TITLE
Use longer delay in test

### DIFF
--- a/src/Testing/test/TaskExtensionsTest.cs
+++ b/src/Testing/test/TaskExtensionsTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,7 +13,9 @@ namespace Microsoft.AspNetCore.Testing
         [Fact]
         public async Task TimeoutAfterTest()
         {
-            await Assert.ThrowsAsync<TimeoutException>(async () => await Task.Delay(1000).TimeoutAfter(TimeSpan.FromMilliseconds(50)));
+            var cts = new CancellationTokenSource();
+            await Assert.ThrowsAsync<TimeoutException>(async () => await Task.Delay(30000, cts.Token).TimeoutAfter(TimeSpan.FromMilliseconds(50)));
+            cts.Cancel();
         }
     }
 }


### PR DESCRIPTION
Test failed on an unrelated PR
1 second is too short, could easily fail on a slow or bogged down computer.