### PR TITLE
Removed unsafe string mutation

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -28,8 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private const ulong _http11VersionLong = 3543824036068086856; // GetAsciiStringAsLong("HTTP/1.1"); const results in better codegen
 
         private static readonly UTF8EncodingSealed DefaultRequestHeaderEncoding = new UTF8EncodingSealed();
-        private static readonly SpanAction<char, IntPtr> _getHeaderName = GetHeaderName;
-        private static readonly SpanAction<char, IntPtr> _getAsciiStringNonNullCharacters = GetAsciiStringNonNullCharacters;
+        private static readonly SpanAction<char, IntPtr> s_getHeaderName = GetHeaderName;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SetKnownMethod(ulong mask, ulong knownMethodUlong, HttpMethod knownMethod, int length)
@@ -86,7 +85,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
             fixed (byte* source = &MemoryMarshal.GetReference(span))
             {
-                return string.Create(span.Length, new IntPtr(source), _getHeaderName);
+                return string.Create(span.Length, new IntPtr(source), s_getHeaderName);
             }
         }
 
@@ -94,7 +93,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         {
             fixed (char* output = &MemoryMarshal.GetReference(buffer))
             {
-                // This version if AsciiUtilities returns null if there are any null (0 byte) characters
+                // This version of AsciiUtilities returns null if there are any null (0 byte) characters
                 // in the string
                 if (!StringUtilities.TryGetAsciiString((byte*)state.ToPointer(), output, buffer.Length))
                 {
@@ -104,37 +103,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         public static string GetAsciiStringNonNullCharacters(this Span<byte> span)
-            => GetAsciiStringNonNullCharacters((ReadOnlySpan<byte>)span);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe string GetAsciiStringNonNullCharacters(this ReadOnlySpan<byte> span)
-        {
-            if (span.IsEmpty)
-            {
-                return string.Empty;
-            }
-
-            fixed (byte* source = &MemoryMarshal.GetReference(span))
-            {
-                return string.Create(span.Length, new IntPtr(source), _getAsciiStringNonNullCharacters);
-            }
-        }
+            => StringUtilities.GetAsciiStringNonNullCharacters(span);
 
         public static string GetAsciiOrUTF8StringNonNullCharacters(this ReadOnlySpan<byte> span)
             => StringUtilities.GetAsciiOrUTF8StringNonNullCharacters(span, DefaultRequestHeaderEncoding);
-
-        private static unsafe void GetAsciiStringNonNullCharacters(Span<char> buffer, IntPtr state)
-        {
-            fixed (char* output = &MemoryMarshal.GetReference(buffer))
-            {
-                // StringUtilities.TryGetAsciiString returns null if there are any null (0 byte) characters
-                // in the string
-                if (!StringUtilities.TryGetAsciiString((byte*)state.ToPointer(), output, buffer.Length))
-                {
-                    throw new InvalidOperationException();
-                }
-            }
-        }
 
         public static string GetRequestHeaderString(this ReadOnlySpan<byte> span, string name, Func<string, Encoding?> encodingSelector)
         {

--- a/src/Shared/Http2cat/Http2Utilities.cs
+++ b/src/Shared/Http2cat/Http2Utilities.cs
@@ -143,64 +143,7 @@ namespace Microsoft.AspNetCore.Http2Cat
 
         void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
-            _decodedHeaders[GetAsciiStringNonNullCharacters(name)] = GetAsciiOrUTF8StringNonNullCharacters(value);
-        }
-
-        public unsafe string GetAsciiStringNonNullCharacters(ReadOnlySpan<byte> span)
-        {
-            if (span.IsEmpty)
-            {
-                return string.Empty;
-            }
-
-            var asciiString = new string('\0', span.Length);
-
-            fixed (char* output = asciiString)
-            fixed (byte* buffer = span)
-            {
-                // This version if AsciiUtilities returns null if there are any null (0 byte) characters
-                // in the string
-                if (!StringUtilities.TryGetAsciiString(buffer, output, span.Length))
-                {
-                    throw new InvalidOperationException();
-                }
-            }
-            return asciiString;
-        }
-
-        public unsafe string GetAsciiOrUTF8StringNonNullCharacters(ReadOnlySpan<byte> span)
-        {
-            if (span.IsEmpty)
-            {
-                return string.Empty;
-            }
-
-            var resultString = new string('\0', span.Length);
-
-            fixed (char* output = resultString)
-            fixed (byte* buffer = span)
-            {
-                // This version if AsciiUtilities returns null if there are any null (0 byte) characters
-                // in the string
-                if (!StringUtilities.TryGetAsciiString(buffer, output, span.Length))
-                {
-                    // null characters are considered invalid
-                    if (span.IndexOf((byte)0) != -1)
-                    {
-                        throw new InvalidOperationException();
-                    }
-
-                    try
-                    {
-                        resultString = HeaderValueEncoding.GetString(buffer, span.Length);
-                    }
-                    catch (DecoderFallbackException)
-                    {
-                        throw new InvalidOperationException();
-                    }
-                }
-            }
-            return resultString;
+            _decodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiOrUTF8StringNonNullCharacters(HeaderValueEncoding);
         }
 
         void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }

--- a/src/Shared/ServerInfrastructure/StringUtilities.cs
+++ b/src/Shared/ServerInfrastructure/StringUtilities.cs
@@ -18,6 +18,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
     internal static class StringUtilities
     {
         private static readonly SpanAction<char, IntPtr> s_getAsciiOrUTF8StringNonNullCharacters = GetAsciiStringNonNullCharactersWithMarker;
+        private static readonly SpanAction<char, IntPtr> s_getAsciiStringNonNullCharacters = GetAsciiStringNonNullCharacters;
+        private static readonly SpanAction<char, IntPtr> s_getLatin1StringNonNullCharacters = GetLatin1StringNonNullCharacters;
+        private static readonly SpanAction<char, (string? str, char separator, uint number)> s_populateSpanWithHexSuffix = PopulateSpanWithHexSuffix;
 
         public static unsafe string GetAsciiOrUTF8StringNonNullCharacters(this ReadOnlySpan<byte> span, Encoding defaultEncoding)
         {
@@ -67,8 +70,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
         }
 
-        private static readonly SpanAction<char, IntPtr> s_getAsciiStringNonNullCharacters = GetAsciiStringNonNullCharacters;
-
         public static unsafe string GetAsciiStringNonNullCharacters(this ReadOnlySpan<byte> span)
         {
             if (span.IsEmpty)
@@ -94,8 +95,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 }
             }
         }
-
-        private static readonly SpanAction<char, IntPtr> s_getLatin1StringNonNullCharacters = GetLatin1StringNonNullCharacters;
 
         public static unsafe string GetLatin1StringNonNullCharacters(this ReadOnlySpan<byte> span)
         {
@@ -691,8 +690,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 return false;
             }
         }
-
-        private static readonly SpanAction<char, (string? str, char separator, uint number)> s_populateSpanWithHexSuffix = PopulateSpanWithHexSuffix;
 
         /// <summary>
         /// A faster version of String.Concat(<paramref name="str"/>, <paramref name="separator"/>, <paramref name="number"/>.ToString("X8"))


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/31821

I didn't ran benchmarks, as it's basically the same as in https://github.com/dotnet/aspnetcore/pull/17556 and there this pattern is an improvement.

These should cover all occurances of mutating strings, based on `new string\(('\\0'|\(char\)0)`-search.

/cc: @GrabYourPitchforks PTAL
