### PR TITLE
[Backport] [Java] Safely call onError on Subjects (#31779)

### DIFF
--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import io.reactivex.Completable;
@@ -29,6 +30,7 @@ import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subjects.ReplaySubject;
 import io.reactivex.subjects.SingleSubject;
 
+@ExtendWith({RxJavaUnhandledExceptionsExtensions.class})
 class HubConnectionTest {
     private static final String RECORD_SEPARATOR = "\u001e";
     private static final Type booleanType = (new TypeReference<Boolean>() { }).getType();

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/RxJavaUnhandledExceptionsExtensions.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/RxJavaUnhandledExceptionsExtensions.java
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+package com.microsoft.signalr;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.reactivex.plugins.RxJavaPlugins;
+
+// Use by adding "@ExtendWith({RxJavaUnhandledExceptionsExtensions.class})" to a test class
+class RxJavaUnhandledExceptionsExtensions implements BeforeAllCallback, AfterAllCallback {
+    private final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<Throwable>();
+
+    @Override
+    public void beforeAll(final ExtensionContext context) {
+        RxJavaPlugins.setErrorHandler(error -> {
+            errors.put(error);
+        });
+    }
+
+    @Override
+    public void afterAll(final ExtensionContext context) {
+        if (errors.size() != 0) {
+            String RxErrors = "";
+            for (final Throwable throwable : errors) {
+                StringWriter stringWriter = new StringWriter();
+                PrintWriter printWriter = new PrintWriter(stringWriter);
+                throwable.printStackTrace(printWriter);
+                RxErrors += String.format("%s\n", stringWriter.toString());
+            }
+            throw new RuntimeException(RxErrors);
+        }
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/31779

## Description

If a connection is being started up and it receives the handshake response at the same time that the handshake timeout occurs the app can crash.

## Customer Impact

App can crash during connection setup due to a race condition with the connection handshake.

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Small change that shouldn't affect any thing except for fixing a race.

## Verification
- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/31491