### PR TITLE
HTTP/3: Add unit test for MaxRequestLineSize limit

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -701,7 +701,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             var requestLineLength = _methodText!.Length + Scheme!.Length + hostText.Length + path.Length;
             if (requestLineLength > ServerOptions.Limits.MaxRequestLineSize)
             {
-                Abort(new ConnectionAbortedException(CoreStrings.BadRequest_RequestLineTooLong), Http3ErrorCode.ProtocolError);
+                Abort(new ConnectionAbortedException(CoreStrings.BadRequest_RequestLineTooLong), Http3ErrorCode.RequestRejected);
                 return false;
             }
 

--- a/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// Defaults to 8,192 bytes (8 KB).
         /// </summary>
         /// <remarks>
-        /// For HTTP/2 this measures the total size of the required pseudo headers
+        /// For HTTP/2 and HTTP/3 this measures the total size of the required pseudo headers
         /// :method, :scheme, :authority, and :path.
         /// </remarks>
         public int MaxRequestLineSize

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2613,6 +2613,24 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task HEADERS_Received_RequestLineLength_StreamError()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, new string('A', 8192 / 2)),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/" + new string('A', 8192 / 2)),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http")
+            };
+
+            await InitializeConnectionAsync(_noopApplication);
+            await StartStreamAsync(1, headers, endStream: true);
+
+            await WaitForStreamErrorAsync(1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.BadRequest_RequestLineTooLong);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
         public async Task PRIORITY_Received_StreamIdZero_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -485,7 +485,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var requestStream = await InitializeConnectionAndStreamsAsync(_noopApplication);
             await requestStream.SendHeadersAsync(headers, endStream: true);
 
-            await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.ProtocolError,
+            await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.RequestRejected,
                 CoreStrings.BadRequest_RequestLineTooLong);
         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2358,5 +2358,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.Equal("200", receivedHeaders[HeaderNames.Status]);
             Assert.Equal("0", receivedHeaders[HeaderNames.ContentLength]);
         }
+        
+        [Fact]
+        public Task HEADERS_Received_RequestLineLength_Error()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, new string('A', 8192 / 2)),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/" + new string('A', 8192 / 2)),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http")
+            };
+
+            return HEADERS_Received_InvalidHeaderFields_StreamError(headers, CoreStrings.BadRequest_RequestLineTooLong, Http3ErrorCode.RequestRejected);
+        }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/29702

~Adds unit test for HTTP/3 (and HTTP/2 because I couldn't find a test for it)~ Ok, there were unit tests. More don't hurt. The protocol error change in PR is still worth it.