### PR TITLE
Still send 100 Continue with null MinRequestBodyDataRate

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
@@ -181,13 +181,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         protected ValueTask<ReadResult> StartTimingReadAsync(ValueTask<ReadResult> readAwaitable, CancellationToken cancellationToken)
         {
-
-            if (!readAwaitable.IsCompleted && _timingEnabled)
+            if (!readAwaitable.IsCompleted)
             {
                 TryProduceContinue();
 
-                _backpressure = true;
-                _context.TimeoutControl.StartTimingRead();
+                if (_timingEnabled)
+                {
+                    _backpressure = true;
+                    _context.TimeoutControl.StartTimingRead();
+                }
             }
 
             return readAwaitable;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -847,6 +847,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
+        public async Task Expect100ContinueHonoredWhenMinRequestBodyDataRateIsDisabled()
+        {
+            var testContext = new TestServiceContext(LoggerFactory);
+
+            // This may seem unrelated, but this is a regression test for
+            // https://github.com/dotnet/aspnetcore/issues/30449
+            testContext.ServerOptions.Limits.MinRequestBodyDataRate = null;
+
+            await using (var server = new TestServer(TestApp.EchoAppChunked, testContext))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        "POST / HTTP/1.1",
+                        "Host:",
+                        "Expect: 100-continue",
+                        "Connection: close",
+                        "Content-Length: 11",
+                        "\r\n");
+                    await connection.Receive(
+                        "HTTP/1.1 100 Continue",
+                        "",
+                        "");
+                    await connection.Send("Hello World");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 200 OK",
+                        "Connection: close",
+                        $"Date: {testContext.DateHeaderValue}",
+                        "Content-Length: 11",
+                        "",
+                        "Hello World");
+                }
+            }
+        }
+
+        [Fact]
         public async Task ZeroContentLengthAssumedOnNonKeepAliveRequestsWithoutContentLengthOrTransferEncodingHeader()
         {
             var testContext = new TestServiceContext(LoggerFactory);


### PR DESCRIPTION
Same as #31284 but targeting `main`.