### PR TITLE
Copy runtimeconfig.json to output directory

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -28,7 +28,7 @@
         SharedFxVersion=$(SharedFxVersion);
       </_RuntimeConfigProperties>
 
-      <_RuntimeConfigPath>$(IntermediateOutputPath)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>
+      <_RuntimeConfigPath>$(OutputPath)blazor-devserver.runtimeconfig.json</_RuntimeConfigPath>
     </PropertyGroup>
 
     <GenerateFileFromTemplate
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <NuspecProperty Include="publishDir=$(PublishDir)" />
-    <NuspecProperty Include="objDir=$(IntermediateOutputPath)" />
+    <NuspecProperty Include="binDir=$(OutputPath)" />
     <NuspecProperty Include="PackageThirdPartyNoticesFile=$(PackageThirdPartyNoticesFile)" />
   </ItemGroup>
 

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -21,6 +21,16 @@
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <Compile Include="$(SharedSourceRoot)CommandLineUtils\**\*.cs" />
   </ItemGroup>
+   
+  <!--  We include this here to ensure that the shared framework is built before we leverage it when running
+  the dev server. -->
+  <ItemGroup>
+    <ProjectReference
+      Include="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
+      PrivateAssets="All"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
 
   <Target Name="_CreateRuntimeConfig" BeforeTargets="CoreBuild">
     <PropertyGroup>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.nuspec
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.nuspec
@@ -8,6 +8,6 @@
     <file src="build\**" target="build" />
     <file src="$publishDir$**\*" target="tools" />
     <file src="$PackageThirdPartyNoticesFile$" target=".\THIRD-PARTY-NOTICES.txt" />
-    <file src="$objDir$blazor-devserver.runtimeconfig.json" target="tools\blazor-devserver.runtimeconfig.json" />
+    <file src="$binDir$blazor-devserver.runtimeconfig.json" target="tools\blazor-devserver.runtimeconfig.json" />
   </files>
 </package>


### PR DESCRIPTION
We don't currently copy the `runtime.config.json` file to the output directory of the DevServer project, which causes running `dotnet run` locally in a WASM app to fail. To resolve this, we copy the JSON file to the output directory.

Address https://github.com/dotnet/aspnetcore/issues/31611

