### PR TITLE
Websocket handshake refactoring.

### DIFF
--- a/src/Middleware/WebSockets/src/HandshakeHelpers.cs
+++ b/src/Middleware/WebSockets/src/HandshakeHelpers.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.WebSockets
             // so this can be hardcoded to 60 bytes for the requestKey + static websocket string
             Span<byte> mergedBytes = stackalloc byte[60];
             Encoding.UTF8.GetBytes(requestKey, mergedBytes);
-            EncodedWebSocketKey.CopyTo(mergedBytes.Slice(24));
+            EncodedWebSocketKey.CopyTo(mergedBytes[24..]);
 
             Span<byte> hashedBytes = stackalloc byte[20];
             var written = SHA1.HashData(mergedBytes, hashedBytes);

--- a/src/Middleware/WebSockets/src/HandshakeHelpers.cs
+++ b/src/Middleware/WebSockets/src/HandshakeHelpers.cs
@@ -11,17 +11,6 @@ namespace Microsoft.AspNetCore.WebSockets
 {
     internal static class HandshakeHelpers
     {
-        /// <summary>
-        /// Gets request headers needed process the handshake on the server.
-        /// </summary>
-        public static readonly string[] NeededHeaders = new[]
-        {
-            HeaderNames.Upgrade,
-            HeaderNames.Connection,
-            HeaderNames.SecWebSocketKey,
-            HeaderNames.SecWebSocketVersion
-        };
-
         // "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
         // This uses C# compiler's ability to refer to static data directly. For more information see https://vcsjones.dev/2019/02/01/csharp-readonly-span-bytes-static
         private static ReadOnlySpan<byte> EncodedWebSocketKey => new byte[]

--- a/src/Middleware/WebSockets/src/HandshakeHelpers.cs
+++ b/src/Middleware/WebSockets/src/HandshakeHelpers.cs
@@ -24,12 +24,12 @@ namespace Microsoft.AspNetCore.WebSockets
         // Verify Method, Upgrade, Connection, version,  key, etc..
         public static void GenerateResponseHeaders(string key, string? subProtocol, IHeaderDictionary headers)
         {
-            headers[HeaderNames.Connection] = HeaderNames.Upgrade;
-            headers[HeaderNames.Upgrade] = Constants.Headers.UpgradeWebSocket;
-            headers[HeaderNames.SecWebSocketAccept] = CreateResponseKey(key);
+            headers.Connection = HeaderNames.Upgrade;
+            headers.Upgrade = Constants.Headers.UpgradeWebSocket;
+            headers.SecWebSocketAccept = CreateResponseKey(key);
             if (!string.IsNullOrWhiteSpace(subProtocol))
             {
-                headers[HeaderNames.SecWebSocketProtocol] = subProtocol;
+                headers.SecWebSocketProtocol = subProtocol;
             }
         }
 

--- a/src/Middleware/WebSockets/src/HandshakeHelpers.cs
+++ b/src/Middleware/WebSockets/src/HandshakeHelpers.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -34,61 +33,6 @@ namespace Microsoft.AspNetCore.WebSockets
         };
 
         // Verify Method, Upgrade, Connection, version,  key, etc..
-        public static bool CheckSupportedWebSocketRequest(string method, List<KeyValuePair<string, string>> interestingHeaders, IHeaderDictionary requestHeaders)
-        {
-            bool validUpgrade = false, validConnection = false, validKey = false, validVersion = false;
-
-            if (!string.Equals("GET", method, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            foreach (var pair in interestingHeaders)
-            {
-                if (string.Equals(HeaderNames.Connection, pair.Key, StringComparison.OrdinalIgnoreCase))
-                {
-                    if (string.Equals(HeaderNames.Upgrade, pair.Value, StringComparison.OrdinalIgnoreCase))
-                    {
-                        validConnection = true;
-                    }
-                }
-                else if (string.Equals(HeaderNames.Upgrade, pair.Key, StringComparison.OrdinalIgnoreCase))
-                {
-                    if (string.Equals(Constants.Headers.UpgradeWebSocket, pair.Value, StringComparison.OrdinalIgnoreCase))
-                    {
-                        validUpgrade = true;
-                    }
-                }
-                else if (string.Equals(HeaderNames.SecWebSocketVersion, pair.Key, StringComparison.OrdinalIgnoreCase))
-                {
-                    if (string.Equals(Constants.Headers.SupportedVersion, pair.Value, StringComparison.OrdinalIgnoreCase))
-                    {
-                        validVersion = true;
-                    }
-                }
-                else if (string.Equals(HeaderNames.SecWebSocketKey, pair.Key, StringComparison.OrdinalIgnoreCase))
-                {
-                    validKey = IsRequestKeyValid(pair.Value);
-                }
-            }
-
-            // WebSockets are long lived; so if the header values are valid we switch them out for the interned versions.
-            if (validConnection && requestHeaders[HeaderNames.Connection].Count == 1)
-            {
-                requestHeaders[HeaderNames.Connection] = HeaderNames.Upgrade;
-            }
-            if (validUpgrade && requestHeaders[HeaderNames.Upgrade].Count == 1)
-            {
-                requestHeaders[HeaderNames.Upgrade] = Constants.Headers.UpgradeWebSocket;
-            }
-            if (validVersion && requestHeaders[HeaderNames.SecWebSocketVersion].Count == 1)
-            {
-                requestHeaders[HeaderNames.SecWebSocketVersion] = Constants.Headers.SupportedVersion;
-            }
-
-            return validConnection && validUpgrade && validVersion && validKey;
-        }
-
         public static void GenerateResponseHeaders(string key, string? subProtocol, IHeaderDictionary headers)
         {
             headers[HeaderNames.Connection] = HeaderNames.Upgrade;

--- a/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
+++ b/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
@@ -183,6 +183,7 @@ namespace Microsoft.AspNetCore.WebSockets
                 {
                     return false;
                 }
+                foundHeader = false;
 
                 values = requestHeaders.GetCommaSeparatedValues(HeaderNames.Connection);
                 foreach (var value in values)
@@ -202,6 +203,7 @@ namespace Microsoft.AspNetCore.WebSockets
                 {
                     return false;
                 }
+                foundHeader = false;
 
                 values = requestHeaders.GetCommaSeparatedValues(HeaderNames.Upgrade);
                 foreach (var value in values)
@@ -221,7 +223,6 @@ namespace Microsoft.AspNetCore.WebSockets
                 {
                     return false;
                 }
-
 
                 return HandshakeHelpers.IsRequestKeyValid(requestHeaders.SecWebSocketKey.ToString());
             }

--- a/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
+++ b/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
@@ -158,33 +158,29 @@ namespace Microsoft.AspNetCore.WebSockets
 
             public static bool CheckSupportedWebSocketRequest(string method, IHeaderDictionary requestHeaders)
             {
-                if (!string.Equals("GET", method, StringComparison.OrdinalIgnoreCase))
+                if (!HttpMethods.IsGet(method))
                 {
                     return false;
                 }
 
-                foreach (var pair in requestHeaders)
+                if (!requestHeaders[HeaderNames.Connection].Contains(HeaderNames.Upgrade))
                 {
-                    if(!requestHeaders[HeaderNames.Connection].Contains(HeaderNames.Upgrade))
-                    {
-                        return false;
-                    }
+                    return false;
+                }
 
-                    if(!requestHeaders[HeaderNames.Upgrade].Contains(Constants.Headers.UpgradeWebSocket))
-                    {
-                        return false;
-                    }
+                if (!requestHeaders[HeaderNames.Upgrade].Contains(Constants.Headers.UpgradeWebSocket))
+                {
+                    return false;
+                }
 
-                    if(!requestHeaders[HeaderNames.SecWebSocketVersion].Contains(Constants.Headers.SupportedVersion))
-                    {
-                        return false;
-                    }
+                if (!requestHeaders[HeaderNames.SecWebSocketVersion].Contains(Constants.Headers.SupportedVersion))
+                {
+                    return false;
+                }
 
-                    if(requestHeaders.ContainsKey(HeaderNames.SecWebSocketKey))
-                    {
-                        if(!HandshakeHelpers.IsRequestKeyValid(pair.Value))
-                            return false;
-                    }
+                if (!HandshakeHelpers.IsRequestKeyValid(requestHeaders[HeaderNames.SecWebSocketKey].ToString()))
+                {
+                    return false;
                 }
 
                 // WebSockets are long lived; so if the header values are valid we switch them out for the interned versions.

--- a/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
+++ b/src/Middleware/WebSockets/src/WebSocketMiddleware.cs
@@ -163,41 +163,60 @@ namespace Microsoft.AspNetCore.WebSockets
                     return false;
                 }
 
-                if (!requestHeaders[HeaderNames.Connection].Contains(HeaderNames.Upgrade))
+                bool validUpgrade = false, validConnection = false, validVersion = false;
+
+                var values = requestHeaders.GetCommaSeparatedValues(HeaderNames.Connection);
+                foreach (var value in values)
                 {
-                    return false;
+                    if (string.Equals(value, HeaderNames.Upgrade, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // WebSockets are long lived; so if the header values are valid we switch them out for the interned versions.
+                        if (values.Length == 1)
+                        {
+                            requestHeaders.Connection = HeaderNames.Upgrade;
+                        }
+                        validConnection = true;
+                        break;
+                    }
                 }
 
-                if (!requestHeaders[HeaderNames.Upgrade].Contains(Constants.Headers.UpgradeWebSocket))
+                values = requestHeaders.GetCommaSeparatedValues(HeaderNames.Upgrade);
+                foreach (var value in values)
                 {
-                    return false;
+                    if (string.Equals(value, Constants.Headers.UpgradeWebSocket, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // WebSockets are long lived; so if the header values are valid we switch them out for the interned versions.
+                        if (values.Length == 1)
+                        {
+                            requestHeaders.Upgrade = Constants.Headers.UpgradeWebSocket;
+                        }
+                        validUpgrade = true;
+                        break;
+                    }
                 }
 
-                if (!requestHeaders[HeaderNames.SecWebSocketVersion].Contains(Constants.Headers.SupportedVersion))
+                values = requestHeaders.GetCommaSeparatedValues(HeaderNames.SecWebSocketVersion);
+                foreach (var value in values)
                 {
-                    return false;
+                    if (string.Equals(value, Constants.Headers.SupportedVersion, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // WebSockets are long lived; so if the header values are valid we switch them out for the interned versions.
+                        if (values.Length == 1)
+                        {
+                            requestHeaders.SecWebSocketVersion = Constants.Headers.SupportedVersion;
+                        }
+                        validVersion = true;
+                        break;
+                    }
                 }
+
 
                 if (!HandshakeHelpers.IsRequestKeyValid(requestHeaders[HeaderNames.SecWebSocketKey].ToString()))
                 {
                     return false;
                 }
 
-                // WebSockets are long lived; so if the header values are valid we switch them out for the interned versions.
-                if (requestHeaders[HeaderNames.Connection].Count == 1)
-                {
-                    requestHeaders[HeaderNames.Connection] = HeaderNames.Upgrade;
-                }
-                if (requestHeaders[HeaderNames.Upgrade].Count == 1)
-                {
-                    requestHeaders[HeaderNames.Upgrade] = Constants.Headers.UpgradeWebSocket;
-                }
-                if (requestHeaders[HeaderNames.SecWebSocketVersion].Count == 1)
-                {
-                    requestHeaders[HeaderNames.SecWebSocketVersion] = Constants.Headers.SupportedVersion;
-                }
-
-                return true;
+                return validConnection && validUpgrade && validVersion;
             }
         }
     }

--- a/src/Middleware/WebSockets/test/UnitTests/KestrelWebSocketHelpers.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/KestrelWebSocketHelpers.cs
@@ -68,6 +68,9 @@ namespace Microsoft.AspNetCore.WebSockets.Test
                         options.Listen(IPAddress.Loopback, 0);
                     })
                     .Configure(startup);
+                }).ConfigureHostOptions(o =>
+                {
+                    o.ShutdownTimeout = TimeSpan.FromSeconds(30);
                 }).Build();
 
             host.Start();

--- a/src/Middleware/WebSockets/test/UnitTests/KestrelWebSocketHelpers.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/KestrelWebSocketHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -18,6 +19,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
     {
         public static IDisposable CreateServer(ILoggerFactory loggerFactory, out int port, Func<HttpContext, Task> app, Action<WebSocketOptions> configure = null)
         {
+            Exception exceptionFromApp = null;
             configure = configure ?? (o => { });
             Action<IApplicationBuilder> startup = builder =>
             {
@@ -31,6 +33,8 @@ namespace Microsoft.AspNetCore.WebSockets.Test
                     }
                     catch (Exception ex)
                     {
+                        // capture the exception from the app, we'll throw this at the end of the test when the server is disposed
+                        exceptionFromApp = ex;
                         if (ct.Response.HasStarted)
                         {
                             throw;
@@ -69,7 +73,29 @@ namespace Microsoft.AspNetCore.WebSockets.Test
             host.Start();
             port = host.GetPort();
 
-            return host;
+            return new Disposable(() =>
+            {
+                host.Dispose();
+                if (exceptionFromApp is not null)
+                {
+                    ExceptionDispatchInfo.Throw(exceptionFromApp);
+                }
+            });
+        }
+
+        private class Disposable : IDisposable
+        {
+            private readonly Action _dispose;
+
+            public Disposable(Action dispose)
+            {
+                _dispose = dispose;
+            }
+
+            public void Dispose()
+            {
+                _dispose();
+            }
         }
     }
 }

--- a/src/Middleware/WebSockets/test/UnitTests/WebSocketMiddlewareTests.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/WebSocketMiddlewareTests.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
@@ -138,6 +137,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         [Fact]
         public async Task SendLongData_Success()
         {
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var orriginalData = Encoding.UTF8.GetBytes(new string('a', 0x1FFFF));
             using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
@@ -146,29 +146,22 @@ namespace Microsoft.AspNetCore.WebSockets.Test
 
                 var serverBuffer = new byte[orriginalData.Length];
                 var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(serverBuffer), CancellationToken.None);
-                int intermediateCount = result.Count;
-                Assert.False(result.EndOfMessage);
-                Assert.Equal(WebSocketMessageType.Text, result.MessageType);
-
-                result = await webSocket.ReceiveAsync(new ArraySegment<byte>(serverBuffer, intermediateCount, orriginalData.Length - intermediateCount), CancellationToken.None);
-                intermediateCount += result.Count;
-                Assert.False(result.EndOfMessage);
-                Assert.Equal(WebSocketMessageType.Text, result.MessageType);
-
-                result = await webSocket.ReceiveAsync(new ArraySegment<byte>(serverBuffer, intermediateCount, orriginalData.Length - intermediateCount), CancellationToken.None);
-                intermediateCount += result.Count;
                 Assert.True(result.EndOfMessage);
-                Assert.Equal(orriginalData.Length, intermediateCount);
-                Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+                Assert.Equal(WebSocketMessageType.Binary, result.MessageType);
 
                 Assert.Equal(orriginalData, serverBuffer);
+
+                tcs.SetResult();
             }))
             {
                 using (var client = new ClientWebSocket())
                 {
                     await client.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None);
                     await client.SendAsync(new ArraySegment<byte>(orriginalData), WebSocketMessageType.Binary, true, CancellationToken.None);
+
                 }
+                // Wait to close the server otherwise the app could throw if it takes longer than the shutdown timeout
+                await tcs.Task;
             }
         }
 
@@ -570,6 +563,63 @@ namespace Microsoft.AspNetCore.WebSockets.Test
 
                         var response = await client.SendAsync(request);
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CommonHeadersAreSetToInternedStrings()
+        {
+            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            {
+                Assert.True(context.WebSockets.IsWebSocketRequest);
+                var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+
+                // Use ReferenceEquals and test against the constants
+                Assert.Same(HeaderNames.Upgrade, context.Request.Headers.Connection.ToString());
+                Assert.Same(Constants.Headers.UpgradeWebSocket, context.Request.Headers.Upgrade.ToString());
+                Assert.Same(Constants.Headers.SupportedVersion, context.Request.Headers.SecWebSocketVersion.ToString());
+            }))
+            {
+                using (var client = new ClientWebSocket())
+                {
+                    await client.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/"), CancellationToken.None);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task MultipleValueHeadersNotOverridden()
+        {
+            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            {
+                Assert.True(context.WebSockets.IsWebSocketRequest);
+                var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+
+                Assert.Equal("Upgrade, keep-alive", context.Request.Headers.Connection.ToString());
+                Assert.Equal("websocket, example", context.Request.Headers.Upgrade.ToString());
+            }))
+            {
+                using (var client = new HttpClient())
+                {
+                    var uri = new UriBuilder(new Uri($"ws://127.0.0.1:{port}/"));
+                    uri.Scheme = "http";
+
+                    // Craft a valid WebSocket Upgrade request
+                    using (var request = new HttpRequestMessage(HttpMethod.Get, uri.ToString()))
+                    {
+                        request.Headers.Connection.Clear();
+                        request.Headers.Connection.Add("Upgrade");
+                        request.Headers.Connection.Add("keep-alive");
+                        request.Headers.Upgrade.Add(new System.Net.Http.Headers.ProductHeaderValue("websocket"));
+                        request.Headers.Upgrade.Add(new System.Net.Http.Headers.ProductHeaderValue("example"));
+                        request.Headers.Add(HeaderNames.SecWebSocketVersion, "13");
+                        // SecWebSocketKey required to be 16 bytes
+                        request.Headers.Add(HeaderNames.SecWebSocketKey, Convert.ToBase64String(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }, Base64FormattingOptions.None));
+
+                        var response = await client.SendAsync(request);
+                        Assert.Equal(HttpStatusCode.SwitchingProtocols, response.StatusCode);
                     }
                 }
             }


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/31373

I have moved `CheckSupportedWebSocketRequest` method from `HandShakeHelpers` to `WebSocketMiddleware`. 
I am not getting what needs to be done for `NeededHeaders` do we want to remove those directly?

cc @Tratcher 