### PR TITLE
Revert "Update assembly check on EventHandlerTagHelperDescriptorProvider"

### DIFF
--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -34,12 +34,6 @@ namespace Microsoft.CodeAnalysis.Razor
                 return;
             }
 
-            var targetAssembly = context.Items.GetTargetAssembly();
-            if (targetAssembly is not null && !SymbolEqualityComparer.Default.Equals(targetAssembly, eventHandlerAttribute.ContainingAssembly))
-            {
-                return;
-            }
-
             var eventHandlerData = GetEventHandlerData(context, compilation, eventHandlerAttribute);
 
             foreach (var tagHelper in CreateEventHandlerTagHelpers(eventHandlerData))


### PR DESCRIPTION
Reverts dotnet/aspnetcore#31458.

This is blocking the insertion over at https://github.com/dotnet/sdk/pull/16674. Working on investigating this but reverting to unblock dependency flow.