### PR TITLE
Re-use cancellation tokens in the https middleware

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/CancellationTokenSourcePool.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CancellationTokenSourcePool.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
+{
+    internal class CancellationTokenSourcePool
+    {
+        private const int MaxQueueSize = 1024;
+
+        private readonly ConcurrentQueue<PooledCancellationTokenSource> _queue = new();
+        private int _count;
+
+        public PooledCancellationTokenSource Rent()
+        {
+            if (_queue.TryDequeue(out var cts))
+            {
+                Interlocked.Decrement(ref _count);
+                return cts;
+            }
+            return new PooledCancellationTokenSource(this);
+        }
+
+        private bool Return(PooledCancellationTokenSource cts)
+        {
+            // This counting isn't accurate, but it's good enough for what we need to avoid using _queue.Count which could be expensive
+            if (!cts.TryReset() || Interlocked.Increment(ref _count) > MaxQueueSize)
+            {
+                Interlocked.Decrement(ref _count);
+                return false;
+            }
+
+            _queue.Enqueue(cts);
+            return true;
+        }
+
+        /// <summary>
+        /// A <see cref="CancellationTokenSource"/> with a back pointer to the pool it came from.
+        /// Dispose will return it to the pool.
+        /// </summary>
+        public class PooledCancellationTokenSource : CancellationTokenSource
+        {
+            private readonly CancellationTokenSourcePool _pool;
+
+            public PooledCancellationTokenSource(CancellationTokenSourcePool pool)
+            {
+                _pool = pool;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // If we failed to return to the pool then dispose
+                    if (!_pool.Return(this))
+                    {
+                        base.Dispose(disposing);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/CancellationTokenSourcePool.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CancellationTokenSourcePool.cs
@@ -25,8 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         private bool Return(PooledCancellationTokenSource cts)
         {
-            // This counting isn't accurate, but it's good enough for what we need to avoid using _queue.Count which could be expensive
-            if (!cts.TryReset() || Interlocked.Increment(ref _count) > MaxQueueSize)
+            if (Interlocked.Increment(ref _count) > MaxQueueSize || !cts.TryReset())
             {
                 Interlocked.Decrement(ref _count);
                 return false;

--- a/src/Servers/Kestrel/Core/src/Internal/CancellationTokenSourcePool.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CancellationTokenSourcePool.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Concurrent;
 using System.Threading;
 


### PR DESCRIPTION
- These tokens are usually short lived and exist for the purposes of cancelling the handshake.
- The implementation doesn't have a dispose. The cost of storing 1024 tokens is tiny and it'll be unrooted once the server is unrooted.

PS: The pool should remain mostly small in the normal case when handshakes are fast. There will be allocations when there are delays in the handshake (more then 1024) handshakes happening concurrently. Returning to pool takes a timer queue lock here so we'll need to run this without handshake test to see if there are any regressions.

cc @stephentoub 