### PR TITLE
Ability to deactivate DataAnnotationsValidation dynamically. Fixes #31027

### DIFF
--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -11,6 +11,7 @@ namespace Microsoft.AspNetCore.Components.Forms
     public class DataAnnotationsValidator : ComponentBase, IDisposable
     {
         private IDisposable? _subscriptions;
+        private EditContext? _originalEditContext;
 
         [CascadingParameter] EditContext? CurrentEditContext { get; set; }
 
@@ -25,6 +26,19 @@ namespace Microsoft.AspNetCore.Components.Forms
             }
 
             _subscriptions = CurrentEditContext.EnableDataAnnotationsValidation();
+            _originalEditContext = CurrentEditContext;
+        }
+
+        /// <inheritdoc />
+        protected override void OnParametersSet()
+        {
+            if (CurrentEditContext != _originalEditContext)
+            {
+                // While we could support this, there's no known use case presently. Since InputBase doesn't support it,
+                // it's more understandable to have the same restriction.
+                throw new InvalidOperationException($"{GetType()} does not support changing the " +
+                    $"{nameof(EditContext)} dynamically.");
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -8,8 +8,10 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// <summary>
     /// Adds Data Annotations validation support to an <see cref="EditContext"/>.
     /// </summary>
-    public class DataAnnotationsValidator : ComponentBase
+    public class DataAnnotationsValidator : ComponentBase, IDisposable
     {
+        private IDisposable? _subscriptions;
+
         [CascadingParameter] EditContext? CurrentEditContext { get; set; }
 
         /// <inheritdoc />
@@ -22,7 +24,20 @@ namespace Microsoft.AspNetCore.Components.Forms
                     $"inside an EditForm.");
             }
 
-            CurrentEditContext.AddDataAnnotationsValidation();
+            _subscriptions = CurrentEditContext.EnableDataAnnotationsValidation();
+        }
+
+        /// <inheritdoc/>
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+
+        void IDisposable.Dispose()
+        {
+            _subscriptions?.Dispose();
+            _subscriptions = null;
+
+            Dispose(disposing: true);
         }
     }
 }

--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             return new DataAnnotationsEventSubscriptions(editContext);
         }
 
-        class DataAnnotationsEventSubscriptions : IDisposable
+        private sealed class DataAnnotationsEventSubscriptions : IDisposable
         {
             private static readonly ConcurrentDictionary<(Type ModelType, string FieldName), PropertyInfo?> _propertyInfoCache = new();
 

--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -16,98 +16,123 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// </summary>
     public static class EditContextDataAnnotationsExtensions
     {
-        private static ConcurrentDictionary<(Type ModelType, string FieldName), PropertyInfo?> _propertyInfoCache
-            = new ConcurrentDictionary<(Type, string), PropertyInfo?>();
-
         /// <summary>
         /// Adds DataAnnotations validation support to the <see cref="EditContext"/>.
         /// </summary>
         /// <param name="editContext">The <see cref="EditContext"/>.</param>
+        [Obsolete("Use " + nameof(EnableDataAnnotationsValidation) + " instead.")]
         public static EditContext AddDataAnnotationsValidation(this EditContext editContext)
         {
-            if (editContext == null)
-            {
-                throw new ArgumentNullException(nameof(editContext));
-            }
-
-            var messages = new ValidationMessageStore(editContext);
-
-            // Perform object-level validation on request
-            editContext.OnValidationRequested +=
-                (sender, eventArgs) => ValidateModel((EditContext)sender!, messages);
-
-            // Perform per-field validation on each field edit
-            editContext.OnFieldChanged +=
-                (sender, eventArgs) => ValidateField(editContext, messages, eventArgs.FieldIdentifier);
-
+            EnableDataAnnotationsValidation(editContext);
             return editContext;
         }
 
-        private static void ValidateModel(EditContext editContext, ValidationMessageStore messages)
+        /// <summary>
+        /// Enables DataAnnotations validation support for the <see cref="EditContext"/>.
+        /// </summary>
+        /// <param name="editContext">The <see cref="EditContext"/>.</param>
+        /// <returns>A disposable object whose disposal will remove DataAnnotations validation support from the <see cref="EditContext"/>.</returns>
+        public static IDisposable EnableDataAnnotationsValidation(this EditContext editContext)
         {
-            var validationContext = new ValidationContext(editContext.Model);
-            var validationResults = new List<ValidationResult>();
-            Validator.TryValidateObject(editContext.Model, validationContext, validationResults, true);
-
-            // Transfer results to the ValidationMessageStore
-            messages.Clear();
-            foreach (var validationResult in validationResults)
-            {
-                if (validationResult == null)
-                {
-                    continue;
-                }
-
-                if (!validationResult.MemberNames.Any())
-                {
-                    messages.Add(new FieldIdentifier(editContext.Model, fieldName: string.Empty), validationResult.ErrorMessage!);
-                    continue;
-                }
-
-                foreach (var memberName in validationResult.MemberNames)
-                {
-                    messages.Add(editContext.Field(memberName), validationResult.ErrorMessage!);
-                }
-            }
-
-            editContext.NotifyValidationStateChanged();
+            return new DataAnnotationsEventSubscriptions(editContext);
         }
 
-        private static void ValidateField(EditContext editContext, ValidationMessageStore messages, in FieldIdentifier fieldIdentifier)
+        class DataAnnotationsEventSubscriptions : IDisposable
         {
-            if (TryGetValidatableProperty(fieldIdentifier, out var propertyInfo))
+            private static ConcurrentDictionary<(Type ModelType, string FieldName), PropertyInfo?> _propertyInfoCache
+                = new ConcurrentDictionary<(Type, string), PropertyInfo?>();
+
+            private readonly EditContext _editContext;
+            private readonly ValidationMessageStore _messages;
+
+            public DataAnnotationsEventSubscriptions(EditContext editContext)
             {
-                var propertyValue = propertyInfo.GetValue(fieldIdentifier.Model);
-                var validationContext = new ValidationContext(fieldIdentifier.Model)
+                if (editContext == null)
                 {
-                    MemberName = propertyInfo.Name
-                };
-                var results = new List<ValidationResult>();
+                    throw new ArgumentNullException(nameof(editContext));
+                }
 
-                Validator.TryValidateProperty(propertyValue, validationContext, results);
-                messages.Clear(fieldIdentifier);
-                messages.Add(fieldIdentifier, results.Select(result => result.ErrorMessage!));
+                _editContext = editContext ?? throw new ArgumentNullException(nameof(editContext));
+                _messages = new ValidationMessageStore(_editContext);
 
-                // We have to notify even if there were no messages before and are still no messages now,
-                // because the "state" that changed might be the completion of some async validation task
-                editContext.NotifyValidationStateChanged();
+                _editContext.OnFieldChanged += OnFieldChanged;
+                _editContext.OnValidationRequested += OnValidationRequested;
             }
-        }
 
-        private static bool TryGetValidatableProperty(in FieldIdentifier fieldIdentifier, [NotNullWhen(true)] out PropertyInfo? propertyInfo)
-        {
-            var cacheKey = (ModelType: fieldIdentifier.Model.GetType(), fieldIdentifier.FieldName);
-            if (!_propertyInfoCache.TryGetValue(cacheKey, out propertyInfo))
+            private void OnFieldChanged(object? sender, FieldChangedEventArgs eventArgs)
             {
-                // DataAnnotations only validates public properties, so that's all we'll look for
-                // If we can't find it, cache 'null' so we don't have to try again next time
-                propertyInfo = cacheKey.ModelType.GetProperty(cacheKey.FieldName);
+                var fieldIdentifier = eventArgs.FieldIdentifier;
+                if (TryGetValidatableProperty(fieldIdentifier, out var propertyInfo))
+                {
+                    var propertyValue = propertyInfo.GetValue(fieldIdentifier.Model);
+                    var validationContext = new ValidationContext(fieldIdentifier.Model)
+                    {
+                        MemberName = propertyInfo.Name
+                    };
+                    var results = new List<ValidationResult>();
 
-                // No need to lock, because it doesn't matter if we write the same value twice
-                _propertyInfoCache[cacheKey] = propertyInfo;
+                    Validator.TryValidateProperty(propertyValue, validationContext, results);
+                    _messages.Clear(fieldIdentifier);
+                    _messages.Add(fieldIdentifier, results.Select(result => result.ErrorMessage!));
+
+                    // We have to notify even if there were no messages before and are still no messages now,
+                    // because the "state" that changed might be the completion of some async validation task
+                    _editContext.NotifyValidationStateChanged();
+                }
             }
 
-            return propertyInfo != null;
+            private void OnValidationRequested(object? sender, ValidationRequestedEventArgs e)
+            {
+                var validationContext = new ValidationContext(_editContext.Model);
+                var validationResults = new List<ValidationResult>();
+                Validator.TryValidateObject(_editContext.Model, validationContext, validationResults, true);
+
+                // Transfer results to the ValidationMessageStore
+                _messages.Clear();
+                foreach (var validationResult in validationResults)
+                {
+                    if (validationResult == null)
+                    {
+                        continue;
+                    }
+
+                    if (!validationResult.MemberNames.Any())
+                    {
+                        _messages.Add(new FieldIdentifier(_editContext.Model, fieldName: string.Empty), validationResult.ErrorMessage!);
+                        continue;
+                    }
+
+                    foreach (var memberName in validationResult.MemberNames)
+                    {
+                        _messages.Add(_editContext.Field(memberName), validationResult.ErrorMessage!);
+                    }
+                }
+
+                _editContext.NotifyValidationStateChanged();
+            }
+
+            public void Dispose()
+            {
+                _editContext.OnFieldChanged -= OnFieldChanged;
+                _editContext.OnValidationRequested -= OnValidationRequested;
+                _messages.Clear();
+            }
+
+            private static bool TryGetValidatableProperty(in FieldIdentifier fieldIdentifier, [NotNullWhen(true)] out PropertyInfo? propertyInfo)
+            {
+                var cacheKey = (ModelType: fieldIdentifier.Model.GetType(), fieldIdentifier.FieldName);
+                if (!_propertyInfoCache.TryGetValue(cacheKey, out propertyInfo))
+                {
+                    // DataAnnotations only validates public properties, so that's all we'll look for
+                    // If we can't find it, cache 'null' so we don't have to try again next time
+                    propertyInfo = cacheKey.ModelType.GetProperty(cacheKey.FieldName);
+
+                    // No need to lock, because it doesn't matter if we write the same value twice
+                    _propertyInfoCache[cacheKey] = propertyInfo;
+                }
+
+                return propertyInfo != null;
+            }
         }
     }
 }

--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -113,9 +113,10 @@ namespace Microsoft.AspNetCore.Components.Forms
 
             public void Dispose()
             {
+                _messages.Clear();
                 _editContext.OnFieldChanged -= OnFieldChanged;
                 _editContext.OnValidationRequested -= OnValidationRequested;
-                _messages.Clear();
+                _editContext.NotifyValidationStateChanged();
             }
 
             private static bool TryGetValidatableProperty(in FieldIdentifier fieldIdentifier, [NotNullWhen(true)] out PropertyInfo? propertyInfo)

--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -39,8 +39,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
         class DataAnnotationsEventSubscriptions : IDisposable
         {
-            private static ConcurrentDictionary<(Type ModelType, string FieldName), PropertyInfo?> _propertyInfoCache
-                = new ConcurrentDictionary<(Type, string), PropertyInfo?>();
+            private static readonly ConcurrentDictionary<(Type ModelType, string FieldName), PropertyInfo?> _propertyInfoCache = new();
 
             private readonly EditContext _editContext;
             private readonly ValidationMessageStore _messages;

--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -46,11 +46,6 @@ namespace Microsoft.AspNetCore.Components.Forms
 
             public DataAnnotationsEventSubscriptions(EditContext editContext)
             {
-                if (editContext == null)
-                {
-                    throw new ArgumentNullException(nameof(editContext));
-                }
-
                 _editContext = editContext ?? throw new ArgumentNullException(nameof(editContext));
                 _messages = new ValidationMessageStore(_editContext);
 

--- a/src/Components/Forms/src/Microsoft.AspNetCore.Components.Forms.WarningSuppressions.xml
+++ b/src/Components/Forms/src/Microsoft.AspNetCore.Components.Forms.WarningSuppressions.xml
@@ -5,19 +5,19 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.ValidateField(Microsoft.AspNetCore.Components.Forms.EditContext,Microsoft.AspNetCore.Components.Forms.ValidationMessageStore,Microsoft.AspNetCore.Components.Forms.FieldIdentifier@)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.DataAnnotationsEventSubscriptions.OnFieldChanged(System.Object,Microsoft.AspNetCore.Components.Forms.FieldChangedEventArgs)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.ValidateModel(Microsoft.AspNetCore.Components.Forms.EditContext,Microsoft.AspNetCore.Components.Forms.ValidationMessageStore)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.DataAnnotationsEventSubscriptions.OnValidationRequested(System.Object,Microsoft.AspNetCore.Components.Forms.ValidationRequestedEventArgs)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2080</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.TryGetValidatableProperty(Microsoft.AspNetCore.Components.Forms.FieldIdentifier@,System.Reflection.PropertyInfo@)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.DataAnnotationsEventSubscriptions.TryGetValidatableProperty(Microsoft.AspNetCore.Components.Forms.FieldIdentifier@,System.Reflection.PropertyInfo@)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/Components/Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+override Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.OnParametersSet() -> void
 static Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.EnableDataAnnotationsValidation(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext) -> System.IDisposable!
 virtual Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.Dispose(bool disposing) -> void

--- a/src/Components/Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.EnableDataAnnotationsValidation(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext) -> System.IDisposable!
+virtual Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.Dispose(bool disposing) -> void

--- a/src/Components/Forms/test/EditContextDataAnnotationsExtensionsTest.cs
+++ b/src/Components/Forms/test/EditContextDataAnnotationsExtensionsTest.cs
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             Assert.False(editContext.Validate());
             Assert.NotEmpty(editContext.GetValidationMessages());
 
-            // Act/Assert 2: when wer're detached
+            // Act/Assert 2: when we're detached
             subscription.Dispose();
             Assert.True(editContext.Validate());
             Assert.Empty(editContext.GetValidationMessages());

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -572,6 +572,24 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Assert.DoesNotContain(log, entry => entry.Level == LogLevel.Severe);
         }
 
+        [Fact]
+        public void EditFormSubscriptionsAreRemovedOnDisposal()
+        {
+            var appElement = MountTypicalValidationComponent();
+            var messagesAccessor = CreateValidationMessagesAccessor(appElement);
+
+            // Remove the old form and add a new one
+            appElement.FindElement(By.Id("recreate-edit-form")).Click();
+            Browser.Equal("Recreated form", () => appElement.FindElement(By.CssSelector(".submission-log-entry:last-of-type")).Text);
+
+            // Verify there's still only one copy of each validation message
+            var nameInput = appElement.FindElement(By.ClassName("name")).FindElement(By.TagName("input"));
+            nameInput.SendKeys("Bert\t");
+            nameInput.Clear();
+            nameInput.SendKeys("\t");
+            Browser.Equal(new[] { "Enter a name" }, messagesAccessor);
+        }
+
         private Func<string[]> CreateValidationMessagesAccessor(IWebElement appElement)
         {
             return () => appElement.FindElements(By.ClassName("validation-message"))

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/NotifyPropertyChangedValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/NotifyPropertyChangedValidationComponent.razor
@@ -41,7 +41,8 @@
 
     protected override void OnInitialized()
     {
-        editContext = new EditContext(person).AddDataAnnotationsValidation();
+        editContext = new EditContext(person);
+        editContext.EnableDataAnnotationsValidation();
 
         // Wire up INotifyPropertyChanged to the EditContext
         person.PropertyChanged += (sender, eventArgs) =>

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
@@ -1,101 +1,101 @@
 ﻿@using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Components.Forms
 
-@if (showForm)
-{
-    <EditForm EditContext="@editContext" OnValidSubmit="@HandleValidSubmit">
+<EditForm EditContext="@editContext" OnValidSubmit="@HandleValidSubmit">
+    @if (enableDataAnnotationsSupport)
+    {
         <DataAnnotationsValidator />
+    }
 
-        <p class="name">
-            Name: <InputText @bind-Value="person.Name" placeholder="Enter your name" />
-        </p>
-        <p class="email">
-            Email: <InputText @bind-Value="person.Email" />
-            <ValidationMessage For="@(() => person.Email)" />
-        </p>
-        <p class="confirm-email">
-            Email: <InputText @bind-Value="person.ConfirmEmail" />
-            <ValidationMessage For="@(() => person.ConfirmEmail)" />
-        </p>
-        <p class="age">
-            Age (years): <InputNumber @bind-Value="person.AgeInYears" placeholder="Enter your age" />
-        </p>
-        <p class="height">
-            Height (optional): <InputNumber @bind-Value="person.OptionalHeight" />
-        </p>
-        <p class="description">
-            Description: <InputTextArea @bind-Value="person.Description" placeholder="Tell us about yourself" />
-        </p>
-        <p class="renewal-date">
-            Renewal date: <InputDate @bind-Value="person.RenewalDate" placeholder="Enter the date" />
-        </p>
-        <p class="expiry-date">
-            Expiry date (optional): <InputDate @bind-Value="person.OptionalExpiryDate" />
-        </p>
-        <p class="ticket-class">
-            Ticket class:
-            <InputSelect @bind-Value="person.TicketClass" size="4">
-                <option>(select)</option>
-                <option value="@TicketClass.Economy">Economy class</option>
-                <option value="@TicketClass.Premium">Premium class</option>
-                <option value="@TicketClass.First">First class</option>
-            </InputSelect>
-            <span id="selected-ticket-class">@person.TicketClass</span>
-        </p>
-        <p class="airline">
-            <InputRadioGroup @bind-Value="person.Airline">
-                Airline:
+    <p class="name">
+        Name: <InputText @bind-Value="person.Name" placeholder="Enter your name" />
+    </p>
+    <p class="email">
+        Email: <InputText @bind-Value="person.Email" />
+        <ValidationMessage For="@(() => person.Email)" />
+    </p>
+    <p class="confirm-email">
+        Email: <InputText @bind-Value="person.ConfirmEmail" />
+        <ValidationMessage For="@(() => person.ConfirmEmail)" />
+    </p>
+    <p class="age">
+        Age (years): <InputNumber @bind-Value="person.AgeInYears" placeholder="Enter your age" />
+    </p>
+    <p class="height">
+        Height (optional): <InputNumber @bind-Value="person.OptionalHeight" />
+    </p>
+    <p class="description">
+        Description: <InputTextArea @bind-Value="person.Description" placeholder="Tell us about yourself" />
+    </p>
+    <p class="renewal-date">
+        Renewal date: <InputDate @bind-Value="person.RenewalDate" placeholder="Enter the date" />
+    </p>
+    <p class="expiry-date">
+        Expiry date (optional): <InputDate @bind-Value="person.OptionalExpiryDate" />
+    </p>
+    <p class="ticket-class">
+        Ticket class:
+        <InputSelect @bind-Value="person.TicketClass" size="4">
+            <option>(select)</option>
+            <option value="@TicketClass.Economy">Economy class</option>
+            <option value="@TicketClass.Premium">Premium class</option>
+            <option value="@TicketClass.First">First class</option>
+        </InputSelect>
+        <span id="selected-ticket-class">@person.TicketClass</span>
+    </p>
+    <p class="airline">
+        <InputRadioGroup @bind-Value="person.Airline">
+            Airline:
+            <br>
+            @foreach (var airline in (Airline[])Enum.GetValues(typeof(Airline)))
+                {
+                <InputRadio Value="airline" extra="additional" />
+                @airline.ToString();
                 <br>
-                @foreach (var airline in (Airline[])Enum.GetValues(typeof(Airline)))
-                    {
-                    <InputRadio Value="airline" extra="additional" />
-                    @airline.ToString();
-                    <br>
-                    }
+                }
+        </InputRadioGroup>
+    </p>
+    <p class="nested-radio-group">
+        Pick one color and one country:
+        <InputRadioGroup Name="country" @bind-Value="person.Country">
+            <InputRadioGroup Name="color" @bind-Value="person.FavoriteColor">
+                <InputRadio Name="color" Value="Color.Red" />red<br>
+                <InputRadio Name="country" Value="Country.Japan" />japan<br>
+                <InputRadio Name="color" Value="Color.Green" />green<br>
+                <InputRadio Name="country" Value="Country.Yemen" />yemen<br>
+                <InputRadio Name="color" Value="Color.Blue" />blue<br>
+                <InputRadio Name="country" Value="Country.Latvia" />latvia<br>
+                <InputRadio Name="color" Value="Color.Orange" />orange<br>
             </InputRadioGroup>
-        </p>
-        <p class="nested-radio-group">
-            Pick one color and one country:
-            <InputRadioGroup Name="country" @bind-Value="person.Country">
-                <InputRadioGroup Name="color" @bind-Value="person.FavoriteColor">
-                    <InputRadio Name="color" Value="Color.Red" />red<br>
-                    <InputRadio Name="country" Value="Country.Japan" />japan<br>
-                    <InputRadio Name="color" Value="Color.Green" />green<br>
-                    <InputRadio Name="country" Value="Country.Yemen" />yemen<br>
-                    <InputRadio Name="color" Value="Color.Blue" />blue<br>
-                    <InputRadio Name="country" Value="Country.Latvia" />latvia<br>
-                    <InputRadio Name="color" Value="Color.Orange" />orange<br>
-                </InputRadioGroup>
-            </InputRadioGroup>
-        </p>
-        <p class="socks">
-            Socks color: <InputText @bind-Value="person.SocksColor" />
-        </p>
-        <p class="accepts-terms">
-            Accepts terms: <InputCheckbox @bind-Value="person.AcceptsTerms" title="You have to check this" />
-        </p>
-        <p class="is-evil">
-            Is evil: <InputCheckbox @bind-Value="person.IsEvil" />
-        </p>
-        <p class="username">
-            Username (optional): <InputText @bind-Value="person.Username" />
-            <button type="button" @onclick="@TriggerAsyncValidationError">Trigger async error</button>
-        </p>
+        </InputRadioGroup>
+    </p>
+    <p class="socks">
+        Socks color: <InputText @bind-Value="person.SocksColor" />
+    </p>
+    <p class="accepts-terms">
+        Accepts terms: <InputCheckbox @bind-Value="person.AcceptsTerms" title="You have to check this" />
+    </p>
+    <p class="is-evil">
+        Is evil: <InputCheckbox @bind-Value="person.IsEvil" />
+    </p>
+    <p class="username">
+        Username (optional): <InputText @bind-Value="person.Username" />
+        <button type="button" @onclick="@TriggerAsyncValidationError">Trigger async error</button>
+    </p>
 
-        <button type="submit">Submit</button>
+    <button type="submit">Submit</button>
 
-        <p class="model-errors">
-            <ValidationSummary Model="person" />
-        </p>
+    <p class="model-errors">
+        <ValidationSummary Model="person" />
+    </p>
 
-        <ValidationSummary />
-    </EditForm>
-}
+    <ValidationSummary />
+</EditForm>
 
 <ul>@foreach (var entry in submissionLog)
 {<li class="submission-log-entry">@entry</li>}</ul>
 
-<button id="recreate-edit-form" @onclick="RecreateEditForm">Recreate EditForm</button>
+<button id="toggle-dataannotations" @onclick="ToggleDataAnnotations">Toggle DataAnnotations support</button>
 
 @code {
     protected virtual bool UseExperimentalValidator => false;
@@ -103,7 +103,7 @@
     Person person = new Person();
     EditContext editContext;
     ValidationMessageStore customValidationMessageStore;
-    bool showForm = true;
+    bool enableDataAnnotationsSupport = true;
 
     protected override void OnInitialized()
     {
@@ -195,14 +195,9 @@
         });
     }
 
-    async Task RecreateEditForm()
+    void ToggleDataAnnotations()
     {
-        // This is to show that, if a form is removed and a new one is added,
-        // the subscriptions related to the old one are cleared.
-        // Represents the bug reported at https://github.com/dotnet/aspnetcore/issues/31027
-        showForm = false;
-        await Task.Delay(1);
-        showForm = true;
-        submissionLog.Add("Recreated form");
+        enableDataAnnotationsSupport = !enableDataAnnotationsSupport;
+        submissionLog.Add($"DataAnnotations support is now {(enableDataAnnotationsSupport ? "enabled" : "disabled")}");
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
@@ -1,95 +1,101 @@
 ﻿@using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Components.Forms
 
-<EditForm EditContext="@editContext" OnValidSubmit="@HandleValidSubmit">
-    <DataAnnotationsValidator />
+@if (showForm)
+{
+    <EditForm EditContext="@editContext" OnValidSubmit="@HandleValidSubmit">
+        <DataAnnotationsValidator />
 
-    <p class="name">
-        Name: <InputText @bind-Value="person.Name" placeholder="Enter your name" />
-    </p>
-    <p class="email">
-        Email: <InputText @bind-Value="person.Email" />
-        <ValidationMessage For="@(() => person.Email)" />
-    </p>
-    <p class="confirm-email">
-        Email: <InputText @bind-Value="person.ConfirmEmail" />
-        <ValidationMessage For="@(() => person.ConfirmEmail)" />
-    </p>
-    <p class="age">
-        Age (years): <InputNumber @bind-Value="person.AgeInYears" placeholder="Enter your age" />
-    </p>
-    <p class="height">
-        Height (optional): <InputNumber @bind-Value="person.OptionalHeight" />
-    </p>
-    <p class="description">
-        Description: <InputTextArea @bind-Value="person.Description" placeholder="Tell us about yourself" />
-    </p>
-    <p class="renewal-date">
-        Renewal date: <InputDate @bind-Value="person.RenewalDate" placeholder="Enter the date" />
-    </p>
-    <p class="expiry-date">
-        Expiry date (optional): <InputDate @bind-Value="person.OptionalExpiryDate" />
-    </p>
-    <p class="ticket-class">
-        Ticket class:
-        <InputSelect @bind-Value="person.TicketClass" size="4">
-            <option>(select)</option>
-            <option value="@TicketClass.Economy">Economy class</option>
-            <option value="@TicketClass.Premium">Premium class</option>
-            <option value="@TicketClass.First">First class</option>
-        </InputSelect>
-        <span id="selected-ticket-class">@person.TicketClass</span>
-    </p>
-    <p class="airline">
-        <InputRadioGroup @bind-Value="person.Airline">
-            Airline:
-            <br>
-            @foreach (var airline in (Airline[])Enum.GetValues(typeof(Airline)))
-            {
-                <InputRadio Value="airline" extra="additional" />
-                @airline.ToString();
+        <p class="name">
+            Name: <InputText @bind-Value="person.Name" placeholder="Enter your name" />
+        </p>
+        <p class="email">
+            Email: <InputText @bind-Value="person.Email" />
+            <ValidationMessage For="@(() => person.Email)" />
+        </p>
+        <p class="confirm-email">
+            Email: <InputText @bind-Value="person.ConfirmEmail" />
+            <ValidationMessage For="@(() => person.ConfirmEmail)" />
+        </p>
+        <p class="age">
+            Age (years): <InputNumber @bind-Value="person.AgeInYears" placeholder="Enter your age" />
+        </p>
+        <p class="height">
+            Height (optional): <InputNumber @bind-Value="person.OptionalHeight" />
+        </p>
+        <p class="description">
+            Description: <InputTextArea @bind-Value="person.Description" placeholder="Tell us about yourself" />
+        </p>
+        <p class="renewal-date">
+            Renewal date: <InputDate @bind-Value="person.RenewalDate" placeholder="Enter the date" />
+        </p>
+        <p class="expiry-date">
+            Expiry date (optional): <InputDate @bind-Value="person.OptionalExpiryDate" />
+        </p>
+        <p class="ticket-class">
+            Ticket class:
+            <InputSelect @bind-Value="person.TicketClass" size="4">
+                <option>(select)</option>
+                <option value="@TicketClass.Economy">Economy class</option>
+                <option value="@TicketClass.Premium">Premium class</option>
+                <option value="@TicketClass.First">First class</option>
+            </InputSelect>
+            <span id="selected-ticket-class">@person.TicketClass</span>
+        </p>
+        <p class="airline">
+            <InputRadioGroup @bind-Value="person.Airline">
+                Airline:
                 <br>
-            }
-        </InputRadioGroup>
-    </p>
-    <p class="nested-radio-group">
-        Pick one color and one country:
-        <InputRadioGroup Name="country" @bind-Value="person.Country">
-            <InputRadioGroup Name="color" @bind-Value="person.FavoriteColor">
-                <InputRadio Name="color" Value="Color.Red" />red<br>
-                <InputRadio Name="country" Value="Country.Japan" />japan<br>
-                <InputRadio Name="color" Value="Color.Green" />green<br>
-                <InputRadio Name="country" Value="Country.Yemen" />yemen<br>
-                <InputRadio Name="color" Value="Color.Blue" />blue<br>
-                <InputRadio Name="country" Value="Country.Latvia" />latvia<br>
-                <InputRadio Name="color" Value="Color.Orange" />orange<br>
+                @foreach (var airline in (Airline[])Enum.GetValues(typeof(Airline)))
+                    {
+                    <InputRadio Value="airline" extra="additional" />
+                    @airline.ToString();
+                    <br>
+                    }
             </InputRadioGroup>
-        </InputRadioGroup>
-    </p>
-    <p class="socks">
-        Socks color: <InputText @bind-Value="person.SocksColor" />
-    </p>
-    <p class="accepts-terms">
-        Accepts terms: <InputCheckbox @bind-Value="person.AcceptsTerms" title="You have to check this" />
-    </p>
-    <p class="is-evil">
-        Is evil: <InputCheckbox @bind-Value="person.IsEvil" />
-    </p>
-    <p class="username">
-        Username (optional): <InputText @bind-Value="person.Username" />
-        <button type="button" @onclick="@TriggerAsyncValidationError">Trigger async error</button>
-    </p>
+        </p>
+        <p class="nested-radio-group">
+            Pick one color and one country:
+            <InputRadioGroup Name="country" @bind-Value="person.Country">
+                <InputRadioGroup Name="color" @bind-Value="person.FavoriteColor">
+                    <InputRadio Name="color" Value="Color.Red" />red<br>
+                    <InputRadio Name="country" Value="Country.Japan" />japan<br>
+                    <InputRadio Name="color" Value="Color.Green" />green<br>
+                    <InputRadio Name="country" Value="Country.Yemen" />yemen<br>
+                    <InputRadio Name="color" Value="Color.Blue" />blue<br>
+                    <InputRadio Name="country" Value="Country.Latvia" />latvia<br>
+                    <InputRadio Name="color" Value="Color.Orange" />orange<br>
+                </InputRadioGroup>
+            </InputRadioGroup>
+        </p>
+        <p class="socks">
+            Socks color: <InputText @bind-Value="person.SocksColor" />
+        </p>
+        <p class="accepts-terms">
+            Accepts terms: <InputCheckbox @bind-Value="person.AcceptsTerms" title="You have to check this" />
+        </p>
+        <p class="is-evil">
+            Is evil: <InputCheckbox @bind-Value="person.IsEvil" />
+        </p>
+        <p class="username">
+            Username (optional): <InputText @bind-Value="person.Username" />
+            <button type="button" @onclick="@TriggerAsyncValidationError">Trigger async error</button>
+        </p>
 
-    <button type="submit">Submit</button>
+        <button type="submit">Submit</button>
 
-    <p class="model-errors">
-        <ValidationSummary Model="person" />
-    </p>
+        <p class="model-errors">
+            <ValidationSummary Model="person" />
+        </p>
 
-    <ValidationSummary />
-</EditForm>
+        <ValidationSummary />
+    </EditForm>
+}
 
-<ul>@foreach (var entry in submissionLog) { <li>@entry</li> }</ul>
+<ul>@foreach (var entry in submissionLog)
+{<li class="submission-log-entry">@entry</li>}</ul>
+
+<button id="recreate-edit-form" @onclick="RecreateEditForm">Recreate EditForm</button>
 
 @code {
     protected virtual bool UseExperimentalValidator => false;
@@ -97,6 +103,7 @@
     Person person = new Person();
     EditContext editContext;
     ValidationMessageStore customValidationMessageStore;
+    bool showForm = true;
 
     protected override void OnInitialized()
     {
@@ -186,5 +193,16 @@
             customValidationMessageStore.Add(editContext.Field(nameof(Person.Username)), "This is invalid, asynchronously");
             _ = InvokeAsync(editContext.NotifyValidationStateChanged);
         });
+    }
+
+    async Task RecreateEditForm()
+    {
+        // This is to show that, if a form is removed and a new one is added,
+        // the subscriptions related to the old one are cleared.
+        // Represents the bug reported at https://github.com/dotnet/aspnetcore/issues/31027
+        showForm = false;
+        await Task.Delay(1);
+        showForm = true;
+        submissionLog.Add("Recreated form");
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
@@ -48,11 +48,11 @@
             Airline:
             <br>
             @foreach (var airline in (Airline[])Enum.GetValues(typeof(Airline)))
-                {
+            {
                 <InputRadio Value="airline" extra="additional" />
                 @airline.ToString();
                 <br>
-                }
+            }
         </InputRadioGroup>
     </p>
     <p class="nested-radio-group">
@@ -92,8 +92,7 @@
     <ValidationSummary />
 </EditForm>
 
-<ul>@foreach (var entry in submissionLog)
-{<li class="submission-log-entry">@entry</li>}</ul>
+<ul>@foreach (var entry in submissionLog) { <li class="submission-log-entry">@entry</li> }</ul>
 
 <button id="toggle-dataannotations" @onclick="ToggleDataAnnotations">Toggle DataAnnotations support</button>
 

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -143,7 +143,8 @@ namespace Microsoft.AspNetCore.E2ETesting
             // Force language to english for tests
             opts.AddUserProfilePreference("intl.accept_languages", "en");
 
-            if (!Debugger.IsAttached && !string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_VISIBLE"), "true", StringComparison.OrdinalIgnoreCase))
+            if (!Debugger.IsAttached &&
+                !string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_VISIBLE"), "true", StringComparison.OrdinalIgnoreCase))
             {
                 opts.AddArgument("--headless");
             }

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -143,8 +143,7 @@ namespace Microsoft.AspNetCore.E2ETesting
             // Force language to english for tests
             opts.AddUserProfilePreference("intl.accept_languages", "en");
 
-            // Comment this out if you want to watch or interact with the browser (e.g., for debugging)
-            if (!Debugger.IsAttached)
+            if (!Debugger.IsAttached && !string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_VISIBLE"), "true", StringComparison.OrdinalIgnoreCase))
             {
                 opts.AddArgument("--headless");
             }


### PR DESCRIPTION
Previously, once you added a `<DataAnnotationsValidator />` to an edit context, there was no way to remove it. If you did remove and re-add it in your markup (e.g., via an `@if` block), you'd end up with double validation and duplicate messages. This was reported in #31027.

The fix here involves an API change, since the registration method now needs to return an `IDisposable` so the subscriptions can later be removed (there's no other contextual information you could use in order to say which specific set of subscriptions you want to unsubscribe). I've marked the old API as obsolete since there's no good reason you'd want to still use it, even if you're not interested in later disposing.

### Code review notes

It looks like I've changed loads of stuff inside `EditContextDataAnnotationsExtensions` but actually I haven't. The only change there is migrating the logic inside a new `IDisposable` class so that we can later remove its event handlers and clear out its validation message store. There should be no other functional difference.