### PR TITLE
Add missing registration for authentication handler

### DIFF
--- a/src/Security/samples/CustomAuthorizationFailureResponse/Startup.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Startup.cs
@@ -30,8 +30,14 @@ namespace CustomAuthorizationFailureResponse
                 .AddAuthentication(SampleAuthenticationSchemes.CustomScheme)
                 .AddScheme<AuthenticationSchemeOptions, SampleAuthenticationHandler>(SampleAuthenticationSchemes.CustomScheme, o => { });
 
-            services.AddAuthorization(options => options.AddPolicy(SamplePolicyNames.CustomPolicy, policy => policy.AddRequirements(new SampleRequirement())));
-            services.AddAuthorization(options => options.AddPolicy(SamplePolicyNames.CustomPolicyWithCustomForbiddenMessage, policy => policy.AddRequirements(new SampleWithCustomMessageRequirement())));
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy(SamplePolicyNames.CustomPolicy, policy => 
+                    policy.AddRequirements(new SampleRequirement()));
+                
+                options.AddPolicy(SamplePolicyNames.CustomPolicyWithCustomForbiddenMessage, policy => 
+                    policy.AddRequirements(new SampleWithCustomMessageRequirement()));
+            });
 
             services.AddTransient<IAuthorizationHandler, SampleRequirementHandler>();
             services.AddTransient<IAuthorizationHandler, SampleWithCustomMessageRequirementHandler>();

--- a/src/Security/samples/CustomAuthorizationFailureResponse/Startup.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Startup.cs
@@ -34,6 +34,7 @@ namespace CustomAuthorizationFailureResponse
             services.AddAuthorization(options => options.AddPolicy(SamplePolicyNames.CustomPolicyWithCustomForbiddenMessage, policy => policy.AddRequirements(new SampleWithCustomMessageRequirement())));
 
             services.AddTransient<IAuthorizationHandler, SampleRequirementHandler>();
+            services.AddTransient<IAuthorizationHandler, SampleWithCustomMessageRequirementHandler>();
             services.AddTransient<IAuthorizationMiddlewareResultHandler, SampleAuthorizationMiddlewareResultHandler>();
         }
 


### PR DESCRIPTION
We have two AuthenticationHandlers one of which was not registered. Fixed.
