### PR TITLE
Add tracing to templates process launch for debugging

### DIFF
--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -102,6 +102,8 @@ namespace Templates.Test.Helpers
             try
             {
                 Output.WriteLine("Acquired DotNetNewLock");
+                // Temporary while investigating why this process occasionally never runs or exits on Debian 9
+                environmentVariables.Add("COREHOST_TRACE", "1");
                 using var execution = ProcessEx.Run(Output, AppContext.BaseDirectory, DotNetMuxer.MuxerPathOrDefault(), argString, environmentVariables);
                 await execution.Exited;
                 return new ProcessResult(execution);
@@ -249,7 +251,7 @@ namespace Templates.Test.Helpers
                 {
                     command = "dotnet-ef";
                 }
-                
+
                 using var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
                 await result.Exited;
                 return new ProcessResult(result);


### PR DESCRIPTION
The templates test hang fairly frequently and every time I've looked into it, they are waiting for `dotnet new -u <something>` to finish. A few observations; the hangs are always on Debian 9, no child process dump is created (even though that's supported and works with manual testing), the `Process` class in the dump has a process id so supposedly it created a process, but either it never really started, or died and didn't trigger Process.Exited.

Thanks @shirhatti for the idea!