### PR TITLE
Remove a URI workaround that is no longer operational

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -421,7 +421,6 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
         MONO.mono_wasm_setenv('LANG',  `${resourceLoader.startOptions.applicationCulture}.UTF-8`);
       }
     }
-    MONO.mono_wasm_setenv("MONO_URI_DOTNETRELATIVEORABSOLUTE", "true");
     let timeZone = "UTC";
     try {
       timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
in .NET 5 and beyond MONO_URI_DOTNETRELATIVEORABSOLUTE no longer has any effect and should be removed.