### PR TITLE
[SignalR TS] Set keep alive timer in receive loop (#31300)

### DIFF
--- a/src/SignalR/clients/ts/signalr/tests/HubConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnection.test.ts
@@ -109,7 +109,7 @@ describe("HubConnection", () => {
     });
 
     describe("ping", () => {
-        it("automatically sends multiple pings", async () => {
+        it("sends pings when receiving pings", async () => {
             await VerifyLogger.run(async (logger) => {
                 const connection = new TestConnection();
                 const hubConnection = createHubConnection(connection, logger);
@@ -118,7 +118,14 @@ describe("HubConnection", () => {
 
                 try {
                     await hubConnection.start();
+
+                    const pingInterval = setInterval(async () => {
+                        await connection.receive({ type: MessageType.Ping });
+                    }, 5);
+
                     await delayUntil(500);
+
+                    clearInterval(pingInterval);
 
                     const numPings = connection.sentData.filter((s) => JSON.parse(s).type === MessageType.Ping).length;
                     expect(numPings).toBeGreaterThanOrEqual(2);


### PR DESCRIPTION
## Description

[Chrome released a timer throttling feature](https://developer.chrome.com/blog/timer-throttling-in-chrome-88/) that causes SignalR clients to disconnect a few minutes after the browser tab becomes inactive. If you start a timer from a network callback then the throttling does not occur. So we changed how we use timers to only be started from a network event.

## Customer Impact

SignalR clients will disconnect a few minutes after the browser tab becomes inactive. This is undesired behavior for users of SignalR.

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The fix has been tested by internal and external people.

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

Addresses https://github.com/dotnet/aspnetcore/issues/31079