### PR TITLE
Default to Kestrel over IISExpress

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Properties/launchSettings.json
@@ -17,13 +17,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "BlazorServerWeb-CSharp": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -37,6 +30,13 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Properties/launchSettings.json
@@ -17,14 +17,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "ComponentsWebAssembly-CSharp": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -36,6 +28,14 @@
       //#else
       "applicationUrl": "http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Properties/launchSettings.json
@@ -12,14 +12,6 @@
       }
     },
     "profiles": {
-      "IIS Express": {
-        "commandName": "IISExpress",
-        "launchBrowser": true,
-        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development"
-        }
-      },
       "ComponentsWebAssembly-CSharp.Server": {
         "commandName": "Project",
         "dotnetRunMessages": "true",
@@ -30,6 +22,14 @@
         //#else
         "applicationUrl": "http://localhost:5000",
         //#endif
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      },
+      "IIS Express": {
+        "commandName": "IISExpress",
+        "launchBrowser": true,
+        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
@@ -17,13 +17,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -34,6 +27,13 @@
       //#else
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
@@ -12,13 +12,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -28,6 +21,13 @@
       //#else
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
@@ -17,18 +17,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        //#if(RazorRuntimeCompilation)
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
-        //#else
-        "ASPNETCORE_ENVIRONMENT": "Development"
-        //#endif
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -38,6 +26,18 @@
       //#else
       "applicationUrl": "http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        //#if(RazorRuntimeCompilation)
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
+        //#else
+        "ASPNETCORE_ENVIRONMENT": "Development"
+        //#endif
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         //#if(RazorRuntimeCompilation)
         "ASPNETCORE_ENVIRONMENT": "Development",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
@@ -17,18 +17,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        //#if(RazorRuntimeCompilation)
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
-        //#else
-        "ASPNETCORE_ENVIRONMENT": "Development"
-        //#endif
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -39,6 +27,18 @@
       //#else
       "applicationUrl": "http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        //#if(RazorRuntimeCompilation)
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
+        //#else
+        "ASPNETCORE_ENVIRONMENT": "Development"
+        //#endif
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         //#if(RazorRuntimeCompilation)
         "ASPNETCORE_ENVIRONMENT": "Development",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
@@ -17,13 +17,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -33,6 +26,13 @@
       //#else
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
@@ -18,18 +18,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      //#if(EnableOpenAPI)
-      "launchUrl": "swagger",
-      //#else
-      "launchUrl": "weatherforecast",
-      //#endif
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -44,6 +32,18 @@
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#else
       "applicationUrl": "http://localhost:5000",
+      //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      //#if(EnableOpenAPI)
+      "launchUrl": "swagger",
+      //#else
+      "launchUrl": "weatherforecast",
       //#endif
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
@@ -18,14 +18,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
@@ -36,6 +28,14 @@
       //#else
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Properties/launchSettings.json
@@ -12,13 +12,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "launchBrowser": true,
@@ -27,6 +20,13 @@
       //#else
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/Properties/launchSettings.json
@@ -12,13 +12,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "launchBrowser": true,
@@ -27,6 +20,13 @@
       //#else
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Properties/launchSettings.json
@@ -12,13 +12,6 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Company.WebApplication1": {
       "commandName": "Project",
       "launchBrowser": true,
@@ -27,6 +20,13 @@
       //#else
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       //#endif
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
For https://github.com/dotnet/aspnetcore/issues/27277

This makes it so by default, F5 in Visual Studio will default to Kestrel over IISExpress in aspnetcore templates. Not sure if there are other places we need to do this as well.