### PR TITLE
Warn that TokenValidated is not the last step of validation

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/src/Events/OpenIdConnectEvents.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/OpenIdConnectEvents.cs
@@ -54,7 +54,8 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public Func<TokenResponseReceivedContext, Task> OnTokenResponseReceived { get; set; } = context => Task.CompletedTask;
 
         /// <summary>
-        /// Invoked when an IdToken has been validated and produced an AuthenticationTicket.
+        /// Invoked when an IdToken has been validated and produced an AuthenticationTicket. Note there are additional checks after this
+        /// event that validate other aspects of the authentication flow like the nonce.
         /// </summary>
         public Func<TokenValidatedContext, Task> OnTokenValidated { get; set; } = context => Task.CompletedTask;
 
@@ -106,7 +107,8 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect
         public virtual Task TokenResponseReceived(TokenResponseReceivedContext context) => OnTokenResponseReceived(context);
 
         /// <summary>
-        /// Invoked when an IdToken has been validated and produced an AuthenticationTicket.
+        /// Invoked when an IdToken has been validated and produced an AuthenticationTicket. Note there are additional checks after this
+        /// event that validate other aspects of the authentication flow like the nonce.
         /// </summary>
         public virtual Task TokenValidated(TokenValidatedContext context) => OnTokenValidated(context);
 


### PR DESCRIPTION
Forward port of https://github.com/aspnet/AspNetKatana/pull/412. 
Users have been confused by TokenValidated, thinking it indicated that all authentication is finished. In fact it only refers to one step of the validation, the token itself. Adding a clarifying comment.