### PR TITLE
Split the HPackEncoder partial class 

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/HPackHeaderWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/HPackHeaderWriter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         /// <summary>
         /// Begin encoding headers in the first HEADERS frame.
         /// </summary>
-        public static bool BeginEncodeHeaders(int statusCode, HPackEncoder hpackEncoder, Http2HeadersEnumerator headersEnumerator, Span<byte> buffer, out int length)
+        public static bool BeginEncodeHeaders(int statusCode, DynamicHPackEncoder hpackEncoder, Http2HeadersEnumerator headersEnumerator, Span<byte> buffer, out int length)
         {
             length = 0;
 
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         /// <summary>
         /// Begin encoding headers in the first HEADERS frame.
         /// </summary>
-        public static bool BeginEncodeHeaders(HPackEncoder hpackEncoder, Http2HeadersEnumerator headersEnumerator, Span<byte> buffer, out int length)
+        public static bool BeginEncodeHeaders(DynamicHPackEncoder hpackEncoder, Http2HeadersEnumerator headersEnumerator, Span<byte> buffer, out int length)
         {
             length = 0;
 
@@ -66,12 +66,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         /// <summary>
         /// Continue encoding headers in the next HEADERS frame. The enumerator should already have a current value.
         /// </summary>
-        public static bool ContinueEncodeHeaders(HPackEncoder hpackEncoder, Http2HeadersEnumerator headersEnumerator, Span<byte> buffer, out int length)
+        public static bool ContinueEncodeHeaders(DynamicHPackEncoder hpackEncoder, Http2HeadersEnumerator headersEnumerator, Span<byte> buffer, out int length)
         {
             return EncodeHeadersCore(hpackEncoder, headersEnumerator, buffer, throwIfNoneEncoded: true, out length);
         }
 
-        private static bool EncodeStatusHeader(int statusCode, HPackEncoder hpackEncoder, Span<byte> buffer, out int length)
+        private static bool EncodeStatusHeader(int statusCode, DynamicHPackEncoder hpackEncoder, Span<byte> buffer, out int length)
         {
             switch (statusCode)
             {
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             }
         }
 
-        private static bool EncodeHeadersCore(HPackEncoder hpackEncoder, Http2HeadersEnumerator headersEnumerator, Span<byte> buffer, bool throwIfNoneEncoded, out int length)
+        private static bool EncodeHeadersCore(DynamicHPackEncoder hpackEncoder, Http2HeadersEnumerator headersEnumerator, Span<byte> buffer, bool throwIfNoneEncoded, out int length)
         {
             var currentLength = 0;
             do

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private readonly ITimeoutControl _timeoutControl;
         private readonly MinDataRate? _minResponseDataRate;
         private readonly TimingPipeFlusher _flusher;
-        private readonly HPackEncoder _hpackEncoder;
+        private readonly DynamicHPackEncoder _hpackEncoder;
 
         private uint _maxFrameSize = Http2PeerSettings.MinAllowedMaxFrameSize;
         private byte[] _headerEncodingBuffer;
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             _outgoingFrame = new Http2Frame();
             _headerEncodingBuffer = new byte[_maxFrameSize];
 
-            _hpackEncoder = new HPackEncoder(serviceContext.ServerOptions.AllowResponseHeaderCompression);
+            _hpackEncoder = new DynamicHPackEncoder(serviceContext.ServerOptions.AllowResponseHeaderCompression);
         }
 
         public void UpdateMaxHeaderTableSize(uint maxHeaderTableSize)

--- a/src/Servers/Kestrel/Core/test/Http2HPackEncoderTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http2HPackEncoderTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var enumerator = new Http2HeadersEnumerator();
             enumerator.Initialize(headers);
 
-            var hpackEncoder = new HPackEncoder();
+            var hpackEncoder = new DynamicHPackEncoder();
             Assert.True(HPackHeaderWriter.BeginEncodeHeaders(302, hpackEncoder, enumerator, buffer, out var length));
 
             var result = buffer.Slice(0, length).ToArray();
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var enumerator = new Http2HeadersEnumerator();
             enumerator.Initialize(headers);
 
-            var hpackEncoder = new HPackEncoder();
+            var hpackEncoder = new DynamicHPackEncoder();
             Assert.True(HPackHeaderWriter.BeginEncodeHeaders(302, hpackEncoder, enumerator, buffer, out var length));
 
             var result = buffer.Slice(5, length - 5).ToArray();
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             var enumerator = new Http2HeadersEnumerator();
 
-            var hpackEncoder = new HPackEncoder(maxHeaderTableSize: 256);
+            var hpackEncoder = new DynamicHPackEncoder(maxHeaderTableSize: 256);
 
             // First response
             enumerator.Initialize(headers);
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var enumerator = new Http2HeadersEnumerator();
             enumerator.Initialize(headers);
 
-            var hpackEncoder = new HPackEncoder(maxHeaderTableSize: Http2PeerSettings.DefaultHeaderTableSize);
+            var hpackEncoder = new DynamicHPackEncoder(maxHeaderTableSize: Http2PeerSettings.DefaultHeaderTableSize);
             Assert.True(HPackHeaderWriter.BeginEncodeHeaders(hpackEncoder, enumerator, buffer, out _));
 
             if (neverIndex)
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var enumerator = new Http2HeadersEnumerator();
             enumerator.Initialize(headers);
 
-            var hpackEncoder = new HPackEncoder();
+            var hpackEncoder = new DynamicHPackEncoder();
             Assert.True(HPackHeaderWriter.BeginEncodeHeaders(200, hpackEncoder, enumerator, buffer, out var length));
 
             Assert.Empty(GetHeaderEntries(hpackEncoder));
@@ -312,7 +312,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [MemberData(nameof(SinglePayloadData))]
         public void EncodesHeadersInSinglePayloadWhenSpaceAvailable(KeyValuePair<string, string>[] headers, byte[] expectedPayload, int? statusCode)
         {
-            HPackEncoder hpackEncoder = new HPackEncoder();
+            var hpackEncoder = new DynamicHPackEncoder();
 
             var payload = new byte[1024];
             var length = 0;
@@ -376,7 +376,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 0x07, 0x4b, 0x65, 0x73, 0x74, 0x72, 0x65, 0x6c
             };
 
-            var hpackEncoder = new HPackEncoder();
+            var hpackEncoder = new DynamicHPackEncoder();
 
             Span<byte> payload = new byte[1024];
             var offset = 0;
@@ -415,7 +415,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             Span<byte> buffer = new byte[1024 * 16];
 
-            var hpackEncoder = new HPackEncoder();
+            var hpackEncoder = new DynamicHPackEncoder();
             hpackEncoder.UpdateMaxHeaderTableSize(100);
 
             var enumerator = new Http2HeadersEnumerator();
@@ -452,7 +452,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return enumerator;
         }
 
-        private EncoderHeaderEntry GetHeaderEntry(HPackEncoder encoder, int index)
+        private EncoderHeaderEntry GetHeaderEntry(DynamicHPackEncoder encoder, int index)
         {
             var entry = encoder.Head;
             while (index-- >= 0)
@@ -462,7 +462,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             return entry;
         }
 
-        private List<EncoderHeaderEntry> GetHeaderEntries(HPackEncoder encoder)
+        private List<EncoderHeaderEntry> GetHeaderEntries(DynamicHPackEncoder encoder)
         {
             var headers = new List<EncoderHeaderEntry>();
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HPackHeaderWriterBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HPackHeaderWriterBenchmark.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
     public class HPackHeaderWriterBenchmark
     {
         private Http2HeadersEnumerator _http2HeadersEnumerator;
-        private HPackEncoder _hpackEncoder;
+        private DynamicHPackEncoder _hpackEncoder;
         private HttpResponseHeaders _knownResponseHeaders;
         private HttpResponseHeaders _unknownResponseHeaders;
         private byte[] _buffer;
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public void GlobalSetup()
         {
             _http2HeadersEnumerator = new Http2HeadersEnumerator();
-            _hpackEncoder = new HPackEncoder();
+            _hpackEncoder = new DynamicHPackEncoder();
             _buffer = new byte[1024 * 1024];
 
             _knownResponseHeaders = new HttpResponseHeaders

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2ConnectionBenchmarkBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         private MemoryPool<byte> _memoryPool;
         private HttpRequestHeaders _httpRequestHeaders;
         private Http2Connection _connection;
-        private HPackEncoder _hpackEncoder;
+        private DynamicHPackEncoder _hpackEncoder;
         private Http2HeadersEnumerator _requestHeadersEnumerator;
         private int _currentStreamId;
         private byte[] _headersBuffer;
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             _httpRequestHeaders.HeaderAuthority = new StringValues("localhost:80");
 
             _headersBuffer = new byte[1024 * 16];
-            _hpackEncoder = new HPackEncoder();
+            _hpackEncoder = new DynamicHPackEncoder();
 
             var serviceContext = TestContextFactory.CreateServiceContext(
                 serverOptions: new KestrelServerOptions(),

--- a/src/Servers/Kestrel/shared/test/PipeWriterHttp2FrameExtensions.cs
+++ b/src/Servers/Kestrel/shared/test/PipeWriterHttp2FrameExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Testing
             writer.Write(payload);
         }
 
-        public static void WriteStartStream(this PipeWriter writer, int streamId, HPackEncoder hpackEncoder, Http2HeadersEnumerator headers, byte[] headerEncodingBuffer, bool endStream, Http2Frame frame = null)
+        public static void WriteStartStream(this PipeWriter writer, int streamId, DynamicHPackEncoder hpackEncoder, Http2HeadersEnumerator headers, byte[] headerEncodingBuffer, bool endStream, Http2Frame frame = null)
         {
             frame ??= new Http2Frame();
             frame.PrepareHeaders(Http2HeadersFrameFlags.NONE, streamId);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
         internal readonly Http2PeerSettings _clientSettings = new Http2PeerSettings();
         internal readonly HPackDecoder _hpackDecoder;
-        internal readonly HPackEncoder _hpackEncoder;
+        internal readonly DynamicHPackEncoder _hpackEncoder;
         private readonly byte[] _headerEncodingBuffer = new byte[Http2PeerSettings.MinAllowedMaxFrameSize];
 
         internal readonly TimeoutControl _timeoutControl;
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public Http2TestBase()
         {
             _hpackDecoder = new HPackDecoder((int)_clientSettings.HeaderTableSize, MaxRequestHeaderFieldSize);
-            _hpackEncoder = new HPackEncoder();
+            _hpackEncoder = new DynamicHPackEncoder();
 
             _timeoutControl = new TimeoutControl(_mockTimeoutHandler.Object);
             _mockTimeoutControl = new Mock<MockTimeoutControlBase>(_timeoutControl) { CallBase = true };


### PR DESCRIPTION
Contributes to #31182: Sharing a partial class across repos is causing some maintenance issues. This splits the non-shared parts into their own class.
cc @stephentoub if this works then you won't need to revert the change in runtime.

Please merge if approved.