### PR TITLE
Unquarantine UseStartupFactoryWorks

### DIFF
--- a/src/Hosting/Hosting/test/WebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/WebHostBuilderTests.cs
@@ -115,7 +115,6 @@ namespace Microsoft.AspNetCore.Hosting
 
         [Theory]
         [MemberData(nameof(DefaultWebHostBuildersWithConfig))]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30582")]
         public async Task UseStartupFactoryWorks(IWebHostBuilder builder)
         {
             void ConfigureServices(IServiceCollection services) { }


### PR DESCRIPTION
#30582 hasn't been closed, but since this is one of many tests that could theoretically fail and it hasn't failed in the ~1000 runs in the last 30 days, I think we should unquarantine this. Either that or we should quarantine all tests in HostingApplicationDiagnosticsTests.