### PR TITLE
[3.1] Mark components assemblies as non shipping

### DIFF
--- a/src/Components/WebAssembly/Authentication.Msal/src/Microsoft.Authentication.WebAssembly.Msal.csproj
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Microsoft.Authentication.WebAssembly.Msal.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Authenticate your Blazor webassembly applications with Azure Active Directory and Azure Active Directory B2C</Description>
     <RazorLangVersion>3.0</RazorLangVersion>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/Authentication.Msal/src/Microsoft.Authentication.WebAssembly.Msal.csproj
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Microsoft.Authentication.WebAssembly.Msal.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Authenticate your Blazor webassembly applications with Azure Active Directory and Azure Active Directory B2C</Description>
     <RazorLangVersion>3.0</RazorLangVersion>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/Build/src/Microsoft.AspNetCore.Components.WebAssembly.Build.csproj
+++ b/src/Components/WebAssembly/Build/src/Microsoft.AspNetCore.Components.WebAssembly.Build.csproj
@@ -5,7 +5,7 @@
     <TargetName>Microsoft.AspNetCore.Components.WebAssembly.Build.Tasks</TargetName>
     <AssemblyName>Microsoft.AspNetCore.Components.WebAssembly.Build</AssemblyName>
     <Description>Build mechanism for ASP.NET Core Blazor WebAssembly applications.</Description>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>

--- a/src/Components/WebAssembly/Build/src/Microsoft.AspNetCore.Components.WebAssembly.Build.csproj
+++ b/src/Components/WebAssembly/Build/src/Microsoft.AspNetCore.Components.WebAssembly.Build.csproj
@@ -5,7 +5,7 @@
     <TargetName>Microsoft.AspNetCore.Components.WebAssembly.Build.Tasks</TargetName>
     <AssemblyName>Microsoft.AspNetCore.Components.WebAssembly.Build</AssemblyName>
     <Description>Build mechanism for ASP.NET Core Blazor WebAssembly applications.</Description>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>false</IsPackable>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>

--- a/src/Components/WebAssembly/DebugProxy/src/Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.csproj
+++ b/src/Components/WebAssembly/DebugProxy/src/Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackageId>Microsoft.AspNetCore.Components.WebAssembly.DebugProxy</PackageId>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <Description>Debug proxy for use when building Blazor applications.</Description>
     <!-- Set this to false because assemblies should not reference this assembly directly, (except for tests, of course). -->

--- a/src/Components/WebAssembly/DebugProxy/src/Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.csproj
+++ b/src/Components/WebAssembly/DebugProxy/src/Microsoft.AspNetCore.Components.WebAssembly.DebugProxy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackageId>Microsoft.AspNetCore.Components.WebAssembly.DebugProxy</PackageId>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>false</IsPackable>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <Description>Debug proxy for use when building Blazor applications.</Description>
     <!-- Set this to false because assemblies should not reference this assembly directly, (except for tests, of course). -->

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>blazor-devserver</AssemblyName>
     <PackageId>Microsoft.AspNetCore.Components.WebAssembly.DevServer</PackageId>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <StartupObject>Microsoft.AspNetCore.Components.WebAssembly.DevServer.Program</StartupObject>
     <Description>Development server for use when building Blazor applications.</Description>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>blazor-devserver</AssemblyName>
     <PackageId>Microsoft.AspNetCore.Components.WebAssembly.DevServer</PackageId>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>false</IsPackable>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <StartupObject>Microsoft.AspNetCore.Components.WebAssembly.DevServer.Program</StartupObject>
     <Description>Development server for use when building Blazor applications.</Description>

--- a/src/Components/WebAssembly/Directory.Build.props
+++ b/src/Components/WebAssembly/Directory.Build.props
@@ -4,6 +4,9 @@
     <!-- Override version labels -->
     <VersionPrefix>$(ComponentsWebAssemblyVersionPrefix)</VersionPrefix>
 
+    <!-- Override shipping to be extra safe -->
+    <IsShippingPackage>false</IsShippingPackage>
+    
     <!-- Avoid source build issues with WebAssembly -->
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>

--- a/src/Components/WebAssembly/Directory.Build.props
+++ b/src/Components/WebAssembly/Directory.Build.props
@@ -4,9 +4,6 @@
     <!-- Override version labels -->
     <VersionPrefix>$(ComponentsWebAssemblyVersionPrefix)</VersionPrefix>
 
-    <!-- Override shipping to be extra safe -->
-    <IsShippingPackage>false</IsShippingPackage>
-    
     <!-- Avoid source build issues with WebAssembly -->
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>

--- a/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
+++ b/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
@@ -5,8 +5,7 @@
     <Description>Abstractions and features for interop between .NET WebAssembly and JavaScript code.</Description>
     <PackageTags>wasm;javascript;interop</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <IsPackable>true</IsPackable>
-    <IsShipping>false</IsShipping>
+    <IsPackable>false</IsPackable>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
+++ b/src/Components/WebAssembly/JSInterop/src/Microsoft.JSInterop.WebAssembly.csproj
@@ -6,7 +6,7 @@
     <PackageTags>wasm;javascript;interop</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
-    <IsShipping>true</IsShipping>
+    <IsShipping>false</IsShipping>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
+++ b/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Description>Runtime server features for ASP.NET Core Blazor applications.</Description>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>false</IsPackable>
     <HasReferenceAssembly>false</HasReferenceAssembly>
 
     <!-- We're deliberately bundling assemblies as content files. Suppress the warning. -->

--- a/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
+++ b/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Description>Runtime server features for ASP.NET Core Blazor applications.</Description>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
 
     <!-- We're deliberately bundling assemblies as content files. Suppress the warning. -->

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Microsoft.AspNetCore.Components.WebAssembly.Authentication.csproj
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Microsoft.AspNetCore.Components.WebAssembly.Authentication.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Build client-side authentication for single-page applications (SPAs).</Description>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>false</IsPackable>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <RazorLangVersion>3.0</RazorLangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Microsoft.AspNetCore.Components.WebAssembly.Authentication.csproj
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Microsoft.AspNetCore.Components.WebAssembly.Authentication.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Build client-side authentication for single-page applications (SPAs).</Description>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <HasReferenceAssembly>false</HasReferenceAssembly>
     <RazorLangVersion>3.0</RazorLangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Build client-side single-page applications (SPAs) with Blazor running under WebAssembly.</Description>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <NoWarn>$(NoWarn);BL0006</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Build client-side single-page applications (SPAs) with Blazor running under WebAssembly.</Description>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);BL0006</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Components/WebAssembly/WebAssemblyHttpHandler/src/Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj
+++ b/src/Components/WebAssembly/WebAssemblyHttpHandler/src/Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj
@@ -8,6 +8,7 @@
     <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
+    <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/WebAssemblyHttpHandler/src/Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj
+++ b/src/Components/WebAssembly/WebAssemblyHttpHandler/src/Microsoft.AspNetCore.Components.WebAssembly.HttpHandler.csproj
@@ -8,7 +8,7 @@
     <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspnetcore/pull/28492

Also mark WebAssembly packages as non shipping