### PR TITLE
Make the transport send timeout configurable

### DIFF
--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO.Pipelines;
+using System.Threading;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Microsoft.AspNetCore.Http.Connections
@@ -18,6 +20,7 @@ namespace Microsoft.AspNetCore.Http.Connections
 
         private PipeOptions? _transportPipeOptions;
         private PipeOptions? _appPipeOptions;
+        private TimeSpan _transportSendTimeout;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpConnectionDispatcherOptions"/> class.
@@ -30,6 +33,7 @@ namespace Microsoft.AspNetCore.Http.Connections
             LongPolling = new LongPollingOptions();
             TransportMaxBufferSize = DefaultPipeBufferSize;
             ApplicationMaxBufferSize = DefaultPipeBufferSize;
+            TransportSendTimeout = TimeSpan.FromSeconds(10);
         }
 
         /// <summary>
@@ -67,6 +71,32 @@ namespace Microsoft.AspNetCore.Http.Connections
         /// The default value is 0, the lowest possible protocol version.
         /// </summary>
         public int MinimumProtocolVersion { get; set; } = 0;
+
+
+        /// <summary>
+        /// Gets or sets the amount of time the transport will wait for a send to complete. If a single send exceeds this timeout
+        /// the connection is closed.
+        /// </summary>
+        /// <remarks>
+        /// The default timeout is 10 seconds.
+        /// </remarks>
+        public TimeSpan TransportSendTimeout
+        {
+            get => _transportSendTimeout;
+            set
+            {
+                if (value == TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _transportSendTimeout = value;
+                TransportSendTimeoutTicks = value.Ticks;
+            }
+        }
+
+        internal long TransportSendTimeoutTicks { get; private set; }
+        internal bool TranspotSendTimeoutEnabled => _transportSendTimeout != Timeout.InfiniteTimeSpan;
 
         // We initialize these lazily based on the state of the options specified here.
         // Though these are mutable it's extremely rare that they would be mutated past the

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         }
 
         internal long TransportSendTimeoutTicks { get; private set; }
-        internal bool TranspotSendTimeoutEnabled => _transportSendTimeout != Timeout.InfiniteTimeSpan;
+        internal bool TransportSendTimeoutEnabled => _transportSendTimeout != Timeout.InfiniteTimeSpan;
 
         // We initialize these lazily based on the state of the options specified here.
         // Though these are mutable it's extremely rare that they would be mutated past the

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Connections.Features;
 using Microsoft.AspNetCore.Http.Connections.Internal.Transports;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -33,7 +32,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                                          IConnectionInherentKeepAliveFeature,
                                          IConnectionLifetimeFeature
     {
-        private static long _tenSeconds = TimeSpan.FromSeconds(10).Ticks;
+        private readonly HttpConnectionDispatcherOptions _options;
 
         private readonly object _stateLock = new object();
         private readonly object _itemsLock = new object();
@@ -59,7 +58,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         /// Creates the DefaultConnectionContext without Pipes to avoid upfront allocations.
         /// The caller is expected to set the <see cref="Transport"/> and <see cref="Application"/> pipes manually.
         /// </summary>
-        public HttpConnectionContext(string connectionId, string connectionToken, ILogger logger, IDuplexPipe transport, IDuplexPipe application)
+        public HttpConnectionContext(string connectionId, string connectionToken, ILogger logger, IDuplexPipe transport, IDuplexPipe application, HttpConnectionDispatcherOptions options)
         {
             Transport = transport;
             _applicationStream = new PipeWriterStream(application.Output);
@@ -68,6 +67,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             ConnectionId = connectionId;
             ConnectionToken = connectionToken;
             LastSeenUtc = DateTime.UtcNow;
+            _options = options;
 
             // The default behavior is that both formats are supported.
             SupportedFormats = TransferFormat.Binary | TransferFormat.Text;
@@ -550,6 +550,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         internal void StartSendCancellation()
         {
+            if (!_options.TranspotSendTimeoutEnabled)
+            {
+                return;
+            }
+
             lock (_sendingLock)
             {
                 if (_sendCts == null || _sendCts.IsCancellationRequested)
@@ -561,21 +566,35 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 _activeSend = true;
             }
         }
+
         internal void TryCancelSend(long currentTicks)
         {
+            if (!_options.TranspotSendTimeoutEnabled)
+            {
+                return;
+            }
+
             lock (_sendingLock)
             {
                 if (_activeSend)
                 {
-                    if (currentTicks - _startedSendTime > _tenSeconds)
+                    if (currentTicks - _startedSendTime > _options.TransportSendTimeoutTicks)
                     {
                         _sendCts!.Cancel();
+
+                        Log.TransportSendTimeout(_logger, _options.TransportSendTimeout, ConnectionId);
                     }
                 }
             }
         }
+
         internal void StopSendCancellation()
         {
+            if (!_options.TranspotSendTimeoutEnabled)
+            {
+                return;
+            }
+
             lock (_sendingLock)
             {
                 _activeSend = false;
@@ -607,6 +626,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             private static readonly Action<ILogger, HttpTransportType, Exception?> _transportAndApplicationComplete =
                 LoggerMessage.Define<HttpTransportType>(LogLevel.Trace, new EventId(8, "TransportAndApplicationComplete"), "The application and {TransportType} transport are both complete.");
+
+            private static readonly Action<ILogger, int, string, Exception?> _transportSendtimeout =
+                LoggerMessage.Define<int, string>(LogLevel.Trace, new EventId(9, "TransportSendTimeout"), "{Timeout}ms elapsed attempting to send a message to the transport. Closing connection {TransportConnectionId}.");
 
             public static void DisposingConnection(ILogger logger, string connectionId)
             {
@@ -686,6 +708,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 }
 
                 _transportAndApplicationComplete(logger, transportType, null);
+            }
+
+            public static void TransportSendTimeout(ILogger logger, TimeSpan transportTimeout, string connectionId)
+            {
+                _transportSendtimeout(logger, (int)transportTimeout.TotalMilliseconds, connectionId, null);
             }
         }
     }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -550,7 +550,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         internal void StartSendCancellation()
         {
-            if (!_options.TranspotSendTimeoutEnabled)
+            if (!_options.TransportSendTimeoutEnabled)
             {
                 return;
             }
@@ -569,7 +569,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         internal void TryCancelSend(long currentTicks)
         {
-            if (!_options.TranspotSendTimeoutEnabled)
+            if (!_options.TransportSendTimeoutEnabled)
             {
                 return;
             }
@@ -590,7 +590,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         internal void StopSendCancellation()
         {
-            if (!_options.TranspotSendTimeoutEnabled)
+            if (!_options.TransportSendTimeoutEnabled)
             {
                 return;
             }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -718,10 +718,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         private HttpConnectionContext CreateConnection(HttpConnectionDispatcherOptions options, int clientProtocolVersion = 0)
         {
-            var transportPipeOptions = options.TransportPipeOptions;
-            var appPipeOptions = options.AppPipeOptions;
-
-            return _manager.CreateConnection(transportPipeOptions, appPipeOptions, clientProtocolVersion);
+            return _manager.CreateConnection(options, clientProtocolVersion);
         }
 
         private class EmptyServiceProvider : IServiceProvider

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -65,14 +65,14 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         internal HttpConnectionContext CreateConnection()
         {
-            return CreateConnection(PipeOptions.Default, PipeOptions.Default);
+            return CreateConnection(new());
         }
 
         /// <summary>
         /// Creates a connection without Pipes setup to allow saving allocations until Pipes are needed.
         /// </summary>
         /// <returns></returns>
-        internal HttpConnectionContext CreateConnection(PipeOptions transportPipeOptions, PipeOptions appPipeOptions, int negotiateVersion = 0)
+        internal HttpConnectionContext CreateConnection(HttpConnectionDispatcherOptions options, int negotiateVersion = 0)
         {
             string connectionToken;
             var id = MakeNewConnectionId();
@@ -87,8 +87,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             Log.CreatedNewConnection(_logger, id);
             var connectionTimer = HttpConnectionsEventSource.Log.ConnectionStart(id);
-            var pair = DuplexPipe.CreateConnectionPair(transportPipeOptions, appPipeOptions);
-            var connection = new HttpConnectionContext(id, connectionToken, _connectionLogger, pair.Application, pair.Transport);
+            var pair = DuplexPipe.CreateConnectionPair(options.TransportPipeOptions, options.AppPipeOptions);
+            var connection = new HttpConnectionContext(id, connectionToken, _connectionLogger, pair.Application, pair.Transport, options);
 
             _connections.TryAdd(connectionToken, (connection, connectionTimer));
 

--- a/src/SignalR/common/Http.Connections/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/Http.Connections/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 *REMOVED*Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext!
 Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext?
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.TransportSendTimeout.get -> System.TimeSpan
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.TransportSendTimeout.set -> void

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -187,8 +187,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             {
                 var manager = CreateConnectionManager(LoggerFactory);
                 var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
-                var pipeOptions = new PipeOptions(pauseWriterThreshold: 8, resumeWriterThreshold: 4);
-                var connection = manager.CreateConnection(pipeOptions, pipeOptions);
+                var options = new HttpConnectionDispatcherOptions();
+                options.TransportMaxBufferSize = 8;
+                options.ApplicationMaxBufferSize = 8;
+                var connection = manager.CreateConnection(options);
                 connection.TransportType = transportType;
 
                 using (var requestBody = new MemoryStream())
@@ -1921,8 +1923,12 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var manager = CreateConnectionManager(LoggerFactory);
-                var pipeOptions = new PipeOptions(pauseWriterThreshold: 2, resumeWriterThreshold: 1);
-                var connection = manager.CreateConnection(pipeOptions, pipeOptions);
+                var options = new HttpConnectionDispatcherOptions
+                {
+                    TransportMaxBufferSize = 2,
+                    ApplicationMaxBufferSize = 2
+                };
+                var connection = manager.CreateConnection(options);
                 connection.TransportType = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
@@ -1934,7 +1940,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var builder = new ConnectionBuilder(services.BuildServiceProvider());
                 builder.UseConnectionHandler<NeverEndingConnectionHandler>();
                 var app = builder.Build();
-                var options = new HttpConnectionDispatcherOptions();
 
                 var pollTask = dispatcher.ExecuteAsync(context, options, app);
                 Assert.True(pollTask.IsCompleted);
@@ -2068,8 +2073,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var manager = CreateConnectionManager(LoggerFactory);
-                var pipeOptions = new PipeOptions(pauseWriterThreshold: 13, resumeWriterThreshold: 10);
-                var connection = manager.CreateConnection(pipeOptions, pipeOptions);
+                var options = new HttpConnectionDispatcherOptions
+                {
+                    TransportMaxBufferSize = 13,
+                    ApplicationMaxBufferSize = 13
+                };
+                
+                var connection = manager.CreateConnection(options);
                 connection.TransportType = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
@@ -2079,7 +2089,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var builder = new ConnectionBuilder(services.BuildServiceProvider());
                 builder.UseConnectionHandler<TestConnectionHandler>();
                 var app = builder.Build();
-                var options = new HttpConnectionDispatcherOptions();
 
                 SyncPoint streamCopySyncPoint = new SyncPoint();
 
@@ -2127,8 +2136,12 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var manager = CreateConnectionManager(LoggerFactory);
-                var pipeOptions = new PipeOptions(pauseWriterThreshold: 13, resumeWriterThreshold: 10);
-                var connection = manager.CreateConnection(pipeOptions, pipeOptions);
+                var options = new HttpConnectionDispatcherOptions
+                {
+                    TransportMaxBufferSize = 13,
+                    ApplicationMaxBufferSize = 13
+                };
+                var connection = manager.CreateConnection(options);
                 connection.TransportType = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
@@ -2138,7 +2151,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var builder = new ConnectionBuilder(services.BuildServiceProvider());
                 builder.UseConnectionHandler<TestConnectionHandler>();
                 var app = builder.Build();
-                var options = new HttpConnectionDispatcherOptions();
 
                 using (var responseBody = new MemoryStream())
                 using (var requestBody = new MemoryStream())
@@ -2181,8 +2193,12 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var manager = CreateConnectionManager(LoggerFactory);
-                var pipeOptions = new PipeOptions(pauseWriterThreshold: 13, resumeWriterThreshold: 10);
-                var connection = manager.CreateConnection(pipeOptions, pipeOptions);
+                var options = new HttpConnectionDispatcherOptions
+                {
+                    TransportMaxBufferSize = 13,
+                    ApplicationMaxBufferSize = 13
+                };
+                var connection = manager.CreateConnection(options);
                 connection.TransportType = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
@@ -2192,7 +2208,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var builder = new ConnectionBuilder(services.BuildServiceProvider());
                 builder.UseConnectionHandler<TestConnectionHandler>();
                 var app = builder.Build();
-                var options = new HttpConnectionDispatcherOptions();
 
                 using (var responseBody = new MemoryStream())
                 using (var requestBody = new MemoryStream())
@@ -2276,8 +2291,12 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var manager = CreateConnectionManager(LoggerFactory);
-                var pipeOptions = new PipeOptions(pauseWriterThreshold: 2, resumeWriterThreshold: 1);
-                var connection = manager.CreateConnection(pipeOptions, pipeOptions);
+                var options = new HttpConnectionDispatcherOptions
+                {
+                    TransportMaxBufferSize = 2,
+                    ApplicationMaxBufferSize = 2
+                };
+                var connection = manager.CreateConnection(options);
                 connection.TransportType = HttpTransportType.LongPolling;
 
                 var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
@@ -2289,7 +2308,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 var builder = new ConnectionBuilder(services.BuildServiceProvider());
                 builder.UseConnectionHandler<NeverEndingConnectionHandler>();
                 var app = builder.Build();
-                var options = new HttpConnectionDispatcherOptions();
 
                 var pollTask = dispatcher.ExecuteAsync(context, options, app);
                 Assert.True(pollTask.IsCompleted);

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
                 var transport = connection.Transport;
 
                 Assert.NotNull(connection.ConnectionId);
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
 
                 var transport = connection.Transport;
 
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default, negotiateVersion: 0);
+                var connection = connectionManager.CreateConnection(new(), negotiateVersion: 0);
 
                 var transport = connection.Transport;
 
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default, negotiateVersion: 1);
+                var connection = connectionManager.CreateConnection(new(), negotiateVersion: 1);
 
                 var transport = connection.Transport;
 
@@ -220,7 +220,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
 
                 connection.ApplicationTask = Task.Run(async () =>
                 {
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
                 var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 connection.ApplicationTask = tcs.Task;
@@ -284,7 +284,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
                 var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 connection.ApplicationTask = tcs.Task;
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
                 var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 connection.ApplicationTask = tcs.Task;
@@ -335,7 +335,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var connectionManager = CreateConnectionManager(LoggerFactory);
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
 
                 Assert.NotNull(connection.ConnectionId);
                 Assert.NotNull(connection.Transport);
@@ -372,7 +372,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 appLifetime.Start();
 
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
 
                 appLifetime.StopApplication();
 
@@ -391,7 +391,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
                 var connectionManager = CreateConnectionManager(LoggerFactory, appLifetime);
 
-                var connection = connectionManager.CreateConnection(PipeOptions.Default, PipeOptions.Default);
+                var connection = connectionManager.CreateConnection();
 
                 appLifetime.StopApplication();
 

--- a/src/SignalR/common/Http.Connections/test/WebSocketsTests.cs
+++ b/src/SignalR/common/Http.Connections/test/WebSocketsTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger("HttpConnectionContext1"), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger("HttpConnectionContext1"), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger("HttpConnectionContext1"), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger("HttpConnectionContext1"), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger("HttpConnectionContext1"), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger("HttpConnectionContext1"), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
@@ -197,7 +197,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
@@ -265,7 +265,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
@@ -304,7 +304,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             using (StartVerifiableLog())
             {
                 var pair = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
-                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application);
+                var connection = new HttpConnectionContext("foo", connectionToken: null, LoggerFactory.CreateLogger(nameof(HttpConnectionContext)), pair.Transport, pair.Application, new());
 
                 using (var feature = new TestWebSocketConnectionFeature())
                 {


### PR DESCRIPTION
- It's hardcoded to 10 seconds, make it configurable.

Should we make it nullable to disable it?