### PR TITLE
Backport #32277 to 3.1

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -323,7 +323,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   }
 
   $msbuildVersionDir = if ([int]$vsMajorVersion -lt 16) { "$vsMajorVersion.0" } else { "Current" }
-  return $global:_MSBuildExe = Join-Path $vsInstallDir "MSBuild\$msbuildVersionDir\Bin\msbuild.exe"
+  return $global:_MSBuildExe = Join-Path $vsInstallDir "MSBuild\$msbuildVersionDir\Bin\amd64\msbuild.exe"
 }
 
 function InitializeVisualStudioEnvironmentVariables([string] $vsInstallDir, [string] $vsMajorVersion) {

--- a/src/Mvc/Mvc.ViewFeatures/src/Buffers/ViewBufferTextWriter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Buffers/ViewBufferTextWriter.cs
@@ -110,14 +110,19 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
                 throw new ArgumentNullException(nameof(buffer));
             }
 
-            if (index < 0 || index >= buffer.Length)
+            if (index < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            if (count < 0 || (buffer.Length - index < count))
+            if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            if (buffer.Length - index < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(buffer.Length));
             }
 
             Buffer.AppendHtml(new string(buffer, index, count));

--- a/src/Mvc/Mvc.ViewFeatures/test/Buffers/ViewBufferTextWriterTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Buffers/ViewBufferTextWriterTest.cs
@@ -125,6 +125,22 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers
         }
 
         [Fact]
+        public void Write_WritesEmptyCharBuffer()
+        {
+            // Arrange
+            var buffer = new ViewBuffer(new TestViewBufferScope(), "some-name", pageSize: 4);
+            var writer = new ViewBufferTextWriter(buffer, Encoding.UTF8);
+            var charBuffer = new char[0];
+
+            // Act
+            writer.Write(charBuffer, 0, 0);
+
+            // Assert
+            var actual = GetValues(buffer);
+            Assert.Equal<object>(new[] { string.Empty }, actual);
+        }
+
+        [Fact]
         public async Task Write_WritesStringBuffer()
         {
             // Arrange


### PR DESCRIPTION
## Description
Update guard logic to permit writing 0 length buffers. This can happen in certain globalized scenarios (ex. `¿` with Portugese) where the first char needs to be encoded.

Patch https://github.com/dotnet/aspnetcore/issues/31299 for 3.1 by cherry-picking the https://github.com/dotnet/aspnetcore/pull/32277 squash commit.


## Customer Impact
Writing 0-length char buffers leads to an ArgumentOutOfRangeException. This may occur in a globalization context with certain chars such as `¿`.

https://github.com/dotnet/aspnetcore/issues/31299#issuecomment-833078949

Also impacts Orchard: https://github.com/dotnet/aspnetcore/issues/31299#issue-842325059


## Regression?
- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Low risk as we've just updated the logic slightly to permit 0 length buffers.

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/31299
