### PR TITLE
Rename 'Blazor component' to 'component' to be more generic

### DIFF
--- a/src/Components/WebView/Samples/WebviewAppShared/SharedComponent.razor
+++ b/src/Components/WebView/Samples/WebviewAppShared/SharedComponent.razor
@@ -1,3 +1,3 @@
 ﻿<div class="my-component">
-    This Blazor component is defined in the <strong>WebviewAppShared</strong> package.
+    This component is defined in the <strong>WebviewAppShared</strong> package.
 </div>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/Component1.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/Component1.razor
@@ -1,3 +1,3 @@
 ﻿<div class="my-component">
-    This Blazor component is defined in the <strong>Company.RazorClassLibrary1</strong> library.
+    This component is defined in the <strong>Company.RazorClassLibrary1</strong> library.
 </div>


### PR DESCRIPTION
Fixes #31559 

Renames "Blazor component" to "component" so to be generic.

e.g.
```razor
<div class="my-component">
    This component is defined in the <strong>WebviewAppShared</strong> package.
</div>
```