### PR TITLE
Switch to serviced dotnet/sdk tag

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 
 ENV StressRunDuration=0
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This `5.0.102-ca-patch-buster-slim` tag is no longer needed and is no longer serviced.

Context: https://github.com/dotnet/dotnet-docker/issues/2742

As an aside, do you have any feedback on how .NET container images can be improved? Do they meet your expectations?