### PR TITLE
SignalR.Common.csproj description typo fixed.

### DIFF
--- a/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
+++ b/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Common serialiation primitives for SignalR Clients Servers</Description>
+    <Description>Common serialization primitives for SignalR Clients Servers</Description>
     <TargetFrameworks>$(DefaultNetFxTargetFramework);netstandard2.0;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>


### PR DESCRIPTION
**SignalR.Common.csproj description typo fixed.**
Fixed a typo in the public description visible from the nuget package manager.
![image](https://user-images.githubusercontent.com/9020471/115514451-64798380-a284-11eb-98ab-0b5149b9877c.png)

No issue created.