### PR TITLE
Minor changes to runtime-compilation to make it extendable

### DIFF
--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, PageLoaderMatcherPolicy>());
             }
 
-            services.TryAddSingleton<RuntimeCompilationFileProvider>();
+            services.TryAddSingleton<IRuntimeCompilationFileProvider, RuntimeCompilationFileProvider>();
             services.TryAddSingleton<RazorReferenceManager>();
             services.TryAddSingleton<CSharpCompiler>();
 

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensions.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.TryAddSingleton<IRuntimeCompilationFileProvider, RuntimeCompilationFileProvider>();
+            services.TryAddSingleton<IRuntimeCompilationAssemblyLoader, RuntimeCompilationAssemblyLoader>();
             services.TryAddSingleton<RazorReferenceManager>();
             services.TryAddSingleton<CSharpCompiler>();
 

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/FileProviderRazorProjectFileSystem.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/FileProviderRazorProjectFileSystem.cs
@@ -13,10 +13,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
     internal class FileProviderRazorProjectFileSystem : RazorProjectFileSystem
     {
         private const string RazorFileExtension = ".cshtml";
-        private readonly RuntimeCompilationFileProvider _fileProvider;
+        private readonly IRuntimeCompilationFileProvider _fileProvider;
         private readonly IWebHostEnvironment _hostingEnvironment;
 
-        public FileProviderRazorProjectFileSystem(RuntimeCompilationFileProvider fileProvider, IWebHostEnvironment hostingEnvironment)
+        public FileProviderRazorProjectFileSystem(IRuntimeCompilationFileProvider fileProvider, IWebHostEnvironment hostingEnvironment)
         {
             if (fileProvider == null)
             {

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/IRuntimeCompilationAssemblyLoader.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/IRuntimeCompilationAssemblyLoader.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Reflection;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
+{
+    public interface IRuntimeCompilationAssemblyLoader
+    {
+        public Assembly Load(RazorCodeDocument codeDocument, MemoryStream assemblyStream, MemoryStream pdbStream);
+    }
+}

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/IRuntimeCompilationFileProvider.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/IRuntimeCompilationFileProvider.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
+{
+    public interface IRuntimeCompilationFileProvider
+    {
+        public IFileProvider FileProvider { get; }
+    }
+}

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationAssemblyLoader.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationAssemblyLoader.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 {
-    public class RuntimeCompilationAssemblyLoader : IRuntimeCompilationAssemblyLoader
+    internal class RuntimeCompilationAssemblyLoader : IRuntimeCompilationAssemblyLoader
     {
         public Assembly Load(RazorCodeDocument codeDocument, MemoryStream assemblyStream, MemoryStream pdbStream)
         {

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationAssemblyLoader.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationAssemblyLoader.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 {
-    public interface RuntimeCompilationAssemblyLoader : IRuntimeCompilationAssemblyLoader
+    public class RuntimeCompilationAssemblyLoader : IRuntimeCompilationAssemblyLoader
     {
         public Assembly Load(RazorCodeDocument codeDocument, MemoryStream assemblyStream, MemoryStream pdbStream)
         {

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationAssemblyLoader.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationAssemblyLoader.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Reflection;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
+{
+    public interface RuntimeCompilationAssemblyLoader : IRuntimeCompilationAssemblyLoader
+    {
+        public Assembly Load(RazorCodeDocument codeDocument, MemoryStream assemblyStream, MemoryStream pdbStream)
+        {
+            return Assembly.Load(assemblyStream.ToArray(), pdbStream?.ToArray());
+        }
+    }
+}

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationFileProvider.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeCompilationFileProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
 {
-    internal class RuntimeCompilationFileProvider
+    internal class RuntimeCompilationFileProvider : IRuntimeCompilationFileProvider
     {
         private readonly MvcRazorRuntimeCompilationOptions _options;
         private IFileProvider _compositeFileProvider;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompiler.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompiler.cs
@@ -33,11 +33,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
         private readonly IMemoryCache _cache;
         private readonly ILogger _logger;
         private readonly CSharpCompiler _csharpCompiler;
+        private readonly IRuntimeCompilationAssemblyLoader _assemblyLoader;
 
         public RuntimeViewCompiler(
             IFileProvider fileProvider,
             RazorProjectEngine projectEngine,
             CSharpCompiler csharpCompiler,
+            IRuntimeCompilationAssemblyLoader assemblyLoader,
             IList<CompiledViewDescriptor> precompiledViews,
             ILogger logger)
         {
@@ -56,6 +58,11 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
                 throw new ArgumentNullException(nameof(csharpCompiler));
             }
 
+            if (assemblyLoader == null)
+            {
+                throw new ArgumentNullException(nameof(assemblyLoader));
+            }
+
             if (precompiledViews == null)
             {
                 throw new ArgumentNullException(nameof(precompiledViews));
@@ -69,6 +76,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
             _fileProvider = fileProvider;
             _projectEngine = projectEngine;
             _csharpCompiler = csharpCompiler;
+            _assemblyLoader = assemblyLoader;
             _logger = logger;
 
 
@@ -387,7 +395,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
                 assemblyStream.Seek(0, SeekOrigin.Begin);
                 pdbStream?.Seek(0, SeekOrigin.Begin);
 
-                var assembly = Assembly.Load(assemblyStream.ToArray(), pdbStream?.ToArray());
+                var assembly = _assemblyLoader.Load(codeDocument, assemblyStream.ToArray(), pdbStream?.ToArray());
                 _logger.GeneratedCodeToAssemblyCompilationEnd(codeDocument.Source.FilePath, startTimestamp);
 
                 return assembly;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompiler.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompiler.cs
@@ -395,7 +395,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
                 assemblyStream.Seek(0, SeekOrigin.Begin);
                 pdbStream?.Seek(0, SeekOrigin.Begin);
 
-                var assembly = _assemblyLoader.Load(codeDocument, assemblyStream.ToArray(), pdbStream?.ToArray());
+                var assembly = _assemblyLoader.Load(codeDocument, assemblyStream, pdbStream);
                 _logger.GeneratedCodeToAssemblyCompilationEnd(codeDocument.Source.FilePath, startTimestamp);
 
                 return assembly;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompilerProvider.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompilerProvider.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
         private readonly RazorProjectEngine _razorProjectEngine;
         private readonly ApplicationPartManager _applicationPartManager;
         private readonly CSharpCompiler _csharpCompiler;
+        private readonly IRuntimeCompilationAssemblyLoader _assemblyLoader;
         private readonly IRuntimeCompilationFileProvider _fileProvider;
         private readonly ILogger<RuntimeViewCompiler> _logger;
         private readonly Func<IViewCompiler> _createCompiler;
@@ -28,6 +29,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
             RazorProjectEngine razorProjectEngine,
             IRuntimeCompilationFileProvider fileProvider,
             CSharpCompiler csharpCompiler,
+            IRuntimeCompilationAssemblyLoader assemblyLoader,
             ILoggerFactory loggerFactory)
         {
             _applicationPartManager = applicationPartManager;
@@ -57,6 +59,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
                 _fileProvider.FileProvider,
                 _razorProjectEngine,
                 _csharpCompiler,
+                _assemblyLoader,
                 feature.ViewDescriptors,
                 _logger);
         }

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompilerProvider.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompilerProvider.cs
@@ -35,6 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
             _applicationPartManager = applicationPartManager;
             _razorProjectEngine = razorProjectEngine;
             _csharpCompiler = csharpCompiler;
+            _assemblyLoader = assemblyLoader;
             _fileProvider = fileProvider;
 
             _logger = loggerFactory.CreateLogger<RuntimeViewCompiler>();

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompilerProvider.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RuntimeViewCompilerProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
         private readonly RazorProjectEngine _razorProjectEngine;
         private readonly ApplicationPartManager _applicationPartManager;
         private readonly CSharpCompiler _csharpCompiler;
-        private readonly RuntimeCompilationFileProvider _fileProvider;
+        private readonly IRuntimeCompilationFileProvider _fileProvider;
         private readonly ILogger<RuntimeViewCompiler> _logger;
         private readonly Func<IViewCompiler> _createCompiler;
 
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
         public RuntimeViewCompilerProvider(
             ApplicationPartManager applicationPartManager,
             RazorProjectEngine razorProjectEngine,
-            RuntimeCompilationFileProvider fileProvider,
+            IRuntimeCompilationFileProvider fileProvider,
             CSharpCompiler csharpCompiler,
             ILoggerFactory loggerFactory)
         {


### PR DESCRIPTION
These are the proposed changes to solve #31314. It can be seen as a proposal and not a ready-to-merge request. 

**PR Title**
Make MVC Razor runtime-compilation extendable

**PR Description**

- add `IRuntimeCompilationFileProvider` to be able to supply an own implementation
- add `IRuntimeCompilationAssemblyLoader` to be able to supply an own assembly loader to use instead of `Assembly.Load`

Addresses #31314