### PR TITLE
[5.0] Still send 100 Continue with null MinRequestBodyDataRate

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
@@ -172,13 +172,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         protected ValueTask<ReadResult> StartTimingReadAsync(ValueTask<ReadResult> readAwaitable, CancellationToken cancellationToken)
         {
-
-            if (!readAwaitable.IsCompleted && _timingEnabled)
+            if (!readAwaitable.IsCompleted)
             {
                 TryProduceContinue();
 
-                _backpressure = true;
-                _context.TimeoutControl.StartTimingRead();
+                if (_timingEnabled)
+                {
+                    _backpressure = true;
+                    _context.TimeoutControl.StartTimingRead();
+                }
             }
 
             return readAwaitable;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -847,6 +847,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
+        public async Task Expect100ContinueHonoredWhenMinRequestBodyDataRateIsDisabled()
+        {
+            var testContext = new TestServiceContext(LoggerFactory);
+
+            // This may seem unrelated, but this is a regression test for
+            // https://github.com/dotnet/aspnetcore/issues/30449
+            testContext.ServerOptions.Limits.MinRequestBodyDataRate = null;
+
+            await using (var server = new TestServer(TestApp.EchoAppChunked, testContext))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        "POST / HTTP/1.1",
+                        "Host:",
+                        "Expect: 100-continue",
+                        "Connection: close",
+                        "Content-Length: 11",
+                        "\r\n");
+                    await connection.Receive(
+                        "HTTP/1.1 100 Continue",
+                        "",
+                        "");
+                    await connection.Send("Hello World");
+                    await connection.ReceiveEnd(
+                        "HTTP/1.1 200 OK",
+                        "Connection: close",
+                        $"Date: {testContext.DateHeaderValue}",
+                        "Content-Length: 11",
+                        "",
+                        "Hello World");
+                }
+            }
+        }
+
+        [Fact]
         public async Task ZeroContentLengthAssumedOnNonKeepAliveRequestsWithoutContentLengthOrTransferEncodingHeader()
         {
             var testContext = new TestServiceContext(LoggerFactory);


### PR DESCRIPTION
Same as #31284 which has already been approved for `release/3.1` but targeting `release/5.0`.

### Description

This fixes a bug in Kestrel where a non-default configuration `MinRequestBodyDataRate = null` causes Kestrel not to send a "100 Continue" response given a "Expect: 100-continue" request header.

### Customer impact

This was found (and eventually debugged) by an internal customer.

> I am trying to migrate our code base from using Kestrel 2.2 (PackageReference 2.2.0 running on runtime 3.1.12) to Kestrel 3.1 (FrameworkReference onto Kestrel 3.1 with Runtime 3.1.12).
> When running our performance tests, we saw a dramatic reduction in throughput, increase in latency and a precipitous drop in CPU – overall reduction in performance for POST workloads
> ...
> If I measure the Stopwatch time to do a 0-byte read of the request body in the beginning of application (server) middleware code, the 2.2 code takes around 3ms, while the 3.1 code takes 15-20ms. 

And it was also reported externally:  https://github.com/dotnet/aspnetcore/issues/21502.

This shows up as a performance regression rather than failed request because clients will eventually start uploading the request body without a  "100 Continue" response from Kestrel, but it will wait for a timeout causing increased latency.

Not all clients use "Expect: 100-continue" request header, but older .NET Framework clients do.

### Regresssion

Yes. This was a regression introduced in 3.0.

### Risk

Low. MinRequestBodyDataRate should have never had any impact on whether or not Kestrel sends a "100 Continue" response.

Addresses #30449 in 5.0
