### PR TITLE
[SignalR] Allocate one StreamItemMessage per stream

### DIFF
--- a/src/SignalR/common/SignalR.Common/src/Protocol/StreamItemMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/StreamItemMessage.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol
         /// <summary>
         /// The single item from a stream.
         /// </summary>
-        public object? Item { get; }
+        public object? Item { get; set; }
 
         /// <summary>
         /// Constructs a <see cref="StreamItemMessage"/>.

--- a/src/SignalR/common/SignalR.Common/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/SignalR.Common/src/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@
 *REMOVED*Microsoft.AspNetCore.SignalR.Protocol.StreamInvocationMessage.StreamInvocationMessage(string! invocationId, string! target, object![]! arguments, string![]! streamIds) -> void
 *REMOVED*Microsoft.AspNetCore.SignalR.Protocol.IHubProtocol.TryParseMessage(ref System.Buffers.ReadOnlySequence<byte> input, Microsoft.AspNetCore.SignalR.IInvocationBinder! binder, out Microsoft.AspNetCore.SignalR.Protocol.HubMessage! message) -> bool
 Microsoft.AspNetCore.SignalR.Protocol.InvocationBindingFailureMessage.InvocationBindingFailureMessage(string? invocationId, string! target, System.Runtime.ExceptionServices.ExceptionDispatchInfo! bindingFailure) -> void
+Microsoft.AspNetCore.SignalR.Protocol.StreamItemMessage.Item.set -> void
 static Microsoft.AspNetCore.SignalR.Protocol.CompletionMessage.WithError(string! invocationId, string? error) -> Microsoft.AspNetCore.SignalR.Protocol.CompletionMessage!
 static Microsoft.AspNetCore.SignalR.Protocol.CompletionMessage.WithResult(string! invocationId, object? payload) -> Microsoft.AspNetCore.SignalR.Protocol.CompletionMessage!
 Microsoft.AspNetCore.SignalR.Protocol.HubMethodInvocationMessage.Arguments.get -> object?[]!

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -473,10 +473,12 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
                 Log.StreamingResult(_logger, invocationId, descriptor.MethodExecutor);
 
+                var streamItemMessage = new StreamItemMessage(invocationId, null);
                 await foreach (var streamItem in enumerable)
                 {
+                    streamItemMessage.Item = streamItem;
                     // Send the stream item
-                    await connection.WriteAsync(new StreamItemMessage(invocationId, streamItem));
+                    await connection.WriteAsync(streamItemMessage);
                 }
             }
             catch (ChannelClosedException ex)


### PR DESCRIPTION
Allocate a single `StreamItemMessage` per stream instead of per stream item

Unfortunately this does add a new API so will need to go to API review.