### PR TITLE
Use integer division trick to get exact base64 length

### DIFF
--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -541,29 +541,12 @@ namespace Microsoft.Net.Http.Headers
             return false;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetBase64Length(int inputLength)
-        {
-            // Based on https://github.com/dotnet/runtime/blob/ac21254184f5a6cec884d8d4049c80d905170b38/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs#L150
-
-            const int MaximumEncodeLength = (int.MaxValue / 4) * 3; // 1610612733
-
-            if ((uint)inputLength <= MaximumEncodeLength)
-            {
-                return ((inputLength + 2) / 3) * 4;
-            }
-
-            Throw();
-            static void Throw() => throw new OutOfMemoryException();
-            throw null!;
-        }
-
         // Encode using MIME encoding
         // And adds surrounding quotes, Encoded data must always be quoted, the equals signs are invalid in tokens
         private string EncodeMimeWithQuotes(StringSegment input)
         {
             var requiredLength = MimePrefix.Length +
-                GetBase64Length(Encoding.UTF8.GetByteCount(input.AsSpan())) +
+                Base64.GetMaxEncodedToUtf8Length(Encoding.UTF8.GetByteCount(input.AsSpan())) +
                 MimeSuffix.Length;
             Span<byte> buffer = requiredLength <= 256
                 ? (stackalloc byte[256]).Slice(0, requiredLength)

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -544,16 +544,18 @@ namespace Microsoft.Net.Http.Headers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int GetBase64Length(int inputLength)
         {
-            // Copied from https://github.com/dotnet/runtime/blob/82ca681cbac89d813a3ce397e0c665e6c051ed67/src/libraries/System.Private.CoreLib/src/System/Convert.cs#L2530
-            long outlen = ((long)inputLength) / 3 * 4;          // the base length - we want integer division here.
-            outlen += ((inputLength % 3) != 0) ? 4 : 0;         // at most 4 more chars for the remainder
+            // Based on https://github.com/dotnet/runtime/blob/ac21254184f5a6cec884d8d4049c80d905170b38/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs#L150
 
-            if (outlen > int.MaxValue)
+            const int MaximumEncodeLength = (int.MaxValue / 4) * 3; // 1610612733
+
+            if ((uint)inputLength <= MaximumEncodeLength)
             {
-                throw new OutOfMemoryException();
+                return ((inputLength + 2) / 3) * 4;
             }
 
-            return (int)outlen;
+            Throw();
+            static void Throw() => throw new OutOfMemoryException();
+            throw null!;
         }
 
         // Encode using MIME encoding


### PR DESCRIPTION
...and avoid (explicit) modulo operation.

Has better [codegen](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgCUBXAOwwEt8YLAMIR8AB14AbGFADKMgG68wMXAG4aNYgGYmpBkIYBvGgzMMA2gFkYGABYQAJgElxkgBQ37T12MkB5MT4ILlwWAEEAc0jYXFxeBRhnLkleLjTIgEoAXVNzMSgE7AwYJnIkBjSMBgBxWwAhPBhUABkYLkj7dyrKrjEODDaO+0y8sxNqcymGAHoZgwgJGEcGADMoUQY7DAwxXBA5yN57DmAWSHwZxwgMLlsZqG4+ARngSQhgGYAOUjBsJC+5DAwGwYC+AE5HIDtNhtCptOCAOwwOhgJBIACszTAdAx5GWSERM1wUDAM1SwCg2EKqhmzBYAAVCgpioIRLAWrxPiSycwZiIuIkoBhzrgAMQtUgY7R0MbTd4dBgQAbSLgMAC8DHc7gVWTS/UG7U6dkyswYugAVAwUGpptM5gx7KUQbhSqrjQw4AwAO6lb3YHi9EqRGQMRwJXjxEJbGSCOVTZUYVUMADUmu1+oGQw9AFJzaaAISauimgD81oYIAYdFtdrMDuKDHwEFw1RQTegpTAdmpuDW0EddlKsHw2DSjhkmkmdd4qy1ieTAD4gywrNgEAA1bCSDgwUbTu0TOvTewbb0MO7n/wDfyrGzNqAATwAoggVEFeCF3JkNAfpgBfKdj2IREtSqTIF3aX8pkAv85WsWwHBcNxPEQnw3ECYJQgiaJYniRJklSdIOhyOUCiKEoygqHo6gwRpXVaI17HIbpA0zQ1hhNOUjzrB16OWJU1W2XZ9kOY47FOc5RCuG47gwB4nn4GBXneT5QQoKUUHIL4UFWDF/hUMEdKhRwUDoFBwTBOhHHBXFyEROhgG0L5iVJckuSpGlcDpVh72gR9XN5cgZnqDhVlWGRvIAFRgBB5P41Bny4SAJygUUJXIDFZWoeNzEgUJqh6NcEH4Dh8CSlKYGzewNTAnhV3XLcd1KeYUFNK1tFtB1ynIOgkHIUhEW0bQgJnOdtQ4cD2OquwGAAHk1YrSvK5KnCqpiuL/KYeOPMwQK1ViDRm1MGFIU15m0drrWgutYNysworsM9vxuu1mAqYh20e57TXVZdTwgc9LwYa8MFvPyn1fd8sJe+7BzPC8OEkSRXoYWD/yAA). The "throw helper" is used to split the exception logic out, helpful as this method should be inlined.

From https://github.com/dotnet/aspnetcore/pull/31267#discussion_r602692873 (I just can't look at the current code 😉).
In runtimes this is fixed by https://github.com/dotnet/runtime/pull/50549

/cc: @BrennanConroy