### PR TITLE
disable on_demand_gc until AOT issues are identified

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -427,7 +427,9 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
       timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     } catch { }
     MONO.mono_wasm_setenv("TZ", timeZone || 'UTC');
-
+    // Turn off full-gc to prevent browser freezing.
+    const mono_wasm_enable_on_demand_gc = cwrap('mono_wasm_enable_on_demand_gc', null, ['number']);
+    mono_wasm_enable_on_demand_gc(0);
     if (resourceLoader.bootConfig.modifiableAssemblies) {
       // Configure the app to enable hot reload in Development.
       MONO.mono_wasm_setenv('DOTNET_MODIFIABLE_ASSEMBLIES', resourceLoader.bootConfig.modifiableAssemblies);


### PR DESCRIPTION
We enabled on_demand_gc in .NET 6 with #29098. Wasm AOT'd e3e benchmarks are seeing errors that appear to go away with on_demand_gc disabled

https://github.com/dotnet/runtime/issues/51319

Staging this for preview 4 while we work the issue.