### PR TITLE
Infer that interface parameters are services

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -203,15 +203,7 @@ namespace Microsoft.AspNetCore.Http
             }
             else if (parameterCustomAttributes.OfType<IFromBodyMetadata>().FirstOrDefault() is { } bodyAttribute)
             {
-                if (factoryContext.JsonRequestBodyType is not null)
-                {
-                    throw new InvalidOperationException("Action cannot have more than one FromBody attribute.");
-                }
-
-                factoryContext.JsonRequestBodyType = parameter.ParameterType;
-                factoryContext.AllowEmptyRequestBody = bodyAttribute.AllowEmpty;
-
-                return Expression.Convert(BodyValueExpr, parameter.ParameterType);
+                return BindParameterFromBody(parameter.ParameterType, bodyAttribute.AllowEmpty, factoryContext);
             }
             else if (parameter.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)))
             {
@@ -229,9 +221,13 @@ namespace Microsoft.AspNetCore.Http
             {
                 return BindParameterFromRouteValueOrQueryString(parameter, parameter.Name, factoryContext);
             }
-            else
+            else if (parameter.ParameterType.IsInterface)
             {
                 return Expression.Call(GetRequiredServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
+            }
+            else
+            {
+                return BindParameterFromBody(parameter.ParameterType, allowEmpty: false, factoryContext);
             }
         }
 
@@ -625,6 +621,19 @@ namespace Microsoft.AspNetCore.Http
             var routeValue = GetValueFromProperty(RouteValuesExpr, key);
             var queryValue = GetValueFromProperty(QueryExpr, key);
             return BindParameterFromValue(parameter, Expression.Coalesce(routeValue, queryValue), factoryContext);
+        }
+
+        private static Expression BindParameterFromBody(Type parameterType, bool allowEmpty, FactoryContext factoryContext)
+        {
+            if (factoryContext.JsonRequestBodyType is not null)
+            {
+                throw new InvalidOperationException("Action cannot have more than one FromBody attribute.");
+            }
+
+            factoryContext.JsonRequestBodyType = parameterType;
+            factoryContext.AllowEmptyRequestBody = allowEmpty;
+
+            return Expression.Convert(BodyValueExpr, parameterType);
         }
 
         private static MethodInfo GetMethodInfo<T>(Expression<T> expr)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -428,7 +428,7 @@ namespace Microsoft.AspNetCore.Http
             var invoker = Expression.Lambda<Func<object?, HttpContext, object?, Task>>(
                 responseWritingMethodCall, TargetExpr, HttpContextExpr, BodyValueExpr).Compile();
 
-            var bodyType = factoryContext.JsonRequestBodyType!;
+            var bodyType = factoryContext.JsonRequestBodyType;
             object? defaultBodyValue = null;
 
             if (factoryContext.AllowEmptyRequestBody && bodyType.IsValueType)

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -416,7 +416,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             Assert.Equal(42, httpContext.Items["tryParsable"]);
         }
 
-        public static object[][] DelegatesWithInvalidAttributes
+        public static object[][] DelegatesWithAttributesOnNotTryParsableParameters
         {
             get
             {
@@ -434,7 +434,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Theory]
-        [MemberData(nameof(DelegatesWithInvalidAttributes))]
+        [MemberData(nameof(DelegatesWithAttributesOnNotTryParsableParameters))]
         public void CreateThrowsInvalidOperationExceptionWhenAttributeRequiresTryParseMethodThatDoesNotExist(Delegate action)
         {
             var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(action));
@@ -719,11 +719,13 @@ namespace Microsoft.AspNetCore.Routing.Internal
         [Fact]
         public void BuildRequestDelegateThrowsInvalidOperationExceptionGivenFromBodyOnMultipleParameters()
         {
-            void TestExplicitlyInvalidAction([FromBody] int value1, [FromBody] int value2) { }
+            void TestAttributedInvalidAction([FromBody] int value1, [FromBody] int value2) { }
             void TestInferredInvalidAction(Todo value1, Todo value2) { }
+            void TestBothInvalidAction(Todo value1, [FromBody] int value2) { }
 
-            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<int, int>)TestExplicitlyInvalidAction));
+            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<int, int>)TestAttributedInvalidAction));
             Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<Todo, Todo>)TestInferredInvalidAction));
+            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<Todo, int>)TestBothInvalidAction));
         }
 
         public static object[][] FromServiceActions

--- a/src/Http/Routing/src/Builder/MinimalActionEndpointConventionBuilder.cs
+++ b/src/Http/Routing/src/Builder/MinimalActionEndpointConventionBuilder.cs
@@ -9,16 +9,16 @@ namespace Microsoft.AspNetCore.Builder
     /// <summary>
     /// Builds conventions that will be used for customization of MapAction <see cref="EndpointBuilder"/> instances.
     /// </summary>
-    public sealed class MapActionEndpointConventionBuilder : IEndpointConventionBuilder
+    public sealed class MinimalActionEndpointConventionBuilder : IEndpointConventionBuilder
     {
         private readonly List<IEndpointConventionBuilder> _endpointConventionBuilders;
 
-        internal MapActionEndpointConventionBuilder(IEndpointConventionBuilder endpointConventionBuilder)
+        internal MinimalActionEndpointConventionBuilder(IEndpointConventionBuilder endpointConventionBuilder)
         {
             _endpointConventionBuilders = new List<IEndpointConventionBuilder>() { endpointConventionBuilder };
         }
 
-        internal MapActionEndpointConventionBuilder(List<IEndpointConventionBuilder> endpointConventionBuilders)
+        internal MinimalActionEndpointConventionBuilder(List<IEndpointConventionBuilder> endpointConventionBuilders)
         {
             _endpointConventionBuilders = endpointConventionBuilders;
         }

--- a/src/Http/Routing/src/Builder/MinimalActionEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/MinimalActionEndpointRouteBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Builder
     /// <summary>
     /// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to define HTTP API endpoints.
     /// </summary>
-    public static class MapActionEndpointRouteBuilderExtensions
+    public static class MinmalActionEndpointRouteBuilderExtensions
     {
         // Avoid creating a new array every call
         private static readonly string[] GetVerb = new[] { "GET" };
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pattern">The route pattern.</param>
         /// <param name="action">The delegate executed when the endpoint is matched.</param>
         /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static MapActionEndpointConventionBuilder MapGet(
+        public static MinimalActionEndpointConventionBuilder MapGet(
             this IEndpointRouteBuilder endpoints,
             string pattern,
             Delegate action)
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pattern">The route pattern.</param>
         /// <param name="action">The delegate executed when the endpoint is matched.</param>
         /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static MapActionEndpointConventionBuilder MapPost(
+        public static MinimalActionEndpointConventionBuilder MapPost(
             this IEndpointRouteBuilder endpoints,
             string pattern,
             Delegate action)
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pattern">The route pattern.</param>
         /// <param name="action">The delegate executed when the endpoint is matched.</param>
         /// <returns>A <see cref="IEndpointConventionBuilder"/> that canaction be used to further customize the endpoint.</returns>
-        public static MapActionEndpointConventionBuilder MapPut(
+        public static MinimalActionEndpointConventionBuilder MapPut(
             this IEndpointRouteBuilder endpoints,
             string pattern,
             Delegate action)
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pattern">The route pattern.</param>
         /// <param name="action">The delegate executed when the endpoint is matched.</param>
         /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static MapActionEndpointConventionBuilder MapDelete(
+        public static MinimalActionEndpointConventionBuilder MapDelete(
             this IEndpointRouteBuilder endpoints,
             string pattern,
             Delegate action)
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="action">The delegate executed when the endpoint is matched.</param>
         /// <param name="httpMethods">HTTP methods that the endpoint will match.</param>
         /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static MapActionEndpointConventionBuilder MapMethods(
+        public static MinimalActionEndpointConventionBuilder MapMethods(
            this IEndpointRouteBuilder endpoints,
            string pattern,
            IEnumerable<string> httpMethods,
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pattern">The route pattern.</param>
         /// <param name="action">The delegate executed when the endpoint is matched.</param>
         /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static MapActionEndpointConventionBuilder Map(
+        public static MinimalActionEndpointConventionBuilder Map(
             this IEndpointRouteBuilder endpoints,
             string pattern,
             Delegate action)
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pattern">The route pattern.</param>
         /// <param name="action">The delegate executed when the endpoint is matched.</param>
         /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static MapActionEndpointConventionBuilder Map(
+        public static MinimalActionEndpointConventionBuilder Map(
             this IEndpointRouteBuilder endpoints,
             RoutePattern pattern,
             Delegate action)
@@ -185,7 +185,7 @@ namespace Microsoft.AspNetCore.Builder
                 endpoints.DataSources.Add(dataSource);
             }
 
-            return new MapActionEndpointConventionBuilder(dataSource.AddEndpointBuilder(builder));
+            return new MinimalActionEndpointConventionBuilder(dataSource.AddEndpointBuilder(builder));
         }
     }
 }

--- a/src/Http/Routing/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing/src/PublicAPI.Unshipped.txt
@@ -5,19 +5,18 @@
 *REMOVED*Microsoft.AspNetCore.Routing.IRouteNameMetadata.RouteName.get -> string!
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteName.get -> string!
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteNameMetadata(string! routeName) -> void
-Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder
-Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder.Add(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! convention) -> void
-Microsoft.AspNetCore.Builder.MapActionEndpointRouteBuilderExtensions
+Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder
+Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions
 Microsoft.AspNetCore.Routing.DataTokensMetadata.DataTokens.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!
 Microsoft.AspNetCore.Routing.DataTokensMetadata.DataTokensMetadata(System.Collections.Generic.IReadOnlyDictionary<string!, object?>! dataTokens) -> void
 Microsoft.AspNetCore.Routing.IDataTokensMetadata.DataTokens.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!
 Microsoft.AspNetCore.Routing.IRouteNameMetadata.RouteName.get -> string?
 Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteName.get -> string?
 Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteNameMetadata(string? routeName) -> void
-static Microsoft.AspNetCore.Builder.MapActionEndpointRouteBuilderExtensions.Map(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, Microsoft.AspNetCore.Routing.Patterns.RoutePattern! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder!
-static Microsoft.AspNetCore.Builder.MapActionEndpointRouteBuilderExtensions.Map(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder!
-static Microsoft.AspNetCore.Builder.MapActionEndpointRouteBuilderExtensions.MapDelete(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder!
-static Microsoft.AspNetCore.Builder.MapActionEndpointRouteBuilderExtensions.MapGet(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder!
-static Microsoft.AspNetCore.Builder.MapActionEndpointRouteBuilderExtensions.MapMethods(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Collections.Generic.IEnumerable<string!>! httpMethods, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder!
-static Microsoft.AspNetCore.Builder.MapActionEndpointRouteBuilderExtensions.MapPost(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder!
-static Microsoft.AspNetCore.Builder.MapActionEndpointRouteBuilderExtensions.MapPut(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MapActionEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions.Map(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, Microsoft.AspNetCore.Routing.Patterns.RoutePattern! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions.Map(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions.MapDelete(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions.MapGet(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions.MapMethods(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Collections.Generic.IEnumerable<string!>! httpMethods, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions.MapPost(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions.MapPut(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! action) -> Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder!

--- a/src/Http/Routing/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing/src/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteName.get -> string!
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteNameMetadata(string! routeName) -> void
 Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder
+Microsoft.AspNetCore.Builder.MinimalActionEndpointConventionBuilder.Add(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! convention) -> void
 Microsoft.AspNetCore.Builder.MinmalActionEndpointRouteBuilderExtensions
 Microsoft.AspNetCore.Routing.DataTokensMetadata.DataTokens.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!
 Microsoft.AspNetCore.Routing.DataTokensMetadata.DataTokensMetadata(System.Collections.Generic.IReadOnlyDictionary<string!, object?>! dataTokens) -> void

--- a/src/Http/Routing/test/FunctionalTests/MinimalActionTest.cs
+++ b/src/Http/Routing/test/FunctionalTests/MinimalActionTest.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Routing.FunctionalTests
 {
-    public class MapActionTest
+    public class MinimalActionTest
     {
         [Fact]
         public async Task MapPost_FromBodyWorksWithJsonPayload()

--- a/src/Http/Routing/test/UnitTests/Builder/MinimalActionEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/MinimalActionEndpointRouteBuilderExtensionsTest.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Builder
 {
-    public class MapActionEndpointDataSourceBuilderExtensionsTest
+    public class MinimalActionEndpointDataSourceBuilderExtensionsTest
     {
         private ModelEndpointDataSource GetBuilderEndpointDataSource(IEndpointRouteBuilder endpointRouteBuilder)
         {


### PR DESCRIPTION
Also some MapAction -> MinimalAction renaming.

Addresses two checkboxes in https://github.com/dotnet/aspnetcore/issues/30248#issuecomment-816870890.

As of https://github.com/dotnet/aspnetcore/pull/31603, all minimal action parameters without an attribute or a simple type (one with a `static bool TryParse(string, out T)` method) are inferred to be services. This was never intended to be the final convention.

We decided to infer only interface parameters are services. Any non-interface parameter without an attribute is now inferred to be a `[FromBody]` parameter (not allowed to be empty).
