### PR TITLE
Do not serialize Parameters property on AuthenticationProperties

### DIFF
--- a/src/Http/Authentication.Abstractions/src/AuthenticationProperties.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationProperties.cs
@@ -71,6 +71,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Gets or sets whether the authentication session is persisted across multiple requests.
         /// </summary>
+        [JsonIgnore]
         public bool IsPersistent
         {
             get => GetString(IsPersistentKey) != null;
@@ -80,6 +81,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Gets or sets the full path or absolute URI to be used as an http redirect response value.
         /// </summary>
+        [JsonIgnore]
         public string? RedirectUri
         {
             get => GetString(RedirectUriKey);
@@ -89,6 +91,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Gets or sets the time at which the authentication ticket was issued.
         /// </summary>
+        [JsonIgnore]
         public DateTimeOffset? IssuedUtc
         {
             get => GetDateTimeOffset(IssuedUtcKey);
@@ -98,6 +101,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Gets or sets the time at which the authentication ticket expires.
         /// </summary>
+        [JsonIgnore]
         public DateTimeOffset? ExpiresUtc
         {
             get => GetDateTimeOffset(ExpiresUtcKey);
@@ -107,6 +111,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// Gets or sets if refreshing the authentication session should be allowed.
         /// </summary>
+        [JsonIgnore]
         public bool? AllowRefresh
         {
             get => GetBool(RefreshKey);

--- a/src/Http/Authentication.Abstractions/src/AuthenticationProperties.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticationProperties.cs
@@ -65,6 +65,7 @@ namespace Microsoft.AspNetCore.Authentication
         /// Collection of parameters that are passed to the authentication handler. These are not intended for
         /// serialization or persistence, only for flowing data between call sites.
         /// </summary>
+        [JsonIgnore]
         public IDictionary<string, object?> Parameters { get; }
 
         /// <summary>

--- a/src/Http/Authentication.Core/test/AuthenticationPropertiesTests.cs
+++ b/src/Http/Authentication.Core/test/AuthenticationPropertiesTests.cs
@@ -386,7 +386,7 @@ namespace Microsoft.AspNetCore.Authentication.Core.Test
     "".redirect"": ""/foo/bar"",
     ""foo"": ""bar""
   }
-}", json);
+}", json, ignoreLineEndingDifferences: true);
         }
 
         public class MyAuthenticationProperties : AuthenticationProperties

--- a/src/Http/Authentication.Core/test/AuthenticationPropertiesTests.cs
+++ b/src/Http/Authentication.Core/test/AuthenticationPropertiesTests.cs
@@ -320,6 +320,12 @@ namespace Microsoft.AspNetCore.Authentication.Core.Test
             props.Parameters.Add("baz", "quux");
 
             var json = JsonSerializer.Serialize(props);
+
+            // Verify that Parameters was not serialized
+            Assert.NotNull(json);
+            Assert.DoesNotContain("baz", json);
+            Assert.DoesNotContain("quux", json);
+
             var deserialized = JsonSerializer.Deserialize<AuthenticationProperties>(json);
 
             Assert.NotNull(deserialized);
@@ -336,6 +342,20 @@ namespace Microsoft.AspNetCore.Authentication.Core.Test
 
             // Ensure that parameters are not round-tripped
             Assert.NotNull(deserialized.Parameters);
+            Assert.Equal(0, deserialized.Parameters.Count);
+        }
+
+        [Fact]
+        public void Parameters_Is_Not_Deserialized_With_SystemTextJson()
+        {
+            var json = @"{""Parameters"":{""baz"":""quux""}}";
+
+            var deserialized = JsonSerializer.Deserialize<AuthenticationProperties>(json);
+
+            Assert.NotNull(deserialized);
+
+            // Ensure that parameters is not deserialized from a raw payload
+            Assert.NotNull(deserialized!.Parameters);
             Assert.Equal(0, deserialized.Parameters.Count);
         }
 

--- a/src/Http/Authentication.Core/test/AuthenticationPropertiesTests.cs
+++ b/src/Http/Authentication.Core/test/AuthenticationPropertiesTests.cs
@@ -359,6 +359,36 @@ namespace Microsoft.AspNetCore.Authentication.Core.Test
             Assert.Equal(0, deserialized.Parameters.Count);
         }
 
+        [Fact]
+        public void Serialization_Is_Minimised_With_SystemTextJson()
+        {
+            var props = new AuthenticationProperties()
+            {
+                AllowRefresh = true,
+                ExpiresUtc = new DateTimeOffset(2021, 03, 28, 13, 47, 00, TimeSpan.Zero),
+                IssuedUtc = new DateTimeOffset(2021, 03, 28, 12, 47, 00, TimeSpan.Zero),
+                IsPersistent = true,
+                RedirectUri = "/foo/bar"
+            };
+
+            props.Items.Add("foo", "bar");
+
+            var options = new JsonSerializerOptions() { WriteIndented = true }; // Indented for readability if test fails
+            var json = JsonSerializer.Serialize(props, options);
+
+            // Verify that the payload doesn't duplicate the properties backed by Items
+            Assert.Equal(@"{
+  ""Items"": {
+    "".refresh"": ""True"",
+    "".expires"": ""Sun, 28 Mar 2021 13:47:00 GMT"",
+    "".issued"": ""Sun, 28 Mar 2021 12:47:00 GMT"",
+    "".persistent"": """",
+    "".redirect"": ""/foo/bar"",
+    ""foo"": ""bar""
+  }
+}", json);
+        }
+
         public class MyAuthenticationProperties : AuthenticationProperties
         {
             public new DateTimeOffset? GetDateTimeOffset(string key)


### PR DESCRIPTION
**PR Title**

Prevent redundant `AuthenticationProperties` being serialized.

**PR Description**

Explicitly prevent the `AuthenticationProperties.Parameters` dictionary as well as other properties backed by the `Items` property from being included in the serialized payload when using System.Text.Json.

Addresses https://github.com/dotnet/aspnetcore/pull/31330#discussion_r605078290.

/cc @Tratcher
