### PR TITLE
Preserve JSON deserialized types from being trimmed away

### DIFF
--- a/src/Components/Shared/src/WebEventData.cs
+++ b/src/Components/Shared/src/WebEventData.cs
@@ -79,6 +79,8 @@ namespace Microsoft.AspNetCore.Components.Web
             }
         }
 
+        [DynamicDependency(JsonSerialized, typeof(DataTransfer))]
+        [DynamicDependency(JsonSerialized, typeof(DataTransferItem))]
         private static bool TryDeserializeStandardWebEventArgs(string eventName, string eventArgsJson, [NotNullWhen(true)] out EventArgs? eventArgs)
         {
             // For back-compatibility, we recognize the built-in list of web event names and hard-code


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/31950
-------------------

## Description

We're working on enabling Blazor's functional tests to run on trimmed output. As part of the change, we discovered that certain types associated with Blazor's event handlers are being trimmed away resulting in a runtime error if used. This is a port of the fix.

## Customer Impact

Using `DragEventArgs` with blazor wasm will result in a runtime error in a trimmed app.

## Regression?
- [x] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

6.0-preview3. We enabled more extensive trimming on Blazor apps during this time.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The change prevents types from being trimmed.

## Verification
- [x] Manual (required)
- [x] Automated (automation is being applied to the `main` branch)

## Packaging changes reviewed?
- [ ] Yes
- [] No
- [x] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/31950

