### PR TITLE
JsonPatch refactoring

### DIFF
--- a/src/Features/JsonPatch/src/Adapters/AdapterFactory.cs
+++ b/src/Features/JsonPatch/src/Adapters/AdapterFactory.cs
@@ -3,8 +3,6 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.AspNetCore.JsonPatch.Adapters
 {
@@ -13,6 +11,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
     /// </summary>
     public class AdapterFactory : IAdapterFactory
     {
+        internal static AdapterFactory Default { get; } = new();
+
         /// <inheritdoc />
 #pragma warning disable PUB0001
         public virtual IAdapter Create(object target, IContractResolver contractResolver)

--- a/src/Features/JsonPatch/src/Adapters/ObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Adapters/ObjectAdapter.cs
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
             }
         }
 
-        private JsonPatchError CreateOperationFailedError(object target, string path, Operation operation, string errorMessage)
+        private static JsonPatchError CreateOperationFailedError(object target, string path, Operation operation, string errorMessage)
         {
             return new JsonPatchError(
                 target,
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
                 errorMessage ?? Resources.FormatCannotPerformOperation(operation.op, path));
         }
 
-        private JsonPatchError CreatePathNotFoundError(object target, string path, Operation operation, string errorMessage)
+        private static JsonPatchError CreatePathNotFoundError(object target, string path, Operation operation, string errorMessage)
         {
             return new JsonPatchError(
                 target,

--- a/src/Features/JsonPatch/src/Adapters/ObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Adapters/ObjectAdapter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Adapters
         public ObjectAdapter(
             IContractResolver contractResolver,
             Action<JsonPatchError> logErrorAction):
-            this(contractResolver, logErrorAction, new AdapterFactory())
+            this(contractResolver, logErrorAction, Adapters.AdapterFactory.Default)
         {
         }
 

--- a/src/Features/JsonPatch/src/Converters/JsonPatchDocumentConverter.cs
+++ b/src/Features/JsonPatch/src/Converters/JsonPatchDocumentConverter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.JsonPatch.Exceptions;
 using Microsoft.AspNetCore.JsonPatch.Operations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -13,6 +12,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
 {
     public class JsonPatchDocumentConverter : JsonConverter
     {
+        internal static IContractResolver DefaultContractResolver { get; } = new DefaultContractResolver();
+
         public override bool CanConvert(Type objectType)
         {
             return true;
@@ -51,7 +52,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
                 serializer.Populate(jObjectReader, targetOperations);
 
                 // container target: the JsonPatchDocument. 
-                var container = new JsonPatchDocument(targetOperations, new DefaultContractResolver());
+                var container = new JsonPatchDocument(targetOperations, DefaultContractResolver);
 
                 return container;
             }

--- a/src/Features/JsonPatch/src/Converters/JsonPatchDocumentConverter.cs
+++ b/src/Features/JsonPatch/src/Converters/JsonPatchDocumentConverter.cs
@@ -64,9 +64,8 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            if (value is IJsonPatchDocument)
+            if (value is IJsonPatchDocument jsonPatchDoc)
             {
-                var jsonPatchDoc = (IJsonPatchDocument)value;
                 var lst = jsonPatchDoc.GetOperations();
 
                 // write out the operations, no envelope

--- a/src/Features/JsonPatch/src/Converters/JsonPatchDocumentConverter.cs
+++ b/src/Features/JsonPatch/src/Converters/JsonPatchDocumentConverter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
         {
             if (objectType != typeof(JsonPatchDocument))
             {
-                throw new ArgumentException(Resources.FormatParameterMustMatchType("objectType", "JsonPatchDocument"), "objectType");
+                throw new ArgumentException(Resources.FormatParameterMustMatchType(nameof(objectType), "JsonPatchDocument"), nameof(objectType));
             }
 
             try

--- a/src/Features/JsonPatch/src/Converters/JsonPatchDocumentConverter.cs
+++ b/src/Features/JsonPatch/src/Converters/JsonPatchDocumentConverter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
 {
     public class JsonPatchDocumentConverter : JsonConverter
     {
-        internal static IContractResolver DefaultContractResolver { get; } = new DefaultContractResolver();
+        internal static DefaultContractResolver DefaultContractResolver { get; } = new();
 
         public override bool CanConvert(Type objectType)
         {

--- a/src/Features/JsonPatch/src/Converters/TypedJsonPatchDocumentConverter.cs
+++ b/src/Features/JsonPatch/src/Converters/TypedJsonPatchDocumentConverter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Microsoft.AspNetCore.JsonPatch.Operations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -51,7 +50,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Converters
                 serializer.Populate(jObjectReader, targetOperations);
 
                 // container target: the typed JsonPatchDocument.
-                var container = Activator.CreateInstance(objectType, targetOperations, new DefaultContractResolver());
+                var container = Activator.CreateInstance(objectType, targetOperations, JsonPatchDocumentConverter.DefaultContractResolver);
 
                 return container;
             }

--- a/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
+++ b/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
@@ -58,14 +58,14 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 return false;
             }
 
-            if (!dictionary.ContainsKey(convertedKey))
+            if (!dictionary.TryGetValue(convertedKey, out var valueAsT))
             {
                 value = null;
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
             }
 
-            value = dictionary[convertedKey];
+            value = valueAsT;
             errorMessage = null;
             return true;
         }
@@ -86,13 +86,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
             }
 
             // As per JsonPatch spec, the target location must exist for remove to be successful
-            if (!dictionary.ContainsKey(convertedKey))
+            if (!dictionary.Remove(convertedKey))
             {
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
             }
-
-            dictionary.Remove(convertedKey);
 
             errorMessage = null;
             return true;
@@ -198,9 +196,9 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
                 return false;
             }
 
-            if (dictionary.ContainsKey(convertedKey))
+            if (dictionary.TryGetValue(convertedKey, out var valueAsT))
             {
-                nextTarget = dictionary[convertedKey];
+                nextTarget = valueAsT;
                 errorMessage = null;
                 return true;
             }

--- a/src/Features/JsonPatch/src/Internal/JObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/JObjectAdapter.cs
@@ -31,14 +31,14 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             var obj = (JObject) target;
 
-            if (!obj.ContainsKey(segment))
+            if (!obj.TryGetValue(segment, out var valueAsToken))
             {
                 value = null;
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
             }
 
-            value = obj[segment];
+            value = valueAsToken;
             errorMessage = null;
             return true;
         }
@@ -51,13 +51,12 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             var obj = (JObject) target;
 
-            if (!obj.ContainsKey(segment))
+            if (!obj.Remove(segment))
             {
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
             }
 
-            obj.Remove(segment);
             errorMessage = null;
             return true;
         }
@@ -92,13 +91,11 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             var obj = (JObject) target;
 
-            if (!obj.ContainsKey(segment))
+            if (!obj.TryGetValue(segment, out var currentValue))
             {
                 errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
                 return false;
             }
-
-            var currentValue = obj[segment];
             
             if (currentValue == null || string.IsNullOrEmpty(currentValue.ToString()))
             {
@@ -125,14 +122,14 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         {
             var obj = (JObject) target;
 
-            if (!obj.ContainsKey(segment))
+            if (!obj.TryGetValue(segment, out var nextTargetToken))
             {
                 nextTarget = null;
                 errorMessage = null;
                 return false;
             }
 
-            nextTarget = obj[segment];
+            nextTarget = nextTargetToken;
             errorMessage = null;
             return true;
         }

--- a/src/Features/JsonPatch/src/Internal/ObjectVisitor.cs
+++ b/src/Features/JsonPatch/src/Internal/ObjectVisitor.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.JsonPatch.Internal
         /// <param name="path">The path of the JsonPatch operation</param>
         /// <param name="contractResolver">The <see cref="IContractResolver"/>.</param>
         public ObjectVisitor(ParsedPath path, IContractResolver contractResolver)
-            :this(path, contractResolver, new AdapterFactory())
+            :this(path, contractResolver, AdapterFactory.Default)
         {
         }
 

--- a/src/Features/JsonPatch/src/JsonPatchDocument.cs
+++ b/src/Features/JsonPatch/src/JsonPatchDocument.cs
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.JsonPatch
                 throw new ArgumentNullException(nameof(objectToApplyTo));
             }
 
-            ApplyTo(objectToApplyTo, new ObjectAdapter(ContractResolver, null, new AdapterFactory()));
+            ApplyTo(objectToApplyTo, new ObjectAdapter(ContractResolver, null, AdapterFactory.Default));
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.JsonPatch
         /// <param name="logErrorAction">Action to log errors</param>
         public void ApplyTo(object objectToApplyTo, Action<JsonPatchError> logErrorAction)
         {
-            ApplyTo(objectToApplyTo, new ObjectAdapter(ContractResolver, logErrorAction, new AdapterFactory()), logErrorAction);
+            ApplyTo(objectToApplyTo, new ObjectAdapter(ContractResolver, logErrorAction, AdapterFactory.Default), logErrorAction);
         }
 
         /// <summary>

--- a/src/Features/JsonPatch/src/JsonPatchDocument.cs
+++ b/src/Features/JsonPatch/src/JsonPatchDocument.cs
@@ -248,7 +248,7 @@ namespace Microsoft.AspNetCore.JsonPatch
 
         IList<Operation> IJsonPatchDocument.GetOperations()
         {
-            var allOps = new List<Operation>();
+            var allOps = new List<Operation>(Operations?.Count ?? 0);
 
             if (Operations != null)
             {

--- a/src/Features/JsonPatch/src/JsonPatchDocumentOfT.cs
+++ b/src/Features/JsonPatch/src/JsonPatchDocumentOfT.cs
@@ -697,7 +697,7 @@ namespace Microsoft.AspNetCore.JsonPatch
                 throw new ArgumentNullException(nameof(objectToApplyTo));
             }
 
-            ApplyTo(objectToApplyTo, new ObjectAdapter(ContractResolver, null, new AdapterFactory()));
+            ApplyTo(objectToApplyTo, new ObjectAdapter(ContractResolver, null, AdapterFactory.Default));
         }
 
         /// <summary>
@@ -707,7 +707,7 @@ namespace Microsoft.AspNetCore.JsonPatch
         /// <param name="logErrorAction">Action to log errors</param>
         public void ApplyTo(TModel objectToApplyTo, Action<JsonPatchError> logErrorAction)
         {
-            ApplyTo(objectToApplyTo, new ObjectAdapter(ContractResolver, logErrorAction, new AdapterFactory()), logErrorAction);
+            ApplyTo(objectToApplyTo, new ObjectAdapter(ContractResolver, logErrorAction, AdapterFactory.Default), logErrorAction);
         }
 
         /// <summary>

--- a/src/Features/JsonPatch/src/JsonPatchDocumentOfT.cs
+++ b/src/Features/JsonPatch/src/JsonPatchDocumentOfT.cs
@@ -771,7 +771,7 @@ namespace Microsoft.AspNetCore.JsonPatch
 
         IList<Operation> IJsonPatchDocument.GetOperations()
         {
-            var allOps = new List<Operation>();
+            var allOps = new List<Operation>(Operations?.Count ?? 0);
 
             if (Operations != null)
             {


### PR DESCRIPTION
**PR Title**

Minor refactoring in the JsonPatch project.

**PR Description**

Various small refactorings to JsonPatch:

  * Use `TryGetValue()` instead of `ContainsKey()` and indexer.
  * Use `Remove()` and test result instead of `ContainsKey()` and `Remove()`.
  * Use a shared `AdapterFactory` and `DefaultContractResolver` rather than allocating each time needed.
  * Specify the capacity when creating two lists of operations as the count is known.
  * Make two methods that do not access instance state `static`.
  * Use `nameof` instead of hard-coding an argument name twice.
  * Use pattern matching with `is` to remove a need to cast.
