### PR TITLE
Use Random.Shared property

### DIFF
--- a/src/Components/Samples/BlazorServerApp/Data/WeatherForecastService.cs
+++ b/src/Components/Samples/BlazorServerApp/Data/WeatherForecastService.cs
@@ -13,12 +13,11 @@ namespace BlazorServerApp.Data
 
         public Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
         {
-            var rng = new Random();
             return Task.FromResult(Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = startDate.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             }).ToArray());
         }
     }

--- a/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Server/Data/WeatherForecastService.cs
+++ b/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Server/Data/WeatherForecastService.cs
@@ -15,12 +15,11 @@ namespace HostedBlazorWebassemblyApp.Server.Data
 
         public Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
         {
-            var rng = new Random();
             return Task.FromResult(Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = startDate.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             }).ToArray());
         }
     }

--- a/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Controllers/WeatherForecastController.cs
+++ b/src/Components/WebAssembly/testassets/Wasm.Authentication.Server/Controllers/WeatherForecastController.cs
@@ -28,12 +28,11 @@ namespace Wasm.Authentication.Server.Controllers
         [HttpGet]
         public IEnumerable<WeatherForecast> Get()
         {
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }

--- a/src/Components/benchmarkapps/BlazingPizza.Server/Pages/Map.razor
+++ b/src/Components/benchmarkapps/BlazingPizza.Server/Pages/Map.razor
@@ -10,7 +10,6 @@
 @functions {
     private int locX;
     private int locY;
-    private Random random = new Random();
     private Timer timer;
     private string locString;
 
@@ -18,8 +17,8 @@
     {
         timer = new Timer(_ =>
         {
-            locX = random.Next(1000);
-            locY = random.Next(1000);
+            locX = Random.Shared.Next(1000);
+            locY = Random.Shared.Next(1000);
             locString = $"{locX},{locY}";
 
             InvokeAsync(() => StateHasChanged());

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/Pages/TimerComponent.razor
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/Pages/TimerComponent.razor
@@ -7,7 +7,6 @@
 
 @code
 {
-    Random random = new Random();
     Timer timer;
     int red = 128;
     int green = 128;
@@ -22,9 +21,9 @@
     {
         InvokeAsync(() =>
         {
-            red = random.Next(0, 256);
-            green = random.Next(0, 256);
-            blue = random.Next(0, 256);
+            red = Random.Shared.Next(0, 256);
+            green = Random.Shared.Next(0, 256);
+            blue = Random.Shared.Next(0, 256);
             StateHasChanged();
             BenchmarkEvent.Send(JSRuntime, "Finished updating color");
         });

--- a/src/Components/test/testassets/BasicTestApp/ReorderingFocusComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ReorderingFocusComponent.razor
@@ -31,7 +31,6 @@
 </ul>
 
 @code {
-    Random rng = new Random();
     TodoItem[] todoItems = new[]
     {
         new TodoItem { Id = 1, Text = "First" },
@@ -43,7 +42,7 @@
 
     void Shuffle()
     {
-        todoItems = todoItems.OrderBy(x => rng.Next()).ToArray();
+        todoItems = todoItems.OrderBy(x => Random.Shared.Next()).ToArray();
     }
 
     class TodoItem

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -259,7 +259,12 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             // hit a single repository simultaneously. For instance, if the refresh period is 1 hour,
             // we'll return a value in the vicinity of 48 - 60 minutes. We use the Random class since
             // we don't need a secure PRNG for this.
-            return TimeSpan.FromTicks((long)(refreshPeriod.Ticks * (1.0d - (new Random().NextDouble() / 5))));
+#if NET6_0_OR_GREATER
+            var random = Random.Shared;
+#else
+            var random = new Random();
+#endif
+            return TimeSpan.FromTicks((long)(refreshPeriod.Ticks * (1.0d - (random.NextDouble() / 5))));
         }
 
         private static DateTimeOffset Min(DateTimeOffset a, DateTimeOffset b)

--- a/src/Http/Routing/test/UnitTests/RouteCollectionTest.cs
+++ b/src/Http/Routing/test/UnitTests/RouteCollectionTest.cs
@@ -512,8 +512,7 @@ namespace Microsoft.AspNetCore.Routing
 
         private static RouteCollection GetNestedRouteCollection(string[] routeNames)
         {
-            var random = new Random();
-            int index = random.Next(0, routeNames.Length - 1);
+            int index = Random.Shared.Next(0, routeNames.Length - 1);
             var first = routeNames.Take(index).ToArray();
             var second = routeNames.Skip(index).ToArray();
 

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -305,9 +305,8 @@ namespace Microsoft.AspNetCore.Identity.Test
             var manager = CreateManager();
             manager.Options.User.RequireUniqueEmail = true;
             manager.UserValidators.Add(new UserValidator<TUser>());
-            var random = new Random();
-            var email = "foo" + random.Next() + "@example.com";
-            var newEmail = "bar" + random.Next() + "@example.com";
+            var email = "foo" + Random.Shared.Next() + "@example.com";
+            var newEmail = "bar" + Random.Shared.Next() + "@example.com";
             var user = CreateTestUser(email: email);
             IdentityResultAssert.IsSuccess(await manager.CreateAsync(user));
             IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, newEmail));

--- a/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Startup.cs
+++ b/src/Middleware/HeaderPropagation/samples/HeaderPropagationSample/Startup.cs
@@ -111,11 +111,10 @@ namespace HeaderPropagationSample
 
             var threshold = 0.80; // 20% chance for each feature in beta.
 
-            var random = new Random();
             var values = new List<string>();
             for (var i = 0; i < features.Length; i++)
             {
-                if (random.NextDouble() > threshold)
+                if (Random.Shared.NextDouble() > threshold)
                 {
                     values.Add(features[i]);
                 }

--- a/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/HelperPerformanceBenchmark.cs
+++ b/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/HelperPerformanceBenchmark.cs
@@ -34,7 +34,6 @@ namespace Microsoft.AspNetCore.Mvc.Microbenchmarks
 {
     public class HelperPerformanceBenchmark : RuntimePerformanceBenchmarkBase
     {
-        private Random _rand = new Random();
         public HelperPerformanceBenchmark() : base(
             "~/Views/HelperTyped.cshtml",
             "~/Views/HelperDynamic.cshtml",
@@ -45,6 +44,6 @@ namespace Microsoft.AspNetCore.Mvc.Microbenchmarks
         {
         }
 
-        protected override object Model => _rand.Next().ToString(CultureInfo.InvariantCulture);
+        protected override object Model => Random.Shared.Next().ToString(CultureInfo.InvariantCulture);
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Data/WeatherForecastService.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Data/WeatherForecastService.cs
@@ -13,12 +13,11 @@ namespace BlazorServerWeb_CSharp.Data
 
         public Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
         {
-            var rng = new Random();
             return Task.FromResult(Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = startDate.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             }).ToArray());
         }
     }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
@@ -69,12 +69,11 @@ namespace ComponentsWebAssembly_CSharp.Server.Controllers
                 throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}: {error}");
             }
 
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }
@@ -95,12 +94,11 @@ namespace ComponentsWebAssembly_CSharp.Server.Controllers
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
             var user = await _graphServiceClient.Me.Request().GetAsync();
 
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }
@@ -117,12 +115,11 @@ namespace ComponentsWebAssembly_CSharp.Server.Controllers
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
 #endif
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Controllers/WeatherForecastController.cs
@@ -68,11 +68,12 @@ namespace Company.WebApplication1.Controllers
                 throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}: {error}");
             }
 
+            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
-                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
             })
             .ToArray();
         }
@@ -93,11 +94,12 @@ namespace Company.WebApplication1.Controllers
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
             var user = await _graphServiceClient.Me.Request().GetAsync();
 
+            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
-                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
             })
             .ToArray();
         }
@@ -114,11 +116,12 @@ namespace Company.WebApplication1.Controllers
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
 #endif
+            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
-                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
             })
             .ToArray();
         }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Controllers/WeatherForecastController.cs
@@ -68,12 +68,11 @@ namespace Company.WebApplication1.Controllers
                 throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}: {error}");
             }
 
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }
@@ -94,12 +93,11 @@ namespace Company.WebApplication1.Controllers
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
             var user = await _graphServiceClient.Me.Request().GetAsync();
 
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }
@@ -116,12 +114,11 @@ namespace Company.WebApplication1.Controllers
             HttpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
 #endif
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/Controllers/WeatherForecastController.cs
@@ -32,12 +32,11 @@ namespace Company.WebApplication1.Controllers
         [HttpGet]
         public IEnumerable<WeatherForecast> Get()
         {
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/Controllers/WeatherForecastController.cs
@@ -32,12 +32,11 @@ namespace Company.WebApplication1.Controllers
         [HttpGet]
         public IEnumerable<WeatherForecast> Get()
         {
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }

--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Controllers/WeatherForecastController.cs
@@ -26,12 +26,11 @@ namespace Company.WebApplication1.Controllers
         [HttpGet]
         public IEnumerable<WeatherForecast> Get()
         {
-            var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
         }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
@@ -22,8 +22,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         private const int _minPort = 1025;
         private const int _maxPort = 48000;
 
-        private static readonly Random _random = new Random();
-
         public AspNetCorePortTests(PublishedSitesFixture fixture) : base(fixture)
         {
         }
@@ -144,7 +142,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
             for (var i = 0; i < retries; i++)
             {
-                var port = _random.Next(_minPort, _maxPort);
+                var port = Random.Shared.Next(_minPort, _maxPort);
 
                 using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
@@ -672,7 +672,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         {
             var maxRequestSize = 1000;
             var blockSize = 40;
-            var random = new Random();
             async Task RunRequests()
             {
                 using (var connection = _fixture.CreateTestConnection())
@@ -685,7 +684,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
                         "",
                         "");
 
-                    var disconnectAfter = random.Next(maxRequestSize);
+                    var disconnectAfter = Random.Shared.Next(maxRequestSize);
                     var data = new byte[blockSize];
                     for (int i = 0; i < disconnectAfter / blockSize; i++)
                     {

--- a/src/Servers/Kestrel/shared/test/MockSystemClock.cs
+++ b/src/Servers/Kestrel/shared/test/MockSystemClock.cs
@@ -9,8 +9,6 @@ namespace Microsoft.AspNetCore.Testing
 {
     public class MockSystemClock : ISystemClock
     {
-        private static Random _random = new Random();
-
         private long _utcNowTicks;
 
         public MockSystemClock()
@@ -41,7 +39,7 @@ namespace Microsoft.AspNetCore.Testing
 
         private long NextLong(long minValue, long maxValue)
         {
-            return (long)(_random.NextDouble() * (maxValue - minValue) + minValue);
+            return (long)(Random.Shared.NextDouble() * (maxValue - minValue) + minValue);
         }
     }
 }

--- a/src/Servers/Kestrel/stress/Program.cs
+++ b/src/Servers/Kestrel/stress/Program.cs
@@ -64,7 +64,7 @@ public class Program
             logPath             : cmdline.HasOption("-trace") ? cmdline.ValueForOption<string>("-trace") : null,
             aspnetLog           : cmdline.ValueForOption<bool>("-aspnetlog"),
             listOps             : cmdline.ValueForOption<bool>("-listOps"),
-            seed                : cmdline.ValueForOption<int?>("-seed") ?? new Random().Next());
+            seed                : cmdline.ValueForOption<int?>("-seed") ?? Random.Shared.Next());
     }
 
     private static void Run(int concurrentRequests, int maxContentLength, Version[] httpVersions, int? connectionLifetime, int[] opIndices, string logPath, bool aspnetLog, bool listOps, int seed)

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MemoryBufferWriterTests.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MemoryBufferWriterTests.cs
@@ -405,7 +405,7 @@ namespace Microsoft.AspNetCore.SignalR.Common.Tests.Internal.Protocol
             using (var bufferWriter = new MemoryBufferWriter(MinimumSegmentSize))
             {
                 var data = new byte[MinimumSegmentSize];
-                new Random().NextBytes(data);
+                Random.Shared.NextBytes(data);
 
                 // Write half the minimum segment size
                 bufferWriter.Write(data.AsSpan(0, MinimumSegmentSize / 2));

--- a/src/SignalR/perf/Microbenchmarks/MessageParserBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/MessageParserBenchmark.cs
@@ -11,7 +11,6 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
 {
     public class MessageParserBenchmark
     {
-        private static readonly Random Random = new Random();
         private byte[] _binaryInput;
         private byte[] _textInput;
 
@@ -25,7 +24,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
         public void Setup()
         {
             var buffer = new byte[MessageLength];
-            Random.NextBytes(buffer);
+            Random.Shared.NextBytes(buffer);
             var writer = MemoryBufferWriter.Get();
             try
             {
@@ -39,7 +38,7 @@ namespace Microsoft.AspNetCore.SignalR.Microbenchmarks
             }
 
             buffer = new byte[MessageLength];
-            Random.NextBytes(buffer);
+            Random.Shared.NextBytes(buffer);
             writer = MemoryBufferWriter.Get();
             try
             {

--- a/src/SignalR/samples/JwtClientSample/Program.cs
+++ b/src/SignalR/samples/JwtClientSample/Program.cs
@@ -24,7 +24,6 @@ namespace JwtClientSample
         private const string ServerUrl = "http://localhost:54543";
 
         private readonly ConcurrentDictionary<string, Task<string>> _tokens = new ConcurrentDictionary<string, Task<string>>(StringComparer.Ordinal);
-        private readonly Random _random = new Random();
 
         private async Task RunConnection(HttpTransportType transportType)
         {
@@ -72,7 +71,7 @@ namespace JwtClientSample
                     if (ticks % nextMsgAt == 0)
                     {
                         await hubConnection.SendAsync("Broadcast", userId, $"Hello at {DateTime.Now}");
-                        nextMsgAt = _random.Next(2, 5);
+                        nextMsgAt = Random.Shared.Next(2, 5);
                     }
                 }
             }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
@@ -9,8 +9,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 {
     public class MockSystemClock : ISystemClock
     {
-        private static Random _random = new Random();
-
         private long _utcNowTicks;
 
         public MockSystemClock()
@@ -41,7 +39,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
         private long NextLong(long minValue, long maxValue)
         {
-            return (long)(_random.NextDouble() * (maxValue - minValue) + minValue);
+            return (long)(Random.Shared.NextDouble() * (maxValue - minValue) + minValue);
         }
     }
 }

--- a/src/Testing/test/HttpClientSlimTest.cs
+++ b/src/Testing/test/HttpClientSlimTest.cs
@@ -68,7 +68,11 @@ namespace Microsoft.AspNetCore.Testing
         private HttpListener StartHost(out string address, int statusCode = 200, Func<HttpListenerContext, Task> handler = null)
         {
             var listener = new HttpListener();
+#if NET6_0_OR_GREATER
+            var random = Random.Shared;
+#else
             var random = new Random();
+#endif
             address = null;
 
             for (var i = 0; i < 10; i++)


### PR DESCRIPTION
**PR Title**

Use the new `Random.Shared` where appropriate.

**PR Description**

Use the new .NET 6 `Random.Shared` static property (dotnet/runtime#50297) where possible in the repo.

Almost all of the usages where in tests, samples or benchmarks. [`KeyRingProvider`](https://github.com/dotnet/aspnetcore/blob/2afcac2d152c0faca2f0f43407e71820408dc614/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs#L262) was the only product class usage I could find.

The only usages left are in the download files repo task:

https://github.com/dotnet/aspnetcore/blob/2afcac2d152c0faca2f0f43407e71820408dc614/eng/tools/RepoTasks/DownloadFile.cs#L99

and in the Razor tests derived from this code:

https://github.com/dotnet/aspnetcore/blob/2afcac2d152c0faca2f0f43407e71820408dc614/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/FunctionsBlock.cshtml#L5-L10
