### PR TITLE
Set `$env:DOTNET_CLI_HOME` to tool location

### DIFF
--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -29,6 +29,7 @@ namespace RunTests
         {
             try
             {
+                EnvironmentVariables.Add("DOTNET_CLI_HOME", Options.HELIX_WORKITEM_ROOT);
                 EnvironmentVariables.Add("PATH", Options.Path);
                 EnvironmentVariables.Add("helix", Options.HelixQueue);
 
@@ -71,7 +72,7 @@ namespace RunTests
                 DisplayContents(Path.Combine(Options.DotnetRoot, "shared", "Microsoft.NETCore.App"));
                 DisplayContents(Path.Combine(Options.DotnetRoot, "shared", "Microsoft.AspNetCore.App"));
                 DisplayContents(Path.Combine(Options.DotnetRoot, "packs", "Microsoft.AspNetCore.App.Ref"));
-                
+
                 return true;
             }
             catch (Exception e)
@@ -159,7 +160,7 @@ namespace RunTests
                     errorDataReceived: Console.Error.WriteLine,
                     throwOnError: false,
                     cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
-                
+
                 await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                     $"tool install dotnet-dump --tool-path {Options.HELIX_WORKITEM_ROOT} --version 5.0.0-*",
                     environmentVariables: EnvironmentVariables,

--- a/eng/helix/content/runtests.ps1
+++ b/eng/helix/content/runtests.ps1
@@ -16,7 +16,7 @@ $currentDirectory = Get-Location
 $env:PLAYWRIGHT_BROWSERS_PATH = "$currentDirectory\ms-playwright"
 $env:PLAYWRIGHT_DRIVER_PATH = "$currentDirectory\.playwright\win-x64\native\playwright.cmd"
 
-$envPath = "$env:PATH;$env:HELIX_CORRELATION_PAYLOAD\node\bin"
+$env:Path = "$env:PATH;$env:HELIX_WORKITEM_ROOT;$env:HELIX_WORKITEM_ROOT\node\bin"
 
 Write-Host "Restore: dotnet restore RunTests\RunTests.csproj --ignore-failed-sources"
 dotnet restore RunTests\RunTests.csproj --ignore-failed-sources

--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -13,7 +13,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export DOTNET_MULTILEVEL_LOOKUP=0
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
-export PATH="$PATH:$DIR/node/bin"
+export PATH="$PATH:$DIR:$DIR/node/bin"
 
 # Set playwright stuff
 export PLAYWRIGHT_BROWSERS_PATH="$DIR/ms-playwright"


### PR DESCRIPTION
- also update `$env:Path` to include same folder

note: `node` was not present in `$env:Path` on Windows