### PR TITLE
Faster strongly typed features for server FeatureCollection

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -616,7 +616,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         protected override void OnReset()
         {
-            ResetHttp1Features();
 
             _requestTimedOut = false;
             _requestTargetForm = HttpRequestTarget.Unknown;
@@ -625,6 +624,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _requestCount++;
 
             MinResponseDataRate = ServerOptions.Limits.MinResponseDataRate;
+
+            // Reset Http1 Features
+            _currentIHttpMinRequestBodyDataRateFeature = this;
+            _currentIHttpMinResponseDataRateFeature = this;
         }
 
         protected override void OnRequestProcessingEnding()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -255,25 +255,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         Stream IHttpResponseBodyFeature.Stream => ResponseBody;
 
-        protected void ResetHttp1Features()
-        {
-            _currentIHttpMinRequestBodyDataRateFeature = this;
-            _currentIHttpMinResponseDataRateFeature = this;
-        }
-
-        protected void ResetHttp2Features()
-        {
-            _currentIHttp2StreamIdFeature = this;
-            _currentIHttpResponseTrailersFeature = this;
-            _currentIHttpResetFeature = this;
-        }
-
-        protected void ResetHttp3Features()
-        {
-            _currentIHttpResponseTrailersFeature = this;
-            _currentIHttpResetFeature = this;
-        }
-
         void IHttpResponseFeature.OnStarting(Func<object, Task> callback, object state)
         {
             OnStarting(callback, state);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -16,23 +16,11 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    internal partial class HttpProtocol : IHttpRequestFeature,
-                                          IHttpResponseFeature,
-                                          IHttpResponseBodyFeature,
-                                          IRouteValuesFeature,
-                                          IEndpointFeature,
-                                          IHttpRequestIdentifierFeature,
-                                          IHttpRequestTrailersFeature,
-                                          IHttpUpgradeFeature,
-                                          IRequestBodyPipeFeature,
-                                          IHttpConnectionFeature,
-                                          IHttpRequestLifetimeFeature,
-                                          IHttpBodyControlFeature,
-                                          IHttpMaxRequestBodySizeFeature,
-                                          IHttpRequestBodyDetectionFeature
+    internal partial class HttpProtocol
     {
         // NOTE: When feature interfaces are added to or removed from this HttpProtocol class implementation,
-        // then the list of `implementedFeatures` in the generated code project MUST also be updated.
+        // then the list of `implementedFeatures` in the generated code project MUST also be updated first
+        // and the code generator re-reun, which will change the interface list.
         // See also: tools/CodeGenerator/HttpProtocolFeatureCollection.cs
 
         string IHttpRequestFeature.Protocol

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
 using System.Net;
@@ -19,19 +17,19 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal partial class HttpProtocol : IHttpRequestFeature,
-                                          IHttpRequestBodyDetectionFeature,
                                           IHttpResponseFeature,
                                           IHttpResponseBodyFeature,
-                                          IRequestBodyPipeFeature,
-                                          IHttpUpgradeFeature,
-                                          IHttpConnectionFeature,
-                                          IHttpRequestLifetimeFeature,
+                                          IRouteValuesFeature,
+                                          IEndpointFeature,
                                           IHttpRequestIdentifierFeature,
                                           IHttpRequestTrailersFeature,
+                                          IHttpUpgradeFeature,
+                                          IRequestBodyPipeFeature,
+                                          IHttpConnectionFeature,
+                                          IHttpRequestLifetimeFeature,
                                           IHttpBodyControlFeature,
                                           IHttpMaxRequestBodySizeFeature,
-                                          IEndpointFeature,
-                                          IRouteValuesFeature
+                                          IHttpRequestBodyDetectionFeature
     {
         // NOTE: When feature interfaces are added to or removed from this HttpProtocol class implementation,
         // then the list of `implementedFeatures` in the generated code project MUST also be updated.

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
@@ -394,118 +395,122 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         TFeature? IFeatureCollection.Get<TFeature>() where TFeature : default
         {
+            // Using Unsafe.As for the cast due to https://github.com/dotnet/runtime/issues/49614
+            // The type of TFeature is confirmed by the typeof() check and the As cast only accepts
+            // that type; however the Jit does not eliminate a regular cast in a shared generic.
+
             TFeature? feature = default;
             if (typeof(TFeature) == typeof(IHttpRequestFeature))
             {
-                feature = (TFeature?)_currentIHttpRequestFeature;
+                feature = Unsafe.As<IHttpRequestFeature?, TFeature?>(ref _currentIHttpRequestFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
             {
-                feature = (TFeature?)_currentIHttpRequestBodyDetectionFeature;
+                feature = Unsafe.As<IHttpRequestBodyDetectionFeature?, TFeature?>(ref _currentIHttpRequestBodyDetectionFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpResponseFeature))
             {
-                feature = (TFeature?)_currentIHttpResponseFeature;
+                feature = Unsafe.As<IHttpResponseFeature?, TFeature?>(ref _currentIHttpResponseFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpResponseBodyFeature))
             {
-                feature = (TFeature?)_currentIHttpResponseBodyFeature;
+                feature = Unsafe.As<IHttpResponseBodyFeature?, TFeature?>(ref _currentIHttpResponseBodyFeature);
             }
             else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
             {
-                feature = (TFeature?)_currentIRequestBodyPipeFeature;
+                feature = Unsafe.As<IRequestBodyPipeFeature?, TFeature?>(ref _currentIRequestBodyPipeFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestIdentifierFeature))
             {
-                feature = (TFeature?)_currentIHttpRequestIdentifierFeature;
+                feature = Unsafe.As<IHttpRequestIdentifierFeature?, TFeature?>(ref _currentIHttpRequestIdentifierFeature);
             }
             else if (typeof(TFeature) == typeof(IServiceProvidersFeature))
             {
-                feature = (TFeature?)_currentIServiceProvidersFeature;
+                feature = Unsafe.As<IServiceProvidersFeature?, TFeature?>(ref _currentIServiceProvidersFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
             {
-                feature = (TFeature?)_currentIHttpRequestLifetimeFeature;
+                feature = Unsafe.As<IHttpRequestLifetimeFeature?, TFeature?>(ref _currentIHttpRequestLifetimeFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpConnectionFeature))
             {
-                feature = (TFeature?)_currentIHttpConnectionFeature;
+                feature = Unsafe.As<IHttpConnectionFeature?, TFeature?>(ref _currentIHttpConnectionFeature);
             }
             else if (typeof(TFeature) == typeof(IRouteValuesFeature))
             {
-                feature = (TFeature?)_currentIRouteValuesFeature;
+                feature = Unsafe.As<IRouteValuesFeature?, TFeature?>(ref _currentIRouteValuesFeature);
             }
             else if (typeof(TFeature) == typeof(IEndpointFeature))
             {
-                feature = (TFeature?)_currentIEndpointFeature;
+                feature = Unsafe.As<IEndpointFeature?, TFeature?>(ref _currentIEndpointFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
             {
-                feature = (TFeature?)_currentIHttpAuthenticationFeature;
+                feature = Unsafe.As<IHttpAuthenticationFeature?, TFeature?>(ref _currentIHttpAuthenticationFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
             {
-                feature = (TFeature?)_currentIHttpRequestTrailersFeature;
+                feature = Unsafe.As<IHttpRequestTrailersFeature?, TFeature?>(ref _currentIHttpRequestTrailersFeature);
             }
             else if (typeof(TFeature) == typeof(IQueryFeature))
             {
-                feature = (TFeature?)_currentIQueryFeature;
+                feature = Unsafe.As<IQueryFeature?, TFeature?>(ref _currentIQueryFeature);
             }
             else if (typeof(TFeature) == typeof(IFormFeature))
             {
-                feature = (TFeature?)_currentIFormFeature;
+                feature = Unsafe.As<IFormFeature?, TFeature?>(ref _currentIFormFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpUpgradeFeature))
             {
-                feature = (TFeature?)_currentIHttpUpgradeFeature;
+                feature = Unsafe.As<IHttpUpgradeFeature?, TFeature?>(ref _currentIHttpUpgradeFeature);
             }
             else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
-                feature = (TFeature?)_currentIHttp2StreamIdFeature;
+                feature = Unsafe.As<IHttp2StreamIdFeature?, TFeature?>(ref _currentIHttp2StreamIdFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
             {
-                feature = (TFeature?)_currentIHttpResponseTrailersFeature;
+                feature = Unsafe.As<IHttpResponseTrailersFeature?, TFeature?>(ref _currentIHttpResponseTrailersFeature);
             }
             else if (typeof(TFeature) == typeof(IResponseCookiesFeature))
             {
-                feature = (TFeature?)_currentIResponseCookiesFeature;
+                feature = Unsafe.As<IResponseCookiesFeature?, TFeature?>(ref _currentIResponseCookiesFeature);
             }
             else if (typeof(TFeature) == typeof(IItemsFeature))
             {
-                feature = (TFeature?)_currentIItemsFeature;
+                feature = Unsafe.As<IItemsFeature?, TFeature?>(ref _currentIItemsFeature);
             }
             else if (typeof(TFeature) == typeof(ITlsConnectionFeature))
             {
-                feature = (TFeature?)_currentITlsConnectionFeature;
+                feature = Unsafe.As<ITlsConnectionFeature?, TFeature?>(ref _currentITlsConnectionFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpWebSocketFeature))
             {
-                feature = (TFeature?)_currentIHttpWebSocketFeature;
+                feature = Unsafe.As<IHttpWebSocketFeature?, TFeature?>(ref _currentIHttpWebSocketFeature);
             }
             else if (typeof(TFeature) == typeof(ISessionFeature))
             {
-                feature = (TFeature?)_currentISessionFeature;
+                feature = Unsafe.As<ISessionFeature?, TFeature?>(ref _currentISessionFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpMaxRequestBodySizeFeature))
             {
-                feature = (TFeature?)_currentIHttpMaxRequestBodySizeFeature;
+                feature = Unsafe.As<IHttpMaxRequestBodySizeFeature?, TFeature?>(ref _currentIHttpMaxRequestBodySizeFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpMinRequestBodyDataRateFeature))
             {
-                feature = (TFeature?)_currentIHttpMinRequestBodyDataRateFeature;
+                feature = Unsafe.As<IHttpMinRequestBodyDataRateFeature?, TFeature?>(ref _currentIHttpMinRequestBodyDataRateFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpMinResponseDataRateFeature))
             {
-                feature = (TFeature?)_currentIHttpMinResponseDataRateFeature;
+                feature = Unsafe.As<IHttpMinResponseDataRateFeature?, TFeature?>(ref _currentIHttpMinResponseDataRateFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpBodyControlFeature))
             {
-                feature = (TFeature?)_currentIHttpBodyControlFeature;
+                feature = Unsafe.As<IHttpBodyControlFeature?, TFeature?>(ref _currentIHttpBodyControlFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpResetFeature))
             {
-                feature = (TFeature?)_currentIHttpResetFeature;
+                feature = Unsafe.As<IHttpResetFeature?, TFeature?>(ref _currentIHttpResetFeature);
             }
             else if (MaybeExtra != null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -16,33 +16,36 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal partial class HttpProtocol : IFeatureCollection
     {
+        // Implemented features
         internal protected IHttpRequestFeature? _currentIHttpRequestFeature;
         internal protected IHttpResponseFeature? _currentIHttpResponseFeature;
         internal protected IHttpResponseBodyFeature? _currentIHttpResponseBodyFeature;
         internal protected IRouteValuesFeature? _currentIRouteValuesFeature;
         internal protected IEndpointFeature? _currentIEndpointFeature;
+        internal protected IHttpRequestIdentifierFeature? _currentIHttpRequestIdentifierFeature;
+        internal protected IHttpRequestTrailersFeature? _currentIHttpRequestTrailersFeature;
+        internal protected IHttpUpgradeFeature? _currentIHttpUpgradeFeature;
+        internal protected IRequestBodyPipeFeature? _currentIRequestBodyPipeFeature;
+        internal protected IHttpConnectionFeature? _currentIHttpConnectionFeature;
+        internal protected IHttpRequestLifetimeFeature? _currentIHttpRequestLifetimeFeature;
+        internal protected IHttpBodyControlFeature? _currentIHttpBodyControlFeature;
+        internal protected IHttpMaxRequestBodySizeFeature? _currentIHttpMaxRequestBodySizeFeature;
+        internal protected IHttpRequestBodyDetectionFeature? _currentIHttpRequestBodyDetectionFeature;
+        internal protected IHttpMinRequestBodyDataRateFeature? _currentIHttpMinRequestBodyDataRateFeature;
+
+        // Other reserved feature slots
         internal protected IServiceProvidersFeature? _currentIServiceProvidersFeature;
         internal protected IItemsFeature? _currentIItemsFeature;
         internal protected IQueryFeature? _currentIQueryFeature;
         internal protected IFormFeature? _currentIFormFeature;
         internal protected IHttpAuthenticationFeature? _currentIHttpAuthenticationFeature;
-        internal protected IHttpRequestIdentifierFeature? _currentIHttpRequestIdentifierFeature;
-        internal protected IHttpConnectionFeature? _currentIHttpConnectionFeature;
         internal protected ISessionFeature? _currentISessionFeature;
         internal protected IResponseCookiesFeature? _currentIResponseCookiesFeature;
-        internal protected IHttpRequestTrailersFeature? _currentIHttpRequestTrailersFeature;
         internal protected IHttpResponseTrailersFeature? _currentIHttpResponseTrailersFeature;
         internal protected ITlsConnectionFeature? _currentITlsConnectionFeature;
-        internal protected IHttpUpgradeFeature? _currentIHttpUpgradeFeature;
         internal protected IHttpWebSocketFeature? _currentIHttpWebSocketFeature;
         internal protected IHttp2StreamIdFeature? _currentIHttp2StreamIdFeature;
-        internal protected IRequestBodyPipeFeature? _currentIRequestBodyPipeFeature;
-        internal protected IHttpRequestLifetimeFeature? _currentIHttpRequestLifetimeFeature;
-        internal protected IHttpMaxRequestBodySizeFeature? _currentIHttpMaxRequestBodySizeFeature;
-        internal protected IHttpMinRequestBodyDataRateFeature? _currentIHttpMinRequestBodyDataRateFeature;
         internal protected IHttpMinResponseDataRateFeature? _currentIHttpMinResponseDataRateFeature;
-        internal protected IHttpBodyControlFeature? _currentIHttpBodyControlFeature;
-        internal protected IHttpRequestBodyDetectionFeature? _currentIHttpRequestBodyDetectionFeature;
         internal protected IHttpResetFeature? _currentIHttpResetFeature;
 
         private int _featureRevision;
@@ -182,6 +185,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     feature = _currentIQueryFeature;
                 }
+                else if (key == typeof(IRequestBodyPipeFeature))
+                {
+                    feature = _currentIRequestBodyPipeFeature;
+                }
                 else if (key == typeof(IFormFeature))
                 {
                     feature = _currentIFormFeature;
@@ -229,10 +236,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else if (key == typeof(IHttp2StreamIdFeature))
                 {
                     feature = _currentIHttp2StreamIdFeature;
-                }
-                else if (key == typeof(IRequestBodyPipeFeature))
-                {
-                    feature = _currentIRequestBodyPipeFeature;
                 }
                 else if (key == typeof(IHttpRequestLifetimeFeature))
                 {
@@ -306,6 +309,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIQueryFeature = (IQueryFeature?)value;
                 }
+                else if (key == typeof(IRequestBodyPipeFeature))
+                {
+                    _currentIRequestBodyPipeFeature = (IRequestBodyPipeFeature?)value;
+                }
                 else if (key == typeof(IFormFeature))
                 {
                     _currentIFormFeature = (IFormFeature?)value;
@@ -353,10 +360,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else if (key == typeof(IHttp2StreamIdFeature))
                 {
                     _currentIHttp2StreamIdFeature = (IHttp2StreamIdFeature?)value;
-                }
-                else if (key == typeof(IRequestBodyPipeFeature))
-                {
-                    _currentIRequestBodyPipeFeature = (IRequestBodyPipeFeature?)value;
                 }
                 else if (key == typeof(IHttpRequestLifetimeFeature))
                 {
@@ -432,6 +435,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 feature = Unsafe.As<IQueryFeature?, TFeature?>(ref _currentIQueryFeature);
             }
+            else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
+            {
+                feature = Unsafe.As<IRequestBodyPipeFeature?, TFeature?>(ref _currentIRequestBodyPipeFeature);
+            }
             else if (typeof(TFeature) == typeof(IFormFeature))
             {
                 feature = Unsafe.As<IFormFeature?, TFeature?>(ref _currentIFormFeature);
@@ -479,10 +486,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
                 feature = Unsafe.As<IHttp2StreamIdFeature?, TFeature?>(ref _currentIHttp2StreamIdFeature);
-            }
-            else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
-            {
-                feature = Unsafe.As<IRequestBodyPipeFeature?, TFeature?>(ref _currentIRequestBodyPipeFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
             {
@@ -564,6 +567,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIQueryFeature = Unsafe.As<TFeature?, IQueryFeature?>(ref feature);
             }
+            else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
+            {
+                _currentIRequestBodyPipeFeature = Unsafe.As<TFeature?, IRequestBodyPipeFeature?>(ref feature);
+            }
             else if (typeof(TFeature) == typeof(IFormFeature))
             {
                 _currentIFormFeature = Unsafe.As<TFeature?, IFormFeature?>(ref feature);
@@ -611,10 +618,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
                 _currentIHttp2StreamIdFeature = Unsafe.As<TFeature?, IHttp2StreamIdFeature?>(ref feature);
-            }
-            else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
-            {
-                _currentIRequestBodyPipeFeature = Unsafe.As<TFeature?, IRequestBodyPipeFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
             {
@@ -684,6 +687,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 yield return new KeyValuePair<Type, object>(typeof(IQueryFeature), _currentIQueryFeature);
             }
+            if (_currentIRequestBodyPipeFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IRequestBodyPipeFeature), _currentIRequestBodyPipeFeature);
+            }
             if (_currentIFormFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IFormFeature), _currentIFormFeature);
@@ -731,10 +738,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_currentIHttp2StreamIdFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IHttp2StreamIdFeature), _currentIHttp2StreamIdFeature);
-            }
-            if (_currentIRequestBodyPipeFeature != null)
-            {
-                yield return new KeyValuePair<Type, object>(typeof(IRequestBodyPipeFeature), _currentIRequestBodyPipeFeature);
             }
             if (_currentIHttpRequestLifetimeFeature != null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -527,118 +527,122 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         void IFeatureCollection.Set<TFeature>(TFeature? feature) where TFeature : default
         {
+            // Using Unsafe.As for the cast due to https://github.com/dotnet/runtime/issues/49614
+            // The type of TFeature is confirmed by the typeof() check and the As cast only accepts
+            // that type; however the Jit does not eliminate a regular cast in a shared generic.
+
             _featureRevision++;
             if (typeof(TFeature) == typeof(IHttpRequestFeature))
             {
-                _currentIHttpRequestFeature = (IHttpRequestFeature?)feature;
+                _currentIHttpRequestFeature = Unsafe.As<TFeature?, IHttpRequestFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
             {
-                _currentIHttpRequestBodyDetectionFeature = (IHttpRequestBodyDetectionFeature?)feature;
+                _currentIHttpRequestBodyDetectionFeature = Unsafe.As<TFeature?, IHttpRequestBodyDetectionFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpResponseFeature))
             {
-                _currentIHttpResponseFeature = (IHttpResponseFeature?)feature;
+                _currentIHttpResponseFeature = Unsafe.As<TFeature?, IHttpResponseFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpResponseBodyFeature))
             {
-                _currentIHttpResponseBodyFeature = (IHttpResponseBodyFeature?)feature;
+                _currentIHttpResponseBodyFeature = Unsafe.As<TFeature?, IHttpResponseBodyFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
             {
-                _currentIRequestBodyPipeFeature = (IRequestBodyPipeFeature?)feature;
+                _currentIRequestBodyPipeFeature = Unsafe.As<TFeature?, IRequestBodyPipeFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestIdentifierFeature))
             {
-                _currentIHttpRequestIdentifierFeature = (IHttpRequestIdentifierFeature?)feature;
+                _currentIHttpRequestIdentifierFeature = Unsafe.As<TFeature?, IHttpRequestIdentifierFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IServiceProvidersFeature))
             {
-                _currentIServiceProvidersFeature = (IServiceProvidersFeature?)feature;
+                _currentIServiceProvidersFeature = Unsafe.As<TFeature?, IServiceProvidersFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
             {
-                _currentIHttpRequestLifetimeFeature = (IHttpRequestLifetimeFeature?)feature;
+                _currentIHttpRequestLifetimeFeature = Unsafe.As<TFeature?, IHttpRequestLifetimeFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpConnectionFeature))
             {
-                _currentIHttpConnectionFeature = (IHttpConnectionFeature?)feature;
+                _currentIHttpConnectionFeature = Unsafe.As<TFeature?, IHttpConnectionFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IRouteValuesFeature))
             {
-                _currentIRouteValuesFeature = (IRouteValuesFeature?)feature;
+                _currentIRouteValuesFeature = Unsafe.As<TFeature?, IRouteValuesFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IEndpointFeature))
             {
-                _currentIEndpointFeature = (IEndpointFeature?)feature;
+                _currentIEndpointFeature = Unsafe.As<TFeature?, IEndpointFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
             {
-                _currentIHttpAuthenticationFeature = (IHttpAuthenticationFeature?)feature;
+                _currentIHttpAuthenticationFeature = Unsafe.As<TFeature?, IHttpAuthenticationFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
             {
-                _currentIHttpRequestTrailersFeature = (IHttpRequestTrailersFeature?)feature;
+                _currentIHttpRequestTrailersFeature = Unsafe.As<TFeature?, IHttpRequestTrailersFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IQueryFeature))
             {
-                _currentIQueryFeature = (IQueryFeature?)feature;
+                _currentIQueryFeature = Unsafe.As<TFeature?, IQueryFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IFormFeature))
             {
-                _currentIFormFeature = (IFormFeature?)feature;
+                _currentIFormFeature = Unsafe.As<TFeature?, IFormFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpUpgradeFeature))
             {
-                _currentIHttpUpgradeFeature = (IHttpUpgradeFeature?)feature;
+                _currentIHttpUpgradeFeature = Unsafe.As<TFeature?, IHttpUpgradeFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
-                _currentIHttp2StreamIdFeature = (IHttp2StreamIdFeature?)feature;
+                _currentIHttp2StreamIdFeature = Unsafe.As<TFeature?, IHttp2StreamIdFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
             {
-                _currentIHttpResponseTrailersFeature = (IHttpResponseTrailersFeature?)feature;
+                _currentIHttpResponseTrailersFeature = Unsafe.As<TFeature?, IHttpResponseTrailersFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IResponseCookiesFeature))
             {
-                _currentIResponseCookiesFeature = (IResponseCookiesFeature?)feature;
+                _currentIResponseCookiesFeature = Unsafe.As<TFeature?, IResponseCookiesFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IItemsFeature))
             {
-                _currentIItemsFeature = (IItemsFeature?)feature;
+                _currentIItemsFeature = Unsafe.As<TFeature?, IItemsFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(ITlsConnectionFeature))
             {
-                _currentITlsConnectionFeature = (ITlsConnectionFeature?)feature;
+                _currentITlsConnectionFeature = Unsafe.As<TFeature?, ITlsConnectionFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpWebSocketFeature))
             {
-                _currentIHttpWebSocketFeature = (IHttpWebSocketFeature?)feature;
+                _currentIHttpWebSocketFeature = Unsafe.As<TFeature?, IHttpWebSocketFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(ISessionFeature))
             {
-                _currentISessionFeature = (ISessionFeature?)feature;
+                _currentISessionFeature = Unsafe.As<TFeature?, ISessionFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpMaxRequestBodySizeFeature))
             {
-                _currentIHttpMaxRequestBodySizeFeature = (IHttpMaxRequestBodySizeFeature?)feature;
+                _currentIHttpMaxRequestBodySizeFeature = Unsafe.As<TFeature?, IHttpMaxRequestBodySizeFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpMinRequestBodyDataRateFeature))
             {
-                _currentIHttpMinRequestBodyDataRateFeature = (IHttpMinRequestBodyDataRateFeature?)feature;
+                _currentIHttpMinRequestBodyDataRateFeature = Unsafe.As<TFeature?, IHttpMinRequestBodyDataRateFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpMinResponseDataRateFeature))
             {
-                _currentIHttpMinResponseDataRateFeature = (IHttpMinResponseDataRateFeature?)feature;
+                _currentIHttpMinResponseDataRateFeature = Unsafe.As<TFeature?, IHttpMinResponseDataRateFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpBodyControlFeature))
             {
-                _currentIHttpBodyControlFeature = (IHttpBodyControlFeature?)feature;
+                _currentIHttpBodyControlFeature = Unsafe.As<TFeature?, IHttpBodyControlFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpResetFeature))
             {
-                _currentIHttpResetFeature = (IHttpResetFeature?)feature;
+                _currentIHttpResetFeature = Unsafe.As<TFeature?, IHttpResetFeature?>(ref feature);
             }
             else
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -14,7 +14,21 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
-    internal partial class HttpProtocol : IFeatureCollection
+    internal partial class HttpProtocol : IFeatureCollection,
+                                          IHttpRequestFeature,
+                                          IHttpResponseFeature,
+                                          IHttpResponseBodyFeature,
+                                          IRouteValuesFeature,
+                                          IEndpointFeature,
+                                          IHttpRequestIdentifierFeature,
+                                          IHttpRequestTrailersFeature,
+                                          IHttpUpgradeFeature,
+                                          IRequestBodyPipeFeature,
+                                          IHttpConnectionFeature,
+                                          IHttpRequestLifetimeFeature,
+                                          IHttpBodyControlFeature,
+                                          IHttpMaxRequestBodySizeFeature,
+                                          IHttpRequestBodyDetectionFeature
     {
         // Implemented features
         internal protected IHttpRequestFeature? _currentIHttpRequestFeature;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -15,34 +15,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 {
     internal partial class HttpProtocol : IFeatureCollection
     {
-        private object? _currentIHttpRequestFeature;
-        private object? _currentIHttpRequestBodyDetectionFeature;
-        private object? _currentIHttpResponseFeature;
-        private object? _currentIHttpResponseBodyFeature;
-        private object? _currentIRequestBodyPipeFeature;
-        private object? _currentIHttpRequestIdentifierFeature;
-        private object? _currentIServiceProvidersFeature;
-        private object? _currentIHttpRequestLifetimeFeature;
-        private object? _currentIHttpConnectionFeature;
-        private object? _currentIRouteValuesFeature;
-        private object? _currentIEndpointFeature;
-        private object? _currentIHttpAuthenticationFeature;
-        private object? _currentIHttpRequestTrailersFeature;
-        private object? _currentIQueryFeature;
-        private object? _currentIFormFeature;
-        private object? _currentIHttpUpgradeFeature;
-        private object? _currentIHttp2StreamIdFeature;
-        private object? _currentIHttpResponseTrailersFeature;
-        private object? _currentIResponseCookiesFeature;
-        private object? _currentIItemsFeature;
-        private object? _currentITlsConnectionFeature;
-        private object? _currentIHttpWebSocketFeature;
-        private object? _currentISessionFeature;
-        private object? _currentIHttpMaxRequestBodySizeFeature;
-        private object? _currentIHttpMinRequestBodyDataRateFeature;
-        private object? _currentIHttpMinResponseDataRateFeature;
-        private object? _currentIHttpBodyControlFeature;
-        private object? _currentIHttpResetFeature;
+        internal protected IHttpRequestFeature? _currentIHttpRequestFeature;
+        internal protected IHttpRequestBodyDetectionFeature? _currentIHttpRequestBodyDetectionFeature;
+        internal protected IHttpResponseFeature? _currentIHttpResponseFeature;
+        internal protected IHttpResponseBodyFeature? _currentIHttpResponseBodyFeature;
+        internal protected IRequestBodyPipeFeature? _currentIRequestBodyPipeFeature;
+        internal protected IHttpRequestIdentifierFeature? _currentIHttpRequestIdentifierFeature;
+        internal protected IServiceProvidersFeature? _currentIServiceProvidersFeature;
+        internal protected IHttpRequestLifetimeFeature? _currentIHttpRequestLifetimeFeature;
+        internal protected IHttpConnectionFeature? _currentIHttpConnectionFeature;
+        internal protected IRouteValuesFeature? _currentIRouteValuesFeature;
+        internal protected IEndpointFeature? _currentIEndpointFeature;
+        internal protected IHttpAuthenticationFeature? _currentIHttpAuthenticationFeature;
+        internal protected IHttpRequestTrailersFeature? _currentIHttpRequestTrailersFeature;
+        internal protected IQueryFeature? _currentIQueryFeature;
+        internal protected IFormFeature? _currentIFormFeature;
+        internal protected IHttpUpgradeFeature? _currentIHttpUpgradeFeature;
+        internal protected IHttp2StreamIdFeature? _currentIHttp2StreamIdFeature;
+        internal protected IHttpResponseTrailersFeature? _currentIHttpResponseTrailersFeature;
+        internal protected IResponseCookiesFeature? _currentIResponseCookiesFeature;
+        internal protected IItemsFeature? _currentIItemsFeature;
+        internal protected ITlsConnectionFeature? _currentITlsConnectionFeature;
+        internal protected IHttpWebSocketFeature? _currentIHttpWebSocketFeature;
+        internal protected ISessionFeature? _currentISessionFeature;
+        internal protected IHttpMaxRequestBodySizeFeature? _currentIHttpMaxRequestBodySizeFeature;
+        internal protected IHttpMinRequestBodyDataRateFeature? _currentIHttpMinRequestBodyDataRateFeature;
+        internal protected IHttpMinResponseDataRateFeature? _currentIHttpMinResponseDataRateFeature;
+        internal protected IHttpBodyControlFeature? _currentIHttpBodyControlFeature;
+        internal protected IHttpResetFeature? _currentIHttpResetFeature;
 
         private int _featureRevision;
 
@@ -61,7 +61,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentIHttpRequestTrailersFeature = this;
             _currentIHttpConnectionFeature = this;
             _currentIHttpMaxRequestBodySizeFeature = this;
-            _currentIHttpMinRequestBodyDataRateFeature = this;
             _currentIHttpBodyControlFeature = this;
             _currentIRouteValuesFeature = this;
             _currentIEndpointFeature = this;
@@ -276,115 +275,115 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 if (key == typeof(IHttpRequestFeature))
                 {
-                    _currentIHttpRequestFeature = value;
+                    _currentIHttpRequestFeature = (IHttpRequestFeature?)value;
                 }
                 else if (key == typeof(IHttpRequestBodyDetectionFeature))
                 {
-                    _currentIHttpRequestBodyDetectionFeature = value;
+                    _currentIHttpRequestBodyDetectionFeature = (IHttpRequestBodyDetectionFeature?)value;
                 }
                 else if (key == typeof(IHttpResponseFeature))
                 {
-                    _currentIHttpResponseFeature = value;
+                    _currentIHttpResponseFeature = (IHttpResponseFeature?)value;
                 }
                 else if (key == typeof(IHttpResponseBodyFeature))
                 {
-                    _currentIHttpResponseBodyFeature = value;
+                    _currentIHttpResponseBodyFeature = (IHttpResponseBodyFeature?)value;
                 }
                 else if (key == typeof(IRequestBodyPipeFeature))
                 {
-                    _currentIRequestBodyPipeFeature = value;
+                    _currentIRequestBodyPipeFeature = (IRequestBodyPipeFeature?)value;
                 }
                 else if (key == typeof(IHttpRequestIdentifierFeature))
                 {
-                    _currentIHttpRequestIdentifierFeature = value;
+                    _currentIHttpRequestIdentifierFeature = (IHttpRequestIdentifierFeature?)value;
                 }
                 else if (key == typeof(IServiceProvidersFeature))
                 {
-                    _currentIServiceProvidersFeature = value;
+                    _currentIServiceProvidersFeature = (IServiceProvidersFeature?)value;
                 }
                 else if (key == typeof(IHttpRequestLifetimeFeature))
                 {
-                    _currentIHttpRequestLifetimeFeature = value;
+                    _currentIHttpRequestLifetimeFeature = (IHttpRequestLifetimeFeature?)value;
                 }
                 else if (key == typeof(IHttpConnectionFeature))
                 {
-                    _currentIHttpConnectionFeature = value;
+                    _currentIHttpConnectionFeature = (IHttpConnectionFeature?)value;
                 }
                 else if (key == typeof(IRouteValuesFeature))
                 {
-                    _currentIRouteValuesFeature = value;
+                    _currentIRouteValuesFeature = (IRouteValuesFeature?)value;
                 }
                 else if (key == typeof(IEndpointFeature))
                 {
-                    _currentIEndpointFeature = value;
+                    _currentIEndpointFeature = (IEndpointFeature?)value;
                 }
                 else if (key == typeof(IHttpAuthenticationFeature))
                 {
-                    _currentIHttpAuthenticationFeature = value;
+                    _currentIHttpAuthenticationFeature = (IHttpAuthenticationFeature?)value;
                 }
                 else if (key == typeof(IHttpRequestTrailersFeature))
                 {
-                    _currentIHttpRequestTrailersFeature = value;
+                    _currentIHttpRequestTrailersFeature = (IHttpRequestTrailersFeature?)value;
                 }
                 else if (key == typeof(IQueryFeature))
                 {
-                    _currentIQueryFeature = value;
+                    _currentIQueryFeature = (IQueryFeature?)value;
                 }
                 else if (key == typeof(IFormFeature))
                 {
-                    _currentIFormFeature = value;
+                    _currentIFormFeature = (IFormFeature?)value;
                 }
                 else if (key == typeof(IHttpUpgradeFeature))
                 {
-                    _currentIHttpUpgradeFeature = value;
+                    _currentIHttpUpgradeFeature = (IHttpUpgradeFeature?)value;
                 }
                 else if (key == typeof(IHttp2StreamIdFeature))
                 {
-                    _currentIHttp2StreamIdFeature = value;
+                    _currentIHttp2StreamIdFeature = (IHttp2StreamIdFeature?)value;
                 }
                 else if (key == typeof(IHttpResponseTrailersFeature))
                 {
-                    _currentIHttpResponseTrailersFeature = value;
+                    _currentIHttpResponseTrailersFeature = (IHttpResponseTrailersFeature?)value;
                 }
                 else if (key == typeof(IResponseCookiesFeature))
                 {
-                    _currentIResponseCookiesFeature = value;
+                    _currentIResponseCookiesFeature = (IResponseCookiesFeature?)value;
                 }
                 else if (key == typeof(IItemsFeature))
                 {
-                    _currentIItemsFeature = value;
+                    _currentIItemsFeature = (IItemsFeature?)value;
                 }
                 else if (key == typeof(ITlsConnectionFeature))
                 {
-                    _currentITlsConnectionFeature = value;
+                    _currentITlsConnectionFeature = (ITlsConnectionFeature?)value;
                 }
                 else if (key == typeof(IHttpWebSocketFeature))
                 {
-                    _currentIHttpWebSocketFeature = value;
+                    _currentIHttpWebSocketFeature = (IHttpWebSocketFeature?)value;
                 }
                 else if (key == typeof(ISessionFeature))
                 {
-                    _currentISessionFeature = value;
+                    _currentISessionFeature = (ISessionFeature?)value;
                 }
                 else if (key == typeof(IHttpMaxRequestBodySizeFeature))
                 {
-                    _currentIHttpMaxRequestBodySizeFeature = value;
+                    _currentIHttpMaxRequestBodySizeFeature = (IHttpMaxRequestBodySizeFeature?)value;
                 }
                 else if (key == typeof(IHttpMinRequestBodyDataRateFeature))
                 {
-                    _currentIHttpMinRequestBodyDataRateFeature = value;
+                    _currentIHttpMinRequestBodyDataRateFeature = (IHttpMinRequestBodyDataRateFeature?)value;
                 }
                 else if (key == typeof(IHttpMinResponseDataRateFeature))
                 {
-                    _currentIHttpMinResponseDataRateFeature = value;
+                    _currentIHttpMinResponseDataRateFeature = (IHttpMinResponseDataRateFeature?)value;
                 }
                 else if (key == typeof(IHttpBodyControlFeature))
                 {
-                    _currentIHttpBodyControlFeature = value;
+                    _currentIHttpBodyControlFeature = (IHttpBodyControlFeature?)value;
                 }
                 else if (key == typeof(IHttpResetFeature))
                 {
-                    _currentIHttpResetFeature = value;
+                    _currentIHttpResetFeature = (IHttpResetFeature?)value;
                 }
                 else
                 {
@@ -526,115 +525,115 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _featureRevision++;
             if (typeof(TFeature) == typeof(IHttpRequestFeature))
             {
-                _currentIHttpRequestFeature = feature;
+                _currentIHttpRequestFeature = (IHttpRequestFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
             {
-                _currentIHttpRequestBodyDetectionFeature = feature;
+                _currentIHttpRequestBodyDetectionFeature = (IHttpRequestBodyDetectionFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpResponseFeature))
             {
-                _currentIHttpResponseFeature = feature;
+                _currentIHttpResponseFeature = (IHttpResponseFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpResponseBodyFeature))
             {
-                _currentIHttpResponseBodyFeature = feature;
+                _currentIHttpResponseBodyFeature = (IHttpResponseBodyFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
             {
-                _currentIRequestBodyPipeFeature = feature;
+                _currentIRequestBodyPipeFeature = (IRequestBodyPipeFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpRequestIdentifierFeature))
             {
-                _currentIHttpRequestIdentifierFeature = feature;
+                _currentIHttpRequestIdentifierFeature = (IHttpRequestIdentifierFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IServiceProvidersFeature))
             {
-                _currentIServiceProvidersFeature = feature;
+                _currentIServiceProvidersFeature = (IServiceProvidersFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
             {
-                _currentIHttpRequestLifetimeFeature = feature;
+                _currentIHttpRequestLifetimeFeature = (IHttpRequestLifetimeFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpConnectionFeature))
             {
-                _currentIHttpConnectionFeature = feature;
+                _currentIHttpConnectionFeature = (IHttpConnectionFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IRouteValuesFeature))
             {
-                _currentIRouteValuesFeature = feature;
+                _currentIRouteValuesFeature = (IRouteValuesFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IEndpointFeature))
             {
-                _currentIEndpointFeature = feature;
+                _currentIEndpointFeature = (IEndpointFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
             {
-                _currentIHttpAuthenticationFeature = feature;
+                _currentIHttpAuthenticationFeature = (IHttpAuthenticationFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
             {
-                _currentIHttpRequestTrailersFeature = feature;
+                _currentIHttpRequestTrailersFeature = (IHttpRequestTrailersFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IQueryFeature))
             {
-                _currentIQueryFeature = feature;
+                _currentIQueryFeature = (IQueryFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IFormFeature))
             {
-                _currentIFormFeature = feature;
+                _currentIFormFeature = (IFormFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpUpgradeFeature))
             {
-                _currentIHttpUpgradeFeature = feature;
+                _currentIHttpUpgradeFeature = (IHttpUpgradeFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
-                _currentIHttp2StreamIdFeature = feature;
+                _currentIHttp2StreamIdFeature = (IHttp2StreamIdFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
             {
-                _currentIHttpResponseTrailersFeature = feature;
+                _currentIHttpResponseTrailersFeature = (IHttpResponseTrailersFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IResponseCookiesFeature))
             {
-                _currentIResponseCookiesFeature = feature;
+                _currentIResponseCookiesFeature = (IResponseCookiesFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IItemsFeature))
             {
-                _currentIItemsFeature = feature;
+                _currentIItemsFeature = (IItemsFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(ITlsConnectionFeature))
             {
-                _currentITlsConnectionFeature = feature;
+                _currentITlsConnectionFeature = (ITlsConnectionFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpWebSocketFeature))
             {
-                _currentIHttpWebSocketFeature = feature;
+                _currentIHttpWebSocketFeature = (IHttpWebSocketFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(ISessionFeature))
             {
-                _currentISessionFeature = feature;
+                _currentISessionFeature = (ISessionFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpMaxRequestBodySizeFeature))
             {
-                _currentIHttpMaxRequestBodySizeFeature = feature;
+                _currentIHttpMaxRequestBodySizeFeature = (IHttpMaxRequestBodySizeFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpMinRequestBodyDataRateFeature))
             {
-                _currentIHttpMinRequestBodyDataRateFeature = feature;
+                _currentIHttpMinRequestBodyDataRateFeature = (IHttpMinRequestBodyDataRateFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpMinResponseDataRateFeature))
             {
-                _currentIHttpMinResponseDataRateFeature = feature;
+                _currentIHttpMinResponseDataRateFeature = (IHttpMinResponseDataRateFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpBodyControlFeature))
             {
-                _currentIHttpBodyControlFeature = feature;
+                _currentIHttpBodyControlFeature = (IHttpBodyControlFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IHttpResetFeature))
             {
-                _currentIHttpResetFeature = feature;
+                _currentIHttpResetFeature = (IHttpResetFeature?)feature;
             }
             else
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -45,7 +45,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         internal protected IHttpBodyControlFeature? _currentIHttpBodyControlFeature;
         internal protected IHttpMaxRequestBodySizeFeature? _currentIHttpMaxRequestBodySizeFeature;
         internal protected IHttpRequestBodyDetectionFeature? _currentIHttpRequestBodyDetectionFeature;
-        internal protected IHttpMinRequestBodyDataRateFeature? _currentIHttpMinRequestBodyDataRateFeature;
 
         // Other reserved feature slots
         internal protected IServiceProvidersFeature? _currentIServiceProvidersFeature;
@@ -59,6 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         internal protected ITlsConnectionFeature? _currentITlsConnectionFeature;
         internal protected IHttpWebSocketFeature? _currentIHttpWebSocketFeature;
         internal protected IHttp2StreamIdFeature? _currentIHttp2StreamIdFeature;
+        internal protected IHttpMinRequestBodyDataRateFeature? _currentIHttpMinRequestBodyDataRateFeature;
         internal protected IHttpMinResponseDataRateFeature? _currentIHttpMinResponseDataRateFeature;
         internal protected IHttpResetFeature? _currentIHttpResetFeature;
 
@@ -94,6 +94,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _currentITlsConnectionFeature = null;
             _currentIHttpWebSocketFeature = null;
             _currentIHttp2StreamIdFeature = null;
+            _currentIHttpMinRequestBodyDataRateFeature = null;
             _currentIHttpMinResponseDataRateFeature = null;
             _currentIHttpResetFeature = null;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -17,32 +17,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     internal partial class HttpProtocol : IFeatureCollection
     {
         internal protected IHttpRequestFeature? _currentIHttpRequestFeature;
-        internal protected IHttpRequestBodyDetectionFeature? _currentIHttpRequestBodyDetectionFeature;
         internal protected IHttpResponseFeature? _currentIHttpResponseFeature;
         internal protected IHttpResponseBodyFeature? _currentIHttpResponseBodyFeature;
-        internal protected IRequestBodyPipeFeature? _currentIRequestBodyPipeFeature;
-        internal protected IHttpRequestIdentifierFeature? _currentIHttpRequestIdentifierFeature;
-        internal protected IServiceProvidersFeature? _currentIServiceProvidersFeature;
-        internal protected IHttpRequestLifetimeFeature? _currentIHttpRequestLifetimeFeature;
-        internal protected IHttpConnectionFeature? _currentIHttpConnectionFeature;
         internal protected IRouteValuesFeature? _currentIRouteValuesFeature;
         internal protected IEndpointFeature? _currentIEndpointFeature;
-        internal protected IHttpAuthenticationFeature? _currentIHttpAuthenticationFeature;
-        internal protected IHttpRequestTrailersFeature? _currentIHttpRequestTrailersFeature;
+        internal protected IServiceProvidersFeature? _currentIServiceProvidersFeature;
+        internal protected IItemsFeature? _currentIItemsFeature;
         internal protected IQueryFeature? _currentIQueryFeature;
         internal protected IFormFeature? _currentIFormFeature;
-        internal protected IHttpUpgradeFeature? _currentIHttpUpgradeFeature;
-        internal protected IHttp2StreamIdFeature? _currentIHttp2StreamIdFeature;
-        internal protected IHttpResponseTrailersFeature? _currentIHttpResponseTrailersFeature;
-        internal protected IResponseCookiesFeature? _currentIResponseCookiesFeature;
-        internal protected IItemsFeature? _currentIItemsFeature;
-        internal protected ITlsConnectionFeature? _currentITlsConnectionFeature;
-        internal protected IHttpWebSocketFeature? _currentIHttpWebSocketFeature;
+        internal protected IHttpAuthenticationFeature? _currentIHttpAuthenticationFeature;
+        internal protected IHttpRequestIdentifierFeature? _currentIHttpRequestIdentifierFeature;
+        internal protected IHttpConnectionFeature? _currentIHttpConnectionFeature;
         internal protected ISessionFeature? _currentISessionFeature;
+        internal protected IResponseCookiesFeature? _currentIResponseCookiesFeature;
+        internal protected IHttpRequestTrailersFeature? _currentIHttpRequestTrailersFeature;
+        internal protected IHttpResponseTrailersFeature? _currentIHttpResponseTrailersFeature;
+        internal protected ITlsConnectionFeature? _currentITlsConnectionFeature;
+        internal protected IHttpUpgradeFeature? _currentIHttpUpgradeFeature;
+        internal protected IHttpWebSocketFeature? _currentIHttpWebSocketFeature;
+        internal protected IHttp2StreamIdFeature? _currentIHttp2StreamIdFeature;
+        internal protected IRequestBodyPipeFeature? _currentIRequestBodyPipeFeature;
+        internal protected IHttpRequestLifetimeFeature? _currentIHttpRequestLifetimeFeature;
         internal protected IHttpMaxRequestBodySizeFeature? _currentIHttpMaxRequestBodySizeFeature;
         internal protected IHttpMinRequestBodyDataRateFeature? _currentIHttpMinRequestBodyDataRateFeature;
         internal protected IHttpMinResponseDataRateFeature? _currentIHttpMinResponseDataRateFeature;
         internal protected IHttpBodyControlFeature? _currentIHttpBodyControlFeature;
+        internal protected IHttpRequestBodyDetectionFeature? _currentIHttpRequestBodyDetectionFeature;
         internal protected IHttpResetFeature? _currentIHttpResetFeature;
 
         private int _featureRevision;
@@ -52,31 +52,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private void FastReset()
         {
             _currentIHttpRequestFeature = this;
-            _currentIHttpRequestBodyDetectionFeature = this;
             _currentIHttpResponseFeature = this;
             _currentIHttpResponseBodyFeature = this;
-            _currentIRequestBodyPipeFeature = this;
-            _currentIHttpUpgradeFeature = this;
-            _currentIHttpRequestIdentifierFeature = this;
-            _currentIHttpRequestLifetimeFeature = this;
-            _currentIHttpRequestTrailersFeature = this;
-            _currentIHttpConnectionFeature = this;
-            _currentIHttpMaxRequestBodySizeFeature = this;
-            _currentIHttpBodyControlFeature = this;
             _currentIRouteValuesFeature = this;
             _currentIEndpointFeature = this;
+            _currentIHttpRequestIdentifierFeature = this;
+            _currentIHttpRequestTrailersFeature = this;
+            _currentIHttpUpgradeFeature = this;
+            _currentIRequestBodyPipeFeature = this;
+            _currentIHttpConnectionFeature = this;
+            _currentIHttpRequestLifetimeFeature = this;
+            _currentIHttpBodyControlFeature = this;
+            _currentIHttpMaxRequestBodySizeFeature = this;
+            _currentIHttpRequestBodyDetectionFeature = this;
 
             _currentIServiceProvidersFeature = null;
-            _currentIHttpAuthenticationFeature = null;
+            _currentIItemsFeature = null;
             _currentIQueryFeature = null;
             _currentIFormFeature = null;
-            _currentIHttp2StreamIdFeature = null;
-            _currentIHttpResponseTrailersFeature = null;
+            _currentIHttpAuthenticationFeature = null;
+            _currentISessionFeature = null;
             _currentIResponseCookiesFeature = null;
-            _currentIItemsFeature = null;
+            _currentIHttpResponseTrailersFeature = null;
             _currentITlsConnectionFeature = null;
             _currentIHttpWebSocketFeature = null;
-            _currentISessionFeature = null;
+            _currentIHttp2StreamIdFeature = null;
             _currentIHttpMinResponseDataRateFeature = null;
             _currentIHttpResetFeature = null;
         }
@@ -154,10 +154,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     feature = _currentIHttpRequestFeature;
                 }
-                else if (key == typeof(IHttpRequestBodyDetectionFeature))
-                {
-                    feature = _currentIHttpRequestBodyDetectionFeature;
-                }
                 else if (key == typeof(IHttpResponseFeature))
                 {
                     feature = _currentIHttpResponseFeature;
@@ -165,26 +161,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else if (key == typeof(IHttpResponseBodyFeature))
                 {
                     feature = _currentIHttpResponseBodyFeature;
-                }
-                else if (key == typeof(IRequestBodyPipeFeature))
-                {
-                    feature = _currentIRequestBodyPipeFeature;
-                }
-                else if (key == typeof(IHttpRequestIdentifierFeature))
-                {
-                    feature = _currentIHttpRequestIdentifierFeature;
-                }
-                else if (key == typeof(IServiceProvidersFeature))
-                {
-                    feature = _currentIServiceProvidersFeature;
-                }
-                else if (key == typeof(IHttpRequestLifetimeFeature))
-                {
-                    feature = _currentIHttpRequestLifetimeFeature;
-                }
-                else if (key == typeof(IHttpConnectionFeature))
-                {
-                    feature = _currentIHttpConnectionFeature;
                 }
                 else if (key == typeof(IRouteValuesFeature))
                 {
@@ -194,13 +170,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     feature = _currentIEndpointFeature;
                 }
-                else if (key == typeof(IHttpAuthenticationFeature))
+                else if (key == typeof(IServiceProvidersFeature))
                 {
-                    feature = _currentIHttpAuthenticationFeature;
+                    feature = _currentIServiceProvidersFeature;
                 }
-                else if (key == typeof(IHttpRequestTrailersFeature))
+                else if (key == typeof(IItemsFeature))
                 {
-                    feature = _currentIHttpRequestTrailersFeature;
+                    feature = _currentIItemsFeature;
                 }
                 else if (key == typeof(IQueryFeature))
                 {
@@ -210,37 +186,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     feature = _currentIFormFeature;
                 }
-                else if (key == typeof(IHttpUpgradeFeature))
+                else if (key == typeof(IHttpAuthenticationFeature))
                 {
-                    feature = _currentIHttpUpgradeFeature;
+                    feature = _currentIHttpAuthenticationFeature;
                 }
-                else if (key == typeof(IHttp2StreamIdFeature))
+                else if (key == typeof(IHttpRequestIdentifierFeature))
                 {
-                    feature = _currentIHttp2StreamIdFeature;
+                    feature = _currentIHttpRequestIdentifierFeature;
                 }
-                else if (key == typeof(IHttpResponseTrailersFeature))
+                else if (key == typeof(IHttpConnectionFeature))
                 {
-                    feature = _currentIHttpResponseTrailersFeature;
+                    feature = _currentIHttpConnectionFeature;
+                }
+                else if (key == typeof(ISessionFeature))
+                {
+                    feature = _currentISessionFeature;
                 }
                 else if (key == typeof(IResponseCookiesFeature))
                 {
                     feature = _currentIResponseCookiesFeature;
                 }
-                else if (key == typeof(IItemsFeature))
+                else if (key == typeof(IHttpRequestTrailersFeature))
                 {
-                    feature = _currentIItemsFeature;
+                    feature = _currentIHttpRequestTrailersFeature;
+                }
+                else if (key == typeof(IHttpResponseTrailersFeature))
+                {
+                    feature = _currentIHttpResponseTrailersFeature;
                 }
                 else if (key == typeof(ITlsConnectionFeature))
                 {
                     feature = _currentITlsConnectionFeature;
                 }
+                else if (key == typeof(IHttpUpgradeFeature))
+                {
+                    feature = _currentIHttpUpgradeFeature;
+                }
                 else if (key == typeof(IHttpWebSocketFeature))
                 {
                     feature = _currentIHttpWebSocketFeature;
                 }
-                else if (key == typeof(ISessionFeature))
+                else if (key == typeof(IHttp2StreamIdFeature))
                 {
-                    feature = _currentISessionFeature;
+                    feature = _currentIHttp2StreamIdFeature;
+                }
+                else if (key == typeof(IRequestBodyPipeFeature))
+                {
+                    feature = _currentIRequestBodyPipeFeature;
+                }
+                else if (key == typeof(IHttpRequestLifetimeFeature))
+                {
+                    feature = _currentIHttpRequestLifetimeFeature;
                 }
                 else if (key == typeof(IHttpMaxRequestBodySizeFeature))
                 {
@@ -257,6 +253,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else if (key == typeof(IHttpBodyControlFeature))
                 {
                     feature = _currentIHttpBodyControlFeature;
+                }
+                else if (key == typeof(IHttpRequestBodyDetectionFeature))
+                {
+                    feature = _currentIHttpRequestBodyDetectionFeature;
                 }
                 else if (key == typeof(IHttpResetFeature))
                 {
@@ -278,10 +278,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIHttpRequestFeature = (IHttpRequestFeature?)value;
                 }
-                else if (key == typeof(IHttpRequestBodyDetectionFeature))
-                {
-                    _currentIHttpRequestBodyDetectionFeature = (IHttpRequestBodyDetectionFeature?)value;
-                }
                 else if (key == typeof(IHttpResponseFeature))
                 {
                     _currentIHttpResponseFeature = (IHttpResponseFeature?)value;
@@ -289,26 +285,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else if (key == typeof(IHttpResponseBodyFeature))
                 {
                     _currentIHttpResponseBodyFeature = (IHttpResponseBodyFeature?)value;
-                }
-                else if (key == typeof(IRequestBodyPipeFeature))
-                {
-                    _currentIRequestBodyPipeFeature = (IRequestBodyPipeFeature?)value;
-                }
-                else if (key == typeof(IHttpRequestIdentifierFeature))
-                {
-                    _currentIHttpRequestIdentifierFeature = (IHttpRequestIdentifierFeature?)value;
-                }
-                else if (key == typeof(IServiceProvidersFeature))
-                {
-                    _currentIServiceProvidersFeature = (IServiceProvidersFeature?)value;
-                }
-                else if (key == typeof(IHttpRequestLifetimeFeature))
-                {
-                    _currentIHttpRequestLifetimeFeature = (IHttpRequestLifetimeFeature?)value;
-                }
-                else if (key == typeof(IHttpConnectionFeature))
-                {
-                    _currentIHttpConnectionFeature = (IHttpConnectionFeature?)value;
                 }
                 else if (key == typeof(IRouteValuesFeature))
                 {
@@ -318,13 +294,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIEndpointFeature = (IEndpointFeature?)value;
                 }
-                else if (key == typeof(IHttpAuthenticationFeature))
+                else if (key == typeof(IServiceProvidersFeature))
                 {
-                    _currentIHttpAuthenticationFeature = (IHttpAuthenticationFeature?)value;
+                    _currentIServiceProvidersFeature = (IServiceProvidersFeature?)value;
                 }
-                else if (key == typeof(IHttpRequestTrailersFeature))
+                else if (key == typeof(IItemsFeature))
                 {
-                    _currentIHttpRequestTrailersFeature = (IHttpRequestTrailersFeature?)value;
+                    _currentIItemsFeature = (IItemsFeature?)value;
                 }
                 else if (key == typeof(IQueryFeature))
                 {
@@ -334,37 +310,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     _currentIFormFeature = (IFormFeature?)value;
                 }
-                else if (key == typeof(IHttpUpgradeFeature))
+                else if (key == typeof(IHttpAuthenticationFeature))
                 {
-                    _currentIHttpUpgradeFeature = (IHttpUpgradeFeature?)value;
+                    _currentIHttpAuthenticationFeature = (IHttpAuthenticationFeature?)value;
                 }
-                else if (key == typeof(IHttp2StreamIdFeature))
+                else if (key == typeof(IHttpRequestIdentifierFeature))
                 {
-                    _currentIHttp2StreamIdFeature = (IHttp2StreamIdFeature?)value;
+                    _currentIHttpRequestIdentifierFeature = (IHttpRequestIdentifierFeature?)value;
                 }
-                else if (key == typeof(IHttpResponseTrailersFeature))
+                else if (key == typeof(IHttpConnectionFeature))
                 {
-                    _currentIHttpResponseTrailersFeature = (IHttpResponseTrailersFeature?)value;
+                    _currentIHttpConnectionFeature = (IHttpConnectionFeature?)value;
+                }
+                else if (key == typeof(ISessionFeature))
+                {
+                    _currentISessionFeature = (ISessionFeature?)value;
                 }
                 else if (key == typeof(IResponseCookiesFeature))
                 {
                     _currentIResponseCookiesFeature = (IResponseCookiesFeature?)value;
                 }
-                else if (key == typeof(IItemsFeature))
+                else if (key == typeof(IHttpRequestTrailersFeature))
                 {
-                    _currentIItemsFeature = (IItemsFeature?)value;
+                    _currentIHttpRequestTrailersFeature = (IHttpRequestTrailersFeature?)value;
+                }
+                else if (key == typeof(IHttpResponseTrailersFeature))
+                {
+                    _currentIHttpResponseTrailersFeature = (IHttpResponseTrailersFeature?)value;
                 }
                 else if (key == typeof(ITlsConnectionFeature))
                 {
                     _currentITlsConnectionFeature = (ITlsConnectionFeature?)value;
                 }
+                else if (key == typeof(IHttpUpgradeFeature))
+                {
+                    _currentIHttpUpgradeFeature = (IHttpUpgradeFeature?)value;
+                }
                 else if (key == typeof(IHttpWebSocketFeature))
                 {
                     _currentIHttpWebSocketFeature = (IHttpWebSocketFeature?)value;
                 }
-                else if (key == typeof(ISessionFeature))
+                else if (key == typeof(IHttp2StreamIdFeature))
                 {
-                    _currentISessionFeature = (ISessionFeature?)value;
+                    _currentIHttp2StreamIdFeature = (IHttp2StreamIdFeature?)value;
+                }
+                else if (key == typeof(IRequestBodyPipeFeature))
+                {
+                    _currentIRequestBodyPipeFeature = (IRequestBodyPipeFeature?)value;
+                }
+                else if (key == typeof(IHttpRequestLifetimeFeature))
+                {
+                    _currentIHttpRequestLifetimeFeature = (IHttpRequestLifetimeFeature?)value;
                 }
                 else if (key == typeof(IHttpMaxRequestBodySizeFeature))
                 {
@@ -381,6 +377,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 else if (key == typeof(IHttpBodyControlFeature))
                 {
                     _currentIHttpBodyControlFeature = (IHttpBodyControlFeature?)value;
+                }
+                else if (key == typeof(IHttpRequestBodyDetectionFeature))
+                {
+                    _currentIHttpRequestBodyDetectionFeature = (IHttpRequestBodyDetectionFeature?)value;
                 }
                 else if (key == typeof(IHttpResetFeature))
                 {
@@ -404,10 +404,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 feature = Unsafe.As<IHttpRequestFeature?, TFeature?>(ref _currentIHttpRequestFeature);
             }
-            else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
-            {
-                feature = Unsafe.As<IHttpRequestBodyDetectionFeature?, TFeature?>(ref _currentIHttpRequestBodyDetectionFeature);
-            }
             else if (typeof(TFeature) == typeof(IHttpResponseFeature))
             {
                 feature = Unsafe.As<IHttpResponseFeature?, TFeature?>(ref _currentIHttpResponseFeature);
@@ -415,26 +411,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttpResponseBodyFeature))
             {
                 feature = Unsafe.As<IHttpResponseBodyFeature?, TFeature?>(ref _currentIHttpResponseBodyFeature);
-            }
-            else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
-            {
-                feature = Unsafe.As<IRequestBodyPipeFeature?, TFeature?>(ref _currentIRequestBodyPipeFeature);
-            }
-            else if (typeof(TFeature) == typeof(IHttpRequestIdentifierFeature))
-            {
-                feature = Unsafe.As<IHttpRequestIdentifierFeature?, TFeature?>(ref _currentIHttpRequestIdentifierFeature);
-            }
-            else if (typeof(TFeature) == typeof(IServiceProvidersFeature))
-            {
-                feature = Unsafe.As<IServiceProvidersFeature?, TFeature?>(ref _currentIServiceProvidersFeature);
-            }
-            else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
-            {
-                feature = Unsafe.As<IHttpRequestLifetimeFeature?, TFeature?>(ref _currentIHttpRequestLifetimeFeature);
-            }
-            else if (typeof(TFeature) == typeof(IHttpConnectionFeature))
-            {
-                feature = Unsafe.As<IHttpConnectionFeature?, TFeature?>(ref _currentIHttpConnectionFeature);
             }
             else if (typeof(TFeature) == typeof(IRouteValuesFeature))
             {
@@ -444,13 +420,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 feature = Unsafe.As<IEndpointFeature?, TFeature?>(ref _currentIEndpointFeature);
             }
-            else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
+            else if (typeof(TFeature) == typeof(IServiceProvidersFeature))
             {
-                feature = Unsafe.As<IHttpAuthenticationFeature?, TFeature?>(ref _currentIHttpAuthenticationFeature);
+                feature = Unsafe.As<IServiceProvidersFeature?, TFeature?>(ref _currentIServiceProvidersFeature);
             }
-            else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
+            else if (typeof(TFeature) == typeof(IItemsFeature))
             {
-                feature = Unsafe.As<IHttpRequestTrailersFeature?, TFeature?>(ref _currentIHttpRequestTrailersFeature);
+                feature = Unsafe.As<IItemsFeature?, TFeature?>(ref _currentIItemsFeature);
             }
             else if (typeof(TFeature) == typeof(IQueryFeature))
             {
@@ -460,37 +436,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 feature = Unsafe.As<IFormFeature?, TFeature?>(ref _currentIFormFeature);
             }
-            else if (typeof(TFeature) == typeof(IHttpUpgradeFeature))
+            else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
             {
-                feature = Unsafe.As<IHttpUpgradeFeature?, TFeature?>(ref _currentIHttpUpgradeFeature);
+                feature = Unsafe.As<IHttpAuthenticationFeature?, TFeature?>(ref _currentIHttpAuthenticationFeature);
             }
-            else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
+            else if (typeof(TFeature) == typeof(IHttpRequestIdentifierFeature))
             {
-                feature = Unsafe.As<IHttp2StreamIdFeature?, TFeature?>(ref _currentIHttp2StreamIdFeature);
+                feature = Unsafe.As<IHttpRequestIdentifierFeature?, TFeature?>(ref _currentIHttpRequestIdentifierFeature);
             }
-            else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
+            else if (typeof(TFeature) == typeof(IHttpConnectionFeature))
             {
-                feature = Unsafe.As<IHttpResponseTrailersFeature?, TFeature?>(ref _currentIHttpResponseTrailersFeature);
+                feature = Unsafe.As<IHttpConnectionFeature?, TFeature?>(ref _currentIHttpConnectionFeature);
+            }
+            else if (typeof(TFeature) == typeof(ISessionFeature))
+            {
+                feature = Unsafe.As<ISessionFeature?, TFeature?>(ref _currentISessionFeature);
             }
             else if (typeof(TFeature) == typeof(IResponseCookiesFeature))
             {
                 feature = Unsafe.As<IResponseCookiesFeature?, TFeature?>(ref _currentIResponseCookiesFeature);
             }
-            else if (typeof(TFeature) == typeof(IItemsFeature))
+            else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
             {
-                feature = Unsafe.As<IItemsFeature?, TFeature?>(ref _currentIItemsFeature);
+                feature = Unsafe.As<IHttpRequestTrailersFeature?, TFeature?>(ref _currentIHttpRequestTrailersFeature);
+            }
+            else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
+            {
+                feature = Unsafe.As<IHttpResponseTrailersFeature?, TFeature?>(ref _currentIHttpResponseTrailersFeature);
             }
             else if (typeof(TFeature) == typeof(ITlsConnectionFeature))
             {
                 feature = Unsafe.As<ITlsConnectionFeature?, TFeature?>(ref _currentITlsConnectionFeature);
             }
+            else if (typeof(TFeature) == typeof(IHttpUpgradeFeature))
+            {
+                feature = Unsafe.As<IHttpUpgradeFeature?, TFeature?>(ref _currentIHttpUpgradeFeature);
+            }
             else if (typeof(TFeature) == typeof(IHttpWebSocketFeature))
             {
                 feature = Unsafe.As<IHttpWebSocketFeature?, TFeature?>(ref _currentIHttpWebSocketFeature);
             }
-            else if (typeof(TFeature) == typeof(ISessionFeature))
+            else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
-                feature = Unsafe.As<ISessionFeature?, TFeature?>(ref _currentISessionFeature);
+                feature = Unsafe.As<IHttp2StreamIdFeature?, TFeature?>(ref _currentIHttp2StreamIdFeature);
+            }
+            else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
+            {
+                feature = Unsafe.As<IRequestBodyPipeFeature?, TFeature?>(ref _currentIRequestBodyPipeFeature);
+            }
+            else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
+            {
+                feature = Unsafe.As<IHttpRequestLifetimeFeature?, TFeature?>(ref _currentIHttpRequestLifetimeFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpMaxRequestBodySizeFeature))
             {
@@ -507,6 +503,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttpBodyControlFeature))
             {
                 feature = Unsafe.As<IHttpBodyControlFeature?, TFeature?>(ref _currentIHttpBodyControlFeature);
+            }
+            else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
+            {
+                feature = Unsafe.As<IHttpRequestBodyDetectionFeature?, TFeature?>(ref _currentIHttpRequestBodyDetectionFeature);
             }
             else if (typeof(TFeature) == typeof(IHttpResetFeature))
             {
@@ -536,10 +536,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIHttpRequestFeature = Unsafe.As<TFeature?, IHttpRequestFeature?>(ref feature);
             }
-            else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
-            {
-                _currentIHttpRequestBodyDetectionFeature = Unsafe.As<TFeature?, IHttpRequestBodyDetectionFeature?>(ref feature);
-            }
             else if (typeof(TFeature) == typeof(IHttpResponseFeature))
             {
                 _currentIHttpResponseFeature = Unsafe.As<TFeature?, IHttpResponseFeature?>(ref feature);
@@ -547,26 +543,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             else if (typeof(TFeature) == typeof(IHttpResponseBodyFeature))
             {
                 _currentIHttpResponseBodyFeature = Unsafe.As<TFeature?, IHttpResponseBodyFeature?>(ref feature);
-            }
-            else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
-            {
-                _currentIRequestBodyPipeFeature = Unsafe.As<TFeature?, IRequestBodyPipeFeature?>(ref feature);
-            }
-            else if (typeof(TFeature) == typeof(IHttpRequestIdentifierFeature))
-            {
-                _currentIHttpRequestIdentifierFeature = Unsafe.As<TFeature?, IHttpRequestIdentifierFeature?>(ref feature);
-            }
-            else if (typeof(TFeature) == typeof(IServiceProvidersFeature))
-            {
-                _currentIServiceProvidersFeature = Unsafe.As<TFeature?, IServiceProvidersFeature?>(ref feature);
-            }
-            else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
-            {
-                _currentIHttpRequestLifetimeFeature = Unsafe.As<TFeature?, IHttpRequestLifetimeFeature?>(ref feature);
-            }
-            else if (typeof(TFeature) == typeof(IHttpConnectionFeature))
-            {
-                _currentIHttpConnectionFeature = Unsafe.As<TFeature?, IHttpConnectionFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IRouteValuesFeature))
             {
@@ -576,13 +552,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIEndpointFeature = Unsafe.As<TFeature?, IEndpointFeature?>(ref feature);
             }
-            else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
+            else if (typeof(TFeature) == typeof(IServiceProvidersFeature))
             {
-                _currentIHttpAuthenticationFeature = Unsafe.As<TFeature?, IHttpAuthenticationFeature?>(ref feature);
+                _currentIServiceProvidersFeature = Unsafe.As<TFeature?, IServiceProvidersFeature?>(ref feature);
             }
-            else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
+            else if (typeof(TFeature) == typeof(IItemsFeature))
             {
-                _currentIHttpRequestTrailersFeature = Unsafe.As<TFeature?, IHttpRequestTrailersFeature?>(ref feature);
+                _currentIItemsFeature = Unsafe.As<TFeature?, IItemsFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IQueryFeature))
             {
@@ -592,37 +568,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIFormFeature = Unsafe.As<TFeature?, IFormFeature?>(ref feature);
             }
-            else if (typeof(TFeature) == typeof(IHttpUpgradeFeature))
+            else if (typeof(TFeature) == typeof(IHttpAuthenticationFeature))
             {
-                _currentIHttpUpgradeFeature = Unsafe.As<TFeature?, IHttpUpgradeFeature?>(ref feature);
+                _currentIHttpAuthenticationFeature = Unsafe.As<TFeature?, IHttpAuthenticationFeature?>(ref feature);
             }
-            else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
+            else if (typeof(TFeature) == typeof(IHttpRequestIdentifierFeature))
             {
-                _currentIHttp2StreamIdFeature = Unsafe.As<TFeature?, IHttp2StreamIdFeature?>(ref feature);
+                _currentIHttpRequestIdentifierFeature = Unsafe.As<TFeature?, IHttpRequestIdentifierFeature?>(ref feature);
             }
-            else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
+            else if (typeof(TFeature) == typeof(IHttpConnectionFeature))
             {
-                _currentIHttpResponseTrailersFeature = Unsafe.As<TFeature?, IHttpResponseTrailersFeature?>(ref feature);
+                _currentIHttpConnectionFeature = Unsafe.As<TFeature?, IHttpConnectionFeature?>(ref feature);
+            }
+            else if (typeof(TFeature) == typeof(ISessionFeature))
+            {
+                _currentISessionFeature = Unsafe.As<TFeature?, ISessionFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IResponseCookiesFeature))
             {
                 _currentIResponseCookiesFeature = Unsafe.As<TFeature?, IResponseCookiesFeature?>(ref feature);
             }
-            else if (typeof(TFeature) == typeof(IItemsFeature))
+            else if (typeof(TFeature) == typeof(IHttpRequestTrailersFeature))
             {
-                _currentIItemsFeature = Unsafe.As<TFeature?, IItemsFeature?>(ref feature);
+                _currentIHttpRequestTrailersFeature = Unsafe.As<TFeature?, IHttpRequestTrailersFeature?>(ref feature);
+            }
+            else if (typeof(TFeature) == typeof(IHttpResponseTrailersFeature))
+            {
+                _currentIHttpResponseTrailersFeature = Unsafe.As<TFeature?, IHttpResponseTrailersFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(ITlsConnectionFeature))
             {
                 _currentITlsConnectionFeature = Unsafe.As<TFeature?, ITlsConnectionFeature?>(ref feature);
             }
+            else if (typeof(TFeature) == typeof(IHttpUpgradeFeature))
+            {
+                _currentIHttpUpgradeFeature = Unsafe.As<TFeature?, IHttpUpgradeFeature?>(ref feature);
+            }
             else if (typeof(TFeature) == typeof(IHttpWebSocketFeature))
             {
                 _currentIHttpWebSocketFeature = Unsafe.As<TFeature?, IHttpWebSocketFeature?>(ref feature);
             }
-            else if (typeof(TFeature) == typeof(ISessionFeature))
+            else if (typeof(TFeature) == typeof(IHttp2StreamIdFeature))
             {
-                _currentISessionFeature = Unsafe.As<TFeature?, ISessionFeature?>(ref feature);
+                _currentIHttp2StreamIdFeature = Unsafe.As<TFeature?, IHttp2StreamIdFeature?>(ref feature);
+            }
+            else if (typeof(TFeature) == typeof(IRequestBodyPipeFeature))
+            {
+                _currentIRequestBodyPipeFeature = Unsafe.As<TFeature?, IRequestBodyPipeFeature?>(ref feature);
+            }
+            else if (typeof(TFeature) == typeof(IHttpRequestLifetimeFeature))
+            {
+                _currentIHttpRequestLifetimeFeature = Unsafe.As<TFeature?, IHttpRequestLifetimeFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IHttpMaxRequestBodySizeFeature))
             {
@@ -640,6 +636,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 _currentIHttpBodyControlFeature = Unsafe.As<TFeature?, IHttpBodyControlFeature?>(ref feature);
             }
+            else if (typeof(TFeature) == typeof(IHttpRequestBodyDetectionFeature))
+            {
+                _currentIHttpRequestBodyDetectionFeature = Unsafe.As<TFeature?, IHttpRequestBodyDetectionFeature?>(ref feature);
+            }
             else if (typeof(TFeature) == typeof(IHttpResetFeature))
             {
                 _currentIHttpResetFeature = Unsafe.As<TFeature?, IHttpResetFeature?>(ref feature);
@@ -656,10 +656,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 yield return new KeyValuePair<Type, object>(typeof(IHttpRequestFeature), _currentIHttpRequestFeature);
             }
-            if (_currentIHttpRequestBodyDetectionFeature != null)
-            {
-                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestBodyDetectionFeature), _currentIHttpRequestBodyDetectionFeature);
-            }
             if (_currentIHttpResponseFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IHttpResponseFeature), _currentIHttpResponseFeature);
@@ -667,26 +663,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_currentIHttpResponseBodyFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IHttpResponseBodyFeature), _currentIHttpResponseBodyFeature);
-            }
-            if (_currentIRequestBodyPipeFeature != null)
-            {
-                yield return new KeyValuePair<Type, object>(typeof(IRequestBodyPipeFeature), _currentIRequestBodyPipeFeature);
-            }
-            if (_currentIHttpRequestIdentifierFeature != null)
-            {
-                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestIdentifierFeature), _currentIHttpRequestIdentifierFeature);
-            }
-            if (_currentIServiceProvidersFeature != null)
-            {
-                yield return new KeyValuePair<Type, object>(typeof(IServiceProvidersFeature), _currentIServiceProvidersFeature);
-            }
-            if (_currentIHttpRequestLifetimeFeature != null)
-            {
-                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestLifetimeFeature), _currentIHttpRequestLifetimeFeature);
-            }
-            if (_currentIHttpConnectionFeature != null)
-            {
-                yield return new KeyValuePair<Type, object>(typeof(IHttpConnectionFeature), _currentIHttpConnectionFeature);
             }
             if (_currentIRouteValuesFeature != null)
             {
@@ -696,13 +672,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 yield return new KeyValuePair<Type, object>(typeof(IEndpointFeature), _currentIEndpointFeature);
             }
-            if (_currentIHttpAuthenticationFeature != null)
+            if (_currentIServiceProvidersFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(typeof(IHttpAuthenticationFeature), _currentIHttpAuthenticationFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IServiceProvidersFeature), _currentIServiceProvidersFeature);
             }
-            if (_currentIHttpRequestTrailersFeature != null)
+            if (_currentIItemsFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestTrailersFeature), _currentIHttpRequestTrailersFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IItemsFeature), _currentIItemsFeature);
             }
             if (_currentIQueryFeature != null)
             {
@@ -712,37 +688,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 yield return new KeyValuePair<Type, object>(typeof(IFormFeature), _currentIFormFeature);
             }
-            if (_currentIHttpUpgradeFeature != null)
+            if (_currentIHttpAuthenticationFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(typeof(IHttpUpgradeFeature), _currentIHttpUpgradeFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpAuthenticationFeature), _currentIHttpAuthenticationFeature);
             }
-            if (_currentIHttp2StreamIdFeature != null)
+            if (_currentIHttpRequestIdentifierFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(typeof(IHttp2StreamIdFeature), _currentIHttp2StreamIdFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestIdentifierFeature), _currentIHttpRequestIdentifierFeature);
             }
-            if (_currentIHttpResponseTrailersFeature != null)
+            if (_currentIHttpConnectionFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(typeof(IHttpResponseTrailersFeature), _currentIHttpResponseTrailersFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpConnectionFeature), _currentIHttpConnectionFeature);
+            }
+            if (_currentISessionFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(ISessionFeature), _currentISessionFeature);
             }
             if (_currentIResponseCookiesFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IResponseCookiesFeature), _currentIResponseCookiesFeature);
             }
-            if (_currentIItemsFeature != null)
+            if (_currentIHttpRequestTrailersFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(typeof(IItemsFeature), _currentIItemsFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestTrailersFeature), _currentIHttpRequestTrailersFeature);
+            }
+            if (_currentIHttpResponseTrailersFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IHttpResponseTrailersFeature), _currentIHttpResponseTrailersFeature);
             }
             if (_currentITlsConnectionFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(ITlsConnectionFeature), _currentITlsConnectionFeature);
             }
+            if (_currentIHttpUpgradeFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IHttpUpgradeFeature), _currentIHttpUpgradeFeature);
+            }
             if (_currentIHttpWebSocketFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IHttpWebSocketFeature), _currentIHttpWebSocketFeature);
             }
-            if (_currentISessionFeature != null)
+            if (_currentIHttp2StreamIdFeature != null)
             {
-                yield return new KeyValuePair<Type, object>(typeof(ISessionFeature), _currentISessionFeature);
+                yield return new KeyValuePair<Type, object>(typeof(IHttp2StreamIdFeature), _currentIHttp2StreamIdFeature);
+            }
+            if (_currentIRequestBodyPipeFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IRequestBodyPipeFeature), _currentIRequestBodyPipeFeature);
+            }
+            if (_currentIHttpRequestLifetimeFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestLifetimeFeature), _currentIHttpRequestLifetimeFeature);
             }
             if (_currentIHttpMaxRequestBodySizeFeature != null)
             {
@@ -759,6 +755,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             if (_currentIHttpBodyControlFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IHttpBodyControlFeature), _currentIHttpBodyControlFeature);
+            }
+            if (_currentIHttpRequestBodyDetectionFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IHttpRequestBodyDetectionFeature), _currentIHttpRequestBodyDetectionFeature);
             }
             if (_currentIHttpResetFeature != null)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -114,7 +114,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             _keepAlive = true;
             _connectionAborted = false;
 
-            ResetHttp2Features();
+            // Reset Http2 Features
+            _currentIHttpMinRequestBodyDataRateFeature = this;
+            _currentIHttp2StreamIdFeature = this;
+            _currentIHttpResponseTrailersFeature = this;
+            _currentIHttpResetFeature = this;
         }
 
         protected override void OnRequestProcessingEnded()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -577,7 +577,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         protected override void OnReset()
         {
-            ResetHttp3Features();
+            // Reset Http3 Features
+            _currentIHttpMinRequestBodyDataRateFeature = this;
+            _currentIHttpResponseTrailersFeature = this;
+            _currentIHttpResetFeature = this;
         }
 
         protected override void ApplicationAbort() => ApplicationAbort(new ConnectionAbortedException(CoreStrings.ConnectionAbortedByApplication), Http3ErrorCode.InternalError);

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
@@ -28,13 +28,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             return _collection.Get<IHttpRequestFeature>();
         }
 
-        [Benchmark(Description = "Get<IHttpRequestBodyDetectionFeature>*")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpRequestBodyDetectionFeature Get_IHttpRequestBodyDetectionFeature()
-        {
-            return _collection.Get<IHttpRequestBodyDetectionFeature>();
-        }
-
         [Benchmark(Description = "Get<IHttpResponseFeature>*")]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public IHttpResponseFeature Get_IHttpResponseFeature()
@@ -47,41 +40,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public IHttpResponseBodyFeature Get_IHttpResponseBodyFeature()
         {
             return _collection.Get<IHttpResponseBodyFeature>();
-        }
-
-        [Benchmark(Description = "Get<IRequestBodyPipeFeature>*")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public IRequestBodyPipeFeature Get_IRequestBodyPipeFeature()
-        {
-            return _collection.Get<IRequestBodyPipeFeature>();
-        }
-
-        [Benchmark(Description = "Get<IHttpRequestIdentifierFeature>*")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpRequestIdentifierFeature Get_IHttpRequestIdentifierFeature()
-        {
-            return _collection.Get<IHttpRequestIdentifierFeature>();
-        }
-
-        [Benchmark(Description = "Get<IServiceProvidersFeature>")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public IServiceProvidersFeature Get_IServiceProvidersFeature()
-        {
-            return _collection.Get<IServiceProvidersFeature>();
-        }
-
-        [Benchmark(Description = "Get<IHttpRequestLifetimeFeature>*")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpRequestLifetimeFeature Get_IHttpRequestLifetimeFeature()
-        {
-            return _collection.Get<IHttpRequestLifetimeFeature>();
-        }
-
-        [Benchmark(Description = "Get<IHttpConnectionFeature>*")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpConnectionFeature Get_IHttpConnectionFeature()
-        {
-            return _collection.Get<IHttpConnectionFeature>();
         }
 
         [Benchmark(Description = "Get<IRouteValuesFeature>*")]
@@ -98,18 +56,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             return _collection.Get<IEndpointFeature>();
         }
 
-        [Benchmark(Description = "Get<IHttpAuthenticationFeature>")]
+        [Benchmark(Description = "Get<IServiceProvidersFeature>")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpAuthenticationFeature Get_IHttpAuthenticationFeature()
+        public IServiceProvidersFeature Get_IServiceProvidersFeature()
         {
-            return _collection.Get<IHttpAuthenticationFeature>();
+            return _collection.Get<IServiceProvidersFeature>();
         }
 
-        [Benchmark(Description = "Get<IHttpRequestTrailersFeature>*")]
+        [Benchmark(Description = "Get<IItemsFeature>")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpRequestTrailersFeature Get_IHttpRequestTrailersFeature()
+        public IItemsFeature Get_IItemsFeature()
         {
-            return _collection.Get<IHttpRequestTrailersFeature>();
+            return _collection.Get<IItemsFeature>();
         }
 
         [Benchmark(Description = "Get<IQueryFeature>")]
@@ -126,25 +84,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             return _collection.Get<IFormFeature>();
         }
 
-        [Benchmark(Description = "Get<IHttpUpgradeFeature>*")]
+        [Benchmark(Description = "Get<IHttpAuthenticationFeature>")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpUpgradeFeature Get_IHttpUpgradeFeature()
+        public IHttpAuthenticationFeature Get_IHttpAuthenticationFeature()
         {
-            return _collection.Get<IHttpUpgradeFeature>();
+            return _collection.Get<IHttpAuthenticationFeature>();
         }
 
-        [Benchmark(Description = "Get<IHttp2StreamIdFeature>")]
+        [Benchmark(Description = "Get<IHttpRequestIdentifierFeature>*")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttp2StreamIdFeature Get_IHttp2StreamIdFeature()
+        public IHttpRequestIdentifierFeature Get_IHttpRequestIdentifierFeature()
         {
-            return _collection.Get<IHttp2StreamIdFeature>();
+            return _collection.Get<IHttpRequestIdentifierFeature>();
         }
 
-        [Benchmark(Description = "Get<IHttpResponseTrailersFeature>")]
+        [Benchmark(Description = "Get<IHttpConnectionFeature>*")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpResponseTrailersFeature Get_IHttpResponseTrailersFeature()
+        public IHttpConnectionFeature Get_IHttpConnectionFeature()
         {
-            return _collection.Get<IHttpResponseTrailersFeature>();
+            return _collection.Get<IHttpConnectionFeature>();
+        }
+
+        [Benchmark(Description = "Get<ISessionFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public ISessionFeature Get_ISessionFeature()
+        {
+            return _collection.Get<ISessionFeature>();
         }
 
         [Benchmark(Description = "Get<IResponseCookiesFeature>")]
@@ -154,11 +119,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             return _collection.Get<IResponseCookiesFeature>();
         }
 
-        [Benchmark(Description = "Get<IItemsFeature>")]
+        [Benchmark(Description = "Get<IHttpRequestTrailersFeature>*")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IItemsFeature Get_IItemsFeature()
+        public IHttpRequestTrailersFeature Get_IHttpRequestTrailersFeature()
         {
-            return _collection.Get<IItemsFeature>();
+            return _collection.Get<IHttpRequestTrailersFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpResponseTrailersFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpResponseTrailersFeature Get_IHttpResponseTrailersFeature()
+        {
+            return _collection.Get<IHttpResponseTrailersFeature>();
         }
 
         [Benchmark(Description = "Get<ITlsConnectionFeature>")]
@@ -168,6 +140,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             return _collection.Get<ITlsConnectionFeature>();
         }
 
+        [Benchmark(Description = "Get<IHttpUpgradeFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpUpgradeFeature Get_IHttpUpgradeFeature()
+        {
+            return _collection.Get<IHttpUpgradeFeature>();
+        }
+
         [Benchmark(Description = "Get<IHttpWebSocketFeature>")]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public IHttpWebSocketFeature Get_IHttpWebSocketFeature()
@@ -175,11 +154,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             return _collection.Get<IHttpWebSocketFeature>();
         }
 
-        [Benchmark(Description = "Get<ISessionFeature>")]
+        [Benchmark(Description = "Get<IHttp2StreamIdFeature>")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public ISessionFeature Get_ISessionFeature()
+        public IHttp2StreamIdFeature Get_IHttp2StreamIdFeature()
         {
-            return _collection.Get<ISessionFeature>();
+            return _collection.Get<IHttp2StreamIdFeature>();
+        }
+
+        [Benchmark(Description = "Get<IRequestBodyPipeFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IRequestBodyPipeFeature Get_IRequestBodyPipeFeature()
+        {
+            return _collection.Get<IRequestBodyPipeFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpRequestLifetimeFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpRequestLifetimeFeature Get_IHttpRequestLifetimeFeature()
+        {
+            return _collection.Get<IHttpRequestLifetimeFeature>();
         }
 
         [Benchmark(Description = "Get<IHttpMaxRequestBodySizeFeature>*")]
@@ -208,6 +201,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public IHttpBodyControlFeature Get_IHttpBodyControlFeature()
         {
             return _collection.Get<IHttpBodyControlFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpRequestBodyDetectionFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpRequestBodyDetectionFeature Get_IHttpRequestBodyDetectionFeature()
+        {
+            return _collection.Get<IHttpRequestBodyDetectionFeature>();
         }
 
         [Benchmark(Description = "Get<IHttpResetFeature>")]

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
@@ -5,9 +5,13 @@ using System;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
+
 using BenchmarkDotNet.Attributes;
+
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Testing;
 
@@ -17,73 +21,205 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
     {
         private readonly IFeatureCollection _collection;
 
-        [Benchmark]
+        [Benchmark(Description = "Get<IHttpRequestFeature>*")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpRequestFeature GetViaTypeOf_IHttpRequestFeature()
-        {
-            return (IHttpRequestFeature)_collection[typeof(IHttpRequestFeature)];
-        }
-
-        [Benchmark]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpRequestFeature GetViaGeneric_IHttpRequestFeature()
+        public IHttpRequestFeature Get_IHttpRequestFeature()
         {
             return _collection.Get<IHttpRequestFeature>();
         }
 
-        [Benchmark]
+        [Benchmark(Description = "Get<IHttpRequestBodyDetectionFeature>*")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IQueryFeature GetViaTypeOf_IQueryFeature()
+        public IHttpRequestBodyDetectionFeature Get_IHttpRequestBodyDetectionFeature()
         {
-            return (IQueryFeature)_collection[typeof(IQueryFeature)];
+            return _collection.Get<IHttpRequestBodyDetectionFeature>();
         }
 
-        [Benchmark]
+        [Benchmark(Description = "Get<IHttpResponseFeature>*")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IQueryFeature GetViaGeneric_IQueryFeature()
+        public IHttpResponseFeature Get_IHttpResponseFeature()
+        {
+            return _collection.Get<IHttpResponseFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpResponseBodyFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpResponseBodyFeature Get_IHttpResponseBodyFeature()
+        {
+            return _collection.Get<IHttpResponseBodyFeature>();
+        }
+
+        [Benchmark(Description = "Get<IRequestBodyPipeFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IRequestBodyPipeFeature Get_IRequestBodyPipeFeature()
+        {
+            return _collection.Get<IRequestBodyPipeFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpRequestIdentifierFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpRequestIdentifierFeature Get_IHttpRequestIdentifierFeature()
+        {
+            return _collection.Get<IHttpRequestIdentifierFeature>();
+        }
+
+        [Benchmark(Description = "Get<IServiceProvidersFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IServiceProvidersFeature Get_IServiceProvidersFeature()
+        {
+            return _collection.Get<IServiceProvidersFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpRequestLifetimeFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpRequestLifetimeFeature Get_IHttpRequestLifetimeFeature()
+        {
+            return _collection.Get<IHttpRequestLifetimeFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpConnectionFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpConnectionFeature Get_IHttpConnectionFeature()
+        {
+            return _collection.Get<IHttpConnectionFeature>();
+        }
+
+        [Benchmark(Description = "Get<IRouteValuesFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IRouteValuesFeature Get_IRouteValuesFeature()
+        {
+            return _collection.Get<IRouteValuesFeature>();
+        }
+
+        [Benchmark(Description = "Get<IEndpointFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IEndpointFeature Get_IEndpointFeature()
+        {
+            return _collection.Get<IEndpointFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpAuthenticationFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpAuthenticationFeature Get_IHttpAuthenticationFeature()
+        {
+            return _collection.Get<IHttpAuthenticationFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpRequestTrailersFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpRequestTrailersFeature Get_IHttpRequestTrailersFeature()
+        {
+            return _collection.Get<IHttpRequestTrailersFeature>();
+        }
+
+        [Benchmark(Description = "Get<IQueryFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IQueryFeature Get_IQueryFeature()
         {
             return _collection.Get<IQueryFeature>();
         }
 
-        [Benchmark]
+        [Benchmark(Description = "Get<IFormFeature>")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpResetFeature GetViaTypeOf_IHttpResetFeature()
+        public IFormFeature Get_IFormFeature()
         {
-            return (IHttpResetFeature)_collection[typeof(IHttpResetFeature)];
+            return _collection.Get<IFormFeature>();
         }
 
-        [Benchmark]
+        [Benchmark(Description = "Get<IHttpUpgradeFeature>*")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpResetFeature GetViaGeneric_IHttpResetFeature()
+        public IHttpUpgradeFeature Get_IHttpUpgradeFeature()
+        {
+            return _collection.Get<IHttpUpgradeFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttp2StreamIdFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttp2StreamIdFeature Get_IHttp2StreamIdFeature()
+        {
+            return _collection.Get<IHttp2StreamIdFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpResponseTrailersFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpResponseTrailersFeature Get_IHttpResponseTrailersFeature()
+        {
+            return _collection.Get<IHttpResponseTrailersFeature>();
+        }
+
+        [Benchmark(Description = "Get<IResponseCookiesFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IResponseCookiesFeature Get_IResponseCookiesFeature()
+        {
+            return _collection.Get<IResponseCookiesFeature>();
+        }
+
+        [Benchmark(Description = "Get<IItemsFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IItemsFeature Get_IItemsFeature()
+        {
+            return _collection.Get<IItemsFeature>();
+        }
+
+        [Benchmark(Description = "Get<ITlsConnectionFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public ITlsConnectionFeature Get_ITlsConnectionFeature()
+        {
+            return _collection.Get<ITlsConnectionFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpWebSocketFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpWebSocketFeature Get_IHttpWebSocketFeature()
+        {
+            return _collection.Get<IHttpWebSocketFeature>();
+        }
+
+        [Benchmark(Description = "Get<ISessionFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public ISessionFeature Get_ISessionFeature()
+        {
+            return _collection.Get<ISessionFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpMaxRequestBodySizeFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpMaxRequestBodySizeFeature Get_IHttpMaxRequestBodySizeFeature()
+        {
+            return _collection.Get<IHttpMaxRequestBodySizeFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpMinRequestBodyDataRateFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpMinRequestBodyDataRateFeature Get_IHttpMinRequestBodyDataRateFeature()
+        {
+            return _collection.Get<IHttpMinRequestBodyDataRateFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpMinResponseDataRateFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpMinResponseDataRateFeature Get_IHttpMinResponseDataRateFeature()
+        {
+            return _collection.Get<IHttpMinResponseDataRateFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpBodyControlFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpBodyControlFeature Get_IHttpBodyControlFeature()
+        {
+            return _collection.Get<IHttpBodyControlFeature>();
+        }
+
+        [Benchmark(Description = "Get<IHttpResetFeature>")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpResetFeature Get_IHttpResetFeature()
         {
             return _collection.Get<IHttpResetFeature>();
         }
 
-        [Benchmark]
+        [Benchmark(Description = "Get<IHttpNotFoundFeature>")]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public object GetViaTypeOf_Custom()
-        {
-            return (IHttpCustomFeature)_collection[typeof(IHttpCustomFeature)];
-        }
-
-        [Benchmark]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public object GetViaGeneric_Custom()
-        {
-            return _collection.Get<IHttpCustomFeature>();
-        }
-
-
-        [Benchmark]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public object GetViaTypeOf_NotFound()
-        {
-            return (IHttpNotFoundFeature)_collection[typeof(IHttpNotFoundFeature)];
-        }
-
-        [Benchmark]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public object GetViaGeneric_NotFound()
+        public IHttpNotFoundFeature Get_IHttpNotFoundFeature()
         {
             return _collection.Get<IHttpNotFoundFeature>();
         }
@@ -114,11 +250,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             _collection = http1Connection;
         }
 
-        private interface IHttpCustomFeature
-        {
-        }
-
-        private interface IHttpNotFoundFeature
+        public interface IHttpNotFoundFeature
         {
         }
     }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
@@ -5,12 +5,9 @@ using System;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Testing;
 
@@ -22,16 +19,44 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
 
         [Benchmark]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpRequestFeature GetViaTypeOf_First()
+        public IHttpRequestFeature GetViaTypeOf_IHttpRequestFeature()
         {
             return (IHttpRequestFeature)_collection[typeof(IHttpRequestFeature)];
         }
 
         [Benchmark]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public IHttpRequestFeature GetViaGeneric_First()
+        public IHttpRequestFeature GetViaGeneric_IHttpRequestFeature()
         {
             return _collection.Get<IHttpRequestFeature>();
+        }
+
+        [Benchmark]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IQueryFeature GetViaTypeOf_IQueryFeature()
+        {
+            return (IQueryFeature)_collection[typeof(IQueryFeature)];
+        }
+
+        [Benchmark]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IQueryFeature GetViaGeneric_IQueryFeature()
+        {
+            return _collection.Get<IQueryFeature>();
+        }
+
+        [Benchmark]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpResetFeature GetViaTypeOf_IHttpResetFeature()
+        {
+            return (IHttpResetFeature)_collection[typeof(IHttpResetFeature)];
+        }
+
+        [Benchmark]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IHttpResetFeature GetViaGeneric_IHttpResetFeature()
+        {
+            return _collection.Get<IHttpResetFeature>();
         }
 
         [Benchmark]

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpProtocolFeatureCollection.cs
@@ -77,6 +77,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             return _collection.Get<IQueryFeature>();
         }
 
+        [Benchmark(Description = "Get<IRequestBodyPipeFeature>*")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public IRequestBodyPipeFeature Get_IRequestBodyPipeFeature()
+        {
+            return _collection.Get<IRequestBodyPipeFeature>();
+        }
+
         [Benchmark(Description = "Get<IFormFeature>")]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public IFormFeature Get_IFormFeature()
@@ -159,13 +166,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public IHttp2StreamIdFeature Get_IHttp2StreamIdFeature()
         {
             return _collection.Get<IHttp2StreamIdFeature>();
-        }
-
-        [Benchmark(Description = "Get<IRequestBodyPipeFeature>*")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public IRequestBodyPipeFeature Get_IRequestBodyPipeFeature()
-        {
-            return _collection.Get<IRequestBodyPipeFeature>();
         }
 
         [Benchmark(Description = "Get<IHttpRequestLifetimeFeature>*")]

--- a/src/Servers/Kestrel/shared/TransportConnection.FeatureCollection.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.FeatureCollection.cs
@@ -11,14 +11,11 @@ using Microsoft.AspNetCore.Connections.Features;
 
 namespace Microsoft.AspNetCore.Connections
 {
-    internal partial class TransportConnection : IConnectionIdFeature,
-                                                 IConnectionTransportFeature,
-                                                 IConnectionItemsFeature,
-                                                 IMemoryPoolFeature,
-                                                 IConnectionLifetimeFeature
+    internal partial class TransportConnection
     {
         // NOTE: When feature interfaces are added to or removed from this TransportConnection class implementation,
-        // then the list of `features` in the generated code project MUST also be updated.
+        // then the list of `features` in the generated code project MUST also be updated first
+        // and the code generator re-reun, which will change the interface list.
         // See also: tools/CodeGenerator/TransportConnectionFeatureCollection.cs
 
         MemoryPool<byte> IMemoryPoolFeature.MemoryPool => MemoryPool;

--- a/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
@@ -15,11 +15,14 @@ namespace Microsoft.AspNetCore.Connections
 {
     internal partial class TransportConnection : IFeatureCollection
     {
+        // Implemented features
         internal protected IConnectionIdFeature? _currentIConnectionIdFeature;
         internal protected IConnectionTransportFeature? _currentIConnectionTransportFeature;
         internal protected IConnectionItemsFeature? _currentIConnectionItemsFeature;
         internal protected IMemoryPoolFeature? _currentIMemoryPoolFeature;
         internal protected IConnectionLifetimeFeature? _currentIConnectionLifetimeFeature;
+
+        // Other reserved feature slots
 
         private int _featureRevision;
 

--- a/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
@@ -14,11 +14,11 @@ namespace Microsoft.AspNetCore.Connections
 {
     internal partial class TransportConnection : IFeatureCollection
     {
-        private object? _currentIConnectionIdFeature;
-        private object? _currentIConnectionTransportFeature;
-        private object? _currentIConnectionItemsFeature;
-        private object? _currentIMemoryPoolFeature;
-        private object? _currentIConnectionLifetimeFeature;
+        internal protected IConnectionIdFeature? _currentIConnectionIdFeature;
+        internal protected IConnectionTransportFeature? _currentIConnectionTransportFeature;
+        internal protected IConnectionItemsFeature? _currentIConnectionItemsFeature;
+        internal protected IMemoryPoolFeature? _currentIMemoryPoolFeature;
+        internal protected IConnectionLifetimeFeature? _currentIConnectionLifetimeFeature;
 
         private int _featureRevision;
 
@@ -137,23 +137,23 @@ namespace Microsoft.AspNetCore.Connections
 
                 if (key == typeof(IConnectionIdFeature))
                 {
-                    _currentIConnectionIdFeature = value;
+                    _currentIConnectionIdFeature = (IConnectionIdFeature?)value;
                 }
                 else if (key == typeof(IConnectionTransportFeature))
                 {
-                    _currentIConnectionTransportFeature = value;
+                    _currentIConnectionTransportFeature = (IConnectionTransportFeature?)value;
                 }
                 else if (key == typeof(IConnectionItemsFeature))
                 {
-                    _currentIConnectionItemsFeature = value;
+                    _currentIConnectionItemsFeature = (IConnectionItemsFeature?)value;
                 }
                 else if (key == typeof(IMemoryPoolFeature))
                 {
-                    _currentIMemoryPoolFeature = value;
+                    _currentIMemoryPoolFeature = (IMemoryPoolFeature?)value;
                 }
                 else if (key == typeof(IConnectionLifetimeFeature))
                 {
-                    _currentIConnectionLifetimeFeature = value;
+                    _currentIConnectionLifetimeFeature = (IConnectionLifetimeFeature?)value;
                 }
                 else
                 {
@@ -198,23 +198,23 @@ namespace Microsoft.AspNetCore.Connections
             _featureRevision++;
             if (typeof(TFeature) == typeof(IConnectionIdFeature))
             {
-                _currentIConnectionIdFeature = feature;
+                _currentIConnectionIdFeature = (IConnectionIdFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IConnectionTransportFeature))
             {
-                _currentIConnectionTransportFeature = feature;
+                _currentIConnectionTransportFeature = (IConnectionTransportFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IConnectionItemsFeature))
             {
-                _currentIConnectionItemsFeature = feature;
+                _currentIConnectionItemsFeature = (IConnectionItemsFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IMemoryPoolFeature))
             {
-                _currentIMemoryPoolFeature = feature;
+                _currentIMemoryPoolFeature = (IMemoryPoolFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IConnectionLifetimeFeature))
             {
-                _currentIConnectionLifetimeFeature = feature;
+                _currentIConnectionLifetimeFeature = (IConnectionLifetimeFeature?)feature;
             }
             else
             {

--- a/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Features;
@@ -164,26 +165,30 @@ namespace Microsoft.AspNetCore.Connections
 
         TFeature? IFeatureCollection.Get<TFeature>() where TFeature : default
         {
+            // Using Unsafe.As for the cast due to https://github.com/dotnet/runtime/issues/49614
+            // The type of TFeature is confirmed by the typeof() check and the As cast only accepts
+            // that type; however the Jit does not eliminate a regular cast in a shared generic.
+
             TFeature? feature = default;
             if (typeof(TFeature) == typeof(IConnectionIdFeature))
             {
-                feature = (TFeature?)_currentIConnectionIdFeature;
+                feature = Unsafe.As<IConnectionIdFeature?, TFeature?>(ref _currentIConnectionIdFeature);
             }
             else if (typeof(TFeature) == typeof(IConnectionTransportFeature))
             {
-                feature = (TFeature?)_currentIConnectionTransportFeature;
+                feature = Unsafe.As<IConnectionTransportFeature?, TFeature?>(ref _currentIConnectionTransportFeature);
             }
             else if (typeof(TFeature) == typeof(IConnectionItemsFeature))
             {
-                feature = (TFeature?)_currentIConnectionItemsFeature;
+                feature = Unsafe.As<IConnectionItemsFeature?, TFeature?>(ref _currentIConnectionItemsFeature);
             }
             else if (typeof(TFeature) == typeof(IMemoryPoolFeature))
             {
-                feature = (TFeature?)_currentIMemoryPoolFeature;
+                feature = Unsafe.As<IMemoryPoolFeature?, TFeature?>(ref _currentIMemoryPoolFeature);
             }
             else if (typeof(TFeature) == typeof(IConnectionLifetimeFeature))
             {
-                feature = (TFeature?)_currentIConnectionLifetimeFeature;
+                feature = Unsafe.As<IConnectionLifetimeFeature?, TFeature?>(ref _currentIConnectionLifetimeFeature);
             }
             else if (MaybeExtra != null)
             {

--- a/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
@@ -13,7 +13,12 @@ using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Connections
 {
-    internal partial class TransportConnection : IFeatureCollection
+    internal partial class TransportConnection : IFeatureCollection,
+                                                 IConnectionIdFeature,
+                                                 IConnectionTransportFeature,
+                                                 IConnectionItemsFeature,
+                                                 IMemoryPoolFeature,
+                                                 IConnectionLifetimeFeature
     {
         // Implemented features
         internal protected IConnectionIdFeature? _currentIConnectionIdFeature;
@@ -21,8 +26,6 @@ namespace Microsoft.AspNetCore.Connections
         internal protected IConnectionItemsFeature? _currentIConnectionItemsFeature;
         internal protected IMemoryPoolFeature? _currentIMemoryPoolFeature;
         internal protected IConnectionLifetimeFeature? _currentIConnectionLifetimeFeature;
-
-        // Other reserved feature slots
 
         private int _featureRevision;
 

--- a/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
@@ -200,26 +200,30 @@ namespace Microsoft.AspNetCore.Connections
 
         void IFeatureCollection.Set<TFeature>(TFeature? feature) where TFeature : default
         {
+            // Using Unsafe.As for the cast due to https://github.com/dotnet/runtime/issues/49614
+            // The type of TFeature is confirmed by the typeof() check and the As cast only accepts
+            // that type; however the Jit does not eliminate a regular cast in a shared generic.
+
             _featureRevision++;
             if (typeof(TFeature) == typeof(IConnectionIdFeature))
             {
-                _currentIConnectionIdFeature = (IConnectionIdFeature?)feature;
+                _currentIConnectionIdFeature = Unsafe.As<TFeature?, IConnectionIdFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IConnectionTransportFeature))
             {
-                _currentIConnectionTransportFeature = (IConnectionTransportFeature?)feature;
+                _currentIConnectionTransportFeature = Unsafe.As<TFeature?, IConnectionTransportFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IConnectionItemsFeature))
             {
-                _currentIConnectionItemsFeature = (IConnectionItemsFeature?)feature;
+                _currentIConnectionItemsFeature = Unsafe.As<TFeature?, IConnectionItemsFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IMemoryPoolFeature))
             {
-                _currentIMemoryPoolFeature = (IMemoryPoolFeature?)feature;
+                _currentIMemoryPoolFeature = Unsafe.As<TFeature?, IMemoryPoolFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IConnectionLifetimeFeature))
             {
-                _currentIConnectionLifetimeFeature = (IConnectionLifetimeFeature?)feature;
+                _currentIConnectionLifetimeFeature = Unsafe.As<TFeature?, IConnectionLifetimeFeature?>(ref feature);
             }
             else
             {

--- a/src/Servers/Kestrel/shared/TransportMultiplexedConnection.FeatureCollection.cs
+++ b/src/Servers/Kestrel/shared/TransportMultiplexedConnection.FeatureCollection.cs
@@ -3,19 +3,16 @@
 
 using System.Buffers;
 using System.Collections.Generic;
-using System.IO.Pipelines;
 using System.Threading;
 using Microsoft.AspNetCore.Connections.Features;
 
 namespace Microsoft.AspNetCore.Connections
 {
-    internal partial class TransportMultiplexedConnection : IConnectionIdFeature,
-                                                 IConnectionItemsFeature,
-                                                 IMemoryPoolFeature,
-                                                 IConnectionLifetimeFeature
+    internal partial class TransportMultiplexedConnection
     {
         // NOTE: When feature interfaces are added to or removed from this TransportConnection class implementation,
-        // then the list of `features` in the generated code project MUST also be updated.
+        // then the list of `features` in the generated code project MUST also be updated first
+        // and the code generator re-reun, which will change the interface list.
         // See also: tools/CodeGenerator/TransportConnectionFeatureCollection.cs
 
         MemoryPool<byte> IMemoryPoolFeature.MemoryPool => MemoryPool;

--- a/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
@@ -15,11 +15,14 @@ namespace Microsoft.AspNetCore.Connections
 {
     internal partial class TransportMultiplexedConnection : IFeatureCollection
     {
+        // Implemented features
         internal protected IConnectionIdFeature? _currentIConnectionIdFeature;
-        internal protected IConnectionTransportFeature? _currentIConnectionTransportFeature;
         internal protected IConnectionItemsFeature? _currentIConnectionItemsFeature;
         internal protected IMemoryPoolFeature? _currentIMemoryPoolFeature;
         internal protected IConnectionLifetimeFeature? _currentIConnectionLifetimeFeature;
+
+        // Other reserved feature slots
+        internal protected IConnectionTransportFeature? _currentIConnectionTransportFeature;
 
         private int _featureRevision;
 

--- a/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Features;
@@ -164,26 +165,30 @@ namespace Microsoft.AspNetCore.Connections
 
         TFeature? IFeatureCollection.Get<TFeature>() where TFeature : default
         {
+            // Using Unsafe.As for the cast due to https://github.com/dotnet/runtime/issues/49614
+            // The type of TFeature is confirmed by the typeof() check and the As cast only accepts
+            // that type; however the Jit does not eliminate a regular cast in a shared generic.
+
             TFeature? feature = default;
             if (typeof(TFeature) == typeof(IConnectionIdFeature))
             {
-                feature = (TFeature?)_currentIConnectionIdFeature;
+                feature = Unsafe.As<IConnectionIdFeature?, TFeature?>(ref _currentIConnectionIdFeature);
             }
             else if (typeof(TFeature) == typeof(IConnectionTransportFeature))
             {
-                feature = (TFeature?)_currentIConnectionTransportFeature;
+                feature = Unsafe.As<IConnectionTransportFeature?, TFeature?>(ref _currentIConnectionTransportFeature);
             }
             else if (typeof(TFeature) == typeof(IConnectionItemsFeature))
             {
-                feature = (TFeature?)_currentIConnectionItemsFeature;
+                feature = Unsafe.As<IConnectionItemsFeature?, TFeature?>(ref _currentIConnectionItemsFeature);
             }
             else if (typeof(TFeature) == typeof(IMemoryPoolFeature))
             {
-                feature = (TFeature?)_currentIMemoryPoolFeature;
+                feature = Unsafe.As<IMemoryPoolFeature?, TFeature?>(ref _currentIMemoryPoolFeature);
             }
             else if (typeof(TFeature) == typeof(IConnectionLifetimeFeature))
             {
-                feature = (TFeature?)_currentIConnectionLifetimeFeature;
+                feature = Unsafe.As<IConnectionLifetimeFeature?, TFeature?>(ref _currentIConnectionLifetimeFeature);
             }
             else if (MaybeExtra != null)
             {

--- a/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
@@ -13,7 +13,11 @@ using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Connections
 {
-    internal partial class TransportMultiplexedConnection : IFeatureCollection
+    internal partial class TransportMultiplexedConnection : IFeatureCollection,
+                                                            IConnectionIdFeature,
+                                                            IConnectionItemsFeature,
+                                                            IMemoryPoolFeature,
+                                                            IConnectionLifetimeFeature
     {
         // Implemented features
         internal protected IConnectionIdFeature? _currentIConnectionIdFeature;

--- a/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
@@ -14,11 +14,11 @@ namespace Microsoft.AspNetCore.Connections
 {
     internal partial class TransportMultiplexedConnection : IFeatureCollection
     {
-        private object? _currentIConnectionIdFeature;
-        private object? _currentIConnectionTransportFeature;
-        private object? _currentIConnectionItemsFeature;
-        private object? _currentIMemoryPoolFeature;
-        private object? _currentIConnectionLifetimeFeature;
+        internal protected IConnectionIdFeature? _currentIConnectionIdFeature;
+        internal protected IConnectionTransportFeature? _currentIConnectionTransportFeature;
+        internal protected IConnectionItemsFeature? _currentIConnectionItemsFeature;
+        internal protected IMemoryPoolFeature? _currentIMemoryPoolFeature;
+        internal protected IConnectionLifetimeFeature? _currentIConnectionLifetimeFeature;
 
         private int _featureRevision;
 
@@ -27,11 +27,11 @@ namespace Microsoft.AspNetCore.Connections
         private void FastReset()
         {
             _currentIConnectionIdFeature = this;
-            _currentIConnectionTransportFeature = this;
             _currentIConnectionItemsFeature = this;
             _currentIMemoryPoolFeature = this;
             _currentIConnectionLifetimeFeature = this;
 
+            _currentIConnectionTransportFeature = null;
         }
 
         // Internal for testing
@@ -137,23 +137,23 @@ namespace Microsoft.AspNetCore.Connections
 
                 if (key == typeof(IConnectionIdFeature))
                 {
-                    _currentIConnectionIdFeature = value;
+                    _currentIConnectionIdFeature = (IConnectionIdFeature?)value;
                 }
                 else if (key == typeof(IConnectionTransportFeature))
                 {
-                    _currentIConnectionTransportFeature = value;
+                    _currentIConnectionTransportFeature = (IConnectionTransportFeature?)value;
                 }
                 else if (key == typeof(IConnectionItemsFeature))
                 {
-                    _currentIConnectionItemsFeature = value;
+                    _currentIConnectionItemsFeature = (IConnectionItemsFeature?)value;
                 }
                 else if (key == typeof(IMemoryPoolFeature))
                 {
-                    _currentIMemoryPoolFeature = value;
+                    _currentIMemoryPoolFeature = (IMemoryPoolFeature?)value;
                 }
                 else if (key == typeof(IConnectionLifetimeFeature))
                 {
-                    _currentIConnectionLifetimeFeature = value;
+                    _currentIConnectionLifetimeFeature = (IConnectionLifetimeFeature?)value;
                 }
                 else
                 {
@@ -198,23 +198,23 @@ namespace Microsoft.AspNetCore.Connections
             _featureRevision++;
             if (typeof(TFeature) == typeof(IConnectionIdFeature))
             {
-                _currentIConnectionIdFeature = feature;
+                _currentIConnectionIdFeature = (IConnectionIdFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IConnectionTransportFeature))
             {
-                _currentIConnectionTransportFeature = feature;
+                _currentIConnectionTransportFeature = (IConnectionTransportFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IConnectionItemsFeature))
             {
-                _currentIConnectionItemsFeature = feature;
+                _currentIConnectionItemsFeature = (IConnectionItemsFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IMemoryPoolFeature))
             {
-                _currentIMemoryPoolFeature = feature;
+                _currentIMemoryPoolFeature = (IMemoryPoolFeature?)feature;
             }
             else if (typeof(TFeature) == typeof(IConnectionLifetimeFeature))
             {
-                _currentIConnectionLifetimeFeature = feature;
+                _currentIConnectionLifetimeFeature = (IConnectionLifetimeFeature?)feature;
             }
             else
             {

--- a/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportMultiplexedConnection.Generated.cs
@@ -200,26 +200,30 @@ namespace Microsoft.AspNetCore.Connections
 
         void IFeatureCollection.Set<TFeature>(TFeature? feature) where TFeature : default
         {
+            // Using Unsafe.As for the cast due to https://github.com/dotnet/runtime/issues/49614
+            // The type of TFeature is confirmed by the typeof() check and the As cast only accepts
+            // that type; however the Jit does not eliminate a regular cast in a shared generic.
+
             _featureRevision++;
             if (typeof(TFeature) == typeof(IConnectionIdFeature))
             {
-                _currentIConnectionIdFeature = (IConnectionIdFeature?)feature;
+                _currentIConnectionIdFeature = Unsafe.As<TFeature?, IConnectionIdFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IConnectionTransportFeature))
             {
-                _currentIConnectionTransportFeature = (IConnectionTransportFeature?)feature;
+                _currentIConnectionTransportFeature = Unsafe.As<TFeature?, IConnectionTransportFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IConnectionItemsFeature))
             {
-                _currentIConnectionItemsFeature = (IConnectionItemsFeature?)feature;
+                _currentIConnectionItemsFeature = Unsafe.As<TFeature?, IConnectionItemsFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IMemoryPoolFeature))
             {
-                _currentIMemoryPoolFeature = (IMemoryPoolFeature?)feature;
+                _currentIMemoryPoolFeature = Unsafe.As<TFeature?, IMemoryPoolFeature?>(ref feature);
             }
             else if (typeof(TFeature) == typeof(IConnectionLifetimeFeature))
             {
-                _currentIConnectionLifetimeFeature = (IConnectionLifetimeFeature?)feature;
+                _currentIConnectionLifetimeFeature = Unsafe.As<TFeature?, IConnectionLifetimeFeature?>(ref feature);
             }
             else
             {

--- a/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
@@ -9,7 +9,7 @@ namespace CodeGenerator
 {
     public static class FeatureCollectionGenerator
     {
-        public static string GenerateFile(string namespaceName, string className, string[] allFeatures, string[] implementedFeatures, string[] skipResetFeatures, string extraUsings, string fallbackFeatures)
+        public static string GenerateFile(string namespaceName, string className, string[] allFeatures, string[] implementedFeatures, string extraUsings, string fallbackFeatures)
         {
             // NOTE: This list MUST always match the set of feature interfaces implemented by TransportConnection.
             // See also: src/Kestrel/Http/TransportConnection.FeatureCollection.cs
@@ -32,11 +32,10 @@ using System.Runtime.CompilerServices;
 
 namespace {namespaceName}
 {{
-    internal partial class {className} : IFeatureCollection{Each(implementedFeatures.Where(f => !skipResetFeatures.Contains(f)), feature => $@",
+    internal partial class {className} : IFeatureCollection{Each(implementedFeatures, feature => $@",
                               {new string(' ', className.Length)}{feature}")}
     {{
-        // Implemented features{Each(implementedFeatures.Where(f => !skipResetFeatures.Contains(f)), feature => $@"
-        internal protected {feature}? _current{feature};")}{Each(implementedFeatures.Where(f => skipResetFeatures.Contains(f)), feature => $@"
+        // Implemented features{Each(implementedFeatures, feature => $@"
         internal protected {feature}? _current{feature};")}{(allFeatures.Where(f => !implementedFeatures.Contains(f)).FirstOrDefault() is not null ? @"
 
         // Other reserved feature slots" : "")}{Each(allFeatures.Where(f => !implementedFeatures.Contains(f)), feature => $@"
@@ -47,7 +46,7 @@ namespace {namespaceName}
         private List<KeyValuePair<Type, object>>? MaybeExtra;
 
         private void FastReset()
-        {{{Each(implementedFeatures.Where(f => !skipResetFeatures.Contains(f)), feature => $@"
+        {{{Each(implementedFeatures, feature => $@"
             _current{feature} = this;")}
 {Each(allFeatures.Where(f => !implementedFeatures.Contains(f)), feature => $@"
             _current{feature} = null;")}

--- a/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
@@ -32,13 +32,14 @@ using System.Runtime.CompilerServices;
 
 namespace {namespaceName}
 {{
-    internal partial class {className} : IFeatureCollection
+    internal partial class {className} : IFeatureCollection{Each(implementedFeatures.Where(f => !skipResetFeatures.Contains(f)), feature => $@",
+                              {new string(' ', className.Length)}{feature}")}
     {{
         // Implemented features{Each(implementedFeatures.Where(f => !skipResetFeatures.Contains(f)), feature => $@"
         internal protected {feature}? _current{feature};")}{Each(implementedFeatures.Where(f => skipResetFeatures.Contains(f)), feature => $@"
-        internal protected {feature}? _current{feature};")}
+        internal protected {feature}? _current{feature};")}{(allFeatures.Where(f => !implementedFeatures.Contains(f)).FirstOrDefault() is not null ? @"
 
-        // Other reserved feature slots{Each(allFeatures.Where(f => !implementedFeatures.Contains(f)), feature => $@"
+        // Other reserved feature slots" : "")}{Each(allFeatures.Where(f => !implementedFeatures.Contains(f)), feature => $@"
         internal protected {feature}? _current{feature};")}
 
         private int _featureRevision;

--- a/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
@@ -9,7 +9,7 @@ namespace CodeGenerator
 {
     public static class FeatureCollectionGenerator
     {
-        public static string GenerateFile(string namespaceName, string className, string[] allFeatures, string[] implementedFeatures, string extraUsings, string fallbackFeatures)
+        public static string GenerateFile(string namespaceName, string className, string[] allFeatures, string[] implementedFeatures, string[] skipResetFeatures, string extraUsings, string fallbackFeatures)
         {
             // NOTE: This list MUST always match the set of feature interfaces implemented by TransportConnection.
             // See also: src/Kestrel/Http/TransportConnection.FeatureCollection.cs
@@ -33,14 +33,14 @@ namespace {namespaceName}
 {{
     internal partial class {className} : IFeatureCollection
     {{{Each(features, feature => $@"
-        private object? _current{feature.Name};")}
+        internal protected {feature.Name}? _current{feature.Name};")}
 
         private int _featureRevision;
 
         private List<KeyValuePair<Type, object>>? MaybeExtra;
 
         private void FastReset()
-        {{{Each(implementedFeatures, feature => $@"
+        {{{Each(implementedFeatures.Where(f => !skipResetFeatures.Contains(f)), feature => $@"
             _current{feature} = this;")}
 {Each(allFeatures.Where(f => !implementedFeatures.Contains(f)), feature => $@"
             _current{feature} = null;")}
@@ -133,7 +133,7 @@ namespace {namespaceName}
 {Each(features, feature => $@"
                 {(feature.Index != 0 ? "else " : "")}if (key == typeof({feature.Name}))
                 {{
-                    _current{feature.Name} = value;
+                    _current{feature.Name} = ({feature.Name}?)value;
                 }}")}
                 else
                 {{
@@ -167,7 +167,7 @@ namespace {namespaceName}
             _featureRevision++;{Each(features, feature => $@"
             {(feature.Index != 0 ? "else " : "")}if (typeof(TFeature) == typeof({feature.Name}))
             {{
-                _current{feature.Name} = feature;
+                _current{feature.Name} = ({feature.Name}?)feature;
             }}")}
             else
             {{

--- a/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
@@ -33,8 +33,13 @@ using System.Runtime.CompilerServices;
 namespace {namespaceName}
 {{
     internal partial class {className} : IFeatureCollection
-    {{{Each(features, feature => $@"
-        internal protected {feature.Name}? _current{feature.Name};")}
+    {{
+        // Implemented features{Each(implementedFeatures.Where(f => !skipResetFeatures.Contains(f)), feature => $@"
+        internal protected {feature}? _current{feature};")}{Each(implementedFeatures.Where(f => skipResetFeatures.Contains(f)), feature => $@"
+        internal protected {feature}? _current{feature};")}
+
+        // Other reserved feature slots{Each(allFeatures.Where(f => !implementedFeatures.Contains(f)), feature => $@"
+        internal protected {feature}? _current{feature};")}
 
         private int _featureRevision;
 

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -23,6 +23,7 @@ namespace CodeGenerator
             {
                 "IItemsFeature",
                 "IQueryFeature",
+                "IRequestBodyPipeFeature",
                 "IFormFeature",
                 "IHttpAuthenticationFeature",
                 "IHttpRequestIdentifierFeature",
@@ -42,7 +43,6 @@ namespace CodeGenerator
             var maybeFeatures = new[]
             {
                 "IHttp2StreamIdFeature",
-                "IRequestBodyPipeFeature",
                 "IHttpRequestLifetimeFeature",
                 "IHttpMaxRequestBodySizeFeature",
                 "IHttpMinRequestBodyDataRateFeature",

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -12,46 +12,50 @@ namespace CodeGenerator
             var alwaysFeatures = new[]
             {
                 "IHttpRequestFeature",
-                "IHttpRequestBodyDetectionFeature",
                 "IHttpResponseFeature",
                 "IHttpResponseBodyFeature",
-                "IRequestBodyPipeFeature",
-                "IHttpRequestIdentifierFeature",
-                "IServiceProvidersFeature",
-                "IHttpRequestLifetimeFeature",
-                "IHttpConnectionFeature",
                 "IRouteValuesFeature",
-                "IEndpointFeature"
+                "IEndpointFeature",
+                "IServiceProvidersFeature"
             };
 
             var commonFeatures = new[]
             {
-                "IHttpAuthenticationFeature",
-                "IHttpRequestTrailersFeature",
+                "IItemsFeature",
                 "IQueryFeature",
                 "IFormFeature",
+                "IHttpAuthenticationFeature",
+                "IHttpRequestIdentifierFeature",
             };
 
             var sometimesFeatures = new[]
             {
-                "IHttpUpgradeFeature",
-                "IHttp2StreamIdFeature",
-                "IHttpResponseTrailersFeature",
-                "IResponseCookiesFeature",
-                "IItemsFeature",
-                "ITlsConnectionFeature",
-                "IHttpWebSocketFeature",
+                "IHttpConnectionFeature",
                 "ISessionFeature",
+                "IResponseCookiesFeature",
+                "IHttpRequestTrailersFeature",
+                "IHttpResponseTrailersFeature",
+                "ITlsConnectionFeature",
+                "IHttpUpgradeFeature",
+                "IHttpWebSocketFeature"
+            };
+            var maybeFeatures = new[]
+            {
+                "IHttp2StreamIdFeature",
+                "IRequestBodyPipeFeature",
+                "IHttpRequestLifetimeFeature",
                 "IHttpMaxRequestBodySizeFeature",
                 "IHttpMinRequestBodyDataRateFeature",
                 "IHttpMinResponseDataRateFeature",
                 "IHttpBodyControlFeature",
+                "IHttpRequestBodyDetectionFeature",
                 "IHttpResetFeature"
             };
 
             var allFeatures = alwaysFeatures
                 .Concat(commonFeatures)
                 .Concat(sometimesFeatures)
+                .Concat(maybeFeatures)
                 .ToArray();
 
             // NOTE: This list MUST always match the set of feature interfaces implemented by HttpProtocol.
@@ -59,20 +63,20 @@ namespace CodeGenerator
             var implementedFeatures = new[]
             {
                 "IHttpRequestFeature",
-                "IHttpRequestBodyDetectionFeature",
                 "IHttpResponseFeature",
                 "IHttpResponseBodyFeature",
-                "IRequestBodyPipeFeature",
-                "IHttpUpgradeFeature",
+                "IRouteValuesFeature",
+                "IEndpointFeature",
                 "IHttpRequestIdentifierFeature",
-                "IHttpRequestLifetimeFeature",
                 "IHttpRequestTrailersFeature",
+                "IHttpUpgradeFeature",
+                "IRequestBodyPipeFeature",
                 "IHttpConnectionFeature",
+                "IHttpRequestLifetimeFeature",
+                "IHttpBodyControlFeature",
                 "IHttpMaxRequestBodySizeFeature",
                 "IHttpMinRequestBodyDataRateFeature",
-                "IHttpBodyControlFeature",
-                "IRouteValuesFeature",
-                "IEndpointFeature"
+                "IHttpRequestBodyDetectionFeature",
             };
 
             // NOTE: Each item in this list MUST always be reset by each protocol in their OnReset() method

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -74,7 +74,13 @@ namespace CodeGenerator
                 "IRouteValuesFeature",
                 "IEndpointFeature"
             };
-            
+
+            // NOTE: Each item in this list MUST always be reset by each protocol in their OnReset() method
+            var skipResetFeatures = new[]
+            {
+                "IHttpMinRequestBodyDataRateFeature"
+            };
+
             var usings = $@"
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
@@ -85,6 +91,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Features;";
                 className: "HttpProtocol",
                 allFeatures: allFeatures,
                 implementedFeatures: implementedFeatures,
+                skipResetFeatures: skipResetFeatures,
                 extraUsings: usings,
                 fallbackFeatures: "ConnectionFeatures");
         }

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -75,14 +75,7 @@ namespace CodeGenerator
                 "IHttpRequestLifetimeFeature",
                 "IHttpBodyControlFeature",
                 "IHttpMaxRequestBodySizeFeature",
-                "IHttpMinRequestBodyDataRateFeature",
                 "IHttpRequestBodyDetectionFeature",
-            };
-
-            // NOTE: Each item in this list MUST always be reset by each protocol in their OnReset() method
-            var skipResetFeatures = new[]
-            {
-                "IHttpMinRequestBodyDataRateFeature"
             };
 
             var usings = $@"
@@ -95,7 +88,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Features;";
                 className: "HttpProtocol",
                 allFeatures: allFeatures,
                 implementedFeatures: implementedFeatures,
-                skipResetFeatures: skipResetFeatures,
                 extraUsings: usings,
                 fallbackFeatures: "ConnectionFeatures");
         }

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
@@ -29,7 +29,6 @@ using Microsoft.AspNetCore.Http.Features;";
                 className: "TransportConnection",
                 allFeatures: features,
                 implementedFeatures: features,
-                skipResetFeatures: Array.Empty<string>(),
                 extraUsings: usings,
                 fallbackFeatures: null);
         }

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace CodeGenerator
 {
     public class TransportConnectionFeatureCollection
@@ -27,6 +29,7 @@ using Microsoft.AspNetCore.Http.Features;";
                 className: "TransportConnection",
                 allFeatures: features,
                 implementedFeatures: features,
+                skipResetFeatures: Array.Empty<string>(),
                 extraUsings: usings,
                 fallbackFeatures: null);
         }

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportMultiplexedConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportMultiplexedConnectionFeatureCollection.cs
@@ -36,7 +36,6 @@ using Microsoft.AspNetCore.Http.Features;";
                 className: "TransportMultiplexedConnection",
                 allFeatures: allFeatures,
                 implementedFeatures: implementedFeatures,
-                skipResetFeatures: Array.Empty<string>(),
                 extraUsings: usings,
                 fallbackFeatures: null);
         }

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportMultiplexedConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportMultiplexedConnectionFeatureCollection.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace CodeGenerator
 {
     public class TransportMultiplexedConnectionFeatureCollection
@@ -9,10 +11,17 @@ namespace CodeGenerator
         {
             // NOTE: This list MUST always match the set of feature interfaces implemented by TransportConnectionBase.
             // See also: shared/TransportConnectionBase.FeatureCollection.cs
-            var features = new[]
+            var allFeatures = new[]
             {
                 "IConnectionIdFeature",
                 "IConnectionTransportFeature",
+                "IConnectionItemsFeature",
+                "IMemoryPoolFeature",
+                "IConnectionLifetimeFeature"
+            };
+            var implementedFeatures = new[]
+            {
+                "IConnectionIdFeature",
                 "IConnectionItemsFeature",
                 "IMemoryPoolFeature",
                 "IConnectionLifetimeFeature"
@@ -25,8 +34,9 @@ using Microsoft.AspNetCore.Http.Features;";
             return FeatureCollectionGenerator.GenerateFile(
                 namespaceName: "Microsoft.AspNetCore.Connections",
                 className: "TransportMultiplexedConnection",
-                allFeatures: features,
-                implementedFeatures: features,
+                allFeatures: allFeatures,
+                implementedFeatures: implementedFeatures,
+                skipResetFeatures: Array.Empty<string>(),
                 extraUsings: usings,
                 fallbackFeatures: null);
         }


### PR DESCRIPTION
Improves access by +50% for commonly used features
|                                         Method |      Mean |          Op/s |      Diff |
|----------------------------------------------- |----------:|--------------:|----------:|
|                Get&lt;IHttpRequestFeature&gt;* |  8.507 ns | 117,554,189.6 |    +50.0% |
|               Get&lt;IHttpResponseFeature&gt;* |  9.034 ns | 110,689,963.7 |         - |
|           Get&lt;IHttpResponseBodyFeature&gt;* |  9.466 ns | 105,636,431.7 |    +58.7% |
|                Get&lt;IRouteValuesFeature&gt;* | 10.007 ns |  99,927,927.4 |    +50.0% |
|                   Get&lt;IEndpointFeature&gt;* | 10.564 ns |  94,656,794.2 |    +44.7% |

Resolves https://github.com/dotnet/aspnetcore/issues/31321

Performance may be able to be improved depending on https://github.com/dotnet/runtime/issues/49614 by having the casts dropped since they are strongly typed.


Also drops the `CastHelpers.ChkCastAny` that it currently makes for each return

![image](https://user-images.githubusercontent.com/1142958/112739023-25dffa00-8f60-11eb-9b6b-854ca9a31edd.png)
