### PR TITLE
Use unique directory for parallel tests

### DIFF
--- a/src/Components/test/testassets/TestServer/ServerStartup.cs
+++ b/src/Components/test/testassets/TestServer/ServerStartup.cs
@@ -23,6 +23,11 @@ namespace TestServer
             services.AddMvc();
             services.AddServerSideBlazor();
             services.AddSingleton<ResourceRequestLog>();
+
+            // Since tests run in parallel, it's possible multiple servers will startup and read files being written by another test
+            // Use a unique directory per server to avoid this collision
+            services.AddDataProtection()
+                .PersistKeysToFileSystem(Directory.CreateDirectory(Path.GetRandomFileName()));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Components/test/testassets/TestServer/ServerStartup.cs
+++ b/src/Components/test/testassets/TestServer/ServerStartup.cs
@@ -24,10 +24,9 @@ namespace TestServer
             services.AddServerSideBlazor();
             services.AddSingleton<ResourceRequestLog>();
 
-            // Since tests run in parallel, it's possible multiple servers will startup and read files being written by another test
-            // Use a unique directory per server to avoid this collision
-            services.AddDataProtection()
-                .PersistKeysToFileSystem(Directory.CreateDirectory(Path.GetRandomFileName()));
+            // Since tests run in parallel, we use an ephemeral key provider to avoid filesystem
+            // contention issues.
+            services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Components/test/testassets/TestServer/ServerStartup.cs
+++ b/src/Components/test/testassets/TestServer/ServerStartup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Resolves some issues with parallel test runs and data protection keys in the server tests.

```
System.Exception : 1 error(s) logged.\r\nMicrosoft.AspNetCore.DataProtection.KeyManagement.KeyRingProvider - ErrorOccurredWhileReadingKeyRing - An error occurred while reading the key ring.\r\n===================\r\nSystem.IO.IOException: The process cannot access the file 'C:\\Users\\vsagent\\AppData\\Local\\ASP.NET\\DataProtection-Keys\\key-1a9fc521-1369-4d85-afb2-62e55b474fdf.xml' because it is being used by another process.
```

See https://github.com/dotnet/aspnetcore/issues/19666#issuecomment-832815285.