### PR TITLE
Temporarily disable RSG for Wasm.Performance.TestApp

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
@@ -8,6 +8,7 @@
       Clien caching isn't part of our performance measurement, so we'll skip it.
     -->
     <BlazorCacheBootResources>false</BlazorCacheBootResources>
+    <_UseRazorSourceGenerator>false</_UseRazorSourceGenerator>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Trying this out since the SDK update is blocked on an external issue.

If it doesn't work, it'll at least point to where the issue might be in the compiler.