### PR TITLE
Add Microsoft.Extensions.Features to Kestrel slnf

### DIFF
--- a/src/Servers/Kestrel/Kestrel.slnf
+++ b/src/Servers/Kestrel/Kestrel.slnf
@@ -5,6 +5,8 @@
       "src\\Hosting\\Abstractions\\src\\Microsoft.AspNetCore.Hosting.Abstractions.csproj",
       "src\\Hosting\\Hosting\\src\\Microsoft.AspNetCore.Hosting.csproj",
       "src\\Hosting\\Server.Abstractions\\src\\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj",
+      "src\\Http\\Features\\src\\Microsoft.Extensions.Features.csproj",
+      "src\\Http\\Features\\test\\Microsoft.Extensions.Features.Tests.csproj",
       "src\\Http\\Headers\\src\\Microsoft.Net.Http.Headers.csproj",
       "src\\Http\\Http.Abstractions\\src\\Microsoft.AspNetCore.Http.Abstractions.csproj",
       "src\\Http\\Http.Extensions\\src\\Microsoft.AspNetCore.Http.Extensions.csproj",


### PR DESCRIPTION
Fixes Kestrel.sln failing to build after `git clean`