### PR TITLE
[SignalR] Allocate HubCallerClients once per connection

### DIFF
--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -99,6 +99,7 @@ namespace Microsoft.AspNetCore.SignalR
         }
 
         internal HubCallerContext HubCallerContext { get; }
+        internal HubCallerClients HubCallerClients { get; set; } = null!;
 
         internal Exception? CloseException { get; private set; }
 

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -74,6 +74,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         public override async Task OnConnectedAsync(HubConnectionContext connection)
         {
             var scope = _serviceScopeFactory.CreateScope();
+            connection.HubCallerClients =  new HubCallerClients(_hubContext.Clients, connection.ConnectionId);
 
             try
             {
@@ -558,7 +559,7 @@ namespace Microsoft.AspNetCore.SignalR.Internal
 
         private void InitializeHub(THub hub, HubConnectionContext connection)
         {
-            hub.Clients = new HubCallerClients(_hubContext.Clients, connection.ConnectionId);
+            hub.Clients = connection.HubCallerClients;
             hub.Context = connection.HubCallerContext;
             hub.Groups = _hubContext.Groups;
         }


### PR DESCRIPTION
Allocate HubCallerClients once per connection instead of every hub method call