### PR TITLE
Resolve remaining credscan bugs

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -2,6 +2,10 @@
   "tool": "Credential Scanner",
   "suppressions": [
     {
+      "placeholder": "aspnetcore",
+      "_justification": "This is a fake password used in test code."
+    },
+    {
       "placeholder": "password",
       "_justification": "This is a fake password used in test code."
     },
@@ -23,6 +27,98 @@
     },
     {
       "file": "\\src\\Servers\\Kestrel\\shared\\test\\TestCertificates\\testCert.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\DataProtection\\DataProtection\\test\\TestFiles\\TestCert1.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\DataProtection\\DataProtection\\test\\TestFiles\\TestCert2.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\DataProtection\\Extensions\\test\\TestFiles\\TestCert.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\DataProtection\\Extensions\\test\\TestFiles\\TestCert2.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\DataProtection\\Extensions\\test\\TestFiles\\TestCert3.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\DataProtection\\Extensions\\test\\TestFiles\\TestCert3WithoutPrivateKey.pfx",
+      "_justification": "Legitimate UT certificate file without private key"
+    },
+    {
+      "file": "\\src\\DataProtection\\Extensions\\test\\TestFiles\\TestCertWithoutPrivateKey.pfx",
+      "_justification": "Legitimate UT certificate file without private key"
+    },
+    {
+      "file": "\\src\\DefaultBuilder\\test\\Microsoft.AspNetCore.FunctionalTests\\testCert.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Identity\\ApiAuthorization.IdentityServer\\test\\current.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Identity\\ApiAuthorization.IdentityServer\\test\\expired.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Identity\\ApiAuthorization.IdentityServer\\test\\future.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Identity\\ApiAuthorization.IdentityServer\\test\\test.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Middleware\\WebSockets\\test\\ConformanceTests\\AutobahnTestApp\\TestResources\\testCert.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Security\\Authentication\\Negotiate\\test\\Negotiate.FunctionalTest\\negotiateAuthCert.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Servers\\IIS\\tools\\TestCert.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Servers\\Kestrel\\shared\\test\\TestCertificates\\aspnetdevcert.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Servers\\Kestrel\\shared\\test\\TestCertificates\\eku.client.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Servers\\Kestrel\\shared\\test\\TestCertificates\\eku.code_signing.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Servers\\Kestrel\\shared\\test\\TestCertificates\\eku.multiple_usages.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Servers\\Kestrel\\shared\\test\\TestCertificates\\eku.server.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\Servers\\Kestrel\\shared\\test\\TestCertificates\\no_extensions.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\SignalR\\clients\\ts\\FunctionalTests\\testCert.pfx",
+      "_justification": "Legitimate UT certificate file with private key"
+    },
+    {
+      "file": "\\src\\SignalR\\clients\\ts\\FunctionalTests\\testCertECC.pfx",
       "_justification": "Legitimate UT certificate file with private key"
     },
     {
@@ -51,6 +147,10 @@
     },
     {
       "file": "\\src\\Servers\\Kestrel\\shared\\test\\TestCertificates\\https-rsa.key",
+      "_justification": "Legitimate key file used for testing"
+    },
+    {
+      "file": "\\src\\SignalR\\clients\\ts\\FunctionalTests\\node_modules\\https-proxy-agent\\node_modules\\agent-base\\test\\ssl-cert-snakeoil.key",
       "_justification": "Legitimate key file used for testing"
     }
   ]

--- a/src/Http/Headers/test/CacheControlHeaderValueTest.cs
+++ b/src/Http/Headers/test/CacheControlHeaderValueTest.cs
@@ -115,21 +115,21 @@ namespace Microsoft.Net.Http.Headers
 
             cacheControl.NoCache = true;
             Assert.Equal("no-cache", cacheControl.ToString());
-            cacheControl.NoCacheHeaders.Add("token1");
-            Assert.Equal("no-cache=\"token1\"", cacheControl.ToString());
+            cacheControl.NoCacheHeaders.Add("PLACEHOLDER1");
+            Assert.Equal("no-cache=\"PLACEHOLDER1\"", cacheControl.ToString());
             cacheControl.Public = true;
-            Assert.Equal("public, no-cache=\"token1\"", cacheControl.ToString());
+            Assert.Equal("public, no-cache=\"PLACEHOLDER1\"", cacheControl.ToString());
 
             cacheControl = new CacheControlHeaderValue();
             cacheControl.Private = true;
             Assert.Equal("private", cacheControl.ToString());
-            cacheControl.PrivateHeaders.Add("token2");
-            cacheControl.PrivateHeaders.Add("token3");
-            Assert.Equal("private=\"token2, token3\"", cacheControl.ToString());
+            cacheControl.PrivateHeaders.Add("PLACEHOLDER2");
+            cacheControl.PrivateHeaders.Add("PLACEHOLDER3");
+            Assert.Equal("private=\"PLACEHOLDER2, PLACEHOLDER3\"", cacheControl.ToString());
             cacheControl.MustRevalidate = true;
-            Assert.Equal("must-revalidate, private=\"token2, token3\"", cacheControl.ToString());
+            Assert.Equal("must-revalidate, private=\"PLACEHOLDER2, PLACEHOLDER3\"", cacheControl.ToString());
             cacheControl.ProxyRevalidate = true;
-            Assert.Equal("must-revalidate, proxy-revalidate, private=\"token2, token3\"", cacheControl.ToString());
+            Assert.Equal("must-revalidate, proxy-revalidate, private=\"PLACEHOLDER2, PLACEHOLDER3\"", cacheControl.ToString());
         }
 
         [Fact]
@@ -218,21 +218,21 @@ namespace Microsoft.Net.Http.Headers
             var cacheControl5 = new CacheControlHeaderValue();
 
             cacheControl1.NoCache = true;
-            cacheControl1.NoCacheHeaders.Add("token2");
+            cacheControl1.NoCacheHeaders.Add("PLACEHOLDER2");
 
             cacheControl2.NoCache = true;
-            cacheControl2.NoCacheHeaders.Add("token1");
-            cacheControl2.NoCacheHeaders.Add("token2");
+            cacheControl2.NoCacheHeaders.Add("PLACEHOLDER1");
+            cacheControl2.NoCacheHeaders.Add("PLACEHOLDER2");
 
             CompareHashCodes(cacheControl1, cacheControl2, false);
 
-            cacheControl1.NoCacheHeaders.Add("token1");
+            cacheControl1.NoCacheHeaders.Add("PLACEHOLDER1");
             CompareHashCodes(cacheControl1, cacheControl2, true);
 
             // Since NoCache and Private generate different hash codes, even if NoCacheHeaders and PrivateHeaders 
             // have the same values, the hash code will be different.
             cacheControl3.Private = true;
-            cacheControl3.PrivateHeaders.Add("token2");
+            cacheControl3.PrivateHeaders.Add("PLACEHOLDER2");
             CompareHashCodes(cacheControl1, cacheControl3, false);
 
 
@@ -343,27 +343,27 @@ namespace Microsoft.Net.Http.Headers
             var cacheControl6 = new CacheControlHeaderValue();
 
             cacheControl1.NoCache = true;
-            cacheControl1.NoCacheHeaders.Add("token2");
+            cacheControl1.NoCacheHeaders.Add("PLACEHOLDER2");
 
             Assert.False(cacheControl1.Equals(null), "Compare with 'null'");
 
             cacheControl2.NoCache = true;
-            cacheControl2.NoCacheHeaders.Add("token1");
-            cacheControl2.NoCacheHeaders.Add("token2");
+            cacheControl2.NoCacheHeaders.Add("PLACEHOLDER1");
+            cacheControl2.NoCacheHeaders.Add("PLACEHOLDER2");
 
             CompareValues(cacheControl1!, cacheControl2, false);
 
-            cacheControl1!.NoCacheHeaders.Add("token1");
+            cacheControl1!.NoCacheHeaders.Add("PLACEHOLDER1");
             CompareValues(cacheControl1, cacheControl2, true);
 
             // Since NoCache and Private generate different hash codes, even if NoCacheHeaders and PrivateHeaders
             // have the same values, the hash code will be different.
             cacheControl3.Private = true;
-            cacheControl3.PrivateHeaders.Add("token2");
+            cacheControl3.PrivateHeaders.Add("PLACEHOLDER2");
             CompareValues(cacheControl1, cacheControl3, false);
 
             cacheControl4.Private = true;
-            cacheControl4.PrivateHeaders.Add("token3");
+            cacheControl4.PrivateHeaders.Add("PLACEHOLDER3");
             CompareValues(cacheControl3, cacheControl4, false);
 
             cacheControl5.Extensions.Add(new NameValueHeaderValue("custom"));
@@ -386,9 +386,9 @@ namespace Microsoft.Net.Http.Headers
 
             expected = new CacheControlHeaderValue();
             expected.NoCache = true;
-            expected.NoCacheHeaders.Add("token1");
-            expected.NoCacheHeaders.Add("token2");
-            CheckValidTryParse("no-cache=\"token1, token2\"", expected);
+            expected.NoCacheHeaders.Add("PLACEHOLDER1");
+            expected.NoCacheHeaders.Add("PLACEHOLDER2");
+            CheckValidTryParse("no-cache=\"PLACEHOLDER1, PLACEHOLDER2\"", expected);
 
             expected = new CacheControlHeaderValue();
             expected.NoStore = true;
@@ -406,12 +406,12 @@ namespace Microsoft.Net.Http.Headers
             expected = new CacheControlHeaderValue();
             expected.Public = true;
             expected.Private = true;
-            expected.PrivateHeaders.Add("token1");
+            expected.PrivateHeaders.Add("PLACEHOLDER1");
             expected.MustRevalidate = true;
             expected.ProxyRevalidate = true;
             expected.Extensions.Add(new NameValueHeaderValue("c", "d"));
             expected.Extensions.Add(new NameValueHeaderValue("a", "b"));
-            CheckValidTryParse(",public, , private=\"token1\", must-revalidate, c=d, proxy-revalidate, a=b", expected);
+            CheckValidTryParse(",public, , private=\"PLACEHOLDER1\", must-revalidate, c=d, proxy-revalidate, a=b", expected);
 
             expected = new CacheControlHeaderValue();
             expected.Private = true;

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         protected override void ConfigureDefaults(FacebookOptions o)
         {
             o.AppId = "whatever";
-            o.AppSecret = "whatever";
+            o.AppSecret = "PLACEHOLDER";
             o.SignInScheme = "auth1";
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         {
             using var host = await CreateHost(
                 app => { },
-                services => services.AddAuthentication().AddFacebook(o => o.SignInScheme = "Whatever"),
+                services => services.AddAuthentication().AddFacebook(o => o.SignInScheme = "PLACEHOLDER"),
                 async context =>
                 {
                     await Assert.ThrowsAsync<ArgumentException>("AppId", () => context.ChallengeAsync("Facebook"));

--- a/src/Security/Authentication/test/TwitterTests.cs
+++ b/src/Security/Authentication/test/TwitterTests.cs
@@ -36,8 +36,8 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
         protected override void ConfigureDefaults(TwitterOptions o)
         {
-            o.ConsumerKey = "whatever";
-            o.ConsumerSecret = "whatever";
+            o.ConsumerKey = "PLACEHOLDER";
+            o.ConsumerSecret = "PLACEHOLDER";
             o.SignInScheme = "auth1";
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/31002

Resolves remaining credscan bugs, either by adding suppressions for secret files which we've gotten exceptions for (`.pfx`, `.key` files), switching dummy credentials to the string `PLACEHOLDER`, or adding a suppression for places where we read from `.pfx` files using their dummy credentials. I confirmed via Teams/Email with @LBynum77 that adding suppressions for the `.pfx` files was sufficient, rather than re-generating them w/ the string `PLACEHOLDER` as the key (CC @sebastienros - you should be able to the same in benchmarks). CredScan gives no bugs for me locally when run against this branch.

CC @Pilchie 