### PR TITLE
[SignalR] Close connection on auth expiration

### DIFF
--- a/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
+++ b/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
@@ -69,9 +69,14 @@ namespace Microsoft.AspNetCore.Authorization.Policy
                 }
             }
 
-            return (context.User?.Identity?.IsAuthenticated ?? false)
-                ? AuthenticateResult.Success(new AuthenticationTicket(context.User, "context.User"))
-                : AuthenticateResult.NoResult();
+            return context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult ?? DefaultAuthenticateResult(context);
+
+            static AuthenticateResult DefaultAuthenticateResult(HttpContext context)
+            {
+                return (context.User?.Identity?.IsAuthenticated ?? false)
+                    ? AuthenticateResult.Success(new AuthenticationTicket(context.User, "context.User"))
+                    : AuthenticateResult.NoResult();
+            }
         }
 
         /// <summary>

--- a/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
+++ b/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
@@ -69,6 +69,7 @@ namespace Microsoft.AspNetCore.Authorization.Policy
                 }
             }
 
+            // No modifications made to the HttpContext so let's use the existing result if it exists
             return context.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult ?? DefaultAuthenticateResult(context);
 
             static AuthenticateResult DefaultAuthenticateResult(HttpContext context)

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Threading;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Microsoft.AspNetCore.Http.Connections
@@ -93,6 +94,15 @@ namespace Microsoft.AspNetCore.Http.Connections
                 TransportSendTimeoutTicks = value.Ticks;
             }
         }
+
+        /// <summary>
+        /// Authenticated connections that set the <see cref="AuthenticationProperties.ExpiresUtc"/> value will be closed
+        /// and allowed to reconnect when the token expires.
+        /// </summary>
+        /// <remarks>
+        /// Closed connections will not see messages sent while closed.
+        /// </remarks>
+        public bool EnableAuthenticationExpiration { get; set; }
 
         internal long TransportSendTimeoutTicks { get; private set; }
         internal bool TransportSendTimeoutEnabled => _transportSendTimeout != Timeout.InfiniteTimeSpan;

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -96,11 +96,11 @@ namespace Microsoft.AspNetCore.Http.Connections
         }
 
         /// <summary>
-        /// Authenticated connections that set the <see cref="AuthenticationProperties.ExpiresUtc"/> value will be closed
+        /// Authenticated connections whose token sets the <see cref="AuthenticationProperties.ExpiresUtc"/> value will be closed
         /// and allowed to reconnect when the token expires.
         /// </summary>
         /// <remarks>
-        /// Closed connections will not see messages sent while closed.
+        /// Closed connections will miss messages sent while closed.
         /// </remarks>
         public bool EnableAuthenticationExpiration { get; set; }
 

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         /// <remarks>
         /// Closed connections will miss messages sent while closed.
         /// </remarks>
-        public bool EnableAuthenticationExpiration { get; set; }
+        public bool CloseOnAuthenticationExpiration { get; set; }
 
         internal long TransportSendTimeoutTicks { get; private set; }
         internal bool TransportSendTimeoutEnabled => _transportSendTimeout != Timeout.InfiniteTimeSpan;

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -619,7 +619,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             }
         }
 
-        // TODO: Log here or in HttpConnectionManager
         public void RequestClose()
         {
             ThreadPool.UnsafeQueueUserWorkItem(cts => ((CancellationTokenSource)cts!).Cancel(), _connectionClosingTokenSource);

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -621,7 +621,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         public void RequestClose()
         {
-            ThreadPool.UnsafeQueueUserWorkItem(cts => ((CancellationTokenSource)cts!).Cancel(), _connectionCloseRequested);
+            ThreadPool.UnsafeQueueUserWorkItem(static cts => ((CancellationTokenSource)cts!).Cancel(), _connectionCloseRequested);
         }
 
         private static class Log

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -114,10 +114,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         internal DateTimeOffset? AuthenticationExpiration
         {
             get => _authenticationExpiration;
-            set
-            {
-                _authenticationExpiration = value;
-            }
+            set => _authenticationExpiration = value;
         }
 
         public Task? TransportTask { get; set; }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -43,7 +43,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         private PipeWriterStream _applicationStream;
         private IDuplexPipe _application;
         private IDictionary<object, object?>? _items;
-        private DateTimeOffset? _authorizationExpiration;
+        private DateTimeOffset? _authenticationExpiration;
+        private readonly CancellationTokenSource _connectionClosedTokenSource;
         private readonly CancellationTokenSource _connectionClosingTokenSource;
 
         private CancellationTokenSource? _sendCts;
@@ -110,12 +111,12 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         // Used for LongPolling because we need to create a scope that spans the lifetime of multiple requests on the cloned HttpContext
         internal AsyncServiceScope? ServiceScope { get; set; }
 
-        internal DateTimeOffset? AuthorizationExpiration
+        internal DateTimeOffset? AuthenticationExpiration
         {
-            get => _authorizationExpiration;
+            get => _authenticationExpiration;
             set
             {
-                _authorizationExpiration = value;
+                _authenticationExpiration = value;
             }
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -44,8 +44,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         private IDuplexPipe _application;
         private IDictionary<object, object?>? _items;
         private DateTimeOffset? _authenticationExpiration;
-        private readonly CancellationTokenSource _connectionClosedTokenSource;
-        private readonly CancellationTokenSource _connectionClosingTokenSource;
+        private CancellationTokenSource _connectionClosedTokenSource;
+        private CancellationTokenSource _connectionCloseRequested;
 
         private CancellationTokenSource? _sendCts;
         private bool _activeSend;
@@ -95,8 +95,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             _connectionClosedTokenSource = new CancellationTokenSource();
             ConnectionClosed = _connectionClosedTokenSource.Token;
 
-            _connectionClosingTokenSource = new CancellationTokenSource();
-            ConnectionClosedRequested = _connectionClosingTokenSource.Token;
+            _connectionCloseRequested = new CancellationTokenSource();
+            ConnectionClosedRequested = _connectionCloseRequested.Token;
         }
 
         public CancellationTokenSource? Cancellation { get; set; }
@@ -621,7 +621,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         public void RequestClose()
         {
-            ThreadPool.UnsafeQueueUserWorkItem(cts => ((CancellationTokenSource)cts!).Cancel(), _connectionClosingTokenSource);
+            ThreadPool.UnsafeQueueUserWorkItem(cts => ((CancellationTokenSource)cts!).Cancel(), _connectionCloseRequested);
         }
 
         private static class Log

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -44,8 +44,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         private IDuplexPipe _application;
         private IDictionary<object, object?>? _items;
         private DateTimeOffset? _authenticationExpiration;
-        private CancellationTokenSource _connectionClosedTokenSource;
-        private CancellationTokenSource _connectionCloseRequested;
+        private readonly CancellationTokenSource _connectionClosedTokenSource;
+        private readonly CancellationTokenSource _connectionCloseRequested;
 
         private CancellationTokenSource? _sendCts;
         private bool _activeSend;

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         private PipeWriterStream _applicationStream;
         private IDuplexPipe _application;
         private IDictionary<object, object?>? _items;
-        private DateTimeOffset? _authenticationExpiration;
         private readonly CancellationTokenSource _connectionClosedTokenSource;
         private readonly CancellationTokenSource _connectionCloseRequested;
 
@@ -97,6 +96,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             _connectionCloseRequested = new CancellationTokenSource();
             ConnectionClosedRequested = _connectionCloseRequested.Token;
+            AuthenticationExpiration = DateTimeOffset.MaxValue;
         }
 
         public CancellationTokenSource? Cancellation { get; set; }
@@ -111,11 +111,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         // Used for LongPolling because we need to create a scope that spans the lifetime of multiple requests on the cloned HttpContext
         internal AsyncServiceScope? ServiceScope { get; set; }
 
-        internal DateTimeOffset? AuthenticationExpiration
-        {
-            get => _authenticationExpiration;
-            set => _authenticationExpiration = value;
-        }
+        internal DateTimeOffset AuthenticationExpiration { get; set; }
+
+        internal bool IsAuthenticationExpirationEnabled => _options.CloseOnAuthenticationExpiration;
 
         public Task? TransportTask { get; set; }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -11,6 +11,7 @@ using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Connections.Internal.Transports;
 using Microsoft.AspNetCore.Http.Features;
@@ -567,14 +568,16 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             // Setup the connection state from the http context
             connection.User = connection.HttpContext?.User;
 
-            if (connection.HttpContext is not null)
-            {
-                // TODO: Check if auth is being used for endpoint
-                // TODO: Get auth scheme
+            // TODO: option to enable/disable this
+            var authorizeAttribute = connection.HttpContext?.GetEndpoint()?.Metadata.GetMetadata<AuthorizeAttribute>();
 
-                // AuthenticateResult should be cached since the context has already been authenticated. This is just to get the AuthenticateResult
-                var authResult = await connection.HttpContext.AuthenticateAsync();
-                connection.AuthorizationExpiration = authResult.Properties?.ExpiresUtc;
+            // Don't check token if the endpoint doesn't have authorization applied to it
+            if (authorizeAttribute is not null)
+            {
+                // AuthenticateResult should be cached since the context has already been authenticated.
+                // This is just to get the AuthenticateResult
+                var authResult = await connection.HttpContext!.AuthenticateAsync(authorizeAttribute.AuthenticationSchemes);
+                connection.AuthenticationExpiration = authResult.Properties?.ExpiresUtc;
             }
 
             // Set the Connection ID on the logging scope so that logs from now on will have the

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -568,7 +568,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             // Setup the connection state from the http context
             connection.User = connection.HttpContext?.User;
 
-            UpdateExpiration(connection, context);
+            if (options.EnableAuthenticationExpiration)
+            {
+                UpdateExpiration(connection, context);
+            }
 
             // Set the Connection ID on the logging scope so that logs from now on will have the
             // Connection ID metadata set.
@@ -579,7 +582,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         private static void UpdateExpiration(HttpConnectionContext connection, HttpContext context)
         {
-            // TODO: option to enable/disable this
             var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
 
             if (authenticateResultFeature is not null)

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -10,6 +10,7 @@ using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Connections.Internal.Transports;
 using Microsoft.AspNetCore.Http.Features;
@@ -565,6 +566,16 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             // Setup the connection state from the http context
             connection.User = connection.HttpContext?.User;
+
+            if (connection.HttpContext is not null)
+            {
+                // TODO: Check if auth is being used for endpoint
+                // TODO: Get auth scheme
+
+                // AuthenticateResult should be cached since the context has already been authenticated. This is just to get the AuthenticateResult
+                var authResult = await connection.HttpContext.AuthenticateAsync();
+                connection.AuthorizationExpiration = authResult.Properties?.ExpiresUtc;
+            }
 
             // Set the Connection ID on the logging scope so that logs from now on will have the
             // Connection ID metadata set.

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -568,10 +568,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             // Setup the connection state from the http context
             connection.User = connection.HttpContext?.User;
 
-            if (options.EnableAuthenticationExpiration)
-            {
-                UpdateExpiration(connection, context);
-            }
+            UpdateExpiration(connection, context);
 
             // Set the Connection ID on the logging scope so that logs from now on will have the
             // Connection ID metadata set.
@@ -586,7 +583,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             if (authenticateResultFeature is not null)
             {
-                connection.AuthenticationExpiration = authenticateResultFeature.AuthenticateResult?.Properties?.ExpiresUtc;
+                connection.AuthenticationExpiration =
+                    authenticateResultFeature.AuthenticateResult?.Properties?.ExpiresUtc ?? DateTimeOffset.MaxValue;
             }
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.Log.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.Log.cs
@@ -38,6 +38,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             private static readonly Action<ILogger, Exception?> _heartbeatEnded =
                 LoggerMessage.Define(LogLevel.Trace, new EventId(10, "HeartBeatEnded"), "Ending connection heartbeat.");
 
+            private static readonly Action<ILogger, string, Exception?> _authenticationExpired =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(10, "AuthenticationExpired"), "Connection {TransportConnectionId} closing because the authentication token has expired.");
+
             public static void CreatedNewConnection(ILogger logger, string connectionId)
             {
                 _createdNewConnection(logger, connectionId, null);
@@ -76,6 +79,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             public static void HeartBeatEnded(ILogger logger)
             {
                 _heartbeatEnded(logger, null);
+            }
+
+            public static void AuthenticationExpired(ILogger logger, string connectionId)
+            {
+                _authenticationExpired(logger, connectionId, null);
             }
         }
     }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.Log.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.Log.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 LoggerMessage.Define(LogLevel.Trace, new EventId(10, "HeartBeatEnded"), "Ending connection heartbeat.");
 
             private static readonly Action<ILogger, string, Exception?> _authenticationExpired =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(10, "AuthenticationExpired"), "Connection {TransportConnectionId} closing because the authentication token has expired.");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(11, "AuthenticationExpired"), "Connection {TransportConnectionId} closing because the authentication token has expired.");
 
             public static void CreatedNewConnection(ILogger logger, string connectionId)
             {

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                     // Tick the heartbeat, if the connection is still active
                     connection.TickHeartbeat();
 
-                    if (connection.AuthorizationExpiration < utcNow)
+                    if (connection.AuthenticationExpiration < utcNow)
                     {
                         // TODO: Call DisposeAndRemoveAsync after this?
                         // TODO: Log here or in HttpConnectionContext

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -170,7 +170,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                     // Tick the heartbeat, if the connection is still active
                     connection.TickHeartbeat();
 
-                    if (connection.AuthenticationExpiration < utcNow)
+                    if (connection.AuthenticationExpiration < utcNow && !connection.ConnectionClosedRequested.IsCancellationRequested)
                     {
                         Log.AuthenticationExpired(_logger, connection.ConnectionId);
                         connection.RequestClose();

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -172,8 +172,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                     if (connection.AuthenticationExpiration < utcNow)
                     {
-                        // TODO: Call DisposeAndRemoveAsync after this?
-                        // TODO: Log here or in HttpConnectionContext
+                        Log.AuthenticationExpired(_logger, connection.ConnectionId);
                         connection.RequestClose();
                     }
                 }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -169,6 +169,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                     // Tick the heartbeat, if the connection is still active
                     connection.TickHeartbeat();
+
+                    if (connection.AuthorizationExpiration < utcNow)
+                    {
+                        // TODO: Call DisposeAndRemoveAsync after this?
+                        // TODO: Log here or in HttpConnectionContext
+                        connection.RequestClose();
+                    }
                 }
             }
         }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -170,7 +170,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                     // Tick the heartbeat, if the connection is still active
                     connection.TickHeartbeat();
 
-                    if (connection.AuthenticationExpiration < utcNow && !connection.ConnectionClosedRequested.IsCancellationRequested)
+                    if (connection.IsAuthenticationExpirationEnabled && connection.AuthenticationExpiration < utcNow &&
+                        !connection.ConnectionClosedRequested.IsCancellationRequested)
                     {
                         Log.AuthenticationExpired(_logger, connection.ConnectionId);
                         connection.RequestClose();

--- a/src/SignalR/common/Http.Connections/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/Http.Connections/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 *REMOVED*Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext!
 Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext?
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.EnableAuthenticationExpiration.get -> bool
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.EnableAuthenticationExpiration.set -> void
 Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.TransportSendTimeout.get -> System.TimeSpan
 Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.TransportSendTimeout.set -> void

--- a/src/SignalR/common/Http.Connections/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/common/Http.Connections/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 *REMOVED*Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext!
 Microsoft.AspNetCore.Http.Connections.Features.IHttpContextFeature.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext?
-Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.EnableAuthenticationExpiration.get -> bool
-Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.EnableAuthenticationExpiration.set -> void
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.CloseOnAuthenticationExpiration.get -> bool
+Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.CloseOnAuthenticationExpiration.set -> void
 Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.TransportSendTimeout.get -> System.TimeSpan
 Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions.TransportSendTimeout.set -> void

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -2875,8 +2875,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
         [InlineData(HttpTransportType.WebSockets)]
         public async Task AuthenticationExpirationUsesCorrectScheme(HttpTransportType transportType)
         {
-            SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(Guid.NewGuid().ToByteArray());
-            JwtSecurityTokenHandler JwtTokenHandler = new JwtSecurityTokenHandler();
+            var SecurityKey = new SymmetricSecurityKey(Guid.NewGuid().ToByteArray());
+            var JwtTokenHandler = new JwtSecurityTokenHandler();
 
             using var host = CreateHost(services =>
                 {
@@ -3126,10 +3126,9 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                         configureServices(services);
                         services.AddAuthorization();
 
-                        // Since tests run in parallel, it's possible multiple servers will startup and read files being written by another test
-                        // Use a unique directory per server to avoid this collision
-                        services.AddDataProtection()
-                            .PersistKeysToFileSystem(Directory.CreateDirectory(Path.GetRandomFileName()));
+                        // Since tests run in parallel, it's possible multiple servers will startup,
+                        // we use an ephemeral key provider to avoid filesystem contention issues
+                        services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
                     })
                     .Configure(app =>
                     {

--- a/src/SignalR/common/Http.Connections/test/Microsoft.AspNetCore.Http.Connections.Tests.csproj
+++ b/src/SignalR/common/Http.Connections/test/Microsoft.AspNetCore.Http.Connections.Tests.csproj
@@ -16,8 +16,12 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.Core" />
+    <Reference Include="Microsoft.AspNetCore.Authentication" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.AspNetCore.Cors" />
     <Reference Include="Microsoft.AspNetCore.Http.Connections" />
+    <Reference Include="Microsoft.AspNetCore.Http.Connections.Client" />
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Newtonsoft.Json" />
   </ItemGroup>

--- a/src/SignalR/samples/JwtSample/Startup.cs
+++ b/src/SignalR/samples/JwtSample/Startup.cs
@@ -69,6 +69,7 @@ namespace JwtSample
             app.UseFileServer();
 
             app.UseRouting();
+            app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.SignalR
 
             if (connectionContext.Features.Get<IConnectionLifetimeNotificationFeature>() is IConnectionLifetimeNotificationFeature lifetimeNotification)
             {
-                // This feature is used by HttpConnectionManager to gracefully close the connection on authentication expiration
+                // This feature is used by HttpConnectionManager to close the connection with a non-errored closed message on authentication expiration.
                 _closedRequestedRegistration = lifetimeNotification.ConnectionClosedRequested.Register(static (state) => ((HubConnectionContext)state!).AbortAllowReconnect(), this);
             }
 

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -2284,8 +2284,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     var close = Assert.IsType<CloseMessage>(await client.ReadAsync().DefaultTimeout());
 
                     Assert.True(close.AllowReconnect);
-                    // TODO: error message?
-                    Assert.Equal("", close.Error);
 
                     client.Dispose();
 


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/5297

Open questions:
* ~~If expiration of token happens, can we first run auth again to check if the token hasn't had its expiry updated?~~
* What sort of hooks are there in auth to set expiration in case some 3rd party library doesn't set the ExpiresUtc property?

```diff
public class HttpConnectionDispatcherOptions
{
+    bool EnableAuthenticationExpiration { get; set; }
}
```