### PR TITLE
Components test parole for good behavior

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
@@ -19,7 +19,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24688")]
         public override void EventDuringBatchRendering_CanTriggerDOMEvents()
         {
             base.EventDuringBatchRendering_CanTriggerDOMEvents();

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public override void EventDuringBatchRendering_CanTriggerDOMEvents()
         {
             base.EventDuringBatchRendering_CanTriggerDOMEvents();

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerGlobalizationTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerGlobalizationTest.cs
@@ -35,7 +35,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Theory]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27556")]
         [InlineData("en-US")]
         [InlineData("fr-FR")]
         public override void CanSetCultureAndParseCultureSensitiveNumbersAndDates(string culture)

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -42,7 +42,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void CanRenderTextOnlyComponent()
         {
             var appElement = Browser.MountTestComponent<TextOnlyComponent>();

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -48,7 +48,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void BubblingStandardEvent_FiredOnElementWithoutHandler()
         {
             Browser.Exists(By.Id("button-without-onclick")).Click();

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -48,6 +48,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void BubblingStandardEvent_FiredOnElementWithoutHandler()
         {
             Browser.Exists(By.Id("button-without-onclick")).Click();

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -176,6 +176,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void PreventDefault_DotNotApplyByDefault()
         {
             var appElement = Browser.MountTestComponent<EventPreventDefaultComponent>();
@@ -184,6 +185,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void InputEvent_RespondsOnKeystrokes()
         {
             Browser.MountTestComponent<InputEventComponent>();
@@ -201,6 +203,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void InputEvent_RespondsOnKeystrokes_EvenIfUpdatesAreLaggy()
         {
             // This test doesn't mean much on WebAssembly - it just shows that even if the CPU is locked

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -176,7 +176,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25929")]
         public void PreventDefault_DotNotApplyByDefault()
         {
             var appElement = Browser.MountTestComponent<EventPreventDefaultComponent>();
@@ -185,7 +184,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27397")]
         public void InputEvent_RespondsOnKeystrokes()
         {
             Browser.MountTestComponent<InputEventComponent>();
@@ -203,7 +201,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23757")]
         public void InputEvent_RespondsOnKeystrokes_EvenIfUpdatesAreLaggy()
         {
             // This test doesn't mean much on WebAssembly - it just shows that even if the CPU is locked

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -195,7 +195,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27398")]
         public void InputDateInteractsWithEditContext_NonNullableDateTime()
         {
             var appElement = MountTypicalValidationComponent();
@@ -304,7 +303,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24850")]
         public void InputRadioGroupWithoutNameInteractsWithEditContext()
         {
             var appElement = MountTypicalValidationComponent();
@@ -344,7 +342,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24850")]
         public void InputRadioGroupsWithNamesNestedInteractWithEditContext()
         {
             var appElement = MountTypicalValidationComponent();

--- a/src/Components/test/E2ETest/Tests/GlobalizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/GlobalizationTest.cs
@@ -89,7 +89,6 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
         [Theory]
         [InlineData("en-US")]
         [InlineData("fr-FR")]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27155")]
         public void CanSetCultureAndParseCultureInvariantNumbersAndDatesWithInputFields(string culture)
         {
             var cultureInfo = CultureInfo.GetCultureInfo(culture);

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -36,7 +36,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23366")]
         public void BenchmarksRunWithoutError()
         {
             // In CI, we only verify that the benchmarks run without throwing any

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -508,12 +508,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23596")]
         public void PreventDefault_CanBlockNavigation_ForInternalNavigation_PreventDefaultTarget()
             => PreventDefault_CanBlockNavigation("internal", "target");
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23596")]
         public void PreventDefault_CanBlockNavigation_ForExternalNavigation_PreventDefaultAncestor()
             => PreventDefault_CanBlockNavigation("external", "ancestor");
 

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -508,10 +508,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void PreventDefault_CanBlockNavigation_ForInternalNavigation_PreventDefaultTarget()
             => PreventDefault_CanBlockNavigation("internal", "target");
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void PreventDefault_CanBlockNavigation_ForExternalNavigation_PreventDefaultAncestor()
             => PreventDefault_CanBlockNavigation("external", "ancestor");
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyLazyLoadTest.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyLazyLoadTest.cs
@@ -36,7 +36,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23856")]
         public void CanLazyLoadOnRouteChange()
         {
             // Navigate to a page without any lazy-loaded dependencies
@@ -61,7 +60,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23856")]
         public void CanLazyLoadOnFirstVisit()
         {
             // Navigate to a page with lazy loaded assemblies for the first time


### PR DESCRIPTION
Unquarantine tests that are stable in the past 30 days from https://github.com/dotnet/aspnetcore/issues/29698 all of these tests haven't failed except for a weird 6 failure spike on 3/02 where selenium looked borked.

Will split any remaining tests in that issue back out into individual issues