### PR TITLE
Remove ExecutionContext suppression

### DIFF
--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -142,12 +142,7 @@ namespace Microsoft.AspNetCore.Routing
             {
                 var matcher = _matcherFactory.CreateMatcher(_endpointDataSource);
 
-                // Now replace the initialization task with one created with the default execution context.
-                // This is important because capturing the execution context will leak memory in ASP.NET Core.
-                using (ExecutionContext.SuppressFlow())
-                {
-                    _initializationTask = Task.FromResult(matcher);
-                }
+                _initializationTask = Task.FromResult(matcher);
 
                 // Complete the task, this will unblock any requests that came in while initializing.
                 initialization.SetResult(matcher);


### PR DESCRIPTION
- The ExecutionContext shouldn't be captured on tasks created with FromResult (this issue was fixed a while ago).

@stephentoub I was looking through old issues trying to see if this still made sense (I think we fixed a large number of accidental ExecutionContext). AFAIK `Task.FromResult` doesn't capture the context.

EDIT: Confirmed this doesn't capture anything otherwise we'd be in trouble all over the stack.