### PR TITLE
[Http] Remove some unsafe code and save a string allocation

### DIFF
--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -534,7 +534,7 @@ namespace Microsoft.Net.Http.Headers
         // Encode using MIME encoding
         private string EncodeMime(StringSegment input)
         {
-            var buffer = Encoding.UTF8.GetBytes(input.Buffer);
+            var buffer = Encoding.UTF8.GetBytes(new ReadOnlySequence<char>(input.AsMemory()));
             var encodedName = Convert.ToBase64String(buffer);
             return string.Concat("=?utf-8?B?", encodedName, "?=");
         }

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -536,7 +536,7 @@ namespace Microsoft.Net.Http.Headers
         {
             var buffer = Encoding.UTF8.GetBytes(new ReadOnlySequence<char>(input.AsMemory()));
             var encodedName = Convert.ToBase64String(buffer);
-            return string.Concat("=?utf-8?B?", encodedName, "?=");
+            return "=?utf-8?B?" + encodedName + "?=";
         }
 
         // Attempt to decode MIME encoded strings

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -532,19 +532,11 @@ namespace Microsoft.Net.Http.Headers
         }
 
         // Encode using MIME encoding
-        private unsafe string EncodeMime(StringSegment input)
+        private string EncodeMime(StringSegment input)
         {
-            fixed (char* chars = input.Buffer)
-            {
-                var byteCount = Encoding.UTF8.GetByteCount(chars + input.Offset, input.Length);
-                var buffer = new byte[byteCount];
-                fixed (byte* bytes = buffer)
-                {
-                    Encoding.UTF8.GetBytes(chars + input.Offset, input.Length, bytes, byteCount);
-                }
-                var encodedName = Convert.ToBase64String(buffer);
-                return "=?utf-8?B?" + encodedName + "?=";
-            }
+            var buffer = Encoding.UTF8.GetBytes(input.Buffer);
+            var encodedName = Convert.ToBase64String(buffer);
+            return string.Concat("=?utf-8?B?", encodedName, "?=");
         }
 
         // Attempt to decode MIME encoded strings

--- a/src/Http/Headers/src/HeaderUtilities.cs
+++ b/src/Http/Headers/src/HeaderUtilities.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Net.Http.Headers
     /// </summary>
     public static class HeaderUtilities
     {
-        private static readonly int _int64MaxStringLength = 19;
         private static readonly int _qualityValueMaxCharCount = 10; // Little bit more permissive than RFC7231 5.3.1
         private const string QualityName = "q";
         internal const string BytesUnit = "bytes";
@@ -514,18 +513,7 @@ namespace Microsoft.Net.Http.Headers
                 return "0";
             }
 
-            var position = _int64MaxStringLength;
-            Span<char> charBuffer = stackalloc char[_int64MaxStringLength];
-
-            do
-            {
-                var (quotient, rem) = Math.DivRem(value, 10);
-                charBuffer[--position] = (char)(0x30 + rem); // 0x30 = '0'
-                value = quotient;
-            }
-            while (value != 0);
-
-            return new string(charBuffer.Slice(position));
+            return ((ulong)value).ToString(NumberFormatInfo.InvariantInfo);
         }
 
         /// <summary>

--- a/src/Http/Headers/src/HeaderUtilities.cs
+++ b/src/Http/Headers/src/HeaderUtilities.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Net.Http.Headers
                 return false;
             }
 
-            return int.TryParse(value.Buffer.AsSpan().Slice(value.Offset, value.Length), NumberStyles.None, NumberFormatInfo.InvariantInfo, out result);
+            return int.TryParse(value.AsSpan(), NumberStyles.None, NumberFormatInfo.InvariantInfo, out result);
         }
 
         /// <summary>

--- a/src/Http/Headers/src/HeaderUtilities.cs
+++ b/src/Http/Headers/src/HeaderUtilities.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Net.Http.Headers
             return false;
         }
 
-        private static unsafe bool TryParseNonNegativeInt64FromHeaderValue(int startIndex, string headerValue, out long result)
+        private static bool TryParseNonNegativeInt64FromHeaderValue(int startIndex, string headerValue, out long result)
         {
             // Trim leading whitespace
             startIndex += HttpRuleParser.GetWhitespaceLength(headerValue, startIndex);
@@ -366,7 +366,7 @@ namespace Microsoft.Net.Http.Headers
         /// result will be overwritten.
         /// </param>
         /// <returns><see langword="true" /> if parsing succeeded; otherwise, <see langword="false" />.</returns>
-        public static unsafe bool TryParseNonNegativeInt32(StringSegment value, out int result)
+        public static bool TryParseNonNegativeInt32(StringSegment value, out int result)
         {
             if (string.IsNullOrEmpty(value.Buffer) || value.Length == 0)
             {
@@ -374,32 +374,7 @@ namespace Microsoft.Net.Http.Headers
                 return false;
             }
 
-            result = 0;
-            fixed (char* ptr = value.Buffer)
-            {
-                var ch = (ushort*)ptr + value.Offset;
-                var end = ch + value.Length;
-
-                ushort digit = 0;
-                while (ch < end && (digit = (ushort)(*ch - 0x30)) <= 9)
-                {
-                    // Check for overflow
-                    if ((result = result * 10 + digit) < 0)
-                    {
-                        result = 0;
-                        return false;
-                    }
-
-                    ch++;
-                }
-
-                if (ch != end)
-                {
-                    result = 0;
-                    return false;
-                }
-                return true;
-            }
+            return int.TryParse(value.Buffer.AsSpan().Slice(value.Offset, value.Length), NumberStyles.None, NumberFormatInfo.InvariantInfo, out result);
         }
 
         /// <summary>
@@ -417,40 +392,14 @@ namespace Microsoft.Net.Http.Headers
         /// originally supplied in result will be overwritten.
         /// </param>
         /// <returns><see langword="true" /> if parsing succeeded; otherwise, <see langword="false" />.</returns>
-        public static unsafe bool TryParseNonNegativeInt64(StringSegment value, out long result)
+        public static bool TryParseNonNegativeInt64(StringSegment value, out long result)
         {
             if (string.IsNullOrEmpty(value.Buffer) || value.Length == 0)
             {
                 result = 0;
                 return false;
             }
-
-            result = 0;
-            fixed (char* ptr = value.Buffer)
-            {
-                var ch = (ushort*)ptr + value.Offset;
-                var end = ch + value.Length;
-
-                ushort digit = 0;
-                while (ch < end && (digit = (ushort)(*ch - 0x30)) <= 9)
-                {
-                    // Check for overflow
-                    if ((result = result * 10 + digit) < 0)
-                    {
-                        result = 0;
-                        return false;
-                    }
-
-                    ch++;
-                }
-
-                if (ch != end)
-                {
-                    result = 0;
-                    return false;
-                }
-                return true;
-            }
+            return long.TryParse(value.Buffer.AsSpan().Slice(value.Offset, value.Length), NumberStyles.None, NumberFormatInfo.InvariantInfo, out result);
         }
 
         // Strict and fast RFC7231 5.3.1 Quality value parser (and without memory allocation)
@@ -553,7 +502,7 @@ namespace Microsoft.Net.Http.Headers
         /// <returns>
         /// The string representation of the value of this instance, consisting of a sequence of digits ranging from 0 to 9 with no leading zeroes.
         /// </returns>
-        public unsafe static string FormatNonNegativeInt64(long value)
+        public static string FormatNonNegativeInt64(long value)
         {
             if (value < 0)
             {
@@ -566,18 +515,17 @@ namespace Microsoft.Net.Http.Headers
             }
 
             var position = _int64MaxStringLength;
-            char* charBuffer = stackalloc char[_int64MaxStringLength];
+            Span<char> charBuffer = stackalloc char[_int64MaxStringLength];
 
             do
             {
-                // Consider using Math.DivRem() if available
-                var quotient = value / 10;
-                charBuffer[--position] = (char)(0x30 + (value - quotient * 10)); // 0x30 = '0'
+                var (quotient, rem) = Math.DivRem(value, 10);
+                charBuffer[--position] = (char)(0x30 + rem); // 0x30 = '0'
                 value = quotient;
             }
             while (value != 0);
 
-            return new string(charBuffer, position, _int64MaxStringLength - position);
+            return new string(charBuffer.Slice(position));
         }
 
         /// <summary>

--- a/src/Http/Headers/src/HeaderUtilities.cs
+++ b/src/Http/Headers/src/HeaderUtilities.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Net.Http.Headers
                 result = 0;
                 return false;
             }
-            return long.TryParse(value.Buffer.AsSpan().Slice(value.Offset, value.Length), NumberStyles.None, NumberFormatInfo.InvariantInfo, out result);
+            return long.TryParse(value.AsSpan(), NumberStyles.None, NumberFormatInfo.InvariantInfo, out result);
         }
 
         // Strict and fast RFC7231 5.3.1 Quality value parser (and without memory allocation)

--- a/src/Http/Headers/src/MediaTypeHeaderValue.cs
+++ b/src/Http/Headers/src/MediaTypeHeaderValue.cs
@@ -650,7 +650,7 @@ namespace Microsoft.Net.Http.Headers
                 mediaType = string.Create(typeLength + subtypeLength + 1, (input, startIndex, typeLength, subtypeLength, current), static (span, state) =>
                 {
                     var (input, startIndex, typeLength, subtypeLength, current) = state;
-                    var segment = input.Buffer.AsSpan(input.Offset);
+                    var segment = input.AsSpan();
                     segment.Slice(startIndex, typeLength).CopyTo(span);
 
                     span[typeLength] = ForwardSlashCharacter;

--- a/src/Http/Headers/src/MediaTypeHeaderValue.cs
+++ b/src/Http/Headers/src/MediaTypeHeaderValue.cs
@@ -646,9 +646,7 @@ namespace Microsoft.Net.Http.Headers
             }
             else
             {
-                var forwardSlashCharacter = ForwardSlashCharacter;
-                var forwardSlash = MemoryMarshal.CreateReadOnlySpan(ref forwardSlashCharacter, 1);
-                mediaType = string.Concat(input.AsSpan().Slice(startIndex, typeLength), forwardSlash, input.AsSpan().Slice(current, subtypeLength));
+                mediaType = string.Concat(input.AsSpan().Slice(startIndex, typeLength), "/", input.AsSpan().Slice(current, subtypeLength));
             }
 
             return mediaTypeLength;

--- a/src/Http/Headers/src/Microsoft.Net.Http.Headers.csproj
+++ b/src/Http/Headers/src/Microsoft.Net.Http.Headers.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>HTTP header parser implementations.</Description>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>http</PackageTags>
     <IsPackable>false</IsPackable>

--- a/src/Http/Routing/src/Matching/SingleEntryAsciiJumpTable.cs
+++ b/src/Http/Routing/src/Matching/SingleEntryAsciiJumpTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             _destination = destination;
         }
 
-        public unsafe override int GetDestination(string path, PathSegment segment)
+        public override int GetDestination(string path, PathSegment segment)
         {
             var length = segment.Length;
             if (length == 0)

--- a/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
+++ b/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
@@ -9,7 +9,6 @@ Microsoft.AspNetCore.Routing.RouteCollection</Description>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;routing</PackageTags>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Kind of random, removes some unsafe code from stuff we did 4 years ago when the runtime wasn't as good as it is now, and removed an allocation or two in `MediaTypeHeaderValue`.