### PR TITLE
Fix WebSockets tests by gracefully closing server

### DIFF
--- a/src/Middleware/WebSockets/test/UnitTests/WebSocketMiddlewareTests.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/WebSocketMiddlewareTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         [Fact]
         public async Task Connect_Success()
         {
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         [Fact]
         public async Task NegotiateSubProtocol_Success()
         {
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 Assert.Equal("alpha, bravo, charlie", context.Request.Headers["Sec-WebSocket-Protocol"]);
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         [Fact]
         public async Task SendEmptyData_Success()
         {
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task SendShortData_Success()
         {
             var orriginalData = Encoding.UTF8.GetBytes("Hello World");
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task SendMediumData_Success()
         {
             var orriginalData = Encoding.UTF8.GetBytes(new string('a', 130));
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         {
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var orriginalData = Encoding.UTF8.GetBytes(new string('a', 0x1FFFF));
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         {
             var orriginalData = Encoding.UTF8.GetBytes("Hello World");
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task ReceiveShortData_Success()
         {
             var orriginalData = Encoding.UTF8.GetBytes("Hello World");
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -245,7 +245,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task ReceiveMediumData_Success()
         {
             var orriginalData = Encoding.UTF8.GetBytes(new string('a', 130));
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -270,7 +270,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task ReceiveLongData()
         {
             var orriginalData = Encoding.UTF8.GetBytes(new string('a', 0x1FFFF));
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -303,7 +303,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task ReceiveFragmentedData_Success()
         {
             var orriginalData = Encoding.UTF8.GetBytes("Hello World");
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task SendClose_Success()
         {
             string closeDescription = "Test Closed";
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task ReceiveClose_Success()
         {
             string closeDescription = "Test Closed";
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -402,7 +402,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task CloseFromOpen_Success()
         {
             string closeDescription = "Test Closed";
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -432,7 +432,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task CloseFromCloseSent_Success()
         {
             string closeDescription = "Test Closed";
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -464,7 +464,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public async Task CloseFromCloseReceived_Success()
         {
             string closeDescription = "Test Closed";
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -510,7 +510,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         [InlineData(HttpStatusCode.OK, "http://ExAmPLE.cOm")]
         public async Task OriginIsValidatedForWebSocketRequests(HttpStatusCode expectedCode, params string[] origins)
         {
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 return Task.CompletedTask;
@@ -553,7 +553,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         [Fact]
         public async Task OriginIsNotValidatedForNonWebSocketRequests()
         {
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, context =>
             {
                 Assert.False(context.WebSockets.IsWebSocketRequest);
                 return Task.CompletedTask;
@@ -579,7 +579,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         [Fact]
         public async Task CommonHeadersAreSetToInternedStrings()
         {
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();
@@ -600,7 +600,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         [Fact]
         public async Task MultipleValueHeadersNotOverridden()
         {
-            using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
+            await using(var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
             {
                 Assert.True(context.WebSockets.IsWebSocketRequest);
                 var webSocket = await context.WebSockets.AcceptWebSocketAsync();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/32297

`host.Dispose()` would close the connections ungracefully. Calling `host.StopAsync()` will close gracefully with the 30 second host timeout.