### PR TITLE
Add helpful log message and exception when exception handler returns 404

### DIFF
--- a/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
@@ -20,11 +20,6 @@ namespace Microsoft.AspNetCore.Diagnostics
         private static readonly Action<ILogger, Exception> _errorHandlerException =
             LoggerMessage.Define(LogLevel.Error, new EventId(3, "Exception"), "An exception was thrown attempting to execute the error handler.");
 
-        private static readonly Action<ILogger, Exception?> _errorHandlerNotFound =
-            LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), "The exception handler configured on ExceptionHandlerOptions produced a 404 status response. " +
-                "An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured ExceptionHandlerOptions.ExceptionHandlingPath. " +
-                "If the exception handler is expected to return 404 status responses then set ExceptionHandlerOptions.AllowStatusCode404Response to true.");
-
         // DeveloperExceptionPageMiddleware
         private static readonly Action<ILogger, Exception?> _responseStartedErrorPageMiddleware =
             LoggerMessage.Define(LogLevel.Warning, new EventId(2, "ResponseStarted"), "The response has already started, the error page middleware will not be executed.");
@@ -45,11 +40,6 @@ namespace Microsoft.AspNetCore.Diagnostics
         public static void ErrorHandlerException(this ILogger logger, Exception exception)
         {
             _errorHandlerException(logger, exception);
-        }
-
-        public static void ErrorHandlerNotFound(this ILogger logger)
-        {
-            _errorHandlerNotFound(logger, null);
         }
 
         public static void ResponseStartedErrorPageMiddleware(this ILogger logger)

--- a/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Diagnostics
@@ -20,7 +21,9 @@ namespace Microsoft.AspNetCore.Diagnostics
             LoggerMessage.Define(LogLevel.Error, new EventId(3, "Exception"), "An exception was thrown attempting to execute the error handler.");
 
         private static readonly Action<ILogger, Exception?> _errorHandlerNotFound =
-            LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), "No exception handler was found, rethrowing original exception.");
+            LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), $"The exception handler configured on {nameof(ExceptionHandlerOptions)} produced a 404 status response. " +
+                $"An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured {nameof(ExceptionHandlerOptions.ExceptionHandlingPath)}. " +
+                $"If the exception handler should be allowed to return 404 status responses, {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} must be set to true.");
 
         // DeveloperExceptionPageMiddleware
         private static readonly Action<ILogger, Exception?> _responseStartedErrorPageMiddleware =

--- a/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
@@ -21,9 +21,9 @@ namespace Microsoft.AspNetCore.Diagnostics
             LoggerMessage.Define(LogLevel.Error, new EventId(3, "Exception"), "An exception was thrown attempting to execute the error handler.");
 
         private static readonly Action<ILogger, Exception?> _errorHandlerNotFound =
-            LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), $"The exception handler configured on {nameof(ExceptionHandlerOptions)} produced a 404 status response. " +
-                $"An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured {nameof(ExceptionHandlerOptions.ExceptionHandlingPath)}. " +
-                $"If the exception handler is expected to return 404 status responses then set {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} to true.");
+            LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), $"The exception handler configured on ExceptionHandlerOptions produced a 404 status response. " +
+                $"An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured ExceptionHandlerOptions.ExceptionHandlingPath. " +
+                $"If the exception handler is expected to return 404 status responses then set ExceptionHandlerOptions.AllowStatusCode404Response to true.");
 
         // DeveloperExceptionPageMiddleware
         private static readonly Action<ILogger, Exception?> _responseStartedErrorPageMiddleware =

--- a/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
@@ -21,9 +21,9 @@ namespace Microsoft.AspNetCore.Diagnostics
             LoggerMessage.Define(LogLevel.Error, new EventId(3, "Exception"), "An exception was thrown attempting to execute the error handler.");
 
         private static readonly Action<ILogger, Exception?> _errorHandlerNotFound =
-            LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), $"The exception handler configured on ExceptionHandlerOptions produced a 404 status response. " +
-                $"An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured ExceptionHandlerOptions.ExceptionHandlingPath. " +
-                $"If the exception handler is expected to return 404 status responses then set ExceptionHandlerOptions.AllowStatusCode404Response to true.");
+            LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), "The exception handler configured on ExceptionHandlerOptions produced a 404 status response. " +
+                "An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured ExceptionHandlerOptions.ExceptionHandlingPath. " +
+                "If the exception handler is expected to return 404 status responses then set ExceptionHandlerOptions.AllowStatusCode404Response to true.");
 
         // DeveloperExceptionPageMiddleware
         private static readonly Action<ILogger, Exception?> _responseStartedErrorPageMiddleware =

--- a/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsLoggerExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Diagnostics
         private static readonly Action<ILogger, Exception?> _errorHandlerNotFound =
             LoggerMessage.Define(LogLevel.Warning, new EventId(4, "HandlerNotFound"), $"The exception handler configured on {nameof(ExceptionHandlerOptions)} produced a 404 status response. " +
                 $"An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured {nameof(ExceptionHandlerOptions.ExceptionHandlingPath)}. " +
-                $"If the exception handler should be allowed to return 404 status responses, {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} must be set to true.");
+                $"If the exception handler is expected to return 404 status responses then set {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} to true.");
 
         // DeveloperExceptionPageMiddleware
         private static readonly Action<ILogger, Exception?> _responseStartedErrorPageMiddleware =

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -143,6 +143,8 @@ namespace Microsoft.AspNetCore.Diagnostics
                 }
 
                 _logger.ErrorHandlerNotFound();
+
+                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException($"No exception handler was found, see inner exception for details of original exception. If an exception should not be thrown for 404 responses, set {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} to true.", edi.SourceException));
             }
             catch (Exception ex2)
             {
@@ -154,7 +156,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                 context.Request.Path = originalPath;
             }
 
-            edi.Throw(); // Re-throw the original if we couldn't handle it
+            edi.Throw(); // Re-throw wrapped exception or the original if we couldn't handle it
         }
 
         private static void ClearHttpContext(HttpContext context)

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -143,8 +143,8 @@ namespace Microsoft.AspNetCore.Diagnostics
                 }
 
                 edi = ExceptionDispatchInfo.Capture(new InvalidOperationException($"The exception handler configured on {nameof(ExceptionHandlerOptions)} produced a 404 status response. " +
-                $"An {nameof(InvalidOperationException)} containing the original exception will be thrown since this is often due to a misconfigured {nameof(ExceptionHandlerOptions.ExceptionHandlingPath)}. " +
-                $"If the exception handler is expected to return 404 status responses then set {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} to true.", edi.SourceException));
+                    $"This {nameof(InvalidOperationException)} containing the original exception was thrown since this is often due to a misconfigured {nameof(ExceptionHandlerOptions.ExceptionHandlingPath)}. " +
+                    $"If the exception handler is expected to return 404 status responses then set {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} to true.", edi.SourceException));
             }
             catch (Exception ex2)
             {

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -142,9 +142,9 @@ namespace Microsoft.AspNetCore.Diagnostics
                     return;
                 }
 
-                _logger.ErrorHandlerNotFound();
-
-                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException($"No exception handler was found, see inner exception for details of original exception. If an exception should not be thrown for 404 responses, set {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} to true.", edi.SourceException));
+                edi = ExceptionDispatchInfo.Capture(new InvalidOperationException($"The exception handler configured on {nameof(ExceptionHandlerOptions)} produced a 404 status response. " +
+                $"An {nameof(InvalidOperationException)} containing the original exception will be thrown since this is often due to a misconfigured {nameof(ExceptionHandlerOptions.ExceptionHandlingPath)}. " +
+                $"If the exception handler is expected to return 404 status responses then set {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} to true.", edi.SourceException));
             }
             catch (Exception ex2)
             {

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -544,9 +544,9 @@ namespace Microsoft.AspNetCore.Diagnostics
             Assert.Contains(sink.Writes, w =>
                 w.LogLevel == LogLevel.Warning
                 && w.EventId == 4
-                && w.Message == $"The exception handler configured on {nameof(ExceptionHandlerOptions)} produced a 404 status response. " +
-                $"An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured {nameof(ExceptionHandlerOptions.ExceptionHandlingPath)}. " +
-                $"If the exception handler should be allowed to return 404 status responses, {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} must be set to true.");
+                && w.Message == $"The exception handler configured on ExceptionHandlerOptions produced a 404 status response. " +
+                $"An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured ExceptionHandlingPath. " +
+                $"If the exception handler should be allowed to return 404 status responses, AllowStatusCode404Response must be set to true.");
         }
 
         [Fact]

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -496,7 +496,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                             // Invalid operation exception
                             Assert.NotNull(exception);
                             Assert.Equal("The exception handler configured on ExceptionHandlerOptions produced a 404 status response. " +
-                "An InvalidOperationException containing the original exception will be thrown since this is often due to a misconfigured ExceptionHandlingPath. " +
+                "This InvalidOperationException containing the original exception was thrown since this is often due to a misconfigured ExceptionHandlingPath. " +
                 "If the exception handler is expected to return 404 status responses then set AllowStatusCode404Response to true.", exception.Message);
 
                             // The original exception is inner exception

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -502,7 +502,7 @@ namespace Microsoft.AspNetCore.Diagnostics
 
                             // Invalid operation exception
                             Assert.NotNull(exception);
-                            Assert.Equal($"No exception handler was found, see inner exception for details of original exception. If an exception should not be thrown for 404 responses, set {nameof(ExceptionHandlerOptions.AllowStatusCode404Response)} to true.", exception.Message);
+                            Assert.Equal("No exception handler was found, see inner exception for details of original exception. If an exception should not be thrown for 404 responses, set AllowStatusCode404Response to true.", exception.Message);
 
                             // The original exception is inner exception
                             Assert.NotNull(exception.InnerException);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/31024. 

This change adds a more helpful (and vastly more verbose) log message and wraps the original exception when an exception handler returns a 404. Hopefully the log message and wrapped exception guides folks to set `ExceptionHandlerOptions.AllowStatusCode404Response` when needed.