### PR TITLE
Fixed de-duping hosting startup assemblies

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -129,14 +129,22 @@ namespace Microsoft.AspNetCore.Hosting
             }
 
             var exceptions = new List<Exception>();
+            var processed = new HashSet<Assembly>();
+
             _hostingStartupWebHostBuilder = new HostingStartupWebHostBuilder(this);
 
             // Execute the hosting startup assemblies
-            foreach (var assemblyName in webHostOptions.GetFinalHostingStartupAssemblies().Distinct(StringComparer.OrdinalIgnoreCase))
+            foreach (var assemblyName in webHostOptions.GetFinalHostingStartupAssemblies())
             {
                 try
                 {
                     var assembly = Assembly.Load(new AssemblyName(assemblyName));
+
+                    if (!processed.Add(assembly))
+                    {
+                        // Already processed, skip it
+                        continue;
+                    }
 
                     foreach (var attribute in assembly.GetCustomAttributes<HostingStartupAttribute>())
                     {

--- a/src/Hosting/Hosting/src/WebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilder.cs
@@ -229,13 +229,20 @@ namespace Microsoft.AspNetCore.Hosting
             if (!_options.PreventHostingStartup)
             {
                 var exceptions = new List<Exception>();
+                var processed = new HashSet<Assembly>();
 
                 // Execute the hosting startup assemblies
-                foreach (var assemblyName in _options.GetFinalHostingStartupAssemblies().Distinct(StringComparer.OrdinalIgnoreCase))
+                foreach (var assemblyName in _options.GetFinalHostingStartupAssemblies())
                 {
                     try
                     {
                         var assembly = Assembly.Load(new AssemblyName(assemblyName));
+
+                        if (!processed.Add(assembly))
+                        {
+                            // Already processed, skip it
+                            continue;
+                        }
 
                         foreach (var attribute in assembly.GetCustomAttributes<HostingStartupAttribute>())
                         {

--- a/src/Hosting/Hosting/test/WebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/WebHostBuilderTests.cs
@@ -903,6 +903,27 @@ namespace Microsoft.AspNetCore.Hosting
             using (var host = builder.Build())
             {
                 Assert.Equal("1", builder.GetSetting("testhostingstartup1"));
+                Assert.Equal("1", builder.GetSetting("testhostingstartup1_calls"));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultWebHostBuildersWithConfig))]
+        public void Build_RunsDeduplicatedHostingStartupAssembliesIfSpecified(IWebHostBuilder builder)
+        {
+            var fullName = typeof(TestStartupAssembly1.TestHostingStartup1).Assembly.FullName;
+            var name = typeof(TestStartupAssembly1.TestHostingStartup1).Assembly.GetName().Name;
+
+            builder = builder
+                .CaptureStartupErrors(false)
+                .UseSetting(WebHostDefaults.HostingStartupAssembliesKey, fullName + ";" + name)
+                .Configure(app => { })
+                .UseServer(new TestServer());
+
+            using (var host = builder.Build())
+            {
+                Assert.Equal("1", builder.GetSetting("testhostingstartup1"));
+                Assert.Equal("1", builder.GetSetting("testhostingstartup1_calls"));
             }
         }
 

--- a/src/Hosting/test/testassets/TestStartupAssembly1/TestHostingStartup1.cs
+++ b/src/Hosting/test/testassets/TestStartupAssembly1/TestHostingStartup1.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Globalization;
 using Microsoft.AspNetCore.Hosting;
 
 [assembly: HostingStartup(typeof(TestStartupAssembly1.TestHostingStartup1))]
@@ -11,8 +12,17 @@ namespace TestStartupAssembly1
     {
         public void Configure(IWebHostBuilder builder)
         {
+            var calls = builder.GetSetting("testhostingstartup1_calls");
+            var numCalls = 1;
+
+            if (calls != null)
+            {
+                numCalls = int.Parse(calls, CultureInfo.InvariantCulture) + 1;
+            }
+
             builder.UseSetting("testhostingstartup1", "1");
             builder.UseSetting("testhostingstartup_chain", builder.GetSetting("testhostingstartup_chain") + "1");
+            builder.UseSetting("testhostingstartup1_calls", numCalls.ToString(CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
- De-dupe hosting startup assemblies based on assembly instance not the name of the assembly. Names can be short or long and we don't know if they resolve to the same assembly. Instead of trying to mess with names, we just check to make sure that the instance isn't the same.

Fixes https://github.com/dotnet/aspnetcore/issues/31382