### PR TITLE
Data Protection minor tidying

### DIFF
--- a/src/DataProtection/DataProtection/src/EphemeralDataProtectionProvider.cs
+++ b/src/DataProtection/DataProtection/src/EphemeralDataProtectionProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Cryptography.Cng;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
@@ -84,9 +83,6 @@ namespace Microsoft.AspNetCore.DataProtection
             {
                 DefaultAuthenticatedEncryptor = GetDefaultEncryptor(loggerFactory);
             }
-
-            // Currently hardcoded to a 512-bit KDK.
-            private const int NUM_BYTES_IN_KDK = 512 / 8;
 
             public IAuthenticatedEncryptor? DefaultAuthenticatedEncryptor { get; }
 

--- a/src/DataProtection/DataProtection/src/Managed/ManagedAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Managed/ManagedAuthenticatedEncryptor.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.DataProtection.Managed
 
         private byte[] CreateContextHeader()
         {
-            var EMPTY_ARRAY = new byte[0];
+            var EMPTY_ARRAY = Array.Empty<byte>();
             var EMPTY_ARRAY_SEGMENT = new ArraySegment<byte>(EMPTY_ARRAY);
 
             var retVal = new byte[checked(

--- a/src/DataProtection/DataProtection/src/SimpleActivator.cs
+++ b/src/DataProtection/DataProtection/src/SimpleActivator.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using Microsoft.AspNetCore.DataProtection.Internal;
 
 namespace Microsoft.AspNetCore.DataProtection
@@ -13,6 +12,8 @@ namespace Microsoft.AspNetCore.DataProtection
     /// </summary>
     internal class SimpleActivator : IActivator
     {
+        private static readonly Type[] IServiceProviderTypeArray = { typeof(IServiceProvider) };
+
         /// <summary>
         /// A default <see cref="SimpleActivator"/> whose wrapped <see cref="IServiceProvider"/> is null.
         /// </summary>
@@ -42,7 +43,7 @@ namespace Microsoft.AspNetCore.DataProtection
             }
 
             // If an IServiceProvider was specified or if .ctor() doesn't exist, prefer .ctor(IServiceProvider) [if it exists]
-            var ctorWhichTakesServiceProvider = implementationType.GetConstructor(new Type[] { typeof(IServiceProvider) });
+            var ctorWhichTakesServiceProvider = implementationType.GetConstructor(IServiceProviderTypeArray);
             if (ctorWhichTakesServiceProvider != null)
             {
                 return ctorWhichTakesServiceProvider.Invoke(new[] { _services });

--- a/src/DataProtection/DataProtection/src/SimpleActivator.cs
+++ b/src/DataProtection/DataProtection/src/SimpleActivator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.DataProtection
     /// </summary>
     internal class SimpleActivator : IActivator
     {
-        private static readonly Type[] IServiceProviderTypeArray = { typeof(IServiceProvider) };
+        private static readonly Type[] _serviceProviderTypeArray = { typeof(IServiceProvider) };
 
         /// <summary>
         /// A default <see cref="SimpleActivator"/> whose wrapped <see cref="IServiceProvider"/> is null.
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.DataProtection
             }
 
             // If an IServiceProvider was specified or if .ctor() doesn't exist, prefer .ctor(IServiceProvider) [if it exists]
-            var ctorWhichTakesServiceProvider = implementationType.GetConstructor(IServiceProviderTypeArray);
+            var ctorWhichTakesServiceProvider = implementationType.GetConstructor(_serviceProviderTypeArray);
             if (ctorWhichTakesServiceProvider != null)
             {
                 return ctorWhichTakesServiceProvider.Invoke(new[] { _services });

--- a/src/DataProtection/DataProtection/src/XmlEncryption/EncryptedXmlDecryptor.cs
+++ b/src/DataProtection/DataProtection/src/XmlEncryption/EncryptedXmlDecryptor.cs
@@ -59,7 +59,6 @@ namespace Microsoft.AspNetCore.DataProtection.XmlEncryption
             // doesn't handle encrypting the root element all that well.
             var xmlDocument = new XmlDocument();
             xmlDocument.Load(new XElement("root", encryptedElement).CreateReader());
-            var elementToDecrypt = (XmlElement)xmlDocument.DocumentElement!.FirstChild!;
 
             // Perform the decryption and update the document in-place.
             var encryptedXml = new EncryptedXmlWithCertificateKeys(_options, xmlDocument);
@@ -68,7 +67,7 @@ namespace Microsoft.AspNetCore.DataProtection.XmlEncryption
             encryptedXml.DecryptDocument();
 
             // Strip the <root /> element back off and convert the XmlDocument to an XElement.
-            return XElement.Load(xmlDocument.DocumentElement.FirstChild!.CreateNavigator()!.ReadSubtree());
+            return XElement.Load(xmlDocument.DocumentElement!.FirstChild!.CreateNavigator()!.ReadSubtree());
         }
 
         void IInternalEncryptedXmlDecryptor.PerformPreDecryptionSetup(EncryptedXml encryptedXml)

--- a/src/Shared/WebEncoders/WebEncoders.cs
+++ b/src/Shared/WebEncoders/WebEncoders.cs
@@ -404,22 +404,6 @@ namespace Microsoft.Extensions.Internal
         }
 #endif
 
-        private static int GetNumBase64PaddingCharsInString(string str)
-        {
-            // Assumption: input contains a well-formed base64 string with no whitespace.
-
-            // base64 guaranteed have 0 - 2 padding characters.
-            if (str[str.Length - 1] == '=')
-            {
-                if (str[str.Length - 2] == '=')
-                {
-                    return 2;
-                }
-                return 1;
-            }
-            return 0;
-        }
-
         private static int GetNumBase64PaddingCharsToAddForDecode(int inputLength)
         {
             switch (inputLength % 4)


### PR DESCRIPTION
**PR Title**

Some minor code tidy-ups in Data Protection.

**PR Description**

  * Removed an unused constant, a method and a variable.
  * Use `Array.Empty()` instead of allocating an empty array.
  * Use a static array for activation type instead of creating a new one with the same type per invocation.
