### PR TITLE
Fix AuthorizeViewCore.cs invalid rendering logic

### DIFF
--- a/src/Components/Authorization/src/AuthorizeViewCore.cs
+++ b/src/Components/Authorization/src/AuthorizeViewCore.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Components.Authorization
     public abstract class AuthorizeViewCore : ComponentBase
     {
         private AuthenticationState currentAuthenticationState;
-        private bool isAuthorized;
+        private bool? isAuthorized;
 
         /// <summary>
         /// The content that will be displayed if the user is authorized.
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Components.Authorization
         {
             // We're using the same sequence number for each of the content items here
             // so that we can update existing instances if they are the same shape
-            if (currentAuthenticationState == null)
+            if (isAuthorized == null)
             {
                 builder.AddContent(0, Authorizing);
             }
@@ -85,13 +85,10 @@ namespace Microsoft.AspNetCore.Components.Authorization
                 throw new InvalidOperationException($"Authorization requires a cascading parameter of type Task<{nameof(AuthenticationState)}>. Consider using {typeof(CascadingAuthenticationState).Name} to supply this.");
             }
 
-            // First render in pending state
-            // If the task has already completed, this render will be skipped
-            currentAuthenticationState = null;
+            // Clear the previous result of authorization
+            // This will cause the Authorizing state to be displayed until the authorization has been completed
+            isAuthorized = null;
 
-            // Then render in completed state
-            // Importantly, we *don't* call StateHasChanged between the following async steps,
-            // otherwise we'd display an incorrect UI state while waiting for IsAuthorizedAsync
             currentAuthenticationState = await AuthenticationState;
             isAuthorized = await IsAuthorizedAsync(currentAuthenticationState.User);
         }

--- a/src/Components/Authorization/src/AuthorizeViewCore.cs
+++ b/src/Components/Authorization/src/AuthorizeViewCore.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Components.Authorization
             {
                 builder.AddContent(0, Authorizing);
             }
-            else if (isAuthorized)
+            else if (isAuthorized == true)
             {
                 var authorized = Authorized ?? ChildContent;
                 builder.AddContent(0, authorized?.Invoke(currentAuthenticationState));

--- a/src/Components/Authorization/test/AuthorizeViewTest.cs
+++ b/src/Components/Authorization/test/AuthorizeViewTest.cs
@@ -293,7 +293,7 @@ namespace Microsoft.AspNetCore.Components.Authorization
         }
 
         [Fact]
-        public void RendersAuthorizingWhenAuthenticationIsCompletedBeforehandAndAuthorizationIsAsync()
+        public void RendersAuthorizingUntilAuthorizationCompletedAsync()
         {
             // Covers https://github.com/dotnet/aspnetcore/pull/31794
             // Arrange

--- a/src/Components/Authorization/test/TestAsyncAuthorizationService.cs
+++ b/src/Components/Authorization/test/TestAsyncAuthorizationService.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Microsoft.AspNetCore.Components.Authorization
+{
+    public class TestAsyncAuthorizationService : IAuthorizationService
+    {
+        public AuthorizationResult NextResult { get; set; }
+            = AuthorizationResult.Failed();
+
+        public List<(ClaimsPrincipal user, object resource, IEnumerable<IAuthorizationRequirement> requirements)> AuthorizeCalls { get; }
+            = new List<(ClaimsPrincipal user, object resource, IEnumerable<IAuthorizationRequirement> requirements)>();
+
+        public async Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object resource, IEnumerable<IAuthorizationRequirement> requirements)
+        {
+            AuthorizeCalls.Add((user, resource, requirements));
+
+            // Make Authorization run asynchronously
+            await Task.Yield();
+
+            // The TestAuthorizationService doesn't actually apply any authorization requirements
+            // It just returns the specified NextResult, since we're not trying to test the logic
+            // in DefaultAuthorizationService or similar here. So it's up to tests to set a desired
+            // NextResult and assert that the expected criteria were passed by inspecting AuthorizeCalls.
+            return NextResult;
+        }
+
+        public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object resource, string policyName)
+            => throw new NotImplementedException();
+
+    }
+}


### PR DESCRIPTION
Component render would occur between lines 95 and 96 if the AuthenticationState task had already been completed before it was awaited on line 95. 

https://github.com/dotnet/aspnetcore/blob/d70439cc82253ac32cc3eaf94ce965bab1ac9d37/src/Components/Authorization/src/AuthorizeViewCore.cs#L73-L97

That leads to rendering of NotAuthorized state in BuildRenderTree function which is unexpected behaviour (currentAuthenticationState is set but authorization is still in progress). NotAuthorized state should only ever be rendered after IsAuthorizedAsync has been completed.

https://github.com/dotnet/aspnetcore/blob/d70439cc82253ac32cc3eaf94ce965bab1ac9d37/src/Components/Authorization/src/AuthorizeViewCore.cs#L53-L70

If the AuthenticationState had not been completed before it was awaited the rendering would have occurred before line 95 and no render would occur between lines 95 and 96. In that case the AuthorizeViewCore works as expected.

In this fix the isAuthorized field is made nullable and it is used to determine the state to display in the BuildRenderTree function. Until the authorization has completed the isAuthorized is null the Authorizing state is displayed as expected.

Addresses #24381
