### PR TITLE
Add log for unsupported protocol with Negotiate auth

### DIFF
--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateLoggingExtensions.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateLoggingExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.Logging
         private static Action<ILogger, Exception?> _reauthenticating;
         private static Action<ILogger, Exception?> _deferring;
         private static Action<ILogger, string, Exception?> _negotiateError;
+        private static Action<ILogger, string, Exception?> _protocolNotSupported;
 
         static NegotiateLoggingExtensions()
         {
@@ -65,6 +66,10 @@ namespace Microsoft.Extensions.Logging
                 eventId: new EventId(11, "NegotiateError"),
                 logLevel: LogLevel.Debug,
                 formatString: "Negotiate error code: {error}.");
+            _protocolNotSupported = LoggerMessage.Define<string>(
+                eventId: new EventId(12, "ProtocolNotSupported"),
+                logLevel: LogLevel.Information,
+                formatString: "Negotiate is not supported with {protocol}.");
         }
 
         public static void IncompleteNegotiateChallenge(this ILogger logger)
@@ -99,5 +104,8 @@ namespace Microsoft.Extensions.Logging
 
         public static void NegotiateError(this ILogger logger, string error)
             => _negotiateError(logger, error, null);
+
+        public static void ProtocolNotSupported(this ILogger logger, string protocol)
+            => _protocolNotSupported(logger, protocol, null);
     }
 }

--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateLoggingExtensions.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateLoggingExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.Logging
                 formatString: "Negotiate error code: {error}.");
             _protocolNotSupported = LoggerMessage.Define<string>(
                 eventId: new EventId(12, "ProtocolNotSupported"),
-                logLevel: LogLevel.Information,
+                logLevel: LogLevel.Debug,
                 formatString: "Negotiate is not supported with {protocol}.");
         }
 

--- a/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
@@ -82,6 +82,7 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate
                 {
                     // HTTP/1.0 and HTTP/1.1 are supported. Do not throw because this may be running on a server that supports
                     // additional protocols.
+                    Logger.ProtocolNotSupported(Request.Protocol);
                     return false;
                 }
 

--- a/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
@@ -82,7 +82,6 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate
                 {
                     // HTTP/1.0 and HTTP/1.1 are supported. Do not throw because this may be running on a server that supports
                     // additional protocols.
-                    Logger.ProtocolNotSupported(Request.Protocol);
                     return false;
                 }
 
@@ -300,6 +299,7 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate
                 // Not supported. We don't throw because Negotiate may be set as the default auth
                 // handler on a server that's running HTTP/1 and HTTP/2. We'll challenge HTTP/2 requests
                 // that require auth and they'll downgrade to HTTP/1.1.
+                Logger.ProtocolNotSupported(Request.Protocol);
                 return AuthenticateResult.NoResult();
             }
 


### PR DESCRIPTION
Took far too long to figure out that Negotiate wasn't working because I was using an HTTP/2 connection.

Question: What log level? Warning seems too high, Debug might not be noticeable enough.