### PR TITLE
Update `///` comments to help consumers of the API

### DIFF
--- a/src/DefaultBuilder/src/GenericHostBuilderExtensions.cs
+++ b/src/DefaultBuilder/src/GenericHostBuilderExtensions.cs
@@ -13,8 +13,9 @@ namespace Microsoft.Extensions.Hosting
     public static class GenericHostBuilderExtensions
     {
         /// <summary>
-        /// Configures a <see cref="IHostBuilder" /> with defaults for hosting a web app. This will overwrite
-        /// previously configured values and is intended to be called before additional configuration calls.
+        /// Configures a <see cref="IHostBuilder" /> with defaults for hosting a web app. This should be called 
+        /// before application specific configuration to avoid it overwriting provided services, configuration sources, 
+        /// environments, content root, etc.
         /// </summary>
         /// <remarks>
         /// The following defaults are applied to the <see cref="IHostBuilder"/>:

--- a/src/DefaultBuilder/src/GenericHostBuilderExtensions.cs
+++ b/src/DefaultBuilder/src/GenericHostBuilderExtensions.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Extensions.Hosting
     public static class GenericHostBuilderExtensions
     {
         /// <summary>
-        /// Configures a <see cref="IHostBuilder" /> with defaults for hosting a web app.
+        /// Configures a <see cref="IHostBuilder" /> with defaults for hosting a web app. This will overwrite
+        /// previously configured values and is intended to be called before additional configuration calls.
         /// </summary>
         /// <remarks>
         /// The following defaults are applied to the <see cref="IHostBuilder"/>:


### PR DESCRIPTION
**Update `///` comments to help consumers of the API**

As part of dotnet/runtime#51629, it was recommended to also update the `///` comments for this API.

Related to dotnet/runtime#47050
