### PR TITLE
Blazor Server -  Auto reconnect on mobile browsers

### DIFF
--- a/src/Components/Web.JS/src/Boot.Server.ts
+++ b/src/Components/Web.JS/src/Boot.Server.ts
@@ -49,6 +49,7 @@ async function boot(userOptions?: Partial<CircuitStartOptions>): Promise<void> {
     const reconnection = existingConnection || await initializeConnection(options, logger, circuit);
     if (!(await circuit.reconnect(reconnection))) {
       logger.log(LogLevel.Information, 'Reconnection attempt to the circuit was rejected by the server. This may indicate that the associated state is no longer available on the server.');
+      options.reconnectionHandler!.onConnectionRejected(options.reconnectionOptions);
       return false;
     }
 

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -22,11 +22,13 @@ export interface ReconnectionOptions {
   maxRetries: number;
   retryIntervalMilliseconds: number;
   dialogId: string;
+  reloadOnCircuitRejected: boolean;
 }
 
 export interface ReconnectionHandler {
   onConnectionDown(options: ReconnectionOptions, error?: Error): void;
   onConnectionUp(): void;
+  onConnectionRejected(options: ReconnectionOptions): void;
 }
 
 const defaultOptions: CircuitStartOptions = {
@@ -34,7 +36,8 @@ const defaultOptions: CircuitStartOptions = {
     logLevel: LogLevel.Warning,
     reconnectionOptions: {
       maxRetries: 8,
-      retryIntervalMilliseconds: 20000,
+      retryIntervalMilliseconds: 3000,
       dialogId: 'components-reconnect-modal',
+      reloadOnCircuitRejected: true,
     },
 };

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitStartOptions.ts
@@ -36,7 +36,7 @@ const defaultOptions: CircuitStartOptions = {
     logLevel: LogLevel.Warning,
     reconnectionOptions: {
       maxRetries: 8,
-      retryIntervalMilliseconds: 3000,
+      retryIntervalMilliseconds: 20000,
       dialogId: 'components-reconnect-modal',
       reloadOnCircuitRejected: true,
     },

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -75,7 +75,7 @@ class ReconnectionProcess {
         const result = await this.reconnectCallback();
         if (!result) {
           // If the server responded and refused to reconnect, stop auto-retrying.
-          this.reconnectDisplay.rejected();
+          location.reload();
           return;
         }
         return;

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -44,8 +44,6 @@ export class DefaultReconnectionHandler implements ReconnectionHandler {
 };
 
 class ReconnectionProcess {
-  static readonly MaximumFirstRetryInterval = 3000;
-
   readonly reconnectDisplay: ReconnectDisplay;
   isDisposed = false;
 
@@ -83,11 +81,7 @@ class ReconnectionProcess {
         // We got an exception so will try again momentarily
         this.logger.log(LogLevel.Error, err);
       }
-      const delayDuration = i == 0 && options.retryIntervalMilliseconds > ReconnectionProcess.MaximumFirstRetryInterval
-      ? ReconnectionProcess.MaximumFirstRetryInterval
-      : options.retryIntervalMilliseconds;
-        this.logger.log(LogLevel.Debug, `Reconnecting in ${delayDuration}`);    
-      await this.delay(delayDuration);
+      await this.delay(options.retryIntervalMilliseconds);
     }
 
     this.reconnectDisplay.failed();

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -35,6 +35,12 @@ export class DefaultReconnectionHandler implements ReconnectionHandler {
       this._currentReconnectionProcess = null;
     }
   }
+
+  onConnectionRejected(options: ReconnectionOptions) {
+    if (options.reloadOnCircuitRejected) {
+      location.reload();
+    }
+  }
 };
 
 class ReconnectionProcess {
@@ -69,7 +75,7 @@ class ReconnectionProcess {
         const result = await this.reconnectCallback();
         if (!result) {
           // If the server responded and refused to reconnect, stop auto-retrying.
-          location.reload();
+          this.reconnectDisplay.rejected();       
           return;
         }
         return;

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -57,12 +57,6 @@ class ReconnectionProcess {
   async attemptPeriodicReconnection(options: ReconnectionOptions) {
     for (let i = 0; i < options.maxRetries; i++) {
       this.reconnectDisplay.update(i + 1);
-
-      const delayDuration = i == 0 && options.retryIntervalMilliseconds > ReconnectionProcess.MaximumFirstRetryInterval
-                            ? ReconnectionProcess.MaximumFirstRetryInterval
-                            : options.retryIntervalMilliseconds;
-      await this.delay(delayDuration);
-
       if (this.isDisposed) {
         break;
       }
@@ -83,6 +77,11 @@ class ReconnectionProcess {
         // We got an exception so will try again momentarily
         this.logger.log(LogLevel.Error, err);
       }
+      const delayDuration = i == 0 && options.retryIntervalMilliseconds > ReconnectionProcess.MaximumFirstRetryInterval
+      ? ReconnectionProcess.MaximumFirstRetryInterval
+      : options.retryIntervalMilliseconds;
+        this.logger.log(LogLevel.Debug, `Reconnecting in ${delayDuration}`);    
+      await this.delay(delayDuration);
     }
 
     this.reconnectDisplay.failed();

--- a/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/DefaultReconnectionHandler.ts
@@ -73,7 +73,7 @@ class ReconnectionProcess {
         const result = await this.reconnectCallback();
         if (!result) {
           // If the server responded and refused to reconnect, stop auto-retrying.
-          this.reconnectDisplay.rejected();       
+          this.reconnectDisplay.rejected();
           return;
         }
         return;

--- a/src/Components/Web.JS/tests/DefaultReconnectionHandler.test.ts
+++ b/src/Components/Web.JS/tests/DefaultReconnectionHandler.test.ts
@@ -31,7 +31,8 @@ describe('DefaultReconnectionHandler', () => {
     handler.onConnectionDown({
       maxRetries: 1000,
       retryIntervalMilliseconds: 100,
-      dialogId: 'ignored'
+      dialogId: 'ignored',
+      reloadOnCircuitRejected: true
     });
     handler.onConnectionUp();
 
@@ -48,7 +49,8 @@ describe('DefaultReconnectionHandler', () => {
     handler.onConnectionDown({
       maxRetries: 1000,
       retryIntervalMilliseconds: 100,
-      dialogId: 'ignored'
+      dialogId: 'ignored',
+      reloadOnCircuitRejected: true
     });
     expect(testDisplay.show).toHaveBeenCalled();
     expect(testDisplay.failed).not.toHaveBeenCalled();
@@ -67,7 +69,8 @@ describe('DefaultReconnectionHandler', () => {
     handler.onConnectionDown({
       maxRetries: 2,
       retryIntervalMilliseconds: 5,
-      dialogId: 'ignored'
+      dialogId: 'ignored',
+      reloadOnCircuitRejected: true
     });
 
     await delay(500);
@@ -85,7 +88,8 @@ describe('DefaultReconnectionHandler', () => {
     handler.onConnectionDown({
       maxRetries: maxRetries,
       retryIntervalMilliseconds: 5,
-      dialogId: 'ignored'
+      dialogId: 'ignored',
+      reloadOnCircuitRejected: true
     });
 
     await delay(500);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.



<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**Blazor Server - Auto reconnect on mobile browsers**

- On mobile devices when resuming a page after a long time this PR fixes an issue where `Rejected` prompt was displayed because circuit was already recycled on server.
- New `onConnectionRejected` event
- Default implementation of that event reloads the page (configurable in options)
- Changed default reconnection delay from 20s to 3s
- Now reconnection delay will be applied after the attempt instead of before the attempt

Addresses #32113 #26985
Possibly adresses #23340
Related #10325
