### PR TITLE
[Razor] Update the razor compiler to only enable generic type constraints in 6.0 and later

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
@@ -226,8 +226,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             // into the repository.
             ComponentTypeParamDirective.Register(
                 builder,
-                supportConstraints: true);
-                //supportConstraints: razorLanguageVersion.CompareTo(RazorLanguageVersion.Version_6_0) >= 0);
+                supportConstraints: razorLanguageVersion.CompareTo(RazorLanguageVersion.Version_6_0) >= 0);
 
             if (razorLanguageVersion.CompareTo(RazorLanguageVersion.Version_5_0) >= 0)
             {


### PR DESCRIPTION
This is a follow-up for generic type constraints. It should pass once we update the razor SDK to a version containing the updated version