### PR TITLE
Downgrade System.ComponentModel.Annotations to 5.0.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -207,7 +207,7 @@
     <SystemIdentityModelTokensJwtVersion>6.10.0</SystemIdentityModelTokensJwtVersion>
     <NuGetVersioningVersion>5.10.0-preview.2.7203</NuGetVersioningVersion>
     <NuGetFrameworksVersion>5.10.0-preview.2.7203</NuGetFrameworksVersion>
-    <SystemComponentModelAnnotationsVersion>6.0.0-preview.5.21227.1</SystemComponentModelAnnotationsVersion>
+    <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemNetExperimentalMsQuicVersion>5.0.0-alpha.20560.6</SystemNetExperimentalMsQuicVersion>
     <!-- Packages from 2.1, 3.1, and 5.0 branches used for site extension build. -->
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>2.1.1</MicrosoftAspNetCoreAzureAppServicesSiteExtension21Version>


### PR DESCRIPTION
Based on discussion in https://github.com/dotnet/aspnetcore/pull/32468 due to dead-ending in https://github.com/dotnet/runtime/pull/51891

