### PR TITLE
HTTP/3: Header limits and validation

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -390,34 +390,34 @@
   <data name="Http2ErrorStreamIdle" xml:space="preserve">
     <value>The client sent a {frameType} frame to idle stream ID {streamId}.</value>
   </data>
-  <data name="Http2ErrorTrailersContainPseudoHeaderField" xml:space="preserve">
+  <data name="HttpErrorTrailersContainPseudoHeaderField" xml:space="preserve">
     <value>The client sent trailers containing one or more pseudo-header fields.</value>
   </data>
-  <data name="Http2ErrorHeaderNameUppercase" xml:space="preserve">
+  <data name="HttpErrorHeaderNameUppercase" xml:space="preserve">
     <value>The client sent a header with uppercase characters in its name.</value>
   </data>
-  <data name="Http2ErrorTrailerNameUppercase" xml:space="preserve">
+  <data name="HttpErrorTrailerNameUppercase" xml:space="preserve">
     <value>The client sent a trailer with uppercase characters in its name.</value>
   </data>
   <data name="Http2ErrorHeadersWithTrailersNoEndStream" xml:space="preserve">
     <value>The client sent a HEADERS frame containing trailers without setting the END_STREAM flag.</value>
   </data>
-  <data name="Http2ErrorMissingMandatoryPseudoHeaderFields" xml:space="preserve">
+  <data name="HttpErrorMissingMandatoryPseudoHeaderFields" xml:space="preserve">
     <value>Request headers missing one or more mandatory pseudo-header fields.</value>
   </data>
-  <data name="Http2ErrorPseudoHeaderFieldAfterRegularHeaders" xml:space="preserve">
+  <data name="HttpErrorPseudoHeaderFieldAfterRegularHeaders" xml:space="preserve">
     <value>Pseudo-header field found in request headers after regular header fields.</value>
   </data>
-  <data name="Http2ErrorUnknownPseudoHeaderField" xml:space="preserve">
+  <data name="HttpErrorUnknownPseudoHeaderField" xml:space="preserve">
     <value>Request headers contain unknown pseudo-header field.</value>
   </data>
-  <data name="Http2ErrorResponsePseudoHeaderField" xml:space="preserve">
+  <data name="HttpErrorResponsePseudoHeaderField" xml:space="preserve">
     <value>Request headers contain response-specific pseudo-header field.</value>
   </data>
-  <data name="Http2ErrorDuplicatePseudoHeaderField" xml:space="preserve">
+  <data name="HttpErrorDuplicatePseudoHeaderField" xml:space="preserve">
     <value>Request headers contain duplicate pseudo-header field.</value>
   </data>
-  <data name="Http2ErrorConnectionSpecificHeaderField" xml:space="preserve">
+  <data name="HttpErrorConnectionSpecificHeaderField" xml:space="preserve">
     <value>Request headers contain connection-specific header field.</value>
   </data>
   <data name="AuthenticationFailed" xml:space="preserve">

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1026,7 +1026,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     // All HTTP/2 requests MUST include exactly one valid value for the :method, :scheme, and :path pseudo-header
                     // fields, unless it is a CONNECT request (Section 8.3). An HTTP request that omits mandatory pseudo-header
                     // fields is malformed (Section 8.1.2.6).
-                    throw new Http2StreamErrorException(_currentHeadersStream.StreamId, CoreStrings.Http2ErrorMissingMandatoryPseudoHeaderFields, Http2ErrorCode.PROTOCOL_ERROR);
+                    throw new Http2StreamErrorException(_currentHeadersStream.StreamId, CoreStrings.HttpErrorMissingMandatoryPseudoHeaderFields, Http2ErrorCode.PROTOCOL_ERROR);
                 }
 
                 if (_clientActiveStreamCount == _serverSettings.MaxConcurrentStreams)
@@ -1327,7 +1327,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
             if (IsConnectionSpecificHeaderField(name, value))
             {
-                throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorConnectionSpecificHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
+                throw new Http2ConnectionErrorException(CoreStrings.HttpErrorConnectionSpecificHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
             }
 
             // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
@@ -1338,11 +1338,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 {
                     if (_requestHeaderParsingState == RequestHeaderParsingState.Trailers)
                     {
-                        throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorTrailerNameUppercase, Http2ErrorCode.PROTOCOL_ERROR);
+                        throw new Http2ConnectionErrorException(CoreStrings.HttpErrorTrailerNameUppercase, Http2ErrorCode.PROTOCOL_ERROR);
                     }
                     else
                     {
-                        throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorHeaderNameUppercase, Http2ErrorCode.PROTOCOL_ERROR);
+                        throw new Http2ConnectionErrorException(CoreStrings.HttpErrorHeaderNameUppercase, Http2ErrorCode.PROTOCOL_ERROR);
                     }
                 }
             }
@@ -1398,13 +1398,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     // All pseudo-header fields MUST appear in the header block before regular header fields.
                     // Any request or response that contains a pseudo-header field that appears in a header
                     // block after a regular header field MUST be treated as malformed (Section 8.1.2.6).
-                    throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorPseudoHeaderFieldAfterRegularHeaders, Http2ErrorCode.PROTOCOL_ERROR);
+                    throw new Http2ConnectionErrorException(CoreStrings.HttpErrorPseudoHeaderFieldAfterRegularHeaders, Http2ErrorCode.PROTOCOL_ERROR);
                 }
 
                 if (_requestHeaderParsingState == RequestHeaderParsingState.Trailers)
                 {
                     // Pseudo-header fields MUST NOT appear in trailers.
-                    throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorTrailersContainPseudoHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
+                    throw new Http2ConnectionErrorException(CoreStrings.HttpErrorTrailersContainPseudoHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
                 }
 
                 _requestHeaderParsingState = RequestHeaderParsingState.PseudoHeaderFields;
@@ -1413,21 +1413,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 {
                     // Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header
                     // fields as malformed (Section 8.1.2.6).
-                    throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorUnknownPseudoHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
+                    throw new Http2ConnectionErrorException(CoreStrings.HttpErrorUnknownPseudoHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
                 }
 
                 if (headerField == PseudoHeaderFields.Status)
                 {
                     // Pseudo-header fields defined for requests MUST NOT appear in responses; pseudo-header fields
                     // defined for responses MUST NOT appear in requests.
-                    throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorResponsePseudoHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
+                    throw new Http2ConnectionErrorException(CoreStrings.HttpErrorResponsePseudoHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
                 }
 
                 if ((_parsedPseudoHeaderFields & headerField) == headerField)
                 {
                     // http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.3
                     // All HTTP/2 requests MUST include exactly one valid value for the :method, :scheme, and :path pseudo-header fields
-                    throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorDuplicatePseudoHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
+                    throw new Http2ConnectionErrorException(CoreStrings.HttpErrorDuplicatePseudoHeaderField, Http2ErrorCode.PROTOCOL_ERROR);
                 }
 
                 if (headerField == PseudoHeaderFields.Method)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2413,7 +2413,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 ignoreNonGoAwayFrames: false,
                 expectedLastStreamId: 1,
                 expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
-                expectedErrorMessage: CoreStrings.Http2ErrorHeaderNameUppercase);
+                expectedErrorMessage: CoreStrings.HttpErrorHeaderNameUppercase);
         }
 
         [Fact]
@@ -2427,7 +2427,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>(":unknown", "0"),
             };
 
-            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.Http2ErrorUnknownPseudoHeaderField);
+            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.HttpErrorUnknownPseudoHeaderField);
         }
 
         [Fact]
@@ -2441,14 +2441,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>(HeaderNames.Status, "200"),
             };
 
-            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.Http2ErrorResponsePseudoHeaderField);
+            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.HttpErrorResponsePseudoHeaderField);
         }
 
         [Theory]
         [MemberData(nameof(DuplicatePseudoHeaderFieldData))]
         public Task HEADERS_Received_HeaderBlockContainsDuplicatePseudoHeaderField_ConnectionError(IEnumerable<KeyValuePair<string, string>> headers)
         {
-            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.Http2ErrorDuplicatePseudoHeaderField);
+            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.HttpErrorDuplicatePseudoHeaderField);
         }
 
         [Theory]
@@ -2471,7 +2471,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [MemberData(nameof(PseudoHeaderFieldAfterRegularHeadersData))]
         public Task HEADERS_Received_HeaderBlockContainsPseudoHeaderFieldAfterRegularHeaders_ConnectionError(IEnumerable<KeyValuePair<string, string>> headers)
         {
-            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.Http2ErrorPseudoHeaderFieldAfterRegularHeaders);
+            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, expectedErrorMessage: CoreStrings.HttpErrorPseudoHeaderFieldAfterRegularHeaders);
         }
 
         private async Task HEADERS_Received_InvalidHeaderFields_ConnectionError(IEnumerable<KeyValuePair<string, string>> headers, string expectedErrorMessage)
@@ -2495,7 +2495,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForStreamErrorAsync(
                  expectedStreamId: 1,
                  expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
-                 expectedErrorMessage: CoreStrings.Http2ErrorMissingMandatoryPseudoHeaderFields);
+                 expectedErrorMessage: CoreStrings.HttpErrorMissingMandatoryPseudoHeaderFields);
 
             // Verify that the stream ID can't be re-used
             await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, _browserRequestHeaders);
@@ -2572,7 +2572,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>("connection", "keep-alive")
             };
 
-            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.Http2ErrorConnectionSpecificHeaderField);
+            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.HttpErrorConnectionSpecificHeaderField);
         }
 
         [Fact]
@@ -2586,7 +2586,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>("te", "trailers, deflate")
             };
 
-            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.Http2ErrorConnectionSpecificHeaderField);
+            return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.HttpErrorConnectionSpecificHeaderField);
         }
 
         [Fact]
@@ -4291,7 +4291,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForStreamErrorAsync(
                 expectedStreamId: 1,
                 expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
-                expectedErrorMessage: CoreStrings.Http2ErrorMissingMandatoryPseudoHeaderFields);
+                expectedErrorMessage: CoreStrings.HttpErrorMissingMandatoryPseudoHeaderFields);
 
             // Verify that the stream ID can't be re-used
             await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, headers);
@@ -5239,22 +5239,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 var data = new TheoryData<byte[], string>();
 
                 // Indexed Header Field - :method: GET
-                data.Add(new byte[] { 0x82 }, CoreStrings.Http2ErrorTrailersContainPseudoHeaderField);
+                data.Add(new byte[] { 0x82 }, CoreStrings.HttpErrorTrailersContainPseudoHeaderField);
 
                 // Indexed Header Field - :path: /
-                data.Add(new byte[] { 0x84 }, CoreStrings.Http2ErrorTrailersContainPseudoHeaderField);
+                data.Add(new byte[] { 0x84 }, CoreStrings.HttpErrorTrailersContainPseudoHeaderField);
 
                 // Indexed Header Field - :scheme: http
-                data.Add(new byte[] { 0x86 }, CoreStrings.Http2ErrorTrailersContainPseudoHeaderField);
+                data.Add(new byte[] { 0x86 }, CoreStrings.HttpErrorTrailersContainPseudoHeaderField);
 
                 // Literal Header Field without Indexing - Indexed Name - :authority: 127.0.0.1
-                data.Add(new byte[] { 0x01, 0x09 }.Concat(Encoding.ASCII.GetBytes("127.0.0.1")).ToArray(), CoreStrings.Http2ErrorTrailersContainPseudoHeaderField);
+                data.Add(new byte[] { 0x01, 0x09 }.Concat(Encoding.ASCII.GetBytes("127.0.0.1")).ToArray(), CoreStrings.HttpErrorTrailersContainPseudoHeaderField);
 
                 // Literal Header Field without Indexing - New Name - contains-Uppercase: 0
                 data.Add(new byte[] { 0x00, 0x12 }
                     .Concat(Encoding.ASCII.GetBytes("contains-Uppercase"))
                     .Concat(new byte[] { 0x01, (byte)'0' })
-                    .ToArray(), CoreStrings.Http2ErrorTrailerNameUppercase);
+                    .ToArray(), CoreStrings.HttpErrorTrailerNameUppercase);
 
                 return data;
             }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -36,6 +36,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
     public class Http3TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable
     {
+        protected static readonly int MaxRequestHeaderFieldSize = 16 * 1024;
+        protected static readonly string _4kHeaderValue = new string('a', 4096);
+
         internal TestServiceContext _serviceContext;
         internal readonly TimeoutControl _timeoutControl;
         internal readonly Mock<IKestrelTrace> _mockKestrelTrace = new Mock<IKestrelTrace>();
@@ -370,7 +373,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             public bool Disposed => _testStreamContext.Disposed;
             public long Error { get; set; }
 
-            private readonly byte[] _headerEncodingBuffer = new byte[16 * 1024];
+            private readonly byte[] _headerEncodingBuffer = new byte[64 * 1024];
             private QPackEncoder _qpackEncoder = new QPackEncoder();
             private QPackDecoder _qpackDecoder = new QPackDecoder(8192);
             protected readonly Dictionary<string, string> _decodedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Shared/runtime/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/Shared/runtime/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
 
         // public for internal use in aspnetcore
         public const uint OneByteLimit = (1U << 6) - 1;
-        public const uint TwoByteLimit = (1U << 16) - 1;
+        public const uint TwoByteLimit = (1U << 14) - 1;
         public const uint FourByteLimit = (1U << 30) - 1;
         public const long EightByteLimit = (1L << 62) - 1;
 

--- a/src/Shared/runtime/Http3/QPack/HeaderField.cs
+++ b/src/Shared/runtime/Http3/QPack/HeaderField.cs
@@ -5,7 +5,7 @@ namespace System.Net.Http.QPack
 {
     internal readonly struct HeaderField
     {
-        // http://httpwg.org/specs/rfc7541.html#rfc.section.4.1
+        // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.3-1
         // public for internal use in aspnetcore
         public const int RfcOverhead = 32;
 

--- a/src/Shared/runtime/Http3/QPack/HeaderField.cs
+++ b/src/Shared/runtime/Http3/QPack/HeaderField.cs
@@ -5,6 +5,10 @@ namespace System.Net.Http.QPack
 {
     internal readonly struct HeaderField
     {
+        // http://httpwg.org/specs/rfc7541.html#rfc.section.4.1
+        // public for internal use in aspnetcore
+        public const int RfcOverhead = 32;
+
         public HeaderField(byte[] name, byte[] value)
         {
             Name = name;


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/29702

* MaxRequestHeadersTotalSize
* MaxRequestHeaderCount

Also copy tests from HTTP/2.

runtime changes mirrored here - https://github.com/dotnet/runtime/pull/51486