### PR TITLE
Suppress generating source checksums when configured

### DIFF
--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/targets/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.targets
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/targets/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.targets
@@ -10,5 +10,8 @@
     <RazorUpToDateReloadFileTypes>$(RazorUpToDateReloadFileTypes.Replace('.cshtml', ''))</RazorUpToDateReloadFileTypes>
 
     <AddCshtmlFilesToDotNetWatchList>false</AddCshtmlFilesToDotNetWatchList>
+
+    <!-- Generate checksum attributes used to determine if a compiled view is out-of-sync with any of it's inputs -->
+    <GenerateRazorMetadataSourceChecksumAttributes>true</GenerateRazorMetadataSourceChecksumAttributes>
   </PropertyGroup>
 </Project>

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptor.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptionsBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptionsBuilder.cs
@@ -52,7 +52,10 @@ namespace Microsoft.AspNetCore.Razor.Language
                 SuppressMetadataAttributes,
                 SuppressPrimaryMethodBody,
                 SuppressNullabilityEnforcement,
-                OmitMinimizedComponentAttributeValues);
+                OmitMinimizedComponentAttributeValues)
+            {
+                SuppressMetadataSourceChecksumAttributes = SuppressMetadataSourceChecksumAttributes,
+            };
         }
 
         public override void SetDesignTime(bool designTime)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/MetadataAttributePass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/MetadataAttributePass.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -89,6 +89,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
             if (insert == null)
             {
                 // Can't find a place to put the attributes, just bail.
+                return;
+            }
+
+            if (documentNode.Options.SuppressMetadataSourceChecksumAttributes)
+            {
+                // Checksum attributes are turned off (or options not populated), nothing to do.
                 return;
             }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
@@ -108,6 +108,15 @@ namespace Microsoft.AspNetCore.Razor.Language
         public virtual bool SuppressMetadataAttributes { get; protected set; }
 
         /// <summary>
+        /// Gets a value that indicates whether to suppress the <c>RazorSourceChecksumAttribute</c>.
+        /// <para>
+        /// Used by default in .NET 6 apps since including a type-level attribute that changes on every
+        /// edit are treated as rude edits by hot reload.
+        /// </para>
+        /// </summary>
+        internal bool SuppressMetadataSourceChecksumAttributes { get; set; }
+
+        /// <summary>
         /// Gets or sets a value that determines if an empty body is generated for the primary method.
         /// </summary>
         public virtual bool SuppressPrimaryMethodBody { get; protected set; }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
@@ -50,6 +50,15 @@ namespace Microsoft.AspNetCore.Razor.Language
         public virtual bool SuppressMetadataAttributes { get; set; }
 
         /// <summary>
+        /// Gets a value that indicates whether to suppress the <c>RazorSourceChecksumAttribute</c>.
+        /// <para>
+        /// Used by default in .NET 6 apps since including a type-level attribute that changes on every
+        /// edit are treated as rude edits by hot reload.
+        /// </para>
+        /// </summary>
+        internal bool SuppressMetadataSourceChecksumAttributes { get; set; }
+
+        /// <summary>
         /// Gets or sets a value that determines if an empty body is generated for the primary method.
         /// </summary>
         public virtual bool SuppressPrimaryMethodBody { get; set; }


### PR DESCRIPTION
Hot reload / EnC does not like it when type level attributes are modified. Razor views and Pages
include a RazorSourceChecksumAttribute that includes a checksum of all of it's inputs (current cshtml file, and
all _ViewImports that contribute to it). It's used used by runtime compilation to tell if the compiled view is
current compared to it's inputs. However, it gets in the way with enc since editing a file updates the checksum.

We'll disable this feature by default in RazorSourceGenerator, and enable it using an MSBuild switch that's configured
by runtime compilation


