### PR TITLE
Minor changes to runtime-compilation to make it extendable

### DIFF
--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/CSharpCompiler.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/CSharpCompiler.cs
@@ -17,7 +17,7 @@ using DependencyContextCompilationOptions = Microsoft.Extensions.DependencyModel
 
 namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 {
-    internal class CSharpCompiler
+    public class CSharpCompiler
     {
         private readonly RazorReferenceManager _referenceManager;
         private readonly IWebHostEnvironment _hostingEnvironment;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RazorReferenceManager.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RazorReferenceManager.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 {
-    internal class RazorReferenceManager
+    public class RazorReferenceManager
     {
         private readonly ApplicationPartManager _partManager;
         private readonly MvcRazorRuntimeCompilationOptions _options;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationFileProvider.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationFileProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 {
-    internal class RuntimeCompilationFileProvider
+    public class RuntimeCompilationFileProvider
     {
         private readonly MvcRazorRuntimeCompilationOptions _options;
         private IFileProvider _compositeFileProvider;
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
             _options = options.Value;
         }
 
-        public IFileProvider FileProvider
+        public virtual IFileProvider FileProvider
         {
             get
             {


### PR DESCRIPTION
These are the proposed changes to solve #31314. It can be seen as a proposal and not a ready-to-merge request. 

**PR Title**
Make MVC Razor runtime-compilation extendable

**PR Description**

- making `CSharpCompiler` & `RazorReferenceManager` public is needed to be able to inject them in a custom `IViewCompilerProvider` and use/forward them in an extended `RuntimeViewCompiler`
- making `RuntimeCompilationFileProvider` public and the `FileProvider` property virtual is needed to be able to supply a custom `IFileProvider` to be able to add new watched/searched locations during runtime
- making `RuntimeViewCompiler` public and `GetExpirationTokens` & `GetChangeTokensFromImports` `protected virtual` is needed to be able to add dynamically loaded pre-compiled views and add custom change-tokens to unload them
- the extracted `LoadAssembly` method in the `RuntimeViewCompiler`  is needed to use a custom load-context instead of `Assembly.Load` to be able to unload compiled views

Addresses #31314
