### PR TITLE
Avoid allocating TaskCompletionSources

### DIFF
--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -14,6 +14,7 @@
     <Compile Include="$(ComponentsSharedSourceRoot)src\JsonSerializerOptionsProvider.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\HotReloadEnvironment.cs" LinkBase="HotReload" />
     <Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)TaskBuilderExtensions.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -224,8 +225,8 @@ namespace Microsoft.AspNetCore.Components.Routing
             // invocation.
             await _previousOnNavigateTask;
 
-            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            _previousOnNavigateTask = tcs.Task;
+            var atmb = AsyncTaskMethodBuilder.Create();
+            _previousOnNavigateTask = atmb.Task;
 
             if (!OnNavigateAsync.HasDelegate)
             {
@@ -244,7 +245,7 @@ namespace Microsoft.AspNetCore.Components.Routing
                 // Task.WhenAny returns a Task<Task> so we need to await twice to unwrap the exception
                 var task = await Task.WhenAny(OnNavigateAsync.InvokeAsync(navigateContext), cancellationTcs.Task);
                 await task;
-                tcs.SetResult();
+                atmb.SetResult(runContinuationsAsynchronously: true);
                 Refresh(isNavigationIntercepted);
             }
             catch (Exception e)

--- a/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
+++ b/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
@@ -19,6 +19,7 @@
     <Compile Include="$(SharedSourceRoot)Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\StringUtilities.cs" LinkBase="ServerInfrastructure\StringUtilities.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
+    <Compile Include="$(SharedSourceRoot)TaskBuilderExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)CertificateGeneration\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)TaskBuilderExtensions.cs" />
     <Compile Include="$(SharedSourceRoot)UrlDecoder\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\*.cs" Link="Shared\runtime\%(Filename)%(Extension)" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />

--- a/src/Shared/TaskBuilderExtensions.cs
+++ b/src/Shared/TaskBuilderExtensions.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+using System.Runtime.CompilerServices;
+
+namespace System.Threading.Tasks
+{
+    internal static class TaskBuilderExtensions
+    {
+        private static OperationCanceledException s_operationCanceledException = new();
+
+        public static void SetResult(this AsyncTaskMethodBuilder atmb, bool runContinuationsAsynchronously)
+        {
+            if (!runContinuationsAsynchronously)
+            {
+                atmb.SetResult();
+                return;
+            }
+
+#if NET6_0_OR_GREATER
+            ThreadPool.UnsafeQueueUserWorkItem(static atmb => atmb.SetResult(), atmb, preferLocal: true);
+#else
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                AsyncTaskMethodBuilder atmb = Unsafe.Unbox<AsyncTaskMethodBuilder>(state);
+                atmb.SetResult();
+            }, atmb);
+#endif
+        }
+
+        public static void SetResult<TResult>(this AsyncTaskMethodBuilder<TResult> atmb, TResult result, bool runContinuationsAsynchronously)
+        {
+            if (!runContinuationsAsynchronously)
+            {
+                atmb.SetResult(result);
+                return;
+            }
+
+#if NET6_0_OR_GREATER
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                var (atmb, result) = state;
+                atmb.SetResult(result);
+            }, (atmb, result), preferLocal: true);
+#else
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                var (atmb, result) = Unsafe.Unbox<(AsyncTaskMethodBuilder<TResult>, TResult)>(state);
+                atmb.SetResult(result);
+            }, (atmb, result));
+#endif
+        }
+
+        public static void SetResult<TResult>(this AsyncValueTaskMethodBuilder<TResult> avtmb, TResult result, bool runContinuationsAsynchronously)
+        {
+            if (!runContinuationsAsynchronously)
+            {
+                avtmb.SetResult(result);
+                return;
+            }
+
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                var (avtmb, result) = state;
+                avtmb.SetResult(result);
+            }, (avtmb, result), preferLocal: true);
+        }
+
+        public static void SetException(this AsyncTaskMethodBuilder atmb, Exception exception, bool runContinuationsAsynchronously)
+        {
+            if (!runContinuationsAsynchronously)
+            {
+                atmb.SetException(exception);
+                return;
+            }
+
+#if NET6_0_OR_GREATER
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                var (atmb, exception) = state;
+                atmb.SetException(exception);
+            }, (atmb, exception), preferLocal: true);
+#else
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                var (atmb, exception) = Unsafe.Unbox<(AsyncTaskMethodBuilder, Exception)>(state);
+                atmb.SetException(exception);
+            }, (atmb, exception));
+#endif
+        }
+
+        public static void SetException<TResult>(this AsyncTaskMethodBuilder<TResult> atmb, Exception exception, bool runContinuationsAsynchronously)
+        {
+            if (!runContinuationsAsynchronously)
+            {
+                atmb.SetException(exception);
+                return;
+            }
+
+#if NET6_0_OR_GREATER
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                var (atmb, exception) = state;
+                atmb.SetException(exception);
+            }, (atmb, exception), preferLocal: true);
+#else
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                var (atmb, exception) = Unsafe.Unbox<(AsyncTaskMethodBuilder<TResult>, Exception)>(state);
+                atmb.SetException(exception);
+            }, (atmb, exception));
+#endif
+        }
+
+        public static void SetException<TResult>(this AsyncValueTaskMethodBuilder<TResult> avtmb, Exception exception, bool runContinuationsAsynchronously)
+        {
+            if (!runContinuationsAsynchronously)
+            {
+                avtmb.SetException(exception);
+                return;
+            }
+
+            ThreadPool.UnsafeQueueUserWorkItem(static state =>
+            {
+                var (atmb, exception) = state;
+                atmb.SetException(exception);
+            }, (avtmb, exception), preferLocal: true);
+        }
+
+        public static void SetCanceled(this AsyncTaskMethodBuilder atmb, bool runContinuationsAsynchronously = false, OperationCanceledException? operationCanceledException = null)
+        {
+            // This will mark the Task as canceled internally.
+            SetException(atmb, operationCanceledException ?? s_operationCanceledException, runContinuationsAsynchronously);
+        }
+
+        public static void SetCanceled<TResult>(this AsyncTaskMethodBuilder<TResult> atmb, bool runContinuationsAsynchronously = false, OperationCanceledException? operationCanceledException = null)
+        {
+            // This will mark the Task as canceled internally.
+            SetException(atmb, operationCanceledException ?? s_operationCanceledException, runContinuationsAsynchronously);
+        }
+    }
+}

--- a/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -15,6 +15,7 @@
     <Compile Include="$(SignalRSharedSourceRoot)TimerAwaitable.cs" Link="Internal\TimerAwaitable.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)AsyncEnumerableAdapters.cs" Link="Internal\AsyncEnumerableAdapters.cs" />
     <Compile Include="$(SharedSourceRoot)OperatingSystem.cs" Condition="'$(TargetFramework)' != '$(DefaultNetCoreTargetFramework)'" />
+    <Compile Include="$(SharedSourceRoot)TaskBuilderExtensions.cs" Link="Internal\TaskBuilderExtensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignalR/common/Http.Connections/src/Microsoft.AspNetCore.Http.Connections.csproj
+++ b/src/SignalR/common/Http.Connections/src/Microsoft.AspNetCore.Http.Connections.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Components for providing real-time bi-directional communication across the Web.</Description>
@@ -17,6 +17,7 @@
     <Compile Include="$(SignalRSharedSourceRoot)StreamExtensions.cs" Link="StreamExtensions.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)DuplexPipe.cs" Link="DuplexPipe.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)TaskCache.cs" Link="Internal\TaskCache.cs" />
+    <Compile Include="$(SharedSourceRoot)TaskBuilderExtensions.cs" Link="Internal\TaskBuilderExtensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignalR/server/Core/src/Microsoft.AspNetCore.SignalR.Core.csproj
+++ b/src/SignalR/server/Core/src/Microsoft.AspNetCore.SignalR.Core.csproj
@@ -13,6 +13,7 @@
     <Compile Include="$(SignalRSharedSourceRoot)ReflectionHelper.cs" Link="ReflectionHelper.cs" />
     <Compile Include="$(SharedSourceRoot)ClosedGenericMatcher\*.cs" />
     <Compile Include="$(SharedSourceRoot)ObjectMethodExecutor\*.cs" />
+    <Compile Include="$(SharedSourceRoot)TaskBuilderExtensions.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)AsyncEnumerableAdapters.cs" Link="Internal\AsyncEnumerableAdapters.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)TaskCache.cs" Link="Internal\TaskCache.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)ISystemClock.cs" Link="Internal\ISystemClock.cs" />


### PR DESCRIPTION
Replace the `TaskCompletionSource`, which is an allocation, with equivalent `AsyncTaskMethodBuilder`-code, thus avoiding the allocation of the TCS.
(This was an idea in https://github.com/dotnet/aspnetcore/pull/31874#discussion_r614763784).

`TaskCreationOptions.RunContinuationsAsynchronously` goes down to queuing the continuation to the thread-pool.
The `AsyncTaskMethodBuilder` doesn't provide such an option, thus extension methods (`TaskBuilderExtensions`) got introduced, so that the continuates run in the (exact) same behavior.

I looked through the code-base for occurrences, most of the use of `TaskCompletionSource` is in tests and start / stop. These weren't touched (makes no sense there).
TCS in HttpSys, Kestrel, SignalR, and Router got replaced. I'm not sure if every place is "hot enough" to warrant this change.

In a simple isolated benchmark it looks like:
```
|               Method |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| TaskCompletionSource | 35.27 ns | 1.097 ns | 3.217 ns |  1.00 |    0.00 | 0.0280 |     - |     - |      88 B |
|     AsyncTaskBuilder | 41.15 ns | 0.819 ns | 0.910 ns |  1.07 |    0.06 | 0.0229 |     - |     - |      72 B |
```
and saves 16 bytes.

<details>
  <summary>Benchmark code</summary>

```c#
using System.Runtime.CompilerServices;
using System.Threading.Tasks;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkRunner.Run<Bench>();

[MemoryDiagnoser]
public class Bench
{
    [Benchmark(Baseline = true)]
    public Task TaskCompletionSource()
    {
        TaskCompletionSource tcs = new();
        Task task = tcs.Task;
        tcs.SetResult();
        return task;
    }

    [Benchmark]
    public Task AsyncTaskBuilder()
    {
        AsyncTaskMethodBuilder atmb = AsyncTaskMethodBuilder.Create();
        Task task = atmb.Task;
        atmb.SetResult();
        return task;
    }
}
```
</details>

In a not so isolated benchmark it looks like:

```
|                 Method | Categories |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |----------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|   TaskCompletionSource |     Inline | 1.382 μs | 0.0060 μs | 0.0056 μs |  1.00 | 0.0725 |     - |     - |     230 B |
| AsyncTaskMethodBuilder |     Inline | 1.396 μs | 0.0086 μs | 0.0077 μs |  1.01 | 0.0668 |     - |     - |     214 B |
|                        |            |          |           |           |       |        |       |       |           |
|   TaskCompletionSource |      Async | 1.792 μs | 0.0096 μs | 0.0090 μs |  1.00 | 0.0706 |     - |     - |     226 B |
| AsyncTaskMethodBuilder |      Async | 1.361 μs | 0.0094 μs | 0.0083 μs |  0.76 | 0.0668 |     - |     - |     215 B |
```

<details>
  <summary>Benchmark code</summary>

```c#
using System.Runtime.CompilerServices;
using System.Threading;
using System.Threading.Tasks;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Running;

BenchmarkRunner.Run<Bench>();

[MemoryDiagnoser]
[CategoriesColumn]
[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
public class Bench
{
    [Benchmark(Baseline = true, Description = nameof(TaskCompletionSource))]
    [BenchmarkCategory("Inline")]
    public async Task TcsInline()
    {
        TaskCompletionSource tcs = new();
        Task task = tcs.Task;

        ThreadPool.UnsafeQueueUserWorkItem(static tcs => tcs.SetResult(), tcs, preferLocal: false);

        await task;
    }

    [Benchmark(Description = nameof(AsyncTaskMethodBuilder))]
    [BenchmarkCategory("Inline")]
    public async Task AtmbInline()
    {
        AsyncTaskMethodBuilder atmb = AsyncTaskMethodBuilder.Create();
        Task task = atmb.Task;

        ThreadPool.UnsafeQueueUserWorkItem(static atmb => atmb.SetResult(), atmb, preferLocal: false);

        await task;
    }

    [Benchmark(Baseline = true, Description = nameof(TaskCompletionSource))]
    [BenchmarkCategory("Async")]
    public async Task TcsAsync()
    {
        TaskCompletionSource tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
        Task task = tcs.Task;

        ThreadPool.UnsafeQueueUserWorkItem(static tcs => tcs.SetResult(), tcs, preferLocal: false);

        await task;
    }

    [Benchmark(Description = nameof(AsyncTaskMethodBuilder))]
    [BenchmarkCategory("Async")]
    public async Task AtmbAsync()
    {
        AsyncTaskMethodBuilder atmb = AsyncTaskMethodBuilder.Create();
        Task task = atmb.Task;

        atmb.SetResultRunContinuationAsync();

        await task;
    }
}

internal static class TaskHelper
{
    public static void SetResultRunContinuationAsync(this AsyncTaskMethodBuilder atmb)
    {
        ThreadPool.UnsafeQueueUserWorkItem(static atmb => atmb.SetResult(), atmb, preferLocal: false);
    }
}
```
</details>

---

Looking at HttpSys (sample [SelfHostServer](https://github.com/dotnet/aspnetcore/tree/main/src/Servers/HttpSys/samples/SelfHostServer)) in current main-branch there are TCS-allocations
![grafik](https://user-images.githubusercontent.com/5755834/115122490-6b6c7180-9fb8-11eb-959c-67511af37252.png)
and they go away entirely (Diff-view):
![grafik](https://user-images.githubusercontent.com/5755834/115122521-9b1b7980-9fb8-11eb-8fd9-a175061e23d2.png)

It's not a huge contributor to allocations though.

---

How do run these pretty cool benchmarks with the comments here?