### PR TITLE
Remove `$(RemoveDevicePlatformSupport)` workaround

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -175,15 +175,6 @@
     <BuildDependsOn>$(BuildDependsOn);_CopySymbolsToArtifacts</BuildDependsOn>
   </PropertyGroup>
 
-  <!--
-    Where necessary, do not pretend we support iOS or Android. This file is imported after project
-    has a chance to set $(RemoveDevicePlatformSupport) and long after @(SupportedPlatforms) is initialized.
-  -->
-  <ItemGroup Condition=" '$(RemoveDevicePlatformSupport)' == 'true' ">
-    <SupportedPlatform Remove="Android" />
-    <SupportedPlatform Remove="iOS" />
-  </ItemGroup>
-
   <Target Name="_CopySymbolsToArtifacts">
     <Copy SourceFiles="$([System.IO.Path]::ChangeExtension('$(TargetPath)', 'pdb'))"
         DestinationFolder="$(SymbolsOutputPath)$(TargetFramework)"

--- a/src/Components/WebAssembly/BlazorManifest/acquire/dotnet-install-blazoraot.csproj
+++ b/src/Components/WebAssembly/BlazorManifest/acquire/dotnet-install-blazoraot.csproj
@@ -9,7 +9,6 @@
     <AssemblyName>dotnet-install-blazoraot</AssemblyName>
     <PackageId>dotnet-install-blazoraot</PackageId>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
     <!-- Set this to false because there's nothing to reference here. -->
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
   </PropertyGroup>

--- a/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
+++ b/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Description>Runtime server features for ASP.NET Core Blazor applications.</Description>
     <IsShippingPackage>true</IsShippingPackage>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
 
     <!-- We're deliberately bundling assemblies as content files. Suppress the warning. -->
     <NoWarn>$(NoWarn);NU5100</NoWarn>

--- a/src/Middleware/Spa/SpaProxy/src/Microsoft.AspNetCore.SpaProxy.csproj
+++ b/src/Middleware/Spa/SpaProxy/src/Microsoft.AspNetCore.SpaProxy.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
     <!-- This is ok since this assembly is not referenced by any application but it is loaded as a hosting startup
     assembly for apps referencing this package-->
   </PropertyGroup>

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
@@ -4,7 +4,6 @@
     <Description>Helpers for building single-page applications on ASP.NET MVC Core.</Description>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,5 +15,5 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCode.SpaServices.Extensions.Tests" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestGroupName>ProjectTemplates.E2ETests</TestGroupName>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''">true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -7,7 +7,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestGroupName>ProjectTemplates.E2ETests</TestGroupName>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''" >true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>

--- a/src/Security/Authentication/Negotiate/src/Microsoft.AspNetCore.Authentication.Negotiate.csproj
+++ b/src/Security/Authentication/Negotiate/src/Microsoft.AspNetCore.Authentication.Negotiate.csproj
@@ -6,7 +6,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;authentication;security</PackageTags>
     <Nullable>enable</Nullable>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -11,7 +11,6 @@
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);KESTREL</DefineConstants>
     <Nullable>enable</Nullable>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/FirstRunCertGenerator/src/Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj
+++ b/src/Tools/FirstRunCertGenerator/src/Microsoft.AspNetCore.DeveloperCertificates.XPlat.csproj
@@ -5,7 +5,6 @@
     <Description>Package for the CLI first run experience.</Description>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
     <PackageTags>aspnet;cli</PackageTags>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
 
     <!-- This package contains API for the .NET CLI to generate the aspnet HTTPs dev cert during CLI first-run initialization. -->
 

--- a/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
@@ -7,7 +7,6 @@
     <AssemblyName>dotnet-openapi</AssemblyName>
     <PackageId>Microsoft.dotnet-openapi</PackageId>
     <PackAsTool>true</PackAsTool>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
+++ b/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
@@ -7,7 +7,6 @@
     <RootNamespace>Microsoft.AspNetCore.DeveloperCertificates.Tools</RootNamespace>
     <PackageTags>dotnet;developercertificates</PackageTags>
     <PackAsTool>true</PackAsTool>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
     <!-- This package is for internal use only. It contains a CLI which is bundled in the .NET Core SDK. -->
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>

--- a/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
+++ b/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>Microsoft.Extensions.SecretManager.Tools</RootNamespace>
     <PackageTags>configuration;secrets;usersecrets</PackageTags>
     <PackAsTool>true</PackAsTool>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
     <!-- This package is for internal use only. It contains a CLI which is bundled in the .NET Core SDK. -->
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>


### PR DESCRIPTION
- current SDK does not include Android or iOS in the `@(SupportedPlatform)` item group