### PR TITLE
Change return type to nullable string for System.Security.Claims.PrincipalExtensions.FindFirstValue

### DIFF
--- a/src/Identity/Extensions.Core/src/PrincipalExtensions.cs
+++ b/src/Identity/Extensions.Core/src/PrincipalExtensions.cs
@@ -17,7 +17,7 @@ namespace System.Security.Claims
         /// <param name="principal">The <see cref="ClaimsPrincipal"/> instance this method extends.</param>
         /// <param name="claimType">The claim type whose first value should be returned.</param>
         /// <returns>The value of the first instance of the specified claim type, or null if the claim is not present.</returns>
-        public static string FindFirstValue(this ClaimsPrincipal principal, string claimType)
+        public static string? FindFirstValue(this ClaimsPrincipal principal, string claimType)
         {
             if (principal == null)
             {

--- a/src/Identity/Extensions.Core/src/PublicAPI.Shipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Shipped.txt
@@ -371,7 +371,7 @@ virtual Microsoft.AspNetCore.Identity.UserManager<TUser>.SupportsUserTwoFactorRe
 ~static Microsoft.AspNetCore.Identity.UserManager<TUser>.GetChangeEmailTokenPurpose(string newEmail) -> string
 ~static Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentityCore<TUser>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.AspNetCore.Identity.IdentityBuilder
 ~static Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentityCore<TUser>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.Identity.IdentityOptions> setupAction) -> Microsoft.AspNetCore.Identity.IdentityBuilder
-~static System.Security.Claims.PrincipalExtensions.FindFirstValue(this System.Security.Claims.ClaimsPrincipal principal, string claimType) -> string
+~static System.Security.Claims.PrincipalExtensions.FindFirstValue(this System.Security.Claims.ClaimsPrincipal principal, string claimType) -> string?
 ~static readonly Microsoft.AspNetCore.Identity.TokenOptions.DefaultAuthenticatorProvider -> string
 ~static readonly Microsoft.AspNetCore.Identity.TokenOptions.DefaultEmailProvider -> string
 ~static readonly Microsoft.AspNetCore.Identity.TokenOptions.DefaultPhoneProvider -> string


### PR DESCRIPTION
Just changed `string` to `string?`  for System.Security.Claims.PrincipalExtensions.FindFirstValue
because it literally says so in XML doc: or null if the claim is not present. FindFirstValue source code also consistent with this.

Addresses #32264
