### PR TITLE
Shorten default timeout to 5 seconds with a debug build

### DIFF
--- a/src/Shared/TaskExtensions.cs
+++ b/src/Shared/TaskExtensions.cs
@@ -22,7 +22,13 @@ namespace System.Threading.Tasks.Extensions
 #endif
     static class TaskExtensions
     {
+#if DEBUG
+        // Shorter duration when running tests with debug.
+        // Less time waiting for hang unit tests to fail in aspnetcore solution.
+        private const int DefaultTimeoutDuration = 5 * 1000;
+#else
         private const int DefaultTimeoutDuration = 30 * 1000;
+#endif
 
         public static TimeSpan DefaultTimeoutTimeSpan { get; } = TimeSpan.FromMilliseconds(DefaultTimeoutDuration);
 


### PR DESCRIPTION
30 seconds is a long time to wait for a unit test to fail when developing on a local machine. Shorten time to 5 seconds for DEBUG builds.