### PR TITLE
Trim down framework references for Blazor dev server

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -261,6 +261,7 @@
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
     <MicrosoftDataSqlClientVersion>1.0.19249.1</MicrosoftDataSqlClientVersion>
+    <MicrosoftAspNetCoreAppVersion>6.0.0-preview.3.21167.1</MicrosoftAspNetCoreAppVersion>
   </PropertyGroup>
   <!-- Restore feeds -->
   <PropertyGroup Label="Restore feeds">

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -11,6 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Set this to false because assemblies should not reference this assembly directly, (except for tests, of course). -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -25,10 +25,10 @@
   <Target Name="_CreateRuntimeConfig" BeforeTargets="CoreBuild">
     <PropertyGroup>
       <_RuntimeConfigProperties>
-        MicrosoftAspNetCoreAppVersion=$(MicrosoftAspNetCoreAppVersion);
+        SharedFxVersion=$(SharedFxVersion);
       </_RuntimeConfigProperties>
 
-      <_RuntimeConfigPath>$(PublishDir)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>
+      <_RuntimeConfigPath>$(IntermediateOutputPath)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>
     </PropertyGroup>
 
     <GenerateFileFromTemplate
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <NuspecProperty Include="publishDir=$(PublishDir)" />
+    <NuspecProperty Include="objDir=$(IntermediateOutputPath)" />
     <NuspecProperty Include="PackageThirdPartyNoticesFile=$(PackageThirdPartyNoticesFile)" />
   </ItemGroup>
 

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -11,6 +11,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Set this to false because assemblies should not reference this assembly directly, (except for tests, of course). -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
+    <!-- Disable the default runtimeconfig.json in favor of the one that we create which contains the correct
+    framework references. Workaround for issues launching Blazor WASM apps with IIS Express. -->
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
@@ -19,6 +21,21 @@
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <Compile Include="$(SharedSourceRoot)CommandLineUtils\**\*.cs" />
   </ItemGroup>
+
+  <Target Name="_CreateRuntimeConfig" BeforeTargets="CoreBuild">
+    <PropertyGroup>
+      <_RuntimeConfigProperties>
+        MicrosoftAspNetCoreAppVersion=$(MicrosoftAspNetCoreAppVersion);
+      </_RuntimeConfigProperties>
+
+      <_RuntimeConfigPath>$(PublishDir)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>
+    </PropertyGroup>
+
+    <GenerateFileFromTemplate
+      TemplateFile="blazor-devserver.runtimeconfig.json.in"
+      Properties="$(_RuntimeConfigProperties)"
+      OutputPath="$(_RuntimeConfigPath)" />
+  </Target>
 
   <!-- Pack settings -->
   <PropertyGroup>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.nuspec
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.nuspec
@@ -8,6 +8,6 @@
     <file src="build\**" target="build" />
     <file src="$publishDir$**\*" target="tools" />
     <file src="$PackageThirdPartyNoticesFile$" target=".\THIRD-PARTY-NOTICES.txt" />
-    <file src="$publishDir$blazor-devserver.runtimeconfig.json" target="tools\blazor-devserver.runtimeconfig.json" />
+    <file src="$objDir$blazor-devserver.runtimeconfig.json" target="tools\blazor-devserver.runtimeconfig.json" />
   </files>
 </package>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.nuspec
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.nuspec
@@ -8,5 +8,6 @@
     <file src="build\**" target="build" />
     <file src="$publishDir$**\*" target="tools" />
     <file src="$PackageThirdPartyNoticesFile$" target=".\THIRD-PARTY-NOTICES.txt" />
+    <file src="blazor-devserver.runtimeconfig.json" target="tools\blazor-devserver.runtimeconfig.json" />
   </files>
 </package>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.nuspec
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.nuspec
@@ -8,6 +8,6 @@
     <file src="build\**" target="build" />
     <file src="$publishDir$**\*" target="tools" />
     <file src="$PackageThirdPartyNoticesFile$" target=".\THIRD-PARTY-NOTICES.txt" />
-    <file src="blazor-devserver.runtimeconfig.json" target="tools\blazor-devserver.runtimeconfig.json" />
+    <file src="$publishDir$blazor-devserver.runtimeconfig.json" target="tools\blazor-devserver.runtimeconfig.json" />
   </files>
 </package>

--- a/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json
+++ b/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json
@@ -1,0 +1,10 @@
+{
+  "runtimeOptions": {
+    "tfm": "net6.0",
+    "framework": {
+      "name": "Microsoft.AspNetCore.App",
+      "version": "6.0.0-preview.3.21167.1"
+    },
+    "rollForwardOnNoCandidateFx": 2
+  }
+}

--- a/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
+++ b/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
@@ -3,7 +3,7 @@
     "tfm": "net6.0",
     "framework": {
       "name": "Microsoft.AspNetCore.App",
-      "version": "6.0.0-preview.3.21167.1"
+      "version": "${MicrosoftAspNetCoreAppVersion}"
     },
     "rollForwardOnNoCandidateFx": 2
   }

--- a/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
+++ b/src/Components/WebAssembly/DevServer/src/blazor-devserver.runtimeconfig.json.in
@@ -3,7 +3,7 @@
     "tfm": "net6.0",
     "framework": {
       "name": "Microsoft.AspNetCore.App",
-      "version": "${MicrosoftAspNetCoreAppVersion}"
+      "version": "${SharedFxVersion}"
     },
     "rollForwardOnNoCandidateFx": 2
   }

--- a/src/Components/WebAssembly/DevServer/src/runtimeconfig.template.json
+++ b/src/Components/WebAssembly/DevServer/src/runtimeconfig.template.json
@@ -1,7 +1,0 @@
-{
-  "framework": {
-    "name": "Microsoft.AspNetCore.App",
-    "version": "6.0.0-preview.3.21167.1"
-  },
-  "rollForwardOnNoCandidateFx": 2
-}


### PR DESCRIPTION
While investigating https://github.com/dotnet/aspnetcore/issues/30917, we realized that things seems to work when the `runtimeconfig.json` for the Blazor dev server doesn't contain a framework reference to `Microsoft.NETCore.App`. 

Generated runtimeconfig now looks like this:

<img width="786" alt="Screen Shot 2021-03-31 at 2 15 18 PM" src="https://user-images.githubusercontent.com/1857993/113212398-8ce50380-922b-11eb-8587-8a771b34dc2f.png">

This is a stopgap solution.