### PR TITLE
HTTP/3: Handle request stream ending without headers

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -680,4 +680,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http3ControlStreamErrorMultipleInboundStreams" xml:space="preserve">
     <value>The client created multiple inbound {streamType} streams for the connection.</value>
   </data>
+  <data name="Http3StreamErrorRequestEndedNoHeaders" xml:space="preserve">
+    <value>Request stream ended without headers.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -449,6 +449,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private ValueTask OnEndStreamReceived()
         {
+            if (_requestHeaderParsingState == RequestHeaderParsingState.Ready)
+            {
+                // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1-14
+                // Request stream ended without headers received. Unable to provide response.
+                throw new Http3StreamErrorException(CoreStrings.Http3StreamErrorRequestEndedNoHeaders, Http3ErrorCode.RequestIncomplete);
+            }
+
             if (InputRemaining.HasValue)
             {
                 // https://tools.ietf.org/html/rfc7540#section-8.1.2.6

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -1841,6 +1841,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task RequestIncomplete()
+        {
+            var requestStream = await InitializeConnectionAndStreamsAsync(_echoApplication);
+
+            await requestStream.EndStreamAsync();
+
+            await requestStream.WaitForStreamErrorAsync(
+                Http3ErrorCode.RequestIncomplete,
+                expectedErrorMessage: CoreStrings.Http3StreamErrorRequestEndedNoHeaders);
+        }
+
+        [Fact]
         public Task HEADERS_Received_HeaderBlockContainsUnknownPseudoHeaderField_ConnectionError()
         {
             var headers = new[]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -353,8 +353,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                 if (endStream)
                 {
-                    await _pair.Application.Output.CompleteAsync();
+                    await EndStreamAsync();
                 }
+            }
+
+            internal Task EndStreamAsync()
+            {
+                return _pair.Application.Output.CompleteAsync().AsTask();
             }
         }
 


### PR DESCRIPTION
Support https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1-14