### PR TITLE
Quarantine one failing test backport

### DIFF
--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -223,6 +223,7 @@ namespace Templates.Test
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31044")]
         public async Task RazorPagesTemplate_RazorRuntimeCompilation_BuildsAndPublishes()
         {
             var project = await BuildAndPublishRazorPagesTemplate(auth: null, new[] { "--razor-runtime-compilation" });


### PR DESCRIPTION
This is a backport of https://github.com/dotnet/aspnetcore/pull/31045. There was a failure in the public `release/5.0` CI pipeline: https://dev.azure.com/dnceng/public/_build/results?buildId=1034827&view=results

This was from the most recent of these builds, but that was two weeks ago. So this isn't nearly as recent as I originally thought.
