### PR TITLE
Set some new Wasm properties so the Sdk can use Workloads when available

### DIFF
--- a/src/Components/WebAssembly/BlazorManifest/src/WorkloadManifest.json.in
+++ b/src/Components/WebAssembly/BlazorManifest/src/WorkloadManifest.json.in
@@ -2,7 +2,7 @@
   "version": 1,
   "workloads": {
     "microsoft-net-sdk-blazorwebassembly-aot": {
-      "description": "Blazor WebAssembly AOT workload",
+      "description": "Browser WebAssembly runtime optimization tools",
       "packs": [
         "Microsoft.NET.Runtime.MonoAOTCompiler.Task",
         "Microsoft.NET.Runtime.WebAssembly.Sdk",
@@ -26,9 +26,10 @@
       "kind": "Sdk",
       "version": "${MicrosoftNETCoreAppRuntimeAOTwinx64CrossbrowserwasmVersion}",
       "alias-to": {
-        "win-x64": "microsoft.netcore.app.runtime.aot.win-x64.cross.browser-wasm",
-        "linux-x64": "microsoft.netcore.app.runtime.aot.linux-x64.cross.browser-wasm",
-        "osx-x64": "microsoft.netcore.app.runtime.aot.osx-x64.cross.browser-wasm"
+        "win-x86": "Microsoft.NETCore.App.Runtime.AOT.win-x86.Cross.browser-wasm",
+        "win-x64": "Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm",
+        "linux-x64": "Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.browser-wasm",
+        "osx-x64": "Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm"
       }
     },
     "Microsoft.NET.Runtime.Emscripten.Node" : {
@@ -45,6 +46,7 @@
       "kind": "Sdk",
       "version": "${MicrosoftNETRuntimeEmscripten2012Pythonwinx64Version}",
       "alias-to": {
+        "win-x86": "Microsoft.NET.Runtime.Emscripten.2.0.12.Python.win-x86",
         "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Python.win-x64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Python.osx-x64"
       }
@@ -53,6 +55,7 @@
       "kind": "Sdk",
       "version": "${MicrosoftNETRuntimeEmscripten2012Sdkwinx64Version}",
       "alias-to": {
+        "win-x86": "Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.win-x86",
         "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.win-x64",
         "linux-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.linux-x64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64"

--- a/src/Components/WebAssembly/BlazorManifest/src/WorkloadManifest.json.in
+++ b/src/Components/WebAssembly/BlazorManifest/src/WorkloadManifest.json.in
@@ -26,7 +26,6 @@
       "kind": "Sdk",
       "version": "${MicrosoftNETCoreAppRuntimeAOTwinx64CrossbrowserwasmVersion}",
       "alias-to": {
-        "win-x86": "microsoft.netcore.app.runtime.aot.win-x86.cross.browser-wasm",
         "win-x64": "microsoft.netcore.app.runtime.aot.win-x64.cross.browser-wasm",
         "linux-x64": "microsoft.netcore.app.runtime.aot.linux-x64.cross.browser-wasm",
         "osx-x64": "microsoft.netcore.app.runtime.aot.osx-x64.cross.browser-wasm"
@@ -46,7 +45,6 @@
       "kind": "Sdk",
       "version": "${MicrosoftNETRuntimeEmscripten2012Pythonwinx64Version}",
       "alias-to": {
-        "win-x86": "Microsoft.NET.Runtime.Emscripten.2.0.12.Python.win-x86",
         "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Python.win-x64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Python.osx-x64"
       }
@@ -55,7 +53,6 @@
       "kind": "Sdk",
       "version": "${MicrosoftNETRuntimeEmscripten2012Sdkwinx64Version}",
       "alias-to": {
-        "win-x86": "Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.win-x86",
         "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.win-x64",
         "linux-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.linux-x64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.12.Sdk.osx-x64"

--- a/src/Components/WebAssembly/BlazorManifest/src/WorkloadManifest.targets
+++ b/src/Components/WebAssembly/BlazorManifest/src/WorkloadManifest.targets
@@ -1,13 +1,18 @@
 <Project>
-    <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)'=='true' AND '$(RunAOTCompilation)' == 'true'">
+    <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
+        <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)'=='false'" >true</UsingBrowserRuntimeWorkload>
+        <UsingBrowserRuntimeWorkload Condition="'$(UsingBrowserRuntimeWorkload)' == ''" >$(WasmNativeWorkload)</UsingBrowserRuntimeWorkload>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)'=='true' and '$(UsingBrowserRuntimeWorkload)' == 'true'">
+      <WasmGenerateAppBundle>false</WasmGenerateAppBundle>
       <UsingBlazorAOTWorkloadManifest>true</UsingBlazorAOTWorkloadManifest>
     </PropertyGroup>
 
-    <ImportGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)'=='true' AND '$(RunAOTCompilation)' == 'true'">
-      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task" />
+    <ImportGroup Condition="'$(UsingBrowserRuntimeWorkload)' == 'true'">
+      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task" Condition="'$(RunAOTCompilation)' == 'true'" />
       <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk" />
       <Import Project="Sdk.props" Sdk="Microsoft.Netcore.App.Runtime.Aot.Cross.browser-wasm" />
-      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Python" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
+      <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Python" Condition="!$([MSBuild]::IsOSPlatform('linux'))" />
       <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Node" />
       <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Sdk" />
     </ImportGroup>

--- a/src/Components/WebAssembly/BlazorManifest/src/WorkloadManifest.targets
+++ b/src/Components/WebAssembly/BlazorManifest/src/WorkloadManifest.targets
@@ -1,9 +1,9 @@
 <Project>
     <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
-        <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)'=='false'" >true</UsingBrowserRuntimeWorkload>
+        <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true'" >true</UsingBrowserRuntimeWorkload>
         <UsingBrowserRuntimeWorkload Condition="'$(UsingBrowserRuntimeWorkload)' == ''" >$(WasmNativeWorkload)</UsingBrowserRuntimeWorkload>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)'=='true' and '$(UsingBrowserRuntimeWorkload)' == 'true'">
+    <PropertyGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' and '$(UsingBrowserRuntimeWorkload)' == 'true'" >
       <WasmGenerateAppBundle>false</WasmGenerateAppBundle>
       <UsingBlazorAOTWorkloadManifest>true</UsingBlazorAOTWorkloadManifest>
     </PropertyGroup>


### PR DESCRIPTION
sdk part  in https://github.com/dotnet/sdk/pull/17092

This doesn't change any behavior without the sdk change but, with the sdk change it allows the Browser build to enable runtime relink/build outside of RunAOTCompilation during publish.  Enabling additional features and/or size reductions in a published app.