### PR TITLE
Don't separately build arm64 installers

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -277,6 +277,15 @@ stages:
       agentOs: Windows
       installNodeJs: false
       installJdk: false
+      artifacts:
+      - name: Windows_arm64_Logs
+        path: artifacts/log/
+        publishOnError: true
+        includeForks: true
+      - name: Windows_arm64_Packages
+        path: artifacts/packages/
+      - name: Windows_arm64_Installers
+        path: artifacts/installers/
       steps:
       - script: ./eng/build.cmd
                 -ci
@@ -291,13 +300,32 @@ stages:
                 $(_InternalRuntimeDownloadArgs)
                 $(WindowsArm64LogArgs)
         displayName: Build ARM64
-      artifacts:
-      - name: Windows_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_arm64_Packages
-        path: artifacts/packages/
+
+      # Windows installers bundle for arm64
+      - script: ./eng/build.cmd
+                -ci
+                -noBuildRepoTasks
+                -arch arm64
+                -sign
+                -buildInstallers
+                -noBuildNative
+                /p:DotNetSignType=$(_SignType)
+                /p:AssetManifestFileName=aspnetcore-win-arm64.xml
+                $(_BuildArgs)
+                $(_PublishArgs)
+                $(_InternalRuntimeDownloadArgs)
+                $(WindowsArm64InstallersLogArgs)
+        displayName: Build Arm64 Installers
+
+      # A few files must also go to the VS package feed.
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+        - task: NuGetCommand@2
+          displayName: Push Visual Studio packages
+          inputs:
+            command: push
+            packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
+            nuGetFeedType: external
+            publishFeedCredentials: 'DevDiv - VS package feed'
 
 
   # Build MacOS arm64

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -277,15 +277,6 @@ stages:
       agentOs: Windows
       installNodeJs: false
       installJdk: false
-      artifacts:
-      - name: Windows_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_arm64_Packages
-        path: artifacts/packages/
-      - name: Windows_arm64_Installers
-        path: artifacts/installers/
       steps:
       - script: ./eng/build.cmd
                 -ci
@@ -300,32 +291,13 @@ stages:
                 $(_InternalRuntimeDownloadArgs)
                 $(WindowsArm64LogArgs)
         displayName: Build ARM64
-
-      # Windows installers bundle for arm64
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -arch arm64
-                -sign
-                -buildInstallers
-                -noBuildNative
-                /p:DotNetSignType=$(_SignType)
-                /p:AssetManifestFileName=aspnetcore-win-arm64.xml
-                $(_BuildArgs)
-                $(_PublishArgs)
-                $(_InternalRuntimeDownloadArgs)
-                $(WindowsArm64InstallersLogArgs)
-        displayName: Build Arm64 Installers
-
-      # A few files must also go to the VS package feed.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
-        - task: NuGetCommand@2
-          displayName: Push Visual Studio packages
-          inputs:
-            command: push
-            packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
-            nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
+      artifacts:
+      - name: Windows_arm64_Logs
+        path: artifacts/log/
+        publishOnError: true
+        includeForks: true
+      - name: Windows_arm64_Packages
+        path: artifacts/packages/
 
 
   # Build MacOS arm64

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -79,8 +79,7 @@
   <PropertyGroup>
     <!-- When OnlyPackPlatformSpecificPackages is set, only produce packages for projects which set RuntimeIdentifier. -->
     <!-- Keep this below where we set "IsPackageInThisPatch" -->
-    <!-- Do not apply this logic to App.Ref and App.Ref.Internal, it's packability is determined by IsTargetingPackBuilding -->
-    <IsPackable Condition=" '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Ref' AND '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Ref.Internal' AND '$(OnlyPackPlatformSpecificPackages)' == 'true' AND '$(RuntimeIdentifier)' == '' ">false</IsPackable>
+    <IsPackable Condition=" '$(OnlyPackPlatformSpecificPackages)' == 'true' AND '$(RuntimeIdentifier)' == '' ">false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -95,8 +95,8 @@
       </ItemGroup>
 
       <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' == 'arm64' ">
-        <!-- We don't build the bundle here because we'd have to bundle the x86 installer which gets built in a different leg.
-        Instead we only provide the ARM64 MSI-->
+        <!-- We don't build the targeting pack installer here because it's built in the x86/x64 leg.
+        Instead we only provide the ARM64 SharedFramework MSI-->
 
         <!-- Build the SharedFramework wixlib -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\SharedFrameworkLib\SharedFrameworkLib.wixproj" AdditionalProperties="Platform=arm64" />


### PR DESCRIPTION
This should fix BAR push.

I think we should backport this to 3.1 as well. Although the error will only surface when we need to rebuild targeting pack in servicing which is very rare.

I'm going to launch an internal build to verify the artifacts.