### PR TITLE
Update container used for Linux Musl

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -528,7 +528,7 @@ stages:
       jobName: Linux_musl_x64_build
       jobDisplayName: "Build: Linux Musl x64"
       agentOs: Linux
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.9-WithNode-0fc54a3-20190918214015
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673
       buildScript: ./eng/build.sh
       buildArgs:
         --arch x64

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -528,7 +528,7 @@ stages:
       jobName: Linux_musl_x64_build
       jobDisplayName: "Build: Linux Musl x64"
       agentOs: Linux
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200602002622-e06dc59
       buildScript: ./eng/build.sh
       buildArgs:
         --arch x64

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -528,7 +528,7 @@ stages:
       jobName: Linux_musl_x64_build
       jobDisplayName: "Build: Linux Musl x64"
       agentOs: Linux
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200602002622-e06dc59
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20210602183841-ae5be29
       buildScript: ./eng/build.sh
       buildArgs:
         --arch x64

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -528,7 +528,7 @@ stages:
       jobName: Linux_musl_x64_build
       jobDisplayName: "Build: Linux Musl x64"
       agentOs: Linux
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-WithNode-20210602183841-ae5be29
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode-20210910135833-c401c85
       buildScript: ./eng/build.sh
       buildArgs:
         --arch x64


### PR DESCRIPTION
3.9 and 3.10 are EOL. The containers newer than 3.9 don't explicitly state if they have node, so we'll see what happens in CI.