### PR TITLE
Update assembly check on EventHandlerTagHelperDescriptorProvider

### DIFF
--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -34,6 +34,12 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
+            var targetAssembly = context.Items.GetTargetAssembly();
+            if (targetAssembly is not null && !SymbolEqualityComparer.Default.Equals(targetAssembly, eventHandlerAttribute.ContainingAssembly))
+            {
+                return;
+            }
+
             var eventHandlerData = GetEventHandlerData(context, compilation, eventHandlerAttribute);
 
             foreach (var tagHelper in CreateEventHandlerTagHelpers(eventHandlerData))


### PR DESCRIPTION
Adds a containing assembly check to `EventHandlerTagHelperDescriptorProvider`.

We added this check to the other `ITagHelperDescriptorProvider` in https://github.com/dotnet/aspnetcore/pull/30560 but missed doing it for the `EventHandlerTagHelperDescriptorProvider`.

The API is designed to be used in conjunction with the `TargetAssembly` filter feature in the Razor source generator. When a `TargetAssembly` is provided, we only want to search for descriptors in that particular assembly. Without the filter, we end up loading the descriptors multiple times as we iterate through each of the referenced assemblies.