### PR TITLE
Custom event args: support receiving IJSObjectReference

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -404,7 +404,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             WebEventData webEventData;
             try
             {
-                webEventData = WebEventData.Parse(Renderer, eventDescriptorJson, eventArgsJson);
+                var jsonSerializerOptions = JSRuntime.ReadJsonSerializerOptions();
+                webEventData = WebEventData.Parse(Renderer, jsonSerializerOptions, eventDescriptorJson, eventArgsJson);
             }
             catch (Exception ex)
             {

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -28,6 +28,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter(ElementReferenceContext));
         }
 
+        public JsonSerializerOptions ReadJsonSerializerOptions() => JsonSerializerOptions;
+
         internal void Initialize(CircuitClientProxy clientProxy)
         {
             _clientProxy = clientProxy ?? throw new ArgumentNullException(nameof(clientProxy));

--- a/src/Components/Shared/src/WebEventData.cs
+++ b/src/Components/Shared/src/WebEventData.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Components.Web
     {
         // This class represents the second half of parsing incoming event data,
         // once the event ID (and possibly the type of the eventArgs) becomes known.
-        public static WebEventData Parse(Renderer renderer, string eventDescriptorJson, string eventArgsJson)
+        public static WebEventData Parse(Renderer renderer, JsonSerializerOptions jsonSerializerOptions, string eventDescriptorJson, string eventArgsJson)
         {
             WebEventDescriptor eventDescriptor;
             try
@@ -29,13 +29,14 @@ namespace Microsoft.AspNetCore.Components.Web
 
             return Parse(
                 renderer,
+                jsonSerializerOptions,
                 eventDescriptor,
                 eventArgsJson);
         }
 
-        public static WebEventData Parse(Renderer renderer, WebEventDescriptor eventDescriptor, string eventArgsJson)
+        public static WebEventData Parse(Renderer renderer, JsonSerializerOptions jsonSerializerOptions, WebEventDescriptor eventDescriptor, string eventArgsJson)
         {
-            var parsedEventArgs = ParseEventArgsJson(renderer, eventDescriptor.EventHandlerId, eventDescriptor.EventName, eventArgsJson);
+            var parsedEventArgs = ParseEventArgsJson(renderer, jsonSerializerOptions, eventDescriptor.EventHandlerId, eventDescriptor.EventName, eventArgsJson);
             return new WebEventData(
                 eventDescriptor.BrowserRendererId,
                 eventDescriptor.EventHandlerId,
@@ -59,7 +60,7 @@ namespace Microsoft.AspNetCore.Components.Web
 
         public EventArgs EventArgs { get; }
 
-        private static EventArgs ParseEventArgsJson(Renderer renderer, ulong eventHandlerId, string eventName, string eventArgsJson)
+        private static EventArgs ParseEventArgsJson(Renderer renderer, JsonSerializerOptions jsonSerializerOptions, ulong eventHandlerId, string eventName, string eventArgsJson)
         {
             try
             {
@@ -70,7 +71,7 @@ namespace Microsoft.AspNetCore.Components.Web
 
                 // For custom events, the args type is determined from the associated delegate
                 var eventArgsType = renderer.GetEventArgsType(eventHandlerId);
-                return (EventArgs)JsonSerializer.Deserialize(eventArgsJson, eventArgsType, JsonSerializerOptionsProvider.Options)!;
+                return (EventArgs)JsonSerializer.Deserialize(eventArgsJson, eventArgsType, jsonSerializerOptions)!;
             }
             catch (Exception e)
             {

--- a/src/Components/WebAssembly/WebAssembly/src/Infrastructure/JSInteropMethods.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Infrastructure/JSInteropMethods.cs
@@ -38,7 +38,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Infrastructure
         public static Task DispatchEvent(WebEventDescriptor eventDescriptor, string eventArgsJson)
         {
             var renderer = RendererRegistry.Find(eventDescriptor.BrowserRendererId);
-            var webEvent = WebEventData.Parse(renderer, eventDescriptor, eventArgsJson);
+            var jsonSerializerOptions = DefaultWebAssemblyJSRuntime.Instance.ReadJsonSerializerOptions();
+            var webEvent = WebEventData.Parse(renderer, jsonSerializerOptions, eventDescriptor, eventArgsJson);
             return renderer.DispatchEventAsync(
                 webEvent.EventHandlerId,
                 webEvent.EventFieldInfo,

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.WarningSuppressions.xml
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.WarningSuppressions.xml
@@ -35,7 +35,7 @@
       <argument>ILLink</argument>
       <argument>IL2072</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.Web.WebEventData.ParseEventArgsJson(Microsoft.AspNetCore.Components.RenderTree.Renderer,System.UInt64,System.String,System.String)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Components.Web.WebEventData.ParseEventArgsJson(Microsoft.AspNetCore.Components.RenderTree.Renderer,System.Text.Json.JsonSerializerOptions,System.UInt64,System.String,System.String)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text.Json;
 using Microsoft.JSInterop.Infrastructure;
 using Microsoft.JSInterop.WebAssembly;
 
@@ -22,6 +23,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Services
             ElementReferenceContext = new WebElementReferenceContext(this);
             JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter(ElementReferenceContext));
         }
+
+        public JsonSerializerOptions ReadJsonSerializerOptions() => JsonSerializerOptions;
 
         // The following methods are invoke via Mono's JS interop mechanism (invoke_method)
         public static string? InvokeDotNet(string assemblyName, string methodIdentifier, string dotNetObjectId, string argsJson)

--- a/src/Components/WebView/WebView/src/IpcReceiver.cs
+++ b/src/Components/WebView/WebView/src/IpcReceiver.cs
@@ -88,7 +88,8 @@ namespace Microsoft.AspNetCore.Components.WebView
         private Task DispatchBrowserEventAsync(PageContext pageContext, string eventDescriptor, string eventArgs)
         {
             var renderer = pageContext.Renderer;
-            var webEventData = WebEventData.Parse(renderer, eventDescriptor, eventArgs);
+            var jsonSerializerOptions = pageContext.JSRuntime.ReadJsonSerializerOptions();
+            var webEventData = WebEventData.Parse(renderer, jsonSerializerOptions, eventDescriptor, eventArgs);
             return renderer.DispatchEventAsync(
                 webEventData.EventHandlerId,
                 webEventData.EventFieldInfo,

--- a/src/Components/WebView/WebView/src/Services/WebViewJSRuntime.cs
+++ b/src/Components/WebView/WebView/src/Services/WebViewJSRuntime.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Services
             _ipcSender = ipcSender;
         }
 
+        public JsonSerializerOptions ReadJsonSerializerOptions() => JsonSerializerOptions;
+
         protected override void BeginInvokeJS(long taskId, string identifier, string argsJson, JSCallResultType resultType, long targetInstanceId)
         {
             _ipcSender.BeginInvokeJS(taskId, identifier, argsJson, resultType, targetInstanceId);

--- a/src/Components/test/E2ETest/Tests/EventCustomArgsTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventCustomArgsTest.cs
@@ -162,6 +162,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.True(() => GetLogLines().Contains("Received custom mouseover event"));
         }
 
+        [Fact]
+        public void CanRegisterCustomEventAndSupplyIJSObjectReference()
+        {
+            Browser.Exists(By.Id("register-sendjsobject")).Click();
+            Browser.FindElement(By.Id("trigger-sendjsobject-event-directly")).Click();
+            Browser.Equal("Event with IJSObjectReference received: Hello!", () => GetLogLines().Single());
+        }
+
         void SendKeysSequentially(IWebElement target, string text)
         {
             foreach (var c in text)

--- a/src/Components/test/testassets/BasicTestApp/EventCustomArgsComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/EventCustomArgsComponent.razor
@@ -63,7 +63,7 @@
 
 <button id="trigger-sendjsobject-event-directly"
         onclick="document.getElementById('test-event-target-child').dispatchEvent(new CustomEvent('sendjsobject', { bubbles: true, detail: { jsObject: DotNet.createJSObjectReference({ getMyValue: () => 'Hello!' }) } }))">
-    Trigger testevent directly
+    Trigger sendjsobject event directly
 </button>
 
 

--- a/src/Components/test/testassets/BasicTestApp/EventCustomArgsComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/EventCustomArgsComponent.razor
@@ -9,7 +9,8 @@
      @ontestevent="@HandleTestEvent"
      @onkeydown.testvariant="@HandleCustomKeyDown"
      @onkeydown.yetanother="@HandleYetAnotherKeyboardEvent"
-     @oncustommouseover="@(e => { LogMessage("Received custom mouseover event"); })">
+     @oncustommouseover="@(e => { LogMessage("Received custom mouseover event"); })"
+     @onsendjsobject="HandleEventWithIJSObjectReference">
     Event target
     <div id="test-event-target-child" style="background: #afa; padding: 1em;">
         Child
@@ -55,6 +56,17 @@
     Register custom mouseover event (which has no corresponding native listener)
 </button>
 
+<button id="register-sendjsobject"
+        onclick="Blazor.registerCustomEventType('sendjsobject', { createEventArgs: event => event.detail })">
+    Register custom event that sends IJSObjectReference
+</button>
+
+<button id="trigger-sendjsobject-event-directly"
+        onclick="document.getElementById('test-event-target-child').dispatchEvent(new CustomEvent('sendjsobject', { bubbles: true, detail: { jsObject: DotNet.createJSObjectReference({ getMyValue: () => 'Hello!' }) } }))">
+    Trigger testevent directly
+</button>
+
+
 <p>
     <label>
         <input type="checkbox" id="custom-keydown-prevent-default" @bind="customKeyDownPreventDefault" />
@@ -98,5 +110,11 @@
     void HandleYetAnotherKeyboardEvent(YetAnotherCustomKeyboardEventArgs eventArgs)
     {
         LogMessage($"Yet another aliased event received: {eventArgs.YouPressed}");
+    }
+
+    async Task HandleEventWithIJSObjectReference(EventWithIJSObjectReferenceEventArgs eventArgs)
+    {
+        var innerValue = await eventArgs.JsObject.InvokeAsync<string>("getMyValue", null);
+        LogMessage($"Event with IJSObjectReference received: {innerValue}");
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/EventCustomArgsTypes.cs
+++ b/src/Components/test/testassets/BasicTestApp/EventCustomArgsTypes.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace BasicTestApp.CustomEventTypesNamespace
 {
@@ -7,6 +8,7 @@ namespace BasicTestApp.CustomEventTypesNamespace
     [EventHandler("onkeydown.testvariant", typeof(TestKeyDownEventArgs), true, true)]
     [EventHandler("onkeydown.yetanother", typeof(YetAnotherCustomKeyboardEventArgs), true, true)]
     [EventHandler("oncustommouseover", typeof(EventArgs), true, true)]
+    [EventHandler("onsendjsobject", typeof(EventWithIJSObjectReferenceEventArgs), true, true)]
     public static class EventHandlers
     {
     }
@@ -24,5 +26,10 @@ namespace BasicTestApp.CustomEventTypesNamespace
     class YetAnotherCustomKeyboardEventArgs : EventArgs
     {
         public string YouPressed { get; set; }
+    }
+
+    class EventWithIJSObjectReferenceEventArgs : EventArgs
+    {
+        public IJSObjectReference JsObject { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #31238

This is pretty simple. At the point where we deserialize the incoming event args, we need to use the `JsonSerializerOptions` from the `JSRuntime`. Each of the code paths that dispatches events into the system (Server, WebAssembly, WebView) already has the necessary info so in each case we just have to wire it up.