### PR TITLE
[release/2.1] Update branding to 2.1.28 II

### DIFF
--- a/build/SharedFxInstaller.targets
+++ b/build/SharedFxInstaller.targets
@@ -229,7 +229,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <Image>ubuntu.14.04</Image>
+      <Image>ubuntu.18.04</Image>
 
       <DebSharedFxDependencies>@(_DebSharedFxDependencies->'"%(Identity)": { "package_version": "%(Version)" }', ', ')</DebSharedFxDependencies>
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,8 +2,8 @@
   <!-- These package versions may be overridden or updated by automation. -->
   <PropertyGroup Label="Package Versions: Auto" Condition=" '$(DotNetPackageVersionPropsPath)' == '' ">
     <!-- MicrosoftNETCoreApp21PackageVersion is assigned at the bottom so it can automatically pick up MicrosoftNETCoreAppPackageVersion in an orchestrated build. -->
-    <MicrosoftNETCoreAppPackageVersion>2.1.23</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftNETCoreDotNetAppHostPackageVersion>2.1.23</MicrosoftNETCoreDotNetAppHostPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>2.1.26</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreDotNetAppHostPackageVersion>2.1.26</MicrosoftNETCoreDotNetAppHostPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />

--- a/build/docker/alpine.Dockerfile
+++ b/build/docker/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1.0-preview1-runtime-deps-alpine
+FROM mcr.microsoft.com/dotnet/runtime-deps:2.1-alpine
 ARG USER
 ARG USER_ID
 ARG GROUP_ID
@@ -18,10 +18,14 @@ RUN apk add --no-cache \
 
 USER $USER_ID:$GROUP_ID
 
+# Use a location for .dotnet/ that's not under repo root.
+ENV DOTNET_HOME /code/.dotnet
+
 # Disable the invariant mode (set in base image)
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
 
 # Skip package initilization
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1

--- a/build/tools/docker/ubuntu.18.04/Dockerfile
+++ b/build/tools/docker/ubuntu.18.04/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 # Misc Dependencies for build
 RUN apt-get update && \
@@ -15,9 +15,10 @@ RUN apt-get update && \
         sudo \
         libunwind8 \
         libkrb5-3 \
-        libicu52 \
+        libicu60 \
         liblttng-ust0 \
         libssl1.0.0 \
+        locales \
         zlib1g \
         libuuid1 \
         debhelper \
@@ -29,7 +30,8 @@ RUN apt-get update && \
         lldb-3.6 \
         wget && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    locale-gen "en_US.UTF-8"
 
 # Use clang as c++ compiler
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
@@ -39,6 +41,11 @@ RUN update-alternatives --set c++ /usr/bin/clang++-3.5
 ARG USER_ID=0
 RUN useradd -m code_executor -u ${USER_ID} -g sudo
 RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Preset well-known locale
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
 
 # With the User Change, we need to change permissions on these directories
 RUN chmod -R a+rwx /usr/local

--- a/dockerbuild.sh
+++ b/dockerbuild.sh
@@ -90,6 +90,9 @@ fi
 dockerfile="$DIR/build/docker/$image.Dockerfile"
 tagname="aspnetcore-build-$image"
 
+# Use a location for .dotnet/ that's not under repo root in the container and don't reuse host's folder.
+mkdir "$(dirname $DIR)/.dotnet-$image"
+
 docker build "$(dirname "$dockerfile")" \
     --build-arg "USER=$(whoami)" \
     --build-arg "USER_ID=$(id -u)" \
@@ -114,6 +117,7 @@ docker run \
     -e PB_ASSETROOTURL \
     -e PRODUCTBUILDID \
     -v "$DIR:/code/build" \
+    -v "$(dirname $DIR)/.dotnet-$image:/code/.dotnet" \
     ${docker_args[@]+"${docker_args[@]}"} \
     $tagname \
     ./build.sh \

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -100,4 +100,8 @@ Later on, this will be checked using this condition:
       @aspnet/signalr-protocol-msgpack;
     </PackagesInPatch>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.1.28' ">
+    <PackagesInPatch>
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>

--- a/test/SharedFx.UnitTests/SharedFx.UnitTests.csproj
+++ b/test/SharedFx.UnitTests/SharedFx.UnitTests.csproj
@@ -30,14 +30,14 @@
       <_Parameter1>PreviousAspNetCoreReleaseVersion</_Parameter1>
       <_Parameter2>$(PreviousAspNetCoreReleaseVersion)</_Parameter2>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
+      <_Parameter1>ValidateBaseline</_Parameter1>
+      <_Parameter2>$(ValidateBaseline)</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
-    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersPackageVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioPackageVersion)" />
+    <Reference Include="Newtonsoft.Json" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.2" />
   </ItemGroup>
 

--- a/test/SharedFx.UnitTests/SharedFxTests.cs
+++ b/test/SharedFx.UnitTests/SharedFxTests.cs
@@ -17,11 +17,16 @@ namespace Microsoft.AspNetCore
 {
     public class SharedFxTests
     {
-
         [Theory]
         [MemberData(nameof(GetSharedFxConfig))]
         public async Task BaselineTest(SharedFxConfig config)
         {
+            if (!TestData.GetValidateBaseline())
+            {
+                // Inability to validate the package baselines indicates dotnetcli is not up-to-date.
+                return;
+            }
+
             var previousVersion = TestData.GetPreviousAspNetCoreReleaseVersion();
             var url = new Uri($"https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/" + previousVersion + "/aspnetcore-runtime-internal-" + previousVersion + "-win-x64.zip");
             var zipName = "assemblies.zip";

--- a/test/SharedFx.UnitTests/TestData.cs
+++ b/test/SharedFx.UnitTests/TestData.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -19,6 +20,9 @@ namespace Microsoft.AspNetCore
         public static string GetRepositoryCommit() => GetTestDataValue("RepositoryCommit");
 
         public static string GetSharedFxRuntimeIdentifier() => GetTestDataValue("SharedFxRuntimeIdentifier");
+
+        public static bool GetValidateBaseline() =>
+            string.Equals(GetTestDataValue("ValidateBaseline"), "true", StringComparison.OrdinalIgnoreCase);
 
         private static string GetTestDataValue(string key)
              => typeof(TestData).Assembly.GetCustomAttributes<TestDataAttribute>().Single(d => d.Key == key).Value;

--- a/version.props
+++ b/version.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <AspNetCoreMajorVersion>2</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>1</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>27</AspNetCorePatchVersion>
-    <ValidateBaseline>true</ValidateBaseline>
+    <AspNetCorePatchVersion>28</AspNetCorePatchVersion>
+    <ValidateBaseline>false</ValidateBaseline>
 
     <PreReleaseLabel>servicing</PreReleaseLabel>
     <PreReleaseBrandingLabel>Servicing</PreReleaseBrandingLabel>


### PR DESCRIPTION
- update branding to 2.1.28
- bump `$(MicrosoftNETCoreAppPackageVersion)`
    - version flows into `$(MicrosoftNETCoreApp21PackageVersion)` automatically
    - cherry-picked from #30729 internal branch
- get SharedFx.UnitTests working after rebranding
    - skip `SharedFxTests.BaselineTest(...)` between rebranding and baseline updates
        - previous runtime is not available in this window
    - reduce retries in `RetryHelper`
        - download will usually fail repeatedly if it fails even once
    - previous maximum duration (105 min.) was greater than the job timeout
- avoid NETSDK1023 warnings
    - eng/targets/CSharp.Common.props adds packages removed from project
    - cherry-picked from #30729 internal branch
  nit: remove unused `GetTotalRetriesUsed()` method
- stop using Ubuntu 14.04
    - run `locale-gen` to avoid "setlocale: LC_ALL: cannot change locale" and similar
        - needs `locales` package
    - move to still-supported Ubuntu 18.04 image
        - image needs slightly-newer `libicu60` package
        - rename Dockerfile to match
    - cherry-picked from #30729 internal branch for Ubuntu image update
- avoid KoreBuild issues when using dockerbuild.sh
    - avoid MSB4011 warnings (about repeated Directory.Build.targets imports)
        - place `$DOTNET_HOME` beside repo root, not under it
    - cherry-picked from #30729 internal branch for image update