### PR TITLE
Add "hotReloadProfile" to hosted Blazor template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Properties/launchSettings.json
@@ -16,6 +16,7 @@
         "commandName": "Project",
         "dotnetRunMessages": "true",
         "launchBrowser": true,
+        "hotReloadProfile": "blazorwasmhosted",
         "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
         //#if(RequiresHttps)
         "applicationUrl": "https://localhost:5001;http://localhost:5000",


### PR DESCRIPTION
Noticed that the hosted template isn't being created with the `hotReloadProfile` setting.

Edit: I just remembered there was some back-and-forth a while back as to whether we should do this. I believe this was before Pranav added support for hot reload for hosted apps. I think it makes sense to have this now.