### PR TITLE
Reuse HttpProtocol CTS

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -400,8 +400,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             lock (_abortLock)
             {
                 _preventRequestAbortedCancellation = false;
-                localAbortCts = _abortedCts;
-                _abortedCts = null;
+                if (_abortedCts?.TryReset() == false)
+                {
+                    localAbortCts = _abortedCts;
+                    _abortedCts = null;
+                }
             }
 
             localAbortCts?.Dispose();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/30390

Close to 100,000 requests, 125 connections

Before:
| Type | Allocations | Bytes |
| -- | -- | -- | 
CancellationTokenSource | 98,314 | 4,719,072 |

After:
| Type | Allocations | Bytes |
| -- | -- | -- | 
CancellationTokenSource | 125 | 6,000 |

Took longer than it should have because I didn't think about `connectionAborted = true` not being reused so had to think about the race condition there, but since the connection shouldn't be reused the race doesn't matter.