### PR TITLE
Fix "no event handler" in simultaneous blur+removal case

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Rendering/WebAssemblyRenderer.cs
@@ -20,9 +20,9 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Rendering
     {
         private readonly ILogger _logger;
         private readonly int _webAssemblyRendererId;
+        private readonly QueueWithLast<IncomingEventInfo> deferredIncomingEvents = new();
 
         private bool isDispatchingEvent;
-        private QueueWithLast<IncomingEventInfo> deferredIncomingEvents = new();
 
         /// <summary>
         /// Constructs an instance of <see cref="WebAssemblyRenderer"/>.

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -51,6 +51,17 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        public void FocusEvents_CanReceiveBlurCausedByElementRemoval()
+        {
+            // Represents https://github.com/dotnet/aspnetcore/issues/26838
+
+            Browser.MountTestComponent<FocusEventComponent>();
+
+            Browser.FindElement(By.Id("button-that-disappears")).Click();
+            Browser.Equal("True", () => Browser.FindElement(By.Id("button-received-focus-out")).Text);
+        }
+
+        [Fact]
         public void MouseOverAndMouseOut_CanTrigger()
         {
             Browser.MountTestComponent<MouseEventComponent>();

--- a/src/Components/test/testassets/BasicTestApp/FocusEventComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FocusEventComponent.razor
@@ -3,7 +3,7 @@
 <h2>Focus and activation</h2>
 
 <p @onfocusin="OnFocusIn" @onfocusout="OnFocusOut">
-    Input: <input id="input" type="text" @onfocus="OnFocus" @onblur="OnBlur"/>
+    Input: <input id="input" type="text" @onfocus="OnFocus" @onblur="OnBlur" />
 </p>
 <p>
     Output: <span id="output">@message</span>
@@ -13,39 +13,58 @@
 </p>
 
 <p>
+    A button that disappears when clicked:
+    @if (showButtonThatDisappearsWhenClicked)
+    {
+        <button id="button-that-disappears" @onfocusout="DisappearingButtonFocusOut" @onclick="MakeButtonDisappear">
+            Click me
+        </button>
+    }
+
+    Received focus out: <strong id="button-received-focus-out">@buttonReceivedFocusOut</strong>
+</p>
+
+<p>
     Another input (to distract you) <input id="other" />
 </p>
 
 @code {
-
+    bool showButtonThatDisappearsWhenClicked = true;
+    bool buttonReceivedFocusOut;
     string message;
 
     void OnFocus(FocusEventArgs e)
     {
         message += "onfocus,";
-        StateHasChanged();
     }
 
     void OnBlur(FocusEventArgs e)
     {
         message += "onblur,";
-        StateHasChanged();
     }
 
     void OnFocusIn(FocusEventArgs e)
     {
         message += "onfocusin,";
-        StateHasChanged();
     }
 
     void OnFocusOut(FocusEventArgs e)
     {
         message += "onfocusout,";
-        StateHasChanged();
     }
 
     void Clear()
     {
         message = string.Empty;
+    }
+
+    void MakeButtonDisappear()
+    {
+        showButtonThatDisappearsWhenClicked = false;
+    }
+
+    void DisappearingButtonFocusOut()
+    {
+        buttonReceivedFocusOut = true;
     }
 }


### PR DESCRIPTION
Fixes #26838 (a longstanding and tricky bug)

This bug only affects WebAssembly, not Server, due to a difference in how event processing and renderbatch acknowledgement works.

On all hosting platforms, the overall idea for when to dispose event handler ID is this: .NET code should only dispose an event handler after confirmation that the JS-side code has done so. This guarantees that the JS-side code will never raise an event for which .NET has already disposed the handler. .NET knows it's safe to do this once it receives an acknowledgement for the renderbatch that contains the event disposal.

* On Server, all messages from JS to .NET are async and arrive in a single queue. Whenever we process a renderbatch acknowledgement, we know that any preceding event notifications have already started being dispatched (and hence have already captured a reference to the handler they will need) because of that message queue.
* On WebAssembly, there isn't (or wasn't) really a true notion of renderbatch acknowledgements, because we know that batches are always applied synchronously, hence it's valid to just treat all batches as immediately and synchronously acknowledged as soon as we've called the "update DOM" JS method.
  * However, there's an edge case where this is false. In order for WebAssembly to guarantee that events aren't nested inside each other on the stack (which is not possible on Server because of how they arrive as separate async events), it has a system of "deferring" an incoming event if one is already on the call stack, until we pop back off to the top of the call stack. Imagine the deferred event has ID=X. In the unlikely event that the event already on the call stack causes a render that removes X, the fact that we treat the batch as synchronously acknowledged means that we then proceed to dispose X before processing the deferred event. Crash.

To fix this, my overall goal is to bring WebAssembly and Server call ordering more in sync with each other, both to fix this one issue and to reduce the chances of other similar issues in the future. So what I've done is to make WebAssembly no longer treat renderbatch acknowledgements as always completed synchronously, and instead:

 * If there are no deferred events waiting to be processed, behave like before and just return `Task.CompletedTask` (so the ack is indeed still sync - no perf lost)
 * But in the edge case where there is a deferred event, chain the acknowledgement onto a `Task` that fires once the currently-last-in-queue deferred event starts processing. This is as if there was a single queue of incoming messages, and we inserted the renderbatch acknowledgement at the tail of it. Which is exactly like Blazor Server.

So in summary, the WebAssembly/Server ordering inconsistency edge case is gone, and hence so is the bug with `blur`. But it won't have any impact on any event processing other than these deferred ones.

Thanks for reading my long message. If it made no sense, just click *Approve* and move on with your life.