### PR TITLE
Move `System.ComponentModel.Annotations` To Manual Dependency Update

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -185,10 +185,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>65020c946254c9a99497f4fdfa4136131f51f913</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Annotations" Version="6.0.0-preview.5.21227.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>6cde32922e8329c75b2db3e028c7b80b11afd0a8</Sha>
-    </Dependency>
     <Dependency Name="System.Diagnostics.DiagnosticSource" Version="6.0.0-preview.5.21254.12">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>65020c946254c9a99497f4fdfa4136131f51f913</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -111,7 +111,6 @@
     <MicrosoftExtensionsOptionsVersion>6.0.0-preview.5.21254.12</MicrosoftExtensionsOptionsVersion>
     <MicrosoftExtensionsPrimitivesVersion>6.0.0-preview.5.21254.12</MicrosoftExtensionsPrimitivesVersion>
     <MicrosoftAspNetCoreInternalTransportVersion>6.0.0-preview.5.21254.12</MicrosoftAspNetCoreInternalTransportVersion>
-    <SystemComponentModelAnnotationsVersion>6.0.0-preview.5.21227.1</SystemComponentModelAnnotationsVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>6.0.0-preview.5.21254.12</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemDiagnosticsEventLogVersion>6.0.0-preview.5.21254.12</SystemDiagnosticsEventLogVersion>
     <SystemDirectoryServicesProtocolsVersion>6.0.0-preview.5.21254.12</SystemDirectoryServicesProtocolsVersion>
@@ -208,6 +207,7 @@
     <SystemIdentityModelTokensJwtVersion>6.10.0</SystemIdentityModelTokensJwtVersion>
     <NuGetVersioningVersion>5.10.0-preview.2.7203</NuGetVersioningVersion>
     <NuGetFrameworksVersion>5.10.0-preview.2.7203</NuGetFrameworksVersion>
+    <SystemComponentModelAnnotationsVersion>6.0.0-preview.5.21227.1</SystemComponentModelAnnotationsVersion>
     <SystemNetExperimentalMsQuicVersion>5.0.0-alpha.20560.6</SystemNetExperimentalMsQuicVersion>
     <!-- Packages from 2.1, 3.1, and 5.0 branches used for site extension build. -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>


### PR DESCRIPTION
It's not possible to remove this dependency (https://github.com/dotnet/aspnetcore/pull/32447) so making it so we no longer try to automatically update it. With automated updates enabled, it's leading to a 'stale' dependency tree as this package uses a commit that's different from the rest of our dotnet/runtime ingestion.