### PR TITLE
Remove DNT from pre-reserved headers

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -50,7 +50,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         Cookie,
         CorrelationContext,
         Date,
-        DNT,
         ETag,
         Expect,
         Expires,
@@ -1007,29 +1006,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 _headers._UserAgent = value; 
             }
         }
-        public StringValues HeaderDNT
-        {
-            get
-            {
-                StringValues value = default;
-                if ((_bits & 0x800000000000L) != 0)
-                {
-                    value = _headers._DNT;
-                }
-                return value;
-            }
-            set
-            {
-                _bits |= 0x800000000000L;
-                _headers._DNT = value; 
-            }
-        }
         public StringValues HeaderUpgradeInsecureRequests
         {
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x1000000000000L) != 0)
+                if ((_bits & 0x800000000000L) != 0)
                 {
                     value = _headers._UpgradeInsecureRequests;
                 }
@@ -1037,7 +1019,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x1000000000000L;
+                _bits |= 0x800000000000L;
                 _headers._UpgradeInsecureRequests = value; 
             }
         }
@@ -1046,7 +1028,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x2000000000000L) != 0)
+                if ((_bits & 0x1000000000000L) != 0)
                 {
                     value = _headers._RequestId;
                 }
@@ -1054,7 +1036,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x2000000000000L;
+                _bits |= 0x1000000000000L;
                 _headers._RequestId = value; 
             }
         }
@@ -1063,7 +1045,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x4000000000000L) != 0)
+                if ((_bits & 0x2000000000000L) != 0)
                 {
                     value = _headers._CorrelationContext;
                 }
@@ -1071,7 +1053,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x4000000000000L;
+                _bits |= 0x2000000000000L;
                 _headers._CorrelationContext = value; 
             }
         }
@@ -1080,7 +1062,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x8000000000000L) != 0)
+                if ((_bits & 0x4000000000000L) != 0)
                 {
                     value = _headers._TraceParent;
                 }
@@ -1088,7 +1070,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x8000000000000L;
+                _bits |= 0x4000000000000L;
                 _headers._TraceParent = value; 
             }
         }
@@ -1097,7 +1079,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x10000000000000L) != 0)
+                if ((_bits & 0x8000000000000L) != 0)
                 {
                     value = _headers._TraceState;
                 }
@@ -1105,7 +1087,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x10000000000000L;
+                _bits |= 0x8000000000000L;
                 _headers._TraceState = value; 
             }
         }
@@ -1114,7 +1096,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x20000000000000L) != 0)
+                if ((_bits & 0x10000000000000L) != 0)
                 {
                     value = _headers._Baggage;
                 }
@@ -1122,7 +1104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x20000000000000L;
+                _bits |= 0x10000000000000L;
                 _headers._Baggage = value; 
             }
         }
@@ -1131,7 +1113,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x40000000000000L) != 0)
+                if ((_bits & 0x20000000000000L) != 0)
                 {
                     value = _headers._Origin;
                 }
@@ -1139,7 +1121,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x40000000000000L;
+                _bits |= 0x20000000000000L;
                 _headers._Origin = value; 
             }
         }
@@ -1148,7 +1130,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x80000000000000L) != 0)
+                if ((_bits & 0x40000000000000L) != 0)
                 {
                     value = _headers._AccessControlRequestMethod;
                 }
@@ -1156,7 +1138,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x80000000000000L;
+                _bits |= 0x40000000000000L;
                 _headers._AccessControlRequestMethod = value; 
             }
         }
@@ -1165,7 +1147,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x100000000000000L) != 0)
+                if ((_bits & 0x80000000000000L) != 0)
                 {
                     value = _headers._AccessControlRequestHeaders;
                 }
@@ -1173,7 +1155,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x100000000000000L;
+                _bits |= 0x80000000000000L;
                 _headers._AccessControlRequestHeaders = value; 
             }
         }
@@ -1238,30 +1220,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.DNT, key))
-                    {
-                        if ((_bits & 0x800000000000L) != 0)
-                        {
-                            value = _headers._DNT;
-                            return true;
-                        }
-                        return false;
-                    }
 
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._Via;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.DNT.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000000000L) != 0)
-                        {
-                            value = _headers._DNT;
                             return true;
                         }
                         return false;
@@ -1426,7 +1390,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x40000000000000L) != 0)
+                        if ((_bits & 0x20000000000000L) != 0)
                         {
                             value = _headers._Origin;
                             return true;
@@ -1472,7 +1436,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000000L) != 0)
+                        if ((_bits & 0x20000000000000L) != 0)
                         {
                             value = _headers._Origin;
                             return true;
@@ -1548,7 +1512,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x20000000000000L) != 0)
+                        if ((_bits & 0x10000000000000L) != 0)
                         {
                             value = _headers._Baggage;
                             return true;
@@ -1621,7 +1585,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000000L) != 0)
+                        if ((_bits & 0x10000000000000L) != 0)
                         {
                             value = _headers._Baggage;
                             return true;
@@ -1734,7 +1698,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x2000000000000L) != 0)
+                        if ((_bits & 0x1000000000000L) != 0)
                         {
                             value = _headers._RequestId;
                             return true;
@@ -1743,7 +1707,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x10000000000000L) != 0)
+                        if ((_bits & 0x8000000000000L) != 0)
                         {
                             value = _headers._TraceState;
                             return true;
@@ -1789,7 +1753,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000000L) != 0)
+                        if ((_bits & 0x1000000000000L) != 0)
                         {
                             value = _headers._RequestId;
                             return true;
@@ -1798,7 +1762,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000000L) != 0)
+                        if ((_bits & 0x8000000000000L) != 0)
                         {
                             value = _headers._TraceState;
                             return true;
@@ -1820,7 +1784,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x8000000000000L) != 0)
+                        if ((_bits & 0x4000000000000L) != 0)
                         {
                             value = _headers._TraceParent;
                             return true;
@@ -1839,7 +1803,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000000L) != 0)
+                        if ((_bits & 0x4000000000000L) != 0)
                         {
                             value = _headers._TraceParent;
                             return true;
@@ -2224,7 +2188,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.CorrelationContext, key))
                     {
-                        if ((_bits & 0x4000000000000L) != 0)
+                        if ((_bits & 0x2000000000000L) != 0)
                         {
                             value = _headers._CorrelationContext;
                             return true;
@@ -2252,7 +2216,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000000L) != 0)
+                        if ((_bits & 0x2000000000000L) != 0)
                         {
                             value = _headers._CorrelationContext;
                             return true;
@@ -2288,7 +2252,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x1000000000000L) != 0)
+                        if ((_bits & 0x800000000000L) != 0)
                         {
                             value = _headers._UpgradeInsecureRequests;
                             return true;
@@ -2298,7 +2262,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000000L) != 0)
+                        if ((_bits & 0x800000000000L) != 0)
                         {
                             value = _headers._UpgradeInsecureRequests;
                             return true;
@@ -2311,7 +2275,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x80000000000000L) != 0)
+                        if ((_bits & 0x40000000000000L) != 0)
                         {
                             value = _headers._AccessControlRequestMethod;
                             return true;
@@ -2321,7 +2285,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000000L) != 0)
+                        if ((_bits & 0x40000000000000L) != 0)
                         {
                             value = _headers._AccessControlRequestMethod;
                             return true;
@@ -2334,7 +2298,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x100000000000000L) != 0)
+                        if ((_bits & 0x80000000000000L) != 0)
                         {
                             value = _headers._AccessControlRequestHeaders;
                             return true;
@@ -2344,7 +2308,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000000L) != 0)
+                        if ((_bits & 0x80000000000000L) != 0)
                         {
                             value = _headers._AccessControlRequestHeaders;
                             return true;
@@ -2387,23 +2351,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Via = value;
                         return;
                     }
-                    if (ReferenceEquals(HeaderNames.DNT, key))
-                    {
-                        _bits |= 0x800000000000L;
-                        _headers._DNT = value;
-                        return;
-                    }
 
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         _bits |= 0x200L;
                         _headers._Via = value;
-                        return;
-                    }
-                    if (HeaderNames.DNT.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x800000000000L;
-                        _headers._DNT = value;
                         return;
                     }
                     break;
@@ -2518,7 +2470,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        _bits |= 0x40000000000000L;
+                        _bits |= 0x20000000000000L;
                         _headers._Origin = value;
                         return;
                     }
@@ -2549,7 +2501,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000000000000L;
+                        _bits |= 0x20000000000000L;
                         _headers._Origin = value;
                         return;
                     }
@@ -2601,7 +2553,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        _bits |= 0x20000000000000L;
+                        _bits |= 0x10000000000000L;
                         _headers._Baggage = value;
                         return;
                     }
@@ -2650,7 +2602,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000000000000L;
+                        _bits |= 0x10000000000000L;
                         _headers._Baggage = value;
                         return;
                     }
@@ -2730,13 +2682,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        _bits |= 0x2000000000000L;
+                        _bits |= 0x1000000000000L;
                         _headers._RequestId = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        _bits |= 0x10000000000000L;
+                        _bits |= 0x8000000000000L;
                         _headers._TraceState = value;
                         return;
                     }
@@ -2767,13 +2719,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000000000L;
+                        _bits |= 0x1000000000000L;
                         _headers._RequestId = value;
                         return;
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000000000000L;
+                        _bits |= 0x8000000000000L;
                         _headers._TraceState = value;
                         return;
                     }
@@ -2789,7 +2741,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        _bits |= 0x8000000000000L;
+                        _bits |= 0x4000000000000L;
                         _headers._TraceParent = value;
                         return;
                     }
@@ -2802,7 +2754,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000000000000L;
+                        _bits |= 0x4000000000000L;
                         _headers._TraceParent = value;
                         return;
                     }
@@ -3068,7 +3020,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.CorrelationContext, key))
                     {
-                        _bits |= 0x4000000000000L;
+                        _bits |= 0x2000000000000L;
                         _headers._CorrelationContext = value;
                         return;
                     }
@@ -3087,7 +3039,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000000000000L;
+                        _bits |= 0x2000000000000L;
                         _headers._CorrelationContext = value;
                         return;
                     }
@@ -3114,14 +3066,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        _bits |= 0x1000000000000L;
+                        _bits |= 0x800000000000L;
                         _headers._UpgradeInsecureRequests = value;
                         return;
                     }
 
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000000000000L;
+                        _bits |= 0x800000000000L;
                         _headers._UpgradeInsecureRequests = value;
                         return;
                     }
@@ -3131,14 +3083,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        _bits |= 0x80000000000000L;
+                        _bits |= 0x40000000000000L;
                         _headers._AccessControlRequestMethod = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80000000000000L;
+                        _bits |= 0x40000000000000L;
                         _headers._AccessControlRequestMethod = value;
                         return;
                     }
@@ -3148,14 +3100,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        _bits |= 0x100000000000000L;
+                        _bits |= 0x80000000000000L;
                         _headers._AccessControlRequestHeaders = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000000000000L;
+                        _bits |= 0x80000000000000L;
                         _headers._AccessControlRequestHeaders = value;
                         return;
                     }
@@ -3207,16 +3159,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.DNT, key))
-                    {
-                        if ((_bits & 0x800000000000L) == 0)
-                        {
-                            _bits |= 0x800000000000L;
-                            _headers._DNT = value;
-                            return true;
-                        }
-                        return false;
-                    }
     
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
@@ -3224,16 +3166,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits |= 0x200L;
                             _headers._Via = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.DNT.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000000000L) == 0)
-                        {
-                            _bits |= 0x800000000000L;
-                            _headers._DNT = value;
                             return true;
                         }
                         return false;
@@ -3414,9 +3346,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x40000000000000L) == 0)
+                        if ((_bits & 0x20000000000000L) == 0)
                         {
-                            _bits |= 0x40000000000000L;
+                            _bits |= 0x20000000000000L;
                             _headers._Origin = value;
                             return true;
                         }
@@ -3465,9 +3397,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000000L) == 0)
+                        if ((_bits & 0x20000000000000L) == 0)
                         {
-                            _bits |= 0x40000000000000L;
+                            _bits |= 0x20000000000000L;
                             _headers._Origin = value;
                             return true;
                         }
@@ -3549,9 +3481,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x20000000000000L) == 0)
+                        if ((_bits & 0x10000000000000L) == 0)
                         {
-                            _bits |= 0x20000000000000L;
+                            _bits |= 0x10000000000000L;
                             _headers._Baggage = value;
                             return true;
                         }
@@ -3630,9 +3562,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000000L) == 0)
+                        if ((_bits & 0x10000000000000L) == 0)
                         {
-                            _bits |= 0x20000000000000L;
+                            _bits |= 0x10000000000000L;
                             _headers._Baggage = value;
                             return true;
                         }
@@ -3754,9 +3686,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x2000000000000L) == 0)
+                        if ((_bits & 0x1000000000000L) == 0)
                         {
-                            _bits |= 0x2000000000000L;
+                            _bits |= 0x1000000000000L;
                             _headers._RequestId = value;
                             return true;
                         }
@@ -3764,9 +3696,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x10000000000000L) == 0)
+                        if ((_bits & 0x8000000000000L) == 0)
                         {
-                            _bits |= 0x10000000000000L;
+                            _bits |= 0x8000000000000L;
                             _headers._TraceState = value;
                             return true;
                         }
@@ -3815,9 +3747,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000000L) == 0)
+                        if ((_bits & 0x1000000000000L) == 0)
                         {
-                            _bits |= 0x2000000000000L;
+                            _bits |= 0x1000000000000L;
                             _headers._RequestId = value;
                             return true;
                         }
@@ -3825,9 +3757,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000000L) == 0)
+                        if ((_bits & 0x8000000000000L) == 0)
                         {
-                            _bits |= 0x10000000000000L;
+                            _bits |= 0x8000000000000L;
                             _headers._TraceState = value;
                             return true;
                         }
@@ -3849,9 +3781,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x8000000000000L) == 0)
+                        if ((_bits & 0x4000000000000L) == 0)
                         {
-                            _bits |= 0x8000000000000L;
+                            _bits |= 0x4000000000000L;
                             _headers._TraceParent = value;
                             return true;
                         }
@@ -3870,9 +3802,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000000L) == 0)
+                        if ((_bits & 0x4000000000000L) == 0)
                         {
-                            _bits |= 0x8000000000000L;
+                            _bits |= 0x4000000000000L;
                             _headers._TraceParent = value;
                             return true;
                         }
@@ -4292,9 +4224,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.CorrelationContext, key))
                     {
-                        if ((_bits & 0x4000000000000L) == 0)
+                        if ((_bits & 0x2000000000000L) == 0)
                         {
-                            _bits |= 0x4000000000000L;
+                            _bits |= 0x2000000000000L;
                             _headers._CorrelationContext = value;
                             return true;
                         }
@@ -4323,9 +4255,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000000L) == 0)
+                        if ((_bits & 0x2000000000000L) == 0)
                         {
-                            _bits |= 0x4000000000000L;
+                            _bits |= 0x2000000000000L;
                             _headers._CorrelationContext = value;
                             return true;
                         }
@@ -4362,9 +4294,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x1000000000000L) == 0)
+                        if ((_bits & 0x800000000000L) == 0)
                         {
-                            _bits |= 0x1000000000000L;
+                            _bits |= 0x800000000000L;
                             _headers._UpgradeInsecureRequests = value;
                             return true;
                         }
@@ -4373,9 +4305,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000000L) == 0)
+                        if ((_bits & 0x800000000000L) == 0)
                         {
-                            _bits |= 0x1000000000000L;
+                            _bits |= 0x800000000000L;
                             _headers._UpgradeInsecureRequests = value;
                             return true;
                         }
@@ -4387,9 +4319,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x80000000000000L) == 0)
+                        if ((_bits & 0x40000000000000L) == 0)
                         {
-                            _bits |= 0x80000000000000L;
+                            _bits |= 0x40000000000000L;
                             _headers._AccessControlRequestMethod = value;
                             return true;
                         }
@@ -4398,9 +4330,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000000L) == 0)
+                        if ((_bits & 0x40000000000000L) == 0)
                         {
-                            _bits |= 0x80000000000000L;
+                            _bits |= 0x40000000000000L;
                             _headers._AccessControlRequestMethod = value;
                             return true;
                         }
@@ -4412,9 +4344,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x100000000000000L) == 0)
+                        if ((_bits & 0x80000000000000L) == 0)
                         {
-                            _bits |= 0x100000000000000L;
+                            _bits |= 0x80000000000000L;
                             _headers._AccessControlRequestHeaders = value;
                             return true;
                         }
@@ -4423,9 +4355,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000000L) == 0)
+                        if ((_bits & 0x80000000000000L) == 0)
                         {
-                            _bits |= 0x100000000000000L;
+                            _bits |= 0x80000000000000L;
                             _headers._AccessControlRequestHeaders = value;
                             return true;
                         }
@@ -4479,16 +4411,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.DNT, key))
-                    {
-                        if ((_bits & 0x800000000000L) != 0)
-                        {
-                            _bits &= ~0x800000000000L;
-                            _headers._DNT = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
     
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
@@ -4496,16 +4418,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             _bits &= ~0x200L;
                             _headers._Via = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.DNT.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800000000000L) != 0)
-                        {
-                            _bits &= ~0x800000000000L;
-                            _headers._DNT = default(StringValues);
                             return true;
                         }
                         return false;
@@ -4686,9 +4598,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x40000000000000L) != 0)
+                        if ((_bits & 0x20000000000000L) != 0)
                         {
-                            _bits &= ~0x40000000000000L;
+                            _bits &= ~0x20000000000000L;
                             _headers._Origin = default(StringValues);
                             return true;
                         }
@@ -4737,9 +4649,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000000L) != 0)
+                        if ((_bits & 0x20000000000000L) != 0)
                         {
-                            _bits &= ~0x40000000000000L;
+                            _bits &= ~0x20000000000000L;
                             _headers._Origin = default(StringValues);
                             return true;
                         }
@@ -4821,9 +4733,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x20000000000000L) != 0)
+                        if ((_bits & 0x10000000000000L) != 0)
                         {
-                            _bits &= ~0x20000000000000L;
+                            _bits &= ~0x10000000000000L;
                             _headers._Baggage = default(StringValues);
                             return true;
                         }
@@ -4902,9 +4814,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000000L) != 0)
+                        if ((_bits & 0x10000000000000L) != 0)
                         {
-                            _bits &= ~0x20000000000000L;
+                            _bits &= ~0x10000000000000L;
                             _headers._Baggage = default(StringValues);
                             return true;
                         }
@@ -5026,9 +4938,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x2000000000000L) != 0)
+                        if ((_bits & 0x1000000000000L) != 0)
                         {
-                            _bits &= ~0x2000000000000L;
+                            _bits &= ~0x1000000000000L;
                             _headers._RequestId = default(StringValues);
                             return true;
                         }
@@ -5036,9 +4948,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x10000000000000L) != 0)
+                        if ((_bits & 0x8000000000000L) != 0)
                         {
-                            _bits &= ~0x10000000000000L;
+                            _bits &= ~0x8000000000000L;
                             _headers._TraceState = default(StringValues);
                             return true;
                         }
@@ -5087,9 +4999,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000000L) != 0)
+                        if ((_bits & 0x1000000000000L) != 0)
                         {
-                            _bits &= ~0x2000000000000L;
+                            _bits &= ~0x1000000000000L;
                             _headers._RequestId = default(StringValues);
                             return true;
                         }
@@ -5097,9 +5009,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000000L) != 0)
+                        if ((_bits & 0x8000000000000L) != 0)
                         {
-                            _bits &= ~0x10000000000000L;
+                            _bits &= ~0x8000000000000L;
                             _headers._TraceState = default(StringValues);
                             return true;
                         }
@@ -5121,9 +5033,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x8000000000000L) != 0)
+                        if ((_bits & 0x4000000000000L) != 0)
                         {
-                            _bits &= ~0x8000000000000L;
+                            _bits &= ~0x4000000000000L;
                             _headers._TraceParent = default(StringValues);
                             return true;
                         }
@@ -5142,9 +5054,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000000L) != 0)
+                        if ((_bits & 0x4000000000000L) != 0)
                         {
-                            _bits &= ~0x8000000000000L;
+                            _bits &= ~0x4000000000000L;
                             _headers._TraceParent = default(StringValues);
                             return true;
                         }
@@ -5564,9 +5476,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.CorrelationContext, key))
                     {
-                        if ((_bits & 0x4000000000000L) != 0)
+                        if ((_bits & 0x2000000000000L) != 0)
                         {
-                            _bits &= ~0x4000000000000L;
+                            _bits &= ~0x2000000000000L;
                             _headers._CorrelationContext = default(StringValues);
                             return true;
                         }
@@ -5595,9 +5507,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000000L) != 0)
+                        if ((_bits & 0x2000000000000L) != 0)
                         {
-                            _bits &= ~0x4000000000000L;
+                            _bits &= ~0x2000000000000L;
                             _headers._CorrelationContext = default(StringValues);
                             return true;
                         }
@@ -5634,9 +5546,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x1000000000000L) != 0)
+                        if ((_bits & 0x800000000000L) != 0)
                         {
-                            _bits &= ~0x1000000000000L;
+                            _bits &= ~0x800000000000L;
                             _headers._UpgradeInsecureRequests = default(StringValues);
                             return true;
                         }
@@ -5645,9 +5557,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000000L) != 0)
+                        if ((_bits & 0x800000000000L) != 0)
                         {
-                            _bits &= ~0x1000000000000L;
+                            _bits &= ~0x800000000000L;
                             _headers._UpgradeInsecureRequests = default(StringValues);
                             return true;
                         }
@@ -5659,9 +5571,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x80000000000000L) != 0)
+                        if ((_bits & 0x40000000000000L) != 0)
                         {
-                            _bits &= ~0x80000000000000L;
+                            _bits &= ~0x40000000000000L;
                             _headers._AccessControlRequestMethod = default(StringValues);
                             return true;
                         }
@@ -5670,9 +5582,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000000L) != 0)
+                        if ((_bits & 0x40000000000000L) != 0)
                         {
-                            _bits &= ~0x80000000000000L;
+                            _bits &= ~0x40000000000000L;
                             _headers._AccessControlRequestMethod = default(StringValues);
                             return true;
                         }
@@ -5684,9 +5596,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x100000000000000L) != 0)
+                        if ((_bits & 0x80000000000000L) != 0)
                         {
-                            _bits &= ~0x100000000000000L;
+                            _bits &= ~0x80000000000000L;
                             _headers._AccessControlRequestHeaders = default(StringValues);
                             return true;
                         }
@@ -5695,9 +5607,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000000L) != 0)
+                        if ((_bits & 0x80000000000000L) != 0)
                         {
-                            _bits &= ~0x100000000000000L;
+                            _bits &= ~0x80000000000000L;
                             _headers._AccessControlRequestHeaders = default(StringValues);
                             return true;
                         }
@@ -6185,7 +6097,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800000000000L) != 0)
             {
-                _headers._DNT = default;
+                _headers._UpgradeInsecureRequests = default;
                 if((tempBits & ~0x800000000000L) == 0)
                 {
                     return;
@@ -6195,7 +6107,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000000000000L) != 0)
             {
-                _headers._UpgradeInsecureRequests = default;
+                _headers._RequestId = default;
                 if((tempBits & ~0x1000000000000L) == 0)
                 {
                     return;
@@ -6205,7 +6117,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x2000000000000L) != 0)
             {
-                _headers._RequestId = default;
+                _headers._CorrelationContext = default;
                 if((tempBits & ~0x2000000000000L) == 0)
                 {
                     return;
@@ -6215,7 +6127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x4000000000000L) != 0)
             {
-                _headers._CorrelationContext = default;
+                _headers._TraceParent = default;
                 if((tempBits & ~0x4000000000000L) == 0)
                 {
                     return;
@@ -6225,7 +6137,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000000000000L) != 0)
             {
-                _headers._TraceParent = default;
+                _headers._TraceState = default;
                 if((tempBits & ~0x8000000000000L) == 0)
                 {
                     return;
@@ -6235,7 +6147,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10000000000000L) != 0)
             {
-                _headers._TraceState = default;
+                _headers._Baggage = default;
                 if((tempBits & ~0x10000000000000L) == 0)
                 {
                     return;
@@ -6245,7 +6157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000000000000L) != 0)
             {
-                _headers._Baggage = default;
+                _headers._Origin = default;
                 if((tempBits & ~0x20000000000000L) == 0)
                 {
                     return;
@@ -6255,7 +6167,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000000000000L) != 0)
             {
-                _headers._Origin = default;
+                _headers._AccessControlRequestMethod = default;
                 if((tempBits & ~0x40000000000000L) == 0)
                 {
                     return;
@@ -6265,22 +6177,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000000000000L) != 0)
             {
-                _headers._AccessControlRequestMethod = default;
+                _headers._AccessControlRequestHeaders = default;
                 if((tempBits & ~0x80000000000000L) == 0)
                 {
                     return;
                 }
                 tempBits &= ~0x80000000000000L;
-            }
-            
-            if ((tempBits & 0x100000000000000L) != 0)
-            {
-                _headers._AccessControlRequestHeaders = default;
-                if((tempBits & ~0x100000000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x100000000000000L;
             }
             
         }
@@ -6721,7 +6623,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.DNT, _headers._DNT);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _headers._UpgradeInsecureRequests);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000000000000L) != 0)
@@ -6730,7 +6632,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _headers._UpgradeInsecureRequests);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _headers._RequestId);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000000000000L) != 0)
@@ -6739,7 +6641,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _headers._RequestId);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _headers._CorrelationContext);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000000000000L) != 0)
@@ -6748,7 +6650,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _headers._CorrelationContext);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _headers._TraceParent);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000000000000L) != 0)
@@ -6757,7 +6659,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _headers._TraceParent);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _headers._TraceState);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000000000000L) != 0)
@@ -6766,7 +6668,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _headers._TraceState);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _headers._Baggage);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000000000000L) != 0)
@@ -6775,7 +6677,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _headers._Baggage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _headers._Origin);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000000000000L) != 0)
@@ -6784,19 +6686,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _headers._Origin);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x80000000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
                     array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestMethod, _headers._AccessControlRequestMethod);
                     ++arrayIndex;
                 }
-                if ((_bits & 0x100000000000000L) != 0)
+                if ((_bits & 0x80000000000000L) != 0)
                 {
                     if (arrayIndex == array.Length)
                     {
@@ -6839,14 +6732,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     break;
                 case 3:
-                    var firstTerm3 = (Unsafe.ReadUnaligned<ushort>(ref nameStart) & 0xdfdfu);
-                    if ((firstTerm3 == 0x4e44u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)2) & 0xdfu) == 0x54u))
-                    {
-                        flag = 0x800000000000L;
-                        values = ref _headers._DNT;
-                        nameStr = HeaderNames.DNT;
-                    }
-                    else if ((firstTerm3 == 0x4956u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)2) & 0xdfu) == 0x41u))
+                    if (((Unsafe.ReadUnaligned<ushort>(ref nameStart) & 0xdfdfu) == 0x4956u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)2) & 0xdfu) == 0x41u))
                     {
                         flag = 0x200L;
                         values = ref _headers._Via;
@@ -6916,7 +6802,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if ((firstTerm6 == 0x4749524fu) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4e49u))
                     {
-                        flag = 0x40000000000000L;
+                        flag = 0x20000000000000L;
                         values = ref _headers._Origin;
                         nameStr = HeaderNames.Origin;
                     }
@@ -6942,7 +6828,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x47474142u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4741u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x20000000000000L;
+                        flag = 0x10000000000000L;
                         values = ref _headers._Baggage;
                         nameStr = HeaderNames.Baggage;
                     }
@@ -7027,13 +6913,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d54534555514552uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4449u))
                     {
-                        flag = 0x2000000000000L;
+                        flag = 0x1000000000000L;
                         values = ref _headers._RequestId;
                         nameStr = HeaderNames.RequestId;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x4154534543415254uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4554u))
                     {
-                        flag = 0x10000000000000L;
+                        flag = 0x8000000000000L;
                         values = ref _headers._TraceState;
                         nameStr = HeaderNames.TraceState;
                     }
@@ -7047,7 +6933,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x5241504543415254uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4e45u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)10) & 0xdfu) == 0x54u))
                     {
-                        flag = 0x8000000000000L;
+                        flag = 0x4000000000000L;
                         values = ref _headers._TraceParent;
                         nameStr = HeaderNames.TraceParent;
                     }
@@ -7186,7 +7072,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 19:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x54414c4552524f43uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfffdfdfdfuL) == 0x544e4f432d4e4f49uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(8 * sizeof(ushort)))) & 0xdfdfu) == 0x5845u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)18) & 0xdfu) == 0x54u))
                     {
-                        flag = 0x4000000000000L;
+                        flag = 0x2000000000000L;
                         values = ref _headers._CorrelationContext;
                         nameStr = HeaderNames.CorrelationContext;
                     }
@@ -7214,7 +7100,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 25:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d45444152475055uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfdfuL) == 0x4552554345534e49uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfdfdfdfdfdfdfffuL) == 0x545345555145522duL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)24) & 0xdfu) == 0x53u))
                     {
-                        flag = 0x1000000000000L;
+                        flag = 0x800000000000L;
                         values = ref _headers._UpgradeInsecureRequests;
                         nameStr = HeaderNames.UpgradeInsecureRequests;
                     }
@@ -7222,7 +7108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 29:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL) == 0x432d535345434341uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfffdfdfdfdfdfdfuL) == 0x522d4c4f52544e4fuL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfffdfdfdfdfdfdfuL) == 0x4d2d545345555145uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4f485445u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)28) & 0xdfu) == 0x44u))
                     {
-                        flag = 0x80000000000000L;
+                        flag = 0x40000000000000L;
                         values = ref _headers._AccessControlRequestMethod;
                         nameStr = HeaderNames.AccessControlRequestMethod;
                     }
@@ -7230,7 +7116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 30:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL) == 0x432d535345434341uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfffdfdfdfdfdfdfuL) == 0x522d4c4f52544e4fuL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfffdfdfdfdfdfdfuL) == 0x482d545345555145uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x45444145u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(14 * sizeof(ushort)))) & 0xdfdfu) == 0x5352u))
                     {
-                        flag = 0x100000000000000L;
+                        flag = 0x80000000000000L;
                         values = ref _headers._AccessControlRequestHeaders;
                         nameStr = HeaderNames.AccessControlRequestHeaders;
                     }
@@ -7580,7 +7466,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             public StringValues _TE;
             public StringValues _Translate;
             public StringValues _UserAgent;
-            public StringValues _DNT;
             public StringValues _UpgradeInsecureRequests;
             public StringValues _RequestId;
             public StringValues _CorrelationContext;
@@ -7695,26 +7580,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     case 46:
                         goto HeaderUserAgent;
                     case 47:
-                        goto HeaderDNT;
-                    case 48:
                         goto HeaderUpgradeInsecureRequests;
-                    case 49:
+                    case 48:
                         goto HeaderRequestId;
-                    case 50:
+                    case 49:
                         goto HeaderCorrelationContext;
-                    case 51:
+                    case 50:
                         goto HeaderTraceParent;
-                    case 52:
+                    case 51:
                         goto HeaderTraceState;
-                    case 53:
+                    case 52:
                         goto HeaderBaggage;
-                    case 54:
+                    case 53:
                         goto HeaderOrigin;
-                    case 55:
+                    case 54:
                         goto HeaderAccessControlRequestMethod;
-                    case 56:
+                    case 55:
                         goto HeaderAccessControlRequestHeaders;
-                    case 57:
+                    case 56:
                         goto HeaderContentLength;
                     default:
                         goto ExtraHeaders;
@@ -8096,92 +7979,84 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _next = 47;
                         return true;
                     }
-                HeaderDNT: // case 47
+                HeaderUpgradeInsecureRequests: // case 47
                     if ((_bits & 0x800000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.DNT, _collection._headers._DNT);
-                        _currentKnownType = KnownHeaderType.DNT;
-                        _next = 48;
-                        return true;
-                    }
-                HeaderUpgradeInsecureRequests: // case 48
-                    if ((_bits & 0x1000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _collection._headers._UpgradeInsecureRequests);
                         _currentKnownType = KnownHeaderType.UpgradeInsecureRequests;
-                        _next = 49;
+                        _next = 48;
                         return true;
                     }
-                HeaderRequestId: // case 49
-                    if ((_bits & 0x2000000000000L) != 0)
+                HeaderRequestId: // case 48
+                    if ((_bits & 0x1000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _collection._headers._RequestId);
                         _currentKnownType = KnownHeaderType.RequestId;
-                        _next = 50;
+                        _next = 49;
                         return true;
                     }
-                HeaderCorrelationContext: // case 50
-                    if ((_bits & 0x4000000000000L) != 0)
+                HeaderCorrelationContext: // case 49
+                    if ((_bits & 0x2000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _collection._headers._CorrelationContext);
                         _currentKnownType = KnownHeaderType.CorrelationContext;
-                        _next = 51;
+                        _next = 50;
                         return true;
                     }
-                HeaderTraceParent: // case 51
-                    if ((_bits & 0x8000000000000L) != 0)
+                HeaderTraceParent: // case 50
+                    if ((_bits & 0x4000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _collection._headers._TraceParent);
                         _currentKnownType = KnownHeaderType.TraceParent;
-                        _next = 52;
+                        _next = 51;
                         return true;
                     }
-                HeaderTraceState: // case 52
-                    if ((_bits & 0x10000000000000L) != 0)
+                HeaderTraceState: // case 51
+                    if ((_bits & 0x8000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _collection._headers._TraceState);
                         _currentKnownType = KnownHeaderType.TraceState;
-                        _next = 53;
+                        _next = 52;
                         return true;
                     }
-                HeaderBaggage: // case 53
-                    if ((_bits & 0x20000000000000L) != 0)
+                HeaderBaggage: // case 52
+                    if ((_bits & 0x10000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _collection._headers._Baggage);
                         _currentKnownType = KnownHeaderType.Baggage;
-                        _next = 54;
+                        _next = 53;
                         return true;
                     }
-                HeaderOrigin: // case 54
-                    if ((_bits & 0x40000000000000L) != 0)
+                HeaderOrigin: // case 53
+                    if ((_bits & 0x20000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _collection._headers._Origin);
                         _currentKnownType = KnownHeaderType.Origin;
-                        _next = 55;
+                        _next = 54;
                         return true;
                     }
-                HeaderAccessControlRequestMethod: // case 55
-                    if ((_bits & 0x80000000000000L) != 0)
+                HeaderAccessControlRequestMethod: // case 54
+                    if ((_bits & 0x40000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestMethod, _collection._headers._AccessControlRequestMethod);
                         _currentKnownType = KnownHeaderType.AccessControlRequestMethod;
-                        _next = 56;
+                        _next = 55;
                         return true;
                     }
-                HeaderAccessControlRequestHeaders: // case 56
-                    if ((_bits & 0x100000000000000L) != 0)
+                HeaderAccessControlRequestHeaders: // case 55
+                    if ((_bits & 0x80000000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestHeaders, _collection._headers._AccessControlRequestHeaders);
                         _currentKnownType = KnownHeaderType.AccessControlRequestHeaders;
-                        _next = 57;
+                        _next = 56;
                         return true;
                     }
-                HeaderContentLength: // case 57
+                HeaderContentLength: // case 56
                     if (_collection._contentLength.HasValue)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLength, HeaderUtilities.FormatNonNegativeInt64(_collection._contentLength.Value));
                         _currentKnownType = KnownHeaderType.ContentLength;
-                        _next = 58;
+                        _next = 57;
                         return true;
                     }
                 ExtraHeaders:

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -105,7 +105,6 @@ namespace CodeGenerator
                 HeaderNames.TE,
                 HeaderNames.Translate,
                 HeaderNames.UserAgent,
-                HeaderNames.DNT,
                 HeaderNames.UpgradeInsecureRequests,
                 HeaderNames.RequestId,
                 HeaderNames.CorrelationContext,


### PR DESCRIPTION
No modern browser uses it anymore https://github.com/dotnet/aspnetcore/issues/31492#issuecomment-812719719

Contributes to https://github.com/dotnet/aspnetcore/issues/31492