### PR TITLE
Update Alpine ARM docker image

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -565,7 +565,7 @@ stages:
       jobDisplayName: "Build: Linux Musl ARM"
       agentOs: Linux
       useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20200827125937-14441ae
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm-alpine-20210409142327-044d5b9
       buildScript: ./eng/build.sh
       buildArgs:
         --arch arm

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -565,7 +565,7 @@ stages:
       jobDisplayName: "Build: Linux Musl ARM"
       agentOs: Linux
       useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm-alpine-20210409142327-044d5b9
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20210409142425-044d5b9
       buildScript: ./eng/build.sh
       buildArgs:
         --arch arm
@@ -601,7 +601,7 @@ stages:
       jobDisplayName: "Build: Linux Musl ARM64"
       agentOs: Linux
       useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-20200413125008-406629a
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-20210409142425-b2c2436
       buildScript: ./eng/build.sh
       buildArgs:
         --arch arm64


### PR DESCRIPTION
The Alpine ARM docker image is used for cross compilation. There was a
breaking change in Alpine 3.13 - it uses a new MUSL that has 64 bit
time_t even on 32 bit platforms. Since the official support for Alpine
ARM was not announced yet, it was decided that we will support it only
on Alpine >= 3.13 instead of having to build and distribute two
different
versions of runtime.

This change updates the docker image used to build Alpine ARM runtime to
a new version that uses Alpine 3.13 rootfs. It is also using Ubuntu
16.04 instead of 18.04 as a host to unify it with the one we use to
build for Alpine ARM64.
