### PR TITLE
Improve test failures for unexpected logs

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.Tests/StrictTestServerTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/StrictTestServerTests.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 {
@@ -14,7 +16,11 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         public override void Dispose()
         {
             base.Dispose();
-            Assert.DoesNotContain(TestSink.Writes, w => w.LogLevel > LogLevel.Information);
+
+            if (TestSink.Writes.FirstOrDefault(w => w.LogLevel > LogLevel.Information) is WriteContext writeContext)
+            {
+                throw new XunitException($"Unexpected log: {writeContext}");
+            }
         }
 
         protected static TaskCompletionSource<bool> CreateTaskCompletionSource()

--- a/src/Testing/src/Logging/WriteContext.cs
+++ b/src/Testing/src/Logging/WriteContext.cs
@@ -29,5 +29,10 @@ namespace Microsoft.Extensions.Logging.Testing
                 return Formatter(State, Exception);
             }
         }
+
+        public override string ToString()
+        {
+            return $"{LogLevel} {LoggerName}: {Message}";
+        }
     }
 }


### PR DESCRIPTION
Without this ToString() implementation, test failures can be inscrutable. Ex:

```
Assert.DoesNotContain() Failure
Found:    (filter expression)
In value: ConcurrentQueue<WriteContext> [WriteContext { EventId = 0, Exception = null, Formatter = Func3 { ... }, LoggerName = "Microsoft.AspNetCore.Server.IIS.FunctionalTests.Te"..., LogLevel = Debug, ... }, WriteContext
```

See https://github.com/dotnet/aspnetcore/pull/31405#issuecomment-810651059 for more context

After this change:

```
Unexpected log: Error Microsoft.AspNetCore.Server.IIS.FunctionalTests.ResponseAbortTests: Test error log!!!
```

To get a simpler error message I stopped using `Assert.DoesNotContain()` in `StrictTestServerTests.cs` and just print the first log with a higher than expected log level. However, if there are few enough logs, the `ToString()` addition should even help tests that use the normal `Assert` methods.
