### PR TITLE
Fix NullReferenceException if no IdentityServer key configured

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureApiResources.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureApiResources.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
-            var localResources = _localApiDescriptor.GetResourceDefinitions();
+            var localResources = _localApiDescriptor?.GetResourceDefinitions();
             if (localResources != null)
             {
                 foreach (var kvp in localResources)

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureSigningCredentials.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureSigningCredentials.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
         // for testing purposes only
         internal virtual DateTimeOffset GetCurrentTime() => DateTimeOffset.UtcNow;
 
-        private X509KeyStorageFlags GetStorageFlags(KeyDefinition key)
+        private static X509KeyStorageFlags GetStorageFlags(KeyDefinition key)
         {
             var defaultFlags = OperatingSystem.IsLinux() ?
                 UnsafeEphemeralKeySet : (OperatingSystem.IsMacOS() ? X509KeyStorageFlags.PersistKeySet :
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
 
             return result;
 
-            X509KeyStorageFlags ParseCurrentFlag(string candidate)
+            static X509KeyStorageFlags ParseCurrentFlag(string candidate)
             {
                 if (Enum.TryParse<X509KeyStorageFlags>(candidate, out var flag))
                 {

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureSigningCredentials.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureSigningCredentials.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer
                 return defaultFlags;
             }
 
-            var flagsList = key.StorageFlags.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            var flagsList = key.StorageFlags.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (flagsList.Length == 0)
             {
                 return defaultFlags;

--- a/src/Identity/ApiAuthorization.IdentityServer/src/IdentityServerBuilderConfigurationExtensions.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/IdentityServerBuilderConfigurationExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     var logger = sp.GetRequiredService<ILogger<ConfigureApiResources>>();
                     var effectiveConfig = configuration ?? sp.GetRequiredService<IConfiguration>().GetSection("IdentityServer:Resources");
-                    var localApiDescriptor = sp.GetRequiredService<IIdentityServerJwtDescriptor>();
+                    var localApiDescriptor = sp.GetService<IIdentityServerJwtDescriptor>();
                     return new ConfigureApiResources(effectiveConfig, localApiDescriptor, logger);
                 }));
 

--- a/src/Identity/ApiAuthorization.IdentityServer/src/IdentityServerBuilderConfigurationExtensions.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/IdentityServerBuilderConfigurationExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     var logger = sp.GetRequiredService<ILogger<ConfigureApiResources>>();
                     var effectiveConfig = configuration ?? sp.GetRequiredService<IConfiguration>().GetSection("IdentityServer:Resources");
-                    var localApiDescriptor = sp.GetService<IIdentityServerJwtDescriptor>();
+                    var localApiDescriptor = sp.GetRequiredService<IIdentityServerJwtDescriptor>();
                     return new ConfigureApiResources(effectiveConfig, localApiDescriptor, logger);
                 }));
 

--- a/src/Identity/ApiAuthorization.IdentityServer/test/Extensions/IdentityServerBuilderConfigurationExtensionsTests.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/test/Extensions/IdentityServerBuilderConfigurationExtensionsTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using IdentityServer4.EntityFramework.Entities;
+using IdentityServer4.EntityFramework.Interfaces;
+using IdentityServer4.Stores;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Xunit;
+
+namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Extensions
+{
+    public static class IdentityServerBuilderConfigurationExtensionsTests
+    {
+        [Fact]
+        public static void IValidationKeysStore_Service_Resolution_Fails_If_No_Signing_Credential_Configured()
+        {
+            // Arrange
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> { ["MyAPI:Profile"] = "API" })
+                .Build();
+
+            IWebHostEnvironment environment = new MyWebHostEnvironment();
+
+            var services = new ServiceCollection()
+                .AddSingleton(configuration)
+                .AddSingleton(environment)
+                .AddOptions();
+
+            services.AddDefaultIdentity<MyUser>();
+
+            services.AddIdentityServer()
+                    .AddApiAuthorization<MyUser, MyUserContext>();
+
+            services.AddAuthentication()
+                    .AddIdentityServerJwt();
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            // Act and Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => serviceProvider.GetRequiredService<IValidationKeysStore>());
+
+            Assert.Equal("No signing credential is configured by the 'IdentityServer:Key' configuration section.", exception.Message);
+        }
+
+        private class MyWebHostEnvironment : IWebHostEnvironment
+        {
+            public string WebRootPath { get; set; }
+            public IFileProvider WebRootFileProvider { get; set; }
+            public string EnvironmentName { get; set; }
+            public string ApplicationName { get; set; }
+            public string ContentRootPath { get; set; }
+            public IFileProvider ContentRootFileProvider { get; set; }
+        }
+
+        private class MyUser
+        {
+            public string Id { get; set; }
+        }
+
+        private class MyUserContext : DbContext, IPersistedGrantDbContext
+        {
+            public MyUserContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<PersistedGrant> PersistedGrants { get; set; }
+
+            public DbSet<DeviceFlowCodes> DeviceFlowCodes { get; set; }
+
+            public Task<int> SaveChangesAsync()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Identity/ApiAuthorization.IdentityServer/test/Extensions/IdentityServerBuilderConfigurationExtensionsTests.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/test/Extensions/IdentityServerBuilderConfigurationExtensionsTests.cs
@@ -20,6 +20,37 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Extensions
     public static class IdentityServerBuilderConfigurationExtensionsTests
     {
         [Fact]
+        public static void IValidationKeysStore_Service_Resolution_Fails_If_No_Jwt_Handler_Configured()
+        {
+            // Arrange
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string> { ["MyAPI:Profile"] = "API" })
+                .Build();
+
+            IWebHostEnvironment environment = new MyWebHostEnvironment();
+
+            var services = new ServiceCollection()
+                .AddSingleton(configuration)
+                .AddSingleton(environment)
+                .AddOptions();
+
+            services.AddDefaultIdentity<MyUser>();
+
+            services.AddIdentityServer()
+                    .AddApiAuthorization<MyUser, MyUserContext>();
+
+            services.AddAuthentication();
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            // Act and Assert
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => serviceProvider.GetRequiredService<IValidationKeysStore>());
+
+            Assert.Equal("No service for type 'Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration.IIdentityServerJwtDescriptor' has been registered.", exception.Message);
+        }
+
+        [Fact]
         public static void IValidationKeysStore_Service_Resolution_Fails_If_No_Signing_Credential_Configured()
         {
             // Arrange

--- a/src/Identity/Identity.slnf
+++ b/src/Identity/Identity.slnf
@@ -86,7 +86,9 @@
       "src\\Mvc\\Mvc.Testing\\src\\Microsoft.AspNetCore.Mvc.Testing.csproj",
       "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj",
       "src\\Http\\Metadata\\src\\Microsoft.AspNetCore.Metadata.csproj",
-      "src\\Localization\\Abstractions\\src\\Microsoft.Extensions.Localization.Abstractions.csproj"
+      "src\\Localization\\Abstractions\\src\\Microsoft.Extensions.Localization.Abstractions.csproj",
+      "src\\Components\\Web\\src\\Microsoft.AspNetCore.Components.Web.csproj",
+      "src\\Testing\\src\\Microsoft.AspNetCore.Testing.csproj"
     ]
   }
 }


### PR DESCRIPTION
**PR Title**

Fix NullReferenceException if no IdentityServer key configured

**PR Description**

Check that `SigningCredential` is not null when creating `InMemoryValidationKeysStore` to prevent a `NullReferenceException`.

Also fixes up the solution filter file and makes some small refactors I noticed while fixing the issue.

Addresses #32334
