### PR TITLE
Fix UriHelper length calculation when path is empty

### DIFF
--- a/src/Http/Http.Extensions/src/UriHelper.cs
+++ b/src/Http/Http.Extensions/src/UriHelper.cs
@@ -77,12 +77,15 @@ namespace Microsoft.AspNetCore.Http.Extensions
                 queryText.Length +
                 fragmentText.Length;
 
-            if (string.IsNullOrEmpty(pathBaseText) && string.IsNullOrEmpty(pathText))
+            if (string.IsNullOrEmpty(pathText))
             {
-                pathText = "/";
-                length++;
+                if (string.IsNullOrEmpty(pathBaseText))
+                {
+                    pathText = "/";
+                    length++;
+                }
             }
-            else if (pathBaseText.Length > 0 && pathBaseText[^1] == '/')
+            else if (pathBaseText.EndsWith('/'))
             {
                 // If the path string has a trailing slash and the other string has a leading slash, we need
                 // to trim one of them.

--- a/src/Http/Http.Extensions/test/UriHelperTests.cs
+++ b/src/Http/Http.Extensions/test/UriHelperTests.cs
@@ -51,6 +51,7 @@ namespace Microsoft.AspNetCore.Http.Extensions
         [InlineData("http", "example.com", "", "/foo", "?bar=1", "#col=2", "http://example.com/foo?bar=1#col=2")]
         [InlineData("http", "example.com", "/base", "/foo", "?bar=1", "#col=2", "http://example.com/base/foo?bar=1#col=2")]
         [InlineData("http", "example.com", "/base/", "/foo", "?bar=1", "#col=2", "http://example.com/base/foo?bar=1#col=2")]
+        [InlineData("http", "example.com", "/base/", "", "?bar=1", "#col=2", "http://example.com/base/?bar=1#col=2")]
         [InlineData("http", "example.com", "", "", "?bar=1", "#col=2", "http://example.com/?bar=1#col=2")]
         [InlineData("http", "example.com", "", "", "", "#frag?stillfrag/stillfrag", "http://example.com/#frag?stillfrag/stillfrag")]
         [InlineData("http", "example.com", "", "", "?q/stillq", "#frag?stillfrag/stillfrag", "http://example.com/?q/stillq#frag?stillfrag/stillfrag")]


### PR DESCRIPTION
#29448 regressed the `pathBase ends with a slash && path is empty` case in `UriHelper`.

```c#
UriHelper.BuildAbsolute("http", new HostString("example.com"), pathBase: "/", path: "");
```

It would end up substracting 1 from the length even if the path was empty.
The operation throws as the allocated string is too short.