### PR TITLE
[NO MERGE] use a hacky way to run all the tests using new FileStream implementation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -220,6 +220,7 @@
 
     <ArchiveExtension>.tar.gz</ArchiveExtension>
     <ArchiveExtension Condition="'$(TargetOsName)' == 'win'">.zip</ArchiveExtension>
+    <UserRuntimeConfig Condition="'$(IsTestProject)' == 'true'">$(RepoRoot)eng\runtimeconfig.template.json</UserRuntimeConfig>
   </PropertyGroup>
 
   <Import Project="eng\Workarounds.props" />

--- a/eng/runtimeconfig.template.json
+++ b/eng/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+    "configProperties": {
+        "System.IO.UseNet5CompatFileStream": false
+    }
+}

--- a/src/FileProviders/Embedded/test/Net5CompatSwitchTests.cs
+++ b/src/FileProviders/Embedded/test/Net5CompatSwitchTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET6_0
+using System.Reflection;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class Net5CompatSwitchTests
+    {
+        [Fact]
+        public static void LegacySwitchIsHonored()
+        {
+            string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+
+            using (FileStream fileStream = File.Create(filePath))
+            {
+                object strategy = fileStream
+                    .GetType()
+                    .GetField("_strategy", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .GetValue(fileStream);
+
+                if (OperatingSystem.IsWindows())
+                {
+                    Assert.DoesNotContain("Net5Compat", strategy.GetType().FullName);
+                    Assert.DoesNotContain("Legacy", strategy.GetType().FullName);
+                }
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Please ignore this PR, I just want to check if the most recent changes have not broken anything in ASP.NET **before** we enable them by default.