### PR TITLE
Fix HttpSys, setting HttpRequest.ContentLength causes two headers to be enumerated

### DIFF
--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
@@ -187,8 +187,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                StringValues values;
-                return TryGetValue(key, out values) ? values : StringValues.Empty;
+                return TryGetValue(key, out var values) ? values : StringValues.Empty;
             }
             set
             {
@@ -196,31 +195,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 {
                     Remove(key);
                 }
-                else
-                {
-                    Extra[key] = value;
-                }
-            }
-        }
-
-        StringValues IHeaderDictionary.this[string key]
-        {
-            get
-            {
-                if (PropertiesTryGetValue(key, out var value))
-                {
-                    return value;
-                }
-
-                if (Extra.TryGetValue(key, out value))
-                {
-                    return value;
-                }
-                return StringValues.Empty;
-            }
-            set
-            {
-                if (!PropertiesTrySetValue(key, value))
+                else if (!PropertiesTrySetValue(key, value))
                 {
                     Extra[key] = value;
                 }

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             get
             {
                 long value;
-                var rawValue = this[HttpKnownHeaderNames.ContentLength];
+                var rawValue = ((IHeaderDictionary)this)[HttpKnownHeaderNames.ContentLength];
 
                 if (_contentLengthText.Equals(rawValue))
                 {
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                         throw new ArgumentOutOfRangeException("value", value.Value, "Cannot be negative.");
                     }
                     _contentLengthText = HeaderUtilities.FormatNonNegativeInt64(value.Value);
-                    this[HttpKnownHeaderNames.ContentLength] = _contentLengthText;
+                    ((IHeaderDictionary)this)[HttpKnownHeaderNames.ContentLength] = _contentLengthText;
                     _contentLength = value;
                 }
                 else

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
             get
             {
                 long value;
-                var rawValue = ((IHeaderDictionary)this)[HttpKnownHeaderNames.ContentLength];
+                var rawValue = this[HttpKnownHeaderNames.ContentLength];
 
                 if (_contentLengthText.Equals(rawValue))
                 {
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                         throw new ArgumentOutOfRangeException("value", value.Value, "Cannot be negative.");
                     }
                     _contentLengthText = HeaderUtilities.FormatNonNegativeInt64(value.Value);
-                    ((IHeaderDictionary)this)[HttpKnownHeaderNames.ContentLength] = _contentLengthText;
+                    this[HttpKnownHeaderNames.ContentLength] = _contentLengthText;
                     _contentLength = value;
                 }
                 else


### PR DESCRIPTION
**Fix HttpSys, setting HttpRequest.ContentLength causes two headers to be enumerated**
For `RequestHeaders` class, inside `IHeaderDictionary` implementated methods, use other `IHeaderDictionary` implementations instead of own methods.

Fixes #31735
