### PR TITLE
Use consistent property for supported platforms

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/AssemblyInfo.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/AssemblyInfo.cs
@@ -2,9 +2,5 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Runtime.CompilerServices;
-using System.Runtime.Versioning;
 
 [assembly: InternalsVisibleTo("Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
-[assembly: SupportedOSPlatform("windows")]
-[assembly: SupportedOSPlatform("macos")]
-[assembly: SupportedOSPlatform("linux")]

--- a/src/Servers/Kestrel/Transport.Quic/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.csproj
@@ -8,6 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1591;CS0436;$(NoWarn)</NoWarn><!-- Conflicts between internal and public Quic APIs -->
     <Nullable>enable</Nullable>
+    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We talked about https://github.com/dotnet/aspnetcore/pull/31748 during our build triage and felt that we should have a consistent way of specifying supported platforms. Let's see if `<RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>` achieves the same outcome. Verification pending.