### PR TITLE
Fix trailing comma in Caching.slnf

### DIFF
--- a/src/Caching/Caching.slnf
+++ b/src/Caching/Caching.slnf
@@ -5,7 +5,7 @@
       "src\\Caching\\SqlServer\\src\\Microsoft.Extensions.Caching.SqlServer.csproj",
       "src\\Caching\\SqlServer\\test\\Microsoft.Extensions.Caching.SqlServer.Tests.csproj",
       "src\\Caching\\StackExchangeRedis\\src\\Microsoft.Extensions.Caching.StackExchangeRedis.csproj",
-      "src\\Caching\\StackExchangeRedis\\test\\Microsoft.Extensions.Caching.StackExchangeRedis.Tests.csproj",
+      "src\\Caching\\StackExchangeRedis\\test\\Microsoft.Extensions.Caching.StackExchangeRedis.Tests.csproj"
     ]
   }
 }


### PR DESCRIPTION
The comma causes dotnet restore to show the following error:

```
D:\dotnet\aspnetcore>dotnet restore src/Caching/Caching.slnf
D:\dotnet\aspnetcore\src\Caching\Caching.slnf : Solution file error MSB5025: Json in solution filter file "D:\dotnet\aspnetcore\src\Caching\Caching.slnf" is incorrectly formatted.
```

It would be good if MSBuild allowed the trailing comma, but that's a separate issue/feature request.
