### PR TITLE
Reenable on_demand_gc after https://github.com/dotnet/runtime/pull/51580

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -427,8 +427,6 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
       timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     } catch { }
     MONO.mono_wasm_setenv("TZ", timeZone || 'UTC');
-    // Turn off full-gc to prevent browser freezing.
-    const mono_wasm_enable_on_demand_gc = cwrap('mono_wasm_enable_on_demand_gc', null, ['number']);
     mono_wasm_enable_on_demand_gc(0);
     if (resourceLoader.bootConfig.modifiableAssemblies) {
       // Configure the app to enable hot reload in Development.

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -427,7 +427,6 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
       timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     } catch { }
     MONO.mono_wasm_setenv("TZ", timeZone || 'UTC');
-    mono_wasm_enable_on_demand_gc(0);
     if (resourceLoader.bootConfig.modifiableAssemblies) {
       // Configure the app to enable hot reload in Development.
       MONO.mono_wasm_setenv('DOTNET_MODIFIABLE_ASSEMBLIES', resourceLoader.bootConfig.modifiableAssemblies);


### PR DESCRIPTION
[blazorwasm] Turn back on Wasm on_demand_gc now that https://github.com/dotnet/runtime/pull/51580 has addressed known AOT issues.