### PR TITLE
Make Razor.slnf buildable from command-line

### DIFF
--- a/src/Razor/Razor.slnf
+++ b/src/Razor/Razor.slnf
@@ -24,7 +24,7 @@
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim\\Microsoft.AspNetCore.Razor.Test.MvcShim.csproj",
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib\\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib.csproj",
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj",
-      "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj",
+      "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X.csproj"
     ]
   }
 }


### PR DESCRIPTION
With the comma building Razor.slnf from command-line results in error:

Solution file error MSB5025: Json in solution filter file "C:\AspNetCore\src\Razor\razor.slnf" is incorrectly formatted.
