### PR TITLE
Clean up NetCore PBKDF2 provider

### DIFF
--- a/src/DataProtection/Cryptography.KeyDerivation/src/PBKDF2/NetCorePbkdf2Provider.cs
+++ b/src/DataProtection/Cryptography.KeyDerivation/src/PBKDF2/NetCorePbkdf2Provider.cs
@@ -14,8 +14,6 @@ namespace Microsoft.AspNetCore.Cryptography.KeyDerivation.PBKDF2
     /// </summary>
     internal sealed class NetCorePbkdf2Provider : IPbkdf2Provider
     {
-        private static readonly ManagedPbkdf2Provider _fallbackProvider = new ManagedPbkdf2Provider();
-
         public byte[] DeriveKey(string password, byte[] salt, KeyDerivationPrf prf, int iterationCount, int numBytesRequested)
         {
             Debug.Assert(password != null);
@@ -23,21 +21,6 @@ namespace Microsoft.AspNetCore.Cryptography.KeyDerivation.PBKDF2
             Debug.Assert(iterationCount > 0);
             Debug.Assert(numBytesRequested > 0);
 
-            if (salt.Length < 8)
-            {
-                // Rfc2898DeriveBytes enforces the 8 byte recommendation.
-                // To maintain compatibility, we call into ManagedPbkdf2Provider for salts shorter than 8 bytes
-                // because we can't use Rfc2898DeriveBytes with this salt.
-                return _fallbackProvider.DeriveKey(password, salt, prf, iterationCount, numBytesRequested);
-            }
-            else
-            {
-                return DeriveKeyImpl(password, salt, prf, iterationCount, numBytesRequested);
-            }
-        }
-
-        private static byte[] DeriveKeyImpl(string password, byte[] salt, KeyDerivationPrf prf, int iterationCount, int numBytesRequested)
-        {
             HashAlgorithmName algorithmName;
             switch (prf)
             {
@@ -54,7 +37,7 @@ namespace Microsoft.AspNetCore.Cryptography.KeyDerivation.PBKDF2
                     throw new ArgumentOutOfRangeException();
             }
 
-            return Rfc2898DeriveBytes.Pbkdf2(Encoding.UTF8.GetBytes(password), salt, iterationCount, algorithmName, numBytesRequested);
+            return Rfc2898DeriveBytes.Pbkdf2(password, salt, iterationCount, algorithmName, numBytesRequested);
         }
     }
 }


### PR DESCRIPTION
This is a follow up PR to #31200 and contributes to #30941.

1. The one-shot PBKDF2 implementation does not have a minimum salt length, so the fallback to the managed implementation is not needed.
2. There is a `string` overload for the password, so there should be no need to manually convert it to UTF8.
    If this API ever does get spanified, the one-shot has `ReadOnlySpan<char / byte>` for everything too, so there should be no need to do manual stackalloc-y stuff here.

/cc @HaoK  