### PR TITLE
Add a FeaturesCollection constructor that supports initial capacity

### DIFF
--- a/src/Http/Http.Features/src/FeatureCollection.cs
+++ b/src/Http/Http.Features/src/FeatureCollection.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Http.Features
     {
         private static readonly KeyComparer FeatureKeyComparer = new KeyComparer();
         private readonly IFeatureCollection? _defaults;
+        private readonly int _initialCapacity;
         private IDictionary<Type, object>? _features;
         private volatile int _containerRevision;
 
@@ -23,6 +24,21 @@ namespace Microsoft.AspNetCore.Http.Features
         /// </summary>
         public FeatureCollection()
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="FeatureCollection"/> with the specified initial capacity.
+        /// </summary>
+        /// <param name="initialCapacity">The initial number of elements that the collection can contain.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="initialCapacity"/> is less than 0</exception>
+        public FeatureCollection(int initialCapacity)
+        {
+            if (initialCapacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+            }
+
+            _initialCapacity = initialCapacity;
         }
 
         /// <summary>
@@ -73,7 +89,7 @@ namespace Microsoft.AspNetCore.Http.Features
 
                 if (_features == null)
                 {
-                    _features = new Dictionary<Type, object>();
+                    _features = new Dictionary<Type, object>(_initialCapacity);
                 }
                 _features[key] = value;
                 _containerRevision++;

--- a/src/Http/Http.Features/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Features/src/PublicAPI.Unshipped.txt
@@ -14,3 +14,4 @@ Microsoft.AspNetCore.Http.Features.IFeatureCollection.Get<TFeature>() -> TFeatur
 Microsoft.AspNetCore.Http.Features.IFeatureCollection.Set<TFeature>(TFeature? instance) -> void
 Microsoft.AspNetCore.Http.Features.IServerVariablesFeature.this[string! variableName].get -> string?
 Microsoft.AspNetCore.Http.ISession.TryGetValue(string! key, out byte[]? value) -> bool
+Microsoft.AspNetCore.Http.Features.FeatureCollection.FeatureCollection(int initialCapacity) -> void

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -19,6 +19,10 @@ namespace Microsoft.AspNetCore.Http
     /// </summary>
     public sealed class DefaultHttpContext : HttpContext
     {
+        // The initial size of the feature collection when using the default constructor; based on number of common features
+        // https://github.com/dotnet/aspnetcore/issues/31249
+        private const int DefaultFeatureCollectionSize = 10;
+
         // Lambdas hoisted to static readonly fields to improve inlining https://github.com/dotnet/roslyn/issues/13624
         private readonly static Func<IFeatureCollection, IItemsFeature> _newItemsFeature = f => new ItemsFeature();
         private readonly static Func<DefaultHttpContext, IServiceProvidersFeature> _newServiceProvidersFeature = context => new RequestServicesFeature(context, context.ServiceScopeFactory);
@@ -44,7 +48,7 @@ namespace Microsoft.AspNetCore.Http
         /// Initializes a new instance of the <see cref="DefaultHttpContext"/> class.
         /// </summary>
         public DefaultHttpContext()
-            : this(new FeatureCollection(10))
+            : this(new FeatureCollection(DefaultFeatureCollectionSize))
         {
             Features.Set<IHttpRequestFeature>(new HttpRequestFeature());
             Features.Set<IHttpResponseFeature>(new HttpResponseFeature());

--- a/src/Http/Http/src/DefaultHttpContext.cs
+++ b/src/Http/Http/src/DefaultHttpContext.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Http
         /// Initializes a new instance of the <see cref="DefaultHttpContext"/> class.
         /// </summary>
         public DefaultHttpContext()
-            : this(new FeatureCollection())
+            : this(new FeatureCollection(10))
         {
             Features.Set<IHttpRequestFeature>(new HttpRequestFeature());
             Features.Set<IHttpResponseFeature>(new HttpResponseFeature());


### PR DESCRIPTION
**PR Title**
Add a FeaturesCollection constructor that supports initial capacity

**PR Description**
The `initialCapacity` constructor is added and validates its argument to be `>= 0` . The value is later used when the `_features` dictionary is constructed. The default value remains 0.

The new constructor is used by the default `DefaultHttpContext` ctor with an arbitrary value of 10.

There are currently no tests for this functionality - the actual capacity of the underlying dictionary is not easily observable from the outside and other tests (e.g. validation) seem trivial. If some tests are desired, I can add them in another commit.

Fixes #31249