### PR TITLE
Unskip auth samples test 

### DIFF
--- a/src/Security/test/AuthSamples.FunctionalTests/IdentityExternalClaimsTests.cs
+++ b/src/Security/test/AuthSamples.FunctionalTests/IdentityExternalClaimsTests.cs
@@ -29,7 +29,7 @@ namespace AuthSamples.FunctionalTests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/8387")]
+        [Fact]
         public async Task MyClaimsRedirectsToLoginPageWhenNotLoggedIn()
         {
             // Arrange & Act


### PR DESCRIPTION
Test was skipped due to a bug that was fixed in 3.0