### PR TITLE
Dispose the DiagnosticListener

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -84,9 +84,8 @@ namespace Microsoft.AspNetCore.Hosting
 
                 // REVIEW: This is bad since we don't own this type. Anybody could add one of these and it would mess things up
                 // We need to flow this differently
-                var listener = new DiagnosticListener("Microsoft.AspNetCore");
-                services.TryAddSingleton<DiagnosticListener>(listener);
-                services.TryAddSingleton<DiagnosticSource>(listener);
+                services.TryAddSingleton(sp => new DiagnosticListener("Microsoft.AspNetCore"));
+                services.TryAddSingleton<DiagnosticSource>(sp => sp.GetRequiredService<DiagnosticListener>());
 
                 services.TryAddSingleton<IHttpContextFactory, DefaultHttpContextFactory>();
                 services.TryAddScoped<IMiddlewareFactory, MiddlewareFactory>();

--- a/src/Hosting/Hosting/src/WebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilder.cs
@@ -283,9 +283,8 @@ namespace Microsoft.AspNetCore.Hosting
             services.AddSingleton<IConfiguration>(_ => configuration);
             _context.Configuration = configuration;
 
-            var listener = new DiagnosticListener("Microsoft.AspNetCore");
-            services.AddSingleton<DiagnosticListener>(listener);
-            services.AddSingleton<DiagnosticSource>(listener);
+            services.TryAddSingleton(sp => new DiagnosticListener("Microsoft.AspNetCore"));
+            services.TryAddSingleton<DiagnosticSource>(sp => sp.GetRequiredService<DiagnosticListener>());
 
             services.AddTransient<IApplicationBuilderFactory, ApplicationBuilderFactory>();
             services.AddTransient<IHttpContextFactory, DefaultHttpContextFactory>();


### PR DESCRIPTION
- Add the DiagnosticListener to the DI container as a lambda so it gets disposed. Without this, we're part of a static linked list forever.

Contributes to #31125 

The other part of this is in dotnet/runtime