### PR TITLE
Fix event during onafterrender

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
     internal static class WebAssemblyCallQueue
     {
         private static bool _isCallInProgress;
-        private static Queue<Action> _pendingWork = new();
+        private static readonly Queue<Action> _pendingWork = new();
 
         public static bool IsInProgress => _isCallInProgress;
         public static bool HasUnstartedWork => _pendingWork.Count > 0;

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
         private static bool _isCallInProgress;
         private static Queue<Action> _pendingWork = new();
 
+        public static bool IsInProgress => _isCallInProgress;
         public static bool HasUnstartedWork => _pendingWork.Count > 0;
 
         /// <summary>

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
+{
+    // A mechanism for queuing JS-to-.NET calls so they aren't nested on the call stack and hence
+    // have the same ordering behaviors as in Blazor Server. This eliminates serveral inconsistency
+    // problems and bugs that otherwise require special-case solutions in other parts of the code.
+    //
+    // We could use a true SynchronizationContext for this, but that would be much heaver. This
+    // simple work queue doesn't rely on actual asynchrony and is careful to minimize allocations
+    // and extra try/catch layers. It sufficies, at least until we have true multithreading.
+    //
+    // Framework code should dispatch incoming async JS->.NET calls via this work queue. Application
+    // developers don't need to, because we do it for them.
+
+    internal static class WebAssemblyCallQueue
+    {
+        private static bool _isCallInProgress;
+        private static Queue<Action> _pendingWork = new();
+
+        public static bool HasUnstartedWork => _pendingWork.Count > 0;
+
+        /// <summary>
+        /// Runs the supplied callback when possible. If the call queue is empty, the callback is executed
+        /// synchronously. If some call is already executing within the queue, the callback is added to the
+        /// back of the queue and will be executed in turn.
+        /// </summary>
+        /// <typeparam name="T">The type of a state parameter for the callback</typeparam>
+        /// <param name="state">A state parameter for the callback. If the callback is able to execute synchronously, this allows us to avoid any allocations for the closure.</param>
+        /// <param name="callback">The callback to run.</param>
+        /// <remarks>
+        /// In most cases this should only be used for callbacks that will not throw, because
+        /// [1] Unhandled exceptions will be fatal to the application, as the work queue will no longer process
+        ///     further items (just like unhandled hub exceptions in Blazor Server)
+        /// [2] The exception will be thrown at the point of the top-level caller, which is not necessarily the
+        ///     code that scheduled the callback, so you may not be able to observe it.
+        ///
+        /// We could change this to return a Task and do the necessary try/catch things to direct exceptions back
+        /// to the code that scheduled the callback, but it's not required for current use cases and would require
+        /// at least an extra allocation and layer of try/catch per call, plus more work to schedule continuations
+        /// at the call site.
+        /// </remarks>
+        public static void Schedule<T>(T state, Action<T> callback)
+        {
+            if (_isCallInProgress)
+            {
+                _pendingWork.Enqueue(() => callback(state));
+            }
+            else
+            {
+                _isCallInProgress = true;
+                callback(state);
+
+                // Now run any queued work items
+                while (_pendingWork.TryDequeue(out var nextWorkItem))
+                {
+                    nextWorkItem();
+                }
+
+                _isCallInProgress = false;
+            }
+        }
+    }
+}

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCallQueue.cs
@@ -10,12 +10,13 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting
     // have the same ordering behaviors as in Blazor Server. This eliminates serveral inconsistency
     // problems and bugs that otherwise require special-case solutions in other parts of the code.
     //
-    // We could use a true SynchronizationContext for this, but that would be much heaver. This
-    // simple work queue doesn't rely on actual asynchrony and is careful to minimize allocations
-    // and extra try/catch layers. It sufficies, at least until we have true multithreading.
-    //
-    // Framework code should dispatch incoming async JS->.NET calls via this work queue. Application
-    // developers don't need to, because we do it for them.
+    // The reason for not using an actual SynchronizationContext for this is that, historically,
+    // Blazor WebAssembly has not enforced any rule around having to dispatch to a sync context.
+    // Adding such a rule now would be too breaking, given how component libraries may be reliant
+    // on being able to render at any time without InvokeAsync. If we add true multithreading in the
+    // future, we should start enforcing dispatch if (and only if) multithreading is enabled.
+    // For now, this minimal work queue is an internal detail of how the framework dispatches
+    // incoming JS->.NET calls and makes sure they get deferred if a renderbatch is in process.
 
     internal static class WebAssemblyCallQueue
     {

--- a/src/Components/WebAssembly/WebAssembly/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Rendering/WebAssemblyRenderer.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Components.WebAssembly.Services;
 using Microsoft.Extensions.Logging;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
@@ -20,9 +20,6 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Rendering
     {
         private readonly ILogger _logger;
         private readonly int _webAssemblyRendererId;
-        private readonly QueueWithLast<IncomingEventInfo> deferredIncomingEvents = new();
-
-        private bool isDispatchingEvent;
 
         /// <summary>
         /// Constructs an instance of <see cref="WebAssemblyRenderer"/>.
@@ -103,22 +100,21 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Rendering
                 _webAssemblyRendererId,
                 batch);
 
-            if (deferredIncomingEvents.Count == 0)
+            if (WebAssemblyCallQueue.HasUnstartedWork)
             {
-                // In the vast majority of cases, since the call to update the UI is synchronous,
-                // we just return a pre-completed task from here.
-                return Task.CompletedTask;
+                // Because further incoming calls from JS to .NET are already queued (e.g., event notifications),
+                // we have to delay the renderbatch acknowledgement until it gets to the front of that queue.
+                // This is for consistency with Blazor Server which queues all JS-to-.NET calls relative to each
+                // other, and because various bits of cleanup logic rely on this ordering.
+                var tcs = new TaskCompletionSource();
+                WebAssemblyCallQueue.Schedule(tcs, static tcs => tcs.SetResult());
+                return tcs.Task;
             }
             else
             {
-                // However, in the rare case where JS sent us any event notifications that we had to
-                // defer until later, we behave as if the renderbatch isn't acknowledged until we have at
-                // least dispatched those event calls. This is to make the WebAssembly behavior more
-                // consistent with the Server behavior, which receives batch acknowledgements asynchronously
-                // and they are queued up with any other calls from JS such as event calls. If we didn't
-                // do this, then the order of execution could be inconsistent with Server, and in fact
-                // leads to a specific bug: https://github.com/dotnet/aspnetcore/issues/26838
-                return deferredIncomingEvents.Last.StartHandlerCompletionSource.Task;
+                // Nothing else is pending, so we can treat the renderbatch as acknowledged synchronously.
+                // This lets upstream code skip an expensive code path and avoids some allocations.
+                return Task.CompletedTask;
             }
         }
 
@@ -135,90 +131,6 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Rendering
             else
             {
                 Log.UnhandledExceptionRenderingComponent(_logger, exception);
-            }
-        }
-
-        /// <inheritdoc />
-        public override Task DispatchEventAsync(ulong eventHandlerId, EventFieldInfo? eventFieldInfo, EventArgs eventArgs)
-        {
-            // Be sure we only run one event handler at once. Although they couldn't run
-            // simultaneously anyway (there's only one thread), they could run nested on
-            // the stack if somehow one event handler triggers another event synchronously.
-            // We need event handlers not to overlap because (a) that's consistent with
-            // server-side Blazor which uses a sync context, and (b) the rendering logic
-            // relies completely on the idea that within a given scope it's only building
-            // or processing one batch at a time.
-            //
-            // The only currently known case where this makes a difference is in the E2E
-            // tests in ReorderingFocusComponent, where we hit what seems like a Chrome bug
-            // where mutating the DOM cause an element's "change" to fire while its "input"
-            // handler is still running (i.e., nested on the stack) -- this doesn't happen
-            // in Firefox. Possibly a future version of Chrome may fix this, but even then,
-            // it's conceivable that DOM mutation events could trigger this too.
-
-            if (isDispatchingEvent)
-            {
-                var info = new IncomingEventInfo(eventHandlerId, eventFieldInfo, eventArgs);
-                deferredIncomingEvents.Enqueue(info);
-                return info.FinishHandlerCompletionSource.Task;
-            }
-            else
-            {
-                try
-                {
-                    isDispatchingEvent = true;
-                    return base.DispatchEventAsync(eventHandlerId, eventFieldInfo, eventArgs);
-                }
-                finally
-                {
-                    isDispatchingEvent = false;
-
-                    if (deferredIncomingEvents.Count > 0)
-                    {
-                        // Fire-and-forget because the task we return from this method should only reflect the
-                        // completion of its own event dispatch, not that of any others that happen to be queued.
-                        // Also, ProcessNextDeferredEventAsync deals with its own async errors.
-                        _ = ProcessNextDeferredEventAsync();
-                    }
-                }
-            }
-        }
-
-        private async Task ProcessNextDeferredEventAsync()
-        {
-            var info = deferredIncomingEvents.Dequeue();
-
-            try
-            {
-                var handlerTask = DispatchEventAsync(info.EventHandlerId, info.EventFieldInfo, info.EventArgs);
-                info.StartHandlerCompletionSource.SetResult();
-                await handlerTask;
-                info.FinishHandlerCompletionSource.SetResult();
-            }
-            catch (Exception ex)
-            {
-                // Even if the handler threw synchronously, we at least started processing, so always complete successfully
-                info.StartHandlerCompletionSource.TrySetResult();
-
-                info.FinishHandlerCompletionSource.SetException(ex);
-            }
-        }
-
-        readonly struct IncomingEventInfo
-        {
-            public readonly ulong EventHandlerId;
-            public readonly EventFieldInfo? EventFieldInfo;
-            public readonly EventArgs EventArgs;
-            public readonly TaskCompletionSource StartHandlerCompletionSource;
-            public readonly TaskCompletionSource FinishHandlerCompletionSource;
-
-            public IncomingEventInfo(ulong eventHandlerId, EventFieldInfo? eventFieldInfo, EventArgs eventArgs)
-            {
-                EventHandlerId = eventHandlerId;
-                EventFieldInfo = eventFieldInfo;
-                EventArgs = eventArgs;
-                StartHandlerCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                FinishHandlerCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             }
         }
 
@@ -245,31 +157,6 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Rendering
                     logger,
                     exception.Message,
                     exception);
-            }
-        }
-
-        private class QueueWithLast<T>
-        {
-            private readonly Queue<T> _items = new();
-
-            public int Count => _items.Count;
-
-            public T? Last { get; private set; }
-
-            public T Dequeue()
-            {
-                if (_items.Count == 1)
-                {
-                    Last = default;
-                }
-
-                return _items.Dequeue();
-            }
-
-            public void Enqueue(T item)
-            {
-                Last = item;
-                _items.Enqueue(item);
             }
         }
     }

--- a/src/Components/WebAssembly/WebAssembly/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Rendering/WebAssemblyRenderer.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Rendering
             }
         }
 
-        void CallBaseProcessPendingRender() => base.ProcessPendingRender();
+        private void CallBaseProcessPendingRender() => base.ProcessPendingRender();
 
         /// <inheritdoc />
         protected override Task UpdateDisplayAsync(in RenderBatch batch)

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -445,6 +445,23 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        public void CanFocusDuringOnAfterRenderAsyncWithFocusInEvent()
+        {
+            // Represents https://github.com/dotnet/aspnetcore/issues/30070
+            var appElement = Browser.MountTestComponent<ElementFocusComponent>();
+            var didReceiveFocusLabel = appElement.FindElement(By.Id("focus-event-received"));
+            Browser.Equal("False", () => didReceiveFocusLabel.Text);
+
+            appElement.FindElement(By.Id("focus-button-onafterrender")).Click();
+            Browser.Equal("True", () => didReceiveFocusLabel.Text);
+            Browser.Equal("focus-input-onafterrender", () => Browser.SwitchTo().ActiveElement().GetAttribute("id"));
+
+            // As well as actually focusing and triggering the onfocusin event, we should not be seeing any errors
+            var log = Browser.Manage().Logs.GetLog(LogType.Browser);
+            Assert.DoesNotContain(log, entry => entry.Level == LogLevel.Severe);
+        }
+
+        [Fact]
         public void CanCaptureReferencesToDynamicallyAddedElements()
         {
             var appElement = Browser.MountTestComponent<ElementRefComponent>();

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTest.cs
@@ -444,15 +444,20 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             long getPageYOffset() => (long)((IJavaScriptExecutor)Browser).ExecuteScript("return window.pageYOffset");
         }
 
-        [Fact]
-        public void CanFocusDuringOnAfterRenderAsyncWithFocusInEvent()
+        [Theory]
+        [InlineData("focus-button-onafterrender-invoke")]
+        [InlineData("focus-button-onafterrender-await")]
+        public void CanFocusDuringOnAfterRenderAsyncWithFocusInEvent(string triggerButton)
         {
-            // Represents https://github.com/dotnet/aspnetcore/issues/30070
+            // Represents https://github.com/dotnet/aspnetcore/issues/30070, plus a more complicated
+            // variant where the initial rendering doesn't start from a JS interop call and hence
+            // isn't automatically part of the WebAssemblyCallQueue.
+
             var appElement = Browser.MountTestComponent<ElementFocusComponent>();
             var didReceiveFocusLabel = appElement.FindElement(By.Id("focus-event-received"));
             Browser.Equal("False", () => didReceiveFocusLabel.Text);
 
-            appElement.FindElement(By.Id("focus-button-onafterrender")).Click();
+            appElement.FindElement(By.Id(triggerButton)).Click();
             Browser.Equal("True", () => didReceiveFocusLabel.Text);
             Browser.Equal("focus-input-onafterrender", () => Browser.SwitchTo().ActiveElement().GetAttribute("id"));
 

--- a/src/Components/test/testassets/BasicTestApp/ElementFocusComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ElementFocusComponent.razor
@@ -7,7 +7,9 @@
 <hr />
 <button id="focus-button-prevented" @onclick="@(() => FocusInput(true))">Click to focus with preventScroll!</button>
 <hr />
-<button id="focus-button-onafterrender" @onclick="@FocusDuringOnAfterRender">Focus during OnAfterRender</button>
+<button id="focus-button-onafterrender-invoke" @onclick="@FocusDuringOnAfterRenderViaInvoke">Focus during OnAfterRender via Invoke</button>
+<hr />
+<button id="focus-button-onafterrender-await" @onclick="@FocusDuringOnAfterRenderViaAwait">Focus during OnAfterRender via await</button>
 <hr />
 <p>Received focus in: <span id="focus-event-received">@didReceiveFocusIn</span></p>
 <hr />
@@ -24,7 +26,7 @@
         await inputReference.FocusAsync(preventScroll);
     }
 
-    private void FocusDuringOnAfterRender()
+    private void FocusDuringOnAfterRenderViaInvoke()
     {
         Task.Run(async () =>
         {
@@ -32,6 +34,12 @@
             performFocusDuringOnAfterRender = true;
             _ = InvokeAsync(StateHasChanged);
         });
+    }
+
+    private async Task FocusDuringOnAfterRenderViaAwait()
+    {
+        await Task.Yield();
+        performFocusDuringOnAfterRender = true;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Components/test/testassets/BasicTestApp/ElementFocusComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ElementFocusComponent.razor
@@ -1,16 +1,44 @@
-﻿@using Microsoft.JSInterop
+﻿@if (performFocusDuringOnAfterRender)
+{
+    <input id="focus-input-onafterrender" @ref="inputForOnAfterRenderReference" @onfocusin="@(() => { didReceiveFocusIn = true; })" />
+}
 
 <button id="focus-button" @onclick="@(() => FocusInput(false))">Click to focus!</button>
 <hr />
 <button id="focus-button-prevented" @onclick="@(() => FocusInput(true))">Click to focus with preventScroll!</button>
 <hr />
+<button id="focus-button-onafterrender" @onclick="@FocusDuringOnAfterRender">Focus during OnAfterRender</button>
+<hr />
+<p>Received focus in: <span id="focus-event-received">@didReceiveFocusIn</span></p>
+<hr />
 <input id="focus-input" @ref="inputReference" style="margin-top: 10000px" />
 
 @code {
     private ElementReference inputReference;
+    private ElementReference inputForOnAfterRenderReference;
+    private bool performFocusDuringOnAfterRender;
+    private bool didReceiveFocusIn;
 
     private async Task FocusInput(bool preventScroll)
     {
         await inputReference.FocusAsync(preventScroll);
+    }
+
+    private void FocusDuringOnAfterRender()
+    {
+        Task.Run(async () =>
+        {
+            await Task.Yield();
+            performFocusDuringOnAfterRender = true;
+            _ = InvokeAsync(StateHasChanged);
+        });
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (performFocusDuringOnAfterRender)
+        {
+            await inputForOnAfterRenderReference.FocusAsync();
+        }
     }
 }


### PR DESCRIPTION
Fixes #30070, which is another case of execution order inconsistency between Blazor Server and WebAssembly.

Rather than fixing it by putting in another special case, I again wanted to design this class of bug out of existence by bringing WebAssembly hosting more closely into alignment with Server hosting. I say "again" because that was also the approach in #31612, but evidently there are still cases where I didn't go far enough. So now in this PR I'm going significantly further still by taking this out of the renderer and making a general-purpose work queue for all JS-to-.NET calls.

The solution here now simultaneously solves all three of the WebAssembly-specific event ordering problems we've had, and makes it possible to remove a lot of tricky special-case stuff we were using before. Hopefully it also has no perf or compat drawbacks for developers. It looks like not much code but it took a lot of thinking to reduce it to this, especially around things like exception handling. It's still not easy to reason about so please do say so if you have any concerns about whether it's really correct.