### PR TITLE
Explicitly set packable for spec tests

### DIFF
--- a/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -13,7 +13,6 @@
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Logging" />
-    <Reference Include="Microsoft.AspNetCore.Testing" />
     <Reference Include="xunit.assert" />
     <Reference Include="xunit.extensibility.core" />
     <Reference Include="xunit.analyzers" PrivateAssets="All" />

--- a/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageTags>aspnetcore;identity;membership</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #27873

Description
This package is a collection of tests which we have shipped which allows customers who have implemented their own identity stores to verify that their stores behave as expected. Our quarantine process introduced some internal dependencies to this package during 5.0, which resulted in us no longer shipping this package.

Customer impact
Customers were relying on using this library to ensure that their implementations worked against our identity manager implementations.

Regression
Yes. Regression from 3.2

Risk
Low. We currently run our CI tests against this package, this just allows customers to once again be able to run our tests on their CI builds.