### PR TITLE
Remove await for WASM `platform.callEntryPoint`

### DIFF
--- a/src/Components/Web.JS/src/Boot.WebAssembly.ts
+++ b/src/Components/Web.JS/src/Boot.WebAssembly.ts
@@ -119,7 +119,7 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
   }
 
   // Start up the application
-  await platform.callEntryPoint(resourceLoader.bootConfig.entryAssembly);
+  platform.callEntryPoint(resourceLoader.bootConfig.entryAssembly);
 }
 
 function invokeJSFromDotNet(callInfo: Pointer, arg0: any, arg1: any, arg2: any): any {


### PR DESCRIPTION
## Description

Regression introduced via: #31769

* On Blazor Server, `Blazor.start` returns a promise that resolves when the .NET code starts up and the app becomes interactive
* On WebAssembly:
  * Prior to #31769, `Blazor.start` behaves the same as server (the promise resolves when the app becomes interactive)
  * Since #31769, `Blazor.start` returns a promise that doesn’t resolve until the .NET app exits, which typically means never, and hence prevents its usage for triggering post-.NET startup logic

This PR is meant to revert that specific bit of logic, so that we no longer await the `platform.callEntryPoint` function and thus `Blazor.start` returns a promise that resolves when the .NET code starts up and the app becomes interactive. This now matches the behavior from 6.0-preview3.

## Customer Impact
Without this PR we inadvertently introduce a breaking change where the `Blazor.start` promise doesn't resolve until the .NET app exits. This prevents its usage for triggering post-.NET startup logic.

## Regression?
- [x] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]: 

Regression from 6.0-preview3 
Regressed by: #31769

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]
Returning the `await` logic to what it was prior to https://github.com/dotnet/aspnetcore/pull/31769 which was introduced in Preview 4.

## Verification
- [x] Manual (required)
- [x] Automated: https://github.com/dotnet/aspnetcore/pull/31997

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

Addresses https://github.com/dotnet/aspnetcore/issues/31971