### PR TITLE
Configurable SPA console output for stdout WaitForMatch 

### DIFF
--- a/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
@@ -31,6 +31,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
             var pkgManagerCommand = spaBuilder.Options.PackageManagerCommand;
             var sourcePath = spaBuilder.Options.SourcePath;
             var devServerPort = spaBuilder.Options.DevServerPort;
+            var waitForLine = spaBuilder.Options.WaitForConsoleLine;
             if (string.IsNullOrEmpty(sourcePath))
             {
                 throw new ArgumentException("Cannot be null or empty", nameof(sourcePath));
@@ -46,7 +47,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
             var applicationStoppingToken = appBuilder.ApplicationServices.GetRequiredService<IHostApplicationLifetime>().ApplicationStopping;
             var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
             var diagnosticSource = appBuilder.ApplicationServices.GetRequiredService<DiagnosticSource>();
-            var angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, scriptName, pkgManagerCommand, devServerPort, logger, diagnosticSource, applicationStoppingToken);
+            var angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, scriptName, pkgManagerCommand, devServerPort, waitForLine, logger, diagnosticSource, applicationStoppingToken);
 
             SpaProxyingExtensions.UseProxyToSpaDevelopmentServer(spaBuilder, () =>
             {
@@ -61,7 +62,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
         }
 
         private static async Task<Uri> StartAngularCliServerAsync(
-            string sourcePath, string scriptName, string pkgManagerCommand, int portNumber, ILogger logger, DiagnosticSource diagnosticSource, CancellationToken applicationStoppingToken)
+            string sourcePath, string scriptName, string pkgManagerCommand, int portNumber, string waitForLine, ILogger logger, DiagnosticSource diagnosticSource, CancellationToken applicationStoppingToken)
         {
             if (portNumber == default(int))
             {
@@ -79,7 +80,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 try
                 {
                     openBrowserLine = await scriptRunner.StdOut.WaitForMatch(
-                        new Regex("open your browser on (http\\S+)", RegexOptions.None, RegexMatchTimeout));
+                        new Regex(waitForLine ?? "open your browser on (http\\S+)", RegexOptions.None, RegexMatchTimeout));
                 }
                 catch (EndOfStreamException ex)
                 {

--- a/src/Middleware/Spa/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
@@ -32,6 +32,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
             var pkgManagerCommand = spaBuilder.Options.PackageManagerCommand;
             var sourcePath = spaBuilder.Options.SourcePath;
             var devServerPort = spaBuilder.Options.DevServerPort;
+            var waitForLine = spaBuilder.Options.WaitForConsoleLine;
             if (string.IsNullOrEmpty(sourcePath))
             {
                 throw new ArgumentException("Cannot be null or empty", nameof(sourcePath));
@@ -47,7 +48,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
             var applicationStoppingToken = appBuilder.ApplicationServices.GetRequiredService<IHostApplicationLifetime>().ApplicationStopping;
             var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
             var diagnosticSource = appBuilder.ApplicationServices.GetRequiredService<DiagnosticSource>();
-            var portTask = StartCreateReactAppServerAsync(sourcePath, scriptName, pkgManagerCommand, devServerPort, logger, diagnosticSource, applicationStoppingToken);
+            var portTask = StartCreateReactAppServerAsync(sourcePath, scriptName, pkgManagerCommand, devServerPort, waitForLine, logger, diagnosticSource, applicationStoppingToken);
 
             // Everything we proxy is hardcoded to target http://localhost because:
             // - the requests are always from the local machine (we're not accepting remote
@@ -70,7 +71,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
         }
 
         private static async Task<int> StartCreateReactAppServerAsync(
-            string sourcePath, string scriptName, string pkgManagerCommand, int portNumber, ILogger logger, DiagnosticSource diagnosticSource, CancellationToken applicationStoppingToken)
+            string sourcePath, string scriptName, string pkgManagerCommand, int portNumber, string waitForLine, ILogger logger, DiagnosticSource diagnosticSource, CancellationToken applicationStoppingToken)
         {
             if (portNumber == default(int))
             {
@@ -96,7 +97,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                     // no compiler warnings. So instead of waiting for that, consider it ready as soon
                     // as it starts listening for requests.
                     await scriptRunner.StdOut.WaitForMatch(
-                        new Regex("Starting the development server", RegexOptions.None, RegexMatchTimeout));
+                        new Regex(waitForLine ?? "Starting the development server", RegexOptions.None, RegexMatchTimeout));
                 }
                 catch (EndOfStreamException ex)
                 {

--- a/src/Middleware/Spa/SpaServices.Extensions/src/SpaOptions.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/SpaOptions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.SpaServices
         /// <summary>
         /// Gets or sets what console output line to wait for to determine if the spa server host is running properly.
         /// </summary>
-        public string WaitForConsoleLine { get; set; }
+        public string? WaitForConsoleLine { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the package manager executable, (e.g npm,

--- a/src/Middleware/Spa/SpaServices.Extensions/src/SpaOptions.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/SpaOptions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.SpaServices
             DefaultPageStaticFileOptions = copyFromOptions.DefaultPageStaticFileOptions;
             SourcePath = copyFromOptions.SourcePath;
             DevServerPort = copyFromOptions.DevServerPort;
+            WaitForConsoleLine = copyFromOptions.WaitForConsoleLine;
         }
 
         /// <summary>
@@ -75,6 +76,11 @@ namespace Microsoft.AspNetCore.SpaServices
         /// Controls whether the development server should be used with a dynamic or fixed port.
         /// </summary>
         public int DevServerPort { get; set; } = default(int);
+
+        /// <summary>
+        /// Gets or sets what console output line to wait for to determine if the spa server host is running properly.
+        /// </summary>
+        public string WaitForConsoleLine { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the package manager executable, (e.g npm,


### PR DESCRIPTION
The spa extensions are using hard coded values that, in general, are safe to use but there are edge cases where the output won't match.  Switched to, optionally, using a variable in SpaOptions variable to make code work in edge cases.