### PR TITLE
Rebalance common headers

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -206,7 +206,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private HeaderReferences _headers;
 
         public bool HasConnection => (_bits & 0x2L) != 0;
-        public bool HasTransferEncoding => (_bits & 0x80L) != 0;
+        public bool HasTransferEncoding => (_bits & 0x40L) != 0;
 
         public int HostCount => _headers._Host.Count;
 
@@ -232,7 +232,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x80L) != 0)
+                if ((_bits & 0x40L) != 0)
                 {
                     value = _headers._TransferEncoding;
                 }
@@ -240,25 +240,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x80L;
+                _bits |= 0x40L;
                 _headers._TransferEncoding = value; 
-            }
-        }
-        public StringValues HeaderAllow
-        {
-            get
-            {
-                StringValues value = default;
-                if ((_bits & 0x800L) != 0)
-                {
-                    value = _headers._Allow;
-                }
-                return value;
-            }
-            set
-            {
-                _bits |= 0x800L;
-                _headers._Allow = value; 
             }
         }
         public StringValues HeaderAuthority
@@ -266,7 +249,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x100000L) != 0)
+                if ((_bits & 0x800L) != 0)
                 {
                     value = _headers._Authority;
                 }
@@ -274,7 +257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x100000L;
+                _bits |= 0x800L;
                 _headers._Authority = value; 
             }
         }
@@ -283,7 +266,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x200000L) != 0)
+                if ((_bits & 0x1000L) != 0)
                 {
                     value = _headers._Method;
                 }
@@ -291,7 +274,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x200000L;
+                _bits |= 0x1000L;
                 _headers._Method = value; 
             }
         }
@@ -300,7 +283,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x400000L) != 0)
+                if ((_bits & 0x2000L) != 0)
                 {
                     value = _headers._Path;
                 }
@@ -308,7 +291,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x400000L;
+                _bits |= 0x2000L;
                 _headers._Path = value; 
             }
         }
@@ -317,7 +300,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x800000L) != 0)
+                if ((_bits & 0x4000L) != 0)
                 {
                     value = _headers._Scheme;
                 }
@@ -325,7 +308,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x800000L;
+                _bits |= 0x4000L;
                 _headers._Scheme = value; 
             }
         }
@@ -334,7 +317,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x400000000L) != 0)
+                if ((_bits & 0x2000000L) != 0)
                 {
                     value = _headers._Host;
                 }
@@ -342,7 +325,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x400000000L;
+                _bits |= 0x2000000L;
                 _headers._Host = value; 
             }
         }
@@ -531,11 +514,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
         }
-        StringValues IHeaderDictionary.Trailer
+        StringValues IHeaderDictionary.TransferEncoding
         {
             get
             {
-                var value = _headers._Trailer;
+                var value = _headers._TransferEncoding;
                 if ((_bits & 0x40L) != 0)
                 {
                     return value;
@@ -547,34 +530,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x40L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Trailer = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Trailer = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.TransferEncoding
-        {
-            get
-            {
-                var value = _headers._TransferEncoding;
-                if ((_bits & 0x80L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x80L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -592,7 +547,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Upgrade;
-                if ((_bits & 0x100L) != 0)
+                if ((_bits & 0x80L) != 0)
                 {
                     return value;
                 }
@@ -602,7 +557,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x100L;
+                var flag = 0x80L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -620,7 +575,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Via;
-                if ((_bits & 0x200L) != 0)
+                if ((_bits & 0x100L) != 0)
                 {
                     return value;
                 }
@@ -630,7 +585,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x200L;
+                var flag = 0x100L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -648,6 +603,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Warning;
+                if ((_bits & 0x200L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x200L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Warning = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Warning = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentType
+        {
+            get
+            {
+                var value = _headers._ContentType;
                 if ((_bits & 0x400L) != 0)
                 {
                     return value;
@@ -662,62 +645,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Warning = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Warning = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Allow
-        {
-            get
-            {
-                var value = _headers._Allow;
-                if ((_bits & 0x800L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x800L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Allow = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Allow = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentType
-        {
-            get
-            {
-                var value = _headers._ContentType;
-                if ((_bits & 0x1000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x1000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
                     _headers._ContentType = value;
                 }
                 else
@@ -727,67 +654,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
         }
-        StringValues IHeaderDictionary.ContentEncoding
+        StringValues IHeaderDictionary.Accept
         {
             get
             {
-                var value = _headers._ContentEncoding;
-                if ((_bits & 0x2000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x2000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentEncoding = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentEncoding = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentLanguage
-        {
-            get
-            {
-                var value = _headers._ContentLanguage;
-                if ((_bits & 0x4000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x4000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentLanguage = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentLanguage = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentLocation
-        {
-            get
-            {
-                var value = _headers._ContentLocation;
+                var value = _headers._Accept;
                 if ((_bits & 0x8000L) != 0)
                 {
                     return value;
@@ -799,146 +670,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x8000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentLocation = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentLocation = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentMD5
-        {
-            get
-            {
-                var value = _headers._ContentMD5;
-                if ((_bits & 0x10000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x10000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentMD5 = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentMD5 = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentRange
-        {
-            get
-            {
-                var value = _headers._ContentRange;
-                if ((_bits & 0x20000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x20000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentRange = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentRange = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Expires
-        {
-            get
-            {
-                var value = _headers._Expires;
-                if ((_bits & 0x40000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x40000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Expires = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Expires = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.LastModified
-        {
-            get
-            {
-                var value = _headers._LastModified;
-                if ((_bits & 0x80000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x80000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._LastModified = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._LastModified = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Accept
-        {
-            get
-            {
-                var value = _headers._Accept;
-                if ((_bits & 0x1000000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x1000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -956,7 +687,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._AcceptCharset;
-                if ((_bits & 0x2000000L) != 0)
+                if ((_bits & 0x10000L) != 0)
                 {
                     return value;
                 }
@@ -966,7 +697,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x2000000L;
+                var flag = 0x10000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -984,7 +715,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._AcceptEncoding;
-                if ((_bits & 0x4000000L) != 0)
+                if ((_bits & 0x20000L) != 0)
                 {
                     return value;
                 }
@@ -994,7 +725,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x4000000L;
+                var flag = 0x20000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1012,7 +743,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._AcceptLanguage;
-                if ((_bits & 0x8000000L) != 0)
+                if ((_bits & 0x40000L) != 0)
                 {
                     return value;
                 }
@@ -1022,7 +753,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x8000000L;
+                var flag = 0x40000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1040,7 +771,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Authorization;
-                if ((_bits & 0x10000000L) != 0)
+                if ((_bits & 0x80000L) != 0)
                 {
                     return value;
                 }
@@ -1050,7 +781,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x10000000L;
+                var flag = 0x80000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1068,7 +799,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Cookie;
-                if ((_bits & 0x20000000L) != 0)
+                if ((_bits & 0x100000L) != 0)
                 {
                     return value;
                 }
@@ -1078,7 +809,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x20000000L;
+                var flag = 0x100000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1096,7 +827,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Expect;
-                if ((_bits & 0x40000000L) != 0)
+                if ((_bits & 0x200000L) != 0)
                 {
                     return value;
                 }
@@ -1106,7 +837,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x40000000L;
+                var flag = 0x200000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1124,7 +855,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._From;
-                if ((_bits & 0x80000000L) != 0)
+                if ((_bits & 0x400000L) != 0)
                 {
                     return value;
                 }
@@ -1134,7 +865,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x80000000L;
+                var flag = 0x400000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1152,7 +883,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._GrpcAcceptEncoding;
-                if ((_bits & 0x100000000L) != 0)
+                if ((_bits & 0x800000L) != 0)
                 {
                     return value;
                 }
@@ -1162,7 +893,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x100000000L;
+                var flag = 0x800000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1180,7 +911,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._GrpcTimeout;
-                if ((_bits & 0x200000000L) != 0)
+                if ((_bits & 0x1000000L) != 0)
                 {
                     return value;
                 }
@@ -1190,7 +921,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x200000000L;
+                var flag = 0x1000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1208,7 +939,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Host;
-                if ((_bits & 0x400000000L) != 0)
+                if ((_bits & 0x2000000L) != 0)
                 {
                     return value;
                 }
@@ -1218,7 +949,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x400000000L;
+                var flag = 0x2000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1236,7 +967,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfMatch;
-                if ((_bits & 0x800000000L) != 0)
+                if ((_bits & 0x4000000L) != 0)
                 {
                     return value;
                 }
@@ -1246,7 +977,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x800000000L;
+                var flag = 0x4000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1264,7 +995,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfModifiedSince;
-                if ((_bits & 0x1000000000L) != 0)
+                if ((_bits & 0x8000000L) != 0)
                 {
                     return value;
                 }
@@ -1274,7 +1005,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x1000000000L;
+                var flag = 0x8000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1292,7 +1023,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfNoneMatch;
-                if ((_bits & 0x2000000000L) != 0)
+                if ((_bits & 0x10000000L) != 0)
                 {
                     return value;
                 }
@@ -1302,7 +1033,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x2000000000L;
+                var flag = 0x10000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1320,7 +1051,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfRange;
-                if ((_bits & 0x4000000000L) != 0)
+                if ((_bits & 0x20000000L) != 0)
                 {
                     return value;
                 }
@@ -1330,7 +1061,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x4000000000L;
+                var flag = 0x20000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1348,7 +1079,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfUnmodifiedSince;
-                if ((_bits & 0x8000000000L) != 0)
+                if ((_bits & 0x40000000L) != 0)
                 {
                     return value;
                 }
@@ -1358,7 +1089,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x8000000000L;
+                var flag = 0x40000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1376,7 +1107,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._MaxForwards;
-                if ((_bits & 0x10000000000L) != 0)
+                if ((_bits & 0x80000000L) != 0)
                 {
                     return value;
                 }
@@ -1386,7 +1117,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x10000000000L;
+                var flag = 0x80000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1404,7 +1135,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._ProxyAuthorization;
-                if ((_bits & 0x20000000000L) != 0)
+                if ((_bits & 0x100000000L) != 0)
                 {
                     return value;
                 }
@@ -1414,7 +1145,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x20000000000L;
+                var flag = 0x100000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1432,7 +1163,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Referer;
-                if ((_bits & 0x40000000000L) != 0)
+                if ((_bits & 0x200000000L) != 0)
                 {
                     return value;
                 }
@@ -1442,7 +1173,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x40000000000L;
+                var flag = 0x200000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1460,7 +1191,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Range;
-                if ((_bits & 0x80000000000L) != 0)
+                if ((_bits & 0x400000000L) != 0)
                 {
                     return value;
                 }
@@ -1470,7 +1201,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x80000000000L;
+                var flag = 0x400000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1488,7 +1219,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._TE;
-                if ((_bits & 0x100000000000L) != 0)
+                if ((_bits & 0x800000000L) != 0)
                 {
                     return value;
                 }
@@ -1498,7 +1229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x100000000000L;
+                var flag = 0x800000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1516,7 +1247,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Translate;
-                if ((_bits & 0x200000000000L) != 0)
+                if ((_bits & 0x1000000000L) != 0)
                 {
                     return value;
                 }
@@ -1526,7 +1257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x200000000000L;
+                var flag = 0x1000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1544,7 +1275,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._UserAgent;
-                if ((_bits & 0x400000000000L) != 0)
+                if ((_bits & 0x2000000000L) != 0)
                 {
                     return value;
                 }
@@ -1554,7 +1285,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x400000000000L;
+                var flag = 0x2000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1572,7 +1303,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._UpgradeInsecureRequests;
-                if ((_bits & 0x800000000000L) != 0)
+                if ((_bits & 0x4000000000L) != 0)
                 {
                     return value;
                 }
@@ -1582,7 +1313,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x800000000000L;
+                var flag = 0x4000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1600,7 +1331,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._RequestId;
-                if ((_bits & 0x1000000000000L) != 0)
+                if ((_bits & 0x8000000000L) != 0)
                 {
                     return value;
                 }
@@ -1610,7 +1341,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x1000000000000L;
+                var flag = 0x8000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1628,7 +1359,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._CorrelationContext;
-                if ((_bits & 0x2000000000000L) != 0)
+                if ((_bits & 0x10000000000L) != 0)
                 {
                     return value;
                 }
@@ -1638,7 +1369,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x2000000000000L;
+                var flag = 0x10000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1656,7 +1387,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._TraceParent;
-                if ((_bits & 0x4000000000000L) != 0)
+                if ((_bits & 0x20000000000L) != 0)
                 {
                     return value;
                 }
@@ -1666,7 +1397,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x4000000000000L;
+                var flag = 0x20000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1684,7 +1415,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._TraceState;
-                if ((_bits & 0x8000000000000L) != 0)
+                if ((_bits & 0x40000000000L) != 0)
                 {
                     return value;
                 }
@@ -1694,7 +1425,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x8000000000000L;
+                var flag = 0x40000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1712,7 +1443,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Baggage;
-                if ((_bits & 0x10000000000000L) != 0)
+                if ((_bits & 0x80000000000L) != 0)
                 {
                     return value;
                 }
@@ -1722,7 +1453,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x10000000000000L;
+                var flag = 0x80000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1740,7 +1471,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Origin;
-                if ((_bits & 0x20000000000000L) != 0)
+                if ((_bits & 0x100000000000L) != 0)
                 {
                     return value;
                 }
@@ -1750,7 +1481,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x20000000000000L;
+                var flag = 0x100000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1768,7 +1499,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._AccessControlRequestMethod;
-                if ((_bits & 0x40000000000000L) != 0)
+                if ((_bits & 0x200000000000L) != 0)
                 {
                     return value;
                 }
@@ -1778,7 +1509,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x40000000000000L;
+                var flag = 0x200000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1796,7 +1527,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._AccessControlRequestHeaders;
-                if ((_bits & 0x80000000000000L) != 0)
+                if ((_bits & 0x400000000000L) != 0)
                 {
                     return value;
                 }
@@ -1806,7 +1537,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x80000000000000L;
+                var flag = 0x400000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1964,6 +1695,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 SetValueUnknown(HeaderNames.Age, value);
             }
         }
+        StringValues IHeaderDictionary.Allow
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.Allow, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.Allow, value);
+            }
+        }
         StringValues IHeaderDictionary.AltSvc
         {
             get
@@ -1998,6 +1747,96 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 SetValueUnknown(HeaderNames.ContentDisposition, value);
+            }
+        }
+        StringValues IHeaderDictionary.ContentEncoding
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.ContentEncoding, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.ContentEncoding, value);
+            }
+        }
+        StringValues IHeaderDictionary.ContentLanguage
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.ContentLanguage, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.ContentLanguage, value);
+            }
+        }
+        StringValues IHeaderDictionary.ContentLocation
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.ContentLocation, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.ContentLocation, value);
+            }
+        }
+        StringValues IHeaderDictionary.ContentMD5
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.ContentMD5, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.ContentMD5, value);
+            }
+        }
+        StringValues IHeaderDictionary.ContentRange
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.ContentRange, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.ContentRange, value);
             }
         }
         StringValues IHeaderDictionary.ContentSecurityPolicy
@@ -2054,6 +1893,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 SetValueUnknown(HeaderNames.ETag, value);
             }
         }
+        StringValues IHeaderDictionary.Expires
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.Expires, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.Expires, value);
+            }
+        }
         StringValues IHeaderDictionary.GrpcMessage
         {
             get
@@ -2088,6 +1945,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 SetValueUnknown(HeaderNames.GrpcStatus, value);
+            }
+        }
+        StringValues IHeaderDictionary.LastModified
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.LastModified, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.LastModified, value);
             }
         }
         StringValues IHeaderDictionary.Link
@@ -2306,6 +2181,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 SetValueUnknown(HeaderNames.StrictTransportSecurity, value);
             }
         }
+        StringValues IHeaderDictionary.Trailer
+        {
+            get
+            {
+                StringValues value = default;
+                if (!TryGetUnknown(HeaderNames.Trailer, ref value))
+                {
+                    value = default;
+                }
+                return value;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                SetValueUnknown(HeaderNames.Trailer, value);
+            }
+        }
         StringValues IHeaderDictionary.Vary
         {
             get
@@ -2483,7 +2376,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TE, key))
                     {
-                        if ((_bits & 0x100000000000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
                             value = _headers._TE;
                             return true;
@@ -2493,7 +2386,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.TE.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
                             value = _headers._TE;
                             return true;
@@ -2506,7 +2399,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
                             value = _headers._Via;
                             return true;
@@ -2516,7 +2409,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
                             value = _headers._Via;
                             return true;
@@ -2529,7 +2422,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Host, key))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
                             value = _headers._Host;
                             return true;
@@ -2547,7 +2440,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.From, key))
                     {
-                        if ((_bits & 0x80000000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
                             value = _headers._From;
                             return true;
@@ -2557,7 +2450,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Host.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
                             value = _headers._Host;
                             return true;
@@ -2575,7 +2468,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.From.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
                             value = _headers._From;
                             return true;
@@ -2586,18 +2479,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Allow, key))
-                    {
-                        if ((_bits & 0x800L) != 0)
-                        {
-                            value = _headers._Allow;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
                             value = _headers._Path;
                             return true;
@@ -2606,7 +2490,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
                     {
-                        if ((_bits & 0x80000000000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
                             value = _headers._Range;
                             return true;
@@ -2614,18 +2498,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
-                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800L) != 0)
-                        {
-                            value = _headers._Allow;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
                             value = _headers._Path;
                             return true;
@@ -2634,7 +2509,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
                             value = _headers._Range;
                             return true;
@@ -2647,7 +2522,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Accept, key))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
                             value = _headers._Accept;
                             return true;
@@ -2665,7 +2540,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Cookie, key))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
                             value = _headers._Cookie;
                             return true;
@@ -2674,7 +2549,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expect, key))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
                             value = _headers._Expect;
                             return true;
@@ -2683,7 +2558,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x20000000000000L) != 0)
+                        if ((_bits & 0x100000000000L) != 0)
                         {
                             value = _headers._Origin;
                             return true;
@@ -2693,7 +2568,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Accept.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
                             value = _headers._Accept;
                             return true;
@@ -2711,7 +2586,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Cookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
                             value = _headers._Cookie;
                             return true;
@@ -2720,7 +2595,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expect.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
                             value = _headers._Expect;
                             return true;
@@ -2729,7 +2604,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000000L) != 0)
+                        if ((_bits & 0x100000000000L) != 0)
                         {
                             value = _headers._Origin;
                             return true;
@@ -2740,18 +2615,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Trailer, key))
-                    {
-                        if ((_bits & 0x40L) != 0)
-                        {
-                            value = _headers._Trailer;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
                             value = _headers._Upgrade;
                             return true;
@@ -2760,25 +2626,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._Warning;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Expires, key))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            value = _headers._Expires;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Method, key))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
                             value = _headers._Method;
                             return true;
@@ -2787,7 +2644,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Scheme, key))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
                             value = _headers._Scheme;
                             return true;
@@ -2796,7 +2653,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
-                        if ((_bits & 0x40000000000L) != 0)
+                        if ((_bits & 0x200000000L) != 0)
                         {
                             value = _headers._Referer;
                             return true;
@@ -2805,7 +2662,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x10000000000000L) != 0)
+                        if ((_bits & 0x80000000000L) != 0)
                         {
                             value = _headers._Baggage;
                             return true;
@@ -2813,18 +2670,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
-                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x40L) != 0)
-                        {
-                            value = _headers._Trailer;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
                             value = _headers._Upgrade;
                             return true;
@@ -2833,25 +2681,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._Warning;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            value = _headers._Expires;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
                             value = _headers._Method;
                             return true;
@@ -2860,7 +2699,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
                             value = _headers._Scheme;
                             return true;
@@ -2869,7 +2708,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000L) != 0)
+                        if ((_bits & 0x200000000L) != 0)
                         {
                             value = _headers._Referer;
                             return true;
@@ -2878,7 +2717,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000000L) != 0)
+                        if ((_bits & 0x80000000000L) != 0)
                         {
                             value = _headers._Baggage;
                             return true;
@@ -2891,7 +2730,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfMatch, key))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
                             value = _headers._IfMatch;
                             return true;
@@ -2900,7 +2739,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfRange, key))
                     {
-                        if ((_bits & 0x4000000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
                             value = _headers._IfRange;
                             return true;
@@ -2910,7 +2749,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.IfMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
                             value = _headers._IfMatch;
                             return true;
@@ -2919,7 +2758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
                             value = _headers._IfRange;
                             return true;
@@ -2932,7 +2771,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Translate, key))
                     {
-                        if ((_bits & 0x200000000000L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
                         {
                             value = _headers._Translate;
                             return true;
@@ -2942,7 +2781,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Translate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000000L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
                         {
                             value = _headers._Translate;
                             return true;
@@ -2964,7 +2803,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
-                        if ((_bits & 0x400000000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
                             value = _headers._UserAgent;
                             return true;
@@ -2982,7 +2821,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Authority, key))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
                             value = _headers._Authority;
                             return true;
@@ -2991,7 +2830,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x1000000000000L) != 0)
+                        if ((_bits & 0x8000000000L) != 0)
                         {
                             value = _headers._RequestId;
                             return true;
@@ -3000,7 +2839,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x8000000000000L) != 0)
+                        if ((_bits & 0x40000000000L) != 0)
                         {
                             value = _headers._TraceState;
                             return true;
@@ -3019,7 +2858,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
                             value = _headers._UserAgent;
                             return true;
@@ -3037,7 +2876,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
                             value = _headers._Authority;
                             return true;
@@ -3046,7 +2885,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000000L) != 0)
+                        if ((_bits & 0x8000000000L) != 0)
                         {
                             value = _headers._RequestId;
                             return true;
@@ -3055,7 +2894,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000000L) != 0)
+                        if ((_bits & 0x40000000000L) != 0)
                         {
                             value = _headers._TraceState;
                             return true;
@@ -3066,18 +2905,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
-                    {
-                        if ((_bits & 0x10000L) != 0)
-                        {
-                            value = _headers._ContentMD5;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x4000000000000L) != 0)
+                        if ((_bits & 0x20000000000L) != 0)
                         {
                             value = _headers._TraceParent;
                             return true;
@@ -3085,18 +2915,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10000L) != 0)
-                        {
-                            value = _headers._ContentMD5;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000000L) != 0)
+                        if ((_bits & 0x20000000000L) != 0)
                         {
                             value = _headers._TraceParent;
                             return true;
@@ -3109,7 +2930,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
                             value = _headers._ContentType;
                             return true;
@@ -3118,7 +2939,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.GrpcTimeout, key))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
                             value = _headers._GrpcTimeout;
                             return true;
@@ -3127,7 +2948,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.MaxForwards, key))
                     {
-                        if ((_bits & 0x10000000000L) != 0)
+                        if ((_bits & 0x80000000L) != 0)
                         {
                             value = _headers._MaxForwards;
                             return true;
@@ -3137,7 +2958,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
                             value = _headers._ContentType;
                             return true;
@@ -3146,7 +2967,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.GrpcTimeout.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
                             value = _headers._GrpcTimeout;
                             return true;
@@ -3155,7 +2976,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.MaxForwards.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000L) != 0)
+                        if ((_bits & 0x80000000L) != 0)
                         {
                             value = _headers._MaxForwards;
                             return true;
@@ -3184,27 +3005,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.ContentRange, key))
-                    {
-                        if ((_bits & 0x20000L) != 0)
-                        {
-                            value = _headers._ContentRange;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.LastModified, key))
-                    {
-                        if ((_bits & 0x80000L) != 0)
-                        {
-                            value = _headers._LastModified;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Authorization, key))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
                             value = _headers._Authorization;
                             return true;
@@ -3213,7 +3016,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfNoneMatch, key))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
                             value = _headers._IfNoneMatch;
                             return true;
@@ -3239,27 +3042,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x20000L) != 0)
-                        {
-                            value = _headers._ContentRange;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x80000L) != 0)
-                        {
-                            value = _headers._LastModified;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
                             value = _headers._Authorization;
                             return true;
@@ -3268,7 +3053,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfNoneMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
                             value = _headers._IfNoneMatch;
                             return true;
@@ -3281,7 +3066,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptCharset, key))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
                             value = _headers._AcceptCharset;
                             return true;
@@ -3300,7 +3085,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AcceptCharset.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
                             value = _headers._AcceptCharset;
                             return true;
@@ -3322,7 +3107,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptEncoding, key))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
                             value = _headers._AcceptEncoding;
                             return true;
@@ -3331,7 +3116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AcceptLanguage, key))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
                             value = _headers._AcceptLanguage;
                             return true;
@@ -3341,7 +3126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
                             value = _headers._AcceptEncoding;
                             return true;
@@ -3350,68 +3135,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AcceptLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
                             value = _headers._AcceptLanguage;
-                            return true;
-                        }
-                        return false;
-                    }
-                    break;
-                }
-                case 16:
-                {
-                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
-                    {
-                        if ((_bits & 0x2000L) != 0)
-                        {
-                            value = _headers._ContentEncoding;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
-                    {
-                        if ((_bits & 0x4000L) != 0)
-                        {
-                            value = _headers._ContentLanguage;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
-                    {
-                        if ((_bits & 0x8000L) != 0)
-                        {
-                            value = _headers._ContentLocation;
-                            return true;
-                        }
-                        return false;
-                    }
-
-                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x2000L) != 0)
-                        {
-                            value = _headers._ContentEncoding;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x4000L) != 0)
-                        {
-                            value = _headers._ContentLanguage;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x8000L) != 0)
-                        {
-                            value = _headers._ContentLocation;
                             return true;
                         }
                         return false;
@@ -3422,7 +3148,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
                             value = _headers._TransferEncoding;
                             return true;
@@ -3431,7 +3157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
                             value = _headers._IfModifiedSince;
                             return true;
@@ -3441,7 +3167,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
                             value = _headers._TransferEncoding;
                             return true;
@@ -3450,7 +3176,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
                             value = _headers._IfModifiedSince;
                             return true;
@@ -3463,7 +3189,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfUnmodifiedSince, key))
                     {
-                        if ((_bits & 0x8000000000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
                             value = _headers._IfUnmodifiedSince;
                             return true;
@@ -3472,7 +3198,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ProxyAuthorization, key))
                     {
-                        if ((_bits & 0x20000000000L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
                             value = _headers._ProxyAuthorization;
                             return true;
@@ -3481,7 +3207,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.CorrelationContext, key))
                     {
-                        if ((_bits & 0x2000000000000L) != 0)
+                        if ((_bits & 0x10000000000L) != 0)
                         {
                             value = _headers._CorrelationContext;
                             return true;
@@ -3491,7 +3217,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.IfUnmodifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
                             value = _headers._IfUnmodifiedSince;
                             return true;
@@ -3500,7 +3226,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ProxyAuthorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
                             value = _headers._ProxyAuthorization;
                             return true;
@@ -3509,7 +3235,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000000L) != 0)
+                        if ((_bits & 0x10000000000L) != 0)
                         {
                             value = _headers._CorrelationContext;
                             return true;
@@ -3522,7 +3248,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.GrpcAcceptEncoding, key))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
                             value = _headers._GrpcAcceptEncoding;
                             return true;
@@ -3532,7 +3258,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.GrpcAcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
                             value = _headers._GrpcAcceptEncoding;
                             return true;
@@ -3545,7 +3271,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x800000000000L) != 0)
+                        if ((_bits & 0x4000000000L) != 0)
                         {
                             value = _headers._UpgradeInsecureRequests;
                             return true;
@@ -3555,7 +3281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000000L) != 0)
+                        if ((_bits & 0x4000000000L) != 0)
                         {
                             value = _headers._UpgradeInsecureRequests;
                             return true;
@@ -3568,7 +3294,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x40000000000000L) != 0)
+                        if ((_bits & 0x200000000000L) != 0)
                         {
                             value = _headers._AccessControlRequestMethod;
                             return true;
@@ -3578,7 +3304,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000000L) != 0)
+                        if ((_bits & 0x200000000000L) != 0)
                         {
                             value = _headers._AccessControlRequestMethod;
                             return true;
@@ -3591,7 +3317,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x80000000000000L) != 0)
+                        if ((_bits & 0x400000000000L) != 0)
                         {
                             value = _headers._AccessControlRequestHeaders;
                             return true;
@@ -3601,7 +3327,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000000L) != 0)
+                        if ((_bits & 0x400000000000L) != 0)
                         {
                             value = _headers._AccessControlRequestHeaders;
                             return true;
@@ -3623,14 +3349,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TE, key))
                     {
-                        _bits |= 0x100000000000L;
+                        _bits |= 0x800000000L;
                         _headers._TE = value;
                         return;
                     }
 
                     if (HeaderNames.TE.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000000000L;
+                        _bits |= 0x800000000L;
                         _headers._TE = value;
                         return;
                     }
@@ -3640,14 +3366,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        _bits |= 0x200L;
+                        _bits |= 0x100L;
                         _headers._Via = value;
                         return;
                     }
 
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200L;
+                        _bits |= 0x100L;
                         _headers._Via = value;
                         return;
                     }
@@ -3657,7 +3383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Host, key))
                     {
-                        _bits |= 0x400000000L;
+                        _bits |= 0x2000000L;
                         _headers._Host = value;
                         return;
                     }
@@ -3669,14 +3395,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.From, key))
                     {
-                        _bits |= 0x80000000L;
+                        _bits |= 0x400000L;
                         _headers._From = value;
                         return;
                     }
 
                     if (HeaderNames.Host.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000000L;
+                        _bits |= 0x2000000L;
                         _headers._Host = value;
                         return;
                     }
@@ -3688,7 +3414,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.From.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80000000L;
+                        _bits |= 0x400000L;
                         _headers._From = value;
                         return;
                     }
@@ -3696,40 +3422,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Allow, key))
-                    {
-                        _bits |= 0x800L;
-                        _headers._Allow = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
-                        _bits |= 0x400000L;
+                        _bits |= 0x2000L;
                         _headers._Path = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
                     {
-                        _bits |= 0x80000000000L;
+                        _bits |= 0x400000000L;
                         _headers._Range = value;
                         return;
                     }
 
-                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x800L;
-                        _headers._Allow = value;
-                        return;
-                    }
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000L;
+                        _bits |= 0x2000L;
                         _headers._Path = value;
                         return;
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80000000000L;
+                        _bits |= 0x400000000L;
                         _headers._Range = value;
                         return;
                     }
@@ -3739,7 +3453,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Accept, key))
                     {
-                        _bits |= 0x1000000L;
+                        _bits |= 0x8000L;
                         _headers._Accept = value;
                         return;
                     }
@@ -3751,26 +3465,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Cookie, key))
                     {
-                        _bits |= 0x20000000L;
+                        _bits |= 0x100000L;
                         _headers._Cookie = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Expect, key))
                     {
-                        _bits |= 0x40000000L;
+                        _bits |= 0x200000L;
                         _headers._Expect = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        _bits |= 0x20000000000000L;
+                        _bits |= 0x100000000000L;
                         _headers._Origin = value;
                         return;
                     }
 
                     if (HeaderNames.Accept.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000000L;
+                        _bits |= 0x8000L;
                         _headers._Accept = value;
                         return;
                     }
@@ -3782,19 +3496,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Cookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000000L;
+                        _bits |= 0x100000L;
                         _headers._Cookie = value;
                         return;
                     }
                     if (HeaderNames.Expect.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000000L;
+                        _bits |= 0x200000L;
                         _headers._Expect = value;
                         return;
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000000000000L;
+                        _bits |= 0x100000000000L;
                         _headers._Origin = value;
                         return;
                     }
@@ -3802,100 +3516,76 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Trailer, key))
-                    {
-                        _bits |= 0x40L;
-                        _headers._Trailer = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        _bits |= 0x100L;
+                        _bits |= 0x80L;
                         _headers._Upgrade = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        _bits |= 0x400L;
+                        _bits |= 0x200L;
                         _headers._Warning = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Expires, key))
-                    {
-                        _bits |= 0x40000L;
-                        _headers._Expires = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Method, key))
                     {
-                        _bits |= 0x200000L;
+                        _bits |= 0x1000L;
                         _headers._Method = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Scheme, key))
                     {
-                        _bits |= 0x800000L;
+                        _bits |= 0x4000L;
                         _headers._Scheme = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
-                        _bits |= 0x40000000000L;
+                        _bits |= 0x200000000L;
                         _headers._Referer = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        _bits |= 0x10000000000000L;
+                        _bits |= 0x80000000000L;
                         _headers._Baggage = value;
                         return;
                     }
 
-                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x40L;
-                        _headers._Trailer = value;
-                        return;
-                    }
                     if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100L;
+                        _bits |= 0x80L;
                         _headers._Upgrade = value;
                         return;
                     }
                     if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400L;
+                        _bits |= 0x200L;
                         _headers._Warning = value;
-                        return;
-                    }
-                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x40000L;
-                        _headers._Expires = value;
                         return;
                     }
                     if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200000L;
+                        _bits |= 0x1000L;
                         _headers._Method = value;
                         return;
                     }
                     if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800000L;
+                        _bits |= 0x4000L;
                         _headers._Scheme = value;
                         return;
                     }
                     if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000000000L;
+                        _bits |= 0x200000000L;
                         _headers._Referer = value;
                         return;
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000000000000L;
+                        _bits |= 0x80000000000L;
                         _headers._Baggage = value;
                         return;
                     }
@@ -3905,26 +3595,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfMatch, key))
                     {
-                        _bits |= 0x800000000L;
+                        _bits |= 0x4000000L;
                         _headers._IfMatch = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.IfRange, key))
                     {
-                        _bits |= 0x4000000000L;
+                        _bits |= 0x20000000L;
                         _headers._IfRange = value;
                         return;
                     }
 
                     if (HeaderNames.IfMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800000000L;
+                        _bits |= 0x4000000L;
                         _headers._IfMatch = value;
                         return;
                     }
                     if (HeaderNames.IfRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000000000L;
+                        _bits |= 0x20000000L;
                         _headers._IfRange = value;
                         return;
                     }
@@ -3934,14 +3624,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Translate, key))
                     {
-                        _bits |= 0x200000000000L;
+                        _bits |= 0x1000000000L;
                         _headers._Translate = value;
                         return;
                     }
 
                     if (HeaderNames.Translate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200000000000L;
+                        _bits |= 0x1000000000L;
                         _headers._Translate = value;
                         return;
                     }
@@ -3957,7 +3647,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
-                        _bits |= 0x400000000000L;
+                        _bits |= 0x2000000000L;
                         _headers._UserAgent = value;
                         return;
                     }
@@ -3969,19 +3659,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Authority, key))
                     {
-                        _bits |= 0x100000L;
+                        _bits |= 0x800L;
                         _headers._Authority = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        _bits |= 0x1000000000000L;
+                        _bits |= 0x8000000000L;
                         _headers._RequestId = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        _bits |= 0x8000000000000L;
+                        _bits |= 0x40000000000L;
                         _headers._TraceState = value;
                         return;
                     }
@@ -3994,7 +3684,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000000000L;
+                        _bits |= 0x2000000000L;
                         _headers._UserAgent = value;
                         return;
                     }
@@ -4006,19 +3696,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000L;
+                        _bits |= 0x800L;
                         _headers._Authority = value;
                         return;
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000000000000L;
+                        _bits |= 0x8000000000L;
                         _headers._RequestId = value;
                         return;
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000000000000L;
+                        _bits |= 0x40000000000L;
                         _headers._TraceState = value;
                         return;
                     }
@@ -4026,28 +3716,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
-                    {
-                        _bits |= 0x10000L;
-                        _headers._ContentMD5 = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        _bits |= 0x4000000000000L;
+                        _bits |= 0x20000000000L;
                         _headers._TraceParent = value;
                         return;
                     }
 
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x10000L;
-                        _headers._ContentMD5 = value;
-                        return;
-                    }
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000000000000L;
+                        _bits |= 0x20000000000L;
                         _headers._TraceParent = value;
                         return;
                     }
@@ -4057,38 +3735,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        _bits |= 0x1000L;
+                        _bits |= 0x400L;
                         _headers._ContentType = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.GrpcTimeout, key))
                     {
-                        _bits |= 0x200000000L;
+                        _bits |= 0x1000000L;
                         _headers._GrpcTimeout = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.MaxForwards, key))
                     {
-                        _bits |= 0x10000000000L;
+                        _bits |= 0x80000000L;
                         _headers._MaxForwards = value;
                         return;
                     }
 
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000L;
+                        _bits |= 0x400L;
                         _headers._ContentType = value;
                         return;
                     }
                     if (HeaderNames.GrpcTimeout.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200000000L;
+                        _bits |= 0x1000000L;
                         _headers._GrpcTimeout = value;
                         return;
                     }
                     if (HeaderNames.MaxForwards.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000000000L;
+                        _bits |= 0x80000000L;
                         _headers._MaxForwards = value;
                         return;
                     }
@@ -4108,27 +3786,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._GrpcEncoding = value;
                         return;
                     }
-                    if (ReferenceEquals(HeaderNames.ContentRange, key))
-                    {
-                        _bits |= 0x20000L;
-                        _headers._ContentRange = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.LastModified, key))
-                    {
-                        _bits |= 0x80000L;
-                        _headers._LastModified = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Authorization, key))
                     {
-                        _bits |= 0x10000000L;
+                        _bits |= 0x80000L;
                         _headers._Authorization = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.IfNoneMatch, key))
                     {
-                        _bits |= 0x2000000000L;
+                        _bits |= 0x10000000L;
                         _headers._IfNoneMatch = value;
                         return;
                     }
@@ -4145,27 +3811,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._GrpcEncoding = value;
                         return;
                     }
-                    if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x20000L;
-                        _headers._ContentRange = value;
-                        return;
-                    }
-                    if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x80000L;
-                        _headers._LastModified = value;
-                        return;
-                    }
                     if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000000L;
+                        _bits |= 0x80000L;
                         _headers._Authorization = value;
                         return;
                     }
                     if (HeaderNames.IfNoneMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000000L;
+                        _bits |= 0x10000000L;
                         _headers._IfNoneMatch = value;
                         return;
                     }
@@ -4175,7 +3829,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptCharset, key))
                     {
-                        _bits |= 0x2000000L;
+                        _bits |= 0x10000L;
                         _headers._AcceptCharset = value;
                         return;
                     }
@@ -4187,7 +3841,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AcceptCharset.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000L;
+                        _bits |= 0x10000L;
                         _headers._AcceptCharset = value;
                         return;
                     }
@@ -4202,68 +3856,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptEncoding, key))
                     {
-                        _bits |= 0x4000000L;
+                        _bits |= 0x20000L;
                         _headers._AcceptEncoding = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.AcceptLanguage, key))
                     {
-                        _bits |= 0x8000000L;
+                        _bits |= 0x40000L;
                         _headers._AcceptLanguage = value;
                         return;
                     }
 
                     if (HeaderNames.AcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000000L;
+                        _bits |= 0x20000L;
                         _headers._AcceptEncoding = value;
                         return;
                     }
                     if (HeaderNames.AcceptLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000000L;
+                        _bits |= 0x40000L;
                         _headers._AcceptLanguage = value;
-                        return;
-                    }
-                    break;
-                }
-                case 16:
-                {
-                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
-                    {
-                        _bits |= 0x2000L;
-                        _headers._ContentEncoding = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
-                    {
-                        _bits |= 0x4000L;
-                        _headers._ContentLanguage = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
-                    {
-                        _bits |= 0x8000L;
-                        _headers._ContentLocation = value;
-                        return;
-                    }
-
-                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x2000L;
-                        _headers._ContentEncoding = value;
-                        return;
-                    }
-                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x4000L;
-                        _headers._ContentLanguage = value;
-                        return;
-                    }
-                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x8000L;
-                        _headers._ContentLocation = value;
                         return;
                     }
                     break;
@@ -4272,26 +3885,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        _bits |= 0x80L;
+                        _bits |= 0x40L;
                         _headers._TransferEncoding = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
                     {
-                        _bits |= 0x1000000000L;
+                        _bits |= 0x8000000L;
                         _headers._IfModifiedSince = value;
                         return;
                     }
 
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80L;
+                        _bits |= 0x40L;
                         _headers._TransferEncoding = value;
                         return;
                     }
                     if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000000000L;
+                        _bits |= 0x8000000L;
                         _headers._IfModifiedSince = value;
                         return;
                     }
@@ -4301,38 +3914,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfUnmodifiedSince, key))
                     {
-                        _bits |= 0x8000000000L;
+                        _bits |= 0x40000000L;
                         _headers._IfUnmodifiedSince = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.ProxyAuthorization, key))
                     {
-                        _bits |= 0x20000000000L;
+                        _bits |= 0x100000000L;
                         _headers._ProxyAuthorization = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.CorrelationContext, key))
                     {
-                        _bits |= 0x2000000000000L;
+                        _bits |= 0x10000000000L;
                         _headers._CorrelationContext = value;
                         return;
                     }
 
                     if (HeaderNames.IfUnmodifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000000000L;
+                        _bits |= 0x40000000L;
                         _headers._IfUnmodifiedSince = value;
                         return;
                     }
                     if (HeaderNames.ProxyAuthorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000000000L;
+                        _bits |= 0x100000000L;
                         _headers._ProxyAuthorization = value;
                         return;
                     }
                     if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000000000L;
+                        _bits |= 0x10000000000L;
                         _headers._CorrelationContext = value;
                         return;
                     }
@@ -4342,14 +3955,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.GrpcAcceptEncoding, key))
                     {
-                        _bits |= 0x100000000L;
+                        _bits |= 0x800000L;
                         _headers._GrpcAcceptEncoding = value;
                         return;
                     }
 
                     if (HeaderNames.GrpcAcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000000L;
+                        _bits |= 0x800000L;
                         _headers._GrpcAcceptEncoding = value;
                         return;
                     }
@@ -4359,14 +3972,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        _bits |= 0x800000000000L;
+                        _bits |= 0x4000000000L;
                         _headers._UpgradeInsecureRequests = value;
                         return;
                     }
 
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800000000000L;
+                        _bits |= 0x4000000000L;
                         _headers._UpgradeInsecureRequests = value;
                         return;
                     }
@@ -4376,14 +3989,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        _bits |= 0x40000000000000L;
+                        _bits |= 0x200000000000L;
                         _headers._AccessControlRequestMethod = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000000000000L;
+                        _bits |= 0x200000000000L;
                         _headers._AccessControlRequestMethod = value;
                         return;
                     }
@@ -4393,14 +4006,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        _bits |= 0x80000000000000L;
+                        _bits |= 0x400000000000L;
                         _headers._AccessControlRequestHeaders = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80000000000000L;
+                        _bits |= 0x400000000000L;
                         _headers._AccessControlRequestHeaders = value;
                         return;
                     }
@@ -4419,9 +4032,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TE, key))
                     {
-                        if ((_bits & 0x100000000000L) == 0)
+                        if ((_bits & 0x800000000L) == 0)
                         {
-                            _bits |= 0x100000000000L;
+                            _bits |= 0x800000000L;
                             _headers._TE = value;
                             return true;
                         }
@@ -4430,9 +4043,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TE.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000L) == 0)
+                        if ((_bits & 0x800000000L) == 0)
                         {
-                            _bits |= 0x100000000000L;
+                            _bits |= 0x800000000L;
                             _headers._TE = value;
                             return true;
                         }
@@ -4444,9 +4057,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x200L) == 0)
+                        if ((_bits & 0x100L) == 0)
                         {
-                            _bits |= 0x200L;
+                            _bits |= 0x100L;
                             _headers._Via = value;
                             return true;
                         }
@@ -4455,9 +4068,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200L) == 0)
+                        if ((_bits & 0x100L) == 0)
                         {
-                            _bits |= 0x200L;
+                            _bits |= 0x100L;
                             _headers._Via = value;
                             return true;
                         }
@@ -4469,9 +4082,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Host, key))
                     {
-                        if ((_bits & 0x400000000L) == 0)
+                        if ((_bits & 0x2000000L) == 0)
                         {
-                            _bits |= 0x400000000L;
+                            _bits |= 0x2000000L;
                             _headers._Host = value;
                             return true;
                         }
@@ -4489,9 +4102,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.From, key))
                     {
-                        if ((_bits & 0x80000000L) == 0)
+                        if ((_bits & 0x400000L) == 0)
                         {
-                            _bits |= 0x80000000L;
+                            _bits |= 0x400000L;
                             _headers._From = value;
                             return true;
                         }
@@ -4500,9 +4113,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Host.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) == 0)
+                        if ((_bits & 0x2000000L) == 0)
                         {
-                            _bits |= 0x400000000L;
+                            _bits |= 0x2000000L;
                             _headers._Host = value;
                             return true;
                         }
@@ -4520,9 +4133,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.From.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000L) == 0)
+                        if ((_bits & 0x400000L) == 0)
                         {
-                            _bits |= 0x80000000L;
+                            _bits |= 0x400000L;
                             _headers._From = value;
                             return true;
                         }
@@ -4532,21 +4145,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Allow, key))
-                    {
-                        if ((_bits & 0x800L) == 0)
-                        {
-                            _bits |= 0x800L;
-                            _headers._Allow = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
-                        if ((_bits & 0x400000L) == 0)
+                        if ((_bits & 0x2000L) == 0)
                         {
-                            _bits |= 0x400000L;
+                            _bits |= 0x2000L;
                             _headers._Path = value;
                             return true;
                         }
@@ -4554,30 +4157,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
                     {
-                        if ((_bits & 0x80000000000L) == 0)
+                        if ((_bits & 0x400000000L) == 0)
                         {
-                            _bits |= 0x80000000000L;
+                            _bits |= 0x400000000L;
                             _headers._Range = value;
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800L) == 0)
-                        {
-                            _bits |= 0x800L;
-                            _headers._Allow = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) == 0)
+                        if ((_bits & 0x2000L) == 0)
                         {
-                            _bits |= 0x400000L;
+                            _bits |= 0x2000L;
                             _headers._Path = value;
                             return true;
                         }
@@ -4585,9 +4178,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000L) == 0)
+                        if ((_bits & 0x400000000L) == 0)
                         {
-                            _bits |= 0x80000000000L;
+                            _bits |= 0x400000000L;
                             _headers._Range = value;
                             return true;
                         }
@@ -4599,9 +4192,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Accept, key))
                     {
-                        if ((_bits & 0x1000000L) == 0)
+                        if ((_bits & 0x8000L) == 0)
                         {
-                            _bits |= 0x1000000L;
+                            _bits |= 0x8000L;
                             _headers._Accept = value;
                             return true;
                         }
@@ -4619,9 +4212,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Cookie, key))
                     {
-                        if ((_bits & 0x20000000L) == 0)
+                        if ((_bits & 0x100000L) == 0)
                         {
-                            _bits |= 0x20000000L;
+                            _bits |= 0x100000L;
                             _headers._Cookie = value;
                             return true;
                         }
@@ -4629,9 +4222,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expect, key))
                     {
-                        if ((_bits & 0x40000000L) == 0)
+                        if ((_bits & 0x200000L) == 0)
                         {
-                            _bits |= 0x40000000L;
+                            _bits |= 0x200000L;
                             _headers._Expect = value;
                             return true;
                         }
@@ -4639,9 +4232,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x20000000000000L) == 0)
+                        if ((_bits & 0x100000000000L) == 0)
                         {
-                            _bits |= 0x20000000000000L;
+                            _bits |= 0x100000000000L;
                             _headers._Origin = value;
                             return true;
                         }
@@ -4650,9 +4243,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Accept.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000L) == 0)
+                        if ((_bits & 0x8000L) == 0)
                         {
-                            _bits |= 0x1000000L;
+                            _bits |= 0x8000L;
                             _headers._Accept = value;
                             return true;
                         }
@@ -4670,9 +4263,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Cookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) == 0)
+                        if ((_bits & 0x100000L) == 0)
                         {
-                            _bits |= 0x20000000L;
+                            _bits |= 0x100000L;
                             _headers._Cookie = value;
                             return true;
                         }
@@ -4680,9 +4273,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expect.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) == 0)
+                        if ((_bits & 0x200000L) == 0)
                         {
-                            _bits |= 0x40000000L;
+                            _bits |= 0x200000L;
                             _headers._Expect = value;
                             return true;
                         }
@@ -4690,9 +4283,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000000L) == 0)
+                        if ((_bits & 0x100000000000L) == 0)
                         {
-                            _bits |= 0x20000000000000L;
+                            _bits |= 0x100000000000L;
                             _headers._Origin = value;
                             return true;
                         }
@@ -4702,21 +4295,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Trailer, key))
-                    {
-                        if ((_bits & 0x40L) == 0)
-                        {
-                            _bits |= 0x40L;
-                            _headers._Trailer = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x100L) == 0)
+                        if ((_bits & 0x80L) == 0)
                         {
-                            _bits |= 0x100L;
+                            _bits |= 0x80L;
                             _headers._Upgrade = value;
                             return true;
                         }
@@ -4724,29 +4307,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x400L) == 0)
+                        if ((_bits & 0x200L) == 0)
                         {
-                            _bits |= 0x400L;
+                            _bits |= 0x200L;
                             _headers._Warning = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Expires, key))
-                    {
-                        if ((_bits & 0x40000L) == 0)
-                        {
-                            _bits |= 0x40000L;
-                            _headers._Expires = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.Method, key))
                     {
-                        if ((_bits & 0x200000L) == 0)
+                        if ((_bits & 0x1000L) == 0)
                         {
-                            _bits |= 0x200000L;
+                            _bits |= 0x1000L;
                             _headers._Method = value;
                             return true;
                         }
@@ -4754,9 +4327,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Scheme, key))
                     {
-                        if ((_bits & 0x800000L) == 0)
+                        if ((_bits & 0x4000L) == 0)
                         {
-                            _bits |= 0x800000L;
+                            _bits |= 0x4000L;
                             _headers._Scheme = value;
                             return true;
                         }
@@ -4764,9 +4337,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
-                        if ((_bits & 0x40000000000L) == 0)
+                        if ((_bits & 0x200000000L) == 0)
                         {
-                            _bits |= 0x40000000000L;
+                            _bits |= 0x200000000L;
                             _headers._Referer = value;
                             return true;
                         }
@@ -4774,30 +4347,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x10000000000000L) == 0)
+                        if ((_bits & 0x80000000000L) == 0)
                         {
-                            _bits |= 0x10000000000000L;
+                            _bits |= 0x80000000000L;
                             _headers._Baggage = value;
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x40L) == 0)
-                        {
-                            _bits |= 0x40L;
-                            _headers._Trailer = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) == 0)
+                        if ((_bits & 0x80L) == 0)
                         {
-                            _bits |= 0x100L;
+                            _bits |= 0x80L;
                             _headers._Upgrade = value;
                             return true;
                         }
@@ -4805,29 +4368,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) == 0)
+                        if ((_bits & 0x200L) == 0)
                         {
-                            _bits |= 0x400L;
+                            _bits |= 0x200L;
                             _headers._Warning = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x40000L) == 0)
-                        {
-                            _bits |= 0x40000L;
-                            _headers._Expires = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) == 0)
+                        if ((_bits & 0x1000L) == 0)
                         {
-                            _bits |= 0x200000L;
+                            _bits |= 0x1000L;
                             _headers._Method = value;
                             return true;
                         }
@@ -4835,9 +4388,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) == 0)
+                        if ((_bits & 0x4000L) == 0)
                         {
-                            _bits |= 0x800000L;
+                            _bits |= 0x4000L;
                             _headers._Scheme = value;
                             return true;
                         }
@@ -4845,9 +4398,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000L) == 0)
+                        if ((_bits & 0x200000000L) == 0)
                         {
-                            _bits |= 0x40000000000L;
+                            _bits |= 0x200000000L;
                             _headers._Referer = value;
                             return true;
                         }
@@ -4855,9 +4408,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000000L) == 0)
+                        if ((_bits & 0x80000000000L) == 0)
                         {
-                            _bits |= 0x10000000000000L;
+                            _bits |= 0x80000000000L;
                             _headers._Baggage = value;
                             return true;
                         }
@@ -4869,9 +4422,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfMatch, key))
                     {
-                        if ((_bits & 0x800000000L) == 0)
+                        if ((_bits & 0x4000000L) == 0)
                         {
-                            _bits |= 0x800000000L;
+                            _bits |= 0x4000000L;
                             _headers._IfMatch = value;
                             return true;
                         }
@@ -4879,9 +4432,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfRange, key))
                     {
-                        if ((_bits & 0x4000000000L) == 0)
+                        if ((_bits & 0x20000000L) == 0)
                         {
-                            _bits |= 0x4000000000L;
+                            _bits |= 0x20000000L;
                             _headers._IfRange = value;
                             return true;
                         }
@@ -4890,9 +4443,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.IfMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) == 0)
+                        if ((_bits & 0x4000000L) == 0)
                         {
-                            _bits |= 0x800000000L;
+                            _bits |= 0x4000000L;
                             _headers._IfMatch = value;
                             return true;
                         }
@@ -4900,9 +4453,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000L) == 0)
+                        if ((_bits & 0x20000000L) == 0)
                         {
-                            _bits |= 0x4000000000L;
+                            _bits |= 0x20000000L;
                             _headers._IfRange = value;
                             return true;
                         }
@@ -4914,9 +4467,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Translate, key))
                     {
-                        if ((_bits & 0x200000000000L) == 0)
+                        if ((_bits & 0x1000000000L) == 0)
                         {
-                            _bits |= 0x200000000000L;
+                            _bits |= 0x1000000000L;
                             _headers._Translate = value;
                             return true;
                         }
@@ -4925,9 +4478,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Translate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000000L) == 0)
+                        if ((_bits & 0x1000000000L) == 0)
                         {
-                            _bits |= 0x200000000000L;
+                            _bits |= 0x1000000000L;
                             _headers._Translate = value;
                             return true;
                         }
@@ -4949,9 +4502,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
-                        if ((_bits & 0x400000000000L) == 0)
+                        if ((_bits & 0x2000000000L) == 0)
                         {
-                            _bits |= 0x400000000000L;
+                            _bits |= 0x2000000000L;
                             _headers._UserAgent = value;
                             return true;
                         }
@@ -4969,9 +4522,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Authority, key))
                     {
-                        if ((_bits & 0x100000L) == 0)
+                        if ((_bits & 0x800L) == 0)
                         {
-                            _bits |= 0x100000L;
+                            _bits |= 0x800L;
                             _headers._Authority = value;
                             return true;
                         }
@@ -4979,9 +4532,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x1000000000000L) == 0)
+                        if ((_bits & 0x8000000000L) == 0)
                         {
-                            _bits |= 0x1000000000000L;
+                            _bits |= 0x8000000000L;
                             _headers._RequestId = value;
                             return true;
                         }
@@ -4989,9 +4542,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x8000000000000L) == 0)
+                        if ((_bits & 0x40000000000L) == 0)
                         {
-                            _bits |= 0x8000000000000L;
+                            _bits |= 0x40000000000L;
                             _headers._TraceState = value;
                             return true;
                         }
@@ -5010,9 +4563,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000000L) == 0)
+                        if ((_bits & 0x2000000000L) == 0)
                         {
-                            _bits |= 0x400000000000L;
+                            _bits |= 0x2000000000L;
                             _headers._UserAgent = value;
                             return true;
                         }
@@ -5030,9 +4583,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) == 0)
+                        if ((_bits & 0x800L) == 0)
                         {
-                            _bits |= 0x100000L;
+                            _bits |= 0x800L;
                             _headers._Authority = value;
                             return true;
                         }
@@ -5040,9 +4593,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000000L) == 0)
+                        if ((_bits & 0x8000000000L) == 0)
                         {
-                            _bits |= 0x1000000000000L;
+                            _bits |= 0x8000000000L;
                             _headers._RequestId = value;
                             return true;
                         }
@@ -5050,9 +4603,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000000L) == 0)
+                        if ((_bits & 0x40000000000L) == 0)
                         {
-                            _bits |= 0x8000000000000L;
+                            _bits |= 0x40000000000L;
                             _headers._TraceState = value;
                             return true;
                         }
@@ -5062,42 +4615,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
-                    {
-                        if ((_bits & 0x10000L) == 0)
-                        {
-                            _bits |= 0x10000L;
-                            _headers._ContentMD5 = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x4000000000000L) == 0)
+                        if ((_bits & 0x20000000000L) == 0)
                         {
-                            _bits |= 0x4000000000000L;
+                            _bits |= 0x20000000000L;
                             _headers._TraceParent = value;
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10000L) == 0)
-                        {
-                            _bits |= 0x10000L;
-                            _headers._ContentMD5 = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000000L) == 0)
+                        if ((_bits & 0x20000000000L) == 0)
                         {
-                            _bits |= 0x4000000000000L;
+                            _bits |= 0x20000000000L;
                             _headers._TraceParent = value;
                             return true;
                         }
@@ -5109,9 +4642,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x1000L) == 0)
+                        if ((_bits & 0x400L) == 0)
                         {
-                            _bits |= 0x1000L;
+                            _bits |= 0x400L;
                             _headers._ContentType = value;
                             return true;
                         }
@@ -5119,9 +4652,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.GrpcTimeout, key))
                     {
-                        if ((_bits & 0x200000000L) == 0)
+                        if ((_bits & 0x1000000L) == 0)
                         {
-                            _bits |= 0x200000000L;
+                            _bits |= 0x1000000L;
                             _headers._GrpcTimeout = value;
                             return true;
                         }
@@ -5129,9 +4662,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.MaxForwards, key))
                     {
-                        if ((_bits & 0x10000000000L) == 0)
+                        if ((_bits & 0x80000000L) == 0)
                         {
-                            _bits |= 0x10000000000L;
+                            _bits |= 0x80000000L;
                             _headers._MaxForwards = value;
                             return true;
                         }
@@ -5140,9 +4673,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) == 0)
+                        if ((_bits & 0x400L) == 0)
                         {
-                            _bits |= 0x1000L;
+                            _bits |= 0x400L;
                             _headers._ContentType = value;
                             return true;
                         }
@@ -5150,9 +4683,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.GrpcTimeout.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000L) == 0)
+                        if ((_bits & 0x1000000L) == 0)
                         {
-                            _bits |= 0x200000000L;
+                            _bits |= 0x1000000L;
                             _headers._GrpcTimeout = value;
                             return true;
                         }
@@ -5160,9 +4693,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.MaxForwards.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000L) == 0)
+                        if ((_bits & 0x80000000L) == 0)
                         {
-                            _bits |= 0x10000000000L;
+                            _bits |= 0x80000000L;
                             _headers._MaxForwards = value;
                             return true;
                         }
@@ -5192,31 +4725,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.ContentRange, key))
-                    {
-                        if ((_bits & 0x20000L) == 0)
-                        {
-                            _bits |= 0x20000L;
-                            _headers._ContentRange = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.LastModified, key))
+                    if (ReferenceEquals(HeaderNames.Authorization, key))
                     {
                         if ((_bits & 0x80000L) == 0)
                         {
                             _bits |= 0x80000L;
-                            _headers._LastModified = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authorization, key))
-                    {
-                        if ((_bits & 0x10000000L) == 0)
-                        {
-                            _bits |= 0x10000000L;
                             _headers._Authorization = value;
                             return true;
                         }
@@ -5224,9 +4737,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfNoneMatch, key))
                     {
-                        if ((_bits & 0x2000000000L) == 0)
+                        if ((_bits & 0x10000000L) == 0)
                         {
-                            _bits |= 0x2000000000L;
+                            _bits |= 0x10000000L;
                             _headers._IfNoneMatch = value;
                             return true;
                         }
@@ -5253,31 +4766,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x20000L) == 0)
-                        {
-                            _bits |= 0x20000L;
-                            _headers._ContentRange = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x80000L) == 0)
                         {
                             _bits |= 0x80000L;
-                            _headers._LastModified = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10000000L) == 0)
-                        {
-                            _bits |= 0x10000000L;
                             _headers._Authorization = value;
                             return true;
                         }
@@ -5285,9 +4778,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfNoneMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) == 0)
+                        if ((_bits & 0x10000000L) == 0)
                         {
-                            _bits |= 0x2000000000L;
+                            _bits |= 0x10000000L;
                             _headers._IfNoneMatch = value;
                             return true;
                         }
@@ -5299,9 +4792,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptCharset, key))
                     {
-                        if ((_bits & 0x2000000L) == 0)
+                        if ((_bits & 0x10000L) == 0)
                         {
-                            _bits |= 0x2000000L;
+                            _bits |= 0x10000L;
                             _headers._AcceptCharset = value;
                             return true;
                         }
@@ -5319,9 +4812,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AcceptCharset.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) == 0)
+                        if ((_bits & 0x10000L) == 0)
                         {
-                            _bits |= 0x2000000L;
+                            _bits |= 0x10000L;
                             _headers._AcceptCharset = value;
                             return true;
                         }
@@ -5342,9 +4835,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptEncoding, key))
                     {
-                        if ((_bits & 0x4000000L) == 0)
+                        if ((_bits & 0x20000L) == 0)
                         {
-                            _bits |= 0x4000000L;
+                            _bits |= 0x20000L;
                             _headers._AcceptEncoding = value;
                             return true;
                         }
@@ -5352,9 +4845,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AcceptLanguage, key))
                     {
-                        if ((_bits & 0x8000000L) == 0)
+                        if ((_bits & 0x40000L) == 0)
                         {
-                            _bits |= 0x8000000L;
+                            _bits |= 0x40000L;
                             _headers._AcceptLanguage = value;
                             return true;
                         }
@@ -5363,9 +4856,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) == 0)
+                        if ((_bits & 0x20000L) == 0)
                         {
-                            _bits |= 0x4000000L;
+                            _bits |= 0x20000L;
                             _headers._AcceptEncoding = value;
                             return true;
                         }
@@ -5373,75 +4866,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AcceptLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) == 0)
+                        if ((_bits & 0x40000L) == 0)
                         {
-                            _bits |= 0x8000000L;
+                            _bits |= 0x40000L;
                             _headers._AcceptLanguage = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    break;
-                }
-                case 16:
-                {
-                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
-                    {
-                        if ((_bits & 0x2000L) == 0)
-                        {
-                            _bits |= 0x2000L;
-                            _headers._ContentEncoding = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
-                    {
-                        if ((_bits & 0x4000L) == 0)
-                        {
-                            _bits |= 0x4000L;
-                            _headers._ContentLanguage = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
-                    {
-                        if ((_bits & 0x8000L) == 0)
-                        {
-                            _bits |= 0x8000L;
-                            _headers._ContentLocation = value;
-                            return true;
-                        }
-                        return false;
-                    }
-    
-                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x2000L) == 0)
-                        {
-                            _bits |= 0x2000L;
-                            _headers._ContentEncoding = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x4000L) == 0)
-                        {
-                            _bits |= 0x4000L;
-                            _headers._ContentLanguage = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x8000L) == 0)
-                        {
-                            _bits |= 0x8000L;
-                            _headers._ContentLocation = value;
                             return true;
                         }
                         return false;
@@ -5452,9 +4880,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x80L) == 0)
+                        if ((_bits & 0x40L) == 0)
                         {
-                            _bits |= 0x80L;
+                            _bits |= 0x40L;
                             _headers._TransferEncoding = value;
                             return true;
                         }
@@ -5462,9 +4890,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
                     {
-                        if ((_bits & 0x1000000000L) == 0)
+                        if ((_bits & 0x8000000L) == 0)
                         {
-                            _bits |= 0x1000000000L;
+                            _bits |= 0x8000000L;
                             _headers._IfModifiedSince = value;
                             return true;
                         }
@@ -5473,9 +4901,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80L) == 0)
+                        if ((_bits & 0x40L) == 0)
                         {
-                            _bits |= 0x80L;
+                            _bits |= 0x40L;
                             _headers._TransferEncoding = value;
                             return true;
                         }
@@ -5483,9 +4911,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) == 0)
+                        if ((_bits & 0x8000000L) == 0)
                         {
-                            _bits |= 0x1000000000L;
+                            _bits |= 0x8000000L;
                             _headers._IfModifiedSince = value;
                             return true;
                         }
@@ -5497,9 +4925,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfUnmodifiedSince, key))
                     {
-                        if ((_bits & 0x8000000000L) == 0)
+                        if ((_bits & 0x40000000L) == 0)
                         {
-                            _bits |= 0x8000000000L;
+                            _bits |= 0x40000000L;
                             _headers._IfUnmodifiedSince = value;
                             return true;
                         }
@@ -5507,9 +4935,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ProxyAuthorization, key))
                     {
-                        if ((_bits & 0x20000000000L) == 0)
+                        if ((_bits & 0x100000000L) == 0)
                         {
-                            _bits |= 0x20000000000L;
+                            _bits |= 0x100000000L;
                             _headers._ProxyAuthorization = value;
                             return true;
                         }
@@ -5517,9 +4945,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.CorrelationContext, key))
                     {
-                        if ((_bits & 0x2000000000000L) == 0)
+                        if ((_bits & 0x10000000000L) == 0)
                         {
-                            _bits |= 0x2000000000000L;
+                            _bits |= 0x10000000000L;
                             _headers._CorrelationContext = value;
                             return true;
                         }
@@ -5528,9 +4956,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.IfUnmodifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000L) == 0)
+                        if ((_bits & 0x40000000L) == 0)
                         {
-                            _bits |= 0x8000000000L;
+                            _bits |= 0x40000000L;
                             _headers._IfUnmodifiedSince = value;
                             return true;
                         }
@@ -5538,9 +4966,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ProxyAuthorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000L) == 0)
+                        if ((_bits & 0x100000000L) == 0)
                         {
-                            _bits |= 0x20000000000L;
+                            _bits |= 0x100000000L;
                             _headers._ProxyAuthorization = value;
                             return true;
                         }
@@ -5548,9 +4976,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000000L) == 0)
+                        if ((_bits & 0x10000000000L) == 0)
                         {
-                            _bits |= 0x2000000000000L;
+                            _bits |= 0x10000000000L;
                             _headers._CorrelationContext = value;
                             return true;
                         }
@@ -5562,9 +4990,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.GrpcAcceptEncoding, key))
                     {
-                        if ((_bits & 0x100000000L) == 0)
+                        if ((_bits & 0x800000L) == 0)
                         {
-                            _bits |= 0x100000000L;
+                            _bits |= 0x800000L;
                             _headers._GrpcAcceptEncoding = value;
                             return true;
                         }
@@ -5573,9 +5001,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.GrpcAcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) == 0)
+                        if ((_bits & 0x800000L) == 0)
                         {
-                            _bits |= 0x100000000L;
+                            _bits |= 0x800000L;
                             _headers._GrpcAcceptEncoding = value;
                             return true;
                         }
@@ -5587,9 +5015,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x800000000000L) == 0)
+                        if ((_bits & 0x4000000000L) == 0)
                         {
-                            _bits |= 0x800000000000L;
+                            _bits |= 0x4000000000L;
                             _headers._UpgradeInsecureRequests = value;
                             return true;
                         }
@@ -5598,9 +5026,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000000L) == 0)
+                        if ((_bits & 0x4000000000L) == 0)
                         {
-                            _bits |= 0x800000000000L;
+                            _bits |= 0x4000000000L;
                             _headers._UpgradeInsecureRequests = value;
                             return true;
                         }
@@ -5612,9 +5040,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x40000000000000L) == 0)
+                        if ((_bits & 0x200000000000L) == 0)
                         {
-                            _bits |= 0x40000000000000L;
+                            _bits |= 0x200000000000L;
                             _headers._AccessControlRequestMethod = value;
                             return true;
                         }
@@ -5623,9 +5051,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000000L) == 0)
+                        if ((_bits & 0x200000000000L) == 0)
                         {
-                            _bits |= 0x40000000000000L;
+                            _bits |= 0x200000000000L;
                             _headers._AccessControlRequestMethod = value;
                             return true;
                         }
@@ -5637,9 +5065,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x80000000000000L) == 0)
+                        if ((_bits & 0x400000000000L) == 0)
                         {
-                            _bits |= 0x80000000000000L;
+                            _bits |= 0x400000000000L;
                             _headers._AccessControlRequestHeaders = value;
                             return true;
                         }
@@ -5648,9 +5076,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000000L) == 0)
+                        if ((_bits & 0x400000000000L) == 0)
                         {
-                            _bits |= 0x80000000000000L;
+                            _bits |= 0x400000000000L;
                             _headers._AccessControlRequestHeaders = value;
                             return true;
                         }
@@ -5671,9 +5099,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TE, key))
                     {
-                        if ((_bits & 0x100000000000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
-                            _bits &= ~0x100000000000L;
+                            _bits &= ~0x800000000L;
                             _headers._TE = default(StringValues);
                             return true;
                         }
@@ -5682,9 +5110,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TE.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
-                            _bits &= ~0x100000000000L;
+                            _bits &= ~0x800000000L;
                             _headers._TE = default(StringValues);
                             return true;
                         }
@@ -5696,9 +5124,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
-                            _bits &= ~0x200L;
+                            _bits &= ~0x100L;
                             _headers._Via = default(StringValues);
                             return true;
                         }
@@ -5707,9 +5135,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
-                            _bits &= ~0x200L;
+                            _bits &= ~0x100L;
                             _headers._Via = default(StringValues);
                             return true;
                         }
@@ -5721,9 +5149,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Host, key))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
-                            _bits &= ~0x400000000L;
+                            _bits &= ~0x2000000L;
                             _headers._Host = default(StringValues);
                             return true;
                         }
@@ -5741,9 +5169,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.From, key))
                     {
-                        if ((_bits & 0x80000000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
-                            _bits &= ~0x80000000L;
+                            _bits &= ~0x400000L;
                             _headers._From = default(StringValues);
                             return true;
                         }
@@ -5752,9 +5180,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Host.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
-                            _bits &= ~0x400000000L;
+                            _bits &= ~0x2000000L;
                             _headers._Host = default(StringValues);
                             return true;
                         }
@@ -5772,9 +5200,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.From.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
-                            _bits &= ~0x80000000L;
+                            _bits &= ~0x400000L;
                             _headers._From = default(StringValues);
                             return true;
                         }
@@ -5784,21 +5212,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 5:
                 {
-                    if (ReferenceEquals(HeaderNames.Allow, key))
-                    {
-                        if ((_bits & 0x800L) != 0)
-                        {
-                            _bits &= ~0x800L;
-                            _headers._Allow = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
-                            _bits &= ~0x400000L;
+                            _bits &= ~0x2000L;
                             _headers._Path = default(StringValues);
                             return true;
                         }
@@ -5806,30 +5224,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
                     {
-                        if ((_bits & 0x80000000000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
-                            _bits &= ~0x80000000000L;
+                            _bits &= ~0x400000000L;
                             _headers._Range = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x800L) != 0)
-                        {
-                            _bits &= ~0x800L;
-                            _headers._Allow = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
-                            _bits &= ~0x400000L;
+                            _bits &= ~0x2000L;
                             _headers._Path = default(StringValues);
                             return true;
                         }
@@ -5837,9 +5245,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
-                            _bits &= ~0x80000000000L;
+                            _bits &= ~0x400000000L;
                             _headers._Range = default(StringValues);
                             return true;
                         }
@@ -5851,9 +5259,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Accept, key))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
-                            _bits &= ~0x1000000L;
+                            _bits &= ~0x8000L;
                             _headers._Accept = default(StringValues);
                             return true;
                         }
@@ -5871,9 +5279,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Cookie, key))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
-                            _bits &= ~0x20000000L;
+                            _bits &= ~0x100000L;
                             _headers._Cookie = default(StringValues);
                             return true;
                         }
@@ -5881,9 +5289,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expect, key))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
-                            _bits &= ~0x40000000L;
+                            _bits &= ~0x200000L;
                             _headers._Expect = default(StringValues);
                             return true;
                         }
@@ -5891,9 +5299,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x20000000000000L) != 0)
+                        if ((_bits & 0x100000000000L) != 0)
                         {
-                            _bits &= ~0x20000000000000L;
+                            _bits &= ~0x100000000000L;
                             _headers._Origin = default(StringValues);
                             return true;
                         }
@@ -5902,9 +5310,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Accept.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
-                            _bits &= ~0x1000000L;
+                            _bits &= ~0x8000L;
                             _headers._Accept = default(StringValues);
                             return true;
                         }
@@ -5922,9 +5330,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Cookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
-                            _bits &= ~0x20000000L;
+                            _bits &= ~0x100000L;
                             _headers._Cookie = default(StringValues);
                             return true;
                         }
@@ -5932,9 +5340,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expect.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
-                            _bits &= ~0x40000000L;
+                            _bits &= ~0x200000L;
                             _headers._Expect = default(StringValues);
                             return true;
                         }
@@ -5942,9 +5350,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000000L) != 0)
+                        if ((_bits & 0x100000000000L) != 0)
                         {
-                            _bits &= ~0x20000000000000L;
+                            _bits &= ~0x100000000000L;
                             _headers._Origin = default(StringValues);
                             return true;
                         }
@@ -5954,21 +5362,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Trailer, key))
-                    {
-                        if ((_bits & 0x40L) != 0)
-                        {
-                            _bits &= ~0x40L;
-                            _headers._Trailer = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
-                            _bits &= ~0x100L;
+                            _bits &= ~0x80L;
                             _headers._Upgrade = default(StringValues);
                             return true;
                         }
@@ -5976,29 +5374,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
-                            _bits &= ~0x400L;
+                            _bits &= ~0x200L;
                             _headers._Warning = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Expires, key))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            _bits &= ~0x40000L;
-                            _headers._Expires = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.Method, key))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
-                            _bits &= ~0x200000L;
+                            _bits &= ~0x1000L;
                             _headers._Method = default(StringValues);
                             return true;
                         }
@@ -6006,9 +5394,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Scheme, key))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
-                            _bits &= ~0x800000L;
+                            _bits &= ~0x4000L;
                             _headers._Scheme = default(StringValues);
                             return true;
                         }
@@ -6016,9 +5404,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Referer, key))
                     {
-                        if ((_bits & 0x40000000000L) != 0)
+                        if ((_bits & 0x200000000L) != 0)
                         {
-                            _bits &= ~0x40000000000L;
+                            _bits &= ~0x200000000L;
                             _headers._Referer = default(StringValues);
                             return true;
                         }
@@ -6026,30 +5414,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x10000000000000L) != 0)
+                        if ((_bits & 0x80000000000L) != 0)
                         {
-                            _bits &= ~0x10000000000000L;
+                            _bits &= ~0x80000000000L;
                             _headers._Baggage = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x40L) != 0)
-                        {
-                            _bits &= ~0x40L;
-                            _headers._Trailer = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
-                            _bits &= ~0x100L;
+                            _bits &= ~0x80L;
                             _headers._Upgrade = default(StringValues);
                             return true;
                         }
@@ -6057,29 +5435,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
-                            _bits &= ~0x400L;
+                            _bits &= ~0x200L;
                             _headers._Warning = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            _bits &= ~0x40000L;
-                            _headers._Expires = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
-                            _bits &= ~0x200000L;
+                            _bits &= ~0x1000L;
                             _headers._Method = default(StringValues);
                             return true;
                         }
@@ -6087,9 +5455,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
-                            _bits &= ~0x800000L;
+                            _bits &= ~0x4000L;
                             _headers._Scheme = default(StringValues);
                             return true;
                         }
@@ -6097,9 +5465,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000L) != 0)
+                        if ((_bits & 0x200000000L) != 0)
                         {
-                            _bits &= ~0x40000000000L;
+                            _bits &= ~0x200000000L;
                             _headers._Referer = default(StringValues);
                             return true;
                         }
@@ -6107,9 +5475,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000000L) != 0)
+                        if ((_bits & 0x80000000000L) != 0)
                         {
-                            _bits &= ~0x10000000000000L;
+                            _bits &= ~0x80000000000L;
                             _headers._Baggage = default(StringValues);
                             return true;
                         }
@@ -6121,9 +5489,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfMatch, key))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            _bits &= ~0x800000000L;
+                            _bits &= ~0x4000000L;
                             _headers._IfMatch = default(StringValues);
                             return true;
                         }
@@ -6131,9 +5499,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfRange, key))
                     {
-                        if ((_bits & 0x4000000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
-                            _bits &= ~0x4000000000L;
+                            _bits &= ~0x20000000L;
                             _headers._IfRange = default(StringValues);
                             return true;
                         }
@@ -6142,9 +5510,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.IfMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            _bits &= ~0x800000000L;
+                            _bits &= ~0x4000000L;
                             _headers._IfMatch = default(StringValues);
                             return true;
                         }
@@ -6152,9 +5520,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
-                            _bits &= ~0x4000000000L;
+                            _bits &= ~0x20000000L;
                             _headers._IfRange = default(StringValues);
                             return true;
                         }
@@ -6166,9 +5534,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Translate, key))
                     {
-                        if ((_bits & 0x200000000000L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
                         {
-                            _bits &= ~0x200000000000L;
+                            _bits &= ~0x1000000000L;
                             _headers._Translate = default(StringValues);
                             return true;
                         }
@@ -6177,9 +5545,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Translate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000000L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
                         {
-                            _bits &= ~0x200000000000L;
+                            _bits &= ~0x1000000000L;
                             _headers._Translate = default(StringValues);
                             return true;
                         }
@@ -6201,9 +5569,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
-                        if ((_bits & 0x400000000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
-                            _bits &= ~0x400000000000L;
+                            _bits &= ~0x2000000000L;
                             _headers._UserAgent = default(StringValues);
                             return true;
                         }
@@ -6221,9 +5589,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Authority, key))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
-                            _bits &= ~0x100000L;
+                            _bits &= ~0x800L;
                             _headers._Authority = default(StringValues);
                             return true;
                         }
@@ -6231,9 +5599,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x1000000000000L) != 0)
+                        if ((_bits & 0x8000000000L) != 0)
                         {
-                            _bits &= ~0x1000000000000L;
+                            _bits &= ~0x8000000000L;
                             _headers._RequestId = default(StringValues);
                             return true;
                         }
@@ -6241,9 +5609,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x8000000000000L) != 0)
+                        if ((_bits & 0x40000000000L) != 0)
                         {
-                            _bits &= ~0x8000000000000L;
+                            _bits &= ~0x40000000000L;
                             _headers._TraceState = default(StringValues);
                             return true;
                         }
@@ -6262,9 +5630,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
-                            _bits &= ~0x400000000000L;
+                            _bits &= ~0x2000000000L;
                             _headers._UserAgent = default(StringValues);
                             return true;
                         }
@@ -6282,9 +5650,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
-                            _bits &= ~0x100000L;
+                            _bits &= ~0x800L;
                             _headers._Authority = default(StringValues);
                             return true;
                         }
@@ -6292,9 +5660,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000000L) != 0)
+                        if ((_bits & 0x8000000000L) != 0)
                         {
-                            _bits &= ~0x1000000000000L;
+                            _bits &= ~0x8000000000L;
                             _headers._RequestId = default(StringValues);
                             return true;
                         }
@@ -6302,9 +5670,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000000L) != 0)
+                        if ((_bits & 0x40000000000L) != 0)
                         {
-                            _bits &= ~0x8000000000000L;
+                            _bits &= ~0x40000000000L;
                             _headers._TraceState = default(StringValues);
                             return true;
                         }
@@ -6314,42 +5682,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
-                    {
-                        if ((_bits & 0x10000L) != 0)
-                        {
-                            _bits &= ~0x10000L;
-                            _headers._ContentMD5 = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x4000000000000L) != 0)
+                        if ((_bits & 0x20000000000L) != 0)
                         {
-                            _bits &= ~0x4000000000000L;
+                            _bits &= ~0x20000000000L;
                             _headers._TraceParent = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10000L) != 0)
-                        {
-                            _bits &= ~0x10000L;
-                            _headers._ContentMD5 = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000000L) != 0)
+                        if ((_bits & 0x20000000000L) != 0)
                         {
-                            _bits &= ~0x4000000000000L;
+                            _bits &= ~0x20000000000L;
                             _headers._TraceParent = default(StringValues);
                             return true;
                         }
@@ -6361,9 +5709,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
-                            _bits &= ~0x1000L;
+                            _bits &= ~0x400L;
                             _headers._ContentType = default(StringValues);
                             return true;
                         }
@@ -6371,9 +5719,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.GrpcTimeout, key))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
-                            _bits &= ~0x200000000L;
+                            _bits &= ~0x1000000L;
                             _headers._GrpcTimeout = default(StringValues);
                             return true;
                         }
@@ -6381,9 +5729,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.MaxForwards, key))
                     {
-                        if ((_bits & 0x10000000000L) != 0)
+                        if ((_bits & 0x80000000L) != 0)
                         {
-                            _bits &= ~0x10000000000L;
+                            _bits &= ~0x80000000L;
                             _headers._MaxForwards = default(StringValues);
                             return true;
                         }
@@ -6392,9 +5740,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
-                            _bits &= ~0x1000L;
+                            _bits &= ~0x400L;
                             _headers._ContentType = default(StringValues);
                             return true;
                         }
@@ -6402,9 +5750,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.GrpcTimeout.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
-                            _bits &= ~0x200000000L;
+                            _bits &= ~0x1000000L;
                             _headers._GrpcTimeout = default(StringValues);
                             return true;
                         }
@@ -6412,9 +5760,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.MaxForwards.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000L) != 0)
+                        if ((_bits & 0x80000000L) != 0)
                         {
-                            _bits &= ~0x10000000000L;
+                            _bits &= ~0x80000000L;
                             _headers._MaxForwards = default(StringValues);
                             return true;
                         }
@@ -6444,31 +5792,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.ContentRange, key))
-                    {
-                        if ((_bits & 0x20000L) != 0)
-                        {
-                            _bits &= ~0x20000L;
-                            _headers._ContentRange = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.LastModified, key))
+                    if (ReferenceEquals(HeaderNames.Authorization, key))
                     {
                         if ((_bits & 0x80000L) != 0)
                         {
                             _bits &= ~0x80000L;
-                            _headers._LastModified = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authorization, key))
-                    {
-                        if ((_bits & 0x10000000L) != 0)
-                        {
-                            _bits &= ~0x10000000L;
                             _headers._Authorization = default(StringValues);
                             return true;
                         }
@@ -6476,9 +5804,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfNoneMatch, key))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
-                            _bits &= ~0x2000000000L;
+                            _bits &= ~0x10000000L;
                             _headers._IfNoneMatch = default(StringValues);
                             return true;
                         }
@@ -6505,31 +5833,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x20000L) != 0)
-                        {
-                            _bits &= ~0x20000L;
-                            _headers._ContentRange = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x80000L) != 0)
                         {
                             _bits &= ~0x80000L;
-                            _headers._LastModified = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10000000L) != 0)
-                        {
-                            _bits &= ~0x10000000L;
                             _headers._Authorization = default(StringValues);
                             return true;
                         }
@@ -6537,9 +5845,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfNoneMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
-                            _bits &= ~0x2000000000L;
+                            _bits &= ~0x10000000L;
                             _headers._IfNoneMatch = default(StringValues);
                             return true;
                         }
@@ -6551,9 +5859,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptCharset, key))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
-                            _bits &= ~0x2000000L;
+                            _bits &= ~0x10000L;
                             _headers._AcceptCharset = default(StringValues);
                             return true;
                         }
@@ -6571,9 +5879,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AcceptCharset.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
-                            _bits &= ~0x2000000L;
+                            _bits &= ~0x10000L;
                             _headers._AcceptCharset = default(StringValues);
                             return true;
                         }
@@ -6594,9 +5902,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptEncoding, key))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
-                            _bits &= ~0x4000000L;
+                            _bits &= ~0x20000L;
                             _headers._AcceptEncoding = default(StringValues);
                             return true;
                         }
@@ -6604,9 +5912,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AcceptLanguage, key))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            _bits &= ~0x8000000L;
+                            _bits &= ~0x40000L;
                             _headers._AcceptLanguage = default(StringValues);
                             return true;
                         }
@@ -6615,9 +5923,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
-                            _bits &= ~0x4000000L;
+                            _bits &= ~0x20000L;
                             _headers._AcceptEncoding = default(StringValues);
                             return true;
                         }
@@ -6625,75 +5933,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AcceptLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            _bits &= ~0x8000000L;
+                            _bits &= ~0x40000L;
                             _headers._AcceptLanguage = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    break;
-                }
-                case 16:
-                {
-                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
-                    {
-                        if ((_bits & 0x2000L) != 0)
-                        {
-                            _bits &= ~0x2000L;
-                            _headers._ContentEncoding = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
-                    {
-                        if ((_bits & 0x4000L) != 0)
-                        {
-                            _bits &= ~0x4000L;
-                            _headers._ContentLanguage = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
-                    {
-                        if ((_bits & 0x8000L) != 0)
-                        {
-                            _bits &= ~0x8000L;
-                            _headers._ContentLocation = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-    
-                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x2000L) != 0)
-                        {
-                            _bits &= ~0x2000L;
-                            _headers._ContentEncoding = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x4000L) != 0)
-                        {
-                            _bits &= ~0x4000L;
-                            _headers._ContentLanguage = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x8000L) != 0)
-                        {
-                            _bits &= ~0x8000L;
-                            _headers._ContentLocation = default(StringValues);
                             return true;
                         }
                         return false;
@@ -6704,9 +5947,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
-                            _bits &= ~0x80L;
+                            _bits &= ~0x40L;
                             _headers._TransferEncoding = default(StringValues);
                             return true;
                         }
@@ -6714,9 +5957,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
-                            _bits &= ~0x1000000000L;
+                            _bits &= ~0x8000000L;
                             _headers._IfModifiedSince = default(StringValues);
                             return true;
                         }
@@ -6725,9 +5968,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
-                            _bits &= ~0x80L;
+                            _bits &= ~0x40L;
                             _headers._TransferEncoding = default(StringValues);
                             return true;
                         }
@@ -6735,9 +5978,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
-                            _bits &= ~0x1000000000L;
+                            _bits &= ~0x8000000L;
                             _headers._IfModifiedSince = default(StringValues);
                             return true;
                         }
@@ -6749,9 +5992,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfUnmodifiedSince, key))
                     {
-                        if ((_bits & 0x8000000000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
-                            _bits &= ~0x8000000000L;
+                            _bits &= ~0x40000000L;
                             _headers._IfUnmodifiedSince = default(StringValues);
                             return true;
                         }
@@ -6759,9 +6002,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ProxyAuthorization, key))
                     {
-                        if ((_bits & 0x20000000000L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
-                            _bits &= ~0x20000000000L;
+                            _bits &= ~0x100000000L;
                             _headers._ProxyAuthorization = default(StringValues);
                             return true;
                         }
@@ -6769,9 +6012,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.CorrelationContext, key))
                     {
-                        if ((_bits & 0x2000000000000L) != 0)
+                        if ((_bits & 0x10000000000L) != 0)
                         {
-                            _bits &= ~0x2000000000000L;
+                            _bits &= ~0x10000000000L;
                             _headers._CorrelationContext = default(StringValues);
                             return true;
                         }
@@ -6780,9 +6023,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.IfUnmodifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
-                            _bits &= ~0x8000000000L;
+                            _bits &= ~0x40000000L;
                             _headers._IfUnmodifiedSince = default(StringValues);
                             return true;
                         }
@@ -6790,9 +6033,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ProxyAuthorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
-                            _bits &= ~0x20000000000L;
+                            _bits &= ~0x100000000L;
                             _headers._ProxyAuthorization = default(StringValues);
                             return true;
                         }
@@ -6800,9 +6043,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000000L) != 0)
+                        if ((_bits & 0x10000000000L) != 0)
                         {
-                            _bits &= ~0x2000000000000L;
+                            _bits &= ~0x10000000000L;
                             _headers._CorrelationContext = default(StringValues);
                             return true;
                         }
@@ -6814,9 +6057,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.GrpcAcceptEncoding, key))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
-                            _bits &= ~0x100000000L;
+                            _bits &= ~0x800000L;
                             _headers._GrpcAcceptEncoding = default(StringValues);
                             return true;
                         }
@@ -6825,9 +6068,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.GrpcAcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
-                            _bits &= ~0x100000000L;
+                            _bits &= ~0x800000L;
                             _headers._GrpcAcceptEncoding = default(StringValues);
                             return true;
                         }
@@ -6839,9 +6082,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x800000000000L) != 0)
+                        if ((_bits & 0x4000000000L) != 0)
                         {
-                            _bits &= ~0x800000000000L;
+                            _bits &= ~0x4000000000L;
                             _headers._UpgradeInsecureRequests = default(StringValues);
                             return true;
                         }
@@ -6850,9 +6093,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000000L) != 0)
+                        if ((_bits & 0x4000000000L) != 0)
                         {
-                            _bits &= ~0x800000000000L;
+                            _bits &= ~0x4000000000L;
                             _headers._UpgradeInsecureRequests = default(StringValues);
                             return true;
                         }
@@ -6864,9 +6107,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x40000000000000L) != 0)
+                        if ((_bits & 0x200000000000L) != 0)
                         {
-                            _bits &= ~0x40000000000000L;
+                            _bits &= ~0x200000000000L;
                             _headers._AccessControlRequestMethod = default(StringValues);
                             return true;
                         }
@@ -6875,9 +6118,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000000L) != 0)
+                        if ((_bits & 0x200000000000L) != 0)
                         {
-                            _bits &= ~0x40000000000000L;
+                            _bits &= ~0x200000000000L;
                             _headers._AccessControlRequestMethod = default(StringValues);
                             return true;
                         }
@@ -6889,9 +6132,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x80000000000000L) != 0)
+                        if ((_bits & 0x400000000000L) != 0)
                         {
-                            _bits &= ~0x80000000000000L;
+                            _bits &= ~0x400000000000L;
                             _headers._AccessControlRequestHeaders = default(StringValues);
                             return true;
                         }
@@ -6900,9 +6143,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000000000L) != 0)
+                        if ((_bits & 0x400000000000L) != 0)
                         {
-                            _bits &= ~0x80000000000000L;
+                            _bits &= ~0x400000000000L;
                             _headers._AccessControlRequestHeaders = default(StringValues);
                             return true;
                         }
@@ -6928,34 +6171,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x2L;
             }
             
-            if ((tempBits & 0x1000000L) != 0)
+            if ((tempBits & 0x8000L) != 0)
             {
                 _headers._Accept = default;
-                if((tempBits & ~0x1000000L) == 0)
+                if((tempBits & ~0x8000L) == 0)
                 {
                     return;
                 }
-                tempBits &= ~0x1000000L;
+                tempBits &= ~0x8000L;
             }
             
-            if ((tempBits & 0x400000000L) != 0)
+            if ((tempBits & 0x2000000L) != 0)
             {
                 _headers._Host = default;
-                if((tempBits & ~0x400000000L) == 0)
+                if((tempBits & ~0x2000000L) == 0)
                 {
                     return;
                 }
-                tempBits &= ~0x400000000L;
+                tempBits &= ~0x2000000L;
             }
             
-            if ((tempBits & 0x400000000000L) != 0)
+            if ((tempBits & 0x2000000000L) != 0)
             {
                 _headers._UserAgent = default;
-                if((tempBits & ~0x400000000000L) == 0)
+                if((tempBits & ~0x2000000000L) == 0)
                 {
                     return;
                 }
-                tempBits &= ~0x400000000000L;
+                tempBits &= ~0x2000000000L;
             }
             
             if ((tempBits & 0x1L) != 0)
@@ -7010,7 +6253,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40L) != 0)
             {
-                _headers._Trailer = default;
+                _headers._TransferEncoding = default;
                 if((tempBits & ~0x40L) == 0)
                 {
                     return;
@@ -7020,7 +6263,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80L) != 0)
             {
-                _headers._TransferEncoding = default;
+                _headers._Upgrade = default;
                 if((tempBits & ~0x80L) == 0)
                 {
                     return;
@@ -7030,7 +6273,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100L) != 0)
             {
-                _headers._Upgrade = default;
+                _headers._Via = default;
                 if((tempBits & ~0x100L) == 0)
                 {
                     return;
@@ -7040,7 +6283,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200L) != 0)
             {
-                _headers._Via = default;
+                _headers._Warning = default;
                 if((tempBits & ~0x200L) == 0)
                 {
                     return;
@@ -7050,7 +6293,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400L) != 0)
             {
-                _headers._Warning = default;
+                _headers._ContentType = default;
                 if((tempBits & ~0x400L) == 0)
                 {
                     return;
@@ -7060,7 +6303,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800L) != 0)
             {
-                _headers._Allow = default;
+                _headers._Authority = default;
                 if((tempBits & ~0x800L) == 0)
                 {
                     return;
@@ -7070,7 +6313,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000L) != 0)
             {
-                _headers._ContentType = default;
+                _headers._Method = default;
                 if((tempBits & ~0x1000L) == 0)
                 {
                     return;
@@ -7080,7 +6323,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x2000L) != 0)
             {
-                _headers._ContentEncoding = default;
+                _headers._Path = default;
                 if((tempBits & ~0x2000L) == 0)
                 {
                     return;
@@ -7090,7 +6333,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x4000L) != 0)
             {
-                _headers._ContentLanguage = default;
+                _headers._Scheme = default;
                 if((tempBits & ~0x4000L) == 0)
                 {
                     return;
@@ -7098,19 +6341,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x4000L;
             }
             
-            if ((tempBits & 0x8000L) != 0)
-            {
-                _headers._ContentLocation = default;
-                if((tempBits & ~0x8000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x8000L;
-            }
-            
             if ((tempBits & 0x10000L) != 0)
             {
-                _headers._ContentMD5 = default;
+                _headers._AcceptCharset = default;
                 if((tempBits & ~0x10000L) == 0)
                 {
                     return;
@@ -7120,7 +6353,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000L) != 0)
             {
-                _headers._ContentRange = default;
+                _headers._AcceptEncoding = default;
                 if((tempBits & ~0x20000L) == 0)
                 {
                     return;
@@ -7130,7 +6363,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000L) != 0)
             {
-                _headers._Expires = default;
+                _headers._AcceptLanguage = default;
                 if((tempBits & ~0x40000L) == 0)
                 {
                     return;
@@ -7140,7 +6373,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000L) != 0)
             {
-                _headers._LastModified = default;
+                _headers._Authorization = default;
                 if((tempBits & ~0x80000L) == 0)
                 {
                     return;
@@ -7150,7 +6383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100000L) != 0)
             {
-                _headers._Authority = default;
+                _headers._Cookie = default;
                 if((tempBits & ~0x100000L) == 0)
                 {
                     return;
@@ -7160,7 +6393,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200000L) != 0)
             {
-                _headers._Method = default;
+                _headers._Expect = default;
                 if((tempBits & ~0x200000L) == 0)
                 {
                     return;
@@ -7170,7 +6403,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400000L) != 0)
             {
-                _headers._Path = default;
+                _headers._From = default;
                 if((tempBits & ~0x400000L) == 0)
                 {
                     return;
@@ -7180,7 +6413,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800000L) != 0)
             {
-                _headers._Scheme = default;
+                _headers._GrpcAcceptEncoding = default;
                 if((tempBits & ~0x800000L) == 0)
                 {
                     return;
@@ -7188,19 +6421,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x800000L;
             }
             
-            if ((tempBits & 0x2000000L) != 0)
+            if ((tempBits & 0x1000000L) != 0)
             {
-                _headers._AcceptCharset = default;
-                if((tempBits & ~0x2000000L) == 0)
+                _headers._GrpcTimeout = default;
+                if((tempBits & ~0x1000000L) == 0)
                 {
                     return;
                 }
-                tempBits &= ~0x2000000L;
+                tempBits &= ~0x1000000L;
             }
             
             if ((tempBits & 0x4000000L) != 0)
             {
-                _headers._AcceptEncoding = default;
+                _headers._IfMatch = default;
                 if((tempBits & ~0x4000000L) == 0)
                 {
                     return;
@@ -7210,7 +6443,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000000L) != 0)
             {
-                _headers._AcceptLanguage = default;
+                _headers._IfModifiedSince = default;
                 if((tempBits & ~0x8000000L) == 0)
                 {
                     return;
@@ -7220,7 +6453,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10000000L) != 0)
             {
-                _headers._Authorization = default;
+                _headers._IfNoneMatch = default;
                 if((tempBits & ~0x10000000L) == 0)
                 {
                     return;
@@ -7230,7 +6463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000000L) != 0)
             {
-                _headers._Cookie = default;
+                _headers._IfRange = default;
                 if((tempBits & ~0x20000000L) == 0)
                 {
                     return;
@@ -7240,7 +6473,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000000L) != 0)
             {
-                _headers._Expect = default;
+                _headers._IfUnmodifiedSince = default;
                 if((tempBits & ~0x40000000L) == 0)
                 {
                     return;
@@ -7250,7 +6483,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000000L) != 0)
             {
-                _headers._From = default;
+                _headers._MaxForwards = default;
                 if((tempBits & ~0x80000000L) == 0)
                 {
                     return;
@@ -7260,7 +6493,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100000000L) != 0)
             {
-                _headers._GrpcAcceptEncoding = default;
+                _headers._ProxyAuthorization = default;
                 if((tempBits & ~0x100000000L) == 0)
                 {
                     return;
@@ -7270,7 +6503,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200000000L) != 0)
             {
-                _headers._GrpcTimeout = default;
+                _headers._Referer = default;
                 if((tempBits & ~0x200000000L) == 0)
                 {
                     return;
@@ -7278,9 +6511,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x200000000L;
             }
             
+            if ((tempBits & 0x400000000L) != 0)
+            {
+                _headers._Range = default;
+                if((tempBits & ~0x400000000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x400000000L;
+            }
+            
             if ((tempBits & 0x800000000L) != 0)
             {
-                _headers._IfMatch = default;
+                _headers._TE = default;
                 if((tempBits & ~0x800000000L) == 0)
                 {
                     return;
@@ -7290,7 +6533,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000000000L) != 0)
             {
-                _headers._IfModifiedSince = default;
+                _headers._Translate = default;
                 if((tempBits & ~0x1000000000L) == 0)
                 {
                     return;
@@ -7298,19 +6541,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x1000000000L;
             }
             
-            if ((tempBits & 0x2000000000L) != 0)
-            {
-                _headers._IfNoneMatch = default;
-                if((tempBits & ~0x2000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x2000000000L;
-            }
-            
             if ((tempBits & 0x4000000000L) != 0)
             {
-                _headers._IfRange = default;
+                _headers._UpgradeInsecureRequests = default;
                 if((tempBits & ~0x4000000000L) == 0)
                 {
                     return;
@@ -7320,7 +6553,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000000000L) != 0)
             {
-                _headers._IfUnmodifiedSince = default;
+                _headers._RequestId = default;
                 if((tempBits & ~0x8000000000L) == 0)
                 {
                     return;
@@ -7330,7 +6563,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10000000000L) != 0)
             {
-                _headers._MaxForwards = default;
+                _headers._CorrelationContext = default;
                 if((tempBits & ~0x10000000000L) == 0)
                 {
                     return;
@@ -7340,7 +6573,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000000000L) != 0)
             {
-                _headers._ProxyAuthorization = default;
+                _headers._TraceParent = default;
                 if((tempBits & ~0x20000000000L) == 0)
                 {
                     return;
@@ -7350,7 +6583,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000000000L) != 0)
             {
-                _headers._Referer = default;
+                _headers._TraceState = default;
                 if((tempBits & ~0x40000000000L) == 0)
                 {
                     return;
@@ -7360,7 +6593,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000000000L) != 0)
             {
-                _headers._Range = default;
+                _headers._Baggage = default;
                 if((tempBits & ~0x80000000000L) == 0)
                 {
                     return;
@@ -7370,7 +6603,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100000000000L) != 0)
             {
-                _headers._TE = default;
+                _headers._Origin = default;
                 if((tempBits & ~0x100000000000L) == 0)
                 {
                     return;
@@ -7380,7 +6613,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200000000000L) != 0)
             {
-                _headers._Translate = default;
+                _headers._AccessControlRequestMethod = default;
                 if((tempBits & ~0x200000000000L) == 0)
                 {
                     return;
@@ -7388,94 +6621,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x200000000000L;
             }
             
-            if ((tempBits & 0x800000000000L) != 0)
-            {
-                _headers._UpgradeInsecureRequests = default;
-                if((tempBits & ~0x800000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x800000000000L;
-            }
-            
-            if ((tempBits & 0x1000000000000L) != 0)
-            {
-                _headers._RequestId = default;
-                if((tempBits & ~0x1000000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x1000000000000L;
-            }
-            
-            if ((tempBits & 0x2000000000000L) != 0)
-            {
-                _headers._CorrelationContext = default;
-                if((tempBits & ~0x2000000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x2000000000000L;
-            }
-            
-            if ((tempBits & 0x4000000000000L) != 0)
-            {
-                _headers._TraceParent = default;
-                if((tempBits & ~0x4000000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x4000000000000L;
-            }
-            
-            if ((tempBits & 0x8000000000000L) != 0)
-            {
-                _headers._TraceState = default;
-                if((tempBits & ~0x8000000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x8000000000000L;
-            }
-            
-            if ((tempBits & 0x10000000000000L) != 0)
-            {
-                _headers._Baggage = default;
-                if((tempBits & ~0x10000000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x10000000000000L;
-            }
-            
-            if ((tempBits & 0x20000000000000L) != 0)
-            {
-                _headers._Origin = default;
-                if((tempBits & ~0x20000000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x20000000000000L;
-            }
-            
-            if ((tempBits & 0x40000000000000L) != 0)
-            {
-                _headers._AccessControlRequestMethod = default;
-                if((tempBits & ~0x40000000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x40000000000000L;
-            }
-            
-            if ((tempBits & 0x80000000000000L) != 0)
+            if ((tempBits & 0x400000000000L) != 0)
             {
                 _headers._AccessControlRequestHeaders = default;
-                if((tempBits & ~0x80000000000000L) == 0)
+                if((tempBits & ~0x400000000000L) == 0)
                 {
                     return;
                 }
-                tempBits &= ~0x80000000000000L;
+                tempBits &= ~0x400000000000L;
             }
             
         }
@@ -7547,7 +6700,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Trailer, _headers._Trailer);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _headers._TransferEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80L) != 0)
@@ -7556,7 +6709,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _headers._TransferEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _headers._Upgrade);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100L) != 0)
@@ -7565,7 +6718,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _headers._Upgrade);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Via, _headers._Via);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200L) != 0)
@@ -7574,7 +6727,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Via, _headers._Via);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _headers._Warning);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400L) != 0)
@@ -7583,7 +6736,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _headers._Warning);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _headers._ContentType);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800L) != 0)
@@ -7592,7 +6745,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _headers._Allow);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Authority, _headers._Authority);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000L) != 0)
@@ -7601,7 +6754,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _headers._ContentType);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Method, _headers._Method);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000L) != 0)
@@ -7610,7 +6763,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _headers._ContentEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Path, _headers._Path);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000L) != 0)
@@ -7619,7 +6772,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _headers._ContentLanguage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Scheme, _headers._Scheme);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000L) != 0)
@@ -7628,7 +6781,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _headers._ContentLocation);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Accept, _headers._Accept);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000L) != 0)
@@ -7637,7 +6790,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _headers._ContentMD5);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptCharset, _headers._AcceptCharset);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000L) != 0)
@@ -7646,7 +6799,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _headers._ContentRange);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptEncoding, _headers._AcceptEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000L) != 0)
@@ -7655,7 +6808,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _headers._Expires);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptLanguage, _headers._AcceptLanguage);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000L) != 0)
@@ -7664,7 +6817,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _headers._LastModified);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Authorization, _headers._Authorization);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100000L) != 0)
@@ -7673,7 +6826,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Authority, _headers._Authority);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Cookie, _headers._Cookie);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000L) != 0)
@@ -7682,7 +6835,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Method, _headers._Method);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expect, _headers._Expect);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400000L) != 0)
@@ -7691,7 +6844,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Path, _headers._Path);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.From, _headers._From);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800000L) != 0)
@@ -7700,7 +6853,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Scheme, _headers._Scheme);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcAcceptEncoding, _headers._GrpcAcceptEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000000L) != 0)
@@ -7709,7 +6862,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Accept, _headers._Accept);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcTimeout, _headers._GrpcTimeout);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000000L) != 0)
@@ -7718,7 +6871,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptCharset, _headers._AcceptCharset);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Host, _headers._Host);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000000L) != 0)
@@ -7727,7 +6880,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptEncoding, _headers._AcceptEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfMatch, _headers._IfMatch);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000000L) != 0)
@@ -7736,7 +6889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptLanguage, _headers._AcceptLanguage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfModifiedSince, _headers._IfModifiedSince);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000000L) != 0)
@@ -7745,7 +6898,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Authorization, _headers._Authorization);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfNoneMatch, _headers._IfNoneMatch);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000000L) != 0)
@@ -7754,7 +6907,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Cookie, _headers._Cookie);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfRange, _headers._IfRange);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000000L) != 0)
@@ -7763,7 +6916,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expect, _headers._Expect);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfUnmodifiedSince, _headers._IfUnmodifiedSince);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000000L) != 0)
@@ -7772,7 +6925,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.From, _headers._From);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.MaxForwards, _headers._MaxForwards);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100000000L) != 0)
@@ -7781,7 +6934,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcAcceptEncoding, _headers._GrpcAcceptEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthorization, _headers._ProxyAuthorization);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000000L) != 0)
@@ -7790,7 +6943,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcTimeout, _headers._GrpcTimeout);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Referer, _headers._Referer);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400000000L) != 0)
@@ -7799,7 +6952,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Host, _headers._Host);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Range, _headers._Range);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800000000L) != 0)
@@ -7808,7 +6961,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfMatch, _headers._IfMatch);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TE, _headers._TE);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000000000L) != 0)
@@ -7817,7 +6970,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfModifiedSince, _headers._IfModifiedSince);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Translate, _headers._Translate);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000000000L) != 0)
@@ -7826,7 +6979,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfNoneMatch, _headers._IfNoneMatch);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UserAgent, _headers._UserAgent);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000000000L) != 0)
@@ -7835,7 +6988,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfRange, _headers._IfRange);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _headers._UpgradeInsecureRequests);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000000000L) != 0)
@@ -7844,7 +6997,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfUnmodifiedSince, _headers._IfUnmodifiedSince);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _headers._RequestId);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000000000L) != 0)
@@ -7853,7 +7006,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.MaxForwards, _headers._MaxForwards);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _headers._CorrelationContext);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000000000L) != 0)
@@ -7862,7 +7015,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthorization, _headers._ProxyAuthorization);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _headers._TraceParent);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000000000L) != 0)
@@ -7871,7 +7024,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Referer, _headers._Referer);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _headers._TraceState);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000000000L) != 0)
@@ -7880,7 +7033,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Range, _headers._Range);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _headers._Baggage);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100000000000L) != 0)
@@ -7889,7 +7042,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TE, _headers._TE);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _headers._Origin);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000000000L) != 0)
@@ -7898,91 +7051,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Translate, _headers._Translate);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x400000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UserAgent, _headers._UserAgent);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x800000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _headers._UpgradeInsecureRequests);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x1000000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _headers._RequestId);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x2000000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _headers._CorrelationContext);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x4000000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _headers._TraceParent);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x8000000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _headers._TraceState);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x10000000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _headers._Baggage);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x20000000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _headers._Origin);
-                    ++arrayIndex;
-                }
-                if ((_bits & 0x40000000000000L) != 0)
-                {
-                    if (arrayIndex == array.Length)
-                    {
-                        return false;
-                    }
                     array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestMethod, _headers._AccessControlRequestMethod);
                     ++arrayIndex;
                 }
-                if ((_bits & 0x80000000000000L) != 0)
+                if ((_bits & 0x400000000000L) != 0)
                 {
                     if (arrayIndex == array.Length)
                     {
@@ -8019,7 +7091,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 2:
                     if (((Unsafe.ReadUnaligned<ushort>(ref nameStart) & 0xdfdfu) == 0x4554u))
                     {
-                        flag = 0x100000000000L;
+                        flag = 0x800000000L;
                         values = ref _headers._TE;
                         nameStr = HeaderNames.TE;
                     }
@@ -8027,7 +7099,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 3:
                     if (((Unsafe.ReadUnaligned<ushort>(ref nameStart) & 0xdfdfu) == 0x4956u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)2) & 0xdfu) == 0x41u))
                     {
-                        flag = 0x200L;
+                        flag = 0x100L;
                         values = ref _headers._Via;
                         nameStr = HeaderNames.Via;
                     }
@@ -8036,7 +7108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var firstTerm4 = (Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu);
                     if ((firstTerm4 == 0x54534f48u))
                     {
-                        flag = 0x400000000L;
+                        flag = 0x2000000L;
                         values = ref _headers._Host;
                         nameStr = HeaderNames.Host;
                     }
@@ -8048,7 +7120,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if ((firstTerm4 == 0x4d4f5246u))
                     {
-                        flag = 0x80000000L;
+                        flag = 0x400000L;
                         values = ref _headers._From;
                         nameStr = HeaderNames.From;
                     }
@@ -8056,19 +7128,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 5:
                     if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfffu) == 0x5441503au) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)4) & 0xdfu) == 0x48u))
                     {
-                        flag = 0x400000L;
+                        flag = 0x2000L;
                         values = ref _headers._Path;
                         nameStr = HeaderNames.Path;
                     }
-                    else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x4f4c4c41u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)4) & 0xdfu) == 0x57u))
-                    {
-                        flag = 0x800L;
-                        values = ref _headers._Allow;
-                        nameStr = HeaderNames.Allow;
-                    }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x474e4152u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)4) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x80000000000L;
+                        flag = 0x400000000L;
                         values = ref _headers._Range;
                         nameStr = HeaderNames.Range;
                     }
@@ -8077,25 +7143,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var firstTerm6 = (Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu);
                     if ((firstTerm6 == 0x45434341u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x5450u))
                     {
-                        flag = 0x1000000L;
+                        flag = 0x8000L;
                         values = ref _headers._Accept;
                         nameStr = HeaderNames.Accept;
                     }
                     else if ((firstTerm6 == 0x4b4f4f43u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4549u))
                     {
-                        flag = 0x20000000L;
+                        flag = 0x100000L;
                         values = ref _headers._Cookie;
                         nameStr = HeaderNames.Cookie;
                     }
                     else if ((firstTerm6 == 0x45505845u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x5443u))
                     {
-                        flag = 0x40000000L;
+                        flag = 0x200000L;
                         values = ref _headers._Expect;
                         nameStr = HeaderNames.Expect;
                     }
                     else if ((firstTerm6 == 0x4749524fu) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4e49u))
                     {
-                        flag = 0x20000000000000L;
+                        flag = 0x100000000000L;
                         values = ref _headers._Origin;
                         nameStr = HeaderNames.Origin;
                     }
@@ -8109,49 +7175,37 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 7:
                     if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfffu) == 0x54454d3au) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4f48u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x44u))
                     {
-                        flag = 0x200000L;
+                        flag = 0x1000L;
                         values = ref _headers._Method;
                         nameStr = HeaderNames.Method;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfffu) == 0x4843533au) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4d45u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x800000L;
+                        flag = 0x4000L;
                         values = ref _headers._Scheme;
                         nameStr = HeaderNames.Scheme;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x47474142u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4741u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x10000000000000L;
+                        flag = 0x80000000000L;
                         values = ref _headers._Baggage;
                         nameStr = HeaderNames.Baggage;
                     }
-                    else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x49505845u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4552u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x53u))
-                    {
-                        flag = 0x40000L;
-                        values = ref _headers._Expires;
-                        nameStr = HeaderNames.Expires;
-                    }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x45464552u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4552u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x52u))
                     {
-                        flag = 0x40000000000L;
+                        flag = 0x200000000L;
                         values = ref _headers._Referer;
                         nameStr = HeaderNames.Referer;
                     }
-                    else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x49415254u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x454cu) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x52u))
-                    {
-                        flag = 0x40L;
-                        values = ref _headers._Trailer;
-                        nameStr = HeaderNames.Trailer;
-                    }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x52475055u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4441u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x100L;
+                        flag = 0x80L;
                         values = ref _headers._Upgrade;
                         nameStr = HeaderNames.Upgrade;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x4e524157u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4e49u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x47u))
                     {
-                        flag = 0x400L;
+                        flag = 0x200L;
                         values = ref _headers._Warning;
                         nameStr = HeaderNames.Warning;
                     }
@@ -8160,13 +7214,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var firstTerm8 = (Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfffdfdfuL);
                     if ((firstTerm8 == 0x484354414d2d4649uL))
                     {
-                        flag = 0x800000000L;
+                        flag = 0x4000000L;
                         values = ref _headers._IfMatch;
                         nameStr = HeaderNames.IfMatch;
                     }
                     else if ((firstTerm8 == 0x45474e41522d4649uL))
                     {
-                        flag = 0x4000000000L;
+                        flag = 0x20000000L;
                         values = ref _headers._IfRange;
                         nameStr = HeaderNames.IfRange;
                     }
@@ -8174,7 +7228,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 9:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x54414c534e415254uL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)8) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x200000000000L;
+                        flag = 0x1000000000L;
                         values = ref _headers._Translate;
                         nameStr = HeaderNames.Translate;
                     }
@@ -8188,13 +7242,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x4547412d52455355uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x544eu))
                     {
-                        flag = 0x400000000000L;
+                        flag = 0x2000000000L;
                         values = ref _headers._UserAgent;
                         nameStr = HeaderNames.UserAgent;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfffuL) == 0x49524f485455413auL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x5954u))
                     {
-                        flag = 0x100000L;
+                        flag = 0x800L;
                         values = ref _headers._Authority;
                         nameStr = HeaderNames.Authority;
                     }
@@ -8206,27 +7260,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d54534555514552uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4449u))
                     {
-                        flag = 0x1000000000000L;
+                        flag = 0x8000000000L;
                         values = ref _headers._RequestId;
                         nameStr = HeaderNames.RequestId;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x4154534543415254uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4554u))
                     {
-                        flag = 0x8000000000000L;
+                        flag = 0x40000000000L;
                         values = ref _headers._TraceState;
                         nameStr = HeaderNames.TraceState;
                     }
                     break;
                 case 11:
-                    if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d544e45544e4f43uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x444du) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)10) & 0xffu) == 0x35u))
+                    if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x5241504543415254uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4e45u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)10) & 0xdfu) == 0x54u))
                     {
-                        flag = 0x10000L;
-                        values = ref _headers._ContentMD5;
-                        nameStr = HeaderNames.ContentMD5;
-                    }
-                    else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x5241504543415254uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4e45u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)10) & 0xdfu) == 0x54u))
-                    {
-                        flag = 0x4000000000000L;
+                        flag = 0x20000000000L;
                         values = ref _headers._TraceParent;
                         nameStr = HeaderNames.TraceParent;
                     }
@@ -8234,19 +7282,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 12:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d544e45544e4f43uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x45505954u))
                     {
-                        flag = 0x1000L;
+                        flag = 0x400L;
                         values = ref _headers._ContentType;
                         nameStr = HeaderNames.ContentType;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x4d49542d43505247uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x54554f45u))
                     {
-                        flag = 0x200000000L;
+                        flag = 0x1000000L;
                         values = ref _headers._GrpcTimeout;
                         nameStr = HeaderNames.GrpcTimeout;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfffdfdfdfuL) == 0x57524f462d58414duL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x53445241u))
                     {
-                        flag = 0x10000000000L;
+                        flag = 0x80000000L;
                         values = ref _headers._MaxForwards;
                         nameStr = HeaderNames.MaxForwards;
                     }
@@ -8254,7 +7302,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 13:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x5a49524f48545541uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4f495441u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x4eu))
                     {
-                        flag = 0x10000000L;
+                        flag = 0x80000L;
                         values = ref _headers._Authorization;
                         nameStr = HeaderNames.Authorization;
                     }
@@ -8264,12 +7312,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         values = ref _headers._CacheControl;
                         nameStr = HeaderNames.CacheControl;
                     }
-                    else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d544e45544e4f43uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x474e4152u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x45u))
-                    {
-                        flag = 0x20000L;
-                        values = ref _headers._ContentRange;
-                        nameStr = HeaderNames.ContentRange;
-                    }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x434e452d43505247uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4e49444fu) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x47u))
                     {
                         flag = 0x8L;
@@ -8278,21 +7320,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfffdfdfuL) == 0x2d454e4f4e2d4649uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4354414du) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x48u))
                     {
-                        flag = 0x2000000000L;
+                        flag = 0x10000000L;
                         values = ref _headers._IfNoneMatch;
                         nameStr = HeaderNames.IfNoneMatch;
-                    }
-                    else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x444f4d2d5453414cuL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x45494649u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x44u))
-                    {
-                        flag = 0x80000L;
-                        values = ref _headers._LastModified;
-                        nameStr = HeaderNames.LastModified;
                     }
                     break;
                 case 14:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL) == 0x432d545045434341uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x53524148u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(ushort)))) & 0xdfdfu) == 0x5445u))
                     {
-                        flag = 0x2000000L;
+                        flag = 0x10000L;
                         values = ref _headers._AcceptCharset;
                         nameStr = HeaderNames.AcceptCharset;
                     }
@@ -8313,51 +7349,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var firstTerm15 = (Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL);
                     if ((firstTerm15 == 0x452d545045434341uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x444f434eu) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(ushort)))) & 0xdfdfu) == 0x4e49u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)14) & 0xdfu) == 0x47u))
                     {
-                        flag = 0x4000000L;
+                        flag = 0x20000L;
                         values = ref _headers._AcceptEncoding;
                         nameStr = HeaderNames.AcceptEncoding;
                     }
                     else if ((firstTerm15 == 0x4c2d545045434341uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x55474e41u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(ushort)))) & 0xdfdfu) == 0x4741u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)14) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x8000000L;
+                        flag = 0x40000L;
                         values = ref _headers._AcceptLanguage;
                         nameStr = HeaderNames.AcceptLanguage;
-                    }
-                    break;
-                case 16:
-                    var firstTerm16 = (Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL);
-                    if ((firstTerm16 == 0x2d544e45544e4f43uL))
-                    {
-                        if (((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfdfuL) == 0x474e49444f434e45uL))
-                        {
-                            flag = 0x2000L;
-                            values = ref _headers._ContentEncoding;
-                            nameStr = HeaderNames.ContentEncoding;
-                        }
-                        else if (((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfdfuL) == 0x45474155474e414cuL))
-                        {
-                            flag = 0x4000L;
-                            values = ref _headers._ContentLanguage;
-                            nameStr = HeaderNames.ContentLanguage;
-                        }
-                        else if (((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfdfuL) == 0x4e4f495441434f4cuL))
-                        {
-                            flag = 0x8000L;
-                            values = ref _headers._ContentLocation;
-                            nameStr = HeaderNames.ContentLocation;
-                        }
                     }
                     break;
                 case 17:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfffdfdfuL) == 0x4649444f4d2d4649uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfffdfdfdfuL) == 0x434e49532d444549uL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)16) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x1000000000L;
+                        flag = 0x8000000L;
                         values = ref _headers._IfModifiedSince;
                         nameStr = HeaderNames.IfModifiedSince;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x524546534e415254uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfffuL) == 0x4e49444f434e452duL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)16) & 0xdfu) == 0x47u))
                     {
-                        flag = 0x80L;
+                        flag = 0x40L;
                         values = ref _headers._TransferEncoding;
                         nameStr = HeaderNames.TransferEncoding;
                     }
@@ -8365,19 +7377,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 19:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x54414c4552524f43uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfffdfdfdfuL) == 0x544e4f432d4e4f49uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(8 * sizeof(ushort)))) & 0xdfdfu) == 0x5845u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)18) & 0xdfu) == 0x54u))
                     {
-                        flag = 0x2000000000000L;
+                        flag = 0x10000000000L;
                         values = ref _headers._CorrelationContext;
                         nameStr = HeaderNames.CorrelationContext;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfffdfdfuL) == 0x444f4d4e552d4649uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfffdfdfdfdfdfuL) == 0x49532d4445494649uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(8 * sizeof(ushort)))) & 0xdfdfu) == 0x434eu) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)18) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x8000000000L;
+                        flag = 0x40000000L;
                         values = ref _headers._IfUnmodifiedSince;
                         nameStr = HeaderNames.IfUnmodifiedSince;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfffdfdfdfdfdfuL) == 0x55412d59584f5250uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfdfuL) == 0x54415a49524f4854uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(8 * sizeof(ushort)))) & 0xdfdfu) == 0x4f49u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)18) & 0xdfu) == 0x4eu))
                     {
-                        flag = 0x20000000000L;
+                        flag = 0x100000000L;
                         values = ref _headers._ProxyAuthorization;
                         nameStr = HeaderNames.ProxyAuthorization;
                     }
@@ -8385,7 +7397,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 20:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x4343412d43505247uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfffdfdfdfuL) == 0x4f434e452d545045uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x474e4944u))
                     {
-                        flag = 0x100000000L;
+                        flag = 0x800000L;
                         values = ref _headers._GrpcAcceptEncoding;
                         nameStr = HeaderNames.GrpcAcceptEncoding;
                     }
@@ -8393,7 +7405,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 25:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d45444152475055uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfdfuL) == 0x4552554345534e49uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfdfdfdfdfdfdfffuL) == 0x545345555145522duL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)24) & 0xdfu) == 0x53u))
                     {
-                        flag = 0x800000000000L;
+                        flag = 0x4000000000L;
                         values = ref _headers._UpgradeInsecureRequests;
                         nameStr = HeaderNames.UpgradeInsecureRequests;
                     }
@@ -8401,7 +7413,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 29:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL) == 0x432d535345434341uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfffdfdfdfdfdfdfuL) == 0x522d4c4f52544e4fuL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfffdfdfdfdfdfdfuL) == 0x4d2d545345555145uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4f485445u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)28) & 0xdfu) == 0x44u))
                     {
-                        flag = 0x40000000000000L;
+                        flag = 0x200000000000L;
                         values = ref _headers._AccessControlRequestMethod;
                         nameStr = HeaderNames.AccessControlRequestMethod;
                     }
@@ -8409,7 +7421,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 30:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL) == 0x432d535345434341uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfffdfdfdfdfdfdfuL) == 0x522d4c4f52544e4fuL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfffdfdfdfdfdfdfuL) == 0x482d545345555145uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x45444145u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(14 * sizeof(ushort)))) & 0xdfdfu) == 0x5352u))
                     {
-                        flag = 0x80000000000000L;
+                        flag = 0x400000000000L;
                         values = ref _headers._AccessControlRequestHeaders;
                         nameStr = HeaderNames.AccessControlRequestHeaders;
                     }
@@ -8476,55 +7488,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             switch (index)
             {
                 case 1:
-                    flag = 0x100000L;
+                    flag = 0x800L;
                     values = ref _headers._Authority;
                     nameStr = HeaderNames.Authority;
                     break;
                 case 2:
                 case 3:
-                    flag = 0x200000L;
+                    flag = 0x1000L;
                     values = ref _headers._Method;
                     nameStr = HeaderNames.Method;
                     break;
                 case 4:
                 case 5:
-                    flag = 0x400000L;
+                    flag = 0x2000L;
                     values = ref _headers._Path;
                     nameStr = HeaderNames.Path;
                     break;
                 case 6:
                 case 7:
-                    flag = 0x800000L;
+                    flag = 0x4000L;
                     values = ref _headers._Scheme;
                     nameStr = HeaderNames.Scheme;
                     break;
                 case 15:
-                    flag = 0x2000000L;
+                    flag = 0x10000L;
                     values = ref _headers._AcceptCharset;
                     nameStr = HeaderNames.AcceptCharset;
                     break;
                 case 16:
-                    flag = 0x4000000L;
+                    flag = 0x20000L;
                     values = ref _headers._AcceptEncoding;
                     nameStr = HeaderNames.AcceptEncoding;
                     break;
                 case 17:
-                    flag = 0x8000000L;
+                    flag = 0x40000L;
                     values = ref _headers._AcceptLanguage;
                     nameStr = HeaderNames.AcceptLanguage;
                     break;
                 case 19:
-                    flag = 0x1000000L;
+                    flag = 0x8000L;
                     values = ref _headers._Accept;
                     nameStr = HeaderNames.Accept;
                     break;
-                case 22:
-                    flag = 0x800L;
-                    values = ref _headers._Allow;
-                    nameStr = HeaderNames.Allow;
-                    break;
                 case 23:
-                    flag = 0x10000000L;
+                    flag = 0x80000L;
                     values = ref _headers._Authorization;
                     nameStr = HeaderNames.Authorization;
                     break;
@@ -8532,16 +7539,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     flag = 0x1L;
                     values = ref _headers._CacheControl;
                     nameStr = HeaderNames.CacheControl;
-                    break;
-                case 26:
-                    flag = 0x2000L;
-                    values = ref _headers._ContentEncoding;
-                    nameStr = HeaderNames.ContentEncoding;
-                    break;
-                case 27:
-                    flag = 0x4000L;
-                    values = ref _headers._ContentLanguage;
-                    nameStr = HeaderNames.ContentLanguage;
                     break;
                 case 28:
                     if (ReferenceEquals(EncodingSelector, KestrelServerOptions.DefaultRequestHeaderEncodingSelector))
@@ -8553,23 +7550,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         AppendContentLengthCustomEncoding(value, EncodingSelector(HeaderNames.ContentLength));
                     }
                     return true;
-                case 29:
-                    flag = 0x8000L;
-                    values = ref _headers._ContentLocation;
-                    nameStr = HeaderNames.ContentLocation;
-                    break;
-                case 30:
-                    flag = 0x20000L;
-                    values = ref _headers._ContentRange;
-                    nameStr = HeaderNames.ContentRange;
-                    break;
                 case 31:
-                    flag = 0x1000L;
+                    flag = 0x400L;
                     values = ref _headers._ContentType;
                     nameStr = HeaderNames.ContentType;
                     break;
                 case 32:
-                    flag = 0x20000000L;
+                    flag = 0x100000L;
                     values = ref _headers._Cookie;
                     nameStr = HeaderNames.Cookie;
                     break;
@@ -8579,87 +7566,77 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     nameStr = HeaderNames.Date;
                     break;
                 case 35:
-                    flag = 0x40000000L;
+                    flag = 0x200000L;
                     values = ref _headers._Expect;
                     nameStr = HeaderNames.Expect;
                     break;
-                case 36:
-                    flag = 0x40000L;
-                    values = ref _headers._Expires;
-                    nameStr = HeaderNames.Expires;
-                    break;
                 case 37:
-                    flag = 0x80000000L;
+                    flag = 0x400000L;
                     values = ref _headers._From;
                     nameStr = HeaderNames.From;
                     break;
                 case 38:
-                    flag = 0x400000000L;
+                    flag = 0x2000000L;
                     values = ref _headers._Host;
                     nameStr = HeaderNames.Host;
                     break;
                 case 39:
-                    flag = 0x800000000L;
+                    flag = 0x4000000L;
                     values = ref _headers._IfMatch;
                     nameStr = HeaderNames.IfMatch;
                     break;
                 case 40:
-                    flag = 0x1000000000L;
+                    flag = 0x8000000L;
                     values = ref _headers._IfModifiedSince;
                     nameStr = HeaderNames.IfModifiedSince;
                     break;
                 case 41:
-                    flag = 0x2000000000L;
+                    flag = 0x10000000L;
                     values = ref _headers._IfNoneMatch;
                     nameStr = HeaderNames.IfNoneMatch;
                     break;
                 case 42:
-                    flag = 0x4000000000L;
+                    flag = 0x20000000L;
                     values = ref _headers._IfRange;
                     nameStr = HeaderNames.IfRange;
                     break;
                 case 43:
-                    flag = 0x8000000000L;
+                    flag = 0x40000000L;
                     values = ref _headers._IfUnmodifiedSince;
                     nameStr = HeaderNames.IfUnmodifiedSince;
                     break;
-                case 44:
-                    flag = 0x80000L;
-                    values = ref _headers._LastModified;
-                    nameStr = HeaderNames.LastModified;
-                    break;
                 case 47:
-                    flag = 0x10000000000L;
+                    flag = 0x80000000L;
                     values = ref _headers._MaxForwards;
                     nameStr = HeaderNames.MaxForwards;
                     break;
                 case 49:
-                    flag = 0x20000000000L;
+                    flag = 0x100000000L;
                     values = ref _headers._ProxyAuthorization;
                     nameStr = HeaderNames.ProxyAuthorization;
                     break;
                 case 50:
-                    flag = 0x80000000000L;
+                    flag = 0x400000000L;
                     values = ref _headers._Range;
                     nameStr = HeaderNames.Range;
                     break;
                 case 51:
-                    flag = 0x40000000000L;
+                    flag = 0x200000000L;
                     values = ref _headers._Referer;
                     nameStr = HeaderNames.Referer;
                     break;
                 case 57:
-                    flag = 0x80L;
+                    flag = 0x40L;
                     values = ref _headers._TransferEncoding;
                     nameStr = HeaderNames.TransferEncoding;
                     break;
                 case 58:
-                    flag = 0x400000000000L;
+                    flag = 0x2000000000L;
                     values = ref _headers._UserAgent;
                     nameStr = HeaderNames.UserAgent;
                     break;
                 case 60:
-                    flag = 0x200L;
+                    flag = 0x100L;
                     values = ref _headers._Via;
                     nameStr = HeaderNames.Via;
                     break;
@@ -8718,20 +7695,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             public StringValues _GrpcEncoding;
             public StringValues _KeepAlive;
             public StringValues _Pragma;
-            public StringValues _Trailer;
             public StringValues _TransferEncoding;
             public StringValues _Upgrade;
             public StringValues _Via;
             public StringValues _Warning;
-            public StringValues _Allow;
             public StringValues _ContentType;
-            public StringValues _ContentEncoding;
-            public StringValues _ContentLanguage;
-            public StringValues _ContentLocation;
-            public StringValues _ContentMD5;
-            public StringValues _ContentRange;
-            public StringValues _Expires;
-            public StringValues _LastModified;
             public StringValues _Authority;
             public StringValues _Method;
             public StringValues _Path;
@@ -8791,106 +7759,88 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     case 5:
                         goto HeaderPragma;
                     case 6:
-                        goto HeaderTrailer;
-                    case 7:
                         goto HeaderTransferEncoding;
-                    case 8:
+                    case 7:
                         goto HeaderUpgrade;
-                    case 9:
+                    case 8:
                         goto HeaderVia;
-                    case 10:
+                    case 9:
                         goto HeaderWarning;
-                    case 11:
-                        goto HeaderAllow;
-                    case 12:
+                    case 10:
                         goto HeaderContentType;
-                    case 13:
-                        goto HeaderContentEncoding;
-                    case 14:
-                        goto HeaderContentLanguage;
-                    case 15:
-                        goto HeaderContentLocation;
-                    case 16:
-                        goto HeaderContentMD5;
-                    case 17:
-                        goto HeaderContentRange;
-                    case 18:
-                        goto HeaderExpires;
-                    case 19:
-                        goto HeaderLastModified;
-                    case 20:
+                    case 11:
                         goto HeaderAuthority;
-                    case 21:
+                    case 12:
                         goto HeaderMethod;
-                    case 22:
+                    case 13:
                         goto HeaderPath;
-                    case 23:
+                    case 14:
                         goto HeaderScheme;
-                    case 24:
+                    case 15:
                         goto HeaderAccept;
-                    case 25:
+                    case 16:
                         goto HeaderAcceptCharset;
-                    case 26:
+                    case 17:
                         goto HeaderAcceptEncoding;
-                    case 27:
+                    case 18:
                         goto HeaderAcceptLanguage;
-                    case 28:
+                    case 19:
                         goto HeaderAuthorization;
-                    case 29:
+                    case 20:
                         goto HeaderCookie;
-                    case 30:
+                    case 21:
                         goto HeaderExpect;
-                    case 31:
+                    case 22:
                         goto HeaderFrom;
-                    case 32:
+                    case 23:
                         goto HeaderGrpcAcceptEncoding;
-                    case 33:
+                    case 24:
                         goto HeaderGrpcTimeout;
-                    case 34:
+                    case 25:
                         goto HeaderHost;
-                    case 35:
+                    case 26:
                         goto HeaderIfMatch;
-                    case 36:
+                    case 27:
                         goto HeaderIfModifiedSince;
-                    case 37:
+                    case 28:
                         goto HeaderIfNoneMatch;
-                    case 38:
+                    case 29:
                         goto HeaderIfRange;
-                    case 39:
+                    case 30:
                         goto HeaderIfUnmodifiedSince;
-                    case 40:
+                    case 31:
                         goto HeaderMaxForwards;
-                    case 41:
+                    case 32:
                         goto HeaderProxyAuthorization;
-                    case 42:
+                    case 33:
                         goto HeaderReferer;
-                    case 43:
+                    case 34:
                         goto HeaderRange;
-                    case 44:
+                    case 35:
                         goto HeaderTE;
-                    case 45:
+                    case 36:
                         goto HeaderTranslate;
-                    case 46:
+                    case 37:
                         goto HeaderUserAgent;
-                    case 47:
+                    case 38:
                         goto HeaderUpgradeInsecureRequests;
-                    case 48:
+                    case 39:
                         goto HeaderRequestId;
-                    case 49:
+                    case 40:
                         goto HeaderCorrelationContext;
-                    case 50:
+                    case 41:
                         goto HeaderTraceParent;
-                    case 51:
+                    case 42:
                         goto HeaderTraceState;
-                    case 52:
+                    case 43:
                         goto HeaderBaggage;
-                    case 53:
+                    case 44:
                         goto HeaderOrigin;
-                    case 54:
+                    case 45:
                         goto HeaderAccessControlRequestMethod;
-                    case 55:
+                    case 46:
                         goto HeaderAccessControlRequestHeaders;
-                    case 56:
+                    case 47:
                         goto HeaderContentLength;
                     default:
                         goto ExtraHeaders;
@@ -8944,412 +7894,340 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _next = 6;
                         return true;
                     }
-                HeaderTrailer: // case 6
+                HeaderTransferEncoding: // case 6
                     if ((_bits & 0x40L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Trailer, _collection._headers._Trailer);
-                        _currentKnownType = KnownHeaderType.Trailer;
-                        _next = 7;
-                        return true;
-                    }
-                HeaderTransferEncoding: // case 7
-                    if ((_bits & 0x80L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _collection._headers._TransferEncoding);
                         _currentKnownType = KnownHeaderType.TransferEncoding;
-                        _next = 8;
+                        _next = 7;
                         return true;
                     }
-                HeaderUpgrade: // case 8
-                    if ((_bits & 0x100L) != 0)
+                HeaderUpgrade: // case 7
+                    if ((_bits & 0x80L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _collection._headers._Upgrade);
                         _currentKnownType = KnownHeaderType.Upgrade;
-                        _next = 9;
+                        _next = 8;
                         return true;
                     }
-                HeaderVia: // case 9
-                    if ((_bits & 0x200L) != 0)
+                HeaderVia: // case 8
+                    if ((_bits & 0x100L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Via, _collection._headers._Via);
                         _currentKnownType = KnownHeaderType.Via;
-                        _next = 10;
+                        _next = 9;
                         return true;
                     }
-                HeaderWarning: // case 10
-                    if ((_bits & 0x400L) != 0)
+                HeaderWarning: // case 9
+                    if ((_bits & 0x200L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _collection._headers._Warning);
                         _currentKnownType = KnownHeaderType.Warning;
-                        _next = 11;
+                        _next = 10;
                         return true;
                     }
-                HeaderAllow: // case 11
-                    if ((_bits & 0x800L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _collection._headers._Allow);
-                        _currentKnownType = KnownHeaderType.Allow;
-                        _next = 12;
-                        return true;
-                    }
-                HeaderContentType: // case 12
-                    if ((_bits & 0x1000L) != 0)
+                HeaderContentType: // case 10
+                    if ((_bits & 0x400L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _collection._headers._ContentType);
                         _currentKnownType = KnownHeaderType.ContentType;
-                        _next = 13;
+                        _next = 11;
                         return true;
                     }
-                HeaderContentEncoding: // case 13
-                    if ((_bits & 0x2000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _collection._headers._ContentEncoding);
-                        _currentKnownType = KnownHeaderType.ContentEncoding;
-                        _next = 14;
-                        return true;
-                    }
-                HeaderContentLanguage: // case 14
-                    if ((_bits & 0x4000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _collection._headers._ContentLanguage);
-                        _currentKnownType = KnownHeaderType.ContentLanguage;
-                        _next = 15;
-                        return true;
-                    }
-                HeaderContentLocation: // case 15
-                    if ((_bits & 0x8000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _collection._headers._ContentLocation);
-                        _currentKnownType = KnownHeaderType.ContentLocation;
-                        _next = 16;
-                        return true;
-                    }
-                HeaderContentMD5: // case 16
-                    if ((_bits & 0x10000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _collection._headers._ContentMD5);
-                        _currentKnownType = KnownHeaderType.ContentMD5;
-                        _next = 17;
-                        return true;
-                    }
-                HeaderContentRange: // case 17
-                    if ((_bits & 0x20000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _collection._headers._ContentRange);
-                        _currentKnownType = KnownHeaderType.ContentRange;
-                        _next = 18;
-                        return true;
-                    }
-                HeaderExpires: // case 18
-                    if ((_bits & 0x40000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _collection._headers._Expires);
-                        _currentKnownType = KnownHeaderType.Expires;
-                        _next = 19;
-                        return true;
-                    }
-                HeaderLastModified: // case 19
-                    if ((_bits & 0x80000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _collection._headers._LastModified);
-                        _currentKnownType = KnownHeaderType.LastModified;
-                        _next = 20;
-                        return true;
-                    }
-                HeaderAuthority: // case 20
-                    if ((_bits & 0x100000L) != 0)
+                HeaderAuthority: // case 11
+                    if ((_bits & 0x800L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Authority, _collection._headers._Authority);
                         _currentKnownType = KnownHeaderType.Authority;
-                        _next = 21;
+                        _next = 12;
                         return true;
                     }
-                HeaderMethod: // case 21
-                    if ((_bits & 0x200000L) != 0)
+                HeaderMethod: // case 12
+                    if ((_bits & 0x1000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Method, _collection._headers._Method);
                         _currentKnownType = KnownHeaderType.Method;
-                        _next = 22;
+                        _next = 13;
                         return true;
                     }
-                HeaderPath: // case 22
-                    if ((_bits & 0x400000L) != 0)
+                HeaderPath: // case 13
+                    if ((_bits & 0x2000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Path, _collection._headers._Path);
                         _currentKnownType = KnownHeaderType.Path;
-                        _next = 23;
+                        _next = 14;
                         return true;
                     }
-                HeaderScheme: // case 23
-                    if ((_bits & 0x800000L) != 0)
+                HeaderScheme: // case 14
+                    if ((_bits & 0x4000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Scheme, _collection._headers._Scheme);
                         _currentKnownType = KnownHeaderType.Scheme;
-                        _next = 24;
+                        _next = 15;
                         return true;
                     }
-                HeaderAccept: // case 24
-                    if ((_bits & 0x1000000L) != 0)
+                HeaderAccept: // case 15
+                    if ((_bits & 0x8000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Accept, _collection._headers._Accept);
                         _currentKnownType = KnownHeaderType.Accept;
-                        _next = 25;
+                        _next = 16;
                         return true;
                     }
-                HeaderAcceptCharset: // case 25
-                    if ((_bits & 0x2000000L) != 0)
+                HeaderAcceptCharset: // case 16
+                    if ((_bits & 0x10000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptCharset, _collection._headers._AcceptCharset);
                         _currentKnownType = KnownHeaderType.AcceptCharset;
-                        _next = 26;
+                        _next = 17;
                         return true;
                     }
-                HeaderAcceptEncoding: // case 26
-                    if ((_bits & 0x4000000L) != 0)
+                HeaderAcceptEncoding: // case 17
+                    if ((_bits & 0x20000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptEncoding, _collection._headers._AcceptEncoding);
                         _currentKnownType = KnownHeaderType.AcceptEncoding;
-                        _next = 27;
+                        _next = 18;
                         return true;
                     }
-                HeaderAcceptLanguage: // case 27
-                    if ((_bits & 0x8000000L) != 0)
+                HeaderAcceptLanguage: // case 18
+                    if ((_bits & 0x40000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptLanguage, _collection._headers._AcceptLanguage);
                         _currentKnownType = KnownHeaderType.AcceptLanguage;
-                        _next = 28;
+                        _next = 19;
                         return true;
                     }
-                HeaderAuthorization: // case 28
-                    if ((_bits & 0x10000000L) != 0)
+                HeaderAuthorization: // case 19
+                    if ((_bits & 0x80000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Authorization, _collection._headers._Authorization);
                         _currentKnownType = KnownHeaderType.Authorization;
-                        _next = 29;
+                        _next = 20;
                         return true;
                     }
-                HeaderCookie: // case 29
-                    if ((_bits & 0x20000000L) != 0)
+                HeaderCookie: // case 20
+                    if ((_bits & 0x100000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Cookie, _collection._headers._Cookie);
                         _currentKnownType = KnownHeaderType.Cookie;
-                        _next = 30;
+                        _next = 21;
                         return true;
                     }
-                HeaderExpect: // case 30
-                    if ((_bits & 0x40000000L) != 0)
+                HeaderExpect: // case 21
+                    if ((_bits & 0x200000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Expect, _collection._headers._Expect);
                         _currentKnownType = KnownHeaderType.Expect;
-                        _next = 31;
+                        _next = 22;
                         return true;
                     }
-                HeaderFrom: // case 31
-                    if ((_bits & 0x80000000L) != 0)
+                HeaderFrom: // case 22
+                    if ((_bits & 0x400000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.From, _collection._headers._From);
                         _currentKnownType = KnownHeaderType.From;
-                        _next = 32;
+                        _next = 23;
                         return true;
                     }
-                HeaderGrpcAcceptEncoding: // case 32
-                    if ((_bits & 0x100000000L) != 0)
+                HeaderGrpcAcceptEncoding: // case 23
+                    if ((_bits & 0x800000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.GrpcAcceptEncoding, _collection._headers._GrpcAcceptEncoding);
                         _currentKnownType = KnownHeaderType.GrpcAcceptEncoding;
-                        _next = 33;
+                        _next = 24;
                         return true;
                     }
-                HeaderGrpcTimeout: // case 33
-                    if ((_bits & 0x200000000L) != 0)
+                HeaderGrpcTimeout: // case 24
+                    if ((_bits & 0x1000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.GrpcTimeout, _collection._headers._GrpcTimeout);
                         _currentKnownType = KnownHeaderType.GrpcTimeout;
-                        _next = 34;
+                        _next = 25;
                         return true;
                     }
-                HeaderHost: // case 34
-                    if ((_bits & 0x400000000L) != 0)
+                HeaderHost: // case 25
+                    if ((_bits & 0x2000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Host, _collection._headers._Host);
                         _currentKnownType = KnownHeaderType.Host;
-                        _next = 35;
+                        _next = 26;
                         return true;
                     }
-                HeaderIfMatch: // case 35
-                    if ((_bits & 0x800000000L) != 0)
+                HeaderIfMatch: // case 26
+                    if ((_bits & 0x4000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfMatch, _collection._headers._IfMatch);
                         _currentKnownType = KnownHeaderType.IfMatch;
-                        _next = 36;
+                        _next = 27;
                         return true;
                     }
-                HeaderIfModifiedSince: // case 36
-                    if ((_bits & 0x1000000000L) != 0)
+                HeaderIfModifiedSince: // case 27
+                    if ((_bits & 0x8000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfModifiedSince, _collection._headers._IfModifiedSince);
                         _currentKnownType = KnownHeaderType.IfModifiedSince;
-                        _next = 37;
+                        _next = 28;
                         return true;
                     }
-                HeaderIfNoneMatch: // case 37
-                    if ((_bits & 0x2000000000L) != 0)
+                HeaderIfNoneMatch: // case 28
+                    if ((_bits & 0x10000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfNoneMatch, _collection._headers._IfNoneMatch);
                         _currentKnownType = KnownHeaderType.IfNoneMatch;
-                        _next = 38;
+                        _next = 29;
                         return true;
                     }
-                HeaderIfRange: // case 38
-                    if ((_bits & 0x4000000000L) != 0)
+                HeaderIfRange: // case 29
+                    if ((_bits & 0x20000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfRange, _collection._headers._IfRange);
                         _currentKnownType = KnownHeaderType.IfRange;
-                        _next = 39;
+                        _next = 30;
                         return true;
                     }
-                HeaderIfUnmodifiedSince: // case 39
-                    if ((_bits & 0x8000000000L) != 0)
+                HeaderIfUnmodifiedSince: // case 30
+                    if ((_bits & 0x40000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfUnmodifiedSince, _collection._headers._IfUnmodifiedSince);
                         _currentKnownType = KnownHeaderType.IfUnmodifiedSince;
-                        _next = 40;
+                        _next = 31;
                         return true;
                     }
-                HeaderMaxForwards: // case 40
-                    if ((_bits & 0x10000000000L) != 0)
+                HeaderMaxForwards: // case 31
+                    if ((_bits & 0x80000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.MaxForwards, _collection._headers._MaxForwards);
                         _currentKnownType = KnownHeaderType.MaxForwards;
-                        _next = 41;
+                        _next = 32;
                         return true;
                     }
-                HeaderProxyAuthorization: // case 41
-                    if ((_bits & 0x20000000000L) != 0)
+                HeaderProxyAuthorization: // case 32
+                    if ((_bits & 0x100000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthorization, _collection._headers._ProxyAuthorization);
                         _currentKnownType = KnownHeaderType.ProxyAuthorization;
-                        _next = 42;
+                        _next = 33;
                         return true;
                     }
-                HeaderReferer: // case 42
-                    if ((_bits & 0x40000000000L) != 0)
+                HeaderReferer: // case 33
+                    if ((_bits & 0x200000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Referer, _collection._headers._Referer);
                         _currentKnownType = KnownHeaderType.Referer;
-                        _next = 43;
+                        _next = 34;
                         return true;
                     }
-                HeaderRange: // case 43
-                    if ((_bits & 0x80000000000L) != 0)
+                HeaderRange: // case 34
+                    if ((_bits & 0x400000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Range, _collection._headers._Range);
                         _currentKnownType = KnownHeaderType.Range;
-                        _next = 44;
+                        _next = 35;
                         return true;
                     }
-                HeaderTE: // case 44
-                    if ((_bits & 0x100000000000L) != 0)
+                HeaderTE: // case 35
+                    if ((_bits & 0x800000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.TE, _collection._headers._TE);
                         _currentKnownType = KnownHeaderType.TE;
-                        _next = 45;
+                        _next = 36;
                         return true;
                     }
-                HeaderTranslate: // case 45
-                    if ((_bits & 0x200000000000L) != 0)
+                HeaderTranslate: // case 36
+                    if ((_bits & 0x1000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Translate, _collection._headers._Translate);
                         _currentKnownType = KnownHeaderType.Translate;
-                        _next = 46;
+                        _next = 37;
                         return true;
                     }
-                HeaderUserAgent: // case 46
-                    if ((_bits & 0x400000000000L) != 0)
+                HeaderUserAgent: // case 37
+                    if ((_bits & 0x2000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.UserAgent, _collection._headers._UserAgent);
                         _currentKnownType = KnownHeaderType.UserAgent;
-                        _next = 47;
+                        _next = 38;
                         return true;
                     }
-                HeaderUpgradeInsecureRequests: // case 47
-                    if ((_bits & 0x800000000000L) != 0)
+                HeaderUpgradeInsecureRequests: // case 38
+                    if ((_bits & 0x4000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _collection._headers._UpgradeInsecureRequests);
                         _currentKnownType = KnownHeaderType.UpgradeInsecureRequests;
-                        _next = 48;
+                        _next = 39;
                         return true;
                     }
-                HeaderRequestId: // case 48
-                    if ((_bits & 0x1000000000000L) != 0)
+                HeaderRequestId: // case 39
+                    if ((_bits & 0x8000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _collection._headers._RequestId);
                         _currentKnownType = KnownHeaderType.RequestId;
-                        _next = 49;
+                        _next = 40;
                         return true;
                     }
-                HeaderCorrelationContext: // case 49
-                    if ((_bits & 0x2000000000000L) != 0)
+                HeaderCorrelationContext: // case 40
+                    if ((_bits & 0x10000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _collection._headers._CorrelationContext);
                         _currentKnownType = KnownHeaderType.CorrelationContext;
-                        _next = 50;
+                        _next = 41;
                         return true;
                     }
-                HeaderTraceParent: // case 50
-                    if ((_bits & 0x4000000000000L) != 0)
+                HeaderTraceParent: // case 41
+                    if ((_bits & 0x20000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _collection._headers._TraceParent);
                         _currentKnownType = KnownHeaderType.TraceParent;
-                        _next = 51;
+                        _next = 42;
                         return true;
                     }
-                HeaderTraceState: // case 51
-                    if ((_bits & 0x8000000000000L) != 0)
+                HeaderTraceState: // case 42
+                    if ((_bits & 0x40000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _collection._headers._TraceState);
                         _currentKnownType = KnownHeaderType.TraceState;
-                        _next = 52;
+                        _next = 43;
                         return true;
                     }
-                HeaderBaggage: // case 52
-                    if ((_bits & 0x10000000000000L) != 0)
+                HeaderBaggage: // case 43
+                    if ((_bits & 0x80000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _collection._headers._Baggage);
                         _currentKnownType = KnownHeaderType.Baggage;
-                        _next = 53;
+                        _next = 44;
                         return true;
                     }
-                HeaderOrigin: // case 53
-                    if ((_bits & 0x20000000000000L) != 0)
+                HeaderOrigin: // case 44
+                    if ((_bits & 0x100000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _collection._headers._Origin);
                         _currentKnownType = KnownHeaderType.Origin;
-                        _next = 54;
+                        _next = 45;
                         return true;
                     }
-                HeaderAccessControlRequestMethod: // case 54
-                    if ((_bits & 0x40000000000000L) != 0)
+                HeaderAccessControlRequestMethod: // case 45
+                    if ((_bits & 0x200000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestMethod, _collection._headers._AccessControlRequestMethod);
                         _currentKnownType = KnownHeaderType.AccessControlRequestMethod;
-                        _next = 55;
+                        _next = 46;
                         return true;
                     }
-                HeaderAccessControlRequestHeaders: // case 55
-                    if ((_bits & 0x80000000000000L) != 0)
+                HeaderAccessControlRequestHeaders: // case 46
+                    if ((_bits & 0x400000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestHeaders, _collection._headers._AccessControlRequestHeaders);
                         _currentKnownType = KnownHeaderType.AccessControlRequestHeaders;
-                        _next = 56;
+                        _next = 47;
                         return true;
                     }
-                HeaderContentLength: // case 56
+                HeaderContentLength: // case 47
                     if (_collection._contentLength.HasValue)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLength, HeaderUtilities.FormatNonNegativeInt64(_collection._contentLength.Value));
                         _currentKnownType = KnownHeaderType.ContentLength;
-                        _next = 57;
+                        _next = 48;
                         return true;
                     }
                 ExtraHeaders:
@@ -9370,14 +8248,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     {
         private static ReadOnlySpan<byte> HeaderBytes => new byte[]
         {
-            13,10,67,97,99,104,101,45,67,111,110,116,114,111,108,58,32,13,10,67,111,110,110,101,99,116,105,111,110,58,32,13,10,68,97,116,101,58,32,13,10,71,114,112,99,45,69,110,99,111,100,105,110,103,58,32,13,10,75,101,101,112,45,65,108,105,118,101,58,32,13,10,80,114,97,103,109,97,58,32,13,10,84,114,97,105,108,101,114,58,32,13,10,84,114,97,110,115,102,101,114,45,69,110,99,111,100,105,110,103,58,32,13,10,85,112,103,114,97,100,101,58,32,13,10,86,105,97,58,32,13,10,87,97,114,110,105,110,103,58,32,13,10,65,108,108,111,119,58,32,13,10,67,111,110,116,101,110,116,45,84,121,112,101,58,32,13,10,67,111,110,116,101,110,116,45,69,110,99,111,100,105,110,103,58,32,13,10,67,111,110,116,101,110,116,45,76,97,110,103,117,97,103,101,58,32,13,10,67,111,110,116,101,110,116,45,76,111,99,97,116,105,111,110,58,32,13,10,67,111,110,116,101,110,116,45,77,68,53,58,32,13,10,67,111,110,116,101,110,116,45,82,97,110,103,101,58,32,13,10,69,120,112,105,114,101,115,58,32,13,10,76,97,115,116,45,77,111,100,105,102,105,101,100,58,32,13,10,65,99,99,101,112,116,45,82,97,110,103,101,115,58,32,13,10,65,103,101,58,32,13,10,65,108,116,45,83,118,99,58,32,13,10,69,84,97,103,58,32,13,10,76,111,99,97,116,105,111,110,58,32,13,10,80,114,111,120,121,45,65,117,116,104,101,110,116,105,99,97,116,101,58,32,13,10,80,114,111,120,121,45,67,111,110,110,101,99,116,105,111,110,58,32,13,10,82,101,116,114,121,45,65,102,116,101,114,58,32,13,10,83,101,114,118,101,114,58,32,13,10,83,101,116,45,67,111,111,107,105,101,58,32,13,10,86,97,114,121,58,32,13,10,87,87,87,45,65,117,116,104,101,110,116,105,99,97,116,101,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,67,114,101,100,101,110,116,105,97,108,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,72,101,97,100,101,114,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,77,101,116,104,111,100,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,79,114,105,103,105,110,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,69,120,112,111,115,101,45,72,101,97,100,101,114,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,77,97,120,45,65,103,101,58,32,13,10,67,111,110,116,101,110,116,45,76,101,110,103,116,104,58,32,
+            13,10,67,97,99,104,101,45,67,111,110,116,114,111,108,58,32,13,10,67,111,110,110,101,99,116,105,111,110,58,32,13,10,68,97,116,101,58,32,13,10,71,114,112,99,45,69,110,99,111,100,105,110,103,58,32,13,10,75,101,101,112,45,65,108,105,118,101,58,32,13,10,80,114,97,103,109,97,58,32,13,10,84,114,97,110,115,102,101,114,45,69,110,99,111,100,105,110,103,58,32,13,10,85,112,103,114,97,100,101,58,32,13,10,86,105,97,58,32,13,10,87,97,114,110,105,110,103,58,32,13,10,67,111,110,116,101,110,116,45,84,121,112,101,58,32,13,10,65,99,99,101,112,116,45,82,97,110,103,101,115,58,32,13,10,65,103,101,58,32,13,10,65,108,108,111,119,58,32,13,10,65,108,116,45,83,118,99,58,32,13,10,69,84,97,103,58,32,13,10,76,111,99,97,116,105,111,110,58,32,13,10,80,114,111,120,121,45,65,117,116,104,101,110,116,105,99,97,116,101,58,32,13,10,80,114,111,120,121,45,67,111,110,110,101,99,116,105,111,110,58,32,13,10,82,101,116,114,121,45,65,102,116,101,114,58,32,13,10,83,101,114,118,101,114,58,32,13,10,83,101,116,45,67,111,111,107,105,101,58,32,13,10,86,97,114,121,58,32,13,10,69,120,112,105,114,101,115,58,32,13,10,87,87,87,45,65,117,116,104,101,110,116,105,99,97,116,101,58,32,13,10,67,111,110,116,101,110,116,45,82,97,110,103,101,58,32,13,10,67,111,110,116,101,110,116,45,69,110,99,111,100,105,110,103,58,32,13,10,67,111,110,116,101,110,116,45,76,97,110,103,117,97,103,101,58,32,13,10,67,111,110,116,101,110,116,45,76,111,99,97,116,105,111,110,58,32,13,10,67,111,110,116,101,110,116,45,77,68,53,58,32,13,10,76,97,115,116,45,77,111,100,105,102,105,101,100,58,32,13,10,84,114,97,105,108,101,114,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,67,114,101,100,101,110,116,105,97,108,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,72,101,97,100,101,114,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,77,101,116,104,111,100,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,79,114,105,103,105,110,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,69,120,112,111,115,101,45,72,101,97,100,101,114,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,77,97,120,45,65,103,101,58,32,13,10,67,111,110,116,101,110,116,45,76,101,110,103,116,104,58,32,
         };
         private HeaderReferences _headers;
 
         public bool HasConnection => (_bits & 0x2L) != 0;
         public bool HasDate => (_bits & 0x4L) != 0;
-        public bool HasTransferEncoding => (_bits & 0x80L) != 0;
-        public bool HasServer => (_bits & 0x10000000L) != 0;
+        public bool HasTransferEncoding => (_bits & 0x40L) != 0;
+        public bool HasServer => (_bits & 0x100000L) != 0;
 
 
         public override StringValues HeaderConnection
@@ -9403,7 +8281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x80L) != 0)
+                if ((_bits & 0x40L) != 0)
                 {
                     value = _headers._TransferEncoding;
                 }
@@ -9411,7 +8289,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x80L;
+                _bits |= 0x40L;
                 _headers._TransferEncoding = value; 
                 _headers._rawTransferEncoding = null;
             }
@@ -9421,7 +8299,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x800L) != 0)
+                if ((_bits & 0x2000L) != 0)
                 {
                     value = _headers._Allow;
                 }
@@ -9429,7 +8307,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x800L;
+                _bits |= 0x2000L;
                 _headers._Allow = value; 
             }
         }
@@ -9438,7 +8316,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x400000L) != 0)
+                if ((_bits & 0x4000L) != 0)
                 {
                     value = _headers._AltSvc;
                 }
@@ -9446,7 +8324,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x400000L;
+                _bits |= 0x4000L;
                 _headers._AltSvc = value; 
             }
         }
@@ -9637,11 +8515,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
         }
-        StringValues IHeaderDictionary.Trailer
+        StringValues IHeaderDictionary.TransferEncoding
         {
             get
             {
-                var value = _headers._Trailer;
+                var value = _headers._TransferEncoding;
                 if ((_bits & 0x40L) != 0)
                 {
                     return value;
@@ -9653,34 +8531,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x40L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Trailer = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Trailer = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.TransferEncoding
-        {
-            get
-            {
-                var value = _headers._TransferEncoding;
-                if ((_bits & 0x80L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x80L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -9699,7 +8549,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Upgrade;
-                if ((_bits & 0x100L) != 0)
+                if ((_bits & 0x80L) != 0)
                 {
                     return value;
                 }
@@ -9709,7 +8559,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x100L;
+                var flag = 0x80L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -9727,7 +8577,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Via;
-                if ((_bits & 0x200L) != 0)
+                if ((_bits & 0x100L) != 0)
                 {
                     return value;
                 }
@@ -9737,7 +8587,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x200L;
+                var flag = 0x100L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -9755,6 +8605,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Warning;
+                if ((_bits & 0x200L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x200L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Warning = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Warning = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentType
+        {
+            get
+            {
+                var value = _headers._ContentType;
                 if ((_bits & 0x400L) != 0)
                 {
                     return value;
@@ -9769,20 +8647,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Warning = value;
+                    _headers._ContentType = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Warning = default;
+                    _headers._ContentType = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Allow
+        StringValues IHeaderDictionary.AcceptRanges
         {
             get
             {
-                var value = _headers._Allow;
+                var value = _headers._AcceptRanges;
                 if ((_bits & 0x800L) != 0)
                 {
                     return value;
@@ -9794,258 +8672,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x800L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Allow = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Allow = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentType
-        {
-            get
-            {
-                var value = _headers._ContentType;
-                if ((_bits & 0x1000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x1000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentType = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentType = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentEncoding
-        {
-            get
-            {
-                var value = _headers._ContentEncoding;
-                if ((_bits & 0x2000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x2000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentEncoding = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentEncoding = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentLanguage
-        {
-            get
-            {
-                var value = _headers._ContentLanguage;
-                if ((_bits & 0x4000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x4000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentLanguage = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentLanguage = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentLocation
-        {
-            get
-            {
-                var value = _headers._ContentLocation;
-                if ((_bits & 0x8000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x8000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentLocation = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentLocation = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentMD5
-        {
-            get
-            {
-                var value = _headers._ContentMD5;
-                if ((_bits & 0x10000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x10000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentMD5 = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentMD5 = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentRange
-        {
-            get
-            {
-                var value = _headers._ContentRange;
-                if ((_bits & 0x20000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x20000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentRange = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentRange = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Expires
-        {
-            get
-            {
-                var value = _headers._Expires;
-                if ((_bits & 0x40000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x40000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Expires = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Expires = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.LastModified
-        {
-            get
-            {
-                var value = _headers._LastModified;
-                if ((_bits & 0x80000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x80000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._LastModified = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._LastModified = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.AcceptRanges
-        {
-            get
-            {
-                var value = _headers._AcceptRanges;
-                if ((_bits & 0x100000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x100000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10063,7 +8689,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Age;
-                if ((_bits & 0x200000L) != 0)
+                if ((_bits & 0x1000L) != 0)
                 {
                     return value;
                 }
@@ -10073,7 +8699,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x200000L;
+                var flag = 0x1000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10086,12 +8712,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
         }
-        StringValues IHeaderDictionary.AltSvc
+        StringValues IHeaderDictionary.Allow
         {
             get
             {
-                var value = _headers._AltSvc;
-                if ((_bits & 0x400000L) != 0)
+                var value = _headers._Allow;
+                if ((_bits & 0x2000L) != 0)
                 {
                     return value;
                 }
@@ -10101,7 +8727,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x400000L;
+                var flag = 0x2000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Allow = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Allow = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.AltSvc
+        {
+            get
+            {
+                var value = _headers._AltSvc;
+                if ((_bits & 0x4000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x4000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10119,7 +8773,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._ETag;
-                if ((_bits & 0x800000L) != 0)
+                if ((_bits & 0x8000L) != 0)
                 {
                     return value;
                 }
@@ -10129,7 +8783,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x800000L;
+                var flag = 0x8000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10147,7 +8801,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Location;
-                if ((_bits & 0x1000000L) != 0)
+                if ((_bits & 0x10000L) != 0)
                 {
                     return value;
                 }
@@ -10157,7 +8811,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x1000000L;
+                var flag = 0x10000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10175,7 +8829,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._ProxyAuthenticate;
-                if ((_bits & 0x2000000L) != 0)
+                if ((_bits & 0x20000L) != 0)
                 {
                     return value;
                 }
@@ -10185,7 +8839,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x2000000L;
+                var flag = 0x20000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10203,7 +8857,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._ProxyConnection;
-                if ((_bits & 0x4000000L) != 0)
+                if ((_bits & 0x40000L) != 0)
                 {
                     return value;
                 }
@@ -10213,7 +8867,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x4000000L;
+                var flag = 0x40000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10231,7 +8885,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._RetryAfter;
-                if ((_bits & 0x8000000L) != 0)
+                if ((_bits & 0x80000L) != 0)
                 {
                     return value;
                 }
@@ -10241,7 +8895,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x8000000L;
+                var flag = 0x80000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10259,7 +8913,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Server;
-                if ((_bits & 0x10000000L) != 0)
+                if ((_bits & 0x100000L) != 0)
                 {
                     return value;
                 }
@@ -10269,7 +8923,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x10000000L;
+                var flag = 0x100000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10288,7 +8942,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._SetCookie;
-                if ((_bits & 0x20000000L) != 0)
+                if ((_bits & 0x200000L) != 0)
                 {
                     return value;
                 }
@@ -10298,7 +8952,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x20000000L;
+                var flag = 0x200000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -10316,6 +8970,230 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Vary;
+                if ((_bits & 0x400000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x400000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Vary = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Vary = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.Expires
+        {
+            get
+            {
+                var value = _headers._Expires;
+                if ((_bits & 0x800000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x800000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Expires = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Expires = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.WWWAuthenticate
+        {
+            get
+            {
+                var value = _headers._WWWAuthenticate;
+                if ((_bits & 0x1000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x1000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._WWWAuthenticate = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._WWWAuthenticate = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentRange
+        {
+            get
+            {
+                var value = _headers._ContentRange;
+                if ((_bits & 0x2000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x2000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ContentRange = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ContentRange = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentEncoding
+        {
+            get
+            {
+                var value = _headers._ContentEncoding;
+                if ((_bits & 0x4000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x4000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ContentEncoding = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ContentEncoding = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentLanguage
+        {
+            get
+            {
+                var value = _headers._ContentLanguage;
+                if ((_bits & 0x8000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x8000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ContentLanguage = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ContentLanguage = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentLocation
+        {
+            get
+            {
+                var value = _headers._ContentLocation;
+                if ((_bits & 0x10000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x10000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ContentLocation = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ContentLocation = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentMD5
+        {
+            get
+            {
+                var value = _headers._ContentMD5;
+                if ((_bits & 0x20000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x20000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ContentMD5 = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ContentMD5 = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.LastModified
+        {
+            get
+            {
+                var value = _headers._LastModified;
                 if ((_bits & 0x40000000L) != 0)
                 {
                     return value;
@@ -10330,20 +9208,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Vary = value;
+                    _headers._LastModified = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Vary = default;
+                    _headers._LastModified = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.WWWAuthenticate
+        StringValues IHeaderDictionary.Trailer
         {
             get
             {
-                var value = _headers._WWWAuthenticate;
+                var value = _headers._Trailer;
                 if ((_bits & 0x80000000L) != 0)
                 {
                     return value;
@@ -10358,12 +9236,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._WWWAuthenticate = value;
+                    _headers._Trailer = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._WWWAuthenticate = default;
+                    _headers._Trailer = default;
                 }
             }
         }
@@ -11451,13 +10329,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
         public void SetRawTransferEncoding(StringValues value, byte[] raw)
         {
-            _bits |= 0x80L;
+            _bits |= 0x40L;
             _headers._TransferEncoding = value;
             _headers._rawTransferEncoding = raw;
         }
         public void SetRawServer(StringValues value, byte[] raw)
         {
-            _bits |= 0x10000000L;
+            _bits |= 0x100000L;
             _headers._Server = value;
             _headers._rawServer = raw;
         }
@@ -11475,7 +10353,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
                             value = _headers._Via;
                             return true;
@@ -11484,7 +10362,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Age, key))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
                             value = _headers._Age;
                             return true;
@@ -11494,7 +10372,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
                             value = _headers._Via;
                             return true;
@@ -11503,7 +10381,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
                             value = _headers._Age;
                             return true;
@@ -11525,7 +10403,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ETag, key))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
                             value = _headers._ETag;
                             return true;
@@ -11534,7 +10412,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Vary, key))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
                             value = _headers._Vary;
                             return true;
@@ -11553,7 +10431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ETag.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
                             value = _headers._ETag;
                             return true;
@@ -11562,7 +10440,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Vary.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
                             value = _headers._Vary;
                             return true;
@@ -11575,7 +10453,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
                             value = _headers._Allow;
                             return true;
@@ -11585,7 +10463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
                             value = _headers._Allow;
                             return true;
@@ -11598,7 +10476,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Server, key))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
                             value = _headers._Server;
                             return true;
@@ -11617,7 +10495,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Server.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
                             value = _headers._Server;
                             return true;
@@ -11637,18 +10515,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Trailer, key))
-                    {
-                        if ((_bits & 0x40L) != 0)
-                        {
-                            value = _headers._Trailer;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
                             value = _headers._Upgrade;
                             return true;
@@ -11657,44 +10526,44 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._Warning;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Expires, key))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            value = _headers._Expires;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.AltSvc, key))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
                             value = _headers._AltSvc;
                             return true;
                         }
                         return false;
                     }
-
-                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Expires, key))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            value = _headers._Expires;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Trailer, key))
+                    {
+                        if ((_bits & 0x80000000L) != 0)
                         {
                             value = _headers._Trailer;
                             return true;
                         }
                         return false;
                     }
+
                     if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
                             value = _headers._Upgrade;
                             return true;
@@ -11703,27 +10572,36 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._Warning;
                             return true;
                         }
                         return false;
                     }
+                    if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x4000L) != 0)
+                        {
+                            value = _headers._AltSvc;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
                             value = _headers._Expires;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x80000000L) != 0)
                         {
-                            value = _headers._AltSvc;
+                            value = _headers._Trailer;
                             return true;
                         }
                         return false;
@@ -11734,7 +10612,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Location, key))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
                             value = _headers._Location;
                             return true;
@@ -11744,7 +10622,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Location.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
                             value = _headers._Location;
                             return true;
@@ -11775,7 +10653,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.SetCookie, key))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
                             value = _headers._SetCookie;
                             return true;
@@ -11803,7 +10681,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.SetCookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
                             value = _headers._SetCookie;
                             return true;
@@ -11814,39 +10692,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
+                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
-                            value = _headers._ContentMD5;
+                            value = _headers._RetryAfter;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
+                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
-                            value = _headers._RetryAfter;
+                            value = _headers._ContentMD5;
                             return true;
                         }
                         return false;
                     }
 
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
-                            value = _headers._ContentMD5;
+                            value = _headers._RetryAfter;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
-                            value = _headers._RetryAfter;
+                            value = _headers._ContentMD5;
                             return true;
                         }
                         return false;
@@ -11857,7 +10735,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
                             value = _headers._ContentType;
                             return true;
@@ -11867,7 +10745,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
                             value = _headers._ContentType;
                             return true;
@@ -11896,9 +10774,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.AcceptRanges, key))
+                    {
+                        if ((_bits & 0x800L) != 0)
+                        {
+                            value = _headers._AcceptRanges;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.ContentRange, key))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
                             value = _headers._ContentRange;
                             return true;
@@ -11907,18 +10794,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.LastModified, key))
                     {
-                        if ((_bits & 0x80000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
                             value = _headers._LastModified;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.AcceptRanges, key))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            value = _headers._AcceptRanges;
                             return true;
                         }
                         return false;
@@ -11942,9 +10820,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800L) != 0)
+                        {
+                            value = _headers._AcceptRanges;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
                             value = _headers._ContentRange;
                             return true;
@@ -11953,18 +10840,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
                             value = _headers._LastModified;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            value = _headers._AcceptRanges;
                             return true;
                         }
                         return false;
@@ -11996,36 +10874,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 16:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
-                    {
-                        if ((_bits & 0x2000L) != 0)
-                        {
-                            value = _headers._ContentEncoding;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
-                    {
-                        if ((_bits & 0x4000L) != 0)
-                        {
-                            value = _headers._ContentLanguage;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
-                    {
-                        if ((_bits & 0x8000L) != 0)
-                        {
-                            value = _headers._ContentLocation;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.ProxyConnection, key))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
                             value = _headers._ProxyConnection;
                             return true;
@@ -12034,44 +10885,44 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
                     {
-                        if ((_bits & 0x80000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
                             value = _headers._WWWAuthenticate;
                             return true;
                         }
                         return false;
                     }
-
-                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
                             value = _headers._ContentEncoding;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
                             value = _headers._ContentLanguage;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
                             value = _headers._ContentLocation;
                             return true;
                         }
                         return false;
                     }
+
                     if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
                             value = _headers._ProxyConnection;
                             return true;
@@ -12080,9 +10931,36 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
                             value = _headers._WWWAuthenticate;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x4000000L) != 0)
+                        {
+                            value = _headers._ContentEncoding;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x8000000L) != 0)
+                        {
+                            value = _headers._ContentLanguage;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x10000000L) != 0)
+                        {
+                            value = _headers._ContentLocation;
                             return true;
                         }
                         return false;
@@ -12093,7 +10971,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
                             value = _headers._TransferEncoding;
                             return true;
@@ -12103,7 +10981,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
                             value = _headers._TransferEncoding;
                             return true;
@@ -12116,7 +10994,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ProxyAuthenticate, key))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
                             value = _headers._ProxyAuthenticate;
                             return true;
@@ -12126,7 +11004,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.ProxyAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
                             value = _headers._ProxyAuthenticate;
                             return true;
@@ -12282,26 +11160,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        _bits |= 0x200L;
+                        _bits |= 0x100L;
                         _headers._Via = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Age, key))
                     {
-                        _bits |= 0x200000L;
+                        _bits |= 0x1000L;
                         _headers._Age = value;
                         return;
                     }
 
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200L;
+                        _bits |= 0x100L;
                         _headers._Via = value;
                         return;
                     }
                     if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200000L;
+                        _bits |= 0x1000L;
                         _headers._Age = value;
                         return;
                     }
@@ -12318,13 +11196,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ETag, key))
                     {
-                        _bits |= 0x800000L;
+                        _bits |= 0x8000L;
                         _headers._ETag = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Vary, key))
                     {
-                        _bits |= 0x40000000L;
+                        _bits |= 0x400000L;
                         _headers._Vary = value;
                         return;
                     }
@@ -12338,13 +11216,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ETag.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800000L;
+                        _bits |= 0x8000L;
                         _headers._ETag = value;
                         return;
                     }
                     if (HeaderNames.Vary.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000000L;
+                        _bits |= 0x400000L;
                         _headers._Vary = value;
                         return;
                     }
@@ -12354,14 +11232,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
-                        _bits |= 0x800L;
+                        _bits |= 0x2000L;
                         _headers._Allow = value;
                         return;
                     }
 
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800L;
+                        _bits |= 0x2000L;
                         _headers._Allow = value;
                         return;
                     }
@@ -12371,7 +11249,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Server, key))
                     {
-                        _bits |= 0x10000000L;
+                        _bits |= 0x100000L;
                         _headers._Server = value;
                         _headers._rawServer = null;
                         return;
@@ -12385,7 +11263,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Server.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000000L;
+                        _bits |= 0x100000L;
                         _headers._Server = value;
                         _headers._rawServer = null;
                         return;
@@ -12400,65 +11278,65 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Trailer, key))
-                    {
-                        _bits |= 0x40L;
-                        _headers._Trailer = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        _bits |= 0x100L;
+                        _bits |= 0x80L;
                         _headers._Upgrade = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        _bits |= 0x400L;
+                        _bits |= 0x200L;
                         _headers._Warning = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Expires, key))
-                    {
-                        _bits |= 0x40000L;
-                        _headers._Expires = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.AltSvc, key))
                     {
-                        _bits |= 0x400000L;
+                        _bits |= 0x4000L;
                         _headers._AltSvc = value;
                         return;
                     }
-
-                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Expires, key))
                     {
-                        _bits |= 0x40L;
+                        _bits |= 0x800000L;
+                        _headers._Expires = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Trailer, key))
+                    {
+                        _bits |= 0x80000000L;
                         _headers._Trailer = value;
                         return;
                     }
+
                     if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100L;
+                        _bits |= 0x80L;
                         _headers._Upgrade = value;
                         return;
                     }
                     if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400L;
+                        _bits |= 0x200L;
                         _headers._Warning = value;
-                        return;
-                    }
-                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x40000L;
-                        _headers._Expires = value;
                         return;
                     }
                     if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000L;
+                        _bits |= 0x4000L;
                         _headers._AltSvc = value;
+                        return;
+                    }
+                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x800000L;
+                        _headers._Expires = value;
+                        return;
+                    }
+                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x80000000L;
+                        _headers._Trailer = value;
                         return;
                     }
                     break;
@@ -12467,14 +11345,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Location, key))
                     {
-                        _bits |= 0x1000000L;
+                        _bits |= 0x10000L;
                         _headers._Location = value;
                         return;
                     }
 
                     if (HeaderNames.Location.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000000L;
+                        _bits |= 0x10000L;
                         _headers._Location = value;
                         return;
                     }
@@ -12497,7 +11375,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.SetCookie, key))
                     {
-                        _bits |= 0x20000000L;
+                        _bits |= 0x200000L;
                         _headers._SetCookie = value;
                         return;
                     }
@@ -12517,7 +11395,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.SetCookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000000L;
+                        _bits |= 0x200000L;
                         _headers._SetCookie = value;
                         return;
                     }
@@ -12525,29 +11403,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
-                    {
-                        _bits |= 0x10000L;
-                        _headers._ContentMD5 = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.RetryAfter, key))
                     {
-                        _bits |= 0x8000000L;
+                        _bits |= 0x80000L;
                         _headers._RetryAfter = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
+                    {
+                        _bits |= 0x20000000L;
+                        _headers._ContentMD5 = value;
                         return;
                     }
 
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x10000L;
-                        _headers._ContentMD5 = value;
-                        return;
-                    }
                     if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000000L;
+                        _bits |= 0x80000L;
                         _headers._RetryAfter = value;
+                        return;
+                    }
+                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x20000000L;
+                        _headers._ContentMD5 = value;
                         return;
                     }
                     break;
@@ -12556,14 +11434,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        _bits |= 0x1000L;
+                        _bits |= 0x400L;
                         _headers._ContentType = value;
                         return;
                     }
 
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000L;
+                        _bits |= 0x400L;
                         _headers._ContentType = value;
                         return;
                     }
@@ -12583,22 +11461,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._GrpcEncoding = value;
                         return;
                     }
+                    if (ReferenceEquals(HeaderNames.AcceptRanges, key))
+                    {
+                        _bits |= 0x800L;
+                        _headers._AcceptRanges = value;
+                        return;
+                    }
                     if (ReferenceEquals(HeaderNames.ContentRange, key))
                     {
-                        _bits |= 0x20000L;
+                        _bits |= 0x2000000L;
                         _headers._ContentRange = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.LastModified, key))
                     {
-                        _bits |= 0x80000L;
+                        _bits |= 0x40000000L;
                         _headers._LastModified = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.AcceptRanges, key))
-                    {
-                        _bits |= 0x100000L;
-                        _headers._AcceptRanges = value;
                         return;
                     }
 
@@ -12614,22 +11492,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._GrpcEncoding = value;
                         return;
                     }
+                    if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x800L;
+                        _headers._AcceptRanges = value;
+                        return;
+                    }
                     if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000L;
+                        _bits |= 0x2000000L;
                         _headers._ContentRange = value;
                         return;
                     }
                     if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80000L;
+                        _bits |= 0x40000000L;
                         _headers._LastModified = value;
-                        return;
-                    }
-                    if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x100000L;
-                        _headers._AcceptRanges = value;
                         return;
                     }
                     break;
@@ -12651,65 +11529,65 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 16:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
-                    {
-                        _bits |= 0x2000L;
-                        _headers._ContentEncoding = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
-                    {
-                        _bits |= 0x4000L;
-                        _headers._ContentLanguage = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
-                    {
-                        _bits |= 0x8000L;
-                        _headers._ContentLocation = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.ProxyConnection, key))
                     {
-                        _bits |= 0x4000000L;
+                        _bits |= 0x40000L;
                         _headers._ProxyConnection = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
                     {
-                        _bits |= 0x80000000L;
+                        _bits |= 0x1000000L;
                         _headers._WWWAuthenticate = value;
                         return;
                     }
-
-                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
                     {
-                        _bits |= 0x2000L;
+                        _bits |= 0x4000000L;
                         _headers._ContentEncoding = value;
                         return;
                     }
-                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
                     {
-                        _bits |= 0x4000L;
+                        _bits |= 0x8000000L;
                         _headers._ContentLanguage = value;
                         return;
                     }
-                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
                     {
-                        _bits |= 0x8000L;
+                        _bits |= 0x10000000L;
                         _headers._ContentLocation = value;
                         return;
                     }
+
                     if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000000L;
+                        _bits |= 0x40000L;
                         _headers._ProxyConnection = value;
                         return;
                     }
                     if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80000000L;
+                        _bits |= 0x1000000L;
                         _headers._WWWAuthenticate = value;
+                        return;
+                    }
+                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x4000000L;
+                        _headers._ContentEncoding = value;
+                        return;
+                    }
+                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x8000000L;
+                        _headers._ContentLanguage = value;
+                        return;
+                    }
+                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x10000000L;
+                        _headers._ContentLocation = value;
                         return;
                     }
                     break;
@@ -12718,7 +11596,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        _bits |= 0x80L;
+                        _bits |= 0x40L;
                         _headers._TransferEncoding = value;
                         _headers._rawTransferEncoding = null;
                         return;
@@ -12726,7 +11604,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80L;
+                        _bits |= 0x40L;
                         _headers._TransferEncoding = value;
                         _headers._rawTransferEncoding = null;
                         return;
@@ -12737,14 +11615,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ProxyAuthenticate, key))
                     {
-                        _bits |= 0x2000000L;
+                        _bits |= 0x20000L;
                         _headers._ProxyAuthenticate = value;
                         return;
                     }
 
                     if (HeaderNames.ProxyAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000L;
+                        _bits |= 0x20000L;
                         _headers._ProxyAuthenticate = value;
                         return;
                     }
@@ -12861,9 +11739,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x200L) == 0)
+                        if ((_bits & 0x100L) == 0)
                         {
-                            _bits |= 0x200L;
+                            _bits |= 0x100L;
                             _headers._Via = value;
                             return true;
                         }
@@ -12871,9 +11749,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Age, key))
                     {
-                        if ((_bits & 0x200000L) == 0)
+                        if ((_bits & 0x1000L) == 0)
                         {
-                            _bits |= 0x200000L;
+                            _bits |= 0x1000L;
                             _headers._Age = value;
                             return true;
                         }
@@ -12882,9 +11760,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200L) == 0)
+                        if ((_bits & 0x100L) == 0)
                         {
-                            _bits |= 0x200L;
+                            _bits |= 0x100L;
                             _headers._Via = value;
                             return true;
                         }
@@ -12892,9 +11770,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) == 0)
+                        if ((_bits & 0x1000L) == 0)
                         {
-                            _bits |= 0x200000L;
+                            _bits |= 0x1000L;
                             _headers._Age = value;
                             return true;
                         }
@@ -12917,9 +11795,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ETag, key))
                     {
-                        if ((_bits & 0x800000L) == 0)
+                        if ((_bits & 0x8000L) == 0)
                         {
-                            _bits |= 0x800000L;
+                            _bits |= 0x8000L;
                             _headers._ETag = value;
                             return true;
                         }
@@ -12927,9 +11805,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Vary, key))
                     {
-                        if ((_bits & 0x40000000L) == 0)
+                        if ((_bits & 0x400000L) == 0)
                         {
-                            _bits |= 0x40000000L;
+                            _bits |= 0x400000L;
                             _headers._Vary = value;
                             return true;
                         }
@@ -12949,9 +11827,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ETag.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) == 0)
+                        if ((_bits & 0x8000L) == 0)
                         {
-                            _bits |= 0x800000L;
+                            _bits |= 0x8000L;
                             _headers._ETag = value;
                             return true;
                         }
@@ -12959,9 +11837,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Vary.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) == 0)
+                        if ((_bits & 0x400000L) == 0)
                         {
-                            _bits |= 0x40000000L;
+                            _bits |= 0x400000L;
                             _headers._Vary = value;
                             return true;
                         }
@@ -12973,9 +11851,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
-                        if ((_bits & 0x800L) == 0)
+                        if ((_bits & 0x2000L) == 0)
                         {
-                            _bits |= 0x800L;
+                            _bits |= 0x2000L;
                             _headers._Allow = value;
                             return true;
                         }
@@ -12984,9 +11862,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) == 0)
+                        if ((_bits & 0x2000L) == 0)
                         {
-                            _bits |= 0x800L;
+                            _bits |= 0x2000L;
                             _headers._Allow = value;
                             return true;
                         }
@@ -12998,9 +11876,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Server, key))
                     {
-                        if ((_bits & 0x10000000L) == 0)
+                        if ((_bits & 0x100000L) == 0)
                         {
-                            _bits |= 0x10000000L;
+                            _bits |= 0x100000L;
                             _headers._Server = value;
                             _headers._rawServer = null;
                             return true;
@@ -13020,9 +11898,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Server.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000L) == 0)
+                        if ((_bits & 0x100000L) == 0)
                         {
-                            _bits |= 0x10000000L;
+                            _bits |= 0x100000L;
                             _headers._Server = value;
                             _headers._rawServer = null;
                             return true;
@@ -13043,21 +11921,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Trailer, key))
-                    {
-                        if ((_bits & 0x40L) == 0)
-                        {
-                            _bits |= 0x40L;
-                            _headers._Trailer = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x100L) == 0)
+                        if ((_bits & 0x80L) == 0)
                         {
-                            _bits |= 0x100L;
+                            _bits |= 0x80L;
                             _headers._Upgrade = value;
                             return true;
                         }
@@ -13065,50 +11933,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x400L) == 0)
+                        if ((_bits & 0x200L) == 0)
                         {
-                            _bits |= 0x400L;
+                            _bits |= 0x200L;
                             _headers._Warning = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Expires, key))
-                    {
-                        if ((_bits & 0x40000L) == 0)
-                        {
-                            _bits |= 0x40000L;
-                            _headers._Expires = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.AltSvc, key))
                     {
-                        if ((_bits & 0x400000L) == 0)
+                        if ((_bits & 0x4000L) == 0)
                         {
-                            _bits |= 0x400000L;
+                            _bits |= 0x4000L;
                             _headers._AltSvc = value;
                             return true;
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Expires, key))
                     {
-                        if ((_bits & 0x40L) == 0)
+                        if ((_bits & 0x800000L) == 0)
                         {
-                            _bits |= 0x40L;
+                            _bits |= 0x800000L;
+                            _headers._Expires = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Trailer, key))
+                    {
+                        if ((_bits & 0x80000000L) == 0)
+                        {
+                            _bits |= 0x80000000L;
                             _headers._Trailer = value;
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) == 0)
+                        if ((_bits & 0x80L) == 0)
                         {
-                            _bits |= 0x100L;
+                            _bits |= 0x80L;
                             _headers._Upgrade = value;
                             return true;
                         }
@@ -13116,30 +11984,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) == 0)
+                        if ((_bits & 0x200L) == 0)
                         {
-                            _bits |= 0x400L;
+                            _bits |= 0x200L;
                             _headers._Warning = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x40000L) == 0)
-                        {
-                            _bits |= 0x40000L;
-                            _headers._Expires = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) == 0)
+                        if ((_bits & 0x4000L) == 0)
                         {
-                            _bits |= 0x400000L;
+                            _bits |= 0x4000L;
                             _headers._AltSvc = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800000L) == 0)
+                        {
+                            _bits |= 0x800000L;
+                            _headers._Expires = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x80000000L) == 0)
+                        {
+                            _bits |= 0x80000000L;
+                            _headers._Trailer = value;
                             return true;
                         }
                         return false;
@@ -13150,9 +12028,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Location, key))
                     {
-                        if ((_bits & 0x1000000L) == 0)
+                        if ((_bits & 0x10000L) == 0)
                         {
-                            _bits |= 0x1000000L;
+                            _bits |= 0x10000L;
                             _headers._Location = value;
                             return true;
                         }
@@ -13161,9 +12039,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Location.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000L) == 0)
+                        if ((_bits & 0x10000L) == 0)
                         {
-                            _bits |= 0x1000000L;
+                            _bits |= 0x10000L;
                             _headers._Location = value;
                             return true;
                         }
@@ -13196,9 +12074,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.SetCookie, key))
                     {
-                        if ((_bits & 0x20000000L) == 0)
+                        if ((_bits & 0x200000L) == 0)
                         {
-                            _bits |= 0x20000000L;
+                            _bits |= 0x200000L;
                             _headers._SetCookie = value;
                             return true;
                         }
@@ -13228,9 +12106,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.SetCookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) == 0)
+                        if ((_bits & 0x200000L) == 0)
                         {
-                            _bits |= 0x20000000L;
+                            _bits |= 0x200000L;
                             _headers._SetCookie = value;
                             return true;
                         }
@@ -13240,43 +12118,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
+                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
                     {
-                        if ((_bits & 0x10000L) == 0)
+                        if ((_bits & 0x80000L) == 0)
                         {
-                            _bits |= 0x10000L;
-                            _headers._ContentMD5 = value;
+                            _bits |= 0x80000L;
+                            _headers._RetryAfter = value;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
+                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
                     {
-                        if ((_bits & 0x8000000L) == 0)
+                        if ((_bits & 0x20000000L) == 0)
                         {
-                            _bits |= 0x8000000L;
-                            _headers._RetryAfter = value;
+                            _bits |= 0x20000000L;
+                            _headers._ContentMD5 = value;
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) == 0)
+                        if ((_bits & 0x80000L) == 0)
                         {
-                            _bits |= 0x10000L;
-                            _headers._ContentMD5 = value;
+                            _bits |= 0x80000L;
+                            _headers._RetryAfter = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) == 0)
+                        if ((_bits & 0x20000000L) == 0)
                         {
-                            _bits |= 0x8000000L;
-                            _headers._RetryAfter = value;
+                            _bits |= 0x20000000L;
+                            _headers._ContentMD5 = value;
                             return true;
                         }
                         return false;
@@ -13287,9 +12165,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x1000L) == 0)
+                        if ((_bits & 0x400L) == 0)
                         {
-                            _bits |= 0x1000L;
+                            _bits |= 0x400L;
                             _headers._ContentType = value;
                             return true;
                         }
@@ -13298,9 +12176,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) == 0)
+                        if ((_bits & 0x400L) == 0)
                         {
-                            _bits |= 0x1000L;
+                            _bits |= 0x400L;
                             _headers._ContentType = value;
                             return true;
                         }
@@ -13330,11 +12208,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.AcceptRanges, key))
+                    {
+                        if ((_bits & 0x800L) == 0)
+                        {
+                            _bits |= 0x800L;
+                            _headers._AcceptRanges = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.ContentRange, key))
                     {
-                        if ((_bits & 0x20000L) == 0)
+                        if ((_bits & 0x2000000L) == 0)
                         {
-                            _bits |= 0x20000L;
+                            _bits |= 0x2000000L;
                             _headers._ContentRange = value;
                             return true;
                         }
@@ -13342,20 +12230,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.LastModified, key))
                     {
-                        if ((_bits & 0x80000L) == 0)
+                        if ((_bits & 0x40000000L) == 0)
                         {
-                            _bits |= 0x80000L;
+                            _bits |= 0x40000000L;
                             _headers._LastModified = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.AcceptRanges, key))
-                    {
-                        if ((_bits & 0x100000L) == 0)
-                        {
-                            _bits |= 0x100000L;
-                            _headers._AcceptRanges = value;
                             return true;
                         }
                         return false;
@@ -13381,11 +12259,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800L) == 0)
+                        {
+                            _bits |= 0x800L;
+                            _headers._AcceptRanges = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) == 0)
+                        if ((_bits & 0x2000000L) == 0)
                         {
-                            _bits |= 0x20000L;
+                            _bits |= 0x2000000L;
                             _headers._ContentRange = value;
                             return true;
                         }
@@ -13393,20 +12281,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000L) == 0)
+                        if ((_bits & 0x40000000L) == 0)
                         {
-                            _bits |= 0x80000L;
+                            _bits |= 0x40000000L;
                             _headers._LastModified = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) == 0)
-                        {
-                            _bits |= 0x100000L;
-                            _headers._AcceptRanges = value;
                             return true;
                         }
                         return false;
@@ -13438,41 +12316,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 16:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
-                    {
-                        if ((_bits & 0x2000L) == 0)
-                        {
-                            _bits |= 0x2000L;
-                            _headers._ContentEncoding = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
-                    {
-                        if ((_bits & 0x4000L) == 0)
-                        {
-                            _bits |= 0x4000L;
-                            _headers._ContentLanguage = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
-                    {
-                        if ((_bits & 0x8000L) == 0)
-                        {
-                            _bits |= 0x8000L;
-                            _headers._ContentLocation = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.ProxyConnection, key))
                     {
-                        if ((_bits & 0x4000000L) == 0)
+                        if ((_bits & 0x40000L) == 0)
                         {
-                            _bits |= 0x4000000L;
+                            _bits |= 0x40000L;
                             _headers._ProxyConnection = value;
                             return true;
                         }
@@ -13480,50 +12328,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
                     {
-                        if ((_bits & 0x80000000L) == 0)
+                        if ((_bits & 0x1000000L) == 0)
                         {
-                            _bits |= 0x80000000L;
+                            _bits |= 0x1000000L;
                             _headers._WWWAuthenticate = value;
                             return true;
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
                     {
-                        if ((_bits & 0x2000L) == 0)
+                        if ((_bits & 0x4000000L) == 0)
                         {
-                            _bits |= 0x2000L;
+                            _bits |= 0x4000000L;
                             _headers._ContentEncoding = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
                     {
-                        if ((_bits & 0x4000L) == 0)
+                        if ((_bits & 0x8000000L) == 0)
                         {
-                            _bits |= 0x4000L;
+                            _bits |= 0x8000000L;
                             _headers._ContentLanguage = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
                     {
-                        if ((_bits & 0x8000L) == 0)
+                        if ((_bits & 0x10000000L) == 0)
                         {
-                            _bits |= 0x8000L;
+                            _bits |= 0x10000000L;
                             _headers._ContentLocation = value;
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) == 0)
+                        if ((_bits & 0x40000L) == 0)
                         {
-                            _bits |= 0x4000000L;
+                            _bits |= 0x40000L;
                             _headers._ProxyConnection = value;
                             return true;
                         }
@@ -13531,10 +12379,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000L) == 0)
+                        if ((_bits & 0x1000000L) == 0)
                         {
-                            _bits |= 0x80000000L;
+                            _bits |= 0x1000000L;
                             _headers._WWWAuthenticate = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x4000000L) == 0)
+                        {
+                            _bits |= 0x4000000L;
+                            _headers._ContentEncoding = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x8000000L) == 0)
+                        {
+                            _bits |= 0x8000000L;
+                            _headers._ContentLanguage = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x10000000L) == 0)
+                        {
+                            _bits |= 0x10000000L;
+                            _headers._ContentLocation = value;
                             return true;
                         }
                         return false;
@@ -13545,9 +12423,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x80L) == 0)
+                        if ((_bits & 0x40L) == 0)
                         {
-                            _bits |= 0x80L;
+                            _bits |= 0x40L;
                             _headers._TransferEncoding = value;
                             _headers._rawTransferEncoding = null;
                             return true;
@@ -13557,9 +12435,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80L) == 0)
+                        if ((_bits & 0x40L) == 0)
                         {
-                            _bits |= 0x80L;
+                            _bits |= 0x40L;
                             _headers._TransferEncoding = value;
                             _headers._rawTransferEncoding = null;
                             return true;
@@ -13572,9 +12450,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ProxyAuthenticate, key))
                     {
-                        if ((_bits & 0x2000000L) == 0)
+                        if ((_bits & 0x20000L) == 0)
                         {
-                            _bits |= 0x2000000L;
+                            _bits |= 0x20000L;
                             _headers._ProxyAuthenticate = value;
                             return true;
                         }
@@ -13583,9 +12461,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ProxyAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) == 0)
+                        if ((_bits & 0x20000L) == 0)
                         {
-                            _bits |= 0x2000000L;
+                            _bits |= 0x20000L;
                             _headers._ProxyAuthenticate = value;
                             return true;
                         }
@@ -13751,9 +12629,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
-                            _bits &= ~0x200L;
+                            _bits &= ~0x100L;
                             _headers._Via = default(StringValues);
                             return true;
                         }
@@ -13761,9 +12639,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Age, key))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
-                            _bits &= ~0x200000L;
+                            _bits &= ~0x1000L;
                             _headers._Age = default(StringValues);
                             return true;
                         }
@@ -13772,9 +12650,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
-                            _bits &= ~0x200L;
+                            _bits &= ~0x100L;
                             _headers._Via = default(StringValues);
                             return true;
                         }
@@ -13782,9 +12660,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
-                            _bits &= ~0x200000L;
+                            _bits &= ~0x1000L;
                             _headers._Age = default(StringValues);
                             return true;
                         }
@@ -13807,9 +12685,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ETag, key))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
-                            _bits &= ~0x800000L;
+                            _bits &= ~0x8000L;
                             _headers._ETag = default(StringValues);
                             return true;
                         }
@@ -13817,9 +12695,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Vary, key))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
-                            _bits &= ~0x40000000L;
+                            _bits &= ~0x400000L;
                             _headers._Vary = default(StringValues);
                             return true;
                         }
@@ -13839,9 +12717,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ETag.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
-                            _bits &= ~0x800000L;
+                            _bits &= ~0x8000L;
                             _headers._ETag = default(StringValues);
                             return true;
                         }
@@ -13849,9 +12727,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Vary.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
-                            _bits &= ~0x40000000L;
+                            _bits &= ~0x400000L;
                             _headers._Vary = default(StringValues);
                             return true;
                         }
@@ -13863,9 +12741,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
-                            _bits &= ~0x800L;
+                            _bits &= ~0x2000L;
                             _headers._Allow = default(StringValues);
                             return true;
                         }
@@ -13874,9 +12752,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
-                            _bits &= ~0x800L;
+                            _bits &= ~0x2000L;
                             _headers._Allow = default(StringValues);
                             return true;
                         }
@@ -13888,9 +12766,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Server, key))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
-                            _bits &= ~0x10000000L;
+                            _bits &= ~0x100000L;
                             _headers._Server = default(StringValues);
                             _headers._rawServer = null;
                             return true;
@@ -13910,9 +12788,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Server.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
-                            _bits &= ~0x10000000L;
+                            _bits &= ~0x100000L;
                             _headers._Server = default(StringValues);
                             _headers._rawServer = null;
                             return true;
@@ -13933,21 +12811,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Trailer, key))
-                    {
-                        if ((_bits & 0x40L) != 0)
-                        {
-                            _bits &= ~0x40L;
-                            _headers._Trailer = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
-                            _bits &= ~0x100L;
+                            _bits &= ~0x80L;
                             _headers._Upgrade = default(StringValues);
                             return true;
                         }
@@ -13955,50 +12823,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
-                            _bits &= ~0x400L;
+                            _bits &= ~0x200L;
                             _headers._Warning = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Expires, key))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            _bits &= ~0x40000L;
-                            _headers._Expires = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.AltSvc, key))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
-                            _bits &= ~0x400000L;
+                            _bits &= ~0x4000L;
                             _headers._AltSvc = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Expires, key))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
-                            _bits &= ~0x40L;
+                            _bits &= ~0x800000L;
+                            _headers._Expires = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Trailer, key))
+                    {
+                        if ((_bits & 0x80000000L) != 0)
+                        {
+                            _bits &= ~0x80000000L;
                             _headers._Trailer = default(StringValues);
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
-                            _bits &= ~0x100L;
+                            _bits &= ~0x80L;
                             _headers._Upgrade = default(StringValues);
                             return true;
                         }
@@ -14006,30 +12874,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
-                            _bits &= ~0x400L;
+                            _bits &= ~0x200L;
                             _headers._Warning = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            _bits &= ~0x40000L;
-                            _headers._Expires = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
-                            _bits &= ~0x400000L;
+                            _bits &= ~0x4000L;
                             _headers._AltSvc = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800000L) != 0)
+                        {
+                            _bits &= ~0x800000L;
+                            _headers._Expires = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Trailer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x80000000L) != 0)
+                        {
+                            _bits &= ~0x80000000L;
+                            _headers._Trailer = default(StringValues);
                             return true;
                         }
                         return false;
@@ -14040,9 +12918,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Location, key))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
-                            _bits &= ~0x1000000L;
+                            _bits &= ~0x10000L;
                             _headers._Location = default(StringValues);
                             return true;
                         }
@@ -14051,9 +12929,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Location.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
-                            _bits &= ~0x1000000L;
+                            _bits &= ~0x10000L;
                             _headers._Location = default(StringValues);
                             return true;
                         }
@@ -14086,9 +12964,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.SetCookie, key))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
-                            _bits &= ~0x20000000L;
+                            _bits &= ~0x200000L;
                             _headers._SetCookie = default(StringValues);
                             return true;
                         }
@@ -14118,9 +12996,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.SetCookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
-                            _bits &= ~0x20000000L;
+                            _bits &= ~0x200000L;
                             _headers._SetCookie = default(StringValues);
                             return true;
                         }
@@ -14130,43 +13008,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
+                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
-                            _bits &= ~0x10000L;
-                            _headers._ContentMD5 = default(StringValues);
+                            _bits &= ~0x80000L;
+                            _headers._RetryAfter = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
+                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
-                            _bits &= ~0x8000000L;
-                            _headers._RetryAfter = default(StringValues);
+                            _bits &= ~0x20000000L;
+                            _headers._ContentMD5 = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
-                            _bits &= ~0x10000L;
-                            _headers._ContentMD5 = default(StringValues);
+                            _bits &= ~0x80000L;
+                            _headers._RetryAfter = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
-                            _bits &= ~0x8000000L;
-                            _headers._RetryAfter = default(StringValues);
+                            _bits &= ~0x20000000L;
+                            _headers._ContentMD5 = default(StringValues);
                             return true;
                         }
                         return false;
@@ -14177,9 +13055,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
-                            _bits &= ~0x1000L;
+                            _bits &= ~0x400L;
                             _headers._ContentType = default(StringValues);
                             return true;
                         }
@@ -14188,9 +13066,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
-                            _bits &= ~0x1000L;
+                            _bits &= ~0x400L;
                             _headers._ContentType = default(StringValues);
                             return true;
                         }
@@ -14220,11 +13098,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.AcceptRanges, key))
+                    {
+                        if ((_bits & 0x800L) != 0)
+                        {
+                            _bits &= ~0x800L;
+                            _headers._AcceptRanges = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.ContentRange, key))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
-                            _bits &= ~0x20000L;
+                            _bits &= ~0x2000000L;
                             _headers._ContentRange = default(StringValues);
                             return true;
                         }
@@ -14232,20 +13120,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.LastModified, key))
                     {
-                        if ((_bits & 0x80000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
-                            _bits &= ~0x80000L;
+                            _bits &= ~0x40000000L;
                             _headers._LastModified = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.AcceptRanges, key))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            _bits &= ~0x100000L;
-                            _headers._AcceptRanges = default(StringValues);
                             return true;
                         }
                         return false;
@@ -14271,11 +13149,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x800L) != 0)
+                        {
+                            _bits &= ~0x800L;
+                            _headers._AcceptRanges = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
-                            _bits &= ~0x20000L;
+                            _bits &= ~0x2000000L;
                             _headers._ContentRange = default(StringValues);
                             return true;
                         }
@@ -14283,20 +13171,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
-                            _bits &= ~0x80000L;
+                            _bits &= ~0x40000000L;
                             _headers._LastModified = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x100000L) != 0)
-                        {
-                            _bits &= ~0x100000L;
-                            _headers._AcceptRanges = default(StringValues);
                             return true;
                         }
                         return false;
@@ -14328,41 +13206,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 16:
                 {
-                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
-                    {
-                        if ((_bits & 0x2000L) != 0)
-                        {
-                            _bits &= ~0x2000L;
-                            _headers._ContentEncoding = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
-                    {
-                        if ((_bits & 0x4000L) != 0)
-                        {
-                            _bits &= ~0x4000L;
-                            _headers._ContentLanguage = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
-                    {
-                        if ((_bits & 0x8000L) != 0)
-                        {
-                            _bits &= ~0x8000L;
-                            _headers._ContentLocation = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.ProxyConnection, key))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            _bits &= ~0x4000000L;
+                            _bits &= ~0x40000L;
                             _headers._ProxyConnection = default(StringValues);
                             return true;
                         }
@@ -14370,50 +13218,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
                     {
-                        if ((_bits & 0x80000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
-                            _bits &= ~0x80000000L;
+                            _bits &= ~0x1000000L;
                             _headers._WWWAuthenticate = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentEncoding, key))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            _bits &= ~0x2000L;
+                            _bits &= ~0x4000000L;
                             _headers._ContentEncoding = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentLanguage, key))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
-                            _bits &= ~0x4000L;
+                            _bits &= ~0x8000000L;
                             _headers._ContentLanguage = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ContentLocation, key))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
-                            _bits &= ~0x8000L;
+                            _bits &= ~0x10000000L;
                             _headers._ContentLocation = default(StringValues);
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            _bits &= ~0x4000000L;
+                            _bits &= ~0x40000L;
                             _headers._ProxyConnection = default(StringValues);
                             return true;
                         }
@@ -14421,10 +13269,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
-                            _bits &= ~0x80000000L;
+                            _bits &= ~0x1000000L;
                             _headers._WWWAuthenticate = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x4000000L) != 0)
+                        {
+                            _bits &= ~0x4000000L;
+                            _headers._ContentEncoding = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x8000000L) != 0)
+                        {
+                            _bits &= ~0x8000000L;
+                            _headers._ContentLanguage = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x10000000L) != 0)
+                        {
+                            _bits &= ~0x10000000L;
+                            _headers._ContentLocation = default(StringValues);
                             return true;
                         }
                         return false;
@@ -14435,9 +13313,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
-                            _bits &= ~0x80L;
+                            _bits &= ~0x40L;
                             _headers._TransferEncoding = default(StringValues);
                             _headers._rawTransferEncoding = null;
                             return true;
@@ -14447,9 +13325,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
-                            _bits &= ~0x80L;
+                            _bits &= ~0x40L;
                             _headers._TransferEncoding = default(StringValues);
                             _headers._rawTransferEncoding = null;
                             return true;
@@ -14462,9 +13340,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ProxyAuthenticate, key))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
-                            _bits &= ~0x2000000L;
+                            _bits &= ~0x20000L;
                             _headers._ProxyAuthenticate = default(StringValues);
                             return true;
                         }
@@ -14473,9 +13351,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ProxyAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
-                            _bits &= ~0x2000000L;
+                            _bits &= ~0x20000L;
                             _headers._ProxyAuthenticate = default(StringValues);
                             return true;
                         }
@@ -14664,24 +13542,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x4L;
             }
             
-            if ((tempBits & 0x1000L) != 0)
+            if ((tempBits & 0x400L) != 0)
             {
                 _headers._ContentType = default;
-                if((tempBits & ~0x1000L) == 0)
+                if((tempBits & ~0x400L) == 0)
                 {
                     return;
                 }
-                tempBits &= ~0x1000L;
+                tempBits &= ~0x400L;
             }
             
-            if ((tempBits & 0x10000000L) != 0)
+            if ((tempBits & 0x100000L) != 0)
             {
                 _headers._Server = default;
-                if((tempBits & ~0x10000000L) == 0)
+                if((tempBits & ~0x100000L) == 0)
                 {
                     return;
                 }
-                tempBits &= ~0x10000000L;
+                tempBits &= ~0x100000L;
             }
             
             if ((tempBits & 0x1L) != 0)
@@ -14726,7 +13604,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40L) != 0)
             {
-                _headers._Trailer = default;
+                _headers._TransferEncoding = default;
                 if((tempBits & ~0x40L) == 0)
                 {
                     return;
@@ -14736,7 +13614,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80L) != 0)
             {
-                _headers._TransferEncoding = default;
+                _headers._Upgrade = default;
                 if((tempBits & ~0x80L) == 0)
                 {
                     return;
@@ -14746,7 +13624,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100L) != 0)
             {
-                _headers._Upgrade = default;
+                _headers._Via = default;
                 if((tempBits & ~0x100L) == 0)
                 {
                     return;
@@ -14756,7 +13634,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200L) != 0)
             {
-                _headers._Via = default;
+                _headers._Warning = default;
                 if((tempBits & ~0x200L) == 0)
                 {
                     return;
@@ -14764,19 +13642,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x200L;
             }
             
-            if ((tempBits & 0x400L) != 0)
-            {
-                _headers._Warning = default;
-                if((tempBits & ~0x400L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x400L;
-            }
-            
             if ((tempBits & 0x800L) != 0)
             {
-                _headers._Allow = default;
+                _headers._AcceptRanges = default;
                 if((tempBits & ~0x800L) == 0)
                 {
                     return;
@@ -14784,9 +13652,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x800L;
             }
             
+            if ((tempBits & 0x1000L) != 0)
+            {
+                _headers._Age = default;
+                if((tempBits & ~0x1000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x1000L;
+            }
+            
             if ((tempBits & 0x2000L) != 0)
             {
-                _headers._ContentEncoding = default;
+                _headers._Allow = default;
                 if((tempBits & ~0x2000L) == 0)
                 {
                     return;
@@ -14796,7 +13674,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x4000L) != 0)
             {
-                _headers._ContentLanguage = default;
+                _headers._AltSvc = default;
                 if((tempBits & ~0x4000L) == 0)
                 {
                     return;
@@ -14806,7 +13684,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000L) != 0)
             {
-                _headers._ContentLocation = default;
+                _headers._ETag = default;
                 if((tempBits & ~0x8000L) == 0)
                 {
                     return;
@@ -14816,7 +13694,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10000L) != 0)
             {
-                _headers._ContentMD5 = default;
+                _headers._Location = default;
                 if((tempBits & ~0x10000L) == 0)
                 {
                     return;
@@ -14826,7 +13704,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000L) != 0)
             {
-                _headers._ContentRange = default;
+                _headers._ProxyAuthenticate = default;
                 if((tempBits & ~0x20000L) == 0)
                 {
                     return;
@@ -14836,7 +13714,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000L) != 0)
             {
-                _headers._Expires = default;
+                _headers._ProxyConnection = default;
                 if((tempBits & ~0x40000L) == 0)
                 {
                     return;
@@ -14846,7 +13724,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000L) != 0)
             {
-                _headers._LastModified = default;
+                _headers._RetryAfter = default;
                 if((tempBits & ~0x80000L) == 0)
                 {
                     return;
@@ -14854,19 +13732,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x80000L;
             }
             
-            if ((tempBits & 0x100000L) != 0)
-            {
-                _headers._AcceptRanges = default;
-                if((tempBits & ~0x100000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x100000L;
-            }
-            
             if ((tempBits & 0x200000L) != 0)
             {
-                _headers._Age = default;
+                _headers._SetCookie = default;
                 if((tempBits & ~0x200000L) == 0)
                 {
                     return;
@@ -14876,7 +13744,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400000L) != 0)
             {
-                _headers._AltSvc = default;
+                _headers._Vary = default;
                 if((tempBits & ~0x400000L) == 0)
                 {
                     return;
@@ -14886,7 +13754,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800000L) != 0)
             {
-                _headers._ETag = default;
+                _headers._Expires = default;
                 if((tempBits & ~0x800000L) == 0)
                 {
                     return;
@@ -14896,7 +13764,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000000L) != 0)
             {
-                _headers._Location = default;
+                _headers._WWWAuthenticate = default;
                 if((tempBits & ~0x1000000L) == 0)
                 {
                     return;
@@ -14906,7 +13774,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x2000000L) != 0)
             {
-                _headers._ProxyAuthenticate = default;
+                _headers._ContentRange = default;
                 if((tempBits & ~0x2000000L) == 0)
                 {
                     return;
@@ -14916,7 +13784,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x4000000L) != 0)
             {
-                _headers._ProxyConnection = default;
+                _headers._ContentEncoding = default;
                 if((tempBits & ~0x4000000L) == 0)
                 {
                     return;
@@ -14926,7 +13794,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000000L) != 0)
             {
-                _headers._RetryAfter = default;
+                _headers._ContentLanguage = default;
                 if((tempBits & ~0x8000000L) == 0)
                 {
                     return;
@@ -14934,9 +13802,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x8000000L;
             }
             
+            if ((tempBits & 0x10000000L) != 0)
+            {
+                _headers._ContentLocation = default;
+                if((tempBits & ~0x10000000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x10000000L;
+            }
+            
             if ((tempBits & 0x20000000L) != 0)
             {
-                _headers._SetCookie = default;
+                _headers._ContentMD5 = default;
                 if((tempBits & ~0x20000000L) == 0)
                 {
                     return;
@@ -14946,7 +13824,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000000L) != 0)
             {
-                _headers._Vary = default;
+                _headers._LastModified = default;
                 if((tempBits & ~0x40000000L) == 0)
                 {
                     return;
@@ -14956,7 +13834,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000000L) != 0)
             {
-                _headers._WWWAuthenticate = default;
+                _headers._Trailer = default;
                 if((tempBits & ~0x80000000L) == 0)
                 {
                     return;
@@ -15093,7 +13971,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Trailer, _headers._Trailer);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _headers._TransferEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80L) != 0)
@@ -15102,7 +13980,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _headers._TransferEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _headers._Upgrade);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100L) != 0)
@@ -15111,7 +13989,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _headers._Upgrade);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Via, _headers._Via);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200L) != 0)
@@ -15120,7 +13998,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Via, _headers._Via);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _headers._Warning);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400L) != 0)
@@ -15129,7 +14007,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _headers._Warning);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _headers._ContentType);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800L) != 0)
@@ -15138,7 +14016,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _headers._Allow);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptRanges, _headers._AcceptRanges);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000L) != 0)
@@ -15147,7 +14025,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _headers._ContentType);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Age, _headers._Age);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000L) != 0)
@@ -15156,7 +14034,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _headers._ContentEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _headers._Allow);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000L) != 0)
@@ -15165,7 +14043,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _headers._ContentLanguage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AltSvc, _headers._AltSvc);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000L) != 0)
@@ -15174,7 +14052,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _headers._ContentLocation);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ETag, _headers._ETag);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000L) != 0)
@@ -15183,7 +14061,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _headers._ContentMD5);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Location, _headers._Location);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000L) != 0)
@@ -15192,7 +14070,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _headers._ContentRange);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthenticate, _headers._ProxyAuthenticate);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000L) != 0)
@@ -15201,7 +14079,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _headers._Expires);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyConnection, _headers._ProxyConnection);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000L) != 0)
@@ -15210,7 +14088,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _headers._LastModified);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RetryAfter, _headers._RetryAfter);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100000L) != 0)
@@ -15219,7 +14097,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptRanges, _headers._AcceptRanges);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Server, _headers._Server);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000L) != 0)
@@ -15228,7 +14106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Age, _headers._Age);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.SetCookie, _headers._SetCookie);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400000L) != 0)
@@ -15237,7 +14115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AltSvc, _headers._AltSvc);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Vary, _headers._Vary);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800000L) != 0)
@@ -15246,7 +14124,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ETag, _headers._ETag);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _headers._Expires);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000000L) != 0)
@@ -15255,7 +14133,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Location, _headers._Location);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.WWWAuthenticate, _headers._WWWAuthenticate);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000000L) != 0)
@@ -15264,7 +14142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthenticate, _headers._ProxyAuthenticate);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _headers._ContentRange);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000000L) != 0)
@@ -15273,7 +14151,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyConnection, _headers._ProxyConnection);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _headers._ContentEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000000L) != 0)
@@ -15282,7 +14160,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RetryAfter, _headers._RetryAfter);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _headers._ContentLanguage);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000000L) != 0)
@@ -15291,7 +14169,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Server, _headers._Server);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _headers._ContentLocation);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000000L) != 0)
@@ -15300,7 +14178,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.SetCookie, _headers._SetCookie);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _headers._ContentMD5);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000000L) != 0)
@@ -15309,7 +14187,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Vary, _headers._Vary);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _headers._LastModified);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000000L) != 0)
@@ -15318,7 +14196,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.WWWAuthenticate, _headers._WWWAuthenticate);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Trailer, _headers._Trailer);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100000000L) != 0)
@@ -15389,10 +14267,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return true;
         }
         
-        internal bool HasInvalidH2H3Headers => (_bits & 67109266) != 0;
+        internal bool HasInvalidH2H3Headers => (_bits & 262354) != 0;
         internal void ClearInvalidH2H3Headers()
         {
-            _bits &= ~67109266;
+            _bits &= ~262354;
         }
         internal unsafe void CopyToFast(ref BufferWriter<PipeWriter> output)
         {
@@ -15443,20 +14321,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         goto case 2;
                     case 2: // Header: "Content-Type"
-                        if ((tempBits & 0x1000L) != 0)
+                        if ((tempBits & 0x400L) != 0)
                         {
-                            tempBits ^= 0x1000L;
+                            tempBits ^= 0x400L;
                             values = ref _headers._ContentType;
-                            keyStart = 150;
+                            keyStart = 130;
                             keyLength = 16;
                             next = 3;
                             break; // OutputHeader
                         }
                         goto case 3;
                     case 3: // Header: "Server"
-                        if ((tempBits & 0x10000000L) != 0)
+                        if ((tempBits & 0x100000L) != 0)
                         {
-                            tempBits ^= 0x10000000L;
+                            tempBits ^= 0x100000L;
                             if (_headers._rawServer != null)
                             {
                                 output.Write(_headers._rawServer);
@@ -15464,7 +14342,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             else
                             {
                                 values = ref _headers._Server;
-                                keyStart = 398;
+                                keyStart = 267;
                                 keyLength = 10;
                                 next = 4;
                                 break; // OutputHeader
@@ -15527,21 +14405,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             break; // OutputHeader
                         }
                         goto case 9;
-                    case 9: // Header: "Trailer"
+                    case 9: // Header: "Transfer-Encoding"
                         if ((tempBits & 0x40L) != 0)
                         {
                             tempBits ^= 0x40L;
-                            values = ref _headers._Trailer;
-                            keyStart = 80;
-                            keyLength = 11;
-                            next = 10;
-                            break; // OutputHeader
-                        }
-                        goto case 10;
-                    case 10: // Header: "Transfer-Encoding"
-                        if ((tempBits & 0x80L) != 0)
-                        {
-                            tempBits ^= 0x80L;
                             if (_headers._rawTransferEncoding != null)
                             {
                                 output.Write(_headers._rawTransferEncoding);
@@ -15549,251 +14416,262 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             else
                             {
                                 values = ref _headers._TransferEncoding;
-                                keyStart = 91;
+                                keyStart = 80;
                                 keyLength = 21;
-                                next = 11;
+                                next = 10;
                                 break; // OutputHeader
                             }
                         }
+                        goto case 10;
+                    case 10: // Header: "Upgrade"
+                        if ((tempBits & 0x80L) != 0)
+                        {
+                            tempBits ^= 0x80L;
+                            values = ref _headers._Upgrade;
+                            keyStart = 101;
+                            keyLength = 11;
+                            next = 11;
+                            break; // OutputHeader
+                        }
                         goto case 11;
-                    case 11: // Header: "Upgrade"
+                    case 11: // Header: "Via"
                         if ((tempBits & 0x100L) != 0)
                         {
                             tempBits ^= 0x100L;
-                            values = ref _headers._Upgrade;
+                            values = ref _headers._Via;
                             keyStart = 112;
-                            keyLength = 11;
+                            keyLength = 7;
                             next = 12;
                             break; // OutputHeader
                         }
                         goto case 12;
-                    case 12: // Header: "Via"
+                    case 12: // Header: "Warning"
                         if ((tempBits & 0x200L) != 0)
                         {
                             tempBits ^= 0x200L;
-                            values = ref _headers._Via;
-                            keyStart = 123;
-                            keyLength = 7;
+                            values = ref _headers._Warning;
+                            keyStart = 119;
+                            keyLength = 11;
                             next = 13;
                             break; // OutputHeader
                         }
                         goto case 13;
-                    case 13: // Header: "Warning"
-                        if ((tempBits & 0x400L) != 0)
+                    case 13: // Header: "Accept-Ranges"
+                        if ((tempBits & 0x800L) != 0)
                         {
-                            tempBits ^= 0x400L;
-                            values = ref _headers._Warning;
-                            keyStart = 130;
-                            keyLength = 11;
+                            tempBits ^= 0x800L;
+                            values = ref _headers._AcceptRanges;
+                            keyStart = 146;
+                            keyLength = 17;
                             next = 14;
                             break; // OutputHeader
                         }
                         goto case 14;
-                    case 14: // Header: "Allow"
-                        if ((tempBits & 0x800L) != 0)
+                    case 14: // Header: "Age"
+                        if ((tempBits & 0x1000L) != 0)
                         {
-                            tempBits ^= 0x800L;
-                            values = ref _headers._Allow;
-                            keyStart = 141;
-                            keyLength = 9;
+                            tempBits ^= 0x1000L;
+                            values = ref _headers._Age;
+                            keyStart = 163;
+                            keyLength = 7;
                             next = 15;
                             break; // OutputHeader
                         }
                         goto case 15;
-                    case 15: // Header: "Content-Encoding"
+                    case 15: // Header: "Allow"
                         if ((tempBits & 0x2000L) != 0)
                         {
                             tempBits ^= 0x2000L;
-                            values = ref _headers._ContentEncoding;
-                            keyStart = 166;
-                            keyLength = 20;
+                            values = ref _headers._Allow;
+                            keyStart = 170;
+                            keyLength = 9;
                             next = 16;
                             break; // OutputHeader
                         }
                         goto case 16;
-                    case 16: // Header: "Content-Language"
+                    case 16: // Header: "Alt-Svc"
                         if ((tempBits & 0x4000L) != 0)
                         {
                             tempBits ^= 0x4000L;
-                            values = ref _headers._ContentLanguage;
-                            keyStart = 186;
-                            keyLength = 20;
+                            values = ref _headers._AltSvc;
+                            keyStart = 179;
+                            keyLength = 11;
                             next = 17;
                             break; // OutputHeader
                         }
                         goto case 17;
-                    case 17: // Header: "Content-Location"
+                    case 17: // Header: "ETag"
                         if ((tempBits & 0x8000L) != 0)
                         {
                             tempBits ^= 0x8000L;
-                            values = ref _headers._ContentLocation;
-                            keyStart = 206;
-                            keyLength = 20;
+                            values = ref _headers._ETag;
+                            keyStart = 190;
+                            keyLength = 8;
                             next = 18;
                             break; // OutputHeader
                         }
                         goto case 18;
-                    case 18: // Header: "Content-MD5"
+                    case 18: // Header: "Location"
                         if ((tempBits & 0x10000L) != 0)
                         {
                             tempBits ^= 0x10000L;
-                            values = ref _headers._ContentMD5;
-                            keyStart = 226;
-                            keyLength = 15;
+                            values = ref _headers._Location;
+                            keyStart = 198;
+                            keyLength = 12;
                             next = 19;
                             break; // OutputHeader
                         }
                         goto case 19;
-                    case 19: // Header: "Content-Range"
+                    case 19: // Header: "Proxy-Authenticate"
                         if ((tempBits & 0x20000L) != 0)
                         {
                             tempBits ^= 0x20000L;
-                            values = ref _headers._ContentRange;
-                            keyStart = 241;
-                            keyLength = 17;
+                            values = ref _headers._ProxyAuthenticate;
+                            keyStart = 210;
+                            keyLength = 22;
                             next = 20;
                             break; // OutputHeader
                         }
                         goto case 20;
-                    case 20: // Header: "Expires"
+                    case 20: // Header: "Proxy-Connection"
                         if ((tempBits & 0x40000L) != 0)
                         {
                             tempBits ^= 0x40000L;
-                            values = ref _headers._Expires;
-                            keyStart = 258;
-                            keyLength = 11;
+                            values = ref _headers._ProxyConnection;
+                            keyStart = 232;
+                            keyLength = 20;
                             next = 21;
                             break; // OutputHeader
                         }
                         goto case 21;
-                    case 21: // Header: "Last-Modified"
+                    case 21: // Header: "Retry-After"
                         if ((tempBits & 0x80000L) != 0)
                         {
                             tempBits ^= 0x80000L;
-                            values = ref _headers._LastModified;
-                            keyStart = 269;
-                            keyLength = 17;
+                            values = ref _headers._RetryAfter;
+                            keyStart = 252;
+                            keyLength = 15;
                             next = 22;
                             break; // OutputHeader
                         }
                         goto case 22;
-                    case 22: // Header: "Accept-Ranges"
-                        if ((tempBits & 0x100000L) != 0)
+                    case 22: // Header: "Set-Cookie"
+                        if ((tempBits & 0x200000L) != 0)
                         {
-                            tempBits ^= 0x100000L;
-                            values = ref _headers._AcceptRanges;
-                            keyStart = 286;
-                            keyLength = 17;
+                            tempBits ^= 0x200000L;
+                            values = ref _headers._SetCookie;
+                            keyStart = 277;
+                            keyLength = 14;
                             next = 23;
                             break; // OutputHeader
                         }
                         goto case 23;
-                    case 23: // Header: "Age"
-                        if ((tempBits & 0x200000L) != 0)
+                    case 23: // Header: "Vary"
+                        if ((tempBits & 0x400000L) != 0)
                         {
-                            tempBits ^= 0x200000L;
-                            values = ref _headers._Age;
-                            keyStart = 303;
-                            keyLength = 7;
+                            tempBits ^= 0x400000L;
+                            values = ref _headers._Vary;
+                            keyStart = 291;
+                            keyLength = 8;
                             next = 24;
                             break; // OutputHeader
                         }
                         goto case 24;
-                    case 24: // Header: "Alt-Svc"
-                        if ((tempBits & 0x400000L) != 0)
+                    case 24: // Header: "Expires"
+                        if ((tempBits & 0x800000L) != 0)
                         {
-                            tempBits ^= 0x400000L;
-                            values = ref _headers._AltSvc;
-                            keyStart = 310;
+                            tempBits ^= 0x800000L;
+                            values = ref _headers._Expires;
+                            keyStart = 299;
                             keyLength = 11;
                             next = 25;
                             break; // OutputHeader
                         }
                         goto case 25;
-                    case 25: // Header: "ETag"
-                        if ((tempBits & 0x800000L) != 0)
+                    case 25: // Header: "WWW-Authenticate"
+                        if ((tempBits & 0x1000000L) != 0)
                         {
-                            tempBits ^= 0x800000L;
-                            values = ref _headers._ETag;
-                            keyStart = 321;
-                            keyLength = 8;
+                            tempBits ^= 0x1000000L;
+                            values = ref _headers._WWWAuthenticate;
+                            keyStart = 310;
+                            keyLength = 20;
                             next = 26;
                             break; // OutputHeader
                         }
                         goto case 26;
-                    case 26: // Header: "Location"
-                        if ((tempBits & 0x1000000L) != 0)
+                    case 26: // Header: "Content-Range"
+                        if ((tempBits & 0x2000000L) != 0)
                         {
-                            tempBits ^= 0x1000000L;
-                            values = ref _headers._Location;
-                            keyStart = 329;
-                            keyLength = 12;
+                            tempBits ^= 0x2000000L;
+                            values = ref _headers._ContentRange;
+                            keyStart = 330;
+                            keyLength = 17;
                             next = 27;
                             break; // OutputHeader
                         }
                         goto case 27;
-                    case 27: // Header: "Proxy-Authenticate"
-                        if ((tempBits & 0x2000000L) != 0)
+                    case 27: // Header: "Content-Encoding"
+                        if ((tempBits & 0x4000000L) != 0)
                         {
-                            tempBits ^= 0x2000000L;
-                            values = ref _headers._ProxyAuthenticate;
-                            keyStart = 341;
-                            keyLength = 22;
+                            tempBits ^= 0x4000000L;
+                            values = ref _headers._ContentEncoding;
+                            keyStart = 347;
+                            keyLength = 20;
                             next = 28;
                             break; // OutputHeader
                         }
                         goto case 28;
-                    case 28: // Header: "Proxy-Connection"
-                        if ((tempBits & 0x4000000L) != 0)
+                    case 28: // Header: "Content-Language"
+                        if ((tempBits & 0x8000000L) != 0)
                         {
-                            tempBits ^= 0x4000000L;
-                            values = ref _headers._ProxyConnection;
-                            keyStart = 363;
+                            tempBits ^= 0x8000000L;
+                            values = ref _headers._ContentLanguage;
+                            keyStart = 367;
                             keyLength = 20;
                             next = 29;
                             break; // OutputHeader
                         }
                         goto case 29;
-                    case 29: // Header: "Retry-After"
-                        if ((tempBits & 0x8000000L) != 0)
+                    case 29: // Header: "Content-Location"
+                        if ((tempBits & 0x10000000L) != 0)
                         {
-                            tempBits ^= 0x8000000L;
-                            values = ref _headers._RetryAfter;
-                            keyStart = 383;
-                            keyLength = 15;
+                            tempBits ^= 0x10000000L;
+                            values = ref _headers._ContentLocation;
+                            keyStart = 387;
+                            keyLength = 20;
                             next = 30;
                             break; // OutputHeader
                         }
                         goto case 30;
-                    case 30: // Header: "Set-Cookie"
+                    case 30: // Header: "Content-MD5"
                         if ((tempBits & 0x20000000L) != 0)
                         {
                             tempBits ^= 0x20000000L;
-                            values = ref _headers._SetCookie;
-                            keyStart = 408;
-                            keyLength = 14;
+                            values = ref _headers._ContentMD5;
+                            keyStart = 407;
+                            keyLength = 15;
                             next = 31;
                             break; // OutputHeader
                         }
                         goto case 31;
-                    case 31: // Header: "Vary"
+                    case 31: // Header: "Last-Modified"
                         if ((tempBits & 0x40000000L) != 0)
                         {
                             tempBits ^= 0x40000000L;
-                            values = ref _headers._Vary;
+                            values = ref _headers._LastModified;
                             keyStart = 422;
-                            keyLength = 8;
+                            keyLength = 17;
                             next = 32;
                             break; // OutputHeader
                         }
                         goto case 32;
-                    case 32: // Header: "WWW-Authenticate"
+                    case 32: // Header: "Trailer"
                         if ((tempBits & 0x80000000L) != 0)
                         {
                             tempBits ^= 0x80000000L;
-                            values = ref _headers._WWWAuthenticate;
-                            keyStart = 430;
-                            keyLength = 20;
+                            values = ref _headers._Trailer;
+                            keyStart = 439;
+                            keyLength = 11;
                             next = 33;
                             break; // OutputHeader
                         }
@@ -15893,22 +14771,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             public StringValues _GrpcEncoding;
             public StringValues _KeepAlive;
             public StringValues _Pragma;
-            public StringValues _Trailer;
             public StringValues _TransferEncoding;
             public StringValues _Upgrade;
             public StringValues _Via;
             public StringValues _Warning;
-            public StringValues _Allow;
             public StringValues _ContentType;
-            public StringValues _ContentEncoding;
-            public StringValues _ContentLanguage;
-            public StringValues _ContentLocation;
-            public StringValues _ContentMD5;
-            public StringValues _ContentRange;
-            public StringValues _Expires;
-            public StringValues _LastModified;
             public StringValues _AcceptRanges;
             public StringValues _Age;
+            public StringValues _Allow;
             public StringValues _AltSvc;
             public StringValues _ETag;
             public StringValues _Location;
@@ -15918,7 +14788,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             public StringValues _Server;
             public StringValues _SetCookie;
             public StringValues _Vary;
+            public StringValues _Expires;
             public StringValues _WWWAuthenticate;
+            public StringValues _ContentRange;
+            public StringValues _ContentEncoding;
+            public StringValues _ContentLanguage;
+            public StringValues _ContentLocation;
+            public StringValues _ContentMD5;
+            public StringValues _LastModified;
+            public StringValues _Trailer;
             public StringValues _AccessControlAllowCredentials;
             public StringValues _AccessControlAllowHeaders;
             public StringValues _AccessControlAllowMethods;
@@ -15952,57 +14830,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     case 5:
                         goto HeaderPragma;
                     case 6:
-                        goto HeaderTrailer;
-                    case 7:
                         goto HeaderTransferEncoding;
-                    case 8:
+                    case 7:
                         goto HeaderUpgrade;
-                    case 9:
+                    case 8:
                         goto HeaderVia;
-                    case 10:
+                    case 9:
                         goto HeaderWarning;
-                    case 11:
-                        goto HeaderAllow;
-                    case 12:
+                    case 10:
                         goto HeaderContentType;
-                    case 13:
-                        goto HeaderContentEncoding;
-                    case 14:
-                        goto HeaderContentLanguage;
-                    case 15:
-                        goto HeaderContentLocation;
-                    case 16:
-                        goto HeaderContentMD5;
-                    case 17:
-                        goto HeaderContentRange;
-                    case 18:
-                        goto HeaderExpires;
-                    case 19:
-                        goto HeaderLastModified;
-                    case 20:
+                    case 11:
                         goto HeaderAcceptRanges;
-                    case 21:
+                    case 12:
                         goto HeaderAge;
-                    case 22:
+                    case 13:
+                        goto HeaderAllow;
+                    case 14:
                         goto HeaderAltSvc;
-                    case 23:
+                    case 15:
                         goto HeaderETag;
-                    case 24:
+                    case 16:
                         goto HeaderLocation;
-                    case 25:
+                    case 17:
                         goto HeaderProxyAuthenticate;
-                    case 26:
+                    case 18:
                         goto HeaderProxyConnection;
-                    case 27:
+                    case 19:
                         goto HeaderRetryAfter;
-                    case 28:
+                    case 20:
                         goto HeaderServer;
-                    case 29:
+                    case 21:
                         goto HeaderSetCookie;
-                    case 30:
+                    case 22:
                         goto HeaderVary;
-                    case 31:
+                    case 23:
+                        goto HeaderExpires;
+                    case 24:
                         goto HeaderWWWAuthenticate;
+                    case 25:
+                        goto HeaderContentRange;
+                    case 26:
+                        goto HeaderContentEncoding;
+                    case 27:
+                        goto HeaderContentLanguage;
+                    case 28:
+                        goto HeaderContentLocation;
+                    case 29:
+                        goto HeaderContentMD5;
+                    case 30:
+                        goto HeaderLastModified;
+                    case 31:
+                        goto HeaderTrailer;
                     case 32:
                         goto HeaderAccessControlAllowCredentials;
                     case 33:
@@ -16069,211 +14947,211 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _next = 6;
                         return true;
                     }
-                HeaderTrailer: // case 6
+                HeaderTransferEncoding: // case 6
                     if ((_bits & 0x40L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Trailer, _collection._headers._Trailer);
-                        _currentKnownType = KnownHeaderType.Trailer;
-                        _next = 7;
-                        return true;
-                    }
-                HeaderTransferEncoding: // case 7
-                    if ((_bits & 0x80L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _collection._headers._TransferEncoding);
                         _currentKnownType = KnownHeaderType.TransferEncoding;
-                        _next = 8;
+                        _next = 7;
                         return true;
                     }
-                HeaderUpgrade: // case 8
-                    if ((_bits & 0x100L) != 0)
+                HeaderUpgrade: // case 7
+                    if ((_bits & 0x80L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _collection._headers._Upgrade);
                         _currentKnownType = KnownHeaderType.Upgrade;
-                        _next = 9;
+                        _next = 8;
                         return true;
                     }
-                HeaderVia: // case 9
-                    if ((_bits & 0x200L) != 0)
+                HeaderVia: // case 8
+                    if ((_bits & 0x100L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Via, _collection._headers._Via);
                         _currentKnownType = KnownHeaderType.Via;
-                        _next = 10;
+                        _next = 9;
                         return true;
                     }
-                HeaderWarning: // case 10
-                    if ((_bits & 0x400L) != 0)
+                HeaderWarning: // case 9
+                    if ((_bits & 0x200L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _collection._headers._Warning);
                         _currentKnownType = KnownHeaderType.Warning;
-                        _next = 11;
+                        _next = 10;
                         return true;
                     }
-                HeaderAllow: // case 11
-                    if ((_bits & 0x800L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _collection._headers._Allow);
-                        _currentKnownType = KnownHeaderType.Allow;
-                        _next = 12;
-                        return true;
-                    }
-                HeaderContentType: // case 12
-                    if ((_bits & 0x1000L) != 0)
+                HeaderContentType: // case 10
+                    if ((_bits & 0x400L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _collection._headers._ContentType);
                         _currentKnownType = KnownHeaderType.ContentType;
-                        _next = 13;
+                        _next = 11;
                         return true;
                     }
-                HeaderContentEncoding: // case 13
-                    if ((_bits & 0x2000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _collection._headers._ContentEncoding);
-                        _currentKnownType = KnownHeaderType.ContentEncoding;
-                        _next = 14;
-                        return true;
-                    }
-                HeaderContentLanguage: // case 14
-                    if ((_bits & 0x4000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _collection._headers._ContentLanguage);
-                        _currentKnownType = KnownHeaderType.ContentLanguage;
-                        _next = 15;
-                        return true;
-                    }
-                HeaderContentLocation: // case 15
-                    if ((_bits & 0x8000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _collection._headers._ContentLocation);
-                        _currentKnownType = KnownHeaderType.ContentLocation;
-                        _next = 16;
-                        return true;
-                    }
-                HeaderContentMD5: // case 16
-                    if ((_bits & 0x10000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _collection._headers._ContentMD5);
-                        _currentKnownType = KnownHeaderType.ContentMD5;
-                        _next = 17;
-                        return true;
-                    }
-                HeaderContentRange: // case 17
-                    if ((_bits & 0x20000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _collection._headers._ContentRange);
-                        _currentKnownType = KnownHeaderType.ContentRange;
-                        _next = 18;
-                        return true;
-                    }
-                HeaderExpires: // case 18
-                    if ((_bits & 0x40000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _collection._headers._Expires);
-                        _currentKnownType = KnownHeaderType.Expires;
-                        _next = 19;
-                        return true;
-                    }
-                HeaderLastModified: // case 19
-                    if ((_bits & 0x80000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _collection._headers._LastModified);
-                        _currentKnownType = KnownHeaderType.LastModified;
-                        _next = 20;
-                        return true;
-                    }
-                HeaderAcceptRanges: // case 20
-                    if ((_bits & 0x100000L) != 0)
+                HeaderAcceptRanges: // case 11
+                    if ((_bits & 0x800L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptRanges, _collection._headers._AcceptRanges);
                         _currentKnownType = KnownHeaderType.AcceptRanges;
-                        _next = 21;
+                        _next = 12;
                         return true;
                     }
-                HeaderAge: // case 21
-                    if ((_bits & 0x200000L) != 0)
+                HeaderAge: // case 12
+                    if ((_bits & 0x1000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Age, _collection._headers._Age);
                         _currentKnownType = KnownHeaderType.Age;
-                        _next = 22;
+                        _next = 13;
                         return true;
                     }
-                HeaderAltSvc: // case 22
-                    if ((_bits & 0x400000L) != 0)
+                HeaderAllow: // case 13
+                    if ((_bits & 0x2000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _collection._headers._Allow);
+                        _currentKnownType = KnownHeaderType.Allow;
+                        _next = 14;
+                        return true;
+                    }
+                HeaderAltSvc: // case 14
+                    if ((_bits & 0x4000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AltSvc, _collection._headers._AltSvc);
                         _currentKnownType = KnownHeaderType.AltSvc;
-                        _next = 23;
+                        _next = 15;
                         return true;
                     }
-                HeaderETag: // case 23
-                    if ((_bits & 0x800000L) != 0)
+                HeaderETag: // case 15
+                    if ((_bits & 0x8000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ETag, _collection._headers._ETag);
                         _currentKnownType = KnownHeaderType.ETag;
-                        _next = 24;
+                        _next = 16;
                         return true;
                     }
-                HeaderLocation: // case 24
-                    if ((_bits & 0x1000000L) != 0)
+                HeaderLocation: // case 16
+                    if ((_bits & 0x10000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Location, _collection._headers._Location);
                         _currentKnownType = KnownHeaderType.Location;
-                        _next = 25;
+                        _next = 17;
                         return true;
                     }
-                HeaderProxyAuthenticate: // case 25
-                    if ((_bits & 0x2000000L) != 0)
+                HeaderProxyAuthenticate: // case 17
+                    if ((_bits & 0x20000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthenticate, _collection._headers._ProxyAuthenticate);
                         _currentKnownType = KnownHeaderType.ProxyAuthenticate;
-                        _next = 26;
+                        _next = 18;
                         return true;
                     }
-                HeaderProxyConnection: // case 26
-                    if ((_bits & 0x4000000L) != 0)
+                HeaderProxyConnection: // case 18
+                    if ((_bits & 0x40000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyConnection, _collection._headers._ProxyConnection);
                         _currentKnownType = KnownHeaderType.ProxyConnection;
-                        _next = 27;
+                        _next = 19;
                         return true;
                     }
-                HeaderRetryAfter: // case 27
-                    if ((_bits & 0x8000000L) != 0)
+                HeaderRetryAfter: // case 19
+                    if ((_bits & 0x80000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.RetryAfter, _collection._headers._RetryAfter);
                         _currentKnownType = KnownHeaderType.RetryAfter;
-                        _next = 28;
+                        _next = 20;
                         return true;
                     }
-                HeaderServer: // case 28
-                    if ((_bits & 0x10000000L) != 0)
+                HeaderServer: // case 20
+                    if ((_bits & 0x100000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Server, _collection._headers._Server);
                         _currentKnownType = KnownHeaderType.Server;
-                        _next = 29;
+                        _next = 21;
                         return true;
                     }
-                HeaderSetCookie: // case 29
-                    if ((_bits & 0x20000000L) != 0)
+                HeaderSetCookie: // case 21
+                    if ((_bits & 0x200000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.SetCookie, _collection._headers._SetCookie);
                         _currentKnownType = KnownHeaderType.SetCookie;
-                        _next = 30;
+                        _next = 22;
                         return true;
                     }
-                HeaderVary: // case 30
-                    if ((_bits & 0x40000000L) != 0)
+                HeaderVary: // case 22
+                    if ((_bits & 0x400000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Vary, _collection._headers._Vary);
                         _currentKnownType = KnownHeaderType.Vary;
-                        _next = 31;
+                        _next = 23;
                         return true;
                     }
-                HeaderWWWAuthenticate: // case 31
-                    if ((_bits & 0x80000000L) != 0)
+                HeaderExpires: // case 23
+                    if ((_bits & 0x800000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _collection._headers._Expires);
+                        _currentKnownType = KnownHeaderType.Expires;
+                        _next = 24;
+                        return true;
+                    }
+                HeaderWWWAuthenticate: // case 24
+                    if ((_bits & 0x1000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.WWWAuthenticate, _collection._headers._WWWAuthenticate);
                         _currentKnownType = KnownHeaderType.WWWAuthenticate;
+                        _next = 25;
+                        return true;
+                    }
+                HeaderContentRange: // case 25
+                    if ((_bits & 0x2000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _collection._headers._ContentRange);
+                        _currentKnownType = KnownHeaderType.ContentRange;
+                        _next = 26;
+                        return true;
+                    }
+                HeaderContentEncoding: // case 26
+                    if ((_bits & 0x4000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _collection._headers._ContentEncoding);
+                        _currentKnownType = KnownHeaderType.ContentEncoding;
+                        _next = 27;
+                        return true;
+                    }
+                HeaderContentLanguage: // case 27
+                    if ((_bits & 0x8000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _collection._headers._ContentLanguage);
+                        _currentKnownType = KnownHeaderType.ContentLanguage;
+                        _next = 28;
+                        return true;
+                    }
+                HeaderContentLocation: // case 28
+                    if ((_bits & 0x10000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _collection._headers._ContentLocation);
+                        _currentKnownType = KnownHeaderType.ContentLocation;
+                        _next = 29;
+                        return true;
+                    }
+                HeaderContentMD5: // case 29
+                    if ((_bits & 0x20000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _collection._headers._ContentMD5);
+                        _currentKnownType = KnownHeaderType.ContentMD5;
+                        _next = 30;
+                        return true;
+                    }
+                HeaderLastModified: // case 30
+                    if ((_bits & 0x40000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _collection._headers._LastModified);
+                        _currentKnownType = KnownHeaderType.LastModified;
+                        _next = 31;
+                        return true;
+                    }
+                HeaderTrailer: // case 31
+                    if ((_bits & 0x80000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Trailer, _collection._headers._Trailer);
+                        _currentKnownType = KnownHeaderType.Trailer;
                         _next = 32;
                         return true;
                     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -206,7 +206,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private HeaderReferences _headers;
 
         public bool HasConnection => (_bits & 0x2L) != 0;
-        public bool HasTransferEncoding => (_bits & 0x40L) != 0;
+        public bool HasTransferEncoding => (_bits & 0x20000000000L) != 0;
 
         public int HostCount => _headers._Host.Count;
 
@@ -227,21 +227,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 _headers._Connection = value; 
             }
         }
-        public StringValues HeaderTransferEncoding
+        public StringValues HeaderHost
         {
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x40L) != 0)
+                if ((_bits & 0x4L) != 0)
                 {
-                    value = _headers._TransferEncoding;
+                    value = _headers._Host;
                 }
                 return value;
             }
             set
             {
-                _bits |= 0x40L;
-                _headers._TransferEncoding = value; 
+                _bits |= 0x4L;
+                _headers._Host = value; 
             }
         }
         public StringValues HeaderAuthority
@@ -249,7 +249,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x800L) != 0)
+                if ((_bits & 0x10L) != 0)
                 {
                     value = _headers._Authority;
                 }
@@ -257,7 +257,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x800L;
+                _bits |= 0x10L;
                 _headers._Authority = value; 
             }
         }
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x1000L) != 0)
+                if ((_bits & 0x20L) != 0)
                 {
                     value = _headers._Method;
                 }
@@ -274,7 +274,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x1000L;
+                _bits |= 0x20L;
                 _headers._Method = value; 
             }
         }
@@ -283,7 +283,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x2000L) != 0)
+                if ((_bits & 0x40L) != 0)
                 {
                     value = _headers._Path;
                 }
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x2000L;
+                _bits |= 0x40L;
                 _headers._Path = value; 
             }
         }
@@ -300,7 +300,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x4000L) != 0)
+                if ((_bits & 0x80L) != 0)
                 {
                     value = _headers._Scheme;
                 }
@@ -308,25 +308,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x4000L;
+                _bits |= 0x80L;
                 _headers._Scheme = value; 
             }
         }
-        public StringValues HeaderHost
+        public StringValues HeaderTransferEncoding
         {
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x2000000L) != 0)
+                if ((_bits & 0x20000000000L) != 0)
                 {
-                    value = _headers._Host;
+                    value = _headers._TransferEncoding;
                 }
                 return value;
             }
             set
             {
-                _bits |= 0x2000000L;
-                _headers._Host = value; 
+                _bits |= 0x20000000000L;
+                _headers._TransferEncoding = value; 
             }
         }
         public StringValues HeaderContentLength
@@ -346,11 +346,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
         
-        StringValues IHeaderDictionary.CacheControl
+        StringValues IHeaderDictionary.Accept
         {
             get
             {
-                var value = _headers._CacheControl;
+                var value = _headers._Accept;
                 if ((_bits & 0x1L) != 0)
                 {
                     return value;
@@ -365,12 +365,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._CacheControl = value;
+                    _headers._Accept = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._CacheControl = default;
+                    _headers._Accept = default;
                 }
             }
         }
@@ -402,11 +402,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
         }
-        StringValues IHeaderDictionary.Date
+        StringValues IHeaderDictionary.Host
         {
             get
             {
-                var value = _headers._Date;
+                var value = _headers._Host;
                 if ((_bits & 0x4L) != 0)
                 {
                     return value;
@@ -421,20 +421,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Date = value;
+                    _headers._Host = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Date = default;
+                    _headers._Host = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.GrpcEncoding
+        StringValues IHeaderDictionary.UserAgent
         {
             get
             {
-                var value = _headers._GrpcEncoding;
+                var value = _headers._UserAgent;
                 if ((_bits & 0x8L) != 0)
                 {
                     return value;
@@ -449,132 +449,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._GrpcEncoding = value;
+                    _headers._UserAgent = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._GrpcEncoding = default;
+                    _headers._UserAgent = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.KeepAlive
+        StringValues IHeaderDictionary.AcceptCharset
         {
             get
             {
-                var value = _headers._KeepAlive;
-                if ((_bits & 0x10L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x10L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._KeepAlive = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._KeepAlive = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Pragma
-        {
-            get
-            {
-                var value = _headers._Pragma;
-                if ((_bits & 0x20L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x20L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Pragma = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Pragma = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.TransferEncoding
-        {
-            get
-            {
-                var value = _headers._TransferEncoding;
-                if ((_bits & 0x40L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x40L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._TransferEncoding = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._TransferEncoding = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Upgrade
-        {
-            get
-            {
-                var value = _headers._Upgrade;
-                if ((_bits & 0x80L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x80L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Upgrade = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Upgrade = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Via
-        {
-            get
-            {
-                var value = _headers._Via;
+                var value = _headers._AcceptCharset;
                 if ((_bits & 0x100L) != 0)
                 {
                     return value;
@@ -586,118 +474,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x100L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Via = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Via = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Warning
-        {
-            get
-            {
-                var value = _headers._Warning;
-                if ((_bits & 0x200L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x200L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Warning = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Warning = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentType
-        {
-            get
-            {
-                var value = _headers._ContentType;
-                if ((_bits & 0x400L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x400L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentType = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentType = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Accept
-        {
-            get
-            {
-                var value = _headers._Accept;
-                if ((_bits & 0x8000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x8000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Accept = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Accept = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.AcceptCharset
-        {
-            get
-            {
-                var value = _headers._AcceptCharset;
-                if ((_bits & 0x10000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x10000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -715,7 +491,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._AcceptEncoding;
-                if ((_bits & 0x20000L) != 0)
+                if ((_bits & 0x200L) != 0)
                 {
                     return value;
                 }
@@ -725,7 +501,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x20000L;
+                var flag = 0x200L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -743,6 +519,230 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._AcceptLanguage;
+                if ((_bits & 0x400L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x400L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._AcceptLanguage = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._AcceptLanguage = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.AccessControlRequestHeaders
+        {
+            get
+            {
+                var value = _headers._AccessControlRequestHeaders;
+                if ((_bits & 0x800L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x800L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._AccessControlRequestHeaders = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._AccessControlRequestHeaders = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.AccessControlRequestMethod
+        {
+            get
+            {
+                var value = _headers._AccessControlRequestMethod;
+                if ((_bits & 0x1000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x1000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._AccessControlRequestMethod = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._AccessControlRequestMethod = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.Authorization
+        {
+            get
+            {
+                var value = _headers._Authorization;
+                if ((_bits & 0x2000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x2000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Authorization = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Authorization = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.Baggage
+        {
+            get
+            {
+                var value = _headers._Baggage;
+                if ((_bits & 0x4000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x4000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Baggage = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Baggage = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.CacheControl
+        {
+            get
+            {
+                var value = _headers._CacheControl;
+                if ((_bits & 0x8000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x8000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._CacheControl = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._CacheControl = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentType
+        {
+            get
+            {
+                var value = _headers._ContentType;
+                if ((_bits & 0x10000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x10000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ContentType = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ContentType = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.Cookie
+        {
+            get
+            {
+                var value = _headers._Cookie;
+                if ((_bits & 0x20000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x20000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Cookie = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Cookie = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.CorrelationContext
+        {
+            get
+            {
+                var value = _headers._CorrelationContext;
                 if ((_bits & 0x40000L) != 0)
                 {
                     return value;
@@ -757,20 +757,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AcceptLanguage = value;
+                    _headers._CorrelationContext = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AcceptLanguage = default;
+                    _headers._CorrelationContext = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Authorization
+        StringValues IHeaderDictionary.Date
         {
             get
             {
-                var value = _headers._Authorization;
+                var value = _headers._Date;
                 if ((_bits & 0x80000L) != 0)
                 {
                     return value;
@@ -785,20 +785,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Authorization = value;
+                    _headers._Date = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Authorization = default;
+                    _headers._Date = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Cookie
+        StringValues IHeaderDictionary.Expect
         {
             get
             {
-                var value = _headers._Cookie;
+                var value = _headers._Expect;
                 if ((_bits & 0x100000L) != 0)
                 {
                     return value;
@@ -810,34 +810,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x100000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Cookie = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Cookie = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Expect
-        {
-            get
-            {
-                var value = _headers._Expect;
-                if ((_bits & 0x200000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x200000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -855,7 +827,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._From;
-                if ((_bits & 0x400000L) != 0)
+                if ((_bits & 0x200000L) != 0)
                 {
                     return value;
                 }
@@ -865,7 +837,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x400000L;
+                var flag = 0x200000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -883,6 +855,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._GrpcAcceptEncoding;
+                if ((_bits & 0x400000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x400000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._GrpcAcceptEncoding = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._GrpcAcceptEncoding = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.GrpcEncoding
+        {
+            get
+            {
+                var value = _headers._GrpcEncoding;
                 if ((_bits & 0x800000L) != 0)
                 {
                     return value;
@@ -897,12 +897,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._GrpcAcceptEncoding = value;
+                    _headers._GrpcEncoding = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._GrpcAcceptEncoding = default;
+                    _headers._GrpcEncoding = default;
                 }
             }
         }
@@ -934,11 +934,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
         }
-        StringValues IHeaderDictionary.Host
+        StringValues IHeaderDictionary.IfMatch
         {
             get
             {
-                var value = _headers._Host;
+                var value = _headers._IfMatch;
                 if ((_bits & 0x2000000L) != 0)
                 {
                     return value;
@@ -950,34 +950,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x2000000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Host = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Host = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.IfMatch
-        {
-            get
-            {
-                var value = _headers._IfMatch;
-                if ((_bits & 0x4000000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x4000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -995,7 +967,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfModifiedSince;
-                if ((_bits & 0x8000000L) != 0)
+                if ((_bits & 0x4000000L) != 0)
                 {
                     return value;
                 }
@@ -1005,7 +977,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x8000000L;
+                var flag = 0x4000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1023,7 +995,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfNoneMatch;
-                if ((_bits & 0x10000000L) != 0)
+                if ((_bits & 0x8000000L) != 0)
                 {
                     return value;
                 }
@@ -1033,7 +1005,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x10000000L;
+                var flag = 0x8000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1051,7 +1023,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfRange;
-                if ((_bits & 0x20000000L) != 0)
+                if ((_bits & 0x10000000L) != 0)
                 {
                     return value;
                 }
@@ -1061,7 +1033,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x20000000L;
+                var flag = 0x10000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1079,6 +1051,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._IfUnmodifiedSince;
+                if ((_bits & 0x20000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x20000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._IfUnmodifiedSince = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._IfUnmodifiedSince = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.KeepAlive
+        {
+            get
+            {
+                var value = _headers._KeepAlive;
                 if ((_bits & 0x40000000L) != 0)
                 {
                     return value;
@@ -1093,12 +1093,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._IfUnmodifiedSince = value;
+                    _headers._KeepAlive = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._IfUnmodifiedSince = default;
+                    _headers._KeepAlive = default;
                 }
             }
         }
@@ -1130,11 +1130,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
         }
-        StringValues IHeaderDictionary.ProxyAuthorization
+        StringValues IHeaderDictionary.Origin
         {
             get
             {
-                var value = _headers._ProxyAuthorization;
+                var value = _headers._Origin;
                 if ((_bits & 0x100000000L) != 0)
                 {
                     return value;
@@ -1149,20 +1149,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._ProxyAuthorization = value;
+                    _headers._Origin = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._ProxyAuthorization = default;
+                    _headers._Origin = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Referer
+        StringValues IHeaderDictionary.Pragma
         {
             get
             {
-                var value = _headers._Referer;
+                var value = _headers._Pragma;
                 if ((_bits & 0x200000000L) != 0)
                 {
                     return value;
@@ -1177,20 +1177,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Referer = value;
+                    _headers._Pragma = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Referer = default;
+                    _headers._Pragma = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Range
+        StringValues IHeaderDictionary.ProxyAuthorization
         {
             get
             {
-                var value = _headers._Range;
+                var value = _headers._ProxyAuthorization;
                 if ((_bits & 0x400000000L) != 0)
                 {
                     return value;
@@ -1205,20 +1205,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Range = value;
+                    _headers._ProxyAuthorization = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Range = default;
+                    _headers._ProxyAuthorization = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.TE
+        StringValues IHeaderDictionary.Range
         {
             get
             {
-                var value = _headers._TE;
+                var value = _headers._Range;
                 if ((_bits & 0x800000000L) != 0)
                 {
                     return value;
@@ -1233,20 +1233,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._TE = value;
+                    _headers._Range = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._TE = default;
+                    _headers._Range = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Translate
+        StringValues IHeaderDictionary.Referer
         {
             get
             {
-                var value = _headers._Translate;
+                var value = _headers._Referer;
                 if ((_bits & 0x1000000000L) != 0)
                 {
                     return value;
@@ -1261,20 +1261,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Translate = value;
+                    _headers._Referer = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Translate = default;
+                    _headers._Referer = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.UserAgent
+        StringValues IHeaderDictionary.RequestId
         {
             get
             {
-                var value = _headers._UserAgent;
+                var value = _headers._RequestId;
                 if ((_bits & 0x2000000000L) != 0)
                 {
                     return value;
@@ -1289,20 +1289,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._UserAgent = value;
+                    _headers._RequestId = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._UserAgent = default;
+                    _headers._RequestId = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.UpgradeInsecureRequests
+        StringValues IHeaderDictionary.TE
         {
             get
             {
-                var value = _headers._UpgradeInsecureRequests;
+                var value = _headers._TE;
                 if ((_bits & 0x4000000000L) != 0)
                 {
                     return value;
@@ -1317,20 +1317,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._UpgradeInsecureRequests = value;
+                    _headers._TE = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._UpgradeInsecureRequests = default;
+                    _headers._TE = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.RequestId
+        StringValues IHeaderDictionary.TraceParent
         {
             get
             {
-                var value = _headers._RequestId;
+                var value = _headers._TraceParent;
                 if ((_bits & 0x8000000000L) != 0)
                 {
                     return value;
@@ -1342,62 +1342,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x8000000000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._RequestId = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._RequestId = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.CorrelationContext
-        {
-            get
-            {
-                var value = _headers._CorrelationContext;
-                if ((_bits & 0x10000000000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x10000000000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._CorrelationContext = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._CorrelationContext = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.TraceParent
-        {
-            get
-            {
-                var value = _headers._TraceParent;
-                if ((_bits & 0x20000000000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x20000000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -1415,6 +1359,62 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._TraceState;
+                if ((_bits & 0x10000000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x10000000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._TraceState = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._TraceState = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.TransferEncoding
+        {
+            get
+            {
+                var value = _headers._TransferEncoding;
+                if ((_bits & 0x20000000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x20000000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._TransferEncoding = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._TransferEncoding = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.Translate
+        {
+            get
+            {
+                var value = _headers._Translate;
                 if ((_bits & 0x40000000000L) != 0)
                 {
                     return value;
@@ -1429,20 +1429,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._TraceState = value;
+                    _headers._Translate = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._TraceState = default;
+                    _headers._Translate = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Baggage
+        StringValues IHeaderDictionary.Upgrade
         {
             get
             {
-                var value = _headers._Baggage;
+                var value = _headers._Upgrade;
                 if ((_bits & 0x80000000000L) != 0)
                 {
                     return value;
@@ -1457,20 +1457,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Baggage = value;
+                    _headers._Upgrade = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Baggage = default;
+                    _headers._Upgrade = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Origin
+        StringValues IHeaderDictionary.UpgradeInsecureRequests
         {
             get
             {
-                var value = _headers._Origin;
+                var value = _headers._UpgradeInsecureRequests;
                 if ((_bits & 0x100000000000L) != 0)
                 {
                     return value;
@@ -1485,20 +1485,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Origin = value;
+                    _headers._UpgradeInsecureRequests = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Origin = default;
+                    _headers._UpgradeInsecureRequests = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.AccessControlRequestMethod
+        StringValues IHeaderDictionary.Via
         {
             get
             {
-                var value = _headers._AccessControlRequestMethod;
+                var value = _headers._Via;
                 if ((_bits & 0x200000000000L) != 0)
                 {
                     return value;
@@ -1513,20 +1513,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AccessControlRequestMethod = value;
+                    _headers._Via = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AccessControlRequestMethod = default;
+                    _headers._Via = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.AccessControlRequestHeaders
+        StringValues IHeaderDictionary.Warning
         {
             get
             {
-                var value = _headers._AccessControlRequestHeaders;
+                var value = _headers._Warning;
                 if ((_bits & 0x400000000000L) != 0)
                 {
                     return value;
@@ -1541,12 +1541,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AccessControlRequestHeaders = value;
+                    _headers._Warning = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AccessControlRequestHeaders = default;
+                    _headers._Warning = default;
                 }
             }
         }
@@ -2376,7 +2376,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TE, key))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x4000000000L) != 0)
                         {
                             value = _headers._TE;
                             return true;
@@ -2386,7 +2386,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.TE.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x4000000000L) != 0)
                         {
                             value = _headers._TE;
                             return true;
@@ -2399,7 +2399,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x200000000000L) != 0)
                         {
                             value = _headers._Via;
                             return true;
@@ -2409,7 +2409,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x200000000000L) != 0)
                         {
                             value = _headers._Via;
                             return true;
@@ -2422,7 +2422,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Host, key))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x4L) != 0)
                         {
                             value = _headers._Host;
                             return true;
@@ -2431,7 +2431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Date, key))
                     {
-                        if ((_bits & 0x4L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
                             value = _headers._Date;
                             return true;
@@ -2440,7 +2440,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.From, key))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
                             value = _headers._From;
                             return true;
@@ -2450,7 +2450,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Host.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x4L) != 0)
                         {
                             value = _headers._Host;
                             return true;
@@ -2459,7 +2459,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Date.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
                             value = _headers._Date;
                             return true;
@@ -2468,7 +2468,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.From.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
                             value = _headers._From;
                             return true;
@@ -2481,7 +2481,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
                             value = _headers._Path;
                             return true;
@@ -2490,7 +2490,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
                             value = _headers._Range;
                             return true;
@@ -2500,7 +2500,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
                             value = _headers._Path;
                             return true;
@@ -2509,7 +2509,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
                             value = _headers._Range;
                             return true;
@@ -2522,25 +2522,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Accept, key))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x1L) != 0)
                         {
                             value = _headers._Accept;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Pragma, key))
-                    {
-                        if ((_bits & 0x20L) != 0)
-                        {
-                            value = _headers._Pragma;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Cookie, key))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
                             value = _headers._Cookie;
                             return true;
@@ -2549,7 +2540,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expect, key))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
                             value = _headers._Expect;
                             return true;
@@ -2558,9 +2549,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x100000000000L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
                             value = _headers._Origin;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Pragma, key))
+                    {
+                        if ((_bits & 0x200000000L) != 0)
+                        {
+                            value = _headers._Pragma;
                             return true;
                         }
                         return false;
@@ -2568,25 +2568,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Accept.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x1L) != 0)
                         {
                             value = _headers._Accept;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x20L) != 0)
-                        {
-                            value = _headers._Pragma;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Cookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
                             value = _headers._Cookie;
                             return true;
@@ -2595,7 +2586,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expect.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
                             value = _headers._Expect;
                             return true;
@@ -2604,9 +2595,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
                             value = _headers._Origin;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000000L) != 0)
+                        {
+                            value = _headers._Pragma;
                             return true;
                         }
                         return false;
@@ -2615,27 +2615,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Upgrade, key))
-                    {
-                        if ((_bits & 0x80L) != 0)
-                        {
-                            value = _headers._Upgrade;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Warning, key))
-                    {
-                        if ((_bits & 0x200L) != 0)
-                        {
-                            value = _headers._Warning;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Method, key))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x20L) != 0)
                         {
                             value = _headers._Method;
                             return true;
@@ -2644,53 +2626,53 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Scheme, key))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
                             value = _headers._Scheme;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Referer, key))
-                    {
-                        if ((_bits & 0x200000000L) != 0)
-                        {
-                            value = _headers._Referer;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x80000000000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
                             value = _headers._Baggage;
                             return true;
                         }
                         return false;
                     }
-
-                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Referer, key))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
+                        {
+                            value = _headers._Referer;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Upgrade, key))
+                    {
+                        if ((_bits & 0x80000000000L) != 0)
                         {
                             value = _headers._Upgrade;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x400000000000L) != 0)
                         {
                             value = _headers._Warning;
                             return true;
                         }
                         return false;
                     }
+
                     if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x20L) != 0)
                         {
                             value = _headers._Method;
                             return true;
@@ -2699,27 +2681,45 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
                             value = _headers._Scheme;
                             return true;
                         }
                         return false;
                     }
+                    if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x4000L) != 0)
+                        {
+                            value = _headers._Baggage;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
                         {
                             value = _headers._Referer;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x80000000000L) != 0)
                         {
-                            value = _headers._Baggage;
+                            value = _headers._Upgrade;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000000000L) != 0)
+                        {
+                            value = _headers._Warning;
                             return true;
                         }
                         return false;
@@ -2730,7 +2730,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfMatch, key))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
                             value = _headers._IfMatch;
                             return true;
@@ -2739,7 +2739,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfRange, key))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
                             value = _headers._IfRange;
                             return true;
@@ -2749,7 +2749,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.IfMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
                             value = _headers._IfMatch;
                             return true;
@@ -2758,7 +2758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
                             value = _headers._IfRange;
                             return true;
@@ -2771,7 +2771,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Translate, key))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x40000000000L) != 0)
                         {
                             value = _headers._Translate;
                             return true;
@@ -2781,7 +2781,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Translate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x40000000000L) != 0)
                         {
                             value = _headers._Translate;
                             return true;
@@ -2803,34 +2803,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x8L) != 0)
                         {
                             value = _headers._UserAgent;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.KeepAlive, key))
-                    {
-                        if ((_bits & 0x10L) != 0)
-                        {
-                            value = _headers._KeepAlive;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Authority, key))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x10L) != 0)
                         {
                             value = _headers._Authority;
                             return true;
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.KeepAlive, key))
+                    {
+                        if ((_bits & 0x40000000L) != 0)
+                        {
+                            value = _headers._KeepAlive;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x8000000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
                             value = _headers._RequestId;
                             return true;
@@ -2839,7 +2839,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x40000000000L) != 0)
+                        if ((_bits & 0x10000000000L) != 0)
                         {
                             value = _headers._TraceState;
                             return true;
@@ -2858,34 +2858,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x8L) != 0)
                         {
                             value = _headers._UserAgent;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10L) != 0)
-                        {
-                            value = _headers._KeepAlive;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x10L) != 0)
                         {
                             value = _headers._Authority;
                             return true;
                         }
                         return false;
                     }
+                    if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x40000000L) != 0)
+                        {
+                            value = _headers._KeepAlive;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
                             value = _headers._RequestId;
                             return true;
@@ -2894,7 +2894,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000L) != 0)
+                        if ((_bits & 0x10000000000L) != 0)
                         {
                             value = _headers._TraceState;
                             return true;
@@ -2907,7 +2907,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x20000000000L) != 0)
+                        if ((_bits & 0x8000000000L) != 0)
                         {
                             value = _headers._TraceParent;
                             return true;
@@ -2917,7 +2917,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000L) != 0)
+                        if ((_bits & 0x8000000000L) != 0)
                         {
                             value = _headers._TraceParent;
                             return true;
@@ -2930,7 +2930,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
                             value = _headers._ContentType;
                             return true;
@@ -2958,7 +2958,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
                             value = _headers._ContentType;
                             return true;
@@ -2987,9 +2987,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 13:
                 {
+                    if (ReferenceEquals(HeaderNames.Authorization, key))
+                    {
+                        if ((_bits & 0x2000L) != 0)
+                        {
+                            value = _headers._Authorization;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.CacheControl, key))
                     {
-                        if ((_bits & 0x1L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
                             value = _headers._CacheControl;
                             return true;
@@ -2998,25 +3007,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
                     {
-                        if ((_bits & 0x8L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
                             value = _headers._GrpcEncoding;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Authorization, key))
-                    {
-                        if ((_bits & 0x80000L) != 0)
-                        {
-                            value = _headers._Authorization;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.IfNoneMatch, key))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
                             value = _headers._IfNoneMatch;
                             return true;
@@ -3024,9 +3024,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
+                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x2000L) != 0)
+                        {
+                            value = _headers._Authorization;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
                             value = _headers._CacheControl;
                             return true;
@@ -3035,25 +3044,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
                             value = _headers._GrpcEncoding;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x80000L) != 0)
-                        {
-                            value = _headers._Authorization;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.IfNoneMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
                             value = _headers._IfNoneMatch;
                             return true;
@@ -3066,7 +3066,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptCharset, key))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
                             value = _headers._AcceptCharset;
                             return true;
@@ -3085,7 +3085,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AcceptCharset.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
                             value = _headers._AcceptCharset;
                             return true;
@@ -3107,7 +3107,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptEncoding, key))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._AcceptEncoding;
                             return true;
@@ -3116,7 +3116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AcceptLanguage, key))
                     {
-                        if ((_bits & 0x40000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
                             value = _headers._AcceptLanguage;
                             return true;
@@ -3126,7 +3126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._AcceptEncoding;
                             return true;
@@ -3135,7 +3135,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AcceptLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
                             value = _headers._AcceptLanguage;
                             return true;
@@ -3146,39 +3146,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 17:
                 {
-                    if (ReferenceEquals(HeaderNames.TransferEncoding, key))
+                    if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            value = _headers._TransferEncoding;
+                            value = _headers._IfModifiedSince;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
+                    if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x20000000000L) != 0)
                         {
-                            value = _headers._IfModifiedSince;
+                            value = _headers._TransferEncoding;
                             return true;
                         }
                         return false;
                     }
 
-                    if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            value = _headers._TransferEncoding;
+                            value = _headers._IfModifiedSince;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x20000000000L) != 0)
                         {
-                            value = _headers._IfModifiedSince;
+                            value = _headers._TransferEncoding;
                             return true;
                         }
                         return false;
@@ -3187,9 +3187,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 19:
                 {
+                    if (ReferenceEquals(HeaderNames.CorrelationContext, key))
+                    {
+                        if ((_bits & 0x40000L) != 0)
+                        {
+                            value = _headers._CorrelationContext;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.IfUnmodifiedSince, key))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
                             value = _headers._IfUnmodifiedSince;
                             return true;
@@ -3198,26 +3207,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ProxyAuthorization, key))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
                             value = _headers._ProxyAuthorization;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.CorrelationContext, key))
+
+                    if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
                             value = _headers._CorrelationContext;
                             return true;
                         }
                         return false;
                     }
-
                     if (HeaderNames.IfUnmodifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
                             value = _headers._IfUnmodifiedSince;
                             return true;
@@ -3226,18 +3235,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ProxyAuthorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
                             value = _headers._ProxyAuthorization;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10000000000L) != 0)
-                        {
-                            value = _headers._CorrelationContext;
                             return true;
                         }
                         return false;
@@ -3248,7 +3248,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.GrpcAcceptEncoding, key))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
                             value = _headers._GrpcAcceptEncoding;
                             return true;
@@ -3258,7 +3258,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.GrpcAcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
                             value = _headers._GrpcAcceptEncoding;
                             return true;
@@ -3271,7 +3271,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x4000000000L) != 0)
+                        if ((_bits & 0x100000000000L) != 0)
                         {
                             value = _headers._UpgradeInsecureRequests;
                             return true;
@@ -3281,7 +3281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000L) != 0)
+                        if ((_bits & 0x100000000000L) != 0)
                         {
                             value = _headers._UpgradeInsecureRequests;
                             return true;
@@ -3294,7 +3294,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x200000000000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
                             value = _headers._AccessControlRequestMethod;
                             return true;
@@ -3304,7 +3304,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
                             value = _headers._AccessControlRequestMethod;
                             return true;
@@ -3317,7 +3317,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x400000000000L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
                             value = _headers._AccessControlRequestHeaders;
                             return true;
@@ -3327,7 +3327,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000000L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
                             value = _headers._AccessControlRequestHeaders;
                             return true;
@@ -3349,14 +3349,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TE, key))
                     {
-                        _bits |= 0x800000000L;
+                        _bits |= 0x4000000000L;
                         _headers._TE = value;
                         return;
                     }
 
                     if (HeaderNames.TE.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800000000L;
+                        _bits |= 0x4000000000L;
                         _headers._TE = value;
                         return;
                     }
@@ -3366,14 +3366,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        _bits |= 0x100L;
+                        _bits |= 0x200000000000L;
                         _headers._Via = value;
                         return;
                     }
 
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100L;
+                        _bits |= 0x200000000000L;
                         _headers._Via = value;
                         return;
                     }
@@ -3383,38 +3383,38 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Host, key))
                     {
-                        _bits |= 0x2000000L;
+                        _bits |= 0x4L;
                         _headers._Host = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Date, key))
                     {
-                        _bits |= 0x4L;
+                        _bits |= 0x80000L;
                         _headers._Date = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.From, key))
                     {
-                        _bits |= 0x400000L;
+                        _bits |= 0x200000L;
                         _headers._From = value;
                         return;
                     }
 
                     if (HeaderNames.Host.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000L;
+                        _bits |= 0x4L;
                         _headers._Host = value;
                         return;
                     }
                     if (HeaderNames.Date.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4L;
+                        _bits |= 0x80000L;
                         _headers._Date = value;
                         return;
                     }
                     if (HeaderNames.From.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000L;
+                        _bits |= 0x200000L;
                         _headers._From = value;
                         return;
                     }
@@ -3424,26 +3424,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
-                        _bits |= 0x2000L;
+                        _bits |= 0x40L;
                         _headers._Path = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
                     {
-                        _bits |= 0x400000000L;
+                        _bits |= 0x800000000L;
                         _headers._Range = value;
                         return;
                     }
 
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000L;
+                        _bits |= 0x40L;
                         _headers._Path = value;
                         return;
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000000L;
+                        _bits |= 0x800000000L;
                         _headers._Range = value;
                         return;
                     }
@@ -3453,140 +3453,140 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Accept, key))
                     {
-                        _bits |= 0x8000L;
+                        _bits |= 0x1L;
                         _headers._Accept = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Pragma, key))
-                    {
-                        _bits |= 0x20L;
-                        _headers._Pragma = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Cookie, key))
                     {
-                        _bits |= 0x100000L;
+                        _bits |= 0x20000L;
                         _headers._Cookie = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Expect, key))
                     {
-                        _bits |= 0x200000L;
+                        _bits |= 0x100000L;
                         _headers._Expect = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        _bits |= 0x100000000000L;
+                        _bits |= 0x100000000L;
                         _headers._Origin = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Pragma, key))
+                    {
+                        _bits |= 0x200000000L;
+                        _headers._Pragma = value;
                         return;
                     }
 
                     if (HeaderNames.Accept.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000L;
+                        _bits |= 0x1L;
                         _headers._Accept = value;
-                        return;
-                    }
-                    if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x20L;
-                        _headers._Pragma = value;
                         return;
                     }
                     if (HeaderNames.Cookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000L;
+                        _bits |= 0x20000L;
                         _headers._Cookie = value;
                         return;
                     }
                     if (HeaderNames.Expect.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200000L;
+                        _bits |= 0x100000L;
                         _headers._Expect = value;
                         return;
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000000000L;
+                        _bits |= 0x100000000L;
                         _headers._Origin = value;
+                        return;
+                    }
+                    if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x200000000L;
+                        _headers._Pragma = value;
                         return;
                     }
                     break;
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Upgrade, key))
-                    {
-                        _bits |= 0x80L;
-                        _headers._Upgrade = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Warning, key))
-                    {
-                        _bits |= 0x200L;
-                        _headers._Warning = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Method, key))
                     {
-                        _bits |= 0x1000L;
+                        _bits |= 0x20L;
                         _headers._Method = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Scheme, key))
                     {
-                        _bits |= 0x4000L;
+                        _bits |= 0x80L;
                         _headers._Scheme = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Referer, key))
-                    {
-                        _bits |= 0x200000000L;
-                        _headers._Referer = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        _bits |= 0x80000000000L;
+                        _bits |= 0x4000L;
                         _headers._Baggage = value;
                         return;
                     }
-
-                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Referer, key))
                     {
-                        _bits |= 0x80L;
+                        _bits |= 0x1000000000L;
+                        _headers._Referer = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Upgrade, key))
+                    {
+                        _bits |= 0x80000000000L;
                         _headers._Upgrade = value;
                         return;
                     }
-                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        _bits |= 0x200L;
+                        _bits |= 0x400000000000L;
                         _headers._Warning = value;
                         return;
                     }
+
                     if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000L;
+                        _bits |= 0x20L;
                         _headers._Method = value;
                         return;
                     }
                     if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000L;
+                        _bits |= 0x80L;
                         _headers._Scheme = value;
-                        return;
-                    }
-                    if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x200000000L;
-                        _headers._Referer = value;
                         return;
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x80000000000L;
+                        _bits |= 0x4000L;
                         _headers._Baggage = value;
+                        return;
+                    }
+                    if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x1000000000L;
+                        _headers._Referer = value;
+                        return;
+                    }
+                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x80000000000L;
+                        _headers._Upgrade = value;
+                        return;
+                    }
+                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x400000000000L;
+                        _headers._Warning = value;
                         return;
                     }
                     break;
@@ -3595,26 +3595,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfMatch, key))
                     {
-                        _bits |= 0x4000000L;
+                        _bits |= 0x2000000L;
                         _headers._IfMatch = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.IfRange, key))
                     {
-                        _bits |= 0x20000000L;
+                        _bits |= 0x10000000L;
                         _headers._IfRange = value;
                         return;
                     }
 
                     if (HeaderNames.IfMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000000L;
+                        _bits |= 0x2000000L;
                         _headers._IfMatch = value;
                         return;
                     }
                     if (HeaderNames.IfRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000000L;
+                        _bits |= 0x10000000L;
                         _headers._IfRange = value;
                         return;
                     }
@@ -3624,14 +3624,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Translate, key))
                     {
-                        _bits |= 0x1000000000L;
+                        _bits |= 0x40000000000L;
                         _headers._Translate = value;
                         return;
                     }
 
                     if (HeaderNames.Translate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000000000L;
+                        _bits |= 0x40000000000L;
                         _headers._Translate = value;
                         return;
                     }
@@ -3647,31 +3647,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
-                        _bits |= 0x2000000000L;
+                        _bits |= 0x8L;
                         _headers._UserAgent = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.KeepAlive, key))
-                    {
-                        _bits |= 0x10L;
-                        _headers._KeepAlive = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Authority, key))
                     {
-                        _bits |= 0x800L;
+                        _bits |= 0x10L;
                         _headers._Authority = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.KeepAlive, key))
+                    {
+                        _bits |= 0x40000000L;
+                        _headers._KeepAlive = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        _bits |= 0x8000000000L;
+                        _bits |= 0x2000000000L;
                         _headers._RequestId = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        _bits |= 0x40000000000L;
+                        _bits |= 0x10000000000L;
                         _headers._TraceState = value;
                         return;
                     }
@@ -3684,31 +3684,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000000L;
+                        _bits |= 0x8L;
                         _headers._UserAgent = value;
-                        return;
-                    }
-                    if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x10L;
-                        _headers._KeepAlive = value;
                         return;
                     }
                     if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800L;
+                        _bits |= 0x10L;
                         _headers._Authority = value;
+                        return;
+                    }
+                    if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x40000000L;
+                        _headers._KeepAlive = value;
                         return;
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000000000L;
+                        _bits |= 0x2000000000L;
                         _headers._RequestId = value;
                         return;
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000000000L;
+                        _bits |= 0x10000000000L;
                         _headers._TraceState = value;
                         return;
                     }
@@ -3718,14 +3718,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        _bits |= 0x20000000000L;
+                        _bits |= 0x8000000000L;
                         _headers._TraceParent = value;
                         return;
                     }
 
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000000000L;
+                        _bits |= 0x8000000000L;
                         _headers._TraceParent = value;
                         return;
                     }
@@ -3735,7 +3735,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        _bits |= 0x400L;
+                        _bits |= 0x10000L;
                         _headers._ContentType = value;
                         return;
                     }
@@ -3754,7 +3754,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400L;
+                        _bits |= 0x10000L;
                         _headers._ContentType = value;
                         return;
                     }
@@ -3774,52 +3774,52 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 13:
                 {
+                    if (ReferenceEquals(HeaderNames.Authorization, key))
+                    {
+                        _bits |= 0x2000L;
+                        _headers._Authorization = value;
+                        return;
+                    }
                     if (ReferenceEquals(HeaderNames.CacheControl, key))
                     {
-                        _bits |= 0x1L;
+                        _bits |= 0x8000L;
                         _headers._CacheControl = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
                     {
-                        _bits |= 0x8L;
+                        _bits |= 0x800000L;
                         _headers._GrpcEncoding = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authorization, key))
-                    {
-                        _bits |= 0x80000L;
-                        _headers._Authorization = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.IfNoneMatch, key))
                     {
-                        _bits |= 0x10000000L;
+                        _bits |= 0x8000000L;
                         _headers._IfNoneMatch = value;
                         return;
                     }
 
+                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x2000L;
+                        _headers._Authorization = value;
+                        return;
+                    }
                     if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1L;
+                        _bits |= 0x8000L;
                         _headers._CacheControl = value;
                         return;
                     }
                     if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8L;
+                        _bits |= 0x800000L;
                         _headers._GrpcEncoding = value;
-                        return;
-                    }
-                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x80000L;
-                        _headers._Authorization = value;
                         return;
                     }
                     if (HeaderNames.IfNoneMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000000L;
+                        _bits |= 0x8000000L;
                         _headers._IfNoneMatch = value;
                         return;
                     }
@@ -3829,7 +3829,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptCharset, key))
                     {
-                        _bits |= 0x10000L;
+                        _bits |= 0x100L;
                         _headers._AcceptCharset = value;
                         return;
                     }
@@ -3841,7 +3841,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AcceptCharset.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000L;
+                        _bits |= 0x100L;
                         _headers._AcceptCharset = value;
                         return;
                     }
@@ -3856,26 +3856,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptEncoding, key))
                     {
-                        _bits |= 0x20000L;
+                        _bits |= 0x200L;
                         _headers._AcceptEncoding = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.AcceptLanguage, key))
                     {
-                        _bits |= 0x40000L;
+                        _bits |= 0x400L;
                         _headers._AcceptLanguage = value;
                         return;
                     }
 
                     if (HeaderNames.AcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000L;
+                        _bits |= 0x200L;
                         _headers._AcceptEncoding = value;
                         return;
                     }
                     if (HeaderNames.AcceptLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000L;
+                        _bits |= 0x400L;
                         _headers._AcceptLanguage = value;
                         return;
                     }
@@ -3883,70 +3883,70 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 17:
                 {
-                    if (ReferenceEquals(HeaderNames.TransferEncoding, key))
-                    {
-                        _bits |= 0x40L;
-                        _headers._TransferEncoding = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
                     {
-                        _bits |= 0x8000000L;
+                        _bits |= 0x4000000L;
                         _headers._IfModifiedSince = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.TransferEncoding, key))
+                    {
+                        _bits |= 0x20000000000L;
+                        _headers._TransferEncoding = value;
                         return;
                     }
 
-                    if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x40L;
-                        _headers._TransferEncoding = value;
-                        return;
-                    }
                     if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000000L;
+                        _bits |= 0x4000000L;
                         _headers._IfModifiedSince = value;
+                        return;
+                    }
+                    if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x20000000000L;
+                        _headers._TransferEncoding = value;
                         return;
                     }
                     break;
                 }
                 case 19:
                 {
+                    if (ReferenceEquals(HeaderNames.CorrelationContext, key))
+                    {
+                        _bits |= 0x40000L;
+                        _headers._CorrelationContext = value;
+                        return;
+                    }
                     if (ReferenceEquals(HeaderNames.IfUnmodifiedSince, key))
                     {
-                        _bits |= 0x40000000L;
+                        _bits |= 0x20000000L;
                         _headers._IfUnmodifiedSince = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.ProxyAuthorization, key))
                     {
-                        _bits |= 0x100000000L;
+                        _bits |= 0x400000000L;
                         _headers._ProxyAuthorization = value;
                         return;
                     }
-                    if (ReferenceEquals(HeaderNames.CorrelationContext, key))
+
+                    if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000000000L;
+                        _bits |= 0x40000L;
                         _headers._CorrelationContext = value;
                         return;
                     }
-
                     if (HeaderNames.IfUnmodifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000000L;
+                        _bits |= 0x20000000L;
                         _headers._IfUnmodifiedSince = value;
                         return;
                     }
                     if (HeaderNames.ProxyAuthorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000000L;
+                        _bits |= 0x400000000L;
                         _headers._ProxyAuthorization = value;
-                        return;
-                    }
-                    if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x10000000000L;
-                        _headers._CorrelationContext = value;
                         return;
                     }
                     break;
@@ -3955,14 +3955,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.GrpcAcceptEncoding, key))
                     {
-                        _bits |= 0x800000L;
+                        _bits |= 0x400000L;
                         _headers._GrpcAcceptEncoding = value;
                         return;
                     }
 
                     if (HeaderNames.GrpcAcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800000L;
+                        _bits |= 0x400000L;
                         _headers._GrpcAcceptEncoding = value;
                         return;
                     }
@@ -3972,14 +3972,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        _bits |= 0x4000000000L;
+                        _bits |= 0x100000000000L;
                         _headers._UpgradeInsecureRequests = value;
                         return;
                     }
 
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000000000L;
+                        _bits |= 0x100000000000L;
                         _headers._UpgradeInsecureRequests = value;
                         return;
                     }
@@ -3989,14 +3989,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        _bits |= 0x200000000000L;
+                        _bits |= 0x1000L;
                         _headers._AccessControlRequestMethod = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200000000000L;
+                        _bits |= 0x1000L;
                         _headers._AccessControlRequestMethod = value;
                         return;
                     }
@@ -4006,14 +4006,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        _bits |= 0x400000000000L;
+                        _bits |= 0x800L;
                         _headers._AccessControlRequestHeaders = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000000000L;
+                        _bits |= 0x800L;
                         _headers._AccessControlRequestHeaders = value;
                         return;
                     }
@@ -4032,9 +4032,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TE, key))
                     {
-                        if ((_bits & 0x800000000L) == 0)
+                        if ((_bits & 0x4000000000L) == 0)
                         {
-                            _bits |= 0x800000000L;
+                            _bits |= 0x4000000000L;
                             _headers._TE = value;
                             return true;
                         }
@@ -4043,9 +4043,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TE.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) == 0)
+                        if ((_bits & 0x4000000000L) == 0)
                         {
-                            _bits |= 0x800000000L;
+                            _bits |= 0x4000000000L;
                             _headers._TE = value;
                             return true;
                         }
@@ -4057,9 +4057,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x100L) == 0)
+                        if ((_bits & 0x200000000000L) == 0)
                         {
-                            _bits |= 0x100L;
+                            _bits |= 0x200000000000L;
                             _headers._Via = value;
                             return true;
                         }
@@ -4068,9 +4068,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) == 0)
+                        if ((_bits & 0x200000000000L) == 0)
                         {
-                            _bits |= 0x100L;
+                            _bits |= 0x200000000000L;
                             _headers._Via = value;
                             return true;
                         }
@@ -4082,9 +4082,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Host, key))
                     {
-                        if ((_bits & 0x2000000L) == 0)
+                        if ((_bits & 0x4L) == 0)
                         {
-                            _bits |= 0x2000000L;
+                            _bits |= 0x4L;
                             _headers._Host = value;
                             return true;
                         }
@@ -4092,9 +4092,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Date, key))
                     {
-                        if ((_bits & 0x4L) == 0)
+                        if ((_bits & 0x80000L) == 0)
                         {
-                            _bits |= 0x4L;
+                            _bits |= 0x80000L;
                             _headers._Date = value;
                             return true;
                         }
@@ -4102,9 +4102,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.From, key))
                     {
-                        if ((_bits & 0x400000L) == 0)
+                        if ((_bits & 0x200000L) == 0)
                         {
-                            _bits |= 0x400000L;
+                            _bits |= 0x200000L;
                             _headers._From = value;
                             return true;
                         }
@@ -4113,9 +4113,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Host.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) == 0)
+                        if ((_bits & 0x4L) == 0)
                         {
-                            _bits |= 0x2000000L;
+                            _bits |= 0x4L;
                             _headers._Host = value;
                             return true;
                         }
@@ -4123,9 +4123,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Date.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4L) == 0)
+                        if ((_bits & 0x80000L) == 0)
                         {
-                            _bits |= 0x4L;
+                            _bits |= 0x80000L;
                             _headers._Date = value;
                             return true;
                         }
@@ -4133,9 +4133,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.From.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) == 0)
+                        if ((_bits & 0x200000L) == 0)
                         {
-                            _bits |= 0x400000L;
+                            _bits |= 0x200000L;
                             _headers._From = value;
                             return true;
                         }
@@ -4147,9 +4147,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
-                        if ((_bits & 0x2000L) == 0)
+                        if ((_bits & 0x40L) == 0)
                         {
-                            _bits |= 0x2000L;
+                            _bits |= 0x40L;
                             _headers._Path = value;
                             return true;
                         }
@@ -4157,9 +4157,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
                     {
-                        if ((_bits & 0x400000000L) == 0)
+                        if ((_bits & 0x800000000L) == 0)
                         {
-                            _bits |= 0x400000000L;
+                            _bits |= 0x800000000L;
                             _headers._Range = value;
                             return true;
                         }
@@ -4168,9 +4168,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000L) == 0)
+                        if ((_bits & 0x40L) == 0)
                         {
-                            _bits |= 0x2000L;
+                            _bits |= 0x40L;
                             _headers._Path = value;
                             return true;
                         }
@@ -4178,9 +4178,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) == 0)
+                        if ((_bits & 0x800000000L) == 0)
                         {
-                            _bits |= 0x400000000L;
+                            _bits |= 0x800000000L;
                             _headers._Range = value;
                             return true;
                         }
@@ -4192,29 +4192,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Accept, key))
                     {
-                        if ((_bits & 0x8000L) == 0)
+                        if ((_bits & 0x1L) == 0)
                         {
-                            _bits |= 0x8000L;
+                            _bits |= 0x1L;
                             _headers._Accept = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Pragma, key))
-                    {
-                        if ((_bits & 0x20L) == 0)
-                        {
-                            _bits |= 0x20L;
-                            _headers._Pragma = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.Cookie, key))
                     {
-                        if ((_bits & 0x100000L) == 0)
+                        if ((_bits & 0x20000L) == 0)
                         {
-                            _bits |= 0x100000L;
+                            _bits |= 0x20000L;
                             _headers._Cookie = value;
                             return true;
                         }
@@ -4222,9 +4212,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expect, key))
                     {
-                        if ((_bits & 0x200000L) == 0)
+                        if ((_bits & 0x100000L) == 0)
                         {
-                            _bits |= 0x200000L;
+                            _bits |= 0x100000L;
                             _headers._Expect = value;
                             return true;
                         }
@@ -4232,10 +4222,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x100000000000L) == 0)
+                        if ((_bits & 0x100000000L) == 0)
                         {
-                            _bits |= 0x100000000000L;
+                            _bits |= 0x100000000L;
                             _headers._Origin = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Pragma, key))
+                    {
+                        if ((_bits & 0x200000000L) == 0)
+                        {
+                            _bits |= 0x200000000L;
+                            _headers._Pragma = value;
                             return true;
                         }
                         return false;
@@ -4243,29 +4243,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Accept.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000L) == 0)
+                        if ((_bits & 0x1L) == 0)
                         {
-                            _bits |= 0x8000L;
+                            _bits |= 0x1L;
                             _headers._Accept = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x20L) == 0)
-                        {
-                            _bits |= 0x20L;
-                            _headers._Pragma = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.Cookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) == 0)
+                        if ((_bits & 0x20000L) == 0)
                         {
-                            _bits |= 0x100000L;
+                            _bits |= 0x20000L;
                             _headers._Cookie = value;
                             return true;
                         }
@@ -4273,9 +4263,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expect.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) == 0)
+                        if ((_bits & 0x100000L) == 0)
                         {
-                            _bits |= 0x200000L;
+                            _bits |= 0x100000L;
                             _headers._Expect = value;
                             return true;
                         }
@@ -4283,10 +4273,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000L) == 0)
+                        if ((_bits & 0x100000000L) == 0)
                         {
-                            _bits |= 0x100000000000L;
+                            _bits |= 0x100000000L;
                             _headers._Origin = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000000L) == 0)
+                        {
+                            _bits |= 0x200000000L;
+                            _headers._Pragma = value;
                             return true;
                         }
                         return false;
@@ -4295,31 +4295,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Upgrade, key))
-                    {
-                        if ((_bits & 0x80L) == 0)
-                        {
-                            _bits |= 0x80L;
-                            _headers._Upgrade = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Warning, key))
-                    {
-                        if ((_bits & 0x200L) == 0)
-                        {
-                            _bits |= 0x200L;
-                            _headers._Warning = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Method, key))
                     {
-                        if ((_bits & 0x1000L) == 0)
+                        if ((_bits & 0x20L) == 0)
                         {
-                            _bits |= 0x1000L;
+                            _bits |= 0x20L;
                             _headers._Method = value;
                             return true;
                         }
@@ -4327,60 +4307,60 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Scheme, key))
                     {
-                        if ((_bits & 0x4000L) == 0)
+                        if ((_bits & 0x80L) == 0)
                         {
-                            _bits |= 0x4000L;
+                            _bits |= 0x80L;
                             _headers._Scheme = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Referer, key))
-                    {
-                        if ((_bits & 0x200000000L) == 0)
-                        {
-                            _bits |= 0x200000000L;
-                            _headers._Referer = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x80000000000L) == 0)
+                        if ((_bits & 0x4000L) == 0)
                         {
-                            _bits |= 0x80000000000L;
+                            _bits |= 0x4000L;
                             _headers._Baggage = value;
                             return true;
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Referer, key))
                     {
-                        if ((_bits & 0x80L) == 0)
+                        if ((_bits & 0x1000000000L) == 0)
                         {
-                            _bits |= 0x80L;
+                            _bits |= 0x1000000000L;
+                            _headers._Referer = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Upgrade, key))
+                    {
+                        if ((_bits & 0x80000000000L) == 0)
+                        {
+                            _bits |= 0x80000000000L;
                             _headers._Upgrade = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x200L) == 0)
+                        if ((_bits & 0x400000000000L) == 0)
                         {
-                            _bits |= 0x200L;
+                            _bits |= 0x400000000000L;
                             _headers._Warning = value;
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) == 0)
+                        if ((_bits & 0x20L) == 0)
                         {
-                            _bits |= 0x1000L;
+                            _bits |= 0x20L;
                             _headers._Method = value;
                             return true;
                         }
@@ -4388,30 +4368,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000L) == 0)
+                        if ((_bits & 0x80L) == 0)
                         {
-                            _bits |= 0x4000L;
+                            _bits |= 0x80L;
                             _headers._Scheme = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x200000000L) == 0)
-                        {
-                            _bits |= 0x200000000L;
-                            _headers._Referer = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
+                        if ((_bits & 0x4000L) == 0)
+                        {
+                            _bits |= 0x4000L;
+                            _headers._Baggage = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x1000000000L) == 0)
+                        {
+                            _bits |= 0x1000000000L;
+                            _headers._Referer = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
                         if ((_bits & 0x80000000000L) == 0)
                         {
                             _bits |= 0x80000000000L;
-                            _headers._Baggage = value;
+                            _headers._Upgrade = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000000000L) == 0)
+                        {
+                            _bits |= 0x400000000000L;
+                            _headers._Warning = value;
                             return true;
                         }
                         return false;
@@ -4422,9 +4422,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfMatch, key))
                     {
-                        if ((_bits & 0x4000000L) == 0)
+                        if ((_bits & 0x2000000L) == 0)
                         {
-                            _bits |= 0x4000000L;
+                            _bits |= 0x2000000L;
                             _headers._IfMatch = value;
                             return true;
                         }
@@ -4432,9 +4432,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfRange, key))
                     {
-                        if ((_bits & 0x20000000L) == 0)
+                        if ((_bits & 0x10000000L) == 0)
                         {
-                            _bits |= 0x20000000L;
+                            _bits |= 0x10000000L;
                             _headers._IfRange = value;
                             return true;
                         }
@@ -4443,9 +4443,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.IfMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) == 0)
+                        if ((_bits & 0x2000000L) == 0)
                         {
-                            _bits |= 0x4000000L;
+                            _bits |= 0x2000000L;
                             _headers._IfMatch = value;
                             return true;
                         }
@@ -4453,9 +4453,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) == 0)
+                        if ((_bits & 0x10000000L) == 0)
                         {
-                            _bits |= 0x20000000L;
+                            _bits |= 0x10000000L;
                             _headers._IfRange = value;
                             return true;
                         }
@@ -4467,9 +4467,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Translate, key))
                     {
-                        if ((_bits & 0x1000000000L) == 0)
+                        if ((_bits & 0x40000000000L) == 0)
                         {
-                            _bits |= 0x1000000000L;
+                            _bits |= 0x40000000000L;
                             _headers._Translate = value;
                             return true;
                         }
@@ -4478,9 +4478,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Translate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) == 0)
+                        if ((_bits & 0x40000000000L) == 0)
                         {
-                            _bits |= 0x1000000000L;
+                            _bits |= 0x40000000000L;
                             _headers._Translate = value;
                             return true;
                         }
@@ -4502,39 +4502,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
-                        if ((_bits & 0x2000000000L) == 0)
+                        if ((_bits & 0x8L) == 0)
                         {
-                            _bits |= 0x2000000000L;
+                            _bits |= 0x8L;
                             _headers._UserAgent = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.KeepAlive, key))
-                    {
-                        if ((_bits & 0x10L) == 0)
-                        {
-                            _bits |= 0x10L;
-                            _headers._KeepAlive = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.Authority, key))
                     {
-                        if ((_bits & 0x800L) == 0)
+                        if ((_bits & 0x10L) == 0)
                         {
-                            _bits |= 0x800L;
+                            _bits |= 0x10L;
                             _headers._Authority = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.KeepAlive, key))
+                    {
+                        if ((_bits & 0x40000000L) == 0)
+                        {
+                            _bits |= 0x40000000L;
+                            _headers._KeepAlive = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x8000000000L) == 0)
+                        if ((_bits & 0x2000000000L) == 0)
                         {
-                            _bits |= 0x8000000000L;
+                            _bits |= 0x2000000000L;
                             _headers._RequestId = value;
                             return true;
                         }
@@ -4542,9 +4542,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x40000000000L) == 0)
+                        if ((_bits & 0x10000000000L) == 0)
                         {
-                            _bits |= 0x40000000000L;
+                            _bits |= 0x10000000000L;
                             _headers._TraceState = value;
                             return true;
                         }
@@ -4563,39 +4563,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) == 0)
+                        if ((_bits & 0x8L) == 0)
                         {
-                            _bits |= 0x2000000000L;
+                            _bits |= 0x8L;
                             _headers._UserAgent = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10L) == 0)
-                        {
-                            _bits |= 0x10L;
-                            _headers._KeepAlive = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) == 0)
+                        if ((_bits & 0x10L) == 0)
                         {
-                            _bits |= 0x800L;
+                            _bits |= 0x10L;
                             _headers._Authority = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x40000000L) == 0)
+                        {
+                            _bits |= 0x40000000L;
+                            _headers._KeepAlive = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000L) == 0)
+                        if ((_bits & 0x2000000000L) == 0)
                         {
-                            _bits |= 0x8000000000L;
+                            _bits |= 0x2000000000L;
                             _headers._RequestId = value;
                             return true;
                         }
@@ -4603,9 +4603,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000L) == 0)
+                        if ((_bits & 0x10000000000L) == 0)
                         {
-                            _bits |= 0x40000000000L;
+                            _bits |= 0x10000000000L;
                             _headers._TraceState = value;
                             return true;
                         }
@@ -4617,9 +4617,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x20000000000L) == 0)
+                        if ((_bits & 0x8000000000L) == 0)
                         {
-                            _bits |= 0x20000000000L;
+                            _bits |= 0x8000000000L;
                             _headers._TraceParent = value;
                             return true;
                         }
@@ -4628,9 +4628,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000L) == 0)
+                        if ((_bits & 0x8000000000L) == 0)
                         {
-                            _bits |= 0x20000000000L;
+                            _bits |= 0x8000000000L;
                             _headers._TraceParent = value;
                             return true;
                         }
@@ -4642,9 +4642,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x400L) == 0)
+                        if ((_bits & 0x10000L) == 0)
                         {
-                            _bits |= 0x400L;
+                            _bits |= 0x10000L;
                             _headers._ContentType = value;
                             return true;
                         }
@@ -4673,9 +4673,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) == 0)
+                        if ((_bits & 0x10000L) == 0)
                         {
-                            _bits |= 0x400L;
+                            _bits |= 0x10000L;
                             _headers._ContentType = value;
                             return true;
                         }
@@ -4705,11 +4705,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 13:
                 {
+                    if (ReferenceEquals(HeaderNames.Authorization, key))
+                    {
+                        if ((_bits & 0x2000L) == 0)
+                        {
+                            _bits |= 0x2000L;
+                            _headers._Authorization = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.CacheControl, key))
                     {
-                        if ((_bits & 0x1L) == 0)
+                        if ((_bits & 0x8000L) == 0)
                         {
-                            _bits |= 0x1L;
+                            _bits |= 0x8000L;
                             _headers._CacheControl = value;
                             return true;
                         }
@@ -4717,40 +4727,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
                     {
-                        if ((_bits & 0x8L) == 0)
+                        if ((_bits & 0x800000L) == 0)
                         {
-                            _bits |= 0x8L;
+                            _bits |= 0x800000L;
                             _headers._GrpcEncoding = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authorization, key))
-                    {
-                        if ((_bits & 0x80000L) == 0)
-                        {
-                            _bits |= 0x80000L;
-                            _headers._Authorization = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.IfNoneMatch, key))
                     {
-                        if ((_bits & 0x10000000L) == 0)
+                        if ((_bits & 0x8000000L) == 0)
                         {
-                            _bits |= 0x10000000L;
+                            _bits |= 0x8000000L;
                             _headers._IfNoneMatch = value;
                             return true;
                         }
                         return false;
                     }
     
+                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x2000L) == 0)
+                        {
+                            _bits |= 0x2000L;
+                            _headers._Authorization = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1L) == 0)
+                        if ((_bits & 0x8000L) == 0)
                         {
-                            _bits |= 0x1L;
+                            _bits |= 0x8000L;
                             _headers._CacheControl = value;
                             return true;
                         }
@@ -4758,29 +4768,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8L) == 0)
+                        if ((_bits & 0x800000L) == 0)
                         {
-                            _bits |= 0x8L;
+                            _bits |= 0x800000L;
                             _headers._GrpcEncoding = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x80000L) == 0)
-                        {
-                            _bits |= 0x80000L;
-                            _headers._Authorization = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.IfNoneMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000L) == 0)
+                        if ((_bits & 0x8000000L) == 0)
                         {
-                            _bits |= 0x10000000L;
+                            _bits |= 0x8000000L;
                             _headers._IfNoneMatch = value;
                             return true;
                         }
@@ -4792,9 +4792,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptCharset, key))
                     {
-                        if ((_bits & 0x10000L) == 0)
+                        if ((_bits & 0x100L) == 0)
                         {
-                            _bits |= 0x10000L;
+                            _bits |= 0x100L;
                             _headers._AcceptCharset = value;
                             return true;
                         }
@@ -4812,9 +4812,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AcceptCharset.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) == 0)
+                        if ((_bits & 0x100L) == 0)
                         {
-                            _bits |= 0x10000L;
+                            _bits |= 0x100L;
                             _headers._AcceptCharset = value;
                             return true;
                         }
@@ -4835,9 +4835,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptEncoding, key))
                     {
-                        if ((_bits & 0x20000L) == 0)
+                        if ((_bits & 0x200L) == 0)
                         {
-                            _bits |= 0x20000L;
+                            _bits |= 0x200L;
                             _headers._AcceptEncoding = value;
                             return true;
                         }
@@ -4845,9 +4845,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AcceptLanguage, key))
                     {
-                        if ((_bits & 0x40000L) == 0)
+                        if ((_bits & 0x400L) == 0)
                         {
-                            _bits |= 0x40000L;
+                            _bits |= 0x400L;
                             _headers._AcceptLanguage = value;
                             return true;
                         }
@@ -4856,9 +4856,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) == 0)
+                        if ((_bits & 0x200L) == 0)
                         {
-                            _bits |= 0x20000L;
+                            _bits |= 0x200L;
                             _headers._AcceptEncoding = value;
                             return true;
                         }
@@ -4866,9 +4866,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AcceptLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000L) == 0)
+                        if ((_bits & 0x400L) == 0)
                         {
-                            _bits |= 0x40000L;
+                            _bits |= 0x400L;
                             _headers._AcceptLanguage = value;
                             return true;
                         }
@@ -4878,43 +4878,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 17:
                 {
-                    if (ReferenceEquals(HeaderNames.TransferEncoding, key))
+                    if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
                     {
-                        if ((_bits & 0x40L) == 0)
+                        if ((_bits & 0x4000000L) == 0)
                         {
-                            _bits |= 0x40L;
-                            _headers._TransferEncoding = value;
+                            _bits |= 0x4000000L;
+                            _headers._IfModifiedSince = value;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
+                    if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x8000000L) == 0)
+                        if ((_bits & 0x20000000000L) == 0)
                         {
-                            _bits |= 0x8000000L;
-                            _headers._IfModifiedSince = value;
+                            _bits |= 0x20000000000L;
+                            _headers._TransferEncoding = value;
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40L) == 0)
+                        if ((_bits & 0x4000000L) == 0)
                         {
-                            _bits |= 0x40L;
-                            _headers._TransferEncoding = value;
+                            _bits |= 0x4000000L;
+                            _headers._IfModifiedSince = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) == 0)
+                        if ((_bits & 0x20000000000L) == 0)
                         {
-                            _bits |= 0x8000000L;
-                            _headers._IfModifiedSince = value;
+                            _bits |= 0x20000000000L;
+                            _headers._TransferEncoding = value;
                             return true;
                         }
                         return false;
@@ -4923,11 +4923,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 19:
                 {
+                    if (ReferenceEquals(HeaderNames.CorrelationContext, key))
+                    {
+                        if ((_bits & 0x40000L) == 0)
+                        {
+                            _bits |= 0x40000L;
+                            _headers._CorrelationContext = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.IfUnmodifiedSince, key))
                     {
-                        if ((_bits & 0x40000000L) == 0)
+                        if ((_bits & 0x20000000L) == 0)
                         {
-                            _bits |= 0x40000000L;
+                            _bits |= 0x20000000L;
                             _headers._IfUnmodifiedSince = value;
                             return true;
                         }
@@ -4935,30 +4945,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ProxyAuthorization, key))
                     {
-                        if ((_bits & 0x100000000L) == 0)
+                        if ((_bits & 0x400000000L) == 0)
                         {
-                            _bits |= 0x100000000L;
+                            _bits |= 0x400000000L;
                             _headers._ProxyAuthorization = value;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.CorrelationContext, key))
+    
+                    if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000L) == 0)
+                        if ((_bits & 0x40000L) == 0)
                         {
-                            _bits |= 0x10000000000L;
+                            _bits |= 0x40000L;
                             _headers._CorrelationContext = value;
                             return true;
                         }
                         return false;
                     }
-    
                     if (HeaderNames.IfUnmodifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) == 0)
+                        if ((_bits & 0x20000000L) == 0)
                         {
-                            _bits |= 0x40000000L;
+                            _bits |= 0x20000000L;
                             _headers._IfUnmodifiedSince = value;
                             return true;
                         }
@@ -4966,20 +4976,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ProxyAuthorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) == 0)
+                        if ((_bits & 0x400000000L) == 0)
                         {
-                            _bits |= 0x100000000L;
+                            _bits |= 0x400000000L;
                             _headers._ProxyAuthorization = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10000000000L) == 0)
-                        {
-                            _bits |= 0x10000000000L;
-                            _headers._CorrelationContext = value;
                             return true;
                         }
                         return false;
@@ -4990,9 +4990,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.GrpcAcceptEncoding, key))
                     {
-                        if ((_bits & 0x800000L) == 0)
+                        if ((_bits & 0x400000L) == 0)
                         {
-                            _bits |= 0x800000L;
+                            _bits |= 0x400000L;
                             _headers._GrpcAcceptEncoding = value;
                             return true;
                         }
@@ -5001,9 +5001,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.GrpcAcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) == 0)
+                        if ((_bits & 0x400000L) == 0)
                         {
-                            _bits |= 0x800000L;
+                            _bits |= 0x400000L;
                             _headers._GrpcAcceptEncoding = value;
                             return true;
                         }
@@ -5015,9 +5015,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x4000000000L) == 0)
+                        if ((_bits & 0x100000000000L) == 0)
                         {
-                            _bits |= 0x4000000000L;
+                            _bits |= 0x100000000000L;
                             _headers._UpgradeInsecureRequests = value;
                             return true;
                         }
@@ -5026,9 +5026,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000L) == 0)
+                        if ((_bits & 0x100000000000L) == 0)
                         {
-                            _bits |= 0x4000000000L;
+                            _bits |= 0x100000000000L;
                             _headers._UpgradeInsecureRequests = value;
                             return true;
                         }
@@ -5040,9 +5040,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x200000000000L) == 0)
+                        if ((_bits & 0x1000L) == 0)
                         {
-                            _bits |= 0x200000000000L;
+                            _bits |= 0x1000L;
                             _headers._AccessControlRequestMethod = value;
                             return true;
                         }
@@ -5051,9 +5051,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000000L) == 0)
+                        if ((_bits & 0x1000L) == 0)
                         {
-                            _bits |= 0x200000000000L;
+                            _bits |= 0x1000L;
                             _headers._AccessControlRequestMethod = value;
                             return true;
                         }
@@ -5065,9 +5065,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x400000000000L) == 0)
+                        if ((_bits & 0x800L) == 0)
                         {
-                            _bits |= 0x400000000000L;
+                            _bits |= 0x800L;
                             _headers._AccessControlRequestHeaders = value;
                             return true;
                         }
@@ -5076,9 +5076,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000000L) == 0)
+                        if ((_bits & 0x800L) == 0)
                         {
-                            _bits |= 0x400000000000L;
+                            _bits |= 0x800L;
                             _headers._AccessControlRequestHeaders = value;
                             return true;
                         }
@@ -5099,9 +5099,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TE, key))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x4000000000L) != 0)
                         {
-                            _bits &= ~0x800000000L;
+                            _bits &= ~0x4000000000L;
                             _headers._TE = default(StringValues);
                             return true;
                         }
@@ -5110,9 +5110,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TE.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x4000000000L) != 0)
                         {
-                            _bits &= ~0x800000000L;
+                            _bits &= ~0x4000000000L;
                             _headers._TE = default(StringValues);
                             return true;
                         }
@@ -5124,9 +5124,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x200000000000L) != 0)
                         {
-                            _bits &= ~0x100L;
+                            _bits &= ~0x200000000000L;
                             _headers._Via = default(StringValues);
                             return true;
                         }
@@ -5135,9 +5135,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x200000000000L) != 0)
                         {
-                            _bits &= ~0x100L;
+                            _bits &= ~0x200000000000L;
                             _headers._Via = default(StringValues);
                             return true;
                         }
@@ -5149,9 +5149,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Host, key))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x4L) != 0)
                         {
-                            _bits &= ~0x2000000L;
+                            _bits &= ~0x4L;
                             _headers._Host = default(StringValues);
                             return true;
                         }
@@ -5159,9 +5159,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Date, key))
                     {
-                        if ((_bits & 0x4L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
-                            _bits &= ~0x4L;
+                            _bits &= ~0x80000L;
                             _headers._Date = default(StringValues);
                             return true;
                         }
@@ -5169,9 +5169,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.From, key))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
-                            _bits &= ~0x400000L;
+                            _bits &= ~0x200000L;
                             _headers._From = default(StringValues);
                             return true;
                         }
@@ -5180,9 +5180,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Host.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x4L) != 0)
                         {
-                            _bits &= ~0x2000000L;
+                            _bits &= ~0x4L;
                             _headers._Host = default(StringValues);
                             return true;
                         }
@@ -5190,9 +5190,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Date.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
-                            _bits &= ~0x4L;
+                            _bits &= ~0x80000L;
                             _headers._Date = default(StringValues);
                             return true;
                         }
@@ -5200,9 +5200,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.From.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
-                            _bits &= ~0x400000L;
+                            _bits &= ~0x200000L;
                             _headers._From = default(StringValues);
                             return true;
                         }
@@ -5214,9 +5214,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Path, key))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
-                            _bits &= ~0x2000L;
+                            _bits &= ~0x40L;
                             _headers._Path = default(StringValues);
                             return true;
                         }
@@ -5224,9 +5224,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Range, key))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
-                            _bits &= ~0x400000000L;
+                            _bits &= ~0x800000000L;
                             _headers._Range = default(StringValues);
                             return true;
                         }
@@ -5235,9 +5235,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Path.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
-                            _bits &= ~0x2000L;
+                            _bits &= ~0x40L;
                             _headers._Path = default(StringValues);
                             return true;
                         }
@@ -5245,9 +5245,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Range.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
-                            _bits &= ~0x400000000L;
+                            _bits &= ~0x800000000L;
                             _headers._Range = default(StringValues);
                             return true;
                         }
@@ -5259,29 +5259,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Accept, key))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x1L) != 0)
                         {
-                            _bits &= ~0x8000L;
+                            _bits &= ~0x1L;
                             _headers._Accept = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Pragma, key))
-                    {
-                        if ((_bits & 0x20L) != 0)
-                        {
-                            _bits &= ~0x20L;
-                            _headers._Pragma = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.Cookie, key))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
-                            _bits &= ~0x100000L;
+                            _bits &= ~0x20000L;
                             _headers._Cookie = default(StringValues);
                             return true;
                         }
@@ -5289,9 +5279,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expect, key))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
-                            _bits &= ~0x200000L;
+                            _bits &= ~0x100000L;
                             _headers._Expect = default(StringValues);
                             return true;
                         }
@@ -5299,10 +5289,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Origin, key))
                     {
-                        if ((_bits & 0x100000000000L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
-                            _bits &= ~0x100000000000L;
+                            _bits &= ~0x100000000L;
                             _headers._Origin = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Pragma, key))
+                    {
+                        if ((_bits & 0x200000000L) != 0)
+                        {
+                            _bits &= ~0x200000000L;
+                            _headers._Pragma = default(StringValues);
                             return true;
                         }
                         return false;
@@ -5310,29 +5310,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Accept.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x1L) != 0)
                         {
-                            _bits &= ~0x8000L;
+                            _bits &= ~0x1L;
                             _headers._Accept = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x20L) != 0)
-                        {
-                            _bits &= ~0x20L;
-                            _headers._Pragma = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.Cookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
-                            _bits &= ~0x100000L;
+                            _bits &= ~0x20000L;
                             _headers._Cookie = default(StringValues);
                             return true;
                         }
@@ -5340,9 +5330,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expect.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
-                            _bits &= ~0x200000L;
+                            _bits &= ~0x100000L;
                             _headers._Expect = default(StringValues);
                             return true;
                         }
@@ -5350,10 +5340,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Origin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000000L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
-                            _bits &= ~0x100000000000L;
+                            _bits &= ~0x100000000L;
                             _headers._Origin = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000000L) != 0)
+                        {
+                            _bits &= ~0x200000000L;
+                            _headers._Pragma = default(StringValues);
                             return true;
                         }
                         return false;
@@ -5362,31 +5362,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Upgrade, key))
-                    {
-                        if ((_bits & 0x80L) != 0)
-                        {
-                            _bits &= ~0x80L;
-                            _headers._Upgrade = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Warning, key))
-                    {
-                        if ((_bits & 0x200L) != 0)
-                        {
-                            _bits &= ~0x200L;
-                            _headers._Warning = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.Method, key))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x20L) != 0)
                         {
-                            _bits &= ~0x1000L;
+                            _bits &= ~0x20L;
                             _headers._Method = default(StringValues);
                             return true;
                         }
@@ -5394,60 +5374,60 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Scheme, key))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
-                            _bits &= ~0x4000L;
+                            _bits &= ~0x80L;
                             _headers._Scheme = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Referer, key))
-                    {
-                        if ((_bits & 0x200000000L) != 0)
-                        {
-                            _bits &= ~0x200000000L;
-                            _headers._Referer = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.Baggage, key))
                     {
-                        if ((_bits & 0x80000000000L) != 0)
+                        if ((_bits & 0x4000L) != 0)
                         {
-                            _bits &= ~0x80000000000L;
+                            _bits &= ~0x4000L;
                             _headers._Baggage = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Referer, key))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
                         {
-                            _bits &= ~0x80L;
+                            _bits &= ~0x1000000000L;
+                            _headers._Referer = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.Upgrade, key))
+                    {
+                        if ((_bits & 0x80000000000L) != 0)
+                        {
+                            _bits &= ~0x80000000000L;
                             _headers._Upgrade = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x400000000000L) != 0)
                         {
-                            _bits &= ~0x200L;
+                            _bits &= ~0x400000000000L;
                             _headers._Warning = default(StringValues);
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.Method.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x20L) != 0)
                         {
-                            _bits &= ~0x1000L;
+                            _bits &= ~0x20L;
                             _headers._Method = default(StringValues);
                             return true;
                         }
@@ -5455,30 +5435,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Scheme.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
-                            _bits &= ~0x4000L;
+                            _bits &= ~0x80L;
                             _headers._Scheme = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x200000000L) != 0)
-                        {
-                            _bits &= ~0x200000000L;
-                            _headers._Referer = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.Baggage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
+                        if ((_bits & 0x4000L) != 0)
+                        {
+                            _bits &= ~0x4000L;
+                            _headers._Baggage = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Referer.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x1000000000L) != 0)
+                        {
+                            _bits &= ~0x1000000000L;
+                            _headers._Referer = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
                         if ((_bits & 0x80000000000L) != 0)
                         {
                             _bits &= ~0x80000000000L;
-                            _headers._Baggage = default(StringValues);
+                            _headers._Upgrade = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000000000L) != 0)
+                        {
+                            _bits &= ~0x400000000000L;
+                            _headers._Warning = default(StringValues);
                             return true;
                         }
                         return false;
@@ -5489,9 +5489,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.IfMatch, key))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
-                            _bits &= ~0x4000000L;
+                            _bits &= ~0x2000000L;
                             _headers._IfMatch = default(StringValues);
                             return true;
                         }
@@ -5499,9 +5499,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.IfRange, key))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
-                            _bits &= ~0x20000000L;
+                            _bits &= ~0x10000000L;
                             _headers._IfRange = default(StringValues);
                             return true;
                         }
@@ -5510,9 +5510,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.IfMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
-                            _bits &= ~0x4000000L;
+                            _bits &= ~0x2000000L;
                             _headers._IfMatch = default(StringValues);
                             return true;
                         }
@@ -5520,9 +5520,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.IfRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
-                            _bits &= ~0x20000000L;
+                            _bits &= ~0x10000000L;
                             _headers._IfRange = default(StringValues);
                             return true;
                         }
@@ -5534,9 +5534,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Translate, key))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x40000000000L) != 0)
                         {
-                            _bits &= ~0x1000000000L;
+                            _bits &= ~0x40000000000L;
                             _headers._Translate = default(StringValues);
                             return true;
                         }
@@ -5545,9 +5545,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Translate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x40000000000L) != 0)
                         {
-                            _bits &= ~0x1000000000L;
+                            _bits &= ~0x40000000000L;
                             _headers._Translate = default(StringValues);
                             return true;
                         }
@@ -5569,39 +5569,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.UserAgent, key))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x8L) != 0)
                         {
-                            _bits &= ~0x2000000000L;
+                            _bits &= ~0x8L;
                             _headers._UserAgent = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.KeepAlive, key))
-                    {
-                        if ((_bits & 0x10L) != 0)
-                        {
-                            _bits &= ~0x10L;
-                            _headers._KeepAlive = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.Authority, key))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x10L) != 0)
                         {
-                            _bits &= ~0x800L;
+                            _bits &= ~0x10L;
                             _headers._Authority = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.KeepAlive, key))
+                    {
+                        if ((_bits & 0x40000000L) != 0)
+                        {
+                            _bits &= ~0x40000000L;
+                            _headers._KeepAlive = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.RequestId, key))
                     {
-                        if ((_bits & 0x8000000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
-                            _bits &= ~0x8000000000L;
+                            _bits &= ~0x2000000000L;
                             _headers._RequestId = default(StringValues);
                             return true;
                         }
@@ -5609,9 +5609,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.TraceState, key))
                     {
-                        if ((_bits & 0x40000000000L) != 0)
+                        if ((_bits & 0x10000000000L) != 0)
                         {
-                            _bits &= ~0x40000000000L;
+                            _bits &= ~0x10000000000L;
                             _headers._TraceState = default(StringValues);
                             return true;
                         }
@@ -5630,39 +5630,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.UserAgent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x8L) != 0)
                         {
-                            _bits &= ~0x2000000000L;
+                            _bits &= ~0x8L;
                             _headers._UserAgent = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10L) != 0)
-                        {
-                            _bits &= ~0x10L;
-                            _headers._KeepAlive = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.Authority.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x10L) != 0)
                         {
-                            _bits &= ~0x800L;
+                            _bits &= ~0x10L;
                             _headers._Authority = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x40000000L) != 0)
+                        {
+                            _bits &= ~0x40000000L;
+                            _headers._KeepAlive = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.RequestId.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
-                            _bits &= ~0x8000000000L;
+                            _bits &= ~0x2000000000L;
                             _headers._RequestId = default(StringValues);
                             return true;
                         }
@@ -5670,9 +5670,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.TraceState.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000000L) != 0)
+                        if ((_bits & 0x10000000000L) != 0)
                         {
-                            _bits &= ~0x40000000000L;
+                            _bits &= ~0x10000000000L;
                             _headers._TraceState = default(StringValues);
                             return true;
                         }
@@ -5684,9 +5684,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TraceParent, key))
                     {
-                        if ((_bits & 0x20000000000L) != 0)
+                        if ((_bits & 0x8000000000L) != 0)
                         {
-                            _bits &= ~0x20000000000L;
+                            _bits &= ~0x8000000000L;
                             _headers._TraceParent = default(StringValues);
                             return true;
                         }
@@ -5695,9 +5695,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TraceParent.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000000000L) != 0)
+                        if ((_bits & 0x8000000000L) != 0)
                         {
-                            _bits &= ~0x20000000000L;
+                            _bits &= ~0x8000000000L;
                             _headers._TraceParent = default(StringValues);
                             return true;
                         }
@@ -5709,9 +5709,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
-                            _bits &= ~0x400L;
+                            _bits &= ~0x10000L;
                             _headers._ContentType = default(StringValues);
                             return true;
                         }
@@ -5740,9 +5740,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
-                            _bits &= ~0x400L;
+                            _bits &= ~0x10000L;
                             _headers._ContentType = default(StringValues);
                             return true;
                         }
@@ -5772,11 +5772,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 13:
                 {
+                    if (ReferenceEquals(HeaderNames.Authorization, key))
+                    {
+                        if ((_bits & 0x2000L) != 0)
+                        {
+                            _bits &= ~0x2000L;
+                            _headers._Authorization = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.CacheControl, key))
                     {
-                        if ((_bits & 0x1L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
-                            _bits &= ~0x1L;
+                            _bits &= ~0x8000L;
                             _headers._CacheControl = default(StringValues);
                             return true;
                         }
@@ -5784,40 +5794,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
                     {
-                        if ((_bits & 0x8L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
-                            _bits &= ~0x8L;
+                            _bits &= ~0x800000L;
                             _headers._GrpcEncoding = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Authorization, key))
-                    {
-                        if ((_bits & 0x80000L) != 0)
-                        {
-                            _bits &= ~0x80000L;
-                            _headers._Authorization = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.IfNoneMatch, key))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
-                            _bits &= ~0x10000000L;
+                            _bits &= ~0x8000000L;
                             _headers._IfNoneMatch = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
+                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x2000L) != 0)
+                        {
+                            _bits &= ~0x2000L;
+                            _headers._Authorization = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
-                            _bits &= ~0x1L;
+                            _bits &= ~0x8000L;
                             _headers._CacheControl = default(StringValues);
                             return true;
                         }
@@ -5825,29 +5835,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
-                            _bits &= ~0x8L;
+                            _bits &= ~0x800000L;
                             _headers._GrpcEncoding = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.Authorization.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x80000L) != 0)
-                        {
-                            _bits &= ~0x80000L;
-                            _headers._Authorization = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.IfNoneMatch.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
-                            _bits &= ~0x10000000L;
+                            _bits &= ~0x8000000L;
                             _headers._IfNoneMatch = default(StringValues);
                             return true;
                         }
@@ -5859,9 +5859,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptCharset, key))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
-                            _bits &= ~0x10000L;
+                            _bits &= ~0x100L;
                             _headers._AcceptCharset = default(StringValues);
                             return true;
                         }
@@ -5879,9 +5879,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AcceptCharset.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
-                            _bits &= ~0x10000L;
+                            _bits &= ~0x100L;
                             _headers._AcceptCharset = default(StringValues);
                             return true;
                         }
@@ -5902,9 +5902,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AcceptEncoding, key))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
-                            _bits &= ~0x20000L;
+                            _bits &= ~0x200L;
                             _headers._AcceptEncoding = default(StringValues);
                             return true;
                         }
@@ -5912,9 +5912,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AcceptLanguage, key))
                     {
-                        if ((_bits & 0x40000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
-                            _bits &= ~0x40000L;
+                            _bits &= ~0x400L;
                             _headers._AcceptLanguage = default(StringValues);
                             return true;
                         }
@@ -5923,9 +5923,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
-                            _bits &= ~0x20000L;
+                            _bits &= ~0x200L;
                             _headers._AcceptEncoding = default(StringValues);
                             return true;
                         }
@@ -5933,9 +5933,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AcceptLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
-                            _bits &= ~0x40000L;
+                            _bits &= ~0x400L;
                             _headers._AcceptLanguage = default(StringValues);
                             return true;
                         }
@@ -5945,43 +5945,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 17:
                 {
-                    if (ReferenceEquals(HeaderNames.TransferEncoding, key))
+                    if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            _bits &= ~0x40L;
-                            _headers._TransferEncoding = default(StringValues);
+                            _bits &= ~0x4000000L;
+                            _headers._IfModifiedSince = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.IfModifiedSince, key))
+                    if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x20000000000L) != 0)
                         {
-                            _bits &= ~0x8000000L;
-                            _headers._IfModifiedSince = default(StringValues);
+                            _bits &= ~0x20000000000L;
+                            _headers._TransferEncoding = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            _bits &= ~0x40L;
-                            _headers._TransferEncoding = default(StringValues);
+                            _bits &= ~0x4000000L;
+                            _headers._IfModifiedSince = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.IfModifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x20000000000L) != 0)
                         {
-                            _bits &= ~0x8000000L;
-                            _headers._IfModifiedSince = default(StringValues);
+                            _bits &= ~0x20000000000L;
+                            _headers._TransferEncoding = default(StringValues);
                             return true;
                         }
                         return false;
@@ -5990,11 +5990,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 19:
                 {
+                    if (ReferenceEquals(HeaderNames.CorrelationContext, key))
+                    {
+                        if ((_bits & 0x40000L) != 0)
+                        {
+                            _bits &= ~0x40000L;
+                            _headers._CorrelationContext = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.IfUnmodifiedSince, key))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
-                            _bits &= ~0x40000000L;
+                            _bits &= ~0x20000000L;
                             _headers._IfUnmodifiedSince = default(StringValues);
                             return true;
                         }
@@ -6002,30 +6012,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ProxyAuthorization, key))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
-                            _bits &= ~0x100000000L;
+                            _bits &= ~0x400000000L;
                             _headers._ProxyAuthorization = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.CorrelationContext, key))
+    
+                    if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            _bits &= ~0x10000000000L;
+                            _bits &= ~0x40000L;
                             _headers._CorrelationContext = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-    
                     if (HeaderNames.IfUnmodifiedSince.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x20000000L) != 0)
                         {
-                            _bits &= ~0x40000000L;
+                            _bits &= ~0x20000000L;
                             _headers._IfUnmodifiedSince = default(StringValues);
                             return true;
                         }
@@ -6033,20 +6043,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ProxyAuthorization.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
-                            _bits &= ~0x100000000L;
+                            _bits &= ~0x400000000L;
                             _headers._ProxyAuthorization = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.CorrelationContext.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x10000000000L) != 0)
-                        {
-                            _bits &= ~0x10000000000L;
-                            _headers._CorrelationContext = default(StringValues);
                             return true;
                         }
                         return false;
@@ -6057,9 +6057,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.GrpcAcceptEncoding, key))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
-                            _bits &= ~0x800000L;
+                            _bits &= ~0x400000L;
                             _headers._GrpcAcceptEncoding = default(StringValues);
                             return true;
                         }
@@ -6068,9 +6068,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.GrpcAcceptEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x400000L) != 0)
                         {
-                            _bits &= ~0x800000L;
+                            _bits &= ~0x400000L;
                             _headers._GrpcAcceptEncoding = default(StringValues);
                             return true;
                         }
@@ -6082,9 +6082,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.UpgradeInsecureRequests, key))
                     {
-                        if ((_bits & 0x4000000000L) != 0)
+                        if ((_bits & 0x100000000000L) != 0)
                         {
-                            _bits &= ~0x4000000000L;
+                            _bits &= ~0x100000000000L;
                             _headers._UpgradeInsecureRequests = default(StringValues);
                             return true;
                         }
@@ -6093,9 +6093,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.UpgradeInsecureRequests.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000000L) != 0)
+                        if ((_bits & 0x100000000000L) != 0)
                         {
-                            _bits &= ~0x4000000000L;
+                            _bits &= ~0x100000000000L;
                             _headers._UpgradeInsecureRequests = default(StringValues);
                             return true;
                         }
@@ -6107,9 +6107,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestMethod, key))
                     {
-                        if ((_bits & 0x200000000000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
-                            _bits &= ~0x200000000000L;
+                            _bits &= ~0x1000L;
                             _headers._AccessControlRequestMethod = default(StringValues);
                             return true;
                         }
@@ -6118,9 +6118,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestMethod.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
-                            _bits &= ~0x200000000000L;
+                            _bits &= ~0x1000L;
                             _headers._AccessControlRequestMethod = default(StringValues);
                             return true;
                         }
@@ -6132,9 +6132,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlRequestHeaders, key))
                     {
-                        if ((_bits & 0x400000000000L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
-                            _bits &= ~0x400000000000L;
+                            _bits &= ~0x800L;
                             _headers._AccessControlRequestHeaders = default(StringValues);
                             return true;
                         }
@@ -6143,9 +6143,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlRequestHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000000L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
-                            _bits &= ~0x400000000000L;
+                            _bits &= ~0x800L;
                             _headers._AccessControlRequestHeaders = default(StringValues);
                             return true;
                         }
@@ -6161,6 +6161,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             var tempBits = bitsToClear;
             
+            if ((tempBits & 0x1L) != 0)
+            {
+                _headers._Accept = default;
+                if((tempBits & ~0x1L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x1L;
+            }
+            
             if ((tempBits & 0x2L) != 0)
             {
                 _headers._Connection = default;
@@ -6171,49 +6181,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x2L;
             }
             
-            if ((tempBits & 0x8000L) != 0)
-            {
-                _headers._Accept = default;
-                if((tempBits & ~0x8000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x8000L;
-            }
-            
-            if ((tempBits & 0x2000000L) != 0)
-            {
-                _headers._Host = default;
-                if((tempBits & ~0x2000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x2000000L;
-            }
-            
-            if ((tempBits & 0x2000000000L) != 0)
-            {
-                _headers._UserAgent = default;
-                if((tempBits & ~0x2000000000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x2000000000L;
-            }
-            
-            if ((tempBits & 0x1L) != 0)
-            {
-                _headers._CacheControl = default;
-                if((tempBits & ~0x1L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x1L;
-            }
-            
             if ((tempBits & 0x4L) != 0)
             {
-                _headers._Date = default;
+                _headers._Host = default;
                 if((tempBits & ~0x4L) == 0)
                 {
                     return;
@@ -6223,7 +6193,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8L) != 0)
             {
-                _headers._GrpcEncoding = default;
+                _headers._UserAgent = default;
                 if((tempBits & ~0x8L) == 0)
                 {
                     return;
@@ -6233,7 +6203,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10L) != 0)
             {
-                _headers._KeepAlive = default;
+                _headers._Authority = default;
                 if((tempBits & ~0x10L) == 0)
                 {
                     return;
@@ -6243,7 +6213,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20L) != 0)
             {
-                _headers._Pragma = default;
+                _headers._Method = default;
                 if((tempBits & ~0x20L) == 0)
                 {
                     return;
@@ -6253,7 +6223,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40L) != 0)
             {
-                _headers._TransferEncoding = default;
+                _headers._Path = default;
                 if((tempBits & ~0x40L) == 0)
                 {
                     return;
@@ -6263,7 +6233,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80L) != 0)
             {
-                _headers._Upgrade = default;
+                _headers._Scheme = default;
                 if((tempBits & ~0x80L) == 0)
                 {
                     return;
@@ -6273,7 +6243,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100L) != 0)
             {
-                _headers._Via = default;
+                _headers._AcceptCharset = default;
                 if((tempBits & ~0x100L) == 0)
                 {
                     return;
@@ -6283,7 +6253,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200L) != 0)
             {
-                _headers._Warning = default;
+                _headers._AcceptEncoding = default;
                 if((tempBits & ~0x200L) == 0)
                 {
                     return;
@@ -6293,7 +6263,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400L) != 0)
             {
-                _headers._ContentType = default;
+                _headers._AcceptLanguage = default;
                 if((tempBits & ~0x400L) == 0)
                 {
                     return;
@@ -6303,7 +6273,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800L) != 0)
             {
-                _headers._Authority = default;
+                _headers._AccessControlRequestHeaders = default;
                 if((tempBits & ~0x800L) == 0)
                 {
                     return;
@@ -6313,7 +6283,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000L) != 0)
             {
-                _headers._Method = default;
+                _headers._AccessControlRequestMethod = default;
                 if((tempBits & ~0x1000L) == 0)
                 {
                     return;
@@ -6323,7 +6293,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x2000L) != 0)
             {
-                _headers._Path = default;
+                _headers._Authorization = default;
                 if((tempBits & ~0x2000L) == 0)
                 {
                     return;
@@ -6333,7 +6303,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x4000L) != 0)
             {
-                _headers._Scheme = default;
+                _headers._Baggage = default;
                 if((tempBits & ~0x4000L) == 0)
                 {
                     return;
@@ -6341,9 +6311,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x4000L;
             }
             
+            if ((tempBits & 0x8000L) != 0)
+            {
+                _headers._CacheControl = default;
+                if((tempBits & ~0x8000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x8000L;
+            }
+            
             if ((tempBits & 0x10000L) != 0)
             {
-                _headers._AcceptCharset = default;
+                _headers._ContentType = default;
                 if((tempBits & ~0x10000L) == 0)
                 {
                     return;
@@ -6353,7 +6333,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000L) != 0)
             {
-                _headers._AcceptEncoding = default;
+                _headers._Cookie = default;
                 if((tempBits & ~0x20000L) == 0)
                 {
                     return;
@@ -6363,7 +6343,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000L) != 0)
             {
-                _headers._AcceptLanguage = default;
+                _headers._CorrelationContext = default;
                 if((tempBits & ~0x40000L) == 0)
                 {
                     return;
@@ -6373,7 +6353,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000L) != 0)
             {
-                _headers._Authorization = default;
+                _headers._Date = default;
                 if((tempBits & ~0x80000L) == 0)
                 {
                     return;
@@ -6383,7 +6363,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100000L) != 0)
             {
-                _headers._Cookie = default;
+                _headers._Expect = default;
                 if((tempBits & ~0x100000L) == 0)
                 {
                     return;
@@ -6393,7 +6373,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200000L) != 0)
             {
-                _headers._Expect = default;
+                _headers._From = default;
                 if((tempBits & ~0x200000L) == 0)
                 {
                     return;
@@ -6403,7 +6383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400000L) != 0)
             {
-                _headers._From = default;
+                _headers._GrpcAcceptEncoding = default;
                 if((tempBits & ~0x400000L) == 0)
                 {
                     return;
@@ -6413,7 +6393,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800000L) != 0)
             {
-                _headers._GrpcAcceptEncoding = default;
+                _headers._GrpcEncoding = default;
                 if((tempBits & ~0x800000L) == 0)
                 {
                     return;
@@ -6431,9 +6411,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x1000000L;
             }
             
-            if ((tempBits & 0x4000000L) != 0)
+            if ((tempBits & 0x2000000L) != 0)
             {
                 _headers._IfMatch = default;
+                if((tempBits & ~0x2000000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x2000000L;
+            }
+            
+            if ((tempBits & 0x4000000L) != 0)
+            {
+                _headers._IfModifiedSince = default;
                 if((tempBits & ~0x4000000L) == 0)
                 {
                     return;
@@ -6443,7 +6433,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000000L) != 0)
             {
-                _headers._IfModifiedSince = default;
+                _headers._IfNoneMatch = default;
                 if((tempBits & ~0x8000000L) == 0)
                 {
                     return;
@@ -6453,7 +6443,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10000000L) != 0)
             {
-                _headers._IfNoneMatch = default;
+                _headers._IfRange = default;
                 if((tempBits & ~0x10000000L) == 0)
                 {
                     return;
@@ -6463,7 +6453,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000000L) != 0)
             {
-                _headers._IfRange = default;
+                _headers._IfUnmodifiedSince = default;
                 if((tempBits & ~0x20000000L) == 0)
                 {
                     return;
@@ -6473,7 +6463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000000L) != 0)
             {
-                _headers._IfUnmodifiedSince = default;
+                _headers._KeepAlive = default;
                 if((tempBits & ~0x40000000L) == 0)
                 {
                     return;
@@ -6493,7 +6483,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100000000L) != 0)
             {
-                _headers._ProxyAuthorization = default;
+                _headers._Origin = default;
                 if((tempBits & ~0x100000000L) == 0)
                 {
                     return;
@@ -6503,7 +6493,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200000000L) != 0)
             {
-                _headers._Referer = default;
+                _headers._Pragma = default;
                 if((tempBits & ~0x200000000L) == 0)
                 {
                     return;
@@ -6513,7 +6503,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400000000L) != 0)
             {
-                _headers._Range = default;
+                _headers._ProxyAuthorization = default;
                 if((tempBits & ~0x400000000L) == 0)
                 {
                     return;
@@ -6523,7 +6513,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800000000L) != 0)
             {
-                _headers._TE = default;
+                _headers._Range = default;
                 if((tempBits & ~0x800000000L) == 0)
                 {
                     return;
@@ -6533,7 +6523,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000000000L) != 0)
             {
-                _headers._Translate = default;
+                _headers._Referer = default;
                 if((tempBits & ~0x1000000000L) == 0)
                 {
                     return;
@@ -6541,9 +6531,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x1000000000L;
             }
             
+            if ((tempBits & 0x2000000000L) != 0)
+            {
+                _headers._RequestId = default;
+                if((tempBits & ~0x2000000000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x2000000000L;
+            }
+            
             if ((tempBits & 0x4000000000L) != 0)
             {
-                _headers._UpgradeInsecureRequests = default;
+                _headers._TE = default;
                 if((tempBits & ~0x4000000000L) == 0)
                 {
                     return;
@@ -6553,7 +6553,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000000000L) != 0)
             {
-                _headers._RequestId = default;
+                _headers._TraceParent = default;
                 if((tempBits & ~0x8000000000L) == 0)
                 {
                     return;
@@ -6563,7 +6563,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10000000000L) != 0)
             {
-                _headers._CorrelationContext = default;
+                _headers._TraceState = default;
                 if((tempBits & ~0x10000000000L) == 0)
                 {
                     return;
@@ -6573,7 +6573,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000000000L) != 0)
             {
-                _headers._TraceParent = default;
+                _headers._TransferEncoding = default;
                 if((tempBits & ~0x20000000000L) == 0)
                 {
                     return;
@@ -6583,7 +6583,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000000000L) != 0)
             {
-                _headers._TraceState = default;
+                _headers._Translate = default;
                 if((tempBits & ~0x40000000000L) == 0)
                 {
                     return;
@@ -6593,7 +6593,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000000000L) != 0)
             {
-                _headers._Baggage = default;
+                _headers._Upgrade = default;
                 if((tempBits & ~0x80000000000L) == 0)
                 {
                     return;
@@ -6603,7 +6603,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100000000000L) != 0)
             {
-                _headers._Origin = default;
+                _headers._UpgradeInsecureRequests = default;
                 if((tempBits & ~0x100000000000L) == 0)
                 {
                     return;
@@ -6613,7 +6613,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200000000000L) != 0)
             {
-                _headers._AccessControlRequestMethod = default;
+                _headers._Via = default;
                 if((tempBits & ~0x200000000000L) == 0)
                 {
                     return;
@@ -6623,7 +6623,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400000000000L) != 0)
             {
-                _headers._AccessControlRequestHeaders = default;
+                _headers._Warning = default;
                 if((tempBits & ~0x400000000000L) == 0)
                 {
                     return;
@@ -6646,7 +6646,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CacheControl, _headers._CacheControl);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Accept, _headers._Accept);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2L) != 0)
@@ -6664,7 +6664,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Date, _headers._Date);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Host, _headers._Host);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8L) != 0)
@@ -6673,7 +6673,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcEncoding, _headers._GrpcEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UserAgent, _headers._UserAgent);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10L) != 0)
@@ -6682,7 +6682,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.KeepAlive, _headers._KeepAlive);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Authority, _headers._Authority);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20L) != 0)
@@ -6691,7 +6691,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Pragma, _headers._Pragma);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Method, _headers._Method);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40L) != 0)
@@ -6700,7 +6700,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _headers._TransferEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Path, _headers._Path);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80L) != 0)
@@ -6709,7 +6709,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _headers._Upgrade);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Scheme, _headers._Scheme);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100L) != 0)
@@ -6718,7 +6718,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Via, _headers._Via);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptCharset, _headers._AcceptCharset);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200L) != 0)
@@ -6727,7 +6727,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _headers._Warning);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptEncoding, _headers._AcceptEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400L) != 0)
@@ -6736,7 +6736,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _headers._ContentType);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptLanguage, _headers._AcceptLanguage);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800L) != 0)
@@ -6745,7 +6745,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Authority, _headers._Authority);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestHeaders, _headers._AccessControlRequestHeaders);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000L) != 0)
@@ -6754,7 +6754,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Method, _headers._Method);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestMethod, _headers._AccessControlRequestMethod);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000L) != 0)
@@ -6763,7 +6763,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Path, _headers._Path);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Authorization, _headers._Authorization);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000L) != 0)
@@ -6772,7 +6772,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Scheme, _headers._Scheme);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _headers._Baggage);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000L) != 0)
@@ -6781,7 +6781,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Accept, _headers._Accept);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CacheControl, _headers._CacheControl);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000L) != 0)
@@ -6790,7 +6790,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptCharset, _headers._AcceptCharset);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _headers._ContentType);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000L) != 0)
@@ -6799,7 +6799,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptEncoding, _headers._AcceptEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Cookie, _headers._Cookie);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000L) != 0)
@@ -6808,7 +6808,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptLanguage, _headers._AcceptLanguage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _headers._CorrelationContext);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000L) != 0)
@@ -6817,7 +6817,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Authorization, _headers._Authorization);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Date, _headers._Date);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100000L) != 0)
@@ -6826,7 +6826,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Cookie, _headers._Cookie);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expect, _headers._Expect);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000L) != 0)
@@ -6835,7 +6835,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expect, _headers._Expect);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.From, _headers._From);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400000L) != 0)
@@ -6844,7 +6844,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.From, _headers._From);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcAcceptEncoding, _headers._GrpcAcceptEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800000L) != 0)
@@ -6853,7 +6853,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcAcceptEncoding, _headers._GrpcAcceptEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcEncoding, _headers._GrpcEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000000L) != 0)
@@ -6871,7 +6871,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Host, _headers._Host);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfMatch, _headers._IfMatch);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000000L) != 0)
@@ -6880,7 +6880,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfMatch, _headers._IfMatch);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfModifiedSince, _headers._IfModifiedSince);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000000L) != 0)
@@ -6889,7 +6889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfModifiedSince, _headers._IfModifiedSince);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfNoneMatch, _headers._IfNoneMatch);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000000L) != 0)
@@ -6898,7 +6898,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfNoneMatch, _headers._IfNoneMatch);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfRange, _headers._IfRange);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000000L) != 0)
@@ -6907,7 +6907,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfRange, _headers._IfRange);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfUnmodifiedSince, _headers._IfUnmodifiedSince);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000000L) != 0)
@@ -6916,7 +6916,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.IfUnmodifiedSince, _headers._IfUnmodifiedSince);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.KeepAlive, _headers._KeepAlive);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000000L) != 0)
@@ -6934,7 +6934,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthorization, _headers._ProxyAuthorization);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _headers._Origin);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000000L) != 0)
@@ -6943,7 +6943,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Referer, _headers._Referer);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Pragma, _headers._Pragma);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400000000L) != 0)
@@ -6952,7 +6952,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Range, _headers._Range);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthorization, _headers._ProxyAuthorization);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800000000L) != 0)
@@ -6961,7 +6961,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TE, _headers._TE);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Range, _headers._Range);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000000000L) != 0)
@@ -6970,7 +6970,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Translate, _headers._Translate);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Referer, _headers._Referer);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000000000L) != 0)
@@ -6979,7 +6979,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UserAgent, _headers._UserAgent);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _headers._RequestId);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000000000L) != 0)
@@ -6988,7 +6988,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _headers._UpgradeInsecureRequests);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TE, _headers._TE);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000000000L) != 0)
@@ -6997,7 +6997,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _headers._RequestId);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _headers._TraceParent);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000000000L) != 0)
@@ -7006,7 +7006,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _headers._CorrelationContext);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _headers._TraceState);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000000000L) != 0)
@@ -7015,7 +7015,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _headers._TraceParent);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _headers._TransferEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000000000L) != 0)
@@ -7024,7 +7024,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _headers._TraceState);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Translate, _headers._Translate);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000000000L) != 0)
@@ -7033,7 +7033,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _headers._Baggage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _headers._Upgrade);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100000000000L) != 0)
@@ -7042,7 +7042,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _headers._Origin);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _headers._UpgradeInsecureRequests);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000000000L) != 0)
@@ -7051,7 +7051,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestMethod, _headers._AccessControlRequestMethod);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Via, _headers._Via);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400000000000L) != 0)
@@ -7060,7 +7060,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestHeaders, _headers._AccessControlRequestHeaders);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _headers._Warning);
                     ++arrayIndex;
                 }
                 if (_contentLength.HasValue)
@@ -7091,7 +7091,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 2:
                     if (((Unsafe.ReadUnaligned<ushort>(ref nameStart) & 0xdfdfu) == 0x4554u))
                     {
-                        flag = 0x800000000L;
+                        flag = 0x4000000000L;
                         values = ref _headers._TE;
                         nameStr = HeaderNames.TE;
                     }
@@ -7099,7 +7099,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 3:
                     if (((Unsafe.ReadUnaligned<ushort>(ref nameStart) & 0xdfdfu) == 0x4956u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)2) & 0xdfu) == 0x41u))
                     {
-                        flag = 0x100L;
+                        flag = 0x200000000000L;
                         values = ref _headers._Via;
                         nameStr = HeaderNames.Via;
                     }
@@ -7108,19 +7108,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var firstTerm4 = (Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu);
                     if ((firstTerm4 == 0x54534f48u))
                     {
-                        flag = 0x2000000L;
+                        flag = 0x4L;
                         values = ref _headers._Host;
                         nameStr = HeaderNames.Host;
                     }
                     else if ((firstTerm4 == 0x45544144u))
                     {
-                        flag = 0x4L;
+                        flag = 0x80000L;
                         values = ref _headers._Date;
                         nameStr = HeaderNames.Date;
                     }
                     else if ((firstTerm4 == 0x4d4f5246u))
                     {
-                        flag = 0x400000L;
+                        flag = 0x200000L;
                         values = ref _headers._From;
                         nameStr = HeaderNames.From;
                     }
@@ -7128,13 +7128,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 5:
                     if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfffu) == 0x5441503au) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)4) & 0xdfu) == 0x48u))
                     {
-                        flag = 0x2000L;
+                        flag = 0x40L;
                         values = ref _headers._Path;
                         nameStr = HeaderNames.Path;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x474e4152u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)4) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x400000000L;
+                        flag = 0x800000000L;
                         values = ref _headers._Range;
                         nameStr = HeaderNames.Range;
                     }
@@ -7143,31 +7143,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var firstTerm6 = (Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu);
                     if ((firstTerm6 == 0x45434341u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x5450u))
                     {
-                        flag = 0x8000L;
+                        flag = 0x1L;
                         values = ref _headers._Accept;
                         nameStr = HeaderNames.Accept;
                     }
                     else if ((firstTerm6 == 0x4b4f4f43u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4549u))
                     {
-                        flag = 0x100000L;
+                        flag = 0x20000L;
                         values = ref _headers._Cookie;
                         nameStr = HeaderNames.Cookie;
                     }
                     else if ((firstTerm6 == 0x45505845u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x5443u))
                     {
-                        flag = 0x200000L;
+                        flag = 0x100000L;
                         values = ref _headers._Expect;
                         nameStr = HeaderNames.Expect;
                     }
                     else if ((firstTerm6 == 0x4749524fu) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4e49u))
                     {
-                        flag = 0x100000000000L;
+                        flag = 0x100000000L;
                         values = ref _headers._Origin;
                         nameStr = HeaderNames.Origin;
                     }
                     else if ((firstTerm6 == 0x47415250u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x414du))
                     {
-                        flag = 0x20L;
+                        flag = 0x200000000L;
                         values = ref _headers._Pragma;
                         nameStr = HeaderNames.Pragma;
                     }
@@ -7175,37 +7175,37 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 7:
                     if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfffu) == 0x54454d3au) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4f48u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x44u))
                     {
-                        flag = 0x1000L;
+                        flag = 0x20L;
                         values = ref _headers._Method;
                         nameStr = HeaderNames.Method;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfffu) == 0x4843533au) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4d45u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x4000L;
+                        flag = 0x80L;
                         values = ref _headers._Scheme;
                         nameStr = HeaderNames.Scheme;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x47474142u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4741u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x80000000000L;
+                        flag = 0x4000L;
                         values = ref _headers._Baggage;
                         nameStr = HeaderNames.Baggage;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x45464552u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4552u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x52u))
                     {
-                        flag = 0x200000000L;
+                        flag = 0x1000000000L;
                         values = ref _headers._Referer;
                         nameStr = HeaderNames.Referer;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x52475055u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4441u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x80L;
+                        flag = 0x80000000000L;
                         values = ref _headers._Upgrade;
                         nameStr = HeaderNames.Upgrade;
                     }
                     else if (((Unsafe.ReadUnaligned<uint>(ref nameStart) & 0xdfdfdfdfu) == 0x4e524157u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ushort)))) & 0xdfdfu) == 0x4e49u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)6) & 0xdfu) == 0x47u))
                     {
-                        flag = 0x200L;
+                        flag = 0x400000000000L;
                         values = ref _headers._Warning;
                         nameStr = HeaderNames.Warning;
                     }
@@ -7214,13 +7214,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var firstTerm8 = (Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfffdfdfuL);
                     if ((firstTerm8 == 0x484354414d2d4649uL))
                     {
-                        flag = 0x4000000L;
+                        flag = 0x2000000L;
                         values = ref _headers._IfMatch;
                         nameStr = HeaderNames.IfMatch;
                     }
                     else if ((firstTerm8 == 0x45474e41522d4649uL))
                     {
-                        flag = 0x20000000L;
+                        flag = 0x10000000L;
                         values = ref _headers._IfRange;
                         nameStr = HeaderNames.IfRange;
                     }
@@ -7228,7 +7228,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 9:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x54414c534e415254uL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)8) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x1000000000L;
+                        flag = 0x40000000000L;
                         values = ref _headers._Translate;
                         nameStr = HeaderNames.Translate;
                     }
@@ -7242,31 +7242,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x4547412d52455355uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x544eu))
                     {
-                        flag = 0x2000000000L;
+                        flag = 0x8L;
                         values = ref _headers._UserAgent;
                         nameStr = HeaderNames.UserAgent;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfffuL) == 0x49524f485455413auL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x5954u))
                     {
-                        flag = 0x800L;
+                        flag = 0x10L;
                         values = ref _headers._Authority;
                         nameStr = HeaderNames.Authority;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x494c412d5045454buL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4556u))
                     {
-                        flag = 0x10L;
+                        flag = 0x40000000L;
                         values = ref _headers._KeepAlive;
                         nameStr = HeaderNames.KeepAlive;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d54534555514552uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4449u))
                     {
-                        flag = 0x8000000000L;
+                        flag = 0x2000000000L;
                         values = ref _headers._RequestId;
                         nameStr = HeaderNames.RequestId;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x4154534543415254uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4554u))
                     {
-                        flag = 0x40000000000L;
+                        flag = 0x10000000000L;
                         values = ref _headers._TraceState;
                         nameStr = HeaderNames.TraceState;
                     }
@@ -7274,7 +7274,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 11:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x5241504543415254uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(ushort)))) & 0xdfdfu) == 0x4e45u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)10) & 0xdfu) == 0x54u))
                     {
-                        flag = 0x20000000000L;
+                        flag = 0x8000000000L;
                         values = ref _headers._TraceParent;
                         nameStr = HeaderNames.TraceParent;
                     }
@@ -7282,7 +7282,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 12:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d544e45544e4f43uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x45505954u))
                     {
-                        flag = 0x400L;
+                        flag = 0x10000L;
                         values = ref _headers._ContentType;
                         nameStr = HeaderNames.ContentType;
                     }
@@ -7302,25 +7302,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 13:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x5a49524f48545541uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4f495441u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x4eu))
                     {
-                        flag = 0x80000L;
+                        flag = 0x2000L;
                         values = ref _headers._Authorization;
                         nameStr = HeaderNames.Authorization;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfffdfdfdfdfdfuL) == 0x4f432d4548434143uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4f52544eu) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x4cu))
                     {
-                        flag = 0x1L;
+                        flag = 0x8000L;
                         values = ref _headers._CacheControl;
                         nameStr = HeaderNames.CacheControl;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x434e452d43505247uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4e49444fu) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x47u))
                     {
-                        flag = 0x8L;
+                        flag = 0x800000L;
                         values = ref _headers._GrpcEncoding;
                         nameStr = HeaderNames.GrpcEncoding;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfffdfdfuL) == 0x2d454e4f4e2d4649uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4354414du) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)12) & 0xdfu) == 0x48u))
                     {
-                        flag = 0x10000000L;
+                        flag = 0x8000000L;
                         values = ref _headers._IfNoneMatch;
                         nameStr = HeaderNames.IfNoneMatch;
                     }
@@ -7328,7 +7328,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 14:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL) == 0x432d545045434341uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x53524148u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(ushort)))) & 0xdfdfu) == 0x5445u))
                     {
-                        flag = 0x10000L;
+                        flag = 0x100L;
                         values = ref _headers._AcceptCharset;
                         nameStr = HeaderNames.AcceptCharset;
                     }
@@ -7349,13 +7349,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     var firstTerm15 = (Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL);
                     if ((firstTerm15 == 0x452d545045434341uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x444f434eu) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(ushort)))) & 0xdfdfu) == 0x4e49u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)14) & 0xdfu) == 0x47u))
                     {
-                        flag = 0x20000L;
+                        flag = 0x200L;
                         values = ref _headers._AcceptEncoding;
                         nameStr = HeaderNames.AcceptEncoding;
                     }
                     else if ((firstTerm15 == 0x4c2d545045434341uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x55474e41u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(ushort)))) & 0xdfdfu) == 0x4741u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)14) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x40000L;
+                        flag = 0x400L;
                         values = ref _headers._AcceptLanguage;
                         nameStr = HeaderNames.AcceptLanguage;
                     }
@@ -7363,13 +7363,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 17:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfffdfdfuL) == 0x4649444f4d2d4649uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfffdfdfdfuL) == 0x434e49532d444549uL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)16) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x8000000L;
+                        flag = 0x4000000L;
                         values = ref _headers._IfModifiedSince;
                         nameStr = HeaderNames.IfModifiedSince;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x524546534e415254uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfffuL) == 0x4e49444f434e452duL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)16) & 0xdfu) == 0x47u))
                     {
-                        flag = 0x40L;
+                        flag = 0x20000000000L;
                         values = ref _headers._TransferEncoding;
                         nameStr = HeaderNames.TransferEncoding;
                     }
@@ -7377,19 +7377,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 19:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfdfdfdfuL) == 0x54414c4552524f43uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfffdfdfdfuL) == 0x544e4f432d4e4f49uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(8 * sizeof(ushort)))) & 0xdfdfu) == 0x5845u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)18) & 0xdfu) == 0x54u))
                     {
-                        flag = 0x10000000000L;
+                        flag = 0x40000L;
                         values = ref _headers._CorrelationContext;
                         nameStr = HeaderNames.CorrelationContext;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfdfdfffdfdfuL) == 0x444f4d4e552d4649uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfffdfdfdfdfdfuL) == 0x49532d4445494649uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(8 * sizeof(ushort)))) & 0xdfdfu) == 0x434eu) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)18) & 0xdfu) == 0x45u))
                     {
-                        flag = 0x40000000L;
+                        flag = 0x20000000L;
                         values = ref _headers._IfUnmodifiedSince;
                         nameStr = HeaderNames.IfUnmodifiedSince;
                     }
                     else if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfffdfdfdfdfdfuL) == 0x55412d59584f5250uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfdfuL) == 0x54415a49524f4854uL) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(8 * sizeof(ushort)))) & 0xdfdfu) == 0x4f49u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)18) & 0xdfu) == 0x4eu))
                     {
-                        flag = 0x100000000L;
+                        flag = 0x400000000L;
                         values = ref _headers._ProxyAuthorization;
                         nameStr = HeaderNames.ProxyAuthorization;
                     }
@@ -7397,7 +7397,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 20:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfdfdfffdfdfdfdfuL) == 0x4343412d43505247uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfffdfdfdfuL) == 0x4f434e452d545045uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(4 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x474e4944u))
                     {
-                        flag = 0x800000L;
+                        flag = 0x400000L;
                         values = ref _headers._GrpcAcceptEncoding;
                         nameStr = HeaderNames.GrpcAcceptEncoding;
                     }
@@ -7405,7 +7405,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 25:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xffdfdfdfdfdfdfdfuL) == 0x2d45444152475055uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfdfdfdfdfdfdfdfuL) == 0x4552554345534e49uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfdfdfdfdfdfdfffuL) == 0x545345555145522duL) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)24) & 0xdfu) == 0x53u))
                     {
-                        flag = 0x4000000000L;
+                        flag = 0x100000000000L;
                         values = ref _headers._UpgradeInsecureRequests;
                         nameStr = HeaderNames.UpgradeInsecureRequests;
                     }
@@ -7413,7 +7413,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 29:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL) == 0x432d535345434341uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfffdfdfdfdfdfdfuL) == 0x522d4c4f52544e4fuL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfffdfdfdfdfdfdfuL) == 0x4d2d545345555145uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x4f485445u) && ((Unsafe.AddByteOffset(ref nameStart, (IntPtr)28) & 0xdfu) == 0x44u))
                     {
-                        flag = 0x200000000000L;
+                        flag = 0x1000L;
                         values = ref _headers._AccessControlRequestMethod;
                         nameStr = HeaderNames.AccessControlRequestMethod;
                     }
@@ -7421,7 +7421,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 case 30:
                     if (((Unsafe.ReadUnaligned<ulong>(ref nameStart) & 0xdfffdfdfdfdfdfdfuL) == 0x432d535345434341uL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)sizeof(ulong))) & 0xdfffdfdfdfdfdfdfuL) == 0x522d4c4f52544e4fuL) && ((Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(2 * sizeof(ulong)))) & 0xdfffdfdfdfdfdfdfuL) == 0x482d545345555145uL) && ((Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(6 * sizeof(uint)))) & 0xdfdfdfdfu) == 0x45444145u) && ((Unsafe.ReadUnaligned<ushort>(ref Unsafe.AddByteOffset(ref nameStart, (IntPtr)(14 * sizeof(ushort)))) & 0xdfdfu) == 0x5352u))
                     {
-                        flag = 0x400000000000L;
+                        flag = 0x800L;
                         values = ref _headers._AccessControlRequestHeaders;
                         nameStr = HeaderNames.AccessControlRequestHeaders;
                     }
@@ -7488,55 +7488,55 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             switch (index)
             {
                 case 1:
-                    flag = 0x800L;
+                    flag = 0x10L;
                     values = ref _headers._Authority;
                     nameStr = HeaderNames.Authority;
                     break;
                 case 2:
                 case 3:
-                    flag = 0x1000L;
+                    flag = 0x20L;
                     values = ref _headers._Method;
                     nameStr = HeaderNames.Method;
                     break;
                 case 4:
                 case 5:
-                    flag = 0x2000L;
+                    flag = 0x40L;
                     values = ref _headers._Path;
                     nameStr = HeaderNames.Path;
                     break;
                 case 6:
                 case 7:
-                    flag = 0x4000L;
+                    flag = 0x80L;
                     values = ref _headers._Scheme;
                     nameStr = HeaderNames.Scheme;
                     break;
                 case 15:
-                    flag = 0x10000L;
+                    flag = 0x100L;
                     values = ref _headers._AcceptCharset;
                     nameStr = HeaderNames.AcceptCharset;
                     break;
                 case 16:
-                    flag = 0x20000L;
+                    flag = 0x200L;
                     values = ref _headers._AcceptEncoding;
                     nameStr = HeaderNames.AcceptEncoding;
                     break;
                 case 17:
-                    flag = 0x40000L;
+                    flag = 0x400L;
                     values = ref _headers._AcceptLanguage;
                     nameStr = HeaderNames.AcceptLanguage;
                     break;
                 case 19:
-                    flag = 0x8000L;
+                    flag = 0x1L;
                     values = ref _headers._Accept;
                     nameStr = HeaderNames.Accept;
                     break;
                 case 23:
-                    flag = 0x80000L;
+                    flag = 0x2000L;
                     values = ref _headers._Authorization;
                     nameStr = HeaderNames.Authorization;
                     break;
                 case 24:
-                    flag = 0x1L;
+                    flag = 0x8000L;
                     values = ref _headers._CacheControl;
                     nameStr = HeaderNames.CacheControl;
                     break;
@@ -7551,57 +7551,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     return true;
                 case 31:
-                    flag = 0x400L;
+                    flag = 0x10000L;
                     values = ref _headers._ContentType;
                     nameStr = HeaderNames.ContentType;
                     break;
                 case 32:
-                    flag = 0x100000L;
+                    flag = 0x20000L;
                     values = ref _headers._Cookie;
                     nameStr = HeaderNames.Cookie;
                     break;
                 case 33:
-                    flag = 0x4L;
+                    flag = 0x80000L;
                     values = ref _headers._Date;
                     nameStr = HeaderNames.Date;
                     break;
                 case 35:
-                    flag = 0x200000L;
+                    flag = 0x100000L;
                     values = ref _headers._Expect;
                     nameStr = HeaderNames.Expect;
                     break;
                 case 37:
-                    flag = 0x400000L;
+                    flag = 0x200000L;
                     values = ref _headers._From;
                     nameStr = HeaderNames.From;
                     break;
                 case 38:
-                    flag = 0x2000000L;
+                    flag = 0x4L;
                     values = ref _headers._Host;
                     nameStr = HeaderNames.Host;
                     break;
                 case 39:
-                    flag = 0x4000000L;
+                    flag = 0x2000000L;
                     values = ref _headers._IfMatch;
                     nameStr = HeaderNames.IfMatch;
                     break;
                 case 40:
-                    flag = 0x8000000L;
+                    flag = 0x4000000L;
                     values = ref _headers._IfModifiedSince;
                     nameStr = HeaderNames.IfModifiedSince;
                     break;
                 case 41:
-                    flag = 0x10000000L;
+                    flag = 0x8000000L;
                     values = ref _headers._IfNoneMatch;
                     nameStr = HeaderNames.IfNoneMatch;
                     break;
                 case 42:
-                    flag = 0x20000000L;
+                    flag = 0x10000000L;
                     values = ref _headers._IfRange;
                     nameStr = HeaderNames.IfRange;
                     break;
                 case 43:
-                    flag = 0x40000000L;
+                    flag = 0x20000000L;
                     values = ref _headers._IfUnmodifiedSince;
                     nameStr = HeaderNames.IfUnmodifiedSince;
                     break;
@@ -7611,32 +7611,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     nameStr = HeaderNames.MaxForwards;
                     break;
                 case 49:
-                    flag = 0x100000000L;
+                    flag = 0x400000000L;
                     values = ref _headers._ProxyAuthorization;
                     nameStr = HeaderNames.ProxyAuthorization;
                     break;
                 case 50:
-                    flag = 0x400000000L;
+                    flag = 0x800000000L;
                     values = ref _headers._Range;
                     nameStr = HeaderNames.Range;
                     break;
                 case 51:
-                    flag = 0x200000000L;
+                    flag = 0x1000000000L;
                     values = ref _headers._Referer;
                     nameStr = HeaderNames.Referer;
                     break;
                 case 57:
-                    flag = 0x40L;
+                    flag = 0x20000000000L;
                     values = ref _headers._TransferEncoding;
                     nameStr = HeaderNames.TransferEncoding;
                     break;
                 case 58:
-                    flag = 0x2000000000L;
+                    flag = 0x8L;
                     values = ref _headers._UserAgent;
                     nameStr = HeaderNames.UserAgent;
                     break;
                 case 60:
-                    flag = 0x100L;
+                    flag = 0x200000000000L;
                     values = ref _headers._Via;
                     nameStr = HeaderNames.Via;
                     break;
@@ -7689,53 +7689,53 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private struct HeaderReferences
         {
-            public StringValues _CacheControl;
+            public StringValues _Accept;
             public StringValues _Connection;
-            public StringValues _Date;
-            public StringValues _GrpcEncoding;
-            public StringValues _KeepAlive;
-            public StringValues _Pragma;
-            public StringValues _TransferEncoding;
-            public StringValues _Upgrade;
-            public StringValues _Via;
-            public StringValues _Warning;
-            public StringValues _ContentType;
+            public StringValues _Host;
+            public StringValues _UserAgent;
             public StringValues _Authority;
             public StringValues _Method;
             public StringValues _Path;
             public StringValues _Scheme;
-            public StringValues _Accept;
             public StringValues _AcceptCharset;
             public StringValues _AcceptEncoding;
             public StringValues _AcceptLanguage;
+            public StringValues _AccessControlRequestHeaders;
+            public StringValues _AccessControlRequestMethod;
             public StringValues _Authorization;
+            public StringValues _Baggage;
+            public StringValues _CacheControl;
+            public StringValues _ContentType;
             public StringValues _Cookie;
+            public StringValues _CorrelationContext;
+            public StringValues _Date;
             public StringValues _Expect;
             public StringValues _From;
             public StringValues _GrpcAcceptEncoding;
+            public StringValues _GrpcEncoding;
             public StringValues _GrpcTimeout;
-            public StringValues _Host;
             public StringValues _IfMatch;
             public StringValues _IfModifiedSince;
             public StringValues _IfNoneMatch;
             public StringValues _IfRange;
             public StringValues _IfUnmodifiedSince;
+            public StringValues _KeepAlive;
             public StringValues _MaxForwards;
+            public StringValues _Origin;
+            public StringValues _Pragma;
             public StringValues _ProxyAuthorization;
-            public StringValues _Referer;
             public StringValues _Range;
-            public StringValues _TE;
-            public StringValues _Translate;
-            public StringValues _UserAgent;
-            public StringValues _UpgradeInsecureRequests;
+            public StringValues _Referer;
             public StringValues _RequestId;
-            public StringValues _CorrelationContext;
+            public StringValues _TE;
             public StringValues _TraceParent;
             public StringValues _TraceState;
-            public StringValues _Baggage;
-            public StringValues _Origin;
-            public StringValues _AccessControlRequestMethod;
-            public StringValues _AccessControlRequestHeaders;
+            public StringValues _TransferEncoding;
+            public StringValues _Translate;
+            public StringValues _Upgrade;
+            public StringValues _UpgradeInsecureRequests;
+            public StringValues _Via;
+            public StringValues _Warning;
             
         }
 
@@ -7747,110 +7747,110 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 switch (_next)
                 {
                     case 0:
-                        goto HeaderCacheControl;
+                        goto HeaderAccept;
                     case 1:
                         goto HeaderConnection;
                     case 2:
-                        goto HeaderDate;
+                        goto HeaderHost;
                     case 3:
-                        goto HeaderGrpcEncoding;
+                        goto HeaderUserAgent;
                     case 4:
-                        goto HeaderKeepAlive;
-                    case 5:
-                        goto HeaderPragma;
-                    case 6:
-                        goto HeaderTransferEncoding;
-                    case 7:
-                        goto HeaderUpgrade;
-                    case 8:
-                        goto HeaderVia;
-                    case 9:
-                        goto HeaderWarning;
-                    case 10:
-                        goto HeaderContentType;
-                    case 11:
                         goto HeaderAuthority;
-                    case 12:
+                    case 5:
                         goto HeaderMethod;
-                    case 13:
+                    case 6:
                         goto HeaderPath;
-                    case 14:
+                    case 7:
                         goto HeaderScheme;
-                    case 15:
-                        goto HeaderAccept;
-                    case 16:
+                    case 8:
                         goto HeaderAcceptCharset;
-                    case 17:
+                    case 9:
                         goto HeaderAcceptEncoding;
-                    case 18:
+                    case 10:
                         goto HeaderAcceptLanguage;
-                    case 19:
+                    case 11:
+                        goto HeaderAccessControlRequestHeaders;
+                    case 12:
+                        goto HeaderAccessControlRequestMethod;
+                    case 13:
                         goto HeaderAuthorization;
-                    case 20:
+                    case 14:
+                        goto HeaderBaggage;
+                    case 15:
+                        goto HeaderCacheControl;
+                    case 16:
+                        goto HeaderContentType;
+                    case 17:
                         goto HeaderCookie;
-                    case 21:
+                    case 18:
+                        goto HeaderCorrelationContext;
+                    case 19:
+                        goto HeaderDate;
+                    case 20:
                         goto HeaderExpect;
-                    case 22:
+                    case 21:
                         goto HeaderFrom;
-                    case 23:
+                    case 22:
                         goto HeaderGrpcAcceptEncoding;
+                    case 23:
+                        goto HeaderGrpcEncoding;
                     case 24:
                         goto HeaderGrpcTimeout;
                     case 25:
-                        goto HeaderHost;
-                    case 26:
                         goto HeaderIfMatch;
-                    case 27:
+                    case 26:
                         goto HeaderIfModifiedSince;
-                    case 28:
+                    case 27:
                         goto HeaderIfNoneMatch;
-                    case 29:
+                    case 28:
                         goto HeaderIfRange;
-                    case 30:
+                    case 29:
                         goto HeaderIfUnmodifiedSince;
+                    case 30:
+                        goto HeaderKeepAlive;
                     case 31:
                         goto HeaderMaxForwards;
                     case 32:
-                        goto HeaderProxyAuthorization;
-                    case 33:
-                        goto HeaderReferer;
-                    case 34:
-                        goto HeaderRange;
-                    case 35:
-                        goto HeaderTE;
-                    case 36:
-                        goto HeaderTranslate;
-                    case 37:
-                        goto HeaderUserAgent;
-                    case 38:
-                        goto HeaderUpgradeInsecureRequests;
-                    case 39:
-                        goto HeaderRequestId;
-                    case 40:
-                        goto HeaderCorrelationContext;
-                    case 41:
-                        goto HeaderTraceParent;
-                    case 42:
-                        goto HeaderTraceState;
-                    case 43:
-                        goto HeaderBaggage;
-                    case 44:
                         goto HeaderOrigin;
+                    case 33:
+                        goto HeaderPragma;
+                    case 34:
+                        goto HeaderProxyAuthorization;
+                    case 35:
+                        goto HeaderRange;
+                    case 36:
+                        goto HeaderReferer;
+                    case 37:
+                        goto HeaderRequestId;
+                    case 38:
+                        goto HeaderTE;
+                    case 39:
+                        goto HeaderTraceParent;
+                    case 40:
+                        goto HeaderTraceState;
+                    case 41:
+                        goto HeaderTransferEncoding;
+                    case 42:
+                        goto HeaderTranslate;
+                    case 43:
+                        goto HeaderUpgrade;
+                    case 44:
+                        goto HeaderUpgradeInsecureRequests;
                     case 45:
-                        goto HeaderAccessControlRequestMethod;
+                        goto HeaderVia;
                     case 46:
-                        goto HeaderAccessControlRequestHeaders;
+                        goto HeaderWarning;
                     case 47:
                         goto HeaderContentLength;
                     default:
                         goto ExtraHeaders;
                 }
                 
-                HeaderCacheControl: // case 0
+                HeaderAccept: // case 0
                     if ((_bits & 0x1L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.CacheControl, _collection._headers._CacheControl);
-                        _currentKnownType = KnownHeaderType.CacheControl;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Accept, _collection._headers._Accept);
+                        _currentKnownType = KnownHeaderType.Accept;
                         _next = 1;
                         return true;
                     }
@@ -7862,179 +7862,179 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _next = 2;
                         return true;
                     }
-                HeaderDate: // case 2
+                HeaderHost: // case 2
                     if ((_bits & 0x4L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Date, _collection._headers._Date);
-                        _currentKnownType = KnownHeaderType.Date;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Host, _collection._headers._Host);
+                        _currentKnownType = KnownHeaderType.Host;
                         _next = 3;
                         return true;
                     }
-                HeaderGrpcEncoding: // case 3
+                HeaderUserAgent: // case 3
                     if ((_bits & 0x8L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.GrpcEncoding, _collection._headers._GrpcEncoding);
-                        _currentKnownType = KnownHeaderType.GrpcEncoding;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.UserAgent, _collection._headers._UserAgent);
+                        _currentKnownType = KnownHeaderType.UserAgent;
                         _next = 4;
                         return true;
                     }
-                HeaderKeepAlive: // case 4
+                HeaderAuthority: // case 4
                     if ((_bits & 0x10L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.KeepAlive, _collection._headers._KeepAlive);
-                        _currentKnownType = KnownHeaderType.KeepAlive;
-                        _next = 5;
-                        return true;
-                    }
-                HeaderPragma: // case 5
-                    if ((_bits & 0x20L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Pragma, _collection._headers._Pragma);
-                        _currentKnownType = KnownHeaderType.Pragma;
-                        _next = 6;
-                        return true;
-                    }
-                HeaderTransferEncoding: // case 6
-                    if ((_bits & 0x40L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _collection._headers._TransferEncoding);
-                        _currentKnownType = KnownHeaderType.TransferEncoding;
-                        _next = 7;
-                        return true;
-                    }
-                HeaderUpgrade: // case 7
-                    if ((_bits & 0x80L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _collection._headers._Upgrade);
-                        _currentKnownType = KnownHeaderType.Upgrade;
-                        _next = 8;
-                        return true;
-                    }
-                HeaderVia: // case 8
-                    if ((_bits & 0x100L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Via, _collection._headers._Via);
-                        _currentKnownType = KnownHeaderType.Via;
-                        _next = 9;
-                        return true;
-                    }
-                HeaderWarning: // case 9
-                    if ((_bits & 0x200L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _collection._headers._Warning);
-                        _currentKnownType = KnownHeaderType.Warning;
-                        _next = 10;
-                        return true;
-                    }
-                HeaderContentType: // case 10
-                    if ((_bits & 0x400L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _collection._headers._ContentType);
-                        _currentKnownType = KnownHeaderType.ContentType;
-                        _next = 11;
-                        return true;
-                    }
-                HeaderAuthority: // case 11
-                    if ((_bits & 0x800L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Authority, _collection._headers._Authority);
                         _currentKnownType = KnownHeaderType.Authority;
-                        _next = 12;
+                        _next = 5;
                         return true;
                     }
-                HeaderMethod: // case 12
-                    if ((_bits & 0x1000L) != 0)
+                HeaderMethod: // case 5
+                    if ((_bits & 0x20L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Method, _collection._headers._Method);
                         _currentKnownType = KnownHeaderType.Method;
-                        _next = 13;
+                        _next = 6;
                         return true;
                     }
-                HeaderPath: // case 13
-                    if ((_bits & 0x2000L) != 0)
+                HeaderPath: // case 6
+                    if ((_bits & 0x40L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Path, _collection._headers._Path);
                         _currentKnownType = KnownHeaderType.Path;
-                        _next = 14;
+                        _next = 7;
                         return true;
                     }
-                HeaderScheme: // case 14
-                    if ((_bits & 0x4000L) != 0)
+                HeaderScheme: // case 7
+                    if ((_bits & 0x80L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Scheme, _collection._headers._Scheme);
                         _currentKnownType = KnownHeaderType.Scheme;
-                        _next = 15;
+                        _next = 8;
                         return true;
                     }
-                HeaderAccept: // case 15
-                    if ((_bits & 0x8000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Accept, _collection._headers._Accept);
-                        _currentKnownType = KnownHeaderType.Accept;
-                        _next = 16;
-                        return true;
-                    }
-                HeaderAcceptCharset: // case 16
-                    if ((_bits & 0x10000L) != 0)
+                HeaderAcceptCharset: // case 8
+                    if ((_bits & 0x100L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptCharset, _collection._headers._AcceptCharset);
                         _currentKnownType = KnownHeaderType.AcceptCharset;
-                        _next = 17;
+                        _next = 9;
                         return true;
                     }
-                HeaderAcceptEncoding: // case 17
-                    if ((_bits & 0x20000L) != 0)
+                HeaderAcceptEncoding: // case 9
+                    if ((_bits & 0x200L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptEncoding, _collection._headers._AcceptEncoding);
                         _currentKnownType = KnownHeaderType.AcceptEncoding;
-                        _next = 18;
+                        _next = 10;
                         return true;
                     }
-                HeaderAcceptLanguage: // case 18
-                    if ((_bits & 0x40000L) != 0)
+                HeaderAcceptLanguage: // case 10
+                    if ((_bits & 0x400L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptLanguage, _collection._headers._AcceptLanguage);
                         _currentKnownType = KnownHeaderType.AcceptLanguage;
-                        _next = 19;
+                        _next = 11;
                         return true;
                     }
-                HeaderAuthorization: // case 19
-                    if ((_bits & 0x80000L) != 0)
+                HeaderAccessControlRequestHeaders: // case 11
+                    if ((_bits & 0x800L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestHeaders, _collection._headers._AccessControlRequestHeaders);
+                        _currentKnownType = KnownHeaderType.AccessControlRequestHeaders;
+                        _next = 12;
+                        return true;
+                    }
+                HeaderAccessControlRequestMethod: // case 12
+                    if ((_bits & 0x1000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestMethod, _collection._headers._AccessControlRequestMethod);
+                        _currentKnownType = KnownHeaderType.AccessControlRequestMethod;
+                        _next = 13;
+                        return true;
+                    }
+                HeaderAuthorization: // case 13
+                    if ((_bits & 0x2000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Authorization, _collection._headers._Authorization);
                         _currentKnownType = KnownHeaderType.Authorization;
-                        _next = 20;
+                        _next = 14;
                         return true;
                     }
-                HeaderCookie: // case 20
-                    if ((_bits & 0x100000L) != 0)
+                HeaderBaggage: // case 14
+                    if ((_bits & 0x4000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _collection._headers._Baggage);
+                        _currentKnownType = KnownHeaderType.Baggage;
+                        _next = 15;
+                        return true;
+                    }
+                HeaderCacheControl: // case 15
+                    if ((_bits & 0x8000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.CacheControl, _collection._headers._CacheControl);
+                        _currentKnownType = KnownHeaderType.CacheControl;
+                        _next = 16;
+                        return true;
+                    }
+                HeaderContentType: // case 16
+                    if ((_bits & 0x10000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _collection._headers._ContentType);
+                        _currentKnownType = KnownHeaderType.ContentType;
+                        _next = 17;
+                        return true;
+                    }
+                HeaderCookie: // case 17
+                    if ((_bits & 0x20000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Cookie, _collection._headers._Cookie);
                         _currentKnownType = KnownHeaderType.Cookie;
-                        _next = 21;
+                        _next = 18;
                         return true;
                     }
-                HeaderExpect: // case 21
-                    if ((_bits & 0x200000L) != 0)
+                HeaderCorrelationContext: // case 18
+                    if ((_bits & 0x40000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _collection._headers._CorrelationContext);
+                        _currentKnownType = KnownHeaderType.CorrelationContext;
+                        _next = 19;
+                        return true;
+                    }
+                HeaderDate: // case 19
+                    if ((_bits & 0x80000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Date, _collection._headers._Date);
+                        _currentKnownType = KnownHeaderType.Date;
+                        _next = 20;
+                        return true;
+                    }
+                HeaderExpect: // case 20
+                    if ((_bits & 0x100000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Expect, _collection._headers._Expect);
                         _currentKnownType = KnownHeaderType.Expect;
-                        _next = 22;
+                        _next = 21;
                         return true;
                     }
-                HeaderFrom: // case 22
-                    if ((_bits & 0x400000L) != 0)
+                HeaderFrom: // case 21
+                    if ((_bits & 0x200000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.From, _collection._headers._From);
                         _currentKnownType = KnownHeaderType.From;
-                        _next = 23;
+                        _next = 22;
                         return true;
                     }
-                HeaderGrpcAcceptEncoding: // case 23
-                    if ((_bits & 0x800000L) != 0)
+                HeaderGrpcAcceptEncoding: // case 22
+                    if ((_bits & 0x400000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.GrpcAcceptEncoding, _collection._headers._GrpcAcceptEncoding);
                         _currentKnownType = KnownHeaderType.GrpcAcceptEncoding;
+                        _next = 23;
+                        return true;
+                    }
+                HeaderGrpcEncoding: // case 23
+                    if ((_bits & 0x800000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.GrpcEncoding, _collection._headers._GrpcEncoding);
+                        _currentKnownType = KnownHeaderType.GrpcEncoding;
                         _next = 24;
                         return true;
                     }
@@ -8046,51 +8046,51 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _next = 25;
                         return true;
                     }
-                HeaderHost: // case 25
+                HeaderIfMatch: // case 25
                     if ((_bits & 0x2000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Host, _collection._headers._Host);
-                        _currentKnownType = KnownHeaderType.Host;
-                        _next = 26;
-                        return true;
-                    }
-                HeaderIfMatch: // case 26
-                    if ((_bits & 0x4000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfMatch, _collection._headers._IfMatch);
                         _currentKnownType = KnownHeaderType.IfMatch;
-                        _next = 27;
+                        _next = 26;
                         return true;
                     }
-                HeaderIfModifiedSince: // case 27
-                    if ((_bits & 0x8000000L) != 0)
+                HeaderIfModifiedSince: // case 26
+                    if ((_bits & 0x4000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfModifiedSince, _collection._headers._IfModifiedSince);
                         _currentKnownType = KnownHeaderType.IfModifiedSince;
-                        _next = 28;
+                        _next = 27;
                         return true;
                     }
-                HeaderIfNoneMatch: // case 28
-                    if ((_bits & 0x10000000L) != 0)
+                HeaderIfNoneMatch: // case 27
+                    if ((_bits & 0x8000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfNoneMatch, _collection._headers._IfNoneMatch);
                         _currentKnownType = KnownHeaderType.IfNoneMatch;
-                        _next = 29;
+                        _next = 28;
                         return true;
                     }
-                HeaderIfRange: // case 29
-                    if ((_bits & 0x20000000L) != 0)
+                HeaderIfRange: // case 28
+                    if ((_bits & 0x10000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfRange, _collection._headers._IfRange);
                         _currentKnownType = KnownHeaderType.IfRange;
-                        _next = 30;
+                        _next = 29;
                         return true;
                     }
-                HeaderIfUnmodifiedSince: // case 30
-                    if ((_bits & 0x40000000L) != 0)
+                HeaderIfUnmodifiedSince: // case 29
+                    if ((_bits & 0x20000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.IfUnmodifiedSince, _collection._headers._IfUnmodifiedSince);
                         _currentKnownType = KnownHeaderType.IfUnmodifiedSince;
+                        _next = 30;
+                        return true;
+                    }
+                HeaderKeepAlive: // case 30
+                    if ((_bits & 0x40000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.KeepAlive, _collection._headers._KeepAlive);
+                        _currentKnownType = KnownHeaderType.KeepAlive;
                         _next = 31;
                         return true;
                     }
@@ -8102,123 +8102,123 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _next = 32;
                         return true;
                     }
-                HeaderProxyAuthorization: // case 32
+                HeaderOrigin: // case 32
                     if ((_bits & 0x100000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthorization, _collection._headers._ProxyAuthorization);
-                        _currentKnownType = KnownHeaderType.ProxyAuthorization;
-                        _next = 33;
-                        return true;
-                    }
-                HeaderReferer: // case 33
-                    if ((_bits & 0x200000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Referer, _collection._headers._Referer);
-                        _currentKnownType = KnownHeaderType.Referer;
-                        _next = 34;
-                        return true;
-                    }
-                HeaderRange: // case 34
-                    if ((_bits & 0x400000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Range, _collection._headers._Range);
-                        _currentKnownType = KnownHeaderType.Range;
-                        _next = 35;
-                        return true;
-                    }
-                HeaderTE: // case 35
-                    if ((_bits & 0x800000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TE, _collection._headers._TE);
-                        _currentKnownType = KnownHeaderType.TE;
-                        _next = 36;
-                        return true;
-                    }
-                HeaderTranslate: // case 36
-                    if ((_bits & 0x1000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Translate, _collection._headers._Translate);
-                        _currentKnownType = KnownHeaderType.Translate;
-                        _next = 37;
-                        return true;
-                    }
-                HeaderUserAgent: // case 37
-                    if ((_bits & 0x2000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.UserAgent, _collection._headers._UserAgent);
-                        _currentKnownType = KnownHeaderType.UserAgent;
-                        _next = 38;
-                        return true;
-                    }
-                HeaderUpgradeInsecureRequests: // case 38
-                    if ((_bits & 0x4000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _collection._headers._UpgradeInsecureRequests);
-                        _currentKnownType = KnownHeaderType.UpgradeInsecureRequests;
-                        _next = 39;
-                        return true;
-                    }
-                HeaderRequestId: // case 39
-                    if ((_bits & 0x8000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _collection._headers._RequestId);
-                        _currentKnownType = KnownHeaderType.RequestId;
-                        _next = 40;
-                        return true;
-                    }
-                HeaderCorrelationContext: // case 40
-                    if ((_bits & 0x10000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.CorrelationContext, _collection._headers._CorrelationContext);
-                        _currentKnownType = KnownHeaderType.CorrelationContext;
-                        _next = 41;
-                        return true;
-                    }
-                HeaderTraceParent: // case 41
-                    if ((_bits & 0x20000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _collection._headers._TraceParent);
-                        _currentKnownType = KnownHeaderType.TraceParent;
-                        _next = 42;
-                        return true;
-                    }
-                HeaderTraceState: // case 42
-                    if ((_bits & 0x40000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _collection._headers._TraceState);
-                        _currentKnownType = KnownHeaderType.TraceState;
-                        _next = 43;
-                        return true;
-                    }
-                HeaderBaggage: // case 43
-                    if ((_bits & 0x80000000000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Baggage, _collection._headers._Baggage);
-                        _currentKnownType = KnownHeaderType.Baggage;
-                        _next = 44;
-                        return true;
-                    }
-                HeaderOrigin: // case 44
-                    if ((_bits & 0x100000000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Origin, _collection._headers._Origin);
                         _currentKnownType = KnownHeaderType.Origin;
+                        _next = 33;
+                        return true;
+                    }
+                HeaderPragma: // case 33
+                    if ((_bits & 0x200000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Pragma, _collection._headers._Pragma);
+                        _currentKnownType = KnownHeaderType.Pragma;
+                        _next = 34;
+                        return true;
+                    }
+                HeaderProxyAuthorization: // case 34
+                    if ((_bits & 0x400000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthorization, _collection._headers._ProxyAuthorization);
+                        _currentKnownType = KnownHeaderType.ProxyAuthorization;
+                        _next = 35;
+                        return true;
+                    }
+                HeaderRange: // case 35
+                    if ((_bits & 0x800000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Range, _collection._headers._Range);
+                        _currentKnownType = KnownHeaderType.Range;
+                        _next = 36;
+                        return true;
+                    }
+                HeaderReferer: // case 36
+                    if ((_bits & 0x1000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Referer, _collection._headers._Referer);
+                        _currentKnownType = KnownHeaderType.Referer;
+                        _next = 37;
+                        return true;
+                    }
+                HeaderRequestId: // case 37
+                    if ((_bits & 0x2000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.RequestId, _collection._headers._RequestId);
+                        _currentKnownType = KnownHeaderType.RequestId;
+                        _next = 38;
+                        return true;
+                    }
+                HeaderTE: // case 38
+                    if ((_bits & 0x4000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TE, _collection._headers._TE);
+                        _currentKnownType = KnownHeaderType.TE;
+                        _next = 39;
+                        return true;
+                    }
+                HeaderTraceParent: // case 39
+                    if ((_bits & 0x8000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TraceParent, _collection._headers._TraceParent);
+                        _currentKnownType = KnownHeaderType.TraceParent;
+                        _next = 40;
+                        return true;
+                    }
+                HeaderTraceState: // case 40
+                    if ((_bits & 0x10000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TraceState, _collection._headers._TraceState);
+                        _currentKnownType = KnownHeaderType.TraceState;
+                        _next = 41;
+                        return true;
+                    }
+                HeaderTransferEncoding: // case 41
+                    if ((_bits & 0x20000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _collection._headers._TransferEncoding);
+                        _currentKnownType = KnownHeaderType.TransferEncoding;
+                        _next = 42;
+                        return true;
+                    }
+                HeaderTranslate: // case 42
+                    if ((_bits & 0x40000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Translate, _collection._headers._Translate);
+                        _currentKnownType = KnownHeaderType.Translate;
+                        _next = 43;
+                        return true;
+                    }
+                HeaderUpgrade: // case 43
+                    if ((_bits & 0x80000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _collection._headers._Upgrade);
+                        _currentKnownType = KnownHeaderType.Upgrade;
+                        _next = 44;
+                        return true;
+                    }
+                HeaderUpgradeInsecureRequests: // case 44
+                    if ((_bits & 0x100000000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.UpgradeInsecureRequests, _collection._headers._UpgradeInsecureRequests);
+                        _currentKnownType = KnownHeaderType.UpgradeInsecureRequests;
                         _next = 45;
                         return true;
                     }
-                HeaderAccessControlRequestMethod: // case 45
+                HeaderVia: // case 45
                     if ((_bits & 0x200000000000L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestMethod, _collection._headers._AccessControlRequestMethod);
-                        _currentKnownType = KnownHeaderType.AccessControlRequestMethod;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Via, _collection._headers._Via);
+                        _currentKnownType = KnownHeaderType.Via;
                         _next = 46;
                         return true;
                     }
-                HeaderAccessControlRequestHeaders: // case 46
+                HeaderWarning: // case 46
                     if ((_bits & 0x400000000000L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlRequestHeaders, _collection._headers._AccessControlRequestHeaders);
-                        _currentKnownType = KnownHeaderType.AccessControlRequestHeaders;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _collection._headers._Warning);
+                        _currentKnownType = KnownHeaderType.Warning;
                         _next = 47;
                         return true;
                     }
@@ -8248,14 +8248,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     {
         private static ReadOnlySpan<byte> HeaderBytes => new byte[]
         {
-            13,10,67,97,99,104,101,45,67,111,110,116,114,111,108,58,32,13,10,67,111,110,110,101,99,116,105,111,110,58,32,13,10,68,97,116,101,58,32,13,10,71,114,112,99,45,69,110,99,111,100,105,110,103,58,32,13,10,75,101,101,112,45,65,108,105,118,101,58,32,13,10,80,114,97,103,109,97,58,32,13,10,84,114,97,110,115,102,101,114,45,69,110,99,111,100,105,110,103,58,32,13,10,85,112,103,114,97,100,101,58,32,13,10,86,105,97,58,32,13,10,87,97,114,110,105,110,103,58,32,13,10,67,111,110,116,101,110,116,45,84,121,112,101,58,32,13,10,65,99,99,101,112,116,45,82,97,110,103,101,115,58,32,13,10,65,103,101,58,32,13,10,65,108,108,111,119,58,32,13,10,65,108,116,45,83,118,99,58,32,13,10,69,84,97,103,58,32,13,10,76,111,99,97,116,105,111,110,58,32,13,10,80,114,111,120,121,45,65,117,116,104,101,110,116,105,99,97,116,101,58,32,13,10,80,114,111,120,121,45,67,111,110,110,101,99,116,105,111,110,58,32,13,10,82,101,116,114,121,45,65,102,116,101,114,58,32,13,10,83,101,114,118,101,114,58,32,13,10,83,101,116,45,67,111,111,107,105,101,58,32,13,10,86,97,114,121,58,32,13,10,69,120,112,105,114,101,115,58,32,13,10,87,87,87,45,65,117,116,104,101,110,116,105,99,97,116,101,58,32,13,10,67,111,110,116,101,110,116,45,82,97,110,103,101,58,32,13,10,67,111,110,116,101,110,116,45,69,110,99,111,100,105,110,103,58,32,13,10,67,111,110,116,101,110,116,45,76,97,110,103,117,97,103,101,58,32,13,10,67,111,110,116,101,110,116,45,76,111,99,97,116,105,111,110,58,32,13,10,67,111,110,116,101,110,116,45,77,68,53,58,32,13,10,76,97,115,116,45,77,111,100,105,102,105,101,100,58,32,13,10,84,114,97,105,108,101,114,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,67,114,101,100,101,110,116,105,97,108,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,72,101,97,100,101,114,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,77,101,116,104,111,100,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,79,114,105,103,105,110,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,69,120,112,111,115,101,45,72,101,97,100,101,114,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,77,97,120,45,65,103,101,58,32,13,10,67,111,110,116,101,110,116,45,76,101,110,103,116,104,58,32,
+            13,10,67,111,110,110,101,99,116,105,111,110,58,32,13,10,67,111,110,116,101,110,116,45,84,121,112,101,58,32,13,10,68,97,116,101,58,32,13,10,83,101,114,118,101,114,58,32,13,10,65,99,99,101,112,116,45,82,97,110,103,101,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,67,114,101,100,101,110,116,105,97,108,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,72,101,97,100,101,114,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,77,101,116,104,111,100,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,65,108,108,111,119,45,79,114,105,103,105,110,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,69,120,112,111,115,101,45,72,101,97,100,101,114,115,58,32,13,10,65,99,99,101,115,115,45,67,111,110,116,114,111,108,45,77,97,120,45,65,103,101,58,32,13,10,65,103,101,58,32,13,10,65,108,108,111,119,58,32,13,10,65,108,116,45,83,118,99,58,32,13,10,67,97,99,104,101,45,67,111,110,116,114,111,108,58,32,13,10,67,111,110,116,101,110,116,45,69,110,99,111,100,105,110,103,58,32,13,10,67,111,110,116,101,110,116,45,76,97,110,103,117,97,103,101,58,32,13,10,67,111,110,116,101,110,116,45,76,111,99,97,116,105,111,110,58,32,13,10,67,111,110,116,101,110,116,45,77,68,53,58,32,13,10,67,111,110,116,101,110,116,45,82,97,110,103,101,58,32,13,10,69,84,97,103,58,32,13,10,69,120,112,105,114,101,115,58,32,13,10,71,114,112,99,45,69,110,99,111,100,105,110,103,58,32,13,10,75,101,101,112,45,65,108,105,118,101,58,32,13,10,76,97,115,116,45,77,111,100,105,102,105,101,100,58,32,13,10,76,111,99,97,116,105,111,110,58,32,13,10,80,114,97,103,109,97,58,32,13,10,80,114,111,120,121,45,65,117,116,104,101,110,116,105,99,97,116,101,58,32,13,10,80,114,111,120,121,45,67,111,110,110,101,99,116,105,111,110,58,32,13,10,82,101,116,114,121,45,65,102,116,101,114,58,32,13,10,83,101,116,45,67,111,111,107,105,101,58,32,13,10,84,114,97,105,108,101,114,58,32,13,10,84,114,97,110,115,102,101,114,45,69,110,99,111,100,105,110,103,58,32,13,10,85,112,103,114,97,100,101,58,32,13,10,86,97,114,121,58,32,13,10,86,105,97,58,32,13,10,87,97,114,110,105,110,103,58,32,13,10,87,87,87,45,65,117,116,104,101,110,116,105,99,97,116,101,58,32,13,10,67,111,110,116,101,110,116,45,76,101,110,103,116,104,58,32,
         };
         private HeaderReferences _headers;
 
-        public bool HasConnection => (_bits & 0x2L) != 0;
+        public bool HasConnection => (_bits & 0x1L) != 0;
         public bool HasDate => (_bits & 0x4L) != 0;
-        public bool HasTransferEncoding => (_bits & 0x40L) != 0;
-        public bool HasServer => (_bits & 0x100000L) != 0;
+        public bool HasServer => (_bits & 0x8L) != 0;
+        public bool HasTransferEncoding => (_bits & 0x100000000L) != 0;
 
 
         public override StringValues HeaderConnection
@@ -8263,7 +8263,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x2L) != 0)
+                if ((_bits & 0x1L) != 0)
                 {
                     value = _headers._Connection;
                 }
@@ -8271,27 +8271,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x2L;
+                _bits |= 0x1L;
                 _headers._Connection = value; 
                 _headers._rawConnection = null;
-            }
-        }
-        public StringValues HeaderTransferEncoding
-        {
-            get
-            {
-                StringValues value = default;
-                if ((_bits & 0x40L) != 0)
-                {
-                    value = _headers._TransferEncoding;
-                }
-                return value;
-            }
-            set
-            {
-                _bits |= 0x40L;
-                _headers._TransferEncoding = value; 
-                _headers._rawTransferEncoding = null;
             }
         }
         public StringValues HeaderAllow
@@ -8299,7 +8281,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x2000L) != 0)
+                if ((_bits & 0x1000L) != 0)
                 {
                     value = _headers._Allow;
                 }
@@ -8307,7 +8289,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x2000L;
+                _bits |= 0x1000L;
                 _headers._Allow = value; 
             }
         }
@@ -8316,7 +8298,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 StringValues value = default;
-                if ((_bits & 0x4000L) != 0)
+                if ((_bits & 0x2000L) != 0)
                 {
                     value = _headers._AltSvc;
                 }
@@ -8324,8 +8306,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x4000L;
+                _bits |= 0x2000L;
                 _headers._AltSvc = value; 
+            }
+        }
+        public StringValues HeaderTransferEncoding
+        {
+            get
+            {
+                StringValues value = default;
+                if ((_bits & 0x100000000L) != 0)
+                {
+                    value = _headers._TransferEncoding;
+                }
+                return value;
+            }
+            set
+            {
+                _bits |= 0x100000000L;
+                _headers._TransferEncoding = value; 
+                _headers._rawTransferEncoding = null;
             }
         }
         public StringValues HeaderContentLength
@@ -8345,11 +8345,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
         
-        StringValues IHeaderDictionary.CacheControl
+        StringValues IHeaderDictionary.Connection
         {
             get
             {
-                var value = _headers._CacheControl;
+                var value = _headers._Connection;
                 if ((_bits & 0x1L) != 0)
                 {
                     return value;
@@ -8364,20 +8364,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._CacheControl = value;
+                    _headers._Connection = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._CacheControl = default;
+                    _headers._Connection = default;
                 }
+                    _headers._rawConnection = null;
             }
         }
-        StringValues IHeaderDictionary.Connection
+        StringValues IHeaderDictionary.ContentType
         {
             get
             {
-                var value = _headers._Connection;
+                var value = _headers._ContentType;
                 if ((_bits & 0x2L) != 0)
                 {
                     return value;
@@ -8392,14 +8393,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Connection = value;
+                    _headers._ContentType = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Connection = default;
+                    _headers._ContentType = default;
                 }
-                    _headers._rawConnection = null;
             }
         }
         StringValues IHeaderDictionary.Date
@@ -8431,11 +8431,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     _headers._rawDate = null;
             }
         }
-        StringValues IHeaderDictionary.GrpcEncoding
+        StringValues IHeaderDictionary.Server
         {
             get
             {
-                var value = _headers._GrpcEncoding;
+                var value = _headers._Server;
                 if ((_bits & 0x8L) != 0)
                 {
                     return value;
@@ -8450,20 +8450,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._GrpcEncoding = value;
+                    _headers._Server = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._GrpcEncoding = default;
+                    _headers._Server = default;
                 }
+                    _headers._rawServer = null;
             }
         }
-        StringValues IHeaderDictionary.KeepAlive
+        StringValues IHeaderDictionary.AcceptRanges
         {
             get
             {
-                var value = _headers._KeepAlive;
+                var value = _headers._AcceptRanges;
                 if ((_bits & 0x10L) != 0)
                 {
                     return value;
@@ -8478,20 +8479,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._KeepAlive = value;
+                    _headers._AcceptRanges = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._KeepAlive = default;
+                    _headers._AcceptRanges = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Pragma
+        StringValues IHeaderDictionary.AccessControlAllowCredentials
         {
             get
             {
-                var value = _headers._Pragma;
+                var value = _headers._AccessControlAllowCredentials;
                 if ((_bits & 0x20L) != 0)
                 {
                     return value;
@@ -8506,20 +8507,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Pragma = value;
+                    _headers._AccessControlAllowCredentials = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Pragma = default;
+                    _headers._AccessControlAllowCredentials = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.TransferEncoding
+        StringValues IHeaderDictionary.AccessControlAllowHeaders
         {
             get
             {
-                var value = _headers._TransferEncoding;
+                var value = _headers._AccessControlAllowHeaders;
                 if ((_bits & 0x40L) != 0)
                 {
                     return value;
@@ -8534,21 +8535,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._TransferEncoding = value;
+                    _headers._AccessControlAllowHeaders = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._TransferEncoding = default;
+                    _headers._AccessControlAllowHeaders = default;
                 }
-                    _headers._rawTransferEncoding = null;
             }
         }
-        StringValues IHeaderDictionary.Upgrade
+        StringValues IHeaderDictionary.AccessControlAllowMethods
         {
             get
             {
-                var value = _headers._Upgrade;
+                var value = _headers._AccessControlAllowMethods;
                 if ((_bits & 0x80L) != 0)
                 {
                     return value;
@@ -8563,20 +8563,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Upgrade = value;
+                    _headers._AccessControlAllowMethods = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Upgrade = default;
+                    _headers._AccessControlAllowMethods = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Via
+        StringValues IHeaderDictionary.AccessControlAllowOrigin
         {
             get
             {
-                var value = _headers._Via;
+                var value = _headers._AccessControlAllowOrigin;
                 if ((_bits & 0x100L) != 0)
                 {
                     return value;
@@ -8591,20 +8591,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Via = value;
+                    _headers._AccessControlAllowOrigin = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Via = default;
+                    _headers._AccessControlAllowOrigin = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.Warning
+        StringValues IHeaderDictionary.AccessControlExposeHeaders
         {
             get
             {
-                var value = _headers._Warning;
+                var value = _headers._AccessControlExposeHeaders;
                 if ((_bits & 0x200L) != 0)
                 {
                     return value;
@@ -8619,20 +8619,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._Warning = value;
+                    _headers._AccessControlExposeHeaders = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._Warning = default;
+                    _headers._AccessControlExposeHeaders = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.ContentType
+        StringValues IHeaderDictionary.AccessControlMaxAge
         {
             get
             {
-                var value = _headers._ContentType;
+                var value = _headers._AccessControlMaxAge;
                 if ((_bits & 0x400L) != 0)
                 {
                     return value;
@@ -8647,20 +8647,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._ContentType = value;
+                    _headers._AccessControlMaxAge = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._ContentType = default;
+                    _headers._AccessControlMaxAge = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.AcceptRanges
+        StringValues IHeaderDictionary.Age
         {
             get
             {
-                var value = _headers._AcceptRanges;
+                var value = _headers._Age;
                 if ((_bits & 0x800L) != 0)
                 {
                     return value;
@@ -8672,34 +8672,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x800L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._AcceptRanges = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._AcceptRanges = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Age
-        {
-            get
-            {
-                var value = _headers._Age;
-                if ((_bits & 0x1000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x1000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -8717,7 +8689,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._Allow;
-                if ((_bits & 0x2000L) != 0)
+                if ((_bits & 0x1000L) != 0)
                 {
                     return value;
                 }
@@ -8727,7 +8699,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x2000L;
+                var flag = 0x1000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -8745,6 +8717,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._AltSvc;
+                if ((_bits & 0x2000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x2000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._AltSvc = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._AltSvc = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.CacheControl
+        {
+            get
+            {
+                var value = _headers._CacheControl;
                 if ((_bits & 0x4000L) != 0)
                 {
                     return value;
@@ -8759,20 +8759,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AltSvc = value;
+                    _headers._CacheControl = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AltSvc = default;
+                    _headers._CacheControl = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.ETag
+        StringValues IHeaderDictionary.ContentEncoding
         {
             get
             {
-                var value = _headers._ETag;
+                var value = _headers._ContentEncoding;
                 if ((_bits & 0x8000L) != 0)
                 {
                     return value;
@@ -8784,315 +8784,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
                 var flag = 0x8000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ETag = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ETag = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Location
-        {
-            get
-            {
-                var value = _headers._Location;
-                if ((_bits & 0x10000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x10000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Location = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Location = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ProxyAuthenticate
-        {
-            get
-            {
-                var value = _headers._ProxyAuthenticate;
-                if ((_bits & 0x20000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x20000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ProxyAuthenticate = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ProxyAuthenticate = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ProxyConnection
-        {
-            get
-            {
-                var value = _headers._ProxyConnection;
-                if ((_bits & 0x40000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x40000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ProxyConnection = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ProxyConnection = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.RetryAfter
-        {
-            get
-            {
-                var value = _headers._RetryAfter;
-                if ((_bits & 0x80000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x80000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._RetryAfter = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._RetryAfter = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Server
-        {
-            get
-            {
-                var value = _headers._Server;
-                if ((_bits & 0x100000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x100000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Server = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Server = default;
-                }
-                    _headers._rawServer = null;
-            }
-        }
-        StringValues IHeaderDictionary.SetCookie
-        {
-            get
-            {
-                var value = _headers._SetCookie;
-                if ((_bits & 0x200000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x200000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._SetCookie = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._SetCookie = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Vary
-        {
-            get
-            {
-                var value = _headers._Vary;
-                if ((_bits & 0x400000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x400000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Vary = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Vary = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.Expires
-        {
-            get
-            {
-                var value = _headers._Expires;
-                if ((_bits & 0x800000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x800000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._Expires = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._Expires = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.WWWAuthenticate
-        {
-            get
-            {
-                var value = _headers._WWWAuthenticate;
-                if ((_bits & 0x1000000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x1000000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._WWWAuthenticate = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._WWWAuthenticate = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentRange
-        {
-            get
-            {
-                var value = _headers._ContentRange;
-                if ((_bits & 0x2000000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x2000000L;
-                if (value.Count > 0)
-                {
-                    _bits |= flag;
-                    _headers._ContentRange = value;
-                }
-                else
-                {
-                    _bits &= ~flag;
-                    _headers._ContentRange = default;
-                }
-            }
-        }
-        StringValues IHeaderDictionary.ContentEncoding
-        {
-            get
-            {
-                var value = _headers._ContentEncoding;
-                if ((_bits & 0x4000000L) != 0)
-                {
-                    return value;
-                }
-                return default;
-            }
-            set
-            {
-                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
-
-                var flag = 0x4000000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -9110,7 +8801,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._ContentLanguage;
-                if ((_bits & 0x8000000L) != 0)
+                if ((_bits & 0x10000L) != 0)
                 {
                     return value;
                 }
@@ -9120,7 +8811,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x8000000L;
+                var flag = 0x10000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -9138,7 +8829,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._ContentLocation;
-                if ((_bits & 0x10000000L) != 0)
+                if ((_bits & 0x20000L) != 0)
                 {
                     return value;
                 }
@@ -9148,7 +8839,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
 
-                var flag = 0x10000000L;
+                var flag = 0x20000L;
                 if (value.Count > 0)
                 {
                     _bits |= flag;
@@ -9166,6 +8857,314 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             get
             {
                 var value = _headers._ContentMD5;
+                if ((_bits & 0x40000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x40000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ContentMD5 = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ContentMD5 = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ContentRange
+        {
+            get
+            {
+                var value = _headers._ContentRange;
+                if ((_bits & 0x80000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x80000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ContentRange = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ContentRange = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ETag
+        {
+            get
+            {
+                var value = _headers._ETag;
+                if ((_bits & 0x100000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x100000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ETag = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ETag = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.Expires
+        {
+            get
+            {
+                var value = _headers._Expires;
+                if ((_bits & 0x200000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x200000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Expires = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Expires = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.GrpcEncoding
+        {
+            get
+            {
+                var value = _headers._GrpcEncoding;
+                if ((_bits & 0x400000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x400000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._GrpcEncoding = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._GrpcEncoding = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.KeepAlive
+        {
+            get
+            {
+                var value = _headers._KeepAlive;
+                if ((_bits & 0x800000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x800000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._KeepAlive = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._KeepAlive = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.LastModified
+        {
+            get
+            {
+                var value = _headers._LastModified;
+                if ((_bits & 0x1000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x1000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._LastModified = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._LastModified = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.Location
+        {
+            get
+            {
+                var value = _headers._Location;
+                if ((_bits & 0x2000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x2000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Location = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Location = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.Pragma
+        {
+            get
+            {
+                var value = _headers._Pragma;
+                if ((_bits & 0x4000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x4000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._Pragma = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._Pragma = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ProxyAuthenticate
+        {
+            get
+            {
+                var value = _headers._ProxyAuthenticate;
+                if ((_bits & 0x8000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x8000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ProxyAuthenticate = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ProxyAuthenticate = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.ProxyConnection
+        {
+            get
+            {
+                var value = _headers._ProxyConnection;
+                if ((_bits & 0x10000000L) != 0)
+                {
+                    return value;
+                }
+                return default;
+            }
+            set
+            {
+                if (_isReadOnly) { ThrowHeadersReadOnlyException(); }
+
+                var flag = 0x10000000L;
+                if (value.Count > 0)
+                {
+                    _bits |= flag;
+                    _headers._ProxyConnection = value;
+                }
+                else
+                {
+                    _bits &= ~flag;
+                    _headers._ProxyConnection = default;
+                }
+            }
+        }
+        StringValues IHeaderDictionary.RetryAfter
+        {
+            get
+            {
+                var value = _headers._RetryAfter;
                 if ((_bits & 0x20000000L) != 0)
                 {
                     return value;
@@ -9180,20 +9179,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._ContentMD5 = value;
+                    _headers._RetryAfter = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._ContentMD5 = default;
+                    _headers._RetryAfter = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.LastModified
+        StringValues IHeaderDictionary.SetCookie
         {
             get
             {
-                var value = _headers._LastModified;
+                var value = _headers._SetCookie;
                 if ((_bits & 0x40000000L) != 0)
                 {
                     return value;
@@ -9208,12 +9207,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._LastModified = value;
+                    _headers._SetCookie = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._LastModified = default;
+                    _headers._SetCookie = default;
                 }
             }
         }
@@ -9245,11 +9244,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
         }
-        StringValues IHeaderDictionary.AccessControlAllowCredentials
+        StringValues IHeaderDictionary.TransferEncoding
         {
             get
             {
-                var value = _headers._AccessControlAllowCredentials;
+                var value = _headers._TransferEncoding;
                 if ((_bits & 0x100000000L) != 0)
                 {
                     return value;
@@ -9264,20 +9263,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AccessControlAllowCredentials = value;
+                    _headers._TransferEncoding = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AccessControlAllowCredentials = default;
+                    _headers._TransferEncoding = default;
                 }
+                    _headers._rawTransferEncoding = null;
             }
         }
-        StringValues IHeaderDictionary.AccessControlAllowHeaders
+        StringValues IHeaderDictionary.Upgrade
         {
             get
             {
-                var value = _headers._AccessControlAllowHeaders;
+                var value = _headers._Upgrade;
                 if ((_bits & 0x200000000L) != 0)
                 {
                     return value;
@@ -9292,20 +9292,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AccessControlAllowHeaders = value;
+                    _headers._Upgrade = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AccessControlAllowHeaders = default;
+                    _headers._Upgrade = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.AccessControlAllowMethods
+        StringValues IHeaderDictionary.Vary
         {
             get
             {
-                var value = _headers._AccessControlAllowMethods;
+                var value = _headers._Vary;
                 if ((_bits & 0x400000000L) != 0)
                 {
                     return value;
@@ -9320,20 +9320,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AccessControlAllowMethods = value;
+                    _headers._Vary = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AccessControlAllowMethods = default;
+                    _headers._Vary = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.AccessControlAllowOrigin
+        StringValues IHeaderDictionary.Via
         {
             get
             {
-                var value = _headers._AccessControlAllowOrigin;
+                var value = _headers._Via;
                 if ((_bits & 0x800000000L) != 0)
                 {
                     return value;
@@ -9348,20 +9348,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AccessControlAllowOrigin = value;
+                    _headers._Via = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AccessControlAllowOrigin = default;
+                    _headers._Via = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.AccessControlExposeHeaders
+        StringValues IHeaderDictionary.Warning
         {
             get
             {
-                var value = _headers._AccessControlExposeHeaders;
+                var value = _headers._Warning;
                 if ((_bits & 0x1000000000L) != 0)
                 {
                     return value;
@@ -9376,20 +9376,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AccessControlExposeHeaders = value;
+                    _headers._Warning = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AccessControlExposeHeaders = default;
+                    _headers._Warning = default;
                 }
             }
         }
-        StringValues IHeaderDictionary.AccessControlMaxAge
+        StringValues IHeaderDictionary.WWWAuthenticate
         {
             get
             {
-                var value = _headers._AccessControlMaxAge;
+                var value = _headers._WWWAuthenticate;
                 if ((_bits & 0x2000000000L) != 0)
                 {
                     return value;
@@ -9404,12 +9404,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (value.Count > 0)
                 {
                     _bits |= flag;
-                    _headers._AccessControlMaxAge = value;
+                    _headers._WWWAuthenticate = value;
                 }
                 else
                 {
                     _bits &= ~flag;
-                    _headers._AccessControlMaxAge = default;
+                    _headers._WWWAuthenticate = default;
                 }
             }
         }
@@ -10317,7 +10317,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public void SetRawConnection(StringValues value, byte[] raw)
         {
-            _bits |= 0x2L;
+            _bits |= 0x1L;
             _headers._Connection = value;
             _headers._rawConnection = raw;
         }
@@ -10327,17 +10327,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _headers._Date = value;
             _headers._rawDate = raw;
         }
-        public void SetRawTransferEncoding(StringValues value, byte[] raw)
-        {
-            _bits |= 0x40L;
-            _headers._TransferEncoding = value;
-            _headers._rawTransferEncoding = raw;
-        }
         public void SetRawServer(StringValues value, byte[] raw)
         {
-            _bits |= 0x100000L;
+            _bits |= 0x8L;
             _headers._Server = value;
             _headers._rawServer = raw;
+        }
+        public void SetRawTransferEncoding(StringValues value, byte[] raw)
+        {
+            _bits |= 0x100000000L;
+            _headers._TransferEncoding = value;
+            _headers._rawTransferEncoding = raw;
         }
         protected override int GetCountFast()
         {
@@ -10351,39 +10351,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 case 3:
                 {
-                    if (ReferenceEquals(HeaderNames.Via, key))
+                    if (ReferenceEquals(HeaderNames.Age, key))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
-                            value = _headers._Via;
+                            value = _headers._Age;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Age, key))
+                    if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
-                            value = _headers._Age;
+                            value = _headers._Via;
                             return true;
                         }
                         return false;
                     }
 
-                    if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
-                            value = _headers._Via;
+                            value = _headers._Age;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
-                            value = _headers._Age;
+                            value = _headers._Via;
                             return true;
                         }
                         return false;
@@ -10403,7 +10403,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ETag, key))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
                             value = _headers._ETag;
                             return true;
@@ -10412,7 +10412,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Vary, key))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
                             value = _headers._Vary;
                             return true;
@@ -10431,7 +10431,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ETag.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
                             value = _headers._ETag;
                             return true;
@@ -10440,7 +10440,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Vary.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
                             value = _headers._Vary;
                             return true;
@@ -10453,7 +10453,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
                             value = _headers._Allow;
                             return true;
@@ -10463,7 +10463,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
                             value = _headers._Allow;
                             return true;
@@ -10476,7 +10476,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Server, key))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x8L) != 0)
                         {
                             value = _headers._Server;
                             return true;
@@ -10485,7 +10485,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Pragma, key))
                     {
-                        if ((_bits & 0x20L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
                             value = _headers._Pragma;
                             return true;
@@ -10495,7 +10495,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Server.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x8L) != 0)
                         {
                             value = _headers._Server;
                             return true;
@@ -10504,7 +10504,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
                             value = _headers._Pragma;
                             return true;
@@ -10515,27 +10515,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Upgrade, key))
-                    {
-                        if ((_bits & 0x80L) != 0)
-                        {
-                            value = _headers._Upgrade;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Warning, key))
-                    {
-                        if ((_bits & 0x200L) != 0)
-                        {
-                            value = _headers._Warning;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.AltSvc, key))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
                             value = _headers._AltSvc;
                             return true;
@@ -10544,7 +10526,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expires, key))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
                             value = _headers._Expires;
                             return true;
@@ -10560,28 +10542,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-
-                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x200000000L) != 0)
                         {
                             value = _headers._Upgrade;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
                         {
                             value = _headers._Warning;
                             return true;
                         }
                         return false;
                     }
+
                     if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
                             value = _headers._AltSvc;
                             return true;
@@ -10590,7 +10572,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
                             value = _headers._Expires;
                             return true;
@@ -10606,13 +10588,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000000L) != 0)
+                        {
+                            value = _headers._Upgrade;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x1000000000L) != 0)
+                        {
+                            value = _headers._Warning;
+                            return true;
+                        }
+                        return false;
+                    }
                     break;
                 }
                 case 8:
                 {
                     if (ReferenceEquals(HeaderNames.Location, key))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
                             value = _headers._Location;
                             return true;
@@ -10622,7 +10622,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Location.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
                             value = _headers._Location;
                             return true;
@@ -10635,7 +10635,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Connection, key))
                     {
-                        if ((_bits & 0x2L) != 0)
+                        if ((_bits & 0x1L) != 0)
                         {
                             value = _headers._Connection;
                             return true;
@@ -10644,7 +10644,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.KeepAlive, key))
                     {
-                        if ((_bits & 0x10L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
                             value = _headers._KeepAlive;
                             return true;
@@ -10653,7 +10653,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.SetCookie, key))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
                             value = _headers._SetCookie;
                             return true;
@@ -10663,7 +10663,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.Connection.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2L) != 0)
+                        if ((_bits & 0x1L) != 0)
                         {
                             value = _headers._Connection;
                             return true;
@@ -10672,7 +10672,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
                             value = _headers._KeepAlive;
                             return true;
@@ -10681,7 +10681,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.SetCookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
                             value = _headers._SetCookie;
                             return true;
@@ -10692,39 +10692,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
+                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
                     {
-                        if ((_bits & 0x80000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            value = _headers._RetryAfter;
+                            value = _headers._ContentMD5;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
+                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
                     {
                         if ((_bits & 0x20000000L) != 0)
                         {
-                            value = _headers._ContentMD5;
+                            value = _headers._RetryAfter;
                             return true;
                         }
                         return false;
                     }
 
-                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            value = _headers._RetryAfter;
+                            value = _headers._ContentMD5;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x20000000L) != 0)
                         {
-                            value = _headers._ContentMD5;
+                            value = _headers._RetryAfter;
                             return true;
                         }
                         return false;
@@ -10735,7 +10735,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x2L) != 0)
                         {
                             value = _headers._ContentType;
                             return true;
@@ -10745,7 +10745,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x2L) != 0)
                         {
                             value = _headers._ContentType;
                             return true;
@@ -10756,45 +10756,45 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 13:
                 {
-                    if (ReferenceEquals(HeaderNames.CacheControl, key))
-                    {
-                        if ((_bits & 0x1L) != 0)
-                        {
-                            value = _headers._CacheControl;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
-                    {
-                        if ((_bits & 0x8L) != 0)
-                        {
-                            value = _headers._GrpcEncoding;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.AcceptRanges, key))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x10L) != 0)
                         {
                             value = _headers._AcceptRanges;
                             return true;
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.CacheControl, key))
+                    {
+                        if ((_bits & 0x4000L) != 0)
+                        {
+                            value = _headers._CacheControl;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.ContentRange, key))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
                             value = _headers._ContentRange;
                             return true;
                         }
                         return false;
                     }
+                    if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
+                    {
+                        if ((_bits & 0x400000L) != 0)
+                        {
+                            value = _headers._GrpcEncoding;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (ReferenceEquals(HeaderNames.LastModified, key))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
                             value = _headers._LastModified;
                             return true;
@@ -10802,45 +10802,45 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         return false;
                     }
 
-                    if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x1L) != 0)
-                        {
-                            value = _headers._CacheControl;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x8L) != 0)
-                        {
-                            value = _headers._GrpcEncoding;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x10L) != 0)
                         {
                             value = _headers._AcceptRanges;
                             return true;
                         }
                         return false;
                     }
+                    if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x4000L) != 0)
+                        {
+                            value = _headers._CacheControl;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
                             value = _headers._ContentRange;
                             return true;
                         }
                         return false;
                     }
+                    if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000L) != 0)
+                        {
+                            value = _headers._GrpcEncoding;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
                             value = _headers._LastModified;
                             return true;
@@ -10874,27 +10874,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 16:
                 {
-                    if (ReferenceEquals(HeaderNames.ProxyConnection, key))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            value = _headers._ProxyConnection;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
-                    {
-                        if ((_bits & 0x1000000L) != 0)
-                        {
-                            value = _headers._WWWAuthenticate;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.ContentEncoding, key))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
                             value = _headers._ContentEncoding;
                             return true;
@@ -10903,7 +10885,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ContentLanguage, key))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
                             value = _headers._ContentLanguage;
                             return true;
@@ -10912,35 +10894,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ContentLocation, key))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
                             value = _headers._ContentLocation;
                             return true;
                         }
                         return false;
                     }
-
-                    if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ProxyConnection, key))
                     {
-                        if ((_bits & 0x40000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
                             value = _headers._ProxyConnection;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
                             value = _headers._WWWAuthenticate;
                             return true;
                         }
                         return false;
                     }
+
                     if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
                             value = _headers._ContentEncoding;
                             return true;
@@ -10949,7 +10931,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
                             value = _headers._ContentLanguage;
                             return true;
@@ -10958,9 +10940,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
                             value = _headers._ContentLocation;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x10000000L) != 0)
+                        {
+                            value = _headers._ProxyConnection;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x2000000000L) != 0)
+                        {
+                            value = _headers._WWWAuthenticate;
                             return true;
                         }
                         return false;
@@ -10971,7 +10971,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
                             value = _headers._TransferEncoding;
                             return true;
@@ -10981,7 +10981,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
                             value = _headers._TransferEncoding;
                             return true;
@@ -10994,7 +10994,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ProxyAuthenticate, key))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
                             value = _headers._ProxyAuthenticate;
                             return true;
@@ -11004,7 +11004,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.ProxyAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
                             value = _headers._ProxyAuthenticate;
                             return true;
@@ -11017,7 +11017,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlMaxAge, key))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
                             value = _headers._AccessControlMaxAge;
                             return true;
@@ -11027,7 +11027,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlMaxAge.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
                             value = _headers._AccessControlMaxAge;
                             return true;
@@ -11040,7 +11040,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowOrigin, key))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
                             value = _headers._AccessControlAllowOrigin;
                             return true;
@@ -11050,7 +11050,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlAllowOrigin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
                             value = _headers._AccessControlAllowOrigin;
                             return true;
@@ -11063,7 +11063,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowHeaders, key))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
                             value = _headers._AccessControlAllowHeaders;
                             return true;
@@ -11072,7 +11072,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AccessControlAllowMethods, key))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
                             value = _headers._AccessControlAllowMethods;
                             return true;
@@ -11082,7 +11082,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlAllowHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
                             value = _headers._AccessControlAllowHeaders;
                             return true;
@@ -11091,7 +11091,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AccessControlAllowMethods.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
                             value = _headers._AccessControlAllowMethods;
                             return true;
@@ -11104,7 +11104,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlExposeHeaders, key))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._AccessControlExposeHeaders;
                             return true;
@@ -11114,7 +11114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlExposeHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
                             value = _headers._AccessControlExposeHeaders;
                             return true;
@@ -11127,7 +11127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowCredentials, key))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x20L) != 0)
                         {
                             value = _headers._AccessControlAllowCredentials;
                             return true;
@@ -11137,7 +11137,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.AccessControlAllowCredentials.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x20L) != 0)
                         {
                             value = _headers._AccessControlAllowCredentials;
                             return true;
@@ -11158,29 +11158,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 case 3:
                 {
-                    if (ReferenceEquals(HeaderNames.Via, key))
-                    {
-                        _bits |= 0x100L;
-                        _headers._Via = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.Age, key))
                     {
-                        _bits |= 0x1000L;
+                        _bits |= 0x800L;
                         _headers._Age = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.Via, key))
+                    {
+                        _bits |= 0x800000000L;
+                        _headers._Via = value;
                         return;
                     }
 
-                    if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x100L;
-                        _headers._Via = value;
-                        return;
-                    }
                     if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000L;
+                        _bits |= 0x800L;
                         _headers._Age = value;
+                        return;
+                    }
+                    if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x800000000L;
+                        _headers._Via = value;
                         return;
                     }
                     break;
@@ -11196,13 +11196,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ETag, key))
                     {
-                        _bits |= 0x8000L;
+                        _bits |= 0x100000L;
                         _headers._ETag = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Vary, key))
                     {
-                        _bits |= 0x400000L;
+                        _bits |= 0x400000000L;
                         _headers._Vary = value;
                         return;
                     }
@@ -11216,13 +11216,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ETag.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000L;
+                        _bits |= 0x100000L;
                         _headers._ETag = value;
                         return;
                     }
                     if (HeaderNames.Vary.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000L;
+                        _bits |= 0x400000000L;
                         _headers._Vary = value;
                         return;
                     }
@@ -11232,14 +11232,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
-                        _bits |= 0x2000L;
+                        _bits |= 0x1000L;
                         _headers._Allow = value;
                         return;
                     }
 
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000L;
+                        _bits |= 0x1000L;
                         _headers._Allow = value;
                         return;
                     }
@@ -11249,28 +11249,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Server, key))
                     {
-                        _bits |= 0x100000L;
+                        _bits |= 0x8L;
                         _headers._Server = value;
                         _headers._rawServer = null;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Pragma, key))
                     {
-                        _bits |= 0x20L;
+                        _bits |= 0x4000000L;
                         _headers._Pragma = value;
                         return;
                     }
 
                     if (HeaderNames.Server.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000L;
+                        _bits |= 0x8L;
                         _headers._Server = value;
                         _headers._rawServer = null;
                         return;
                     }
                     if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20L;
+                        _bits |= 0x4000000L;
                         _headers._Pragma = value;
                         return;
                     }
@@ -11278,27 +11278,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Upgrade, key))
-                    {
-                        _bits |= 0x80L;
-                        _headers._Upgrade = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.Warning, key))
-                    {
-                        _bits |= 0x200L;
-                        _headers._Warning = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.AltSvc, key))
                     {
-                        _bits |= 0x4000L;
+                        _bits |= 0x2000L;
                         _headers._AltSvc = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.Expires, key))
                     {
-                        _bits |= 0x800000L;
+                        _bits |= 0x200000L;
                         _headers._Expires = value;
                         return;
                     }
@@ -11308,28 +11296,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Trailer = value;
                         return;
                     }
-
-                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        _bits |= 0x80L;
+                        _bits |= 0x200000000L;
                         _headers._Upgrade = value;
                         return;
                     }
-                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        _bits |= 0x200L;
+                        _bits |= 0x1000000000L;
                         _headers._Warning = value;
                         return;
                     }
+
                     if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000L;
+                        _bits |= 0x2000L;
                         _headers._AltSvc = value;
                         return;
                     }
                     if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800000L;
+                        _bits |= 0x200000L;
                         _headers._Expires = value;
                         return;
                     }
@@ -11339,20 +11327,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _headers._Trailer = value;
                         return;
                     }
+                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x200000000L;
+                        _headers._Upgrade = value;
+                        return;
+                    }
+                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x1000000000L;
+                        _headers._Warning = value;
+                        return;
+                    }
                     break;
                 }
                 case 8:
                 {
                     if (ReferenceEquals(HeaderNames.Location, key))
                     {
-                        _bits |= 0x10000L;
+                        _bits |= 0x2000000L;
                         _headers._Location = value;
                         return;
                     }
 
                     if (HeaderNames.Location.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000L;
+                        _bits |= 0x2000000L;
                         _headers._Location = value;
                         return;
                     }
@@ -11362,40 +11362,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Connection, key))
                     {
-                        _bits |= 0x2L;
+                        _bits |= 0x1L;
                         _headers._Connection = value;
                         _headers._rawConnection = null;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.KeepAlive, key))
                     {
-                        _bits |= 0x10L;
+                        _bits |= 0x800000L;
                         _headers._KeepAlive = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.SetCookie, key))
                     {
-                        _bits |= 0x200000L;
+                        _bits |= 0x40000000L;
                         _headers._SetCookie = value;
                         return;
                     }
 
                     if (HeaderNames.Connection.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2L;
+                        _bits |= 0x1L;
                         _headers._Connection = value;
                         _headers._rawConnection = null;
                         return;
                     }
                     if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10L;
+                        _bits |= 0x800000L;
                         _headers._KeepAlive = value;
                         return;
                     }
                     if (HeaderNames.SetCookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200000L;
+                        _bits |= 0x40000000L;
                         _headers._SetCookie = value;
                         return;
                     }
@@ -11403,29 +11403,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
-                    {
-                        _bits |= 0x80000L;
-                        _headers._RetryAfter = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.ContentMD5, key))
                     {
-                        _bits |= 0x20000000L;
+                        _bits |= 0x40000L;
                         _headers._ContentMD5 = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
+                    {
+                        _bits |= 0x20000000L;
+                        _headers._RetryAfter = value;
                         return;
                     }
 
-                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x80000L;
-                        _headers._RetryAfter = value;
-                        return;
-                    }
                     if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000000L;
+                        _bits |= 0x40000L;
                         _headers._ContentMD5 = value;
+                        return;
+                    }
+                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x20000000L;
+                        _headers._RetryAfter = value;
                         return;
                     }
                     break;
@@ -11434,14 +11434,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        _bits |= 0x400L;
+                        _bits |= 0x2L;
                         _headers._ContentType = value;
                         return;
                     }
 
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400L;
+                        _bits |= 0x2L;
                         _headers._ContentType = value;
                         return;
                     }
@@ -11449,64 +11449,64 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 13:
                 {
-                    if (ReferenceEquals(HeaderNames.CacheControl, key))
-                    {
-                        _bits |= 0x1L;
-                        _headers._CacheControl = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
-                    {
-                        _bits |= 0x8L;
-                        _headers._GrpcEncoding = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.AcceptRanges, key))
                     {
-                        _bits |= 0x800L;
+                        _bits |= 0x10L;
                         _headers._AcceptRanges = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.CacheControl, key))
+                    {
+                        _bits |= 0x4000L;
+                        _headers._CacheControl = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.ContentRange, key))
                     {
-                        _bits |= 0x2000000L;
+                        _bits |= 0x80000L;
                         _headers._ContentRange = value;
+                        return;
+                    }
+                    if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
+                    {
+                        _bits |= 0x400000L;
+                        _headers._GrpcEncoding = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.LastModified, key))
                     {
-                        _bits |= 0x40000000L;
+                        _bits |= 0x1000000L;
                         _headers._LastModified = value;
                         return;
                     }
 
-                    if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x1L;
-                        _headers._CacheControl = value;
-                        return;
-                    }
-                    if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _bits |= 0x8L;
-                        _headers._GrpcEncoding = value;
-                        return;
-                    }
                     if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800L;
+                        _bits |= 0x10L;
                         _headers._AcceptRanges = value;
+                        return;
+                    }
+                    if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x4000L;
+                        _headers._CacheControl = value;
                         return;
                     }
                     if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000L;
+                        _bits |= 0x80000L;
                         _headers._ContentRange = value;
+                        return;
+                    }
+                    if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x400000L;
+                        _headers._GrpcEncoding = value;
                         return;
                     }
                     if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40000000L;
+                        _bits |= 0x1000000L;
                         _headers._LastModified = value;
                         return;
                     }
@@ -11529,65 +11529,65 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 16:
                 {
-                    if (ReferenceEquals(HeaderNames.ProxyConnection, key))
-                    {
-                        _bits |= 0x40000L;
-                        _headers._ProxyConnection = value;
-                        return;
-                    }
-                    if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
-                    {
-                        _bits |= 0x1000000L;
-                        _headers._WWWAuthenticate = value;
-                        return;
-                    }
                     if (ReferenceEquals(HeaderNames.ContentEncoding, key))
                     {
-                        _bits |= 0x4000000L;
+                        _bits |= 0x8000L;
                         _headers._ContentEncoding = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.ContentLanguage, key))
                     {
-                        _bits |= 0x8000000L;
+                        _bits |= 0x10000L;
                         _headers._ContentLanguage = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.ContentLocation, key))
                     {
-                        _bits |= 0x10000000L;
+                        _bits |= 0x20000L;
                         _headers._ContentLocation = value;
                         return;
                     }
-
-                    if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ProxyConnection, key))
                     {
-                        _bits |= 0x40000L;
+                        _bits |= 0x10000000L;
                         _headers._ProxyConnection = value;
                         return;
                     }
-                    if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
                     {
-                        _bits |= 0x1000000L;
+                        _bits |= 0x2000000000L;
                         _headers._WWWAuthenticate = value;
                         return;
                     }
+
                     if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x4000000L;
+                        _bits |= 0x8000L;
                         _headers._ContentEncoding = value;
                         return;
                     }
                     if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x8000000L;
+                        _bits |= 0x10000L;
                         _headers._ContentLanguage = value;
                         return;
                     }
                     if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x10000000L;
+                        _bits |= 0x20000L;
                         _headers._ContentLocation = value;
+                        return;
+                    }
+                    if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x10000000L;
+                        _headers._ProxyConnection = value;
+                        return;
+                    }
+                    if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bits |= 0x2000000000L;
+                        _headers._WWWAuthenticate = value;
                         return;
                     }
                     break;
@@ -11596,7 +11596,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        _bits |= 0x40L;
+                        _bits |= 0x100000000L;
                         _headers._TransferEncoding = value;
                         _headers._rawTransferEncoding = null;
                         return;
@@ -11604,7 +11604,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x40L;
+                        _bits |= 0x100000000L;
                         _headers._TransferEncoding = value;
                         _headers._rawTransferEncoding = null;
                         return;
@@ -11615,14 +11615,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ProxyAuthenticate, key))
                     {
-                        _bits |= 0x20000L;
+                        _bits |= 0x8000000L;
                         _headers._ProxyAuthenticate = value;
                         return;
                     }
 
                     if (HeaderNames.ProxyAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x20000L;
+                        _bits |= 0x8000000L;
                         _headers._ProxyAuthenticate = value;
                         return;
                     }
@@ -11632,14 +11632,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlMaxAge, key))
                     {
-                        _bits |= 0x2000000000L;
+                        _bits |= 0x400L;
                         _headers._AccessControlMaxAge = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlMaxAge.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x2000000000L;
+                        _bits |= 0x400L;
                         _headers._AccessControlMaxAge = value;
                         return;
                     }
@@ -11649,14 +11649,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowOrigin, key))
                     {
-                        _bits |= 0x800000000L;
+                        _bits |= 0x100L;
                         _headers._AccessControlAllowOrigin = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlAllowOrigin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x800000000L;
+                        _bits |= 0x100L;
                         _headers._AccessControlAllowOrigin = value;
                         return;
                     }
@@ -11666,26 +11666,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowHeaders, key))
                     {
-                        _bits |= 0x200000000L;
+                        _bits |= 0x40L;
                         _headers._AccessControlAllowHeaders = value;
                         return;
                     }
                     if (ReferenceEquals(HeaderNames.AccessControlAllowMethods, key))
                     {
-                        _bits |= 0x400000000L;
+                        _bits |= 0x80L;
                         _headers._AccessControlAllowMethods = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlAllowHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x200000000L;
+                        _bits |= 0x40L;
                         _headers._AccessControlAllowHeaders = value;
                         return;
                     }
                     if (HeaderNames.AccessControlAllowMethods.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x400000000L;
+                        _bits |= 0x80L;
                         _headers._AccessControlAllowMethods = value;
                         return;
                     }
@@ -11695,14 +11695,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlExposeHeaders, key))
                     {
-                        _bits |= 0x1000000000L;
+                        _bits |= 0x200L;
                         _headers._AccessControlExposeHeaders = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlExposeHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x1000000000L;
+                        _bits |= 0x200L;
                         _headers._AccessControlExposeHeaders = value;
                         return;
                     }
@@ -11712,14 +11712,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowCredentials, key))
                     {
-                        _bits |= 0x100000000L;
+                        _bits |= 0x20L;
                         _headers._AccessControlAllowCredentials = value;
                         return;
                     }
 
                     if (HeaderNames.AccessControlAllowCredentials.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        _bits |= 0x100000000L;
+                        _bits |= 0x20L;
                         _headers._AccessControlAllowCredentials = value;
                         return;
                     }
@@ -11737,43 +11737,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 case 3:
                 {
-                    if (ReferenceEquals(HeaderNames.Via, key))
+                    if (ReferenceEquals(HeaderNames.Age, key))
                     {
-                        if ((_bits & 0x100L) == 0)
+                        if ((_bits & 0x800L) == 0)
                         {
-                            _bits |= 0x100L;
-                            _headers._Via = value;
+                            _bits |= 0x800L;
+                            _headers._Age = value;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Age, key))
+                    if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x1000L) == 0)
+                        if ((_bits & 0x800000000L) == 0)
                         {
-                            _bits |= 0x1000L;
-                            _headers._Age = value;
+                            _bits |= 0x800000000L;
+                            _headers._Via = value;
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) == 0)
+                        if ((_bits & 0x800L) == 0)
                         {
-                            _bits |= 0x100L;
-                            _headers._Via = value;
+                            _bits |= 0x800L;
+                            _headers._Age = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) == 0)
+                        if ((_bits & 0x800000000L) == 0)
                         {
-                            _bits |= 0x1000L;
-                            _headers._Age = value;
+                            _bits |= 0x800000000L;
+                            _headers._Via = value;
                             return true;
                         }
                         return false;
@@ -11795,9 +11795,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ETag, key))
                     {
-                        if ((_bits & 0x8000L) == 0)
+                        if ((_bits & 0x100000L) == 0)
                         {
-                            _bits |= 0x8000L;
+                            _bits |= 0x100000L;
                             _headers._ETag = value;
                             return true;
                         }
@@ -11805,9 +11805,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Vary, key))
                     {
-                        if ((_bits & 0x400000L) == 0)
+                        if ((_bits & 0x400000000L) == 0)
                         {
-                            _bits |= 0x400000L;
+                            _bits |= 0x400000000L;
                             _headers._Vary = value;
                             return true;
                         }
@@ -11827,9 +11827,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ETag.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000L) == 0)
+                        if ((_bits & 0x100000L) == 0)
                         {
-                            _bits |= 0x8000L;
+                            _bits |= 0x100000L;
                             _headers._ETag = value;
                             return true;
                         }
@@ -11837,9 +11837,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Vary.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) == 0)
+                        if ((_bits & 0x400000000L) == 0)
                         {
-                            _bits |= 0x400000L;
+                            _bits |= 0x400000000L;
                             _headers._Vary = value;
                             return true;
                         }
@@ -11851,9 +11851,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
-                        if ((_bits & 0x2000L) == 0)
+                        if ((_bits & 0x1000L) == 0)
                         {
-                            _bits |= 0x2000L;
+                            _bits |= 0x1000L;
                             _headers._Allow = value;
                             return true;
                         }
@@ -11862,9 +11862,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000L) == 0)
+                        if ((_bits & 0x1000L) == 0)
                         {
-                            _bits |= 0x2000L;
+                            _bits |= 0x1000L;
                             _headers._Allow = value;
                             return true;
                         }
@@ -11876,9 +11876,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Server, key))
                     {
-                        if ((_bits & 0x100000L) == 0)
+                        if ((_bits & 0x8L) == 0)
                         {
-                            _bits |= 0x100000L;
+                            _bits |= 0x8L;
                             _headers._Server = value;
                             _headers._rawServer = null;
                             return true;
@@ -11887,9 +11887,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Pragma, key))
                     {
-                        if ((_bits & 0x20L) == 0)
+                        if ((_bits & 0x4000000L) == 0)
                         {
-                            _bits |= 0x20L;
+                            _bits |= 0x4000000L;
                             _headers._Pragma = value;
                             return true;
                         }
@@ -11898,9 +11898,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Server.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) == 0)
+                        if ((_bits & 0x8L) == 0)
                         {
-                            _bits |= 0x100000L;
+                            _bits |= 0x8L;
                             _headers._Server = value;
                             _headers._rawServer = null;
                             return true;
@@ -11909,9 +11909,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20L) == 0)
+                        if ((_bits & 0x4000000L) == 0)
                         {
-                            _bits |= 0x20L;
+                            _bits |= 0x4000000L;
                             _headers._Pragma = value;
                             return true;
                         }
@@ -11921,31 +11921,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Upgrade, key))
-                    {
-                        if ((_bits & 0x80L) == 0)
-                        {
-                            _bits |= 0x80L;
-                            _headers._Upgrade = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Warning, key))
-                    {
-                        if ((_bits & 0x200L) == 0)
-                        {
-                            _bits |= 0x200L;
-                            _headers._Warning = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.AltSvc, key))
                     {
-                        if ((_bits & 0x4000L) == 0)
+                        if ((_bits & 0x2000L) == 0)
                         {
-                            _bits |= 0x4000L;
+                            _bits |= 0x2000L;
                             _headers._AltSvc = value;
                             return true;
                         }
@@ -11953,9 +11933,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expires, key))
                     {
-                        if ((_bits & 0x800000L) == 0)
+                        if ((_bits & 0x200000L) == 0)
                         {
-                            _bits |= 0x800000L;
+                            _bits |= 0x200000L;
                             _headers._Expires = value;
                             return true;
                         }
@@ -11971,32 +11951,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x80L) == 0)
+                        if ((_bits & 0x200000000L) == 0)
                         {
-                            _bits |= 0x80L;
+                            _bits |= 0x200000000L;
                             _headers._Upgrade = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x200L) == 0)
+                        if ((_bits & 0x1000000000L) == 0)
                         {
-                            _bits |= 0x200L;
+                            _bits |= 0x1000000000L;
                             _headers._Warning = value;
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000L) == 0)
+                        if ((_bits & 0x2000L) == 0)
                         {
-                            _bits |= 0x4000L;
+                            _bits |= 0x2000L;
                             _headers._AltSvc = value;
                             return true;
                         }
@@ -12004,9 +11984,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) == 0)
+                        if ((_bits & 0x200000L) == 0)
                         {
-                            _bits |= 0x800000L;
+                            _bits |= 0x200000L;
                             _headers._Expires = value;
                             return true;
                         }
@@ -12022,15 +12002,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000000L) == 0)
+                        {
+                            _bits |= 0x200000000L;
+                            _headers._Upgrade = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x1000000000L) == 0)
+                        {
+                            _bits |= 0x1000000000L;
+                            _headers._Warning = value;
+                            return true;
+                        }
+                        return false;
+                    }
                     break;
                 }
                 case 8:
                 {
                     if (ReferenceEquals(HeaderNames.Location, key))
                     {
-                        if ((_bits & 0x10000L) == 0)
+                        if ((_bits & 0x2000000L) == 0)
                         {
-                            _bits |= 0x10000L;
+                            _bits |= 0x2000000L;
                             _headers._Location = value;
                             return true;
                         }
@@ -12039,9 +12039,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Location.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) == 0)
+                        if ((_bits & 0x2000000L) == 0)
                         {
-                            _bits |= 0x10000L;
+                            _bits |= 0x2000000L;
                             _headers._Location = value;
                             return true;
                         }
@@ -12053,9 +12053,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Connection, key))
                     {
-                        if ((_bits & 0x2L) == 0)
+                        if ((_bits & 0x1L) == 0)
                         {
-                            _bits |= 0x2L;
+                            _bits |= 0x1L;
                             _headers._Connection = value;
                             _headers._rawConnection = null;
                             return true;
@@ -12064,9 +12064,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.KeepAlive, key))
                     {
-                        if ((_bits & 0x10L) == 0)
+                        if ((_bits & 0x800000L) == 0)
                         {
-                            _bits |= 0x10L;
+                            _bits |= 0x800000L;
                             _headers._KeepAlive = value;
                             return true;
                         }
@@ -12074,9 +12074,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.SetCookie, key))
                     {
-                        if ((_bits & 0x200000L) == 0)
+                        if ((_bits & 0x40000000L) == 0)
                         {
-                            _bits |= 0x200000L;
+                            _bits |= 0x40000000L;
                             _headers._SetCookie = value;
                             return true;
                         }
@@ -12085,9 +12085,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Connection.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2L) == 0)
+                        if ((_bits & 0x1L) == 0)
                         {
-                            _bits |= 0x2L;
+                            _bits |= 0x1L;
                             _headers._Connection = value;
                             _headers._rawConnection = null;
                             return true;
@@ -12096,9 +12096,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10L) == 0)
+                        if ((_bits & 0x800000L) == 0)
                         {
-                            _bits |= 0x10L;
+                            _bits |= 0x800000L;
                             _headers._KeepAlive = value;
                             return true;
                         }
@@ -12106,9 +12106,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.SetCookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) == 0)
+                        if ((_bits & 0x40000000L) == 0)
                         {
-                            _bits |= 0x200000L;
+                            _bits |= 0x40000000L;
                             _headers._SetCookie = value;
                             return true;
                         }
@@ -12118,43 +12118,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
+                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
                     {
-                        if ((_bits & 0x80000L) == 0)
+                        if ((_bits & 0x40000L) == 0)
                         {
-                            _bits |= 0x80000L;
-                            _headers._RetryAfter = value;
+                            _bits |= 0x40000L;
+                            _headers._ContentMD5 = value;
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
+                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
                     {
                         if ((_bits & 0x20000000L) == 0)
                         {
                             _bits |= 0x20000000L;
-                            _headers._ContentMD5 = value;
+                            _headers._RetryAfter = value;
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000L) == 0)
+                        if ((_bits & 0x40000L) == 0)
                         {
-                            _bits |= 0x80000L;
-                            _headers._RetryAfter = value;
+                            _bits |= 0x40000L;
+                            _headers._ContentMD5 = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x20000000L) == 0)
                         {
                             _bits |= 0x20000000L;
-                            _headers._ContentMD5 = value;
+                            _headers._RetryAfter = value;
                             return true;
                         }
                         return false;
@@ -12165,9 +12165,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x400L) == 0)
+                        if ((_bits & 0x2L) == 0)
                         {
-                            _bits |= 0x400L;
+                            _bits |= 0x2L;
                             _headers._ContentType = value;
                             return true;
                         }
@@ -12176,9 +12176,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) == 0)
+                        if ((_bits & 0x2L) == 0)
                         {
-                            _bits |= 0x400L;
+                            _bits |= 0x2L;
                             _headers._ContentType = value;
                             return true;
                         }
@@ -12188,102 +12188,102 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 13:
                 {
-                    if (ReferenceEquals(HeaderNames.CacheControl, key))
-                    {
-                        if ((_bits & 0x1L) == 0)
-                        {
-                            _bits |= 0x1L;
-                            _headers._CacheControl = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
-                    {
-                        if ((_bits & 0x8L) == 0)
-                        {
-                            _bits |= 0x8L;
-                            _headers._GrpcEncoding = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.AcceptRanges, key))
                     {
-                        if ((_bits & 0x800L) == 0)
+                        if ((_bits & 0x10L) == 0)
                         {
-                            _bits |= 0x800L;
+                            _bits |= 0x10L;
                             _headers._AcceptRanges = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.CacheControl, key))
+                    {
+                        if ((_bits & 0x4000L) == 0)
+                        {
+                            _bits |= 0x4000L;
+                            _headers._CacheControl = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.ContentRange, key))
                     {
-                        if ((_bits & 0x2000000L) == 0)
+                        if ((_bits & 0x80000L) == 0)
                         {
-                            _bits |= 0x2000000L;
+                            _bits |= 0x80000L;
                             _headers._ContentRange = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
+                    {
+                        if ((_bits & 0x400000L) == 0)
+                        {
+                            _bits |= 0x400000L;
+                            _headers._GrpcEncoding = value;
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.LastModified, key))
                     {
-                        if ((_bits & 0x40000000L) == 0)
+                        if ((_bits & 0x1000000L) == 0)
                         {
-                            _bits |= 0x40000000L;
+                            _bits |= 0x1000000L;
                             _headers._LastModified = value;
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x1L) == 0)
-                        {
-                            _bits |= 0x1L;
-                            _headers._CacheControl = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x8L) == 0)
-                        {
-                            _bits |= 0x8L;
-                            _headers._GrpcEncoding = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) == 0)
+                        if ((_bits & 0x10L) == 0)
                         {
-                            _bits |= 0x800L;
+                            _bits |= 0x10L;
                             _headers._AcceptRanges = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x4000L) == 0)
+                        {
+                            _bits |= 0x4000L;
+                            _headers._CacheControl = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) == 0)
+                        if ((_bits & 0x80000L) == 0)
                         {
-                            _bits |= 0x2000000L;
+                            _bits |= 0x80000L;
                             _headers._ContentRange = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000L) == 0)
+                        {
+                            _bits |= 0x400000L;
+                            _headers._GrpcEncoding = value;
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) == 0)
+                        if ((_bits & 0x1000000L) == 0)
                         {
-                            _bits |= 0x40000000L;
+                            _bits |= 0x1000000L;
                             _headers._LastModified = value;
                             return true;
                         }
@@ -12316,31 +12316,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 16:
                 {
-                    if (ReferenceEquals(HeaderNames.ProxyConnection, key))
-                    {
-                        if ((_bits & 0x40000L) == 0)
-                        {
-                            _bits |= 0x40000L;
-                            _headers._ProxyConnection = value;
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
-                    {
-                        if ((_bits & 0x1000000L) == 0)
-                        {
-                            _bits |= 0x1000000L;
-                            _headers._WWWAuthenticate = value;
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.ContentEncoding, key))
                     {
-                        if ((_bits & 0x4000000L) == 0)
+                        if ((_bits & 0x8000L) == 0)
                         {
-                            _bits |= 0x4000000L;
+                            _bits |= 0x8000L;
                             _headers._ContentEncoding = value;
                             return true;
                         }
@@ -12348,9 +12328,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ContentLanguage, key))
                     {
-                        if ((_bits & 0x8000000L) == 0)
+                        if ((_bits & 0x10000L) == 0)
                         {
-                            _bits |= 0x8000000L;
+                            _bits |= 0x10000L;
                             _headers._ContentLanguage = value;
                             return true;
                         }
@@ -12358,40 +12338,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ContentLocation, key))
                     {
-                        if ((_bits & 0x10000000L) == 0)
+                        if ((_bits & 0x20000L) == 0)
                         {
-                            _bits |= 0x10000000L;
+                            _bits |= 0x20000L;
                             _headers._ContentLocation = value;
                             return true;
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ProxyConnection, key))
                     {
-                        if ((_bits & 0x40000L) == 0)
+                        if ((_bits & 0x10000000L) == 0)
                         {
-                            _bits |= 0x40000L;
+                            _bits |= 0x10000000L;
                             _headers._ProxyConnection = value;
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
                     {
-                        if ((_bits & 0x1000000L) == 0)
+                        if ((_bits & 0x2000000000L) == 0)
                         {
-                            _bits |= 0x1000000L;
+                            _bits |= 0x2000000000L;
                             _headers._WWWAuthenticate = value;
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) == 0)
+                        if ((_bits & 0x8000L) == 0)
                         {
-                            _bits |= 0x4000000L;
+                            _bits |= 0x8000L;
                             _headers._ContentEncoding = value;
                             return true;
                         }
@@ -12399,9 +12379,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) == 0)
+                        if ((_bits & 0x10000L) == 0)
                         {
-                            _bits |= 0x8000000L;
+                            _bits |= 0x10000L;
                             _headers._ContentLanguage = value;
                             return true;
                         }
@@ -12409,10 +12389,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
+                        if ((_bits & 0x20000L) == 0)
+                        {
+                            _bits |= 0x20000L;
+                            _headers._ContentLocation = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
                         if ((_bits & 0x10000000L) == 0)
                         {
                             _bits |= 0x10000000L;
-                            _headers._ContentLocation = value;
+                            _headers._ProxyConnection = value;
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x2000000000L) == 0)
+                        {
+                            _bits |= 0x2000000000L;
+                            _headers._WWWAuthenticate = value;
                             return true;
                         }
                         return false;
@@ -12423,9 +12423,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x40L) == 0)
+                        if ((_bits & 0x100000000L) == 0)
                         {
-                            _bits |= 0x40L;
+                            _bits |= 0x100000000L;
                             _headers._TransferEncoding = value;
                             _headers._rawTransferEncoding = null;
                             return true;
@@ -12435,9 +12435,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40L) == 0)
+                        if ((_bits & 0x100000000L) == 0)
                         {
-                            _bits |= 0x40L;
+                            _bits |= 0x100000000L;
                             _headers._TransferEncoding = value;
                             _headers._rawTransferEncoding = null;
                             return true;
@@ -12450,9 +12450,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ProxyAuthenticate, key))
                     {
-                        if ((_bits & 0x20000L) == 0)
+                        if ((_bits & 0x8000000L) == 0)
                         {
-                            _bits |= 0x20000L;
+                            _bits |= 0x8000000L;
                             _headers._ProxyAuthenticate = value;
                             return true;
                         }
@@ -12461,9 +12461,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ProxyAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) == 0)
+                        if ((_bits & 0x8000000L) == 0)
                         {
-                            _bits |= 0x20000L;
+                            _bits |= 0x8000000L;
                             _headers._ProxyAuthenticate = value;
                             return true;
                         }
@@ -12475,9 +12475,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlMaxAge, key))
                     {
-                        if ((_bits & 0x2000000000L) == 0)
+                        if ((_bits & 0x400L) == 0)
                         {
-                            _bits |= 0x2000000000L;
+                            _bits |= 0x400L;
                             _headers._AccessControlMaxAge = value;
                             return true;
                         }
@@ -12486,9 +12486,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlMaxAge.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) == 0)
+                        if ((_bits & 0x400L) == 0)
                         {
-                            _bits |= 0x2000000000L;
+                            _bits |= 0x400L;
                             _headers._AccessControlMaxAge = value;
                             return true;
                         }
@@ -12500,9 +12500,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowOrigin, key))
                     {
-                        if ((_bits & 0x800000000L) == 0)
+                        if ((_bits & 0x100L) == 0)
                         {
-                            _bits |= 0x800000000L;
+                            _bits |= 0x100L;
                             _headers._AccessControlAllowOrigin = value;
                             return true;
                         }
@@ -12511,9 +12511,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlAllowOrigin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) == 0)
+                        if ((_bits & 0x100L) == 0)
                         {
-                            _bits |= 0x800000000L;
+                            _bits |= 0x100L;
                             _headers._AccessControlAllowOrigin = value;
                             return true;
                         }
@@ -12525,9 +12525,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowHeaders, key))
                     {
-                        if ((_bits & 0x200000000L) == 0)
+                        if ((_bits & 0x40L) == 0)
                         {
-                            _bits |= 0x200000000L;
+                            _bits |= 0x40L;
                             _headers._AccessControlAllowHeaders = value;
                             return true;
                         }
@@ -12535,9 +12535,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AccessControlAllowMethods, key))
                     {
-                        if ((_bits & 0x400000000L) == 0)
+                        if ((_bits & 0x80L) == 0)
                         {
-                            _bits |= 0x400000000L;
+                            _bits |= 0x80L;
                             _headers._AccessControlAllowMethods = value;
                             return true;
                         }
@@ -12546,9 +12546,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlAllowHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000L) == 0)
+                        if ((_bits & 0x40L) == 0)
                         {
-                            _bits |= 0x200000000L;
+                            _bits |= 0x40L;
                             _headers._AccessControlAllowHeaders = value;
                             return true;
                         }
@@ -12556,9 +12556,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AccessControlAllowMethods.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) == 0)
+                        if ((_bits & 0x80L) == 0)
                         {
-                            _bits |= 0x400000000L;
+                            _bits |= 0x80L;
                             _headers._AccessControlAllowMethods = value;
                             return true;
                         }
@@ -12570,9 +12570,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlExposeHeaders, key))
                     {
-                        if ((_bits & 0x1000000000L) == 0)
+                        if ((_bits & 0x200L) == 0)
                         {
-                            _bits |= 0x1000000000L;
+                            _bits |= 0x200L;
                             _headers._AccessControlExposeHeaders = value;
                             return true;
                         }
@@ -12581,9 +12581,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlExposeHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) == 0)
+                        if ((_bits & 0x200L) == 0)
                         {
-                            _bits |= 0x1000000000L;
+                            _bits |= 0x200L;
                             _headers._AccessControlExposeHeaders = value;
                             return true;
                         }
@@ -12595,9 +12595,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowCredentials, key))
                     {
-                        if ((_bits & 0x100000000L) == 0)
+                        if ((_bits & 0x20L) == 0)
                         {
-                            _bits |= 0x100000000L;
+                            _bits |= 0x20L;
                             _headers._AccessControlAllowCredentials = value;
                             return true;
                         }
@@ -12606,9 +12606,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlAllowCredentials.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) == 0)
+                        if ((_bits & 0x20L) == 0)
                         {
-                            _bits |= 0x100000000L;
+                            _bits |= 0x20L;
                             _headers._AccessControlAllowCredentials = value;
                             return true;
                         }
@@ -12627,43 +12627,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             {
                 case 3:
                 {
-                    if (ReferenceEquals(HeaderNames.Via, key))
+                    if (ReferenceEquals(HeaderNames.Age, key))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
-                            _bits &= ~0x100L;
-                            _headers._Via = default(StringValues);
+                            _bits &= ~0x800L;
+                            _headers._Age = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.Age, key))
+                    if (ReferenceEquals(HeaderNames.Via, key))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
-                            _bits &= ~0x1000L;
-                            _headers._Age = default(StringValues);
+                            _bits &= ~0x800000000L;
+                            _headers._Via = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100L) != 0)
+                        if ((_bits & 0x800L) != 0)
                         {
-                            _bits &= ~0x100L;
-                            _headers._Via = default(StringValues);
+                            _bits &= ~0x800L;
+                            _headers._Age = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Age.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.Via.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000L) != 0)
+                        if ((_bits & 0x800000000L) != 0)
                         {
-                            _bits &= ~0x1000L;
-                            _headers._Age = default(StringValues);
+                            _bits &= ~0x800000000L;
+                            _headers._Via = default(StringValues);
                             return true;
                         }
                         return false;
@@ -12685,9 +12685,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ETag, key))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
-                            _bits &= ~0x8000L;
+                            _bits &= ~0x100000L;
                             _headers._ETag = default(StringValues);
                             return true;
                         }
@@ -12695,9 +12695,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Vary, key))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
-                            _bits &= ~0x400000L;
+                            _bits &= ~0x400000000L;
                             _headers._Vary = default(StringValues);
                             return true;
                         }
@@ -12717,9 +12717,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ETag.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000L) != 0)
+                        if ((_bits & 0x100000L) != 0)
                         {
-                            _bits &= ~0x8000L;
+                            _bits &= ~0x100000L;
                             _headers._ETag = default(StringValues);
                             return true;
                         }
@@ -12727,9 +12727,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Vary.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000L) != 0)
+                        if ((_bits & 0x400000000L) != 0)
                         {
-                            _bits &= ~0x400000L;
+                            _bits &= ~0x400000000L;
                             _headers._Vary = default(StringValues);
                             return true;
                         }
@@ -12741,9 +12741,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Allow, key))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
-                            _bits &= ~0x2000L;
+                            _bits &= ~0x1000L;
                             _headers._Allow = default(StringValues);
                             return true;
                         }
@@ -12752,9 +12752,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Allow.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000L) != 0)
+                        if ((_bits & 0x1000L) != 0)
                         {
-                            _bits &= ~0x2000L;
+                            _bits &= ~0x1000L;
                             _headers._Allow = default(StringValues);
                             return true;
                         }
@@ -12766,9 +12766,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Server, key))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x8L) != 0)
                         {
-                            _bits &= ~0x100000L;
+                            _bits &= ~0x8L;
                             _headers._Server = default(StringValues);
                             _headers._rawServer = null;
                             return true;
@@ -12777,9 +12777,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Pragma, key))
                     {
-                        if ((_bits & 0x20L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            _bits &= ~0x20L;
+                            _bits &= ~0x4000000L;
                             _headers._Pragma = default(StringValues);
                             return true;
                         }
@@ -12788,9 +12788,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Server.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000L) != 0)
+                        if ((_bits & 0x8L) != 0)
                         {
-                            _bits &= ~0x100000L;
+                            _bits &= ~0x8L;
                             _headers._Server = default(StringValues);
                             _headers._rawServer = null;
                             return true;
@@ -12799,9 +12799,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Pragma.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20L) != 0)
+                        if ((_bits & 0x4000000L) != 0)
                         {
-                            _bits &= ~0x20L;
+                            _bits &= ~0x4000000L;
                             _headers._Pragma = default(StringValues);
                             return true;
                         }
@@ -12811,31 +12811,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 7:
                 {
-                    if (ReferenceEquals(HeaderNames.Upgrade, key))
-                    {
-                        if ((_bits & 0x80L) != 0)
-                        {
-                            _bits &= ~0x80L;
-                            _headers._Upgrade = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.Warning, key))
-                    {
-                        if ((_bits & 0x200L) != 0)
-                        {
-                            _bits &= ~0x200L;
-                            _headers._Warning = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.AltSvc, key))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
-                            _bits &= ~0x4000L;
+                            _bits &= ~0x2000L;
                             _headers._AltSvc = default(StringValues);
                             return true;
                         }
@@ -12843,9 +12823,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.Expires, key))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
-                            _bits &= ~0x800000L;
+                            _bits &= ~0x200000L;
                             _headers._Expires = default(StringValues);
                             return true;
                         }
@@ -12861,32 +12841,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Upgrade, key))
                     {
-                        if ((_bits & 0x80L) != 0)
+                        if ((_bits & 0x200000000L) != 0)
                         {
-                            _bits &= ~0x80L;
+                            _bits &= ~0x200000000L;
                             _headers._Upgrade = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.Warning, key))
                     {
-                        if ((_bits & 0x200L) != 0)
+                        if ((_bits & 0x1000000000L) != 0)
                         {
-                            _bits &= ~0x200L;
+                            _bits &= ~0x1000000000L;
                             _headers._Warning = default(StringValues);
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.AltSvc.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000L) != 0)
+                        if ((_bits & 0x2000L) != 0)
                         {
-                            _bits &= ~0x4000L;
+                            _bits &= ~0x2000L;
                             _headers._AltSvc = default(StringValues);
                             return true;
                         }
@@ -12894,9 +12874,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.Expires.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000L) != 0)
+                        if ((_bits & 0x200000L) != 0)
                         {
-                            _bits &= ~0x800000L;
+                            _bits &= ~0x200000L;
                             _headers._Expires = default(StringValues);
                             return true;
                         }
@@ -12912,15 +12892,35 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         }
                         return false;
                     }
+                    if (HeaderNames.Upgrade.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x200000000L) != 0)
+                        {
+                            _bits &= ~0x200000000L;
+                            _headers._Upgrade = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.Warning.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x1000000000L) != 0)
+                        {
+                            _bits &= ~0x1000000000L;
+                            _headers._Warning = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
                     break;
                 }
                 case 8:
                 {
                     if (ReferenceEquals(HeaderNames.Location, key))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
-                            _bits &= ~0x10000L;
+                            _bits &= ~0x2000000L;
                             _headers._Location = default(StringValues);
                             return true;
                         }
@@ -12929,9 +12929,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Location.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10000L) != 0)
+                        if ((_bits & 0x2000000L) != 0)
                         {
-                            _bits &= ~0x10000L;
+                            _bits &= ~0x2000000L;
                             _headers._Location = default(StringValues);
                             return true;
                         }
@@ -12943,9 +12943,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.Connection, key))
                     {
-                        if ((_bits & 0x2L) != 0)
+                        if ((_bits & 0x1L) != 0)
                         {
-                            _bits &= ~0x2L;
+                            _bits &= ~0x1L;
                             _headers._Connection = default(StringValues);
                             _headers._rawConnection = null;
                             return true;
@@ -12954,9 +12954,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.KeepAlive, key))
                     {
-                        if ((_bits & 0x10L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
-                            _bits &= ~0x10L;
+                            _bits &= ~0x800000L;
                             _headers._KeepAlive = default(StringValues);
                             return true;
                         }
@@ -12964,9 +12964,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.SetCookie, key))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
-                            _bits &= ~0x200000L;
+                            _bits &= ~0x40000000L;
                             _headers._SetCookie = default(StringValues);
                             return true;
                         }
@@ -12975,9 +12975,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.Connection.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2L) != 0)
+                        if ((_bits & 0x1L) != 0)
                         {
-                            _bits &= ~0x2L;
+                            _bits &= ~0x1L;
                             _headers._Connection = default(StringValues);
                             _headers._rawConnection = null;
                             return true;
@@ -12986,9 +12986,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.KeepAlive.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x10L) != 0)
+                        if ((_bits & 0x800000L) != 0)
                         {
-                            _bits &= ~0x10L;
+                            _bits &= ~0x800000L;
                             _headers._KeepAlive = default(StringValues);
                             return true;
                         }
@@ -12996,9 +12996,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.SetCookie.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000L) != 0)
+                        if ((_bits & 0x40000000L) != 0)
                         {
-                            _bits &= ~0x200000L;
+                            _bits &= ~0x40000000L;
                             _headers._SetCookie = default(StringValues);
                             return true;
                         }
@@ -13008,43 +13008,43 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 11:
                 {
-                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
+                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
                     {
-                        if ((_bits & 0x80000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            _bits &= ~0x80000L;
-                            _headers._RetryAfter = default(StringValues);
+                            _bits &= ~0x40000L;
+                            _headers._ContentMD5 = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (ReferenceEquals(HeaderNames.ContentMD5, key))
+                    if (ReferenceEquals(HeaderNames.RetryAfter, key))
                     {
                         if ((_bits & 0x20000000L) != 0)
                         {
                             _bits &= ~0x20000000L;
-                            _headers._ContentMD5 = default(StringValues);
+                            _headers._RetryAfter = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x80000L) != 0)
+                        if ((_bits & 0x40000L) != 0)
                         {
-                            _bits &= ~0x80000L;
-                            _headers._RetryAfter = default(StringValues);
+                            _bits &= ~0x40000L;
+                            _headers._ContentMD5 = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.ContentMD5.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (HeaderNames.RetryAfter.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
                         if ((_bits & 0x20000000L) != 0)
                         {
                             _bits &= ~0x20000000L;
-                            _headers._ContentMD5 = default(StringValues);
+                            _headers._RetryAfter = default(StringValues);
                             return true;
                         }
                         return false;
@@ -13055,9 +13055,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ContentType, key))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x2L) != 0)
                         {
-                            _bits &= ~0x400L;
+                            _bits &= ~0x2L;
                             _headers._ContentType = default(StringValues);
                             return true;
                         }
@@ -13066,9 +13066,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ContentType.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400L) != 0)
+                        if ((_bits & 0x2L) != 0)
                         {
-                            _bits &= ~0x400L;
+                            _bits &= ~0x2L;
                             _headers._ContentType = default(StringValues);
                             return true;
                         }
@@ -13078,102 +13078,102 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 13:
                 {
-                    if (ReferenceEquals(HeaderNames.CacheControl, key))
-                    {
-                        if ((_bits & 0x1L) != 0)
-                        {
-                            _bits &= ~0x1L;
-                            _headers._CacheControl = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
-                    {
-                        if ((_bits & 0x8L) != 0)
-                        {
-                            _bits &= ~0x8L;
-                            _headers._GrpcEncoding = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.AcceptRanges, key))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x10L) != 0)
                         {
-                            _bits &= ~0x800L;
+                            _bits &= ~0x10L;
                             _headers._AcceptRanges = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.CacheControl, key))
+                    {
+                        if ((_bits & 0x4000L) != 0)
+                        {
+                            _bits &= ~0x4000L;
+                            _headers._CacheControl = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.ContentRange, key))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
-                            _bits &= ~0x2000000L;
+                            _bits &= ~0x80000L;
                             _headers._ContentRange = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (ReferenceEquals(HeaderNames.GrpcEncoding, key))
+                    {
+                        if ((_bits & 0x400000L) != 0)
+                        {
+                            _bits &= ~0x400000L;
+                            _headers._GrpcEncoding = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (ReferenceEquals(HeaderNames.LastModified, key))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
-                            _bits &= ~0x40000000L;
+                            _bits &= ~0x1000000L;
                             _headers._LastModified = default(StringValues);
                             return true;
                         }
                         return false;
                     }
     
-                    if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x1L) != 0)
-                        {
-                            _bits &= ~0x1L;
-                            _headers._CacheControl = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
-                    {
-                        if ((_bits & 0x8L) != 0)
-                        {
-                            _bits &= ~0x8L;
-                            _headers._GrpcEncoding = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (HeaderNames.AcceptRanges.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800L) != 0)
+                        if ((_bits & 0x10L) != 0)
                         {
-                            _bits &= ~0x800L;
+                            _bits &= ~0x10L;
                             _headers._AcceptRanges = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.CacheControl.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x4000L) != 0)
+                        {
+                            _bits &= ~0x4000L;
+                            _headers._CacheControl = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.ContentRange.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000L) != 0)
+                        if ((_bits & 0x80000L) != 0)
                         {
-                            _bits &= ~0x2000000L;
+                            _bits &= ~0x80000L;
                             _headers._ContentRange = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.GrpcEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x400000L) != 0)
+                        {
+                            _bits &= ~0x400000L;
+                            _headers._GrpcEncoding = default(StringValues);
                             return true;
                         }
                         return false;
                     }
                     if (HeaderNames.LastModified.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40000000L) != 0)
+                        if ((_bits & 0x1000000L) != 0)
                         {
-                            _bits &= ~0x40000000L;
+                            _bits &= ~0x1000000L;
                             _headers._LastModified = default(StringValues);
                             return true;
                         }
@@ -13206,31 +13206,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
                 case 16:
                 {
-                    if (ReferenceEquals(HeaderNames.ProxyConnection, key))
-                    {
-                        if ((_bits & 0x40000L) != 0)
-                        {
-                            _bits &= ~0x40000L;
-                            _headers._ProxyConnection = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
-                    if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
-                    {
-                        if ((_bits & 0x1000000L) != 0)
-                        {
-                            _bits &= ~0x1000000L;
-                            _headers._WWWAuthenticate = default(StringValues);
-                            return true;
-                        }
-                        return false;
-                    }
                     if (ReferenceEquals(HeaderNames.ContentEncoding, key))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
-                            _bits &= ~0x4000000L;
+                            _bits &= ~0x8000L;
                             _headers._ContentEncoding = default(StringValues);
                             return true;
                         }
@@ -13238,9 +13218,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ContentLanguage, key))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
-                            _bits &= ~0x8000000L;
+                            _bits &= ~0x10000L;
                             _headers._ContentLanguage = default(StringValues);
                             return true;
                         }
@@ -13248,40 +13228,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.ContentLocation, key))
                     {
-                        if ((_bits & 0x10000000L) != 0)
+                        if ((_bits & 0x20000L) != 0)
                         {
-                            _bits &= ~0x10000000L;
+                            _bits &= ~0x20000L;
                             _headers._ContentLocation = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-    
-                    if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.ProxyConnection, key))
                     {
-                        if ((_bits & 0x40000L) != 0)
+                        if ((_bits & 0x10000000L) != 0)
                         {
-                            _bits &= ~0x40000L;
+                            _bits &= ~0x10000000L;
                             _headers._ProxyConnection = default(StringValues);
                             return true;
                         }
                         return false;
                     }
-                    if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    if (ReferenceEquals(HeaderNames.WWWAuthenticate, key))
                     {
-                        if ((_bits & 0x1000000L) != 0)
+                        if ((_bits & 0x2000000000L) != 0)
                         {
-                            _bits &= ~0x1000000L;
+                            _bits &= ~0x2000000000L;
                             _headers._WWWAuthenticate = default(StringValues);
                             return true;
                         }
                         return false;
                     }
+    
                     if (HeaderNames.ContentEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x4000000L) != 0)
+                        if ((_bits & 0x8000L) != 0)
                         {
-                            _bits &= ~0x4000000L;
+                            _bits &= ~0x8000L;
                             _headers._ContentEncoding = default(StringValues);
                             return true;
                         }
@@ -13289,9 +13269,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ContentLanguage.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x8000000L) != 0)
+                        if ((_bits & 0x10000L) != 0)
                         {
-                            _bits &= ~0x8000000L;
+                            _bits &= ~0x10000L;
                             _headers._ContentLanguage = default(StringValues);
                             return true;
                         }
@@ -13299,10 +13279,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.ContentLocation.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
+                        if ((_bits & 0x20000L) != 0)
+                        {
+                            _bits &= ~0x20000L;
+                            _headers._ContentLocation = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.ProxyConnection.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
                         if ((_bits & 0x10000000L) != 0)
                         {
                             _bits &= ~0x10000000L;
-                            _headers._ContentLocation = default(StringValues);
+                            _headers._ProxyConnection = default(StringValues);
+                            return true;
+                        }
+                        return false;
+                    }
+                    if (HeaderNames.WWWAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if ((_bits & 0x2000000000L) != 0)
+                        {
+                            _bits &= ~0x2000000000L;
+                            _headers._WWWAuthenticate = default(StringValues);
                             return true;
                         }
                         return false;
@@ -13313,9 +13313,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.TransferEncoding, key))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
-                            _bits &= ~0x40L;
+                            _bits &= ~0x100000000L;
                             _headers._TransferEncoding = default(StringValues);
                             _headers._rawTransferEncoding = null;
                             return true;
@@ -13325,9 +13325,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.TransferEncoding.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x40L) != 0)
+                        if ((_bits & 0x100000000L) != 0)
                         {
-                            _bits &= ~0x40L;
+                            _bits &= ~0x100000000L;
                             _headers._TransferEncoding = default(StringValues);
                             _headers._rawTransferEncoding = null;
                             return true;
@@ -13340,9 +13340,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.ProxyAuthenticate, key))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
-                            _bits &= ~0x20000L;
+                            _bits &= ~0x8000000L;
                             _headers._ProxyAuthenticate = default(StringValues);
                             return true;
                         }
@@ -13351,9 +13351,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.ProxyAuthenticate.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x20000L) != 0)
+                        if ((_bits & 0x8000000L) != 0)
                         {
-                            _bits &= ~0x20000L;
+                            _bits &= ~0x8000000L;
                             _headers._ProxyAuthenticate = default(StringValues);
                             return true;
                         }
@@ -13365,9 +13365,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlMaxAge, key))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
-                            _bits &= ~0x2000000000L;
+                            _bits &= ~0x400L;
                             _headers._AccessControlMaxAge = default(StringValues);
                             return true;
                         }
@@ -13376,9 +13376,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlMaxAge.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x2000000000L) != 0)
+                        if ((_bits & 0x400L) != 0)
                         {
-                            _bits &= ~0x2000000000L;
+                            _bits &= ~0x400L;
                             _headers._AccessControlMaxAge = default(StringValues);
                             return true;
                         }
@@ -13390,9 +13390,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowOrigin, key))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
-                            _bits &= ~0x800000000L;
+                            _bits &= ~0x100L;
                             _headers._AccessControlAllowOrigin = default(StringValues);
                             return true;
                         }
@@ -13401,9 +13401,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlAllowOrigin.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x800000000L) != 0)
+                        if ((_bits & 0x100L) != 0)
                         {
-                            _bits &= ~0x800000000L;
+                            _bits &= ~0x100L;
                             _headers._AccessControlAllowOrigin = default(StringValues);
                             return true;
                         }
@@ -13415,9 +13415,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowHeaders, key))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
-                            _bits &= ~0x200000000L;
+                            _bits &= ~0x40L;
                             _headers._AccessControlAllowHeaders = default(StringValues);
                             return true;
                         }
@@ -13425,9 +13425,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (ReferenceEquals(HeaderNames.AccessControlAllowMethods, key))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
-                            _bits &= ~0x400000000L;
+                            _bits &= ~0x80L;
                             _headers._AccessControlAllowMethods = default(StringValues);
                             return true;
                         }
@@ -13436,9 +13436,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlAllowHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x200000000L) != 0)
+                        if ((_bits & 0x40L) != 0)
                         {
-                            _bits &= ~0x200000000L;
+                            _bits &= ~0x40L;
                             _headers._AccessControlAllowHeaders = default(StringValues);
                             return true;
                         }
@@ -13446,9 +13446,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     }
                     if (HeaderNames.AccessControlAllowMethods.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x400000000L) != 0)
+                        if ((_bits & 0x80L) != 0)
                         {
-                            _bits &= ~0x400000000L;
+                            _bits &= ~0x80L;
                             _headers._AccessControlAllowMethods = default(StringValues);
                             return true;
                         }
@@ -13460,9 +13460,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlExposeHeaders, key))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
-                            _bits &= ~0x1000000000L;
+                            _bits &= ~0x200L;
                             _headers._AccessControlExposeHeaders = default(StringValues);
                             return true;
                         }
@@ -13471,9 +13471,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlExposeHeaders.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x1000000000L) != 0)
+                        if ((_bits & 0x200L) != 0)
                         {
-                            _bits &= ~0x1000000000L;
+                            _bits &= ~0x200L;
                             _headers._AccessControlExposeHeaders = default(StringValues);
                             return true;
                         }
@@ -13485,9 +13485,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     if (ReferenceEquals(HeaderNames.AccessControlAllowCredentials, key))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x20L) != 0)
                         {
-                            _bits &= ~0x100000000L;
+                            _bits &= ~0x20L;
                             _headers._AccessControlAllowCredentials = default(StringValues);
                             return true;
                         }
@@ -13496,9 +13496,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     
                     if (HeaderNames.AccessControlAllowCredentials.Equals(key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if ((_bits & 0x100000000L) != 0)
+                        if ((_bits & 0x20L) != 0)
                         {
-                            _bits &= ~0x100000000L;
+                            _bits &= ~0x20L;
                             _headers._AccessControlAllowCredentials = default(StringValues);
                             return true;
                         }
@@ -13522,9 +13522,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return;
             }
             
-            if ((tempBits & 0x2L) != 0)
+            if ((tempBits & 0x1L) != 0)
             {
                 _headers._Connection = default;
+                if((tempBits & ~0x1L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x1L;
+            }
+            
+            if ((tempBits & 0x2L) != 0)
+            {
+                _headers._ContentType = default;
                 if((tempBits & ~0x2L) == 0)
                 {
                     return;
@@ -13542,39 +13552,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x4L;
             }
             
-            if ((tempBits & 0x400L) != 0)
-            {
-                _headers._ContentType = default;
-                if((tempBits & ~0x400L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x400L;
-            }
-            
-            if ((tempBits & 0x100000L) != 0)
-            {
-                _headers._Server = default;
-                if((tempBits & ~0x100000L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x100000L;
-            }
-            
-            if ((tempBits & 0x1L) != 0)
-            {
-                _headers._CacheControl = default;
-                if((tempBits & ~0x1L) == 0)
-                {
-                    return;
-                }
-                tempBits &= ~0x1L;
-            }
-            
             if ((tempBits & 0x8L) != 0)
             {
-                _headers._GrpcEncoding = default;
+                _headers._Server = default;
                 if((tempBits & ~0x8L) == 0)
                 {
                     return;
@@ -13584,7 +13564,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10L) != 0)
             {
-                _headers._KeepAlive = default;
+                _headers._AcceptRanges = default;
                 if((tempBits & ~0x10L) == 0)
                 {
                     return;
@@ -13594,7 +13574,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20L) != 0)
             {
-                _headers._Pragma = default;
+                _headers._AccessControlAllowCredentials = default;
                 if((tempBits & ~0x20L) == 0)
                 {
                     return;
@@ -13604,7 +13584,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40L) != 0)
             {
-                _headers._TransferEncoding = default;
+                _headers._AccessControlAllowHeaders = default;
                 if((tempBits & ~0x40L) == 0)
                 {
                     return;
@@ -13614,7 +13594,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80L) != 0)
             {
-                _headers._Upgrade = default;
+                _headers._AccessControlAllowMethods = default;
                 if((tempBits & ~0x80L) == 0)
                 {
                     return;
@@ -13624,7 +13604,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100L) != 0)
             {
-                _headers._Via = default;
+                _headers._AccessControlAllowOrigin = default;
                 if((tempBits & ~0x100L) == 0)
                 {
                     return;
@@ -13634,7 +13614,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200L) != 0)
             {
-                _headers._Warning = default;
+                _headers._AccessControlExposeHeaders = default;
                 if((tempBits & ~0x200L) == 0)
                 {
                     return;
@@ -13642,9 +13622,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x200L;
             }
             
+            if ((tempBits & 0x400L) != 0)
+            {
+                _headers._AccessControlMaxAge = default;
+                if((tempBits & ~0x400L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x400L;
+            }
+            
             if ((tempBits & 0x800L) != 0)
             {
-                _headers._AcceptRanges = default;
+                _headers._Age = default;
                 if((tempBits & ~0x800L) == 0)
                 {
                     return;
@@ -13654,7 +13644,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000L) != 0)
             {
-                _headers._Age = default;
+                _headers._Allow = default;
                 if((tempBits & ~0x1000L) == 0)
                 {
                     return;
@@ -13664,7 +13654,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x2000L) != 0)
             {
-                _headers._Allow = default;
+                _headers._AltSvc = default;
                 if((tempBits & ~0x2000L) == 0)
                 {
                     return;
@@ -13674,7 +13664,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x4000L) != 0)
             {
-                _headers._AltSvc = default;
+                _headers._CacheControl = default;
                 if((tempBits & ~0x4000L) == 0)
                 {
                     return;
@@ -13684,7 +13674,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000L) != 0)
             {
-                _headers._ETag = default;
+                _headers._ContentEncoding = default;
                 if((tempBits & ~0x8000L) == 0)
                 {
                     return;
@@ -13694,7 +13684,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10000L) != 0)
             {
-                _headers._Location = default;
+                _headers._ContentLanguage = default;
                 if((tempBits & ~0x10000L) == 0)
                 {
                     return;
@@ -13704,7 +13694,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000L) != 0)
             {
-                _headers._ProxyAuthenticate = default;
+                _headers._ContentLocation = default;
                 if((tempBits & ~0x20000L) == 0)
                 {
                     return;
@@ -13714,7 +13704,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000L) != 0)
             {
-                _headers._ProxyConnection = default;
+                _headers._ContentMD5 = default;
                 if((tempBits & ~0x40000L) == 0)
                 {
                     return;
@@ -13724,7 +13714,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x80000L) != 0)
             {
-                _headers._RetryAfter = default;
+                _headers._ContentRange = default;
                 if((tempBits & ~0x80000L) == 0)
                 {
                     return;
@@ -13732,9 +13722,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 tempBits &= ~0x80000L;
             }
             
+            if ((tempBits & 0x100000L) != 0)
+            {
+                _headers._ETag = default;
+                if((tempBits & ~0x100000L) == 0)
+                {
+                    return;
+                }
+                tempBits &= ~0x100000L;
+            }
+            
             if ((tempBits & 0x200000L) != 0)
             {
-                _headers._SetCookie = default;
+                _headers._Expires = default;
                 if((tempBits & ~0x200000L) == 0)
                 {
                     return;
@@ -13744,7 +13744,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400000L) != 0)
             {
-                _headers._Vary = default;
+                _headers._GrpcEncoding = default;
                 if((tempBits & ~0x400000L) == 0)
                 {
                     return;
@@ -13754,7 +13754,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800000L) != 0)
             {
-                _headers._Expires = default;
+                _headers._KeepAlive = default;
                 if((tempBits & ~0x800000L) == 0)
                 {
                     return;
@@ -13764,7 +13764,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000000L) != 0)
             {
-                _headers._WWWAuthenticate = default;
+                _headers._LastModified = default;
                 if((tempBits & ~0x1000000L) == 0)
                 {
                     return;
@@ -13774,7 +13774,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x2000000L) != 0)
             {
-                _headers._ContentRange = default;
+                _headers._Location = default;
                 if((tempBits & ~0x2000000L) == 0)
                 {
                     return;
@@ -13784,7 +13784,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x4000000L) != 0)
             {
-                _headers._ContentEncoding = default;
+                _headers._Pragma = default;
                 if((tempBits & ~0x4000000L) == 0)
                 {
                     return;
@@ -13794,7 +13794,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x8000000L) != 0)
             {
-                _headers._ContentLanguage = default;
+                _headers._ProxyAuthenticate = default;
                 if((tempBits & ~0x8000000L) == 0)
                 {
                     return;
@@ -13804,7 +13804,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x10000000L) != 0)
             {
-                _headers._ContentLocation = default;
+                _headers._ProxyConnection = default;
                 if((tempBits & ~0x10000000L) == 0)
                 {
                     return;
@@ -13814,7 +13814,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x20000000L) != 0)
             {
-                _headers._ContentMD5 = default;
+                _headers._RetryAfter = default;
                 if((tempBits & ~0x20000000L) == 0)
                 {
                     return;
@@ -13824,7 +13824,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x40000000L) != 0)
             {
-                _headers._LastModified = default;
+                _headers._SetCookie = default;
                 if((tempBits & ~0x40000000L) == 0)
                 {
                     return;
@@ -13844,7 +13844,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x100000000L) != 0)
             {
-                _headers._AccessControlAllowCredentials = default;
+                _headers._TransferEncoding = default;
                 if((tempBits & ~0x100000000L) == 0)
                 {
                     return;
@@ -13854,7 +13854,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x200000000L) != 0)
             {
-                _headers._AccessControlAllowHeaders = default;
+                _headers._Upgrade = default;
                 if((tempBits & ~0x200000000L) == 0)
                 {
                     return;
@@ -13864,7 +13864,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x400000000L) != 0)
             {
-                _headers._AccessControlAllowMethods = default;
+                _headers._Vary = default;
                 if((tempBits & ~0x400000000L) == 0)
                 {
                     return;
@@ -13874,7 +13874,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x800000000L) != 0)
             {
-                _headers._AccessControlAllowOrigin = default;
+                _headers._Via = default;
                 if((tempBits & ~0x800000000L) == 0)
                 {
                     return;
@@ -13884,7 +13884,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x1000000000L) != 0)
             {
-                _headers._AccessControlExposeHeaders = default;
+                _headers._Warning = default;
                 if((tempBits & ~0x1000000000L) == 0)
                 {
                     return;
@@ -13894,7 +13894,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             
             if ((tempBits & 0x2000000000L) != 0)
             {
-                _headers._AccessControlMaxAge = default;
+                _headers._WWWAuthenticate = default;
                 if((tempBits & ~0x2000000000L) == 0)
                 {
                     return;
@@ -13917,7 +13917,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CacheControl, _headers._CacheControl);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Connection, _headers._Connection);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2L) != 0)
@@ -13926,7 +13926,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Connection, _headers._Connection);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _headers._ContentType);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4L) != 0)
@@ -13944,7 +13944,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcEncoding, _headers._GrpcEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Server, _headers._Server);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10L) != 0)
@@ -13953,7 +13953,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.KeepAlive, _headers._KeepAlive);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptRanges, _headers._AcceptRanges);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20L) != 0)
@@ -13962,7 +13962,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Pragma, _headers._Pragma);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowCredentials, _headers._AccessControlAllowCredentials);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40L) != 0)
@@ -13971,7 +13971,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _headers._TransferEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowHeaders, _headers._AccessControlAllowHeaders);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80L) != 0)
@@ -13980,7 +13980,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _headers._Upgrade);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowMethods, _headers._AccessControlAllowMethods);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100L) != 0)
@@ -13989,7 +13989,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Via, _headers._Via);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowOrigin, _headers._AccessControlAllowOrigin);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200L) != 0)
@@ -13998,7 +13998,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _headers._Warning);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlExposeHeaders, _headers._AccessControlExposeHeaders);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400L) != 0)
@@ -14007,7 +14007,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _headers._ContentType);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlMaxAge, _headers._AccessControlMaxAge);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800L) != 0)
@@ -14016,7 +14016,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AcceptRanges, _headers._AcceptRanges);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Age, _headers._Age);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000L) != 0)
@@ -14025,7 +14025,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Age, _headers._Age);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _headers._Allow);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000L) != 0)
@@ -14034,7 +14034,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _headers._Allow);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AltSvc, _headers._AltSvc);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000L) != 0)
@@ -14043,7 +14043,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AltSvc, _headers._AltSvc);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.CacheControl, _headers._CacheControl);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000L) != 0)
@@ -14052,7 +14052,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ETag, _headers._ETag);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _headers._ContentEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000L) != 0)
@@ -14061,7 +14061,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Location, _headers._Location);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _headers._ContentLanguage);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000L) != 0)
@@ -14070,7 +14070,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthenticate, _headers._ProxyAuthenticate);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _headers._ContentLocation);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000L) != 0)
@@ -14079,7 +14079,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyConnection, _headers._ProxyConnection);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _headers._ContentMD5);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000L) != 0)
@@ -14088,7 +14088,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RetryAfter, _headers._RetryAfter);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _headers._ContentRange);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x100000L) != 0)
@@ -14097,7 +14097,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Server, _headers._Server);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ETag, _headers._ETag);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000L) != 0)
@@ -14106,7 +14106,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.SetCookie, _headers._SetCookie);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _headers._Expires);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400000L) != 0)
@@ -14115,7 +14115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Vary, _headers._Vary);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.GrpcEncoding, _headers._GrpcEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800000L) != 0)
@@ -14124,7 +14124,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _headers._Expires);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.KeepAlive, _headers._KeepAlive);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000000L) != 0)
@@ -14133,7 +14133,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.WWWAuthenticate, _headers._WWWAuthenticate);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _headers._LastModified);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000000L) != 0)
@@ -14142,7 +14142,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _headers._ContentRange);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Location, _headers._Location);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x4000000L) != 0)
@@ -14151,7 +14151,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _headers._ContentEncoding);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Pragma, _headers._Pragma);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x8000000L) != 0)
@@ -14160,7 +14160,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _headers._ContentLanguage);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthenticate, _headers._ProxyAuthenticate);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x10000000L) != 0)
@@ -14169,7 +14169,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _headers._ContentLocation);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ProxyConnection, _headers._ProxyConnection);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x20000000L) != 0)
@@ -14178,7 +14178,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _headers._ContentMD5);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.RetryAfter, _headers._RetryAfter);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x40000000L) != 0)
@@ -14187,7 +14187,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _headers._LastModified);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.SetCookie, _headers._SetCookie);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x80000000L) != 0)
@@ -14205,7 +14205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowCredentials, _headers._AccessControlAllowCredentials);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _headers._TransferEncoding);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x200000000L) != 0)
@@ -14214,7 +14214,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowHeaders, _headers._AccessControlAllowHeaders);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _headers._Upgrade);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x400000000L) != 0)
@@ -14223,7 +14223,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowMethods, _headers._AccessControlAllowMethods);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Vary, _headers._Vary);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x800000000L) != 0)
@@ -14232,7 +14232,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowOrigin, _headers._AccessControlAllowOrigin);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Via, _headers._Via);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x1000000000L) != 0)
@@ -14241,7 +14241,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlExposeHeaders, _headers._AccessControlExposeHeaders);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _headers._Warning);
                     ++arrayIndex;
                 }
                 if ((_bits & 0x2000000000L) != 0)
@@ -14250,7 +14250,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     {
                         return false;
                     }
-                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlMaxAge, _headers._AccessControlMaxAge);
+                    array[arrayIndex] = new KeyValuePair<string, StringValues>(HeaderNames.WWWAuthenticate, _headers._WWWAuthenticate);
                     ++arrayIndex;
                 }
                 if (_contentLength.HasValue)
@@ -14267,10 +14267,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return true;
         }
         
-        internal bool HasInvalidH2H3Headers => (_bits & 262354) != 0;
+        internal bool HasInvalidH2H3Headers => (_bits & 13161725953) != 0;
         internal void ClearInvalidH2H3Headers()
         {
-            _bits &= ~262354;
+            _bits &= ~13161725953;
         }
         internal unsafe void CopyToFast(ref BufferWriter<PipeWriter> output)
         {
@@ -14285,9 +14285,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 switch (next)
                 {
                     case 0: // Header: "Connection"
-                        if ((tempBits & 0x2L) != 0)
+                        if ((tempBits & 0x1L) != 0)
                         {
-                            tempBits ^= 0x2L;
+                            tempBits ^= 0x1L;
                             if (_headers._rawConnection != null)
                             {
                                 output.Write(_headers._rawConnection);
@@ -14295,14 +14295,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             else
                             {
                                 values = ref _headers._Connection;
-                                keyStart = 17;
+                                keyStart = 0;
                                 keyLength = 14;
                                 next = 1;
                                 break; // OutputHeader
                             }
                         }
                         goto case 1;
-                    case 1: // Header: "Date"
+                    case 1: // Header: "Content-Type"
+                        if ((tempBits & 0x2L) != 0)
+                        {
+                            tempBits ^= 0x2L;
+                            values = ref _headers._ContentType;
+                            keyStart = 14;
+                            keyLength = 16;
+                            next = 2;
+                            break; // OutputHeader
+                        }
+                        goto case 2;
+                    case 2: // Header: "Date"
                         if ((tempBits & 0x4L) != 0)
                         {
                             tempBits ^= 0x4L;
@@ -14313,28 +14324,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             else
                             {
                                 values = ref _headers._Date;
-                                keyStart = 31;
+                                keyStart = 30;
                                 keyLength = 8;
-                                next = 2;
+                                next = 3;
                                 break; // OutputHeader
                             }
                         }
-                        goto case 2;
-                    case 2: // Header: "Content-Type"
-                        if ((tempBits & 0x400L) != 0)
-                        {
-                            tempBits ^= 0x400L;
-                            values = ref _headers._ContentType;
-                            keyStart = 130;
-                            keyLength = 16;
-                            next = 3;
-                            break; // OutputHeader
-                        }
                         goto case 3;
                     case 3: // Header: "Server"
-                        if ((tempBits & 0x100000L) != 0)
+                        if ((tempBits & 0x8L) != 0)
                         {
-                            tempBits ^= 0x100000L;
+                            tempBits ^= 0x8L;
                             if (_headers._rawServer != null)
                             {
                                 output.Write(_headers._rawServer);
@@ -14342,7 +14342,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             else
                             {
                                 values = ref _headers._Server;
-                                keyStart = 267;
+                                keyStart = 38;
                                 keyLength = 10;
                                 next = 4;
                                 break; // OutputHeader
@@ -14361,306 +14361,299 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                             }
                         }
                         goto case 5;
-                    case 5: // Header: "Cache-Control"
-                        if ((tempBits & 0x1L) != 0)
+                    case 5: // Header: "Accept-Ranges"
+                        if ((tempBits & 0x10L) != 0)
                         {
-                            tempBits ^= 0x1L;
-                            values = ref _headers._CacheControl;
-                            keyStart = 0;
+                            tempBits ^= 0x10L;
+                            values = ref _headers._AcceptRanges;
+                            keyStart = 48;
                             keyLength = 17;
                             next = 6;
                             break; // OutputHeader
                         }
                         goto case 6;
-                    case 6: // Header: "Grpc-Encoding"
-                        if ((tempBits & 0x8L) != 0)
+                    case 6: // Header: "Access-Control-Allow-Credentials"
+                        if ((tempBits & 0x20L) != 0)
                         {
-                            tempBits ^= 0x8L;
-                            values = ref _headers._GrpcEncoding;
-                            keyStart = 39;
-                            keyLength = 17;
+                            tempBits ^= 0x20L;
+                            values = ref _headers._AccessControlAllowCredentials;
+                            keyStart = 65;
+                            keyLength = 36;
                             next = 7;
                             break; // OutputHeader
                         }
                         goto case 7;
-                    case 7: // Header: "Keep-Alive"
-                        if ((tempBits & 0x10L) != 0)
+                    case 7: // Header: "Access-Control-Allow-Headers"
+                        if ((tempBits & 0x40L) != 0)
                         {
-                            tempBits ^= 0x10L;
-                            values = ref _headers._KeepAlive;
-                            keyStart = 56;
-                            keyLength = 14;
+                            tempBits ^= 0x40L;
+                            values = ref _headers._AccessControlAllowHeaders;
+                            keyStart = 101;
+                            keyLength = 32;
                             next = 8;
                             break; // OutputHeader
                         }
                         goto case 8;
-                    case 8: // Header: "Pragma"
-                        if ((tempBits & 0x20L) != 0)
+                    case 8: // Header: "Access-Control-Allow-Methods"
+                        if ((tempBits & 0x80L) != 0)
                         {
-                            tempBits ^= 0x20L;
-                            values = ref _headers._Pragma;
-                            keyStart = 70;
-                            keyLength = 10;
+                            tempBits ^= 0x80L;
+                            values = ref _headers._AccessControlAllowMethods;
+                            keyStart = 133;
+                            keyLength = 32;
                             next = 9;
                             break; // OutputHeader
                         }
                         goto case 9;
-                    case 9: // Header: "Transfer-Encoding"
-                        if ((tempBits & 0x40L) != 0)
+                    case 9: // Header: "Access-Control-Allow-Origin"
+                        if ((tempBits & 0x100L) != 0)
                         {
-                            tempBits ^= 0x40L;
-                            if (_headers._rawTransferEncoding != null)
-                            {
-                                output.Write(_headers._rawTransferEncoding);
-                            }
-                            else
-                            {
-                                values = ref _headers._TransferEncoding;
-                                keyStart = 80;
-                                keyLength = 21;
-                                next = 10;
-                                break; // OutputHeader
-                            }
+                            tempBits ^= 0x100L;
+                            values = ref _headers._AccessControlAllowOrigin;
+                            keyStart = 165;
+                            keyLength = 31;
+                            next = 10;
+                            break; // OutputHeader
                         }
                         goto case 10;
-                    case 10: // Header: "Upgrade"
-                        if ((tempBits & 0x80L) != 0)
+                    case 10: // Header: "Access-Control-Expose-Headers"
+                        if ((tempBits & 0x200L) != 0)
                         {
-                            tempBits ^= 0x80L;
-                            values = ref _headers._Upgrade;
-                            keyStart = 101;
-                            keyLength = 11;
+                            tempBits ^= 0x200L;
+                            values = ref _headers._AccessControlExposeHeaders;
+                            keyStart = 196;
+                            keyLength = 33;
                             next = 11;
                             break; // OutputHeader
                         }
                         goto case 11;
-                    case 11: // Header: "Via"
-                        if ((tempBits & 0x100L) != 0)
+                    case 11: // Header: "Access-Control-Max-Age"
+                        if ((tempBits & 0x400L) != 0)
                         {
-                            tempBits ^= 0x100L;
-                            values = ref _headers._Via;
-                            keyStart = 112;
-                            keyLength = 7;
+                            tempBits ^= 0x400L;
+                            values = ref _headers._AccessControlMaxAge;
+                            keyStart = 229;
+                            keyLength = 26;
                             next = 12;
                             break; // OutputHeader
                         }
                         goto case 12;
-                    case 12: // Header: "Warning"
-                        if ((tempBits & 0x200L) != 0)
+                    case 12: // Header: "Age"
+                        if ((tempBits & 0x800L) != 0)
                         {
-                            tempBits ^= 0x200L;
-                            values = ref _headers._Warning;
-                            keyStart = 119;
-                            keyLength = 11;
+                            tempBits ^= 0x800L;
+                            values = ref _headers._Age;
+                            keyStart = 255;
+                            keyLength = 7;
                             next = 13;
                             break; // OutputHeader
                         }
                         goto case 13;
-                    case 13: // Header: "Accept-Ranges"
-                        if ((tempBits & 0x800L) != 0)
+                    case 13: // Header: "Allow"
+                        if ((tempBits & 0x1000L) != 0)
                         {
-                            tempBits ^= 0x800L;
-                            values = ref _headers._AcceptRanges;
-                            keyStart = 146;
-                            keyLength = 17;
+                            tempBits ^= 0x1000L;
+                            values = ref _headers._Allow;
+                            keyStart = 262;
+                            keyLength = 9;
                             next = 14;
                             break; // OutputHeader
                         }
                         goto case 14;
-                    case 14: // Header: "Age"
-                        if ((tempBits & 0x1000L) != 0)
+                    case 14: // Header: "Alt-Svc"
+                        if ((tempBits & 0x2000L) != 0)
                         {
-                            tempBits ^= 0x1000L;
-                            values = ref _headers._Age;
-                            keyStart = 163;
-                            keyLength = 7;
+                            tempBits ^= 0x2000L;
+                            values = ref _headers._AltSvc;
+                            keyStart = 271;
+                            keyLength = 11;
                             next = 15;
                             break; // OutputHeader
                         }
                         goto case 15;
-                    case 15: // Header: "Allow"
-                        if ((tempBits & 0x2000L) != 0)
+                    case 15: // Header: "Cache-Control"
+                        if ((tempBits & 0x4000L) != 0)
                         {
-                            tempBits ^= 0x2000L;
-                            values = ref _headers._Allow;
-                            keyStart = 170;
-                            keyLength = 9;
+                            tempBits ^= 0x4000L;
+                            values = ref _headers._CacheControl;
+                            keyStart = 282;
+                            keyLength = 17;
                             next = 16;
                             break; // OutputHeader
                         }
                         goto case 16;
-                    case 16: // Header: "Alt-Svc"
-                        if ((tempBits & 0x4000L) != 0)
+                    case 16: // Header: "Content-Encoding"
+                        if ((tempBits & 0x8000L) != 0)
                         {
-                            tempBits ^= 0x4000L;
-                            values = ref _headers._AltSvc;
-                            keyStart = 179;
-                            keyLength = 11;
+                            tempBits ^= 0x8000L;
+                            values = ref _headers._ContentEncoding;
+                            keyStart = 299;
+                            keyLength = 20;
                             next = 17;
                             break; // OutputHeader
                         }
                         goto case 17;
-                    case 17: // Header: "ETag"
-                        if ((tempBits & 0x8000L) != 0)
+                    case 17: // Header: "Content-Language"
+                        if ((tempBits & 0x10000L) != 0)
                         {
-                            tempBits ^= 0x8000L;
-                            values = ref _headers._ETag;
-                            keyStart = 190;
-                            keyLength = 8;
+                            tempBits ^= 0x10000L;
+                            values = ref _headers._ContentLanguage;
+                            keyStart = 319;
+                            keyLength = 20;
                             next = 18;
                             break; // OutputHeader
                         }
                         goto case 18;
-                    case 18: // Header: "Location"
-                        if ((tempBits & 0x10000L) != 0)
+                    case 18: // Header: "Content-Location"
+                        if ((tempBits & 0x20000L) != 0)
                         {
-                            tempBits ^= 0x10000L;
-                            values = ref _headers._Location;
-                            keyStart = 198;
-                            keyLength = 12;
+                            tempBits ^= 0x20000L;
+                            values = ref _headers._ContentLocation;
+                            keyStart = 339;
+                            keyLength = 20;
                             next = 19;
                             break; // OutputHeader
                         }
                         goto case 19;
-                    case 19: // Header: "Proxy-Authenticate"
-                        if ((tempBits & 0x20000L) != 0)
+                    case 19: // Header: "Content-MD5"
+                        if ((tempBits & 0x40000L) != 0)
                         {
-                            tempBits ^= 0x20000L;
-                            values = ref _headers._ProxyAuthenticate;
-                            keyStart = 210;
-                            keyLength = 22;
+                            tempBits ^= 0x40000L;
+                            values = ref _headers._ContentMD5;
+                            keyStart = 359;
+                            keyLength = 15;
                             next = 20;
                             break; // OutputHeader
                         }
                         goto case 20;
-                    case 20: // Header: "Proxy-Connection"
-                        if ((tempBits & 0x40000L) != 0)
+                    case 20: // Header: "Content-Range"
+                        if ((tempBits & 0x80000L) != 0)
                         {
-                            tempBits ^= 0x40000L;
-                            values = ref _headers._ProxyConnection;
-                            keyStart = 232;
-                            keyLength = 20;
+                            tempBits ^= 0x80000L;
+                            values = ref _headers._ContentRange;
+                            keyStart = 374;
+                            keyLength = 17;
                             next = 21;
                             break; // OutputHeader
                         }
                         goto case 21;
-                    case 21: // Header: "Retry-After"
-                        if ((tempBits & 0x80000L) != 0)
+                    case 21: // Header: "ETag"
+                        if ((tempBits & 0x100000L) != 0)
                         {
-                            tempBits ^= 0x80000L;
-                            values = ref _headers._RetryAfter;
-                            keyStart = 252;
-                            keyLength = 15;
+                            tempBits ^= 0x100000L;
+                            values = ref _headers._ETag;
+                            keyStart = 391;
+                            keyLength = 8;
                             next = 22;
                             break; // OutputHeader
                         }
                         goto case 22;
-                    case 22: // Header: "Set-Cookie"
+                    case 22: // Header: "Expires"
                         if ((tempBits & 0x200000L) != 0)
                         {
                             tempBits ^= 0x200000L;
-                            values = ref _headers._SetCookie;
-                            keyStart = 277;
-                            keyLength = 14;
+                            values = ref _headers._Expires;
+                            keyStart = 399;
+                            keyLength = 11;
                             next = 23;
                             break; // OutputHeader
                         }
                         goto case 23;
-                    case 23: // Header: "Vary"
+                    case 23: // Header: "Grpc-Encoding"
                         if ((tempBits & 0x400000L) != 0)
                         {
                             tempBits ^= 0x400000L;
-                            values = ref _headers._Vary;
-                            keyStart = 291;
-                            keyLength = 8;
+                            values = ref _headers._GrpcEncoding;
+                            keyStart = 410;
+                            keyLength = 17;
                             next = 24;
                             break; // OutputHeader
                         }
                         goto case 24;
-                    case 24: // Header: "Expires"
+                    case 24: // Header: "Keep-Alive"
                         if ((tempBits & 0x800000L) != 0)
                         {
                             tempBits ^= 0x800000L;
-                            values = ref _headers._Expires;
-                            keyStart = 299;
-                            keyLength = 11;
+                            values = ref _headers._KeepAlive;
+                            keyStart = 427;
+                            keyLength = 14;
                             next = 25;
                             break; // OutputHeader
                         }
                         goto case 25;
-                    case 25: // Header: "WWW-Authenticate"
+                    case 25: // Header: "Last-Modified"
                         if ((tempBits & 0x1000000L) != 0)
                         {
                             tempBits ^= 0x1000000L;
-                            values = ref _headers._WWWAuthenticate;
-                            keyStart = 310;
-                            keyLength = 20;
+                            values = ref _headers._LastModified;
+                            keyStart = 441;
+                            keyLength = 17;
                             next = 26;
                             break; // OutputHeader
                         }
                         goto case 26;
-                    case 26: // Header: "Content-Range"
+                    case 26: // Header: "Location"
                         if ((tempBits & 0x2000000L) != 0)
                         {
                             tempBits ^= 0x2000000L;
-                            values = ref _headers._ContentRange;
-                            keyStart = 330;
-                            keyLength = 17;
+                            values = ref _headers._Location;
+                            keyStart = 458;
+                            keyLength = 12;
                             next = 27;
                             break; // OutputHeader
                         }
                         goto case 27;
-                    case 27: // Header: "Content-Encoding"
+                    case 27: // Header: "Pragma"
                         if ((tempBits & 0x4000000L) != 0)
                         {
                             tempBits ^= 0x4000000L;
-                            values = ref _headers._ContentEncoding;
-                            keyStart = 347;
-                            keyLength = 20;
+                            values = ref _headers._Pragma;
+                            keyStart = 470;
+                            keyLength = 10;
                             next = 28;
                             break; // OutputHeader
                         }
                         goto case 28;
-                    case 28: // Header: "Content-Language"
+                    case 28: // Header: "Proxy-Authenticate"
                         if ((tempBits & 0x8000000L) != 0)
                         {
                             tempBits ^= 0x8000000L;
-                            values = ref _headers._ContentLanguage;
-                            keyStart = 367;
-                            keyLength = 20;
+                            values = ref _headers._ProxyAuthenticate;
+                            keyStart = 480;
+                            keyLength = 22;
                             next = 29;
                             break; // OutputHeader
                         }
                         goto case 29;
-                    case 29: // Header: "Content-Location"
+                    case 29: // Header: "Proxy-Connection"
                         if ((tempBits & 0x10000000L) != 0)
                         {
                             tempBits ^= 0x10000000L;
-                            values = ref _headers._ContentLocation;
-                            keyStart = 387;
+                            values = ref _headers._ProxyConnection;
+                            keyStart = 502;
                             keyLength = 20;
                             next = 30;
                             break; // OutputHeader
                         }
                         goto case 30;
-                    case 30: // Header: "Content-MD5"
+                    case 30: // Header: "Retry-After"
                         if ((tempBits & 0x20000000L) != 0)
                         {
                             tempBits ^= 0x20000000L;
-                            values = ref _headers._ContentMD5;
-                            keyStart = 407;
+                            values = ref _headers._RetryAfter;
+                            keyStart = 522;
                             keyLength = 15;
                             next = 31;
                             break; // OutputHeader
                         }
                         goto case 31;
-                    case 31: // Header: "Last-Modified"
+                    case 31: // Header: "Set-Cookie"
                         if ((tempBits & 0x40000000L) != 0)
                         {
                             tempBits ^= 0x40000000L;
-                            values = ref _headers._LastModified;
-                            keyStart = 422;
-                            keyLength = 17;
+                            values = ref _headers._SetCookie;
+                            keyStart = 537;
+                            keyLength = 14;
                             next = 32;
                             break; // OutputHeader
                         }
@@ -14670,74 +14663,81 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         {
                             tempBits ^= 0x80000000L;
                             values = ref _headers._Trailer;
-                            keyStart = 439;
+                            keyStart = 551;
                             keyLength = 11;
                             next = 33;
                             break; // OutputHeader
                         }
                         goto case 33;
-                    case 33: // Header: "Access-Control-Allow-Credentials"
+                    case 33: // Header: "Transfer-Encoding"
                         if ((tempBits & 0x100000000L) != 0)
                         {
                             tempBits ^= 0x100000000L;
-                            values = ref _headers._AccessControlAllowCredentials;
-                            keyStart = 450;
-                            keyLength = 36;
-                            next = 34;
-                            break; // OutputHeader
+                            if (_headers._rawTransferEncoding != null)
+                            {
+                                output.Write(_headers._rawTransferEncoding);
+                            }
+                            else
+                            {
+                                values = ref _headers._TransferEncoding;
+                                keyStart = 562;
+                                keyLength = 21;
+                                next = 34;
+                                break; // OutputHeader
+                            }
                         }
                         goto case 34;
-                    case 34: // Header: "Access-Control-Allow-Headers"
+                    case 34: // Header: "Upgrade"
                         if ((tempBits & 0x200000000L) != 0)
                         {
                             tempBits ^= 0x200000000L;
-                            values = ref _headers._AccessControlAllowHeaders;
-                            keyStart = 486;
-                            keyLength = 32;
+                            values = ref _headers._Upgrade;
+                            keyStart = 583;
+                            keyLength = 11;
                             next = 35;
                             break; // OutputHeader
                         }
                         goto case 35;
-                    case 35: // Header: "Access-Control-Allow-Methods"
+                    case 35: // Header: "Vary"
                         if ((tempBits & 0x400000000L) != 0)
                         {
                             tempBits ^= 0x400000000L;
-                            values = ref _headers._AccessControlAllowMethods;
-                            keyStart = 518;
-                            keyLength = 32;
+                            values = ref _headers._Vary;
+                            keyStart = 594;
+                            keyLength = 8;
                             next = 36;
                             break; // OutputHeader
                         }
                         goto case 36;
-                    case 36: // Header: "Access-Control-Allow-Origin"
+                    case 36: // Header: "Via"
                         if ((tempBits & 0x800000000L) != 0)
                         {
                             tempBits ^= 0x800000000L;
-                            values = ref _headers._AccessControlAllowOrigin;
-                            keyStart = 550;
-                            keyLength = 31;
+                            values = ref _headers._Via;
+                            keyStart = 602;
+                            keyLength = 7;
                             next = 37;
                             break; // OutputHeader
                         }
                         goto case 37;
-                    case 37: // Header: "Access-Control-Expose-Headers"
+                    case 37: // Header: "Warning"
                         if ((tempBits & 0x1000000000L) != 0)
                         {
                             tempBits ^= 0x1000000000L;
-                            values = ref _headers._AccessControlExposeHeaders;
-                            keyStart = 581;
-                            keyLength = 33;
+                            values = ref _headers._Warning;
+                            keyStart = 609;
+                            keyLength = 11;
                             next = 38;
                             break; // OutputHeader
                         }
                         goto case 38;
-                    case 38: // Header: "Access-Control-Max-Age"
+                    case 38: // Header: "WWW-Authenticate"
                         if ((tempBits & 0x2000000000L) != 0)
                         {
                             tempBits ^= 0x2000000000L;
-                            values = ref _headers._AccessControlMaxAge;
-                            keyStart = 614;
-                            keyLength = 26;
+                            values = ref _headers._WWWAuthenticate;
+                            keyStart = 620;
+                            keyLength = 20;
                             next = 39;
                             break; // OutputHeader
                         }
@@ -14765,49 +14765,49 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         private struct HeaderReferences
         {
-            public StringValues _CacheControl;
             public StringValues _Connection;
-            public StringValues _Date;
-            public StringValues _GrpcEncoding;
-            public StringValues _KeepAlive;
-            public StringValues _Pragma;
-            public StringValues _TransferEncoding;
-            public StringValues _Upgrade;
-            public StringValues _Via;
-            public StringValues _Warning;
             public StringValues _ContentType;
-            public StringValues _AcceptRanges;
-            public StringValues _Age;
-            public StringValues _Allow;
-            public StringValues _AltSvc;
-            public StringValues _ETag;
-            public StringValues _Location;
-            public StringValues _ProxyAuthenticate;
-            public StringValues _ProxyConnection;
-            public StringValues _RetryAfter;
+            public StringValues _Date;
             public StringValues _Server;
-            public StringValues _SetCookie;
-            public StringValues _Vary;
-            public StringValues _Expires;
-            public StringValues _WWWAuthenticate;
-            public StringValues _ContentRange;
-            public StringValues _ContentEncoding;
-            public StringValues _ContentLanguage;
-            public StringValues _ContentLocation;
-            public StringValues _ContentMD5;
-            public StringValues _LastModified;
-            public StringValues _Trailer;
+            public StringValues _AcceptRanges;
             public StringValues _AccessControlAllowCredentials;
             public StringValues _AccessControlAllowHeaders;
             public StringValues _AccessControlAllowMethods;
             public StringValues _AccessControlAllowOrigin;
             public StringValues _AccessControlExposeHeaders;
             public StringValues _AccessControlMaxAge;
+            public StringValues _Age;
+            public StringValues _Allow;
+            public StringValues _AltSvc;
+            public StringValues _CacheControl;
+            public StringValues _ContentEncoding;
+            public StringValues _ContentLanguage;
+            public StringValues _ContentLocation;
+            public StringValues _ContentMD5;
+            public StringValues _ContentRange;
+            public StringValues _ETag;
+            public StringValues _Expires;
+            public StringValues _GrpcEncoding;
+            public StringValues _KeepAlive;
+            public StringValues _LastModified;
+            public StringValues _Location;
+            public StringValues _Pragma;
+            public StringValues _ProxyAuthenticate;
+            public StringValues _ProxyConnection;
+            public StringValues _RetryAfter;
+            public StringValues _SetCookie;
+            public StringValues _Trailer;
+            public StringValues _TransferEncoding;
+            public StringValues _Upgrade;
+            public StringValues _Vary;
+            public StringValues _Via;
+            public StringValues _Warning;
+            public StringValues _WWWAuthenticate;
             
             public byte[]? _rawConnection;
             public byte[]? _rawDate;
-            public byte[]? _rawTransferEncoding;
             public byte[]? _rawServer;
+            public byte[]? _rawTransferEncoding;
         }
 
         public partial struct Enumerator
@@ -14818,100 +14818,100 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 switch (_next)
                 {
                     case 0:
-                        goto HeaderCacheControl;
-                    case 1:
                         goto HeaderConnection;
+                    case 1:
+                        goto HeaderContentType;
                     case 2:
                         goto HeaderDate;
                     case 3:
-                        goto HeaderGrpcEncoding;
-                    case 4:
-                        goto HeaderKeepAlive;
-                    case 5:
-                        goto HeaderPragma;
-                    case 6:
-                        goto HeaderTransferEncoding;
-                    case 7:
-                        goto HeaderUpgrade;
-                    case 8:
-                        goto HeaderVia;
-                    case 9:
-                        goto HeaderWarning;
-                    case 10:
-                        goto HeaderContentType;
-                    case 11:
-                        goto HeaderAcceptRanges;
-                    case 12:
-                        goto HeaderAge;
-                    case 13:
-                        goto HeaderAllow;
-                    case 14:
-                        goto HeaderAltSvc;
-                    case 15:
-                        goto HeaderETag;
-                    case 16:
-                        goto HeaderLocation;
-                    case 17:
-                        goto HeaderProxyAuthenticate;
-                    case 18:
-                        goto HeaderProxyConnection;
-                    case 19:
-                        goto HeaderRetryAfter;
-                    case 20:
                         goto HeaderServer;
-                    case 21:
-                        goto HeaderSetCookie;
-                    case 22:
-                        goto HeaderVary;
-                    case 23:
-                        goto HeaderExpires;
-                    case 24:
-                        goto HeaderWWWAuthenticate;
-                    case 25:
-                        goto HeaderContentRange;
-                    case 26:
+                    case 4:
+                        goto HeaderAcceptRanges;
+                    case 5:
+                        goto HeaderAccessControlAllowCredentials;
+                    case 6:
+                        goto HeaderAccessControlAllowHeaders;
+                    case 7:
+                        goto HeaderAccessControlAllowMethods;
+                    case 8:
+                        goto HeaderAccessControlAllowOrigin;
+                    case 9:
+                        goto HeaderAccessControlExposeHeaders;
+                    case 10:
+                        goto HeaderAccessControlMaxAge;
+                    case 11:
+                        goto HeaderAge;
+                    case 12:
+                        goto HeaderAllow;
+                    case 13:
+                        goto HeaderAltSvc;
+                    case 14:
+                        goto HeaderCacheControl;
+                    case 15:
                         goto HeaderContentEncoding;
-                    case 27:
+                    case 16:
                         goto HeaderContentLanguage;
-                    case 28:
+                    case 17:
                         goto HeaderContentLocation;
-                    case 29:
+                    case 18:
                         goto HeaderContentMD5;
-                    case 30:
+                    case 19:
+                        goto HeaderContentRange;
+                    case 20:
+                        goto HeaderETag;
+                    case 21:
+                        goto HeaderExpires;
+                    case 22:
+                        goto HeaderGrpcEncoding;
+                    case 23:
+                        goto HeaderKeepAlive;
+                    case 24:
                         goto HeaderLastModified;
+                    case 25:
+                        goto HeaderLocation;
+                    case 26:
+                        goto HeaderPragma;
+                    case 27:
+                        goto HeaderProxyAuthenticate;
+                    case 28:
+                        goto HeaderProxyConnection;
+                    case 29:
+                        goto HeaderRetryAfter;
+                    case 30:
+                        goto HeaderSetCookie;
                     case 31:
                         goto HeaderTrailer;
                     case 32:
-                        goto HeaderAccessControlAllowCredentials;
+                        goto HeaderTransferEncoding;
                     case 33:
-                        goto HeaderAccessControlAllowHeaders;
+                        goto HeaderUpgrade;
                     case 34:
-                        goto HeaderAccessControlAllowMethods;
+                        goto HeaderVary;
                     case 35:
-                        goto HeaderAccessControlAllowOrigin;
+                        goto HeaderVia;
                     case 36:
-                        goto HeaderAccessControlExposeHeaders;
+                        goto HeaderWarning;
                     case 37:
-                        goto HeaderAccessControlMaxAge;
+                        goto HeaderWWWAuthenticate;
                     case 38:
                         goto HeaderContentLength;
                     default:
                         goto ExtraHeaders;
                 }
                 
-                HeaderCacheControl: // case 0
+                HeaderConnection: // case 0
                     if ((_bits & 0x1L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.CacheControl, _collection._headers._CacheControl);
-                        _currentKnownType = KnownHeaderType.CacheControl;
-                        _next = 1;
-                        return true;
-                    }
-                HeaderConnection: // case 1
-                    if ((_bits & 0x2L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Connection, _collection._headers._Connection);
                         _currentKnownType = KnownHeaderType.Connection;
+                        _next = 1;
+                        return true;
+                    }
+                HeaderContentType: // case 1
+                    if ((_bits & 0x2L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _collection._headers._ContentType);
+                        _currentKnownType = KnownHeaderType.ContentType;
                         _next = 2;
                         return true;
                     }
@@ -14923,227 +14923,227 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _next = 3;
                         return true;
                     }
-                HeaderGrpcEncoding: // case 3
+                HeaderServer: // case 3
                     if ((_bits & 0x8L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.GrpcEncoding, _collection._headers._GrpcEncoding);
-                        _currentKnownType = KnownHeaderType.GrpcEncoding;
-                        _next = 4;
-                        return true;
-                    }
-                HeaderKeepAlive: // case 4
-                    if ((_bits & 0x10L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.KeepAlive, _collection._headers._KeepAlive);
-                        _currentKnownType = KnownHeaderType.KeepAlive;
-                        _next = 5;
-                        return true;
-                    }
-                HeaderPragma: // case 5
-                    if ((_bits & 0x20L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Pragma, _collection._headers._Pragma);
-                        _currentKnownType = KnownHeaderType.Pragma;
-                        _next = 6;
-                        return true;
-                    }
-                HeaderTransferEncoding: // case 6
-                    if ((_bits & 0x40L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _collection._headers._TransferEncoding);
-                        _currentKnownType = KnownHeaderType.TransferEncoding;
-                        _next = 7;
-                        return true;
-                    }
-                HeaderUpgrade: // case 7
-                    if ((_bits & 0x80L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _collection._headers._Upgrade);
-                        _currentKnownType = KnownHeaderType.Upgrade;
-                        _next = 8;
-                        return true;
-                    }
-                HeaderVia: // case 8
-                    if ((_bits & 0x100L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Via, _collection._headers._Via);
-                        _currentKnownType = KnownHeaderType.Via;
-                        _next = 9;
-                        return true;
-                    }
-                HeaderWarning: // case 9
-                    if ((_bits & 0x200L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _collection._headers._Warning);
-                        _currentKnownType = KnownHeaderType.Warning;
-                        _next = 10;
-                        return true;
-                    }
-                HeaderContentType: // case 10
-                    if ((_bits & 0x400L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentType, _collection._headers._ContentType);
-                        _currentKnownType = KnownHeaderType.ContentType;
-                        _next = 11;
-                        return true;
-                    }
-                HeaderAcceptRanges: // case 11
-                    if ((_bits & 0x800L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptRanges, _collection._headers._AcceptRanges);
-                        _currentKnownType = KnownHeaderType.AcceptRanges;
-                        _next = 12;
-                        return true;
-                    }
-                HeaderAge: // case 12
-                    if ((_bits & 0x1000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Age, _collection._headers._Age);
-                        _currentKnownType = KnownHeaderType.Age;
-                        _next = 13;
-                        return true;
-                    }
-                HeaderAllow: // case 13
-                    if ((_bits & 0x2000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _collection._headers._Allow);
-                        _currentKnownType = KnownHeaderType.Allow;
-                        _next = 14;
-                        return true;
-                    }
-                HeaderAltSvc: // case 14
-                    if ((_bits & 0x4000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AltSvc, _collection._headers._AltSvc);
-                        _currentKnownType = KnownHeaderType.AltSvc;
-                        _next = 15;
-                        return true;
-                    }
-                HeaderETag: // case 15
-                    if ((_bits & 0x8000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ETag, _collection._headers._ETag);
-                        _currentKnownType = KnownHeaderType.ETag;
-                        _next = 16;
-                        return true;
-                    }
-                HeaderLocation: // case 16
-                    if ((_bits & 0x10000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Location, _collection._headers._Location);
-                        _currentKnownType = KnownHeaderType.Location;
-                        _next = 17;
-                        return true;
-                    }
-                HeaderProxyAuthenticate: // case 17
-                    if ((_bits & 0x20000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthenticate, _collection._headers._ProxyAuthenticate);
-                        _currentKnownType = KnownHeaderType.ProxyAuthenticate;
-                        _next = 18;
-                        return true;
-                    }
-                HeaderProxyConnection: // case 18
-                    if ((_bits & 0x40000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyConnection, _collection._headers._ProxyConnection);
-                        _currentKnownType = KnownHeaderType.ProxyConnection;
-                        _next = 19;
-                        return true;
-                    }
-                HeaderRetryAfter: // case 19
-                    if ((_bits & 0x80000L) != 0)
-                    {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.RetryAfter, _collection._headers._RetryAfter);
-                        _currentKnownType = KnownHeaderType.RetryAfter;
-                        _next = 20;
-                        return true;
-                    }
-                HeaderServer: // case 20
-                    if ((_bits & 0x100000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.Server, _collection._headers._Server);
                         _currentKnownType = KnownHeaderType.Server;
-                        _next = 21;
+                        _next = 4;
                         return true;
                     }
-                HeaderSetCookie: // case 21
-                    if ((_bits & 0x200000L) != 0)
+                HeaderAcceptRanges: // case 4
+                    if ((_bits & 0x10L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.SetCookie, _collection._headers._SetCookie);
-                        _currentKnownType = KnownHeaderType.SetCookie;
-                        _next = 22;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AcceptRanges, _collection._headers._AcceptRanges);
+                        _currentKnownType = KnownHeaderType.AcceptRanges;
+                        _next = 5;
                         return true;
                     }
-                HeaderVary: // case 22
-                    if ((_bits & 0x400000L) != 0)
+                HeaderAccessControlAllowCredentials: // case 5
+                    if ((_bits & 0x20L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Vary, _collection._headers._Vary);
-                        _currentKnownType = KnownHeaderType.Vary;
-                        _next = 23;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowCredentials, _collection._headers._AccessControlAllowCredentials);
+                        _currentKnownType = KnownHeaderType.AccessControlAllowCredentials;
+                        _next = 6;
                         return true;
                     }
-                HeaderExpires: // case 23
-                    if ((_bits & 0x800000L) != 0)
+                HeaderAccessControlAllowHeaders: // case 6
+                    if ((_bits & 0x40L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _collection._headers._Expires);
-                        _currentKnownType = KnownHeaderType.Expires;
-                        _next = 24;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowHeaders, _collection._headers._AccessControlAllowHeaders);
+                        _currentKnownType = KnownHeaderType.AccessControlAllowHeaders;
+                        _next = 7;
                         return true;
                     }
-                HeaderWWWAuthenticate: // case 24
-                    if ((_bits & 0x1000000L) != 0)
+                HeaderAccessControlAllowMethods: // case 7
+                    if ((_bits & 0x80L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.WWWAuthenticate, _collection._headers._WWWAuthenticate);
-                        _currentKnownType = KnownHeaderType.WWWAuthenticate;
-                        _next = 25;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowMethods, _collection._headers._AccessControlAllowMethods);
+                        _currentKnownType = KnownHeaderType.AccessControlAllowMethods;
+                        _next = 8;
                         return true;
                     }
-                HeaderContentRange: // case 25
-                    if ((_bits & 0x2000000L) != 0)
+                HeaderAccessControlAllowOrigin: // case 8
+                    if ((_bits & 0x100L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _collection._headers._ContentRange);
-                        _currentKnownType = KnownHeaderType.ContentRange;
-                        _next = 26;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowOrigin, _collection._headers._AccessControlAllowOrigin);
+                        _currentKnownType = KnownHeaderType.AccessControlAllowOrigin;
+                        _next = 9;
                         return true;
                     }
-                HeaderContentEncoding: // case 26
-                    if ((_bits & 0x4000000L) != 0)
+                HeaderAccessControlExposeHeaders: // case 9
+                    if ((_bits & 0x200L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlExposeHeaders, _collection._headers._AccessControlExposeHeaders);
+                        _currentKnownType = KnownHeaderType.AccessControlExposeHeaders;
+                        _next = 10;
+                        return true;
+                    }
+                HeaderAccessControlMaxAge: // case 10
+                    if ((_bits & 0x400L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlMaxAge, _collection._headers._AccessControlMaxAge);
+                        _currentKnownType = KnownHeaderType.AccessControlMaxAge;
+                        _next = 11;
+                        return true;
+                    }
+                HeaderAge: // case 11
+                    if ((_bits & 0x800L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Age, _collection._headers._Age);
+                        _currentKnownType = KnownHeaderType.Age;
+                        _next = 12;
+                        return true;
+                    }
+                HeaderAllow: // case 12
+                    if ((_bits & 0x1000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Allow, _collection._headers._Allow);
+                        _currentKnownType = KnownHeaderType.Allow;
+                        _next = 13;
+                        return true;
+                    }
+                HeaderAltSvc: // case 13
+                    if ((_bits & 0x2000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AltSvc, _collection._headers._AltSvc);
+                        _currentKnownType = KnownHeaderType.AltSvc;
+                        _next = 14;
+                        return true;
+                    }
+                HeaderCacheControl: // case 14
+                    if ((_bits & 0x4000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.CacheControl, _collection._headers._CacheControl);
+                        _currentKnownType = KnownHeaderType.CacheControl;
+                        _next = 15;
+                        return true;
+                    }
+                HeaderContentEncoding: // case 15
+                    if ((_bits & 0x8000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentEncoding, _collection._headers._ContentEncoding);
                         _currentKnownType = KnownHeaderType.ContentEncoding;
-                        _next = 27;
+                        _next = 16;
                         return true;
                     }
-                HeaderContentLanguage: // case 27
-                    if ((_bits & 0x8000000L) != 0)
+                HeaderContentLanguage: // case 16
+                    if ((_bits & 0x10000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLanguage, _collection._headers._ContentLanguage);
                         _currentKnownType = KnownHeaderType.ContentLanguage;
-                        _next = 28;
+                        _next = 17;
                         return true;
                     }
-                HeaderContentLocation: // case 28
-                    if ((_bits & 0x10000000L) != 0)
+                HeaderContentLocation: // case 17
+                    if ((_bits & 0x20000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentLocation, _collection._headers._ContentLocation);
                         _currentKnownType = KnownHeaderType.ContentLocation;
-                        _next = 29;
+                        _next = 18;
                         return true;
                     }
-                HeaderContentMD5: // case 29
-                    if ((_bits & 0x20000000L) != 0)
+                HeaderContentMD5: // case 18
+                    if ((_bits & 0x40000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentMD5, _collection._headers._ContentMD5);
                         _currentKnownType = KnownHeaderType.ContentMD5;
-                        _next = 30;
+                        _next = 19;
                         return true;
                     }
-                HeaderLastModified: // case 30
-                    if ((_bits & 0x40000000L) != 0)
+                HeaderContentRange: // case 19
+                    if ((_bits & 0x80000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ContentRange, _collection._headers._ContentRange);
+                        _currentKnownType = KnownHeaderType.ContentRange;
+                        _next = 20;
+                        return true;
+                    }
+                HeaderETag: // case 20
+                    if ((_bits & 0x100000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ETag, _collection._headers._ETag);
+                        _currentKnownType = KnownHeaderType.ETag;
+                        _next = 21;
+                        return true;
+                    }
+                HeaderExpires: // case 21
+                    if ((_bits & 0x200000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Expires, _collection._headers._Expires);
+                        _currentKnownType = KnownHeaderType.Expires;
+                        _next = 22;
+                        return true;
+                    }
+                HeaderGrpcEncoding: // case 22
+                    if ((_bits & 0x400000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.GrpcEncoding, _collection._headers._GrpcEncoding);
+                        _currentKnownType = KnownHeaderType.GrpcEncoding;
+                        _next = 23;
+                        return true;
+                    }
+                HeaderKeepAlive: // case 23
+                    if ((_bits & 0x800000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.KeepAlive, _collection._headers._KeepAlive);
+                        _currentKnownType = KnownHeaderType.KeepAlive;
+                        _next = 24;
+                        return true;
+                    }
+                HeaderLastModified: // case 24
+                    if ((_bits & 0x1000000L) != 0)
                     {
                         _current = new KeyValuePair<string, StringValues>(HeaderNames.LastModified, _collection._headers._LastModified);
                         _currentKnownType = KnownHeaderType.LastModified;
+                        _next = 25;
+                        return true;
+                    }
+                HeaderLocation: // case 25
+                    if ((_bits & 0x2000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Location, _collection._headers._Location);
+                        _currentKnownType = KnownHeaderType.Location;
+                        _next = 26;
+                        return true;
+                    }
+                HeaderPragma: // case 26
+                    if ((_bits & 0x4000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Pragma, _collection._headers._Pragma);
+                        _currentKnownType = KnownHeaderType.Pragma;
+                        _next = 27;
+                        return true;
+                    }
+                HeaderProxyAuthenticate: // case 27
+                    if ((_bits & 0x8000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyAuthenticate, _collection._headers._ProxyAuthenticate);
+                        _currentKnownType = KnownHeaderType.ProxyAuthenticate;
+                        _next = 28;
+                        return true;
+                    }
+                HeaderProxyConnection: // case 28
+                    if ((_bits & 0x10000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.ProxyConnection, _collection._headers._ProxyConnection);
+                        _currentKnownType = KnownHeaderType.ProxyConnection;
+                        _next = 29;
+                        return true;
+                    }
+                HeaderRetryAfter: // case 29
+                    if ((_bits & 0x20000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.RetryAfter, _collection._headers._RetryAfter);
+                        _currentKnownType = KnownHeaderType.RetryAfter;
+                        _next = 30;
+                        return true;
+                    }
+                HeaderSetCookie: // case 30
+                    if ((_bits & 0x40000000L) != 0)
+                    {
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.SetCookie, _collection._headers._SetCookie);
+                        _currentKnownType = KnownHeaderType.SetCookie;
                         _next = 31;
                         return true;
                     }
@@ -15155,51 +15155,51 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         _next = 32;
                         return true;
                     }
-                HeaderAccessControlAllowCredentials: // case 32
+                HeaderTransferEncoding: // case 32
                     if ((_bits & 0x100000000L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowCredentials, _collection._headers._AccessControlAllowCredentials);
-                        _currentKnownType = KnownHeaderType.AccessControlAllowCredentials;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.TransferEncoding, _collection._headers._TransferEncoding);
+                        _currentKnownType = KnownHeaderType.TransferEncoding;
                         _next = 33;
                         return true;
                     }
-                HeaderAccessControlAllowHeaders: // case 33
+                HeaderUpgrade: // case 33
                     if ((_bits & 0x200000000L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowHeaders, _collection._headers._AccessControlAllowHeaders);
-                        _currentKnownType = KnownHeaderType.AccessControlAllowHeaders;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Upgrade, _collection._headers._Upgrade);
+                        _currentKnownType = KnownHeaderType.Upgrade;
                         _next = 34;
                         return true;
                     }
-                HeaderAccessControlAllowMethods: // case 34
+                HeaderVary: // case 34
                     if ((_bits & 0x400000000L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowMethods, _collection._headers._AccessControlAllowMethods);
-                        _currentKnownType = KnownHeaderType.AccessControlAllowMethods;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Vary, _collection._headers._Vary);
+                        _currentKnownType = KnownHeaderType.Vary;
                         _next = 35;
                         return true;
                     }
-                HeaderAccessControlAllowOrigin: // case 35
+                HeaderVia: // case 35
                     if ((_bits & 0x800000000L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlAllowOrigin, _collection._headers._AccessControlAllowOrigin);
-                        _currentKnownType = KnownHeaderType.AccessControlAllowOrigin;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Via, _collection._headers._Via);
+                        _currentKnownType = KnownHeaderType.Via;
                         _next = 36;
                         return true;
                     }
-                HeaderAccessControlExposeHeaders: // case 36
+                HeaderWarning: // case 36
                     if ((_bits & 0x1000000000L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlExposeHeaders, _collection._headers._AccessControlExposeHeaders);
-                        _currentKnownType = KnownHeaderType.AccessControlExposeHeaders;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.Warning, _collection._headers._Warning);
+                        _currentKnownType = KnownHeaderType.Warning;
                         _next = 37;
                         return true;
                     }
-                HeaderAccessControlMaxAge: // case 37
+                HeaderWWWAuthenticate: // case 37
                     if ((_bits & 0x2000000000L) != 0)
                     {
-                        _current = new KeyValuePair<string, StringValues>(HeaderNames.AccessControlMaxAge, _collection._headers._AccessControlMaxAge);
-                        _currentKnownType = KnownHeaderType.AccessControlMaxAge;
+                        _current = new KeyValuePair<string, StringValues>(HeaderNames.WWWAuthenticate, _collection._headers._WWWAuthenticate);
+                        _currentKnownType = KnownHeaderType.WWWAuthenticate;
                         _next = 38;
                         return true;
                     }

--- a/src/Servers/Kestrel/Core/test/Http2HPackEncoderTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http2HPackEncoderTests.cs
@@ -86,9 +86,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var result = buffer.Slice(0, length).ToArray();
             var hex = BitConverter.ToString(result);
             Assert.Equal(
-                "48-03-33-30-32-58-07-70-72-69-76-61-74-65-61-1D-" +
-                "4D-6F-6E-2C-20-32-31-20-4F-63-74-20-32-30-31-33-" +
-                "20-32-30-3A-31-33-3A-32-31-20-47-4D-54-6E-17-68-" +
+                "48-03-33-30-32-61-1D-4D-6F-6E-2C-20-32-31-20-4F-" +
+                "63-74-20-32-30-31-33-20-32-30-3A-31-33-3A-32-31-" +
+                "20-47-4D-54-58-07-70-72-69-76-61-74-65-6E-17-68-" +
                 "74-74-70-73-3A-2F-2F-77-77-77-2E-65-78-61-6D-70-" +
                 "6C-65-2E-63-6F-6D", hex);
 
@@ -101,13 +101,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 },
                 e =>
                 {
-                    Assert.Equal("Date", e.Name);
-                    Assert.Equal("Mon, 21 Oct 2013 20:13:21 GMT", e.Value);
+                    Assert.Equal("Cache-Control", e.Name);
+                    Assert.Equal("private", e.Value);
                 },
                 e =>
                 {
-                    Assert.Equal("Cache-Control", e.Name);
-                    Assert.Equal("private", e.Value);
+                    Assert.Equal("Date", e.Name);
+                    Assert.Equal("Mon, 21 Oct 2013 20:13:21 GMT", e.Value);
                 },
                 e =>
                 {
@@ -137,13 +137,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 },
                 e =>
                 {
-                    Assert.Equal("Date", e.Name);
-                    Assert.Equal("Mon, 21 Oct 2013 20:13:21 GMT", e.Value);
+                    Assert.Equal("Cache-Control", e.Name);
+                    Assert.Equal("private", e.Value);
                 },
                 e =>
                 {
-                    Assert.Equal("Cache-Control", e.Name);
-                    Assert.Equal("private", e.Value);
+                    Assert.Equal("Date", e.Name);
+                    Assert.Equal("Mon, 21 Oct 2013 20:13:21 GMT", e.Value);
                 });
 
             // Third response
@@ -157,9 +157,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             result = buffer.Slice(0, length).ToArray();
             hex = BitConverter.ToString(result);
             Assert.Equal(
-                "88-C1-61-1D-4D-6F-6E-2C-20-32-31-20-4F-63-74-20-" +
-                "32-30-31-33-20-32-30-3A-31-33-3A-32-32-20-47-4D-" +
-                "54-5A-04-67-7A-69-70-C1-1F-28-38-66-6F-6F-3D-41-" +
+                "88-61-1D-4D-6F-6E-2C-20-32-31-20-4F-63-74-20-32-" +
+                "30-31-33-20-32-30-3A-31-33-3A-32-32-20-47-4D-54-" +
+                "C1-5A-04-67-7A-69-70-C1-1F-28-38-66-6F-6F-3D-41-" +
                 "53-44-4A-4B-48-51-4B-42-5A-58-4F-51-57-45-4F-50-" +
                 "49-55-41-58-51-57-45-4F-49-55-3B-20-6D-61-78-2D-" +
                 "61-67-65-3D-33-36-30-30-3B-20-76-65-72-73-69-6F-" +

--- a/src/Servers/Kestrel/Core/test/Http2HeadersEnumeratorTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http2HeadersEnumeratorTests.cs
@@ -40,10 +40,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal(new[]
             {
                 CreateHeaderResult(H2StaticTable.Date, "Date", "Date!"),
-                CreateHeaderResult(-1, "Grpc-Encoding", "Identity!"),
                 CreateHeaderResult(H2StaticTable.AcceptRanges, "Accept-Ranges", "AcceptRanges!"),
                 CreateHeaderResult(H2StaticTable.Age, "Age", "1"),
                 CreateHeaderResult(H2StaticTable.Age, "Age", "2"),
+                CreateHeaderResult(-1, "Grpc-Encoding", "Identity!"),
                 CreateHeaderResult(H2StaticTable.ContentLength, "Content-Length", "9"),
                 CreateHeaderResult(-1, "Name1", "Value1"),
                 CreateHeaderResult(-1, "Name2", "Value2-1"),

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -85,20 +85,11 @@ namespace CodeGenerator
                 HeaderNames.GrpcEncoding,
                 HeaderNames.KeepAlive,
                 HeaderNames.Pragma,
-                HeaderNames.Trailer,
                 HeaderNames.TransferEncoding,
                 HeaderNames.Upgrade,
                 HeaderNames.Via,
                 HeaderNames.Warning,
-                HeaderNames.Allow,
                 HeaderNames.ContentType,
-                HeaderNames.ContentEncoding,
-                HeaderNames.ContentLanguage,
-                HeaderNames.ContentLocation,
-                HeaderNames.ContentMD5,
-                HeaderNames.ContentRange,
-                HeaderNames.Expires,
-                HeaderNames.LastModified
             };
             // http://www.w3.org/TR/cors/#syntax
             var corsRequestHeaders = new[]
@@ -150,7 +141,7 @@ namespace CodeGenerator
                 HeaderNames.CorrelationContext,
                 HeaderNames.TraceParent,
                 HeaderNames.TraceState,
-                HeaderNames.Baggage
+                HeaderNames.Baggage,
             })
             .Concat(corsRequestHeaders)
             .Select((header, index) => new KnownHeader
@@ -197,6 +188,7 @@ namespace CodeGenerator
             {
                 HeaderNames.AcceptRanges,
                 HeaderNames.Age,
+                HeaderNames.Allow,
                 HeaderNames.AltSvc,
                 HeaderNames.ETag,
                 HeaderNames.Location,
@@ -206,7 +198,15 @@ namespace CodeGenerator
                 HeaderNames.Server,
                 HeaderNames.SetCookie,
                 HeaderNames.Vary,
+                HeaderNames.Expires,
                 HeaderNames.WWWAuthenticate,
+                HeaderNames.ContentRange,
+                HeaderNames.ContentEncoding,
+                HeaderNames.ContentLanguage,
+                HeaderNames.ContentLocation,
+                HeaderNames.ContentMD5,
+                HeaderNames.LastModified,
+                HeaderNames.Trailer,
             })
             .Concat(corsResponseHeaders)
             .Select((header, index) => new KnownHeader

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -144,6 +144,8 @@ namespace CodeGenerator
                 HeaderNames.Baggage,
             })
             .Concat(corsRequestHeaders)
+            .OrderBy(header => header)
+            .OrderBy(header => !requestPrimaryHeaders.Contains(header))
             .Select((header, index) => new KnownHeader
             {
                 Name = header,
@@ -209,6 +211,8 @@ namespace CodeGenerator
                 HeaderNames.Trailer,
             })
             .Concat(corsResponseHeaders)
+            .OrderBy(header => header)
+            .OrderBy(header => !responsePrimaryHeaders.Contains(header))
             .Select((header, index) => new KnownHeader
             {
                 Name = header,
@@ -232,6 +236,8 @@ namespace CodeGenerator
                 HeaderNames.GrpcMessage,
                 HeaderNames.GrpcStatus
             }
+            .OrderBy(header => header)
+            .OrderBy(header => !responsePrimaryHeaders.Contains(header))
             .Select((header, index) => new KnownHeader
             {
                 Name = header,


### PR DESCRIPTION
Some headers in common are only used for request or response; so move them to those collections rather than having them in both.

Note: this doesn't mean they are common enough to be kept in the collections; however they definitely shouldn't be in both request and response collections.

Moved from both to only Response headers; shrinking Request headers by 72 bytes.
* Trailer
* Allow
* ContentEncoding
* ContentLanguage
* ContentLocation
* ContentMD5
* ContentRange
* Expires
* LastModified

Contributes to https://github.com/dotnet/aspnetcore/issues/31492