### PR TITLE
For Blazor.WebView.Wpf, use application dispatcher

### DIFF
--- a/src/Components/WebView/Platforms/Wpf/src/WpfDispatcher.cs
+++ b/src/Components/WebView/Platforms/Wpf/src/WpfDispatcher.cs
@@ -4,31 +4,39 @@
 using System;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-using static System.Windows.Threading.Dispatcher;
+using System.Windows;
+using WindowsDispatcher = System.Windows.Threading.Dispatcher;
 
 namespace Microsoft.AspNetCore.Components.WebView.Wpf
 {
     internal class WpfDispatcher : Dispatcher
     {
-        public static Dispatcher Instance { get; } = new WpfDispatcher();
+        private readonly WindowsDispatcher _windowsDispatcher;
+
+        private WpfDispatcher(WindowsDispatcher windowsDispatcher)
+        {
+            _windowsDispatcher = windowsDispatcher ?? throw new ArgumentNullException(nameof(windowsDispatcher));
+        }
+
+        public static Dispatcher Instance { get; } = new WpfDispatcher(Application.Current.Dispatcher);
 
         private static Action<Exception> RethrowException = exception =>
             ExceptionDispatchInfo.Capture(exception).Throw();
 
         public override bool CheckAccess()
-            => CurrentDispatcher.CheckAccess();
+            => _windowsDispatcher.CheckAccess();
 
         public override async Task InvokeAsync(Action workItem)
         {
             try
             {
-                if (CurrentDispatcher.CheckAccess())
+                if (_windowsDispatcher.CheckAccess())
                 {
                     workItem();
                 }
                 else
                 {
-                    await CurrentDispatcher.InvokeAsync(workItem);
+                    await _windowsDispatcher.InvokeAsync(workItem);
                 }
             }
             catch (Exception ex)
@@ -36,7 +44,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
                 // TODO: Determine whether this is the right kind of rethrowing pattern
                 // You do have to do something like this otherwise unhandled exceptions
                 // throw from inside Dispatcher.InvokeAsync are simply lost.
-                _ = CurrentDispatcher.BeginInvoke(RethrowException, ex);
+                _ = _windowsDispatcher.BeginInvoke(RethrowException, ex);
                 throw;
             }
         }
@@ -45,13 +53,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
         {
             try
             {
-                if (CurrentDispatcher.CheckAccess())
+                if (_windowsDispatcher.CheckAccess())
                 {
                     await workItem();
                 }
                 else
                 {
-                    await CurrentDispatcher.InvokeAsync(workItem);
+                    await _windowsDispatcher.InvokeAsync(workItem);
                 }
             }
             catch (Exception ex)
@@ -59,7 +67,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
                 // TODO: Determine whether this is the right kind of rethrowing pattern
                 // You do have to do something like this otherwise unhandled exceptions
                 // throw from inside Dispatcher.InvokeAsync are simply lost.
-                _ = CurrentDispatcher.BeginInvoke(RethrowException, ex);
+                _ = _windowsDispatcher.BeginInvoke(RethrowException, ex);
                 throw;
             }
         }
@@ -68,13 +76,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
         {
             try
             {
-                if (CurrentDispatcher.CheckAccess())
+                if (_windowsDispatcher.CheckAccess())
                 {
                     return workItem();
                 }
                 else
                 {
-                    return await CurrentDispatcher.InvokeAsync(workItem);
+                    return await _windowsDispatcher.InvokeAsync(workItem);
                 }
             }
             catch (Exception ex)
@@ -82,7 +90,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
                 // TODO: Determine whether this is the right kind of rethrowing pattern
                 // You do have to do something like this otherwise unhandled exceptions
                 // throw from inside Dispatcher.InvokeAsync are simply lost.
-                _ = CurrentDispatcher.BeginInvoke(RethrowException, ex);
+                _ = _windowsDispatcher.BeginInvoke(RethrowException, ex);
                 throw;
             }
         }
@@ -91,13 +99,13 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
         {
             try
             {
-                if (CurrentDispatcher.CheckAccess())
+                if (_windowsDispatcher.CheckAccess())
                 {
                     return await workItem();
                 }
                 else
                 {
-                    return await CurrentDispatcher.InvokeAsync(workItem).Task.Unwrap();
+                    return await _windowsDispatcher.InvokeAsync(workItem).Task.Unwrap();
                 }
             }
             catch (Exception ex)
@@ -105,7 +113,7 @@ namespace Microsoft.AspNetCore.Components.WebView.Wpf
                 // TODO: Determine whether this is the right kind of rethrowing pattern
                 // You do have to do something like this otherwise unhandled exceptions
                 // throw from inside Dispatcher.InvokeAsync are simply lost.
-                _ = CurrentDispatcher.BeginInvoke(RethrowException, ex);
+                _ = _windowsDispatcher.BeginInvoke(RethrowException, ex);
                 throw;
             }
         }

--- a/src/Components/WebView/Platforms/Wpf/src/WpfDispatcher.cs
+++ b/src/Components/WebView/Platforms/Wpf/src/WpfDispatcher.cs
@@ -9,7 +9,7 @@ using WindowsDispatcher = System.Windows.Threading.Dispatcher;
 
 namespace Microsoft.AspNetCore.Components.WebView.Wpf
 {
-    internal class WpfDispatcher : Dispatcher
+    internal sealed class WpfDispatcher : Dispatcher
     {
         private readonly WindowsDispatcher _windowsDispatcher;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/32057

Previously we were nonsensically dispatching to the *current thread's* dispatcher, not the dispatcher for the UI thread. So it was  always no-opping before.