### PR TITLE
Fix CachedReusableFilters typo

### DIFF
--- a/src/Mvc/Mvc.Abstractions/src/Abstractions/ActionDescriptor.cs
+++ b/src/Mvc/Mvc.Abstractions/src/Abstractions/ActionDescriptor.cs
@@ -76,6 +76,6 @@ namespace Microsoft.AspNetCore.Mvc.Abstractions
         /// </summary>
         public IDictionary<object, object> Properties { get; set; } = default!;
 
-        internal IFilterMetadata[]? CachedResuableFilters { get; set; }
+        internal IFilterMetadata[]? CachedReusableFilters { get; set; }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Filters/FilterFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Filters/FilterFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
             {
                 // If we know we can safely cache all filters and only the default filter provider is registered, we can
                 // probably re-use filters between requests.
-                actionDescriptor.CachedResuableFilters = filters;
+                actionDescriptor.CachedReusableFilters = filters;
             }
 
             return new FilterFactoryResult(staticFilterItems, filters);
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Mvc.Filters
                 throw new ArgumentNullException(nameof(cachedFilterItems));
             }
 
-            if (actionContext.ActionDescriptor.CachedResuableFilters is { } cached)
+            if (actionContext.ActionDescriptor.CachedReusableFilters is { } cached)
             {
                 return cached;
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->



- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Fix CachedReusableFilters typo

**PR Description**
There is a typo in **Microsoft.AspNetCore.Mvc.Abstractions**:
https://github.com/dotnet/aspnetcore/blob/52eff90fbcfca39b7eb58baad597df6a99a542b0/src/Mvc/Mvc.Abstractions/src/Abstractions/ActionDescriptor.cs#L79
Method `CachedResuableFilters` should be `CachedReusableFilters`.

This fixes #32212.
