### PR TITLE
Fix project path in slnf

### DIFF
--- a/src/Components/Components.slnf
+++ b/src/Components/Components.slnf
@@ -34,7 +34,7 @@
       "src\\Components\\WebAssembly\\testassets\\Wasm.Authentication.Client\\Wasm.Authentication.Client.csproj",
       "src\\Components\\WebAssembly\\testassets\\Wasm.Authentication.Shared\\Wasm.Authentication.Shared.csproj",
       "src\\Components\\WebAssembly\\testassets\\Wasm.Authentication.Server\\Wasm.Authentication.Server.csproj",
-      "src\\Components\\WebAssembly\\testassets\\WasmLinkerTest.csproj",
+      "src\\Components\\WebAssembly\\testassets\\WasmLinkerTest\\WasmLinkerTest.csproj",
       "src\\Components\\Web\\src\\Microsoft.AspNetCore.Components.Web.csproj",
       "src\\Components\\Web\\test\\Microsoft.AspNetCore.Components.Web.Tests.csproj",
       "src\\Components\\benchmarkapps\\Wasm.Performance\\Driver\\Wasm.Performance.Driver.csproj",


### PR DESCRIPTION
Figured this out when restoring the slnf.

```
D:\dotnet\aspnetcore>dotnet restore src/Components/Components.slnf
D:\dotnet\aspnetcore\src\Components\WebAssembly\testassets\WasmLinkerTest.csproj : Solution file error MSB5028: Solution filter file at "D:\dotnet\aspnetcore\src\Components\Components.slnf" includes project "src\Components\WebAssembly\testassets\WasmLinkerTest.csproj" that is not in the solution file at "D:\dotnet\aspnetcore\AspNetCore.sln".
```