### PR TITLE
Allow missing platforms in alias packs

### DIFF
--- a/src/Components/WebAssembly/BlazorManifest/acquire/Program.cs
+++ b/src/Components/WebAssembly/BlazorManifest/acquire/Program.cs
@@ -96,17 +96,19 @@ namespace acquire
                 var packageName = item.Key;
                 if (item.Value.AliasTo is Dictionary<string, string> alias)
                 {
+                    packageName = ""; // if this is an alias pack and platform isn't in the alias it isn't required
+
                     if (OperatingSystem.IsWindows())
                     {
-                        packageName = Environment.Is64BitProcess ? alias["win-x64"] : alias["win-x86"];
+                        alias.TryGetValue(Environment.Is64BitProcess ? "win-x64" : "win-x86", out packageName);
                     }
                     else if (OperatingSystem.IsMacOS())
                     {
-                        packageName = alias["osx-x64"];
+                        alias.TryGetValue("osx-x64", out packageName);
                     }
                     else if (OperatingSystem.IsLinux())
                     {
-                        packageName = alias["linux-x64"];
+                        alias.TryGetValue("linux-x64", out packageName);
                     }
                     else
                     {


### PR DESCRIPTION
Follow the design in https://github.com/dotnet/designs/pull/206 when looking up packs