### PR TITLE
fix NavLink with query string can't be selected correctly

### DIFF
--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -26,3 +26,5 @@ Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventName.get -> s
 Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventName.set -> void
 *REMOVED*Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventArgsType.get -> string!
 *REMOVED*Microsoft.AspNetCore.Components.RenderTree.WebEventDescriptor.EventArgsType.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.IgnoreQueryString.get -> bool
+Microsoft.AspNetCore.Components.Routing.NavLink.IgnoreQueryString.set -> void

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -52,6 +52,12 @@ namespace Microsoft.AspNetCore.Components.Routing
         [Parameter]
         public NavLinkMatch Match { get; set; }
 
+        /// <summary>
+        /// Gets or sets a flag to indicate whether route matching should ignore the query string.
+        /// </summary>
+        [Parameter]
+        public bool IgnoreQueryString { get; set; }
+
         [Inject] private NavigationManager NavigationManager { get; set; } = default!;
 
         /// <inheritdoc />
@@ -72,7 +78,7 @@ namespace Microsoft.AspNetCore.Components.Routing
             }
 
             _hrefAbsolute = href == null ? null : NavigationManager.ToAbsoluteUri(href).AbsoluteUri;
-            _isActive = ShouldMatch(RemoveQueryString(NavigationManager.Uri));
+            _isActive = ShouldMatch(NavigationManager.Uri);
 
             _class = (string?)null;
             if (AdditionalAttributes != null && AdditionalAttributes.TryGetValue("class", out obj))
@@ -99,7 +105,7 @@ namespace Microsoft.AspNetCore.Components.Routing
         {
             // We could just re-render always, but for this component we know the
             // only relevant state change is to the _isActive property.
-            var shouldBeActiveNow = ShouldMatch(RemoveQueryString(args.Location));
+            var shouldBeActiveNow = ShouldMatch(args.Location);
             if (shouldBeActiveNow != _isActive)
             {
                 _isActive = shouldBeActiveNow;
@@ -115,13 +121,15 @@ namespace Microsoft.AspNetCore.Components.Routing
                 return false;
             }
 
-            if (EqualsHrefExactlyOrIfTrailingSlashAdded(currentUriAbsolute))
+            var matchingUri = IgnoreQueryString? RemoveQueryString(currentUriAbsolute) : currentUriAbsolute;
+
+            if (EqualsHrefExactlyOrIfTrailingSlashAdded(matchingUri))
             {
                 return true;
             }
 
             if (Match == NavLinkMatch.Prefix
-                && IsStrictlyPrefixWithSeparator(currentUriAbsolute, _hrefAbsolute))
+                && IsStrictlyPrefixWithSeparator(matchingUri, _hrefAbsolute))
             {
                 return true;
             }

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Components.Routing
             }
 
             _hrefAbsolute = href == null ? null : NavigationManager.ToAbsoluteUri(href).AbsoluteUri;
-            _isActive = ShouldMatch(NavigationManager.Uri);
+            _isActive = ShouldMatch(RemoveQueryString(NavigationManager.Uri));
 
             _class = (string?)null;
             if (AdditionalAttributes != null && AdditionalAttributes.TryGetValue("class", out obj))
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Components.Routing
         {
             // We could just re-render always, but for this component we know the
             // only relevant state change is to the _isActive property.
-            var shouldBeActiveNow = ShouldMatch(args.Location);
+            var shouldBeActiveNow = ShouldMatch(RemoveQueryString(args.Location));
             if (shouldBeActiveNow != _isActive)
             {
                 _isActive = shouldBeActiveNow;
@@ -172,6 +172,9 @@ namespace Microsoft.AspNetCore.Components.Routing
 
         private string? CombineWithSpace(string? str1, string str2)
             => str1 == null ? str2 : $"{str1} {str2}";
+
+        private string RemoveQueryString(string path)
+            => path.Split('?')[0];
 
         private static bool IsStrictlyPrefixWithSeparator(string value, string prefix)
         {

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Components.Routing
                 return false;
             }
 
-            var matchingUri = IgnoreQueryString? RemoveQueryString(currentUriAbsolute) : currentUriAbsolute;
+            var matchingUri = IgnoreQueryString ? RemoveQueryString(currentUriAbsolute) : currentUriAbsolute;
 
             if (EqualsHrefExactlyOrIfTrailingSlashAdded(matchingUri))
             {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Summary of the changes (Less than 80 chars)

Remove query string when handling path matching.

**PR Description**
Detail 1
Detail 2

Addresses #bugnumber (in this specific format)

fixed #31312 