### PR TITLE
Enable CA2012 (Use ValueTask Correctly)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -72,3 +72,9 @@ charset = utf-8-bom
 [*.{cs,vb}]
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = error
+
+[*.{cs,vb}]
+# CA2012: Use ValueTask correctly
+dotnet_diagnostic.CA2012.severity = warning
+[**/{test,perf}/**.{cs,vb}]
+dotnet_diagnostic.CA2012.severity = suggestion

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -267,7 +267,7 @@ namespace Microsoft.AspNetCore.Components.Routing
             _locationAbsolute = args.Location;
             if (_renderHandle.IsInitialized && Routes != null)
             {
-                _ = RunOnNavigateAsync(NavigationManager.ToBaseRelativePath(_locationAbsolute), args.IsNavigationIntercepted);
+                _ = RunOnNavigateAsync(NavigationManager.ToBaseRelativePath(_locationAbsolute), args.IsNavigationIntercepted).Preserve();
             }
         }
 

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 throw new NavigationException(absoluteUriString);
             }
 
-            _jsRuntime.InvokeAsync<object>(Interop.NavigateTo, uri, forceLoad);
+            _jsRuntime.InvokeAsync<object>(Interop.NavigateTo, uri, forceLoad).Preserve();
         }
 
         private static class Log

--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -334,7 +334,7 @@ namespace Microsoft.AspNetCore.Hosting
 
         public void Dispose()
         {
-            DisposeAsync().GetAwaiter().GetResult();
+            DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Http/Http/src/Features/RequestServicesFeature.cs
+++ b/src/Http/Http/src/Features/RequestServicesFeature.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Http.Features
         /// <inheritdoc />
         public void Dispose()
         {
-            DisposeAsync().GetAwaiter().GetResult();
+            DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamInputFlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/StreamInputFlowControl.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl
             if (streamWindowUpdateSize > 0)
             {
                 // Writing with the FrameWriter should only fail if given a canceled token, so just fire and forget.
-                _ = _frameWriter.WriteWindowUpdateAsync(StreamId, streamWindowUpdateSize);
+                _ = _frameWriter.WriteWindowUpdateAsync(StreamId, streamWindowUpdateSize).Preserve();
             }
 
             UpdateConnectionWindow(bytes);
@@ -90,7 +90,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl
             if (connectionWindowUpdateSize > 0)
             {
                 // Writing with the FrameWriter should only fail if given a canceled token, so just fire and forget.
-                _ = _frameWriter.WriteWindowUpdateAsync(0, connectionWindowUpdateSize);
+                _ = _frameWriter.WriteWindowUpdateAsync(0, connectionWindowUpdateSize).Preserve();
             }
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             if (TryClose())
             {
-                _frameWriter.WriteGoAwayAsync(int.MaxValue, Http2ErrorCode.INTERNAL_ERROR);
+                _frameWriter.WriteGoAwayAsync(int.MaxValue, Http2ErrorCode.INTERNAL_ERROR).Preserve();
             }
 
             _frameWriter.Abort(ex);
@@ -1214,7 +1214,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
                 if (_gracefulCloseInitiator == GracefulCloseInitiator.Server && _clientActiveStreamCount > 0)
                 {
-                    _frameWriter.WriteGoAwayAsync(int.MaxValue, Http2ErrorCode.NO_ERROR);
+                    _frameWriter.WriteGoAwayAsync(int.MaxValue, Http2ErrorCode.NO_ERROR).Preserve();
                 }
             }
 
@@ -1224,7 +1224,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 {
                     if (TryClose())
                     {
-                        _frameWriter.WriteGoAwayAsync(_highestOpenedStreamId, Http2ErrorCode.NO_ERROR);
+                        _frameWriter.WriteGoAwayAsync(_highestOpenedStreamId, Http2ErrorCode.NO_ERROR).Preserve();
                     }
                 }
                 else

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         private bool _writerComplete;
 
         // Internal for testing
-        internal ValueTask _dataWriteProcessingTask;
+        internal Task _dataWriteProcessingTask;
         internal bool _disposed;
 
         /// <summary>The core logic for the IValueTaskSource implementation.</summary>
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // The minimum output data rate is enforced at the connection level by Http2FrameWriter.
             _flusher = new TimingPipeFlusher(_pipeWriter, timeoutControl: null, _log);
 
-            _dataWriteProcessingTask = ProcessDataWrites().Preserve();
+            _dataWriteProcessingTask = ProcessDataWrites();
         }
 
         public void StreamReset()
@@ -394,7 +394,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
         }
 
-        private async ValueTask ProcessDataWrites()
+        private async Task ProcessDataWrites()
         {
             // ProcessDataWrites runs for the lifetime of the Http2OutputProducer, and is designed to be reused by multiple streams.
             // When Http2OutputProducer is no longer used (e.g. a stream is aborted and will no longer be used, or the connection is closed)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // The minimum output data rate is enforced at the connection level by Http2FrameWriter.
             _flusher = new TimingPipeFlusher(_pipeWriter, timeoutControl: null, _log);
 
-            _dataWriteProcessingTask = ProcessDataWrites();
+            _dataWriteProcessingTask = ProcessDataWrites().Preserve();
         }
 
         public void StreamReset()

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                         if (!errored)
                         {
                             // Don't block on IO. This never faults.
-                            _ = _http2Output.WriteRstStreamAsync(Http2ErrorCode.NO_ERROR);
+                            _ = _http2Output.WriteRstStreamAsync(Http2ErrorCode.NO_ERROR).Preserve();
                         }
                         RequestBodyPipe.Writer.Complete();
                     }
@@ -545,7 +545,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
             DecrementActiveClientStreamCount();
             // Don't block on IO. This never faults.
-            _ = _http2Output.WriteRstStreamAsync(error);
+            _ = _http2Output.WriteRstStreamAsync(error).Preserve();
 
             AbortCore(abortReason);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             {
                 if (TryClose())
                 {
-                    SendGoAway(_highestOpenedStreamId);
+                    SendGoAway(_highestOpenedStreamId).Preserve();
                 }
 
                 _errorCodeFeature.Error = (long)errorCode;
@@ -213,10 +213,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             switch (reason)
             {
                 case TimeoutReason.KeepAlive:
-                    SendGoAway(_highestOpenedStreamId);
+                    SendGoAway(_highestOpenedStreamId).Preserve();
                     break;
                 case TimeoutReason.TimeoutFeature:
-                    SendGoAway(_highestOpenedStreamId);
+                    SendGoAway(_highestOpenedStreamId).Preserve();
                     break;
                 case TimeoutReason.RequestHeaders:
                 case TimeoutReason.ReadDataRate:
@@ -396,7 +396,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 if (_gracefulCloseInitiator == GracefulCloseInitiator.Server && activeRequestCount > 0)
                 {
                     // Go away with largest streamid to initiate graceful shutdown.
-                    SendGoAway(VariableLengthIntegerHelper.EightByteLimit);
+                    SendGoAway(VariableLengthIntegerHelper.EightByteLimit).Preserve();
                 }
             }
 
@@ -406,7 +406,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 {
                     if (TryClose())
                     {
-                        SendGoAway(_highestOpenedStreamId);
+                        SendGoAway(_highestOpenedStreamId).Preserve();
                     }
                 }
                 else

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             _pipeReader = pipe.Reader;
 
             _flusher = new TimingPipeFlusher(_pipeWriter, timeoutControl: null, log);
-            _dataWriteProcessingTask = ProcessDataWrites();
+            _dataWriteProcessingTask = ProcessDataWrites().Preserve();
         }
 
         public void Dispose()

--- a/src/Shared/ServerInfrastructure/DuplexPipeStream.cs
+++ b/src/Shared/ServerInfrastructure/DuplexPipeStream.cs
@@ -71,9 +71,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            // ValueTask uses .GetAwaiter().GetResult() if necessary
-            // https://github.com/dotnet/corefx/blob/f9da3b4af08214764a51b2331f3595ffaf162abe/src/System.Threading.Tasks.Extensions/src/System/Threading/Tasks/ValueTask.cs#L156
-            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), default).Result;
+            ValueTask<int> vt = ReadAsyncInternal(new Memory<byte>(buffer, offset, count), default);
+            return vt.IsCompleted ?
+                vt.Result :
+                vt.AsTask().GetAwaiter().GetResult();
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)

--- a/src/SignalR/samples/ClientSample/Tcp/TcpConnection.cs
+++ b/src/SignalR/samples/ClientSample/Tcp/TcpConnection.cs
@@ -168,14 +168,7 @@ namespace ClientSample
 
                 _application.Output.Advance(bytesReceived);
 
-                var flushTask = _application.Output.FlushAsync();
-
-                if (!flushTask.IsCompleted)
-                {
-                    await flushTask;
-                }
-
-                var result = flushTask.GetAwaiter().GetResult();
+                var result = await _application.Output.FlushAsync();
                 if (result.IsCompleted)
                 {
                     // Pipe consumer is shut down, do we stop writing

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -625,7 +625,7 @@ namespace Microsoft.AspNetCore.SignalR
                 // If the transport channel is full, this will fail, but that's OK because
                 // adding a Ping message when the transport is full is unnecessary since the
                 // transport is still in the process of sending frames.
-                _ = TryWritePingAsync();
+                _ = TryWritePingAsync().Preserve();
 
                 // We only update the timestamp here, because updating on each sent message is bad for performance
                 // There can be a lot of sent messages per 15 seconds


### PR DESCRIPTION
Enable CA2012 (Use ValueTask Correctly) analyzer for all src in the repo, and fix the violations.
Fixes #16876 