### PR TITLE
Add new Use middleware extension method

### DIFF
--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.DevServer.Server
                 {
                     if (context.Request.PathBase == pathBase)
                     {
-                        return next();
+                        return next(context);
                     }
                     else
                     {

--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Builder
                         context.Response.Headers.Append("DOTNET-MODIFIABLE-ASSEMBLIES", Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES"));
                     }
 
-                    await next();
+                    await next(context);
                 });
 
                 subBuilder.UseMiddleware<ContentEncodingNegotiator>();

--- a/src/Components/WebAssembly/Server/src/WebAssemblyNetDebugProxyAppBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/WebAssemblyNetDebugProxyAppBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Builder
         {
             app.Map("/_framework/debug", app =>
             {
-                app.Use(async (context, next) =>
+                app.Run(async (context) =>
                 {
                     var queryParams = HttpUtility.ParseQueryString(context.Request.QueryString.Value!);
                     var browserParam = queryParams.Get("browser");

--- a/src/Components/WebAssembly/testassets/HostedInAspNet.Server/Startup.cs
+++ b/src/Components/WebAssembly/testassets/HostedInAspNet.Server/Startup.cs
@@ -41,7 +41,7 @@ namespace HostedInAspNet.Server
                 {
                     bootResourceRequestLog.AddRequest(context.Request);
                 }
-                return next();
+                return next(context);
             });
 
             if (env.IsDevelopment())

--- a/src/Components/test/testassets/TestServer/ServerStartup.cs
+++ b/src/Components/test/testassets/TestServer/ServerStartup.cs
@@ -47,7 +47,7 @@ namespace TestServer
                         resourceRequestLog.AddRequest(context.Request);
                     }
 
-                    return next();
+                    return next(context);
                 });
 
                 app.UseStaticFiles();

--- a/src/Hosting/TestHost/test/TestServerTests.cs
+++ b/src/Hosting/TestHost/test/TestServerTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.TestHost
                 container.Services.AddSingleton(new TestService { Message = "ConfigureContainer" });
 
             public void Configure(IApplicationBuilder app) =>
-                app.Use((ctx, next) => ctx.Response.WriteAsync(
+                app.Run(ctx => ctx.Response.WriteAsync(
                     $"{ctx.RequestServices.GetRequiredService<SimpleService>().Message}, {ctx.RequestServices.GetRequiredService<TestService>().Message}"));
         }
 
@@ -472,7 +472,7 @@ namespace Microsoft.AspNetCore.TestHost
                     app.Use(async (context, nxt) =>
                     {
                         context.Features.Set<IServiceProvidersFeature>(this);
-                        await nxt();
+                        await nxt(context);
                     });
                     next(app);
                 };
@@ -514,7 +514,7 @@ namespace Microsoft.AspNetCore.TestHost
                     app.Use(async (context, nxt) =>
                     {
                         context.Features.Set<IServiceProvidersFeature>(this);
-                        await nxt();
+                        await nxt(context);
                     });
                     next(app);
                 };

--- a/src/Http/Http.Abstractions/src/Extensions/UseExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UseExtensions.cs
@@ -14,6 +14,15 @@ namespace Microsoft.AspNetCore.Builder
     {
         /// <summary>
         /// Adds a middleware delegate defined in-line to the application's request pipeline.
+        /// <para>
+        /// Prefer using <see cref="Use(IApplicationBuilder, Func{HttpContext, RequestDelegate, Task})"/> for better performance as shown below:
+        /// <code>
+        /// app.Use((context, next) =>
+        /// {
+        ///     return next(context);
+        /// });
+        /// </code>
+        /// </para>
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
         /// <param name="middleware">A function that handles the request or calls the given next function.</param>
@@ -26,6 +35,23 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     Func<Task> simpleNext = () => next(context);
                     return middleware(context, simpleNext);
+                };
+            });
+        }
+
+        /// <summary>
+        /// Adds a middleware delegate defined in-line to the application's request pipeline.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
+        /// <param name="middleware">A function that handles the request or calls the given next function.</param>
+        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        public static IApplicationBuilder Use(this IApplicationBuilder app, Func<HttpContext, RequestDelegate, Task> middleware)
+        {
+            return app.Use(next =>
+            {
+                return context =>
+                {
+                    return middleware(context, next);
                 };
             });
         }

--- a/src/Http/Http.Abstractions/src/Extensions/UseExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UseExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Builder
     {
         /// <summary>
         /// Adds a middleware delegate defined in-line to the application's request pipeline.
+        /// If you aren't calling the next function, use <see cref="RunExtensions.Run(IApplicationBuilder, RequestDelegate)"/> instead.
         /// <para>
         /// Prefer using <see cref="Use(IApplicationBuilder, Func{HttpContext, RequestDelegate, Task})"/> for better performance as shown below:
         /// <code>
@@ -25,7 +26,7 @@ namespace Microsoft.AspNetCore.Builder
         /// </para>
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
-        /// <param name="middleware">A function that handles the request or calls the given next function.</param>
+        /// <param name="middleware">A function that handles the request and calls the given next function.</param>
         /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
         public static IApplicationBuilder Use(this IApplicationBuilder app, Func<HttpContext, Func<Task>, Task> middleware)
         {
@@ -41,19 +42,14 @@ namespace Microsoft.AspNetCore.Builder
 
         /// <summary>
         /// Adds a middleware delegate defined in-line to the application's request pipeline.
+        /// If you aren't calling the next function, use <see cref="RunExtensions.Run(IApplicationBuilder, RequestDelegate)"/> instead.
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
-        /// <param name="middleware">A function that handles the request or calls the given next function.</param>
+        /// <param name="middleware">A function that handles the request and calls the given next function.</param>
         /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
         public static IApplicationBuilder Use(this IApplicationBuilder app, Func<HttpContext, RequestDelegate, Task> middleware)
         {
-            return app.Use(next =>
-            {
-                return context =>
-                {
-                    return middleware(context, next);
-                };
-            });
+            return app.Use(next => context => middleware(context, next));
         }
     }
 }

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -18,5 +18,6 @@ Microsoft.AspNetCore.Http.Metadata.IFromServiceMetadata
 Microsoft.AspNetCore.Http.Endpoint.Endpoint(Microsoft.AspNetCore.Http.RequestDelegate? requestDelegate, Microsoft.AspNetCore.Http.EndpointMetadataCollection? metadata, string? displayName) -> void
 Microsoft.AspNetCore.Http.Endpoint.RequestDelegate.get -> Microsoft.AspNetCore.Http.RequestDelegate?
 Microsoft.AspNetCore.Routing.RouteValueDictionary.TryAdd(string! key, object? value) -> bool
+static Microsoft.AspNetCore.Builder.UseExtensions.Use(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Func<Microsoft.AspNetCore.Http.HttpContext!, Microsoft.AspNetCore.Http.RequestDelegate!, System.Threading.Tasks.Task!>! middleware) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.UseMiddleware(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Type! middleware, params object?[]! args) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.UseMiddleware<TMiddleware>(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, params object?[]! args) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!

--- a/src/Http/Http.Abstractions/test/UseExtensionsTests.cs
+++ b/src/Http/Http.Abstractions/test/UseExtensionsTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Builder.Extensions
+{
+    public class UseExtensionsTests
+    {
+        [Fact]
+        public async Task UseCallsNextMiddleware()
+        {
+            // Arrange
+            var builder = new ApplicationBuilder(serviceProvider: null!);
+            var context = new DefaultHttpContext();
+            var firstCalled = false;
+            var secondCalled = false;
+            var lastCalled = false;
+
+            builder.Use((context, next) =>
+            {
+                firstCalled = true;
+                return next();
+            });
+            builder.Use((context, next) =>
+            {
+                Assert.True(firstCalled);
+                secondCalled = true;
+                return next(context);
+            });
+            builder.Run(context =>
+            {
+                Assert.True(secondCalled);
+                lastCalled = true;
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await builder.Build().Invoke(context);
+
+            // Assert
+            Assert.True(firstCalled);
+            Assert.True(secondCalled);
+            Assert.True(lastCalled);
+        }
+
+        [Fact]
+        public async Task ThrowFromMiddlewareFlowsBackToInvoke()
+        {
+            // Arrange
+            var builder = new ApplicationBuilder(serviceProvider: null!);
+            var context = new DefaultHttpContext();
+            var shouldThrow = true;
+
+            builder.Use(async (context, next) =>
+            {
+                throw await Assert.ThrowsAsync<Exception>(() => next());
+            });
+            builder.Use(async (context, next) =>
+            {
+                throw await Assert.ThrowsAsync<Exception>(() => next(context));
+            });
+            builder.Run(context =>
+            {
+                if (shouldThrow)
+                {
+                    throw new Exception("From Use");
+                }
+                return Task.CompletedTask;
+            });
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<Exception>(() => builder.Build().Invoke(context));
+            Assert.Equal("From Use", ex.Message);
+        }
+    }
+}

--- a/src/Http/Http/test/ApplicationBuilderTests.cs
+++ b/src/Http/Http/test/ApplicationBuilderTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Builder.Internal
         public void BuildDoesNotCallMatchedEndpointWhenTerminated()
         {
             var builder = new ApplicationBuilder(null);
-            builder.Use((context, next) =>
+            builder.Run(context =>
             {
                 // Do not call next
                 return Task.CompletedTask;

--- a/src/Http/Routing/test/testassets/RoutingSandbox/UseRouterStartup.cs
+++ b/src/Http/Routing/test/testassets/RoutingSandbox/UseRouterStartup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -31,7 +31,7 @@ namespace RoutingSandbox
                 });
 
                 routes.MapGet("api/get/{id}", (request, response, routeData) => response.WriteAsync($"API Get {routeData.Values["id"]}"))
-                      .MapMiddlewareRoute("api/middleware", (appBuilder) => appBuilder.Use((httpContext, next) => httpContext.Response.WriteAsync("Middleware!")))
+                      .MapMiddlewareRoute("api/middleware", (appBuilder) => appBuilder.Run(httpContext => httpContext.Response.WriteAsync("Middleware!")))
                       .MapRoute(
                         name: "AllVerbs",
                         template: "api/all/{name}/{lastName?}",

--- a/src/Http/Routing/test/testassets/RoutingWebSite/UseRouterStartup.cs
+++ b/src/Http/Routing/test/testassets/RoutingWebSite/UseRouterStartup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -31,7 +31,7 @@ namespace RoutingWebSite
                 });
 
                 routes.MapGet("api/get/{id}", (request, response, routeData) => response.WriteAsync($"API Get {routeData.Values["id"]}"))
-                      .MapMiddlewareRoute("api/middleware", (appBuilder) => appBuilder.Use((httpContext, next) => httpContext.Response.WriteAsync("Middleware!")))
+                      .MapMiddlewareRoute("api/middleware", (appBuilder) => appBuilder.Run(httpContext => httpContext.Response.WriteAsync("Middleware!")))
                       .MapRoute(
                         name: "AllVerbs",
                         template: "api/all/{name}/{lastName?}",

--- a/src/Identity/test/InMemory.Test/FunctionalTest.cs
+++ b/src/Identity/test/InMemory.Test/FunctionalTest.cs
@@ -368,7 +368,7 @@ namespace Microsoft.AspNetCore.Identity.InMemory
                             }
                             else
                             {
-                                await next();
+                                await next(context);
                             }
                         });
                     })

--- a/src/Middleware/CORS/test/UnitTests/CorsMiddlewareTests.cs
+++ b/src/Middleware/CORS/test/UnitTests/CorsMiddlewareTests.cs
@@ -584,7 +584,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                         {
                             try
                             {
-                                await next();
+                                await next(context);
                             }
                             catch (Exception)
                             {

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                             Exception exception = null;
                             try
                             {
-                                await next();
+                                await next(context);
                             }
                             catch (InvalidOperationException ex)
                             {
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Diagnostics
 
                             try
                             {
-                                await next();
+                                await next(context);
                             }
                             finally
                             {
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                             Exception exception = null;
                             try
                             {
-                                await next();
+                                await next(context);
                             }
                             catch (InvalidOperationException ex)
                             {
@@ -483,7 +483,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                             Exception exception = null;
                             try
                             {
-                                await next();
+                                await next(context);
                             }
                             catch (InvalidOperationException ex)
                             {

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                             Exception exception = null;
                             try
                             {
-                                await next(context);
+                                await next(httpContext);
                             }
                             catch (InvalidOperationException ex)
                             {
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Diagnostics
 
                             try
                             {
-                                await next(context);
+                                await next(httpContext);
                             }
                             finally
                             {
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                             Exception exception = null;
                             try
                             {
-                                await next(context);
+                                await next(httpContext);
                             }
                             catch (InvalidOperationException ex)
                             {
@@ -483,7 +483,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                             Exception exception = null;
                             try
                             {
-                                await next(context);
+                                await next(httpContext);
                             }
                             catch (InvalidOperationException ex)
                             {

--- a/src/Middleware/Diagnostics/test/UnitTests/StatusCodeMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/StatusCodeMiddlewareTest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                         app.Use(async (context, next) =>
                         {
                             var beforeNext = context.Request.QueryString;
-                            await next();
+                            await next(context);
                             var afterNext = context.Request.QueryString;
 
                             Assert.Equal(beforeNext, afterNext);
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                         {
                             Assert.Empty(context.Request.RouteValues);
                             Assert.Null(context.GetEndpoint());
-                            return next();
+                            return next(context);
                         });
 
                         app.Map(destination, (innerAppBuilder) =>

--- a/src/Middleware/Diagnostics/test/testassets/DeveloperExceptionPageSample/Startup.cs
+++ b/src/Middleware/Diagnostics/test/testassets/DeveloperExceptionPageSample/Startup.cs
@@ -32,7 +32,7 @@ namespace DeveloperExceptionPageSample
                     "Endpoint display name");
 
                 context.SetEndpoint(endpoint);
-                return next();
+                return next(context);
             });
             app.UseDeveloperExceptionPage();
             app.Run(context =>

--- a/src/Middleware/Diagnostics/test/testassets/StatusCodePagesSample/Startup.cs
+++ b/src/Middleware/Diagnostics/test/testassets/StatusCodePagesSample/Startup.cs
@@ -55,7 +55,7 @@ namespace StatusCodePagesSample
                 }
                 else
                 {
-                    await next();
+                    await next(context);
                 }
             });
 

--- a/src/Middleware/HostFiltering/test/HostFilteringMiddlewareTests.cs
+++ b/src/Middleware/HostFiltering/test/HostFilteringMiddlewareTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.HostFiltering
                         app.Use((ctx, next) =>
                         {
                             ctx.Request.Headers.Remove(HeaderNames.Host);
-                            return next();
+                            return next(ctx);
                         });
                         app.UseHostFiltering();
                         app.Run(c =>
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.HostFiltering
                         app.Use((ctx, next) =>
                         {
                             ctx.Request.Headers[HeaderNames.Host] = "";
-                            return next();
+                            return next(ctx);
                         });
                         app.UseHostFiltering();
                         app.Run(c =>
@@ -159,7 +159,7 @@ namespace Microsoft.AspNetCore.HostFiltering
                             // TestHost's ClientHandler doesn't let you set the host header, only the host in the URI
                             // and that would over-normalize some of our test conditions like casing.
                             ctx.Request.Headers[HeaderNames.Host] = hosturl;
-                            return next();
+                            return next(ctx);
                         });
                         app.UseHostFiltering();
                         app.Run(c => Task.CompletedTask);
@@ -211,7 +211,7 @@ namespace Microsoft.AspNetCore.HostFiltering
                             // TestHost's ClientHandler doesn't let you set the host header, only the host in the URI
                             // and that would reject some of our test conditions.
                             ctx.Request.Headers[HeaderNames.Host] = hosturl;
-                            return next();
+                            return next(ctx);
                         });
                         app.UseHostFiltering();
                         app.Run(c => throw new NotImplementedException("App"));
@@ -250,7 +250,7 @@ namespace Microsoft.AspNetCore.HostFiltering
                         app.Use((ctx, next) =>
                         {
                             ctx.Request.Headers[HeaderNames.Host] = currentHost;
-                            return next();
+                            return next(ctx);
                         });
                         app.UseHostFiltering();
                         app.Run(c => Task.CompletedTask);

--- a/src/Middleware/HttpOverrides/test/CertificateForwardingTest.cs
+++ b/src/Middleware/HttpOverrides/test/CertificateForwardingTest.cs
@@ -57,13 +57,13 @@ namespace Microsoft.AspNetCore.HttpOverrides
                         app.Use(async (context, next) =>
                         {
                             Assert.Null(context.Connection.ClientCertificate);
-                            await next();
+                            await next(context);
                         });
                         app.UseCertificateForwarding();
                         app.Use(async (context, next) =>
                         {
                             Assert.Equal(context.Connection.ClientCertificate, Certificates.SelfSignedValidWithNoEku);
-                            await next();
+                            await next(context);
                         });
                     });
                 }).Build();
@@ -96,13 +96,13 @@ namespace Microsoft.AspNetCore.HttpOverrides
                         {
                             Assert.Null(context.Connection.ClientCertificate);
                             context.Connection.ClientCertificate = Certificates.SelfSignedNotYetValid;
-                            await next();
+                            await next(context);
                         });
                         app.UseCertificateForwarding();
                         app.Use(async (context, next) =>
                         {
                             Assert.Equal(context.Connection.ClientCertificate, Certificates.SelfSignedValidWithNoEku);
-                            await next();
+                            await next(context);
                         });
                     });
                 }).Build();
@@ -134,13 +134,13 @@ namespace Microsoft.AspNetCore.HttpOverrides
                         app.Use(async (context, next) =>
                         {
                             Assert.Null(context.Connection.ClientCertificate);
-                            await next();
+                            await next(context);
                         });
                         app.UseCertificateForwarding();
                         app.Use(async (context, next) =>
                         {
                             Assert.Equal(context.Connection.ClientCertificate, Certificates.SelfSignedValidWithNoEku);
-                            await next();
+                            await next(context);
                         });
                     });
                 }).Build();
@@ -172,13 +172,13 @@ namespace Microsoft.AspNetCore.HttpOverrides
                         app.Use(async (context, next) =>
                         {
                             Assert.Null(context.Connection.ClientCertificate);
-                            await next();
+                            await next(context);
                         });
                         app.UseCertificateForwarding();
                         app.Use(async (context, next) =>
                         {
                             Assert.Null(context.Connection.ClientCertificate);
-                            await next();
+                            await next(context);
                         });
                     });
                 }).Build();
@@ -210,13 +210,13 @@ namespace Microsoft.AspNetCore.HttpOverrides
                         app.Use(async (context, next) =>
                         {
                             Assert.Null(context.Connection.ClientCertificate);
-                            await next();
+                            await next(context);
                         });
                         app.UseCertificateForwarding();
                         app.Use(async (context, next) =>
                         {
                             Assert.Null(context.Connection.ClientCertificate);
-                            await next();
+                            await next(context);
                         });
                     });
                 }).Build();

--- a/src/Middleware/Localization/sample/Startup.cs
+++ b/src/Middleware/Localization/sample/Startup.cs
@@ -38,7 +38,7 @@ namespace LocalizationSample
             //}));
             );
 
-            app.Use(async (context, next) =>
+            app.Run(async (context) =>
             {
                 if (context.Request.Path.Value.EndsWith("favicon.ico", StringComparison.Ordinal))
                 {

--- a/src/Middleware/MiddlewareAnalysis/samples/MiddlewareAnalysisSample/Startup.cs
+++ b/src/Middleware/MiddlewareAnalysis/samples/MiddlewareAnalysisSample/Startup.cs
@@ -33,7 +33,7 @@ namespace MiddlewareAnaysisSample
             app.Use((context, next) =>
             {
                 // No-op
-                return next();
+                return next(context);
             });
 
             app.Map("/map", subApp =>
@@ -74,7 +74,7 @@ namespace MiddlewareAnaysisSample
                 }
                 else
                 {
-                    await next();
+                    await next(context);
                 }
             });
 

--- a/src/Middleware/ResponseCompression/test/ResponseCompressionMiddlewareTest.cs
+++ b/src/Middleware/ResponseCompression/test/ResponseCompressionMiddlewareTest.cs
@@ -980,7 +980,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
                         {
                             fakeSendFile = new FakeSendFileFeature(context.Features.Get<IHttpResponseBodyFeature>());
                             context.Features.Set<IHttpResponseBodyFeature>(fakeSendFile);
-                            return next();
+                            return next(context);
                         });
                         app.UseResponseCompression();
                         app.Run(context =>
@@ -1030,7 +1030,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
                         {
                             fakeSendFile = new FakeSendFileFeature(context.Features.Get<IHttpResponseBodyFeature>());
                             context.Features.Set<IHttpResponseBodyFeature>(fakeSendFile);
-                            return next();
+                            return next(context);
                         });
                         app.UseResponseCompression();
                         app.Run(context =>
@@ -1080,7 +1080,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
                         {
                             fakeSendFile = new FakeSendFileFeature(context.Features.Get<IHttpResponseBodyFeature>());
                             context.Features.Set<IHttpResponseBodyFeature>(fakeSendFile);
-                            return next();
+                            return next(context);
                         });
                         app.UseResponseCompression();
                         app.Run(async context =>
@@ -1130,7 +1130,7 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
                         app.Use((context, next) =>
                         {
                             context.Response.Body = new NoSyncWrapperStream(context.Response.Body);
-                            return next();
+                            return next(context);
                         });
                         app.UseResponseCompression();
                         app.Run(async context =>

--- a/src/Middleware/Session/test/SessionTests.cs
+++ b/src/Middleware/Session/test/SessionTests.cs
@@ -524,7 +524,7 @@ namespace Microsoft.AspNetCore.Session
                     {
                         app.Use(async (httpContext, next) =>
                         {
-                            await next();
+                            await next(httpContext);
 
                             Assert.Null(httpContext.Features.Get<ISessionFeature>());
                         });
@@ -569,7 +569,7 @@ namespace Microsoft.AspNetCore.Session
                             var exceptionThrown = false;
                             try
                             {
-                                await next();
+                                await next(httpContext);
                             }
                             catch
                             {

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxyingExtensions.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxyingExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Builder
                 SpaProxy.CreateHttpClientForProxy(Timeout.InfiniteTimeSpan);
 
             // Proxy all requests to the SPA development server
-            applicationBuilder.Use(async (context, next) =>
+            applicationBuilder.Run(async (context) =>
             {
                 var didProxyRequest = await SpaProxy.PerformProxyRequest(
                     context, neverTimeOutHttpClient, baseUriTaskFactory(), applicationStoppingToken,

--- a/src/Middleware/Spa/SpaServices.Extensions/src/SpaDefaultPageMiddleware.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/SpaDefaultPageMiddleware.cs
@@ -28,11 +28,11 @@ namespace Microsoft.AspNetCore.SpaServices
                 // If we have an Endpoint, then this is a deferred match - just noop.
                 if (context.GetEndpoint() != null)
                 {
-                    return next();
+                    return next(context);
                 }
 
                 context.Request.Path = options.DefaultPage;
-                return next();
+                return next(context);
             });
 
             // Serve it as a static file
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.SpaServices
                 // If we have an Endpoint, then this is a deferred match - just noop.
                 if (context.GetEndpoint() != null)
                 {
-                    return next();
+                    return next(context);
                 }
 
                 var message = "The SPA default page middleware could not return the default page " +

--- a/src/Middleware/StaticFiles/test/FunctionalTests/StaticFileMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/FunctionalTests/StaticFileMiddlewareTests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                                 requestReceived.SetResult(0);
                                 await requestCancelled.Task.TimeoutAfter(interval);
                                 Assert.True(context.RequestAborted.WaitHandle.WaitOne(interval), "not aborted");
-                                await next();
+                                await next(context);
                             }
                             catch (Exception ex)
                             {

--- a/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                         app.Use(async (ctx, next) =>
                         {
                             ctx.Features.Set(mockSendFile.Object);
-                            await next();
+                            await next(ctx);
                         });
                         app.UseStaticFiles(new StaticFileOptions { ServeUnknownFileTypes = true });
                     })

--- a/src/Middleware/WebSockets/samples/EchoApp/Startup.cs
+++ b/src/Middleware/WebSockets/samples/EchoApp/Startup.cs
@@ -42,7 +42,7 @@ namespace EchoApp
                 }
                 else
                 {
-                    await next();
+                    await next(context);
                 }
             });
 

--- a/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTestApp/Startup.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/AutobahnTestApp/Startup.cs
@@ -17,7 +17,7 @@ namespace AutobahnTestApp
             app.UseWebSockets();
 
             var logger = loggerFactory.CreateLogger<Startup>();
-            app.Use(async (context, next) =>
+            app.Run(async (context) =>
             {
                 if (context.WebSockets.IsWebSocketRequest)
                 {

--- a/src/Middleware/WebSockets/test/UnitTests/KestrelWebSocketHelpers.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/KestrelWebSocketHelpers.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
                     {
                         // Kestrel does not return proper error responses:
                         // https://github.com/aspnet/KestrelHttpServer/issues/43
-                        await next();
+                        await next(ct);
                     }
                     catch (Exception ex)
                     {

--- a/src/Mvc/Mvc.Core/test/Filters/MiddlewareFilterAttributeTest.cs
+++ b/src/Mvc/Mvc.Core/test/Filters/MiddlewareFilterAttributeTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
                 configureCallCount++;
                 ab.Use((httpContext, next) =>
                 {
-                    return next();
+                    return next(httpContext);
                 });
             };
 

--- a/src/Mvc/Mvc.Core/test/Filters/MiddlewareFilterBuilderTest.cs
+++ b/src/Mvc/Mvc.Core/test/Filters/MiddlewareFilterBuilderTest.cs
@@ -91,9 +91,9 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             var httpContext = new DefaultHttpContext();
             Pipeline1.ConfigurePipeline = ab =>
             {
-                ab.Use((_, next) =>
+                ab.Use((ctx, next) =>
                 {
-                    return next();
+                    return next(ctx);
                 });
             };
 
@@ -119,9 +119,9 @@ namespace Microsoft.AspNetCore.Mvc.Filters
 
             Pipeline1.ConfigurePipeline = ab =>
             {
-                ab.Use((_, next) =>
+                ab.Use((ctx, next) =>
                 {
-                    return next();
+                    return next(ctx);
                 });
             };
 
@@ -171,9 +171,9 @@ namespace Microsoft.AspNetCore.Mvc.Filters
 
             Pipeline1.ConfigurePipeline = ab =>
             {
-                ab.Use((_, next) =>
+                ab.Use((ctx, next) =>
                 {
-                    return next();
+                    return next(ctx);
                 });
             };
 
@@ -239,9 +239,9 @@ namespace Microsoft.AspNetCore.Mvc.Filters
 
             Pipeline1.ConfigurePipeline = ab =>
             {
-                ab.Use((_, next) =>
+                ab.Use((ctx, next) =>
                 {
-                    return next();
+                    return next(ctx);
                 });
             };
 

--- a/src/Mvc/Mvc.Core/test/Filters/MiddlewareFilterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Filters/MiddlewareFilterTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             var expectedHeader = "h1";
             Pipeline1.ConfigurePipeline = (appBuilder) =>
             {
-                appBuilder.Use((httpContext, next) =>
+                appBuilder.Run((httpContext) =>
                 {
                     httpContext.Response.Headers.Add(expectedHeader, "");
                     return Task.FromResult(true); // short circuit the request
@@ -97,12 +97,12 @@ namespace Microsoft.AspNetCore.Mvc.Filters
                 appBuilder.Use((httpContext, next) =>
                 {
                     httpContext.Response.Headers["h1"] = "pipeline1";
-                    return next();
+                    return next(httpContext);
                 });
             };
             Pipeline2.ConfigurePipeline = (appBuilder) =>
             {
-                appBuilder.Use((httpContext, next) =>
+                appBuilder.Run((httpContext) =>
                 {
                     httpContext.Response.Headers["h1"] = httpContext.Response.Headers["h1"] + "-pipeline2";
                     return Task.FromResult(true); // short circuits the request
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             var expectedMessage = "Error!!!";
             Pipeline1.ConfigurePipeline = (appBuilder) =>
             {
-                appBuilder.Use((httpContext, next) =>
+                appBuilder.Run((httpContext) =>
                 {
                     throw new InvalidOperationException(expectedMessage);
                 });
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
                 {
                     try
                     {
-                        await next();
+                        await next(httpContext);
                     }
                     catch
                     {
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             };
             Pipeline2.ConfigurePipeline = (appBuilder) =>
             {
-                appBuilder.Use((httpContext, next) =>
+                appBuilder.Run((httpContext) =>
                 {
                     throw new InvalidOperationException(expectedMessage);
                 });

--- a/src/Mvc/test/WebSites/BasicWebSite/StartupRequestLimitSize.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/StartupRequestLimitSize.cs
@@ -35,7 +35,7 @@ namespace BasicWebSite
                     httpContext.Request.Body,
                     testHttpMaxRequestBodySizeFeature);
 
-                return next();
+                return next(httpContext);
             });
 
             app.UseRouting();

--- a/src/Mvc/test/WebSites/BasicWebSite/StartupWhereReadingRequestBodyThrows.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/StartupWhereReadingRequestBodyThrows.cs
@@ -31,7 +31,7 @@ namespace BasicWebSite
             app.Use((context, next) =>
             {
                 context.Request.Body = new ThrowingStream();
-                return next();
+                return next(context);
             });
 
             app.UseRouting();

--- a/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
+++ b/src/Security/Authentication/JwtBearer/samples/JwtBearerSample/Startup.cs
@@ -59,7 +59,7 @@ namespace JwtBearerSample
                 var authResult = await context.AuthenticateAsync(JwtBearerDefaults.AuthenticationScheme);
                 if (authResult.Succeeded && authResult.Principal.Identity.IsAuthenticated)
                 {
-                    await next();
+                    await next(context);
                 }
                 else if (authResult.Failure != null)
                 {

--- a/src/Security/Authentication/test/CertificateTests.cs
+++ b/src/Security/Authentication/test/CertificateTests.cs
@@ -701,7 +701,7 @@ namespace Microsoft.AspNetCore.Authentication.Certificate.Test
                                 {
                                     context.Connection.ClientCertificate = clientCertificate;
                                 }
-                                return next();
+                                return next(context);
                             });
 
 
@@ -712,7 +712,7 @@ namespace Microsoft.AspNetCore.Authentication.Certificate.Test
 
                             app.UseAuthentication();
 
-                            app.Use(async (context, next) =>
+                            app.Run(async (context) =>
                             {
                                 var request = context.Request;
                                 var response = context.Response;

--- a/src/Security/Authentication/test/CookieTests.cs
+++ b/src/Security/Authentication/test/CookieTests.cs
@@ -1403,7 +1403,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                         .Configure(app =>
                         {
                             app.UseAuthentication();
-                            app.Use((context, next) =>
+                            app.Run((context) =>
                                 context.SignInAsync("Cookies",
                                                 new ClaimsPrincipal(new ClaimsIdentity(new GenericIdentity("Alice", "Cookies"))),
                                                 new AuthenticationProperties()));
@@ -1426,7 +1426,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                     .Configure(app =>
                     {
                         app.UseAuthentication();
-                        app.Use(async (context, next) =>
+                        app.Run(async (context) =>
                         {
                             var result = await context.AuthenticateAsync("Cookies");
                             await DescribeAsync(context.Response, result);
@@ -1635,7 +1635,7 @@ namespace Microsoft.AspNetCore.Authentication.Cookies
                                 }
                                 else
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/DynamicSchemeTests.cs
+++ b/src/Security/Authentication/test/DynamicSchemeTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Authentication
                                 }
                                 else
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -383,7 +383,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
                             {
                                 if (handler == null || !await handler(context))
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/GoogleTests.cs
+++ b/src/Security/Authentication/test/GoogleTests.cs
@@ -1148,7 +1148,7 @@ namespace Microsoft.AspNetCore.Authentication.Google
                                 }
                                 else
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/JwtBearerTests.cs
+++ b/src/Security/Authentication/test/JwtBearerTests.cs
@@ -1018,7 +1018,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer
                                 }
                                 else
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/MicrosoftAccountTests.cs
+++ b/src/Security/Authentication/test/MicrosoftAccountTests.cs
@@ -410,7 +410,7 @@ namespace Microsoft.AspNetCore.Authentication.Tests.MicrosoftAccount
                                 }
                                 else
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/OAuthTests.cs
+++ b/src/Security/Authentication/test/OAuthTests.cs
@@ -406,9 +406,9 @@ namespace Microsoft.AspNetCore.Authentication.OAuth
                             app.UseAuthentication();
                             app.Use(async (context, next) =>
                             {
-                                if (handler == null || ! await handler(context))
+                                if (handler == null || !await handler(context))
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/OpenIdConnect/TestServerBuilder.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/TestServerBuilder.cs
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                                 }
                                 else
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/PolicyTests.cs
+++ b/src/Security/Authentication/test/PolicyTests.cs
@@ -477,7 +477,7 @@ namespace Microsoft.AspNetCore.Authentication
                                 }
                                 else
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/Authentication/test/RemoteAuthenticationTests.cs
+++ b/src/Security/Authentication/test/RemoteAuthenticationTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Authentication
                                 {
                                     await testpath(context);
                                 }
-                                await next();
+                                await next(context);
                             });
                         })
                         .ConfigureServices(configureServices))

--- a/src/Security/Authentication/test/TwitterTests.cs
+++ b/src/Security/Authentication/test/TwitterTests.cs
@@ -406,7 +406,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
                                 }
                                 else if (handler == null || !await handler(context))
                                 {
-                                    await next();
+                                    await next(context);
                                 }
                             });
                         })

--- a/src/Security/samples/StaticFilesAuth/Startup.cs
+++ b/src/Security/samples/StaticFilesAuth/Startup.cs
@@ -95,13 +95,13 @@ namespace StaticFilesAuth
 
             app.Map("/MapAuthenticatedFiles", branch =>
             {
-                branch.Use((context, next) => { SetFileEndpoint(context, files, null); return next(); });
+                branch.Use((context, next) => { SetFileEndpoint(context, files, null); return next(context); });
                 branch.UseAuthorization();
                 SetupFileServer(branch, files);
             });
             app.Map("/MapImperativeFiles", branch =>
             {
-                branch.Use((context, next) => { SetFileEndpoint(context, files, "files"); return next(); });
+                branch.Use((context, next) => { SetFileEndpoint(context, files, "files"); return next(context); });
                 branch.UseAuthorization();
                 SetupFileServer(branch, files);
             });

--- a/src/Servers/HttpSys/samples/HotAddSample/Startup.cs
+++ b/src/Servers/HttpSys/samples/HotAddSample/Startup.cs
@@ -52,7 +52,7 @@ namespace HotAddSample
                     await context.Response.WriteAsync("</body></html>");
                     return;
                 }
-                await next();
+                await next(context);
             });
 
             app.Use(async (context, next) =>
@@ -76,7 +76,7 @@ namespace HotAddSample
                     await context.Response.WriteAsync("</body></html>");
                     return;
                 }
-                await next();
+                await next(context);
             });
 
             app.Run(async context =>

--- a/src/Servers/Kestrel/samples/Http2SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http2SampleApp/Program.cs
@@ -47,7 +47,7 @@ namespace Http2SampleApp
                                         throw new NotSupportedException("Prohibited cipher: " + tlsFeature.CipherAlgorithm);
                                     }
 
-                                    return next();
+                                    return next(context);
                                 });
                             });
 

--- a/src/Servers/Kestrel/samples/Http2SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http2SampleApp/Program.cs
@@ -47,7 +47,7 @@ namespace Http2SampleApp
                                         throw new NotSupportedException("Prohibited cipher: " + tlsFeature.CipherAlgorithm);
                                     }
 
-                                    return next(context);
+                                    return next();
                                 });
                             });
 

--- a/src/Servers/Kestrel/samples/SampleApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/SampleApp/Startup.cs
@@ -35,7 +35,7 @@ namespace SampleApp
 
                 try
                 {
-                    await next.Invoke();
+                    await next.Invoke(context);
                 }
                 catch (Microsoft.AspNetCore.Http.BadHttpRequestException ex) when (ex.StatusCode == StatusCodes.Status413RequestEntityTooLarge) { }
             });

--- a/src/Servers/testassets/ServerComparison.TestSites/StartupNtlmAuthentication.cs
+++ b/src/Servers/testassets/ServerComparison.TestSites/StartupNtlmAuthentication.cs
@@ -30,7 +30,7 @@ namespace ServerComparison.TestSites
             {
                 try
                 {
-                    await next();
+                    await next(context);
                 }
                 catch (Exception ex)
                 {
@@ -45,7 +45,7 @@ namespace ServerComparison.TestSites
             });
 
             app.UseAuthentication();
-            app.Use((context, next) =>
+            app.Run((context) =>
             {
                 if (context.Request.Path.Equals("/Anonymous"))
                 {

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -145,7 +145,7 @@ namespace FunctionalTests
                     return Task.CompletedTask;
                 }
 
-                return next.Invoke();
+                return next.Invoke(context);
             });
 
             app.Use((context, next) =>
@@ -159,7 +159,7 @@ namespace FunctionalTests
                     return Task.CompletedTask;
                 }
 
-                return next.Invoke();
+                return next.Invoke(context);
             });
 
             app.Use((context, next) =>
@@ -170,7 +170,7 @@ namespace FunctionalTests
                     return context.Response.WriteAsync($"{{ \"url\": \"{newUrl}\" }}");
                 }
 
-                return next();
+                return next(context);
             });
 
             app.Use(async (context, next) =>
@@ -194,7 +194,7 @@ namespace FunctionalTests
                     context.Response.Cookies.Append("expiredCookie", "doesntmatter", expiredCookieOptions);
                 }
 
-                await next.Invoke();
+                await next.Invoke(context);
             });
 
             app.Use((context, next) =>
@@ -205,7 +205,7 @@ namespace FunctionalTests
                     return context.Response.WriteAsync("Some response from server");
                 }
 
-                return next();
+                return next(context);
             });
 
             app.UseRouting();


### PR DESCRIPTION
## Description

Add a new `app.Use` overload that requires users to pass the `HttpContext` to the `next` function which will save 2 per-request allocations over the previous extension method.

## Customer Impact

Less per-request allocations when using simple middleware.

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]
Terminal middleware that used `app.Use` will need to update to use `app.Run` otherwise they'll get an ambiguous method compile error. We'd like to get this in early to get feedback on how bad that is, or if it isn't a problem.

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

Fixes https://github.com/dotnet/aspnetcore/issues/31463

-----

Main change is located at https://github.com/dotnet/aspnetcore/compare/brecon/use?expand=1#diff-e80bc3e234b6da05aea986e2aaa5b92bf492f085e00e7497d268e107169c9c6c
and
https://github.com/dotnet/aspnetcore/compare/brecon/use?expand=1#diff-dcc7a146ff62319dc1f9ab1847a9697596a4d899e7f75b588ed3c74d594ea305

The rest is changing all our tests and samples to use the new overload, or switch to `app.Run` if they never called `next`.

Should we file a breaking change announcement that people calling `app.Use` without calling `next` will be broken?

Note: We should apply this same change to the `ConnectionBuilder`
https://github.com/dotnet/aspnetcore/blob/686da2e6c5b62570a7750bc3d85179ee5e9e75fd/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs#L42

TODO: File docs issue to update code to use new overload