### PR TITLE
Change Router _emptyParametersDictionary to a regular Dictionary

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Components.Routing
     public class Router : IComponent, IHandleAfterRender, IDisposable
     {
         static readonly char[] _queryOrHashStartChar = new[] { '?', '#' };
+        // Dictionary is intentionally used instead of ReadOnlyDictionary to reduce Blazor size
         static readonly IReadOnlyDictionary<string, object> _emptyParametersDictionary
             = new Dictionary<string, object>();
 

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -23,8 +23,8 @@ namespace Microsoft.AspNetCore.Components.Routing
     public class Router : IComponent, IHandleAfterRender, IDisposable
     {
         static readonly char[] _queryOrHashStartChar = new[] { '?', '#' };
-        static readonly ReadOnlyDictionary<string, object> _emptyParametersDictionary
-            = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+        static readonly IReadOnlyDictionary<string, object> _emptyParametersDictionary
+            = new Dictionary<string, object>();
 
         RenderHandle _renderHandle;
         string _baseUri;


### PR DESCRIPTION
This allows for ReadOnlyDictionary to be trimmed in a default Blazor WASM app. Saving roughly 3 KB .br compressed.

Contributes to #30098
