### PR TITLE
Adding nullable type functionality for HttpRequest Context Type

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingRequestStartingLog.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Hosting
         internal string ToStringWithoutPreamble()
             => ToString().Substring(LogPreamble.Length);
 
-        internal static string EscapedValueOrEmptyMarker(string potentialValue)
+        internal static string EscapedValueOrEmptyMarker(string? potentialValue)
             // Encode space as +
             => potentialValue?.Length > 0 ? potentialValue.Replace(' ', '+') : EmptyEntry;
 

--- a/src/Http/Http.Abstractions/src/HttpRequest.cs
+++ b/src/Http/Http.Abstractions/src/HttpRequest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Http
         /// Gets or sets the Content-Type header.
         /// </summary>
         /// <returns>The Content-Type header.</returns>
-        public abstract string ContentType { get; set; }
+        public abstract string? ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the request body <see cref="Stream"/>.

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -18,6 +18,7 @@ Microsoft.AspNetCore.Http.Metadata.IFromServiceMetadata
 Microsoft.AspNetCore.Http.Endpoint.Endpoint(Microsoft.AspNetCore.Http.RequestDelegate? requestDelegate, Microsoft.AspNetCore.Http.EndpointMetadataCollection? metadata, string? displayName) -> void
 Microsoft.AspNetCore.Http.Endpoint.RequestDelegate.get -> Microsoft.AspNetCore.Http.RequestDelegate?
 Microsoft.AspNetCore.Routing.RouteValueDictionary.TryAdd(string! key, object? value) -> bool
+abstract Microsoft.AspNetCore.Http.HttpRequest.ContentType.get -> string?
 static Microsoft.AspNetCore.Builder.UseExtensions.Use(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Func<Microsoft.AspNetCore.Http.HttpContext!, Microsoft.AspNetCore.Http.RequestDelegate!, System.Threading.Tasks.Task!>! middleware) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.UseMiddleware(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Type! middleware, params object?[]! args) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.UseMiddleware<TMiddleware>(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, params object?[]! args) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@
 *REMOVED*Microsoft.AspNetCore.Routing.RouteValueDictionary.TryAdd(string! key, object! value) -> bool
 *REMOVED*static Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.UseMiddleware(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Type! middleware, params object![]! args) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 *REMOVED*static Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.UseMiddleware<TMiddleware>(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, params object![]! args) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+*REMOVED*abstract Microsoft.AspNetCore.Http.HttpRequest.ContentType.get -> string!
 Microsoft.AspNetCore.Http.IResult
 Microsoft.AspNetCore.Http.IResult.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Http.Metadata.IFromBodyMetadata

--- a/src/Http/Http/src/Internal/DefaultHttpRequest.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpRequest.cs
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.Http
             set { RequestCookiesFeature.Cookies = value; }
         }
 
-        public override string ContentType
+        public override string? ContentType
         {
             get { return Headers.ContentType; }
             set { Headers.ContentType = value; }

--- a/src/Middleware/HttpLogging/src/MediaTypeHelpers.cs
+++ b/src/Middleware/HttpLogging/src/MediaTypeHelpers.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.HttpLogging
             Encoding.Latin1 // TODO allowed by default? Make this configurable?
         };
 
-        public static bool TryGetEncodingForMediaType(string contentType, List<MediaTypeState> mediaTypeList, [NotNullWhen(true)] out Encoding? encoding)
+        public static bool TryGetEncodingForMediaType(string? contentType, List<MediaTypeState> mediaTypeList, [NotNullWhen(true)] out Encoding? encoding)
         {
             encoding = null;
             if (mediaTypeList == null || mediaTypeList.Count == 0 || string.IsNullOrEmpty(contentType))

--- a/src/Middleware/HttpLogging/src/MediaTypeHelpers.cs
+++ b/src/Middleware/HttpLogging/src/MediaTypeHelpers.cs
@@ -28,7 +28,10 @@ namespace Microsoft.AspNetCore.HttpLogging
                 return false;
             }
 
-            var mediaType = new MediaTypeHeaderValue(contentType);
+            if (!MediaTypeHeaderValue.TryParse(contentType, out var mediaType))
+            {
+                return false;
+            }
 
             if (mediaType.Charset.HasValue)
             {


### PR DESCRIPTION
…icAPI.Unshipped.txt to reflect change to nullable type.


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Adding nullability annotation on HttpRequest.ContentType 

**PR Description**
Added "?" to make type string nullable for ContentType. Updated PublicAPI.Unshipped.txt to reflect change.  I know there is at least one implementation error, but wanted to let code owners make decisions, provide feedback.
\
Addresses #32097
