### PR TITLE
[release/6.0-preview4] Move 'System.Net.Experimental.MsQuic' reference

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic.csproj
@@ -28,7 +28,6 @@
     <Reference Include="Microsoft.AspNetCore.Connections.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="System.Net.Experimental.MsQuic" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
@@ -16,6 +16,7 @@
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="System.Net.Experimental.MsQuic" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
@@ -9,5 +9,6 @@
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="Microsoft.Extensions.Hosting" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic" />
+    <Reference Include="System.Net.Experimental.MsQuic" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/32058

## Customer Impact

Fixes the publicly-available `Microsoft.AspNetCore.Server.Kestrel.Transport.Experimental.Quic` package so that it no longer depends on a package that isn't on nuget.org - currently customers will get a restore failure when using that package unless they know to add the `dotnet-experimental` feed to their nuget.config, which is unlikely.

## Testing

CI and Manual testing (to confirm that the reference is gone from the package)

## Risk

Low, does not change package behavior - the reference to `System.Net.Experimental.MsQuic` was only used for a native .dll that we don't need to build the package. Moving the reference to tests/samples preserves the old behavior.