### PR TITLE
Use TypeCheckDelegate helper to map Delegate types

### DIFF
--- a/src/Components/Components/src/CompilerServices/RuntimeHelpers.cs
+++ b/src/Components/Components/src/CompilerServices/RuntimeHelpers.cs
@@ -22,6 +22,31 @@ namespace Microsoft.AspNetCore.Components.CompilerServices
         /// <summary>
         /// Not intended for use by application code.
         /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <remarks>
+        /// The method is designed to be used in the logic that generates the
+        /// runtime code for a given delegate attribute in the compiler.
+        /// Components accept delegate attributes with values that include:
+        /// * References to Action parameters
+        /// * References to a method group
+        /// * Actions defined via a lambda expression
+        /// Previously, the Razor compiler used a {node.TypeName} constructor to
+        /// support converting method groups to a delegate types in the compiler.
+        /// However, this made it impossible to pass nullable Action types to
+        /// components. Instead of using the constructor to support the conversion,
+        /// we use the `TypeCheckDelegate` conversion which handles the method group
+        /// conversion and supports null values of T.
+        /// </remarks>
+        public static T TypeCheckDelegate<T>(T value)
+        {
+            T explicitValue = (T) value;
+            return explicitValue;
+        }
+
+        /// <summary>
+        /// Not intended for use by application code.
+        /// </summary>
         /// <param name="receiver"></param>
         /// <param name="callback"></param>
         /// <param name="value"></param>

--- a/src/Components/Components/src/CompilerServices/RuntimeHelpers.cs
+++ b/src/Components/Components/src/CompilerServices/RuntimeHelpers.cs
@@ -22,31 +22,6 @@ namespace Microsoft.AspNetCore.Components.CompilerServices
         /// <summary>
         /// Not intended for use by application code.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="value"></param>
-        /// <remarks>
-        /// The method is designed to be used in the logic that generates the
-        /// runtime code for a given delegate attribute in the compiler.
-        /// Components accept delegate attributes with values that include:
-        /// * References to Action parameters
-        /// * References to a method group
-        /// * Actions defined via a lambda expression
-        /// Previously, the Razor compiler used a {node.TypeName} constructor to
-        /// support converting method groups to a delegate types in the compiler.
-        /// However, this made it impossible to pass nullable Action types to
-        /// components. Instead of using the constructor to support the conversion,
-        /// we use the `TypeCheckDelegate` conversion which handles the method group
-        /// conversion and supports null values of T.
-        /// </remarks>
-        public static T TypeCheckDelegate<T>(T value)
-        {
-            T explicitValue = (T) value;
-            return explicitValue;
-        }
-
-        /// <summary>
-        /// Not intended for use by application code.
-        /// </summary>
         /// <param name="receiver"></param>
         /// <param name="callback"></param>
         /// <param name="value"></param>

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -48,3 +48,4 @@ override Microsoft.AspNetCore.Components.LayoutComponentBase.SetParametersAsync(
 static Microsoft.AspNetCore.Components.ParameterView.FromDictionary(System.Collections.Generic.IDictionary<string!, object?>! parameters) -> Microsoft.AspNetCore.Components.ParameterView
 virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(ulong eventHandlerId, Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo? fieldInfo, System.EventArgs! eventArgs) -> System.Threading.Tasks.Task!
 readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.RemovedAttributeName -> string?
+static Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<T>(T value) -> T

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -48,4 +48,3 @@ override Microsoft.AspNetCore.Components.LayoutComponentBase.SetParametersAsync(
 static Microsoft.AspNetCore.Components.ParameterView.FromDictionary(System.Collections.Generic.IDictionary<string!, object?>! parameters) -> Microsoft.AspNetCore.Components.ParameterView
 virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(ulong eventHandlerId, Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo? fieldInfo, System.EventArgs! eventArgs) -> System.Threading.Tasks.Task!
 readonly Microsoft.AspNetCore.Components.RenderTree.RenderTreeEdit.RemovedAttributeName -> string?
-static Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<T>(T value) -> T

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
@@ -580,10 +580,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                 {
                     if (canTypeCheck)
                     {
-                        context.CodeWriter.Write(ComponentsApi.RuntimeHelpers.TypeCheckDelegate);
-                        context.CodeWriter.Write("<");
+                        context.CodeWriter.Write("(");
                         context.CodeWriter.Write(node.TypeName);
-                        context.CodeWriter.Write(">");
+                        context.CodeWriter.Write(")");
                         context.CodeWriter.Write("(");
                     }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
@@ -580,8 +580,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                 {
                     if (canTypeCheck)
                     {
-                        context.CodeWriter.Write("new ");
+                        context.CodeWriter.Write(ComponentsApi.RuntimeHelpers.TypeCheckDelegate);
+                        context.CodeWriter.Write("<");
                         context.CodeWriter.Write(node.TypeName);
+                        context.CodeWriter.Write(">");
                         context.CodeWriter.Write("(");
                     }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentsApi.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentsApi.cs
@@ -106,6 +106,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         public static class RuntimeHelpers
         {
             public static readonly string TypeCheck = "Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck";
+            public static readonly string TypeCheckDelegate = "Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate";
             public static readonly string CreateInferredEventCallback = "Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback";
         }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentsApi.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentsApi.cs
@@ -106,7 +106,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         public static class RuntimeHelpers
         {
             public static readonly string TypeCheck = "Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck";
-            public static readonly string TypeCheckDelegate = "Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate";
             public static readonly string CreateInferredEventCallback = "Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback";
         }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -466,6 +466,57 @@ namespace Test2
             CompileToAssembly(generated);
         }
 
+        [Fact]
+        public void Component_WithNullableActionParameter()
+        {
+            AdditionalSyntaxTrees.Add(Parse(@"
+using System;
+using Microsoft.AspNetCore.Components;
+namespace Test
+{
+    public class ComponentWithNullableAction : ComponentBase
+    {
+        [Parameter] public Action NullableAction { get; set; }
+    }
+} 
+"));
+            var generated = CompileToCSharp(@"
+<ComponentWithNullableAction NullableAction=""@NullableAction"" />
+@code {
+	[Parameter]
+	public Action NullableAction { get; set; }
+}            
+");
+            AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
+            AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
+            CompileToAssembly(generated);
+        }
+
+        [Fact]
+        public void Component_WithNullableRenderFragmentParameter()
+        {
+            AdditionalSyntaxTrees.Add(Parse(@"
+using System;
+using Microsoft.AspNetCore.Components;
+namespace Test
+{
+    public class ComponentWithNullableRenderFragment : ComponentBase
+    {
+        [Parameter] public RenderFragment Header { get; set; }
+    }
+} 
+"));
+            var generated = CompileToCSharp(@"
+<ComponentWithNullableRenderFragment Header=""@Header"" />
+@code {
+	[Parameter] public RenderFragment Header { get; set; }
+}            
+");
+            AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
+            AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
+            CompileToAssembly(generated);
+        }
+
         #endregion
 
         #region Bind

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.codegen.cs
@@ -10,49 +10,46 @@ namespace Test
     using Microsoft.AspNetCore.Components;
     public partial class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        }
+        #pragma warning restore 219
+        #pragma warning disable 0414
+        private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __o = new System.Action(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-   RenderFragment<Person> template = (person) => 
+                                              NullableAction
 
 #line default
 #line hidden
 #nullable disable
-            (__builder2) => {
-                __builder2.OpenElement(0, "div");
-                __builder2.AddContent(1, 
-#nullable restore
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                                        person.Name
-
-#line default
-#line hidden
-#nullable disable
-                );
-                __builder2.CloseElement();
+            );
+            __builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
+            ));
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                                                         ; 
+__o = typeof(ComponentWithNullableAction);
 
 #line default
 #line hidden
 #nullable disable
-            __builder.OpenComponent<Test.MyComponent>(2);
-            __builder.AddAttribute(3, "PersonTemplate", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<Test.Person>>(
-#nullable restore
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-                              template
-
-#line default
-#line hidden
-#nullable disable
-            ));
-            __builder.CloseComponent();
         }
         #pragma warning restore 1998
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+       
+	[Parameter]
+	public Action NullableAction { get; set; }
+
+#line default
+#line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.ir.txt
@@ -1,0 +1,26 @@
+Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [12] ) - System
+        UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
+        UsingDirective - (53:3,1 [17] ) - System.Linq
+        UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
+            DesignTimeDirective - 
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
+                IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [64] x:\dir\subdir\Test\TestComponent.cshtml) - ComponentWithNullableAction
+                    ComponentAttribute - (45:0,45 [15] x:\dir\subdir\Test\TestComponent.cshtml) - NullableAction - NullableAction - AttributeStructure.DoubleQuotes
+                        CSharpExpression - (46:0,46 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+                            LazyIntermediateToken - (46:0,46 [14] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - NullableAction
+                HtmlContent - (64:0,64 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    LazyIntermediateToken - (64:0,64 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                HtmlContent - (135:4,1 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+                    LazyIntermediateToken - (135:4,1 [14] x:\dir\subdir\Test\TestComponent.cshtml) - Html -             \n
+            CSharpCode - (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml)
+                LazyIntermediateToken - (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n	[Parameter]\n	public Action NullableAction { get; set; }\n

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+Source Location: (46:0,46 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|NullableAction|
+Generated Location: (936:25,46 [14] )
+|NullableAction|
+
+Source Location: (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+	[Parameter]
+	public Action NullableAction { get; set; }
+|
+Generated Location: (1463:45,7 [61] )
+|
+	[Parameter]
+	public Action NullableAction { get; set; }
+|
+

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.codegen.cs
@@ -10,49 +10,45 @@ namespace Test
     using Microsoft.AspNetCore.Components;
     public partial class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
     {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        }
+        #pragma warning restore 219
+        #pragma warning disable 0414
+        private static System.Object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __o = new Microsoft.AspNetCore.Components.RenderFragment(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-   RenderFragment<Person> template = (person) => 
+                                              Header
 
 #line default
 #line hidden
 #nullable disable
-            (__builder2) => {
-                __builder2.OpenElement(0, "div");
-                __builder2.AddContent(1, 
-#nullable restore
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                                        person.Name
-
-#line default
-#line hidden
-#nullable disable
-                );
-                __builder2.CloseElement();
+            );
+            __builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
+            ));
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                                                         ; 
+__o = typeof(ComponentWithNullableRenderFragment);
 
 #line default
 #line hidden
 #nullable disable
-            __builder.OpenComponent<Test.MyComponent>(2);
-            __builder.AddAttribute(3, "PersonTemplate", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<Test.Person>>(
-#nullable restore
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-                              template
-
-#line default
-#line hidden
-#nullable disable
-            ));
-            __builder.CloseComponent();
         }
         #pragma warning restore 1998
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+       
+	[Parameter] public RenderFragment Header { get; set; }
+
+#line default
+#line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.ir.txt
@@ -1,0 +1,26 @@
+Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [12] ) - System
+        UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
+        UsingDirective - (53:3,1 [17] ) - System.Linq
+        UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [37] ) - Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
+            DesignTimeDirective - 
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
+                IntermediateToken -  - CSharp - private static System.Object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [56] x:\dir\subdir\Test\TestComponent.cshtml) - ComponentWithNullableRenderFragment
+                    ComponentAttribute - (45:0,45 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Header - Header - AttributeStructure.DoubleQuotes
+                        CSharpExpression - (46:0,46 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+                            LazyIntermediateToken - (46:0,46 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Header
+                HtmlContent - (56:0,56 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    LazyIntermediateToken - (56:0,56 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                HtmlContent - (125:3,1 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+                    LazyIntermediateToken - (125:3,1 [14] x:\dir\subdir\Test\TestComponent.cshtml) - Html -             \n
+            CSharpCode - (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+                LazyIntermediateToken - (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n	[Parameter] public RenderFragment Header { get; set; }\n

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.mappings.txt
@@ -1,0 +1,14 @@
+Source Location: (46:0,46 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Header|
+Generated Location: (969:25,46 [6] )
+|Header|
+
+Source Location: (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+	[Parameter] public RenderFragment Header { get; set; }
+|
+Generated Location: (1496:45,7 [59] )
+|
+	[Parameter] public RenderFragment Header { get; set; }
+|
+

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "OnChanged", new System.Action<System.Int32>(__value => ParentValue = __value));
+            __builder.AddAttribute(2, "OnChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "OnChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
+            __builder.AddAttribute(2, "OnChanged", (System.Action<System.Int32>)(__value => ParentValue = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1252:31,7 [50] )
+Generated Location: (1171:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1173:31,7 [50] )
+Generated Location: (1252:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
+            __builder.AddAttribute(2, "ValueChanged", (System.Action<System.Int32>)(__value => ParentValue = __value));
             __builder.AddAttribute(3, "ValueExpression", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue));
             __builder.CloseComponent();
         }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", new System.Action<System.Int32>(__value => ParentValue = __value));
+            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
             __builder.AddAttribute(3, "ValueExpression", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Linq.Expressions.Expression<System.Func<System.Int32>>>(() => ParentValue));
             __builder.CloseComponent();
         }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1392:32,7 [50] )
+Generated Location: (1471:32,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1471:32,7 [50] )
+Generated Location: (1390:32,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", new System.Action<System.Int32>(__value => ParentValue = __value));
+            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
+            __builder.AddAttribute(2, "ValueChanged", (System.Action<System.Int32>)(__value => ParentValue = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1176:31,7 [50] )
+Generated Location: (1255:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1255:31,7 [50] )
+Generated Location: (1174:31,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
+            __builder.AddAttribute(2, "ValueChanged", (System.Action<System.Int32>)(__value => ParentValue = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1176:31,7 [55] )
+Generated Location: (1255:31,7 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |
-Generated Location: (1255:31,7 [55] )
+Generated Location: (1174:31,7 [55] )
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", new System.Action<System.String>(__value => person.Name = __value));
+            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.String>>(__value => person.Name = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.String>>(__value => person.Name = __value));
+            __builder.AddAttribute(2, "ValueChanged", (System.Action<System.String>)(__value => person.Name = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |
-Generated Location: (1247:31,1 [37] )
+Generated Location: (1166:31,1 [37] )
 |
     Person person = new Person();
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |
-Generated Location: (1168:31,1 [37] )
+Generated Location: (1247:31,1 [37] )
 |
     Person person = new Person();
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
@@ -41,7 +41,7 @@ namespace Test
 #line hidden
 #nullable disable
             __builder.OpenComponent<Test.MyComponent>(2);
-            __builder.AddAttribute(3, "Header", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<System.String>>(
+            __builder.AddAttribute(3, "Header", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                      header

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
@@ -41,7 +41,7 @@ namespace Test
 #line hidden
 #nullable disable
             __builder.OpenComponent<Test.MyComponent>(2);
-            __builder.AddAttribute(3, "Header", new Microsoft.AspNetCore.Components.RenderFragment<System.String>(
+            __builder.AddAttribute(3, "Header", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<System.String>>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                      header

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
@@ -41,7 +41,7 @@ namespace Test
 #line hidden
 #nullable disable
             __builder.OpenComponent<Test.MyComponent>(2);
-            __builder.AddAttribute(3, "Header", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<System.String>>(
+            __builder.AddAttribute(3, "Header", (Microsoft.AspNetCore.Components.RenderFragment<System.String>)(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                      header

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
@@ -41,7 +41,7 @@ namespace Test
 #line hidden
 #nullable disable
             __builder.OpenComponent<Test.MyComponent>(2);
-            __builder.AddAttribute(3, "Header", new Microsoft.AspNetCore.Components.RenderFragment<System.String>(
+            __builder.AddAttribute(3, "Header", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<System.String>>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                      header

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ItemChanged", new System.Action<string>(__value => Value = __value));
+            __builder.AddAttribute(2, "ItemChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<string>>(__value => Value = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ItemChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<string>>(__value => Value = __value));
+            __builder.AddAttribute(2, "ItemChanged", (System.Action<string>)(__value => Value = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1248:31,7 [21] )
+Generated Location: (1167:31,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |
-Generated Location: (1169:31,7 [21] )
+Generated Location: (1248:31,7 [21] )
 |
     string Value;
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<Test.MyComponent>(0);
-            __builder.AddAttribute(1, "OnClick", new System.Action<System.EventArgs>(
+            __builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.EventArgs>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<Test.MyComponent>(0);
-            __builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.EventArgs>>(
+            __builder.AddAttribute(1, "OnClick", (System.Action<System.EventArgs>)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (46:2,7 [98] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1077:30,7 [98] )
+Generated Location: (996:30,7 [98] )
 |
     private int counter;
     private void Increment(EventArgs e) {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (46:2,7 [98] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (998:30,7 [98] )
+Generated Location: (1077:30,7 [98] )
 |
     private int counter;
     private void Increment(EventArgs e) {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<Test.MyComponent>(0);
-            __builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.EventArgs>>(
+            __builder.AddAttribute(1, "OnClick", (System.Action<System.EventArgs>)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         e => { Increment(); }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<Test.MyComponent>(0);
-            __builder.AddAttribute(1, "OnClick", new System.Action<System.EventArgs>(
+            __builder.AddAttribute(1, "OnClick", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.EventArgs>>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                         e => { Increment(); }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (60:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1090:30,7 [87] )
+Generated Location: (1009:30,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (60:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1011:30,7 [87] )
+Generated Location: (1090:30,7 [87] )
 |
     private int counter;
     private void Increment() {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<Test.ComponentWithNullableAction>(0);
-            __builder.AddAttribute(1, "NullableAction", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action>(
+            __builder.AddAttribute(1, "NullableAction", (System.Action)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               NullableAction

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.codegen.cs
@@ -13,24 +13,24 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.OpenComponent<Test.MyComponent>(0);
-            __builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
+            __builder.OpenComponent<Test.ComponentWithNullableAction>(0);
+            __builder.AddAttribute(1, "NullableAction", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                          ParentValue
+                                              NullableAction
 
 #line default
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-    public string ParentValue { get; set; } = "42";
+	[Parameter]
+	public Action NullableAction { get; set; }
 
 #line default
 #line hidden

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.ir.txt
@@ -1,0 +1,15 @@
+Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [14] ) - System
+        UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
+        UsingDirective - (53:3,1 [19] ) - System.Linq
+        UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [64] x:\dir\subdir\Test\TestComponent.cshtml) - ComponentWithNullableAction
+                    ComponentAttribute - (45:0,45 [15] x:\dir\subdir\Test\TestComponent.cshtml) - NullableAction - NullableAction - AttributeStructure.DoubleQuotes
+                        CSharpExpression - (46:0,46 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+                            LazyIntermediateToken - (46:0,46 [14] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - NullableAction
+            CSharpCode - (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml)
+                LazyIntermediateToken - (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n	[Parameter]\n	public Action NullableAction { get; set; }\n

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.mappings.txt
@@ -3,7 +3,7 @@ Source Location: (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml)
 	[Parameter]
 	public Action NullableAction { get; set; }
 |
-Generated Location: (1110:30,7 [61] )
+Generated Location: (1029:30,7 [61] )
 |
 	[Parameter]
 	public Action NullableAction { get; set; }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+Source Location: (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+	[Parameter]
+	public Action NullableAction { get; set; }
+|
+Generated Location: (1110:30,7 [61] )
+|
+	[Parameter]
+	public Action NullableAction { get; set; }
+|
+

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<Test.ComponentWithNullableRenderFragment>(0);
-            __builder.AddAttribute(1, "Header", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment>(
+            __builder.AddAttribute(1, "Header", (Microsoft.AspNetCore.Components.RenderFragment)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                               Header

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.codegen.cs
@@ -13,24 +13,23 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.OpenComponent<Test.MyComponent>(0);
-            __builder.AddAttribute(1, "Value", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<System.Int32>(
+            __builder.OpenComponent<Test.ComponentWithNullableRenderFragment>(0);
+            __builder.AddAttribute(1, "Header", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment>(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                          ParentValue
+                                              Header
 
 #line default
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "ValueChanged", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<System.Action<System.Int32>>(__value => ParentValue = __value));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
        
-    public string ParentValue { get; set; } = "42";
+	[Parameter] public RenderFragment Header { get; set; }
 
 #line default
 #line hidden

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.ir.txt
@@ -1,0 +1,15 @@
+Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [14] ) - System
+        UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
+        UsingDirective - (53:3,1 [19] ) - System.Linq
+        UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [56] x:\dir\subdir\Test\TestComponent.cshtml) - ComponentWithNullableRenderFragment
+                    ComponentAttribute - (45:0,45 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Header - Header - AttributeStructure.DoubleQuotes
+                        CSharpExpression - (46:0,46 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+                            LazyIntermediateToken - (46:0,46 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Header
+            CSharpCode - (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+                LazyIntermediateToken - (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n	[Parameter] public RenderFragment Header { get; set; }\n

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
 |
 	[Parameter] public RenderFragment Header { get; set; }
 |
-Generated Location: (1135:30,7 [59] )
+Generated Location: (1054:30,7 [59] )
 |
 	[Parameter] public RenderFragment Header { get; set; }
 |

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.mappings.txt
@@ -1,0 +1,9 @@
+Source Location: (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+	[Parameter] public RenderFragment Header { get; set; }
+|
+Generated Location: (1135:30,7 [59] )
+|
+	[Parameter] public RenderFragment Header { get; set; }
+|
+

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
@@ -52,7 +52,7 @@ namespace Test
 #line hidden
 #nullable disable
             __builder.OpenComponent<Test.MyComponent>(5);
-            __builder.AddAttribute(6, "Template", new Microsoft.AspNetCore.Components.RenderFragment<Test.Context>(
+            __builder.AddAttribute(6, "Template", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<Test.Context>>(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                         template

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
@@ -52,7 +52,7 @@ namespace Test
 #line hidden
 #nullable disable
             __builder.OpenComponent<Test.MyComponent>(5);
-            __builder.AddAttribute(6, "Template", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<Test.Context>>(
+            __builder.AddAttribute(6, "Template", (Microsoft.AspNetCore.Components.RenderFragment<Test.Context>)(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                         template

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.codegen.cs
@@ -41,7 +41,7 @@ namespace Test
 #line hidden
 #nullable disable
             __builder.OpenComponent<Test.MyComponent>(2);
-            __builder.AddAttribute(3, "PersonTemplate", Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheckDelegate<Microsoft.AspNetCore.Components.RenderFragment<Test.Person>>(
+            __builder.AddAttribute(3, "PersonTemplate", (Microsoft.AspNetCore.Components.RenderFragment<Test.Person>)(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                               template

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -383,6 +383,7 @@ namespace Microsoft.AspNetCore.Components.CompilerServices
         public static Microsoft.AspNetCore.Components.EventCallback<T> CreateInferredEventCallback<T>(object receiver, System.Action<T> callback, T value) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<T> CreateInferredEventCallback<T>(object receiver, System.Func<T, System.Threading.Tasks.Task> callback, T value) { throw null; }
         public static T TypeCheck<T>(T value) { throw null; }
+        public static T TypeCheckDelegate<T>(T value) { throw null; }
     }
 }
 namespace Microsoft.AspNetCore.Components.Rendering

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -383,7 +383,6 @@ namespace Microsoft.AspNetCore.Components.CompilerServices
         public static Microsoft.AspNetCore.Components.EventCallback<T> CreateInferredEventCallback<T>(object receiver, System.Action<T> callback, T value) { throw null; }
         public static Microsoft.AspNetCore.Components.EventCallback<T> CreateInferredEventCallback<T>(object receiver, System.Func<T, System.Threading.Tasks.Task> callback, T value) { throw null; }
         public static T TypeCheck<T>(T value) { throw null; }
-        public static T TypeCheckDelegate<T>(T value) { throw null; }
     }
 }
 namespace Microsoft.AspNetCore.Components.Rendering


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspnetcore/issues/23892.

**Problem**
Prior to this change, when the Razor compiler encountered an attribute with a delegate type on a component:

```razor
// Component1.razor
@code {
  [Parameter] public Action<int> OnClick { get; set; }
  
  protected override void OnAfterRender(bool firstRender)
  {
    Console.WriteLine(OnClick(3));
  }
}

// Index.razor
<Component1 OnClick="Increment" />

@code {
  private void Increment(int value) {
    System.Console.WriteLine($"Increment by {value}");
  }
}
```

produces the following generated C#:

```csharp
__builder.AddAttribute(29, "OnClick", new System.Action(Increment));
```

This is fine and dandy  for most scenarios, unless you're trying to pass an attribute value that might be null. In which case, the resulting generated C# would effectively be:

```csharp
__builder.AddAttribute(29, "OnClick", new System.Action(null));
```

which leads to unhandled exceptions at runtime because you can't create an Action delegate from a null value:

> System.ArgumentException: 'Delegate to an instance method cannot have null 'this'.'

It would suffice to remove the `System.Action` constructor all together and just produce the following code:

```csharp
__builder.AddAttribute(29, "OnClick", Increment);
__builder.AddAttribute(29, "OnClick", null);
```

However, this causes an issue if the attribute parameter that is passed is a reference to a method group since there's no opportunity for the method group to be converted to a delegate when wrapped in a `System.Action` constructor.

**Proposed Solution**

This proposed solution uses an inline cast to complete the type conversion and validation.

I've verified that this does the right thing in runtime with a few scenarios in https://github.com/captainsafia/NullableParam. You can also view the updated generated source in the repo.

```csharp
__builder.AddAttribute(29, "OnClick", (System.Action<System.EventArgs>)(
#nullable restore
#line 27 "/Users/captainsafia/Verifications/NullableParam/Pages/Index.razor"
  IncrementWithEventArgs
#line default
#line hidden
#nullable disable
));
```

**Alternatives Considered**

I considered adding some cleverness to the compiler to only write the delegate constructor under the right conditions but its almost impossible to accurately determine this without landing into the method-group-to-delegate-conversion problem.

Another alternative considered was adding a new `TypeCheckDelegate` method to the M.A.Components.CompilerServers package that implements the functionality of the `TypeCheck` method but includes a `T assignedValue = originalValue` assignment to complete the method group conversion.
