### PR TITLE
Blazor WebAssembly hot reload does not cause UI refresh

### DIFF
--- a/src/Components/Components/src/HotReload/HotReloadManager.cs
+++ b/src/Components/Components/src/HotReload/HotReloadManager.cs
@@ -20,6 +20,6 @@ namespace Microsoft.AspNetCore.Components.HotReload
             OnDeltaApplied?.Invoke();
         }
 
-        public static void OnAfterUpdate(Type[]? _) => OnDeltaApplied?.Invoke();
+        public static void AfterUpdate(Type[]? _) => OnDeltaApplied?.Invoke();
     }
 }

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
 
         private static void ApplyUpdate(Assembly assembly, byte[] metadataDelta, byte[] ilDeta)
         {
-            _handlerActions ??= GetMetadataUpdateHandlerActions();
+            _handlerActions ??= GetMetadataUpdateHandlerActions(AppDomain.CurrentDomain.GetAssemblies());
             var (beforeUpdates, afterUpdates) = _handlerActions.Value;
 
             beforeUpdates.ForEach(a => a(null));
@@ -109,12 +109,13 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
             afterUpdates.ForEach(a => a(null));
         }
 
-        private static (List<Action<Type[]?>> BeforeUpdates, List<Action<Type[]?>> AfterUpdates) GetMetadataUpdateHandlerActions()
+        // Internal for unit testing.
+        internal static (List<Action<Type[]?>> BeforeUpdates, List<Action<Type[]?>> AfterUpdates) GetMetadataUpdateHandlerActions(Assembly[] assemblies)
         {
             var beforeUpdates = new List<Action<Type[]?>>();
             var afterUpdates = new List<Action<Type[]?>>();
 
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            foreach (var assembly in assemblies)
             {
                 foreach (var attribute in assembly.GetCustomAttributes<MetadataUpdateHandlerAttribute>())
                 {

--- a/src/Components/WebAssembly/WebAssembly/test/WebAssemblyHotReloadTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/WebAssemblyHotReloadTest.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Components.RenderTree;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
+{
+    public class WebAssemblyHotReloadTest
+    {
+        [Fact]
+        public void WebAssemblyHotReload_DiscoversMetadataHandlers_FromComponentsAssembly()
+        {
+            // Arrange
+            var assemblies = new[] { typeof(Renderer).Assembly, };
+
+            // Act
+            var (beforeUpdate, afterUpdate) = WebAssemblyHotReload.GetMetadataUpdateHandlerActions(assemblies);
+
+            // Assert
+            Assert.Empty(beforeUpdate);
+            Assert.Single(afterUpdate);
+        }
+    }
+}


### PR DESCRIPTION
As part of switching to the MetadataUpdateHandler attribute, a typo was introduced that
caused the UI to no longer update after a hot reload delta was applied. This change fixes the
typo and adds a unit test to ensure the reflection code works.

-----------------------

## Description

We discovered during manual testing that the UI would no longer refresh after a hot reload delta was applied. This was a result of a recent change to switch to the `MetataUpdateHandlerAttribute` where the method was no longer being reflection discovered.

## Customer Impact
Poor hot reload experience


## Regression?
- [X] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

6.0-preview4

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]
The change is specific to the hot reload code path. The fix was tested manually, and we added a minimal unit test for sanity testing.

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/31947