### PR TITLE
[5.0] HTTP/2: Ignore additional RST_STREAM frames sent to stream

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -718,8 +718,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                 // Second reset
                 if (stream.RstStreamReceived)
                 {
-                    // Hard abort, do not allow any more frames on this stream.
-                    throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorStreamAborted(_incomingFrame.Type, stream.StreamId), Http2ErrorCode.STREAM_CLOSED);
+                    // https://tools.ietf.org/html/rfc7540#section-5.1
+                    // If RST_STREAM has already been received then the stream is in a closed state.
+                    // Additional frames (other than PRIORITY) are a stream error.
+                    // The server will usually send a RST_STREAM for a stream error, but RST_STREAM
+                    // shouldn't be sent in response to RST_STREAM to avoid a loop. 
+                    // The best course of action here is to do nothing.
+                    return Task.CompletedTask;
                 }
 
                 // No additional inbound header or data frames are allowed for this stream after receiving a reset.

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3048,7 +3048,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public async Task RST_STREAM_IncompleteRequest_AdditionalResetFrame_ConnectionAborted()
+        public async Task RST_STREAM_IncompleteRequest_AdditionalResetFrame_IgnoreAdditionalReset()
         {
             var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -3066,8 +3066,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await SendRstStreamAsync(1);
             tcs.TrySetResult(0);
 
-            await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1,
-                Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.RST_STREAM, 1));
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
         }
 
         [Fact]


### PR DESCRIPTION
## Description
An HTTP/2 client sends multiple RST_STREAM frames for the same stream to Kestrel (this is a spec violation by the client, but the client's violation is exposing a violation in Kestrel)

If both RST_STREAM frames are read from the transport at the same time, Kestrel is incorrectly killing the collection. Kestrel is violating the HTTP/2 specification.

The correct logic is to ignore the second RST_STREAM frame. PR corrects that logic.

This PR takes the changes in https://github.com/dotnet/aspnetcore/pull/32449 and backports them to 5.0

## Customer Impact
Customer using gRPC Java client to call Kestrel. Kestrel is ending the connection when this bug occurs, causing the customer app to break.

https://github.com/dotnet/aspnetcore/pull/32449#issuecomment-833290327

It is unlikely that this bug impacts many people. An HTTP/2 client that violates the spec and the right situation is required to encounter it.

## Regression?
- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Low risk. The connection error on receiving the second RST_STREAM frame is replaced with an ignore. This makes Kestrel match the HTTP/2 spec.

## Verification
- [x] Manual (required)
- [x] Automated

Manually verifying this would be tough. It would require setting up Java client and replicating its code. Might need to ask the customer to retest with 6.0 daily build that contains the fix.

Update: Customer has verified fix using .NET 6 - https://github.com/dotnet/aspnetcore/pull/32478#issuecomment-834266541

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/32442
