### PR TITLE
Refactor WebAssemblyHotReload to use the agent code from the SDK

### DIFF
--- a/src/Components/Components/src/HotReload/HotReloadManager.cs
+++ b/src/Components/Components/src/HotReload/HotReloadManager.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using System.Reflection.Metadata;
 using Microsoft.AspNetCore.Components.HotReload;
 
-[assembly: AssemblyMetadata("ReceiveHotReloadDeltaNotification", "Microsoft.AspNetCore.Components.HotReload.HotReloadManager")]
 [assembly: MetadataUpdateHandler(typeof(HotReloadManager))]
 
 namespace Microsoft.AspNetCore.Components.HotReload
@@ -20,6 +18,6 @@ namespace Microsoft.AspNetCore.Components.HotReload
             OnDeltaApplied?.Invoke();
         }
 
-        public static void AfterUpdate(Type[]? _) => OnDeltaApplied?.Invoke();
+        public static void UpdateApplication(Type[]? _) => OnDeltaApplied?.Invoke();
     }
 }

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/HotReloadAgent.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/HotReloadAgent.cs
@@ -1,0 +1,218 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Based on the implementation in https://raw.githubusercontent.com/dotnet/sdk/f67f46eba6d3bcf2b3054381851a975096652454/src/BuiltInTools/DotNetDeltaApplier/HotReloadAgent.cs
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Extensions.HotReload
+{
+    internal sealed class HotReloadAgent : IDisposable
+    {
+        private readonly Action<string> _log;
+        private readonly AssemblyLoadEventHandler _assemblyLoad;
+        private readonly ConcurrentDictionary<Guid, IReadOnlyList<UpdateDelta>> _deltas = new();
+        private readonly ConcurrentDictionary<Assembly, Assembly> _appliedAssemblies = new();
+        private volatile UpdateHandlerActions? _handlerActions;
+
+        public HotReloadAgent(Action<string> log)
+        {
+            _log = log;
+            _assemblyLoad = OnAssemblyLoad;
+            AppDomain.CurrentDomain.AssemblyLoad += _assemblyLoad;
+        }
+
+        private void OnAssemblyLoad(object? _, AssemblyLoadEventArgs eventArgs)
+        {
+            _handlerActions = null;
+            var loadedAssembly = eventArgs.LoadedAssembly;
+            var moduleId = loadedAssembly.Modules.FirstOrDefault()?.ModuleVersionId;
+            if (moduleId is null)
+            {
+                return;
+            }
+
+            if (_deltas.TryGetValue(moduleId.Value, out var updateDeltas) && _appliedAssemblies.TryAdd(loadedAssembly, loadedAssembly))
+            {
+                // A delta for this specific Module exists and we haven't called ApplyUpdate on this instance of Assembly as yet.
+                ApplyDeltas(updateDeltas);
+            }
+        }
+
+        internal sealed class UpdateHandlerActions
+        {
+            public List<Action<Type[]?>> ClearCache { get; } = new();
+            public List<Action<Type[]?>> UpdateApplication { get; } = new();
+        }
+
+        private UpdateHandlerActions GetMetadataUpdateHandlerActions()
+        {
+            // We need to execute MetadataUpdateHandlers in a well-defined order. For v1, the strategy that is used is to topologically
+            // sort assemblies so that handlers in a dependency are executed before the dependent (e.g. the reflection cache action
+            // in System.Private.CoreLib is executed before System.Text.Json clears it's own cache.)
+            // This would ensure that caches and updates more lower in the application stack are up to date
+            // before ones higher in the stack are recomputed.
+            var sortedAssemblies = TopologicalSort(AppDomain.CurrentDomain.GetAssemblies());
+            var handlerActions = new UpdateHandlerActions();
+            foreach (var assembly in sortedAssemblies)
+            {
+                foreach (var attr in assembly.GetCustomAttributesData())
+                {
+                    // Look up the attribute by name rather than by type. This would allow netstandard targeting libraries to
+                    // define their own copy without having to cross-compile.
+                    if (attr.AttributeType.FullName != "System.Reflection.Metadata.MetadataUpdateHandlerAttribute")
+                    {
+                        continue;
+                    }
+
+                    IList<CustomAttributeTypedArgument> ctorArgs = attr.ConstructorArguments;
+                    if (ctorArgs.Count != 1 ||
+                        ctorArgs[0].Value is not Type handlerType)
+                    {
+                        _log($"'{attr}' found with invalid arguments.");
+                        continue;
+                    }
+
+                    GetHandlerActions(handlerActions, handlerType);
+                }
+            }
+
+            return handlerActions;
+        }
+
+        internal void GetHandlerActions(UpdateHandlerActions handlerActions, Type handlerType)
+        {
+            bool methodFound = false;
+
+            if (GetUpdateMethod(handlerType, "ClearCache") is MethodInfo clearCache)
+            {
+                handlerActions.ClearCache.Add(CreateAction(clearCache));
+                methodFound = true;
+            }
+
+            if (GetUpdateMethod(handlerType, "UpdateApplication") is MethodInfo updateApplication)
+            {
+                handlerActions.UpdateApplication.Add(CreateAction(updateApplication));
+                methodFound = true;
+            }
+
+            if (!methodFound)
+            {
+                _log($"No invokable methods found on metadata handler type '{handlerType}'. " +
+                    $"Allowed methods are ClearCache, UpdateApplication");
+            }
+
+            Action<Type[]?> CreateAction(MethodInfo update)
+            {
+                Action<Type[]?> action = update.CreateDelegate<Action<Type[]?>>();
+                return types =>
+                {
+                    try
+                    {
+                        action(types);
+                    }
+                    catch (Exception ex)
+                    {
+                        _log($"Exception from '{action}': {ex}");
+                    }
+                };
+            }
+
+            MethodInfo? GetUpdateMethod(Type handlerType, string name)
+            {
+                if (handlerType.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, new[] { typeof(Type[]) }) is MethodInfo updateMethod &&
+                    updateMethod.ReturnType == typeof(void))
+                {
+                    return updateMethod;
+                }
+
+                foreach (MethodInfo method in handlerType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance))
+                {
+                    if (method.Name == name)
+                    {
+                        _log($"Type '{handlerType}' has method '{method}' that does not match the required signature.");
+                        break;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        internal static List<Assembly> TopologicalSort(Assembly[] assemblies)
+        {
+            var sortedAssemblies = new List<Assembly>(assemblies.Length);
+
+            var visited = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var assembly in assemblies)
+            {
+                Visit(assemblies, assembly, sortedAssemblies, visited);
+            }
+
+            static void Visit(Assembly[] assemblies, Assembly assembly, List<Assembly> sortedAssemblies, HashSet<string> visited)
+            {
+                var assemblyIdentifier = assembly.GetName().Name!;
+                if (!visited.Add(assemblyIdentifier))
+                {
+                    return;
+                }
+
+                foreach (var dependencyName in assembly.GetReferencedAssemblies())
+                {
+                    var dependency = Array.Find(assemblies, a => a.GetName().Name == dependencyName.Name);
+                    if (dependency is not null)
+                    {
+                        Visit(assemblies, dependency, sortedAssemblies, visited);
+                    }
+                }
+
+                sortedAssemblies.Add(assembly);
+            }
+
+            return sortedAssemblies;
+        }
+
+        public void ApplyDeltas(IReadOnlyList<UpdateDelta> deltas)
+        {
+            try
+            {
+                // Defer discovering the receiving deltas until the first hot reload delta.
+                // This should give enough opportunity for AppDomain.GetAssemblies() to be sufficiently populated.
+                _handlerActions ??= GetMetadataUpdateHandlerActions();
+                var handlerActions = _handlerActions;
+
+                // TODO: Get types to pass in
+                Type[]? updatedTypes = null;
+
+                for (var i = 0; i < deltas.Count; i++)
+                {
+                    var item = deltas[i];
+                    var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.Modules.FirstOrDefault() is Module m && m.ModuleVersionId == item.ModuleId);
+                    if (assembly is not null)
+                    {
+                        System.Reflection.Metadata.AssemblyExtensions.ApplyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
+                    }
+                }
+
+                handlerActions.ClearCache.ForEach(a => a(updatedTypes));
+                handlerActions.UpdateApplication.ForEach(a => a(updatedTypes));
+
+                _log("Deltas applied.");
+            }
+            catch (Exception ex)
+            {
+                _log(ex.ToString());
+            }
+        }
+
+        public void Dispose()
+        {
+            AppDomain.CurrentDomain.AssemblyLoad -= _assemblyLoad;
+        }
+    }
+}

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/UpdateDelta.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/UpdateDelta.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Extensions.HotReload
+{
+    internal sealed class UpdateDelta
+    {
+        public Guid ModuleId { get; set; }
+
+        public byte[] MetadataDelta { get; set; } = default!;
+
+        public byte[] ILDelta { get; set; } = default!;
+    }
+}

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -2,17 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Metadata;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.HotReload;
 using Microsoft.AspNetCore.Components.WebAssembly.Services;
+using Microsoft.Extensions.HotReload;
 using Microsoft.JSInterop;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
@@ -24,39 +19,11 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class WebAssemblyHotReload
     {
-        private static readonly ConcurrentDictionary<Guid, List<(byte[] metadataDelta, byte[] ilDelta)>> _deltas = new();
-        private static readonly ConcurrentDictionary<Assembly, Assembly> _appliedAssemblies = new();
-        private static (List<Action<Type[]?>> BeforeUpdates, List<Action<Type[]?>> AfterUpdates)? _handlerActions;
-
-        static WebAssemblyHotReload()
+        private static HotReloadAgent? _hotReloadAgent;
+        private static UpdateDelta[] _updateDeltas = new[]
         {
-            if (!HotReloadEnvironment.Instance.IsHotReloadEnabled)
-            {
-                return;
-            }
-
-            // An ApplyDelta can be called on an assembly that has not yet been loaded. This is particularly likely
-            // when we're applying deltas on app start and child components are defined in a referenced project.
-            // To account for this, wire up AssemblyLoad
-            AppDomain.CurrentDomain.AssemblyLoad += (_, eventArgs) =>
-            {
-                var loadedAssembly = eventArgs.LoadedAssembly;
-                var moduleId = loadedAssembly.Modules.FirstOrDefault()?.ModuleVersionId;
-                if (moduleId is null)
-                {
-                    return;
-                }
-
-                if (_deltas.TryGetValue(moduleId.Value, out var result) && _appliedAssemblies.TryAdd(loadedAssembly, loadedAssembly))
-                {
-                    // A delta for this specific Module exists and we haven't called ApplyUpdate on this instance of Assembly as yet.
-                    foreach (var (metadataDelta, ilDelta) in CollectionsMarshal.AsSpan(result))
-                    {
-                        ApplyUpdate(loadedAssembly, metadataDelta, ilDelta);
-                    }
-                }
-            };
-        }
+            new UpdateDelta(),
+        };
 
         internal static async Task InitializeAsync()
         {
@@ -64,6 +31,8 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
             {
                 return;
             }
+
+            _hotReloadAgent = new HotReloadAgent(m => Debug.WriteLine(m));
 
             var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "./_framework/blazor-hotreload.js"));
             await jsObjectReference.InvokeUnmarshalled<Task<int>>("receiveHotReload");
@@ -76,109 +45,13 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
         public static void ApplyHotReloadDelta(string moduleIdString, byte[] metadataDelta, byte[] ilDeta)
         {
             var moduleId = Guid.Parse(moduleIdString);
-            var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.Modules.FirstOrDefault() is Module m && m.ModuleVersionId == moduleId);
-
             Debug.Assert(HotReloadEnvironment.Instance.IsHotReloadEnabled);
 
-            if (assembly is not null)
-            {
-                ApplyUpdate(assembly, metadataDelta, ilDeta);
-                _appliedAssemblies.TryAdd(assembly, assembly);
-            }
+            _updateDeltas[0].ModuleId = moduleId;
+            _updateDeltas[0].MetadataDelta = metadataDelta;
+            _updateDeltas[0].ILDelta = ilDeta;
 
-            if (_deltas.TryGetValue(moduleId, out var deltas))
-            {
-                deltas.Add((metadataDelta, ilDeta));
-            }
-            else
-            {
-                _deltas[moduleId] = new List<(byte[], byte[])>(1)
-                {
-                    (metadataDelta, ilDeta)
-                };
-            }
-        }
-
-        private static void ApplyUpdate(Assembly assembly, byte[] metadataDelta, byte[] ilDeta)
-        {
-            _handlerActions ??= GetMetadataUpdateHandlerActions(AppDomain.CurrentDomain.GetAssemblies());
-            var (beforeUpdates, afterUpdates) = _handlerActions.Value;
-
-            beforeUpdates.ForEach(a => a(null));
-            System.Reflection.Metadata.AssemblyExtensions.ApplyUpdate(assembly, metadataDelta, ilDeta, ReadOnlySpan<byte>.Empty);
-            afterUpdates.ForEach(a => a(null));
-        }
-
-        // Internal for unit testing.
-        internal static (List<Action<Type[]?>> BeforeUpdates, List<Action<Type[]?>> AfterUpdates) GetMetadataUpdateHandlerActions(Assembly[] assemblies)
-        {
-            var beforeUpdates = new List<Action<Type[]?>>();
-            var afterUpdates = new List<Action<Type[]?>>();
-
-            foreach (var assembly in assemblies)
-            {
-                foreach (var attribute in assembly.GetCustomAttributes<MetadataUpdateHandlerAttribute>())
-                {
-                    var handlerType = attribute.HandlerType;
-
-                    var methodFound = false;
-                    if (GetUpdateMethod(handlerType, "BeforeUpdate") is MethodInfo beforeUpdate)
-                    {
-                        beforeUpdates.Add(CreateAction(beforeUpdate));
-                        methodFound = true;
-                    }
-
-                    if (GetUpdateMethod(handlerType, "AfterUpdate") is MethodInfo afterUpdate)
-                    {
-                        afterUpdates.Add(CreateAction(afterUpdate));
-                        methodFound = true;
-                    }
-
-                    if (!methodFound)
-                    {
-                        Debug.WriteLine($"No BeforeUpdate or AfterUpdate method found on '{handlerType}'.");
-                    }
-
-                    static Action<Type[]?> CreateAction(MethodInfo update)
-                    {
-                        var action = update.CreateDelegate<Action<Type[]?>>();
-                        return types =>
-                        {
-                            try
-                            {
-                                action(types);
-                            }
-                            catch (Exception ex)
-                            {
-                                Debug.WriteLine($"Exception from '{action}': {ex}");
-                            }
-                        };
-                    }
-                }
-            }
-
-            static MethodInfo? GetUpdateMethod(Type handlerType, string name)
-            {
-                var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
-                var updateMethod = handlerType.GetMethod(name, bindingFlags, new[] { typeof(Type[]) });
-                if (updateMethod is not null)
-                {
-                    return updateMethod;
-                }
-
-                var methods = handlerType.GetMethods(bindingFlags)
-                    .Where(m => m.Name == name)
-                    .ToArray();
-
-                if (methods.Length > 0)
-                {
-                    Debug.WriteLine($"MetadataUpdateHandler type '{handlerType}' has a method named '{name}' that does not match the required signature.");
-                }
-
-                return null;
-            }
-
-            return (beforeUpdates, afterUpdates);
+            _hotReloadAgent!.ApplyDeltas(_updateDeltas);
         }
     }
 }

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.WarningSuppressions.xml
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.WarningSuppressions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <linker>
   <assembly fullname="Microsoft.AspNetCore.Components.WebAssembly, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -17,6 +17,12 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.AspNetCore.Components.Web.WebEventData.ParseEventArgsJson(Microsoft.AspNetCore.Components.RenderTree.Renderer,System.Text.Json.JsonSerializerOptions,System.UInt64,System.String,System.String)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.InitializeRegisteredRootComponents(Microsoft.JSInterop.IJSUnmarshalledRuntime)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -27,15 +33,21 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2070</argument>
+      <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.WebAssembly.HotReload.WebAssemblyHotReload.&lt;GetMetadataUpdateHandlerActions&gt;g__GetUpdateMethod|7_0(System.Type,System.String)</property>
+      <property name="Target">M:Microsoft.AspNetCore.Components.WebAssemblyComponentParameterDeserializer.DeserializeParameters(System.Collections.Generic.IList{Microsoft.AspNetCore.Components.ComponentParameter},System.Collections.Generic.IList{System.Object})</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.Web.WebEventData.ParseEventArgsJson(Microsoft.AspNetCore.Components.RenderTree.Renderer,System.Text.Json.JsonSerializerOptions,System.UInt64,System.String,System.String)</property>
+      <property name="Target">M:Microsoft.Extensions.HotReload.HotReloadAgent.&lt;TopologicalSort&gt;g__Visit|10_0(System.Reflection.Assembly[],System.Reflection.Assembly,System.Collections.Generic.List{System.Reflection.Assembly},System.Collections.Generic.HashSet{System.String})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2070</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.Extensions.HotReload.HotReloadAgent.&lt;GetHandlerActions&gt;g__GetUpdateMethod|9_1(System.Type,System.String)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -52,12 +64,6 @@
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2072</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.WebAssemblyComponentParameterDeserializer.DeserializeParameters(System.Collections.Generic.IList{Microsoft.AspNetCore.Components.ComponentParameter},System.Collections.Generic.IList{System.Object})</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.AspNetCore.Components.WebAssemblyComponentParameterDeserializer.DeserializeParameters(System.Collections.Generic.IList{Microsoft.AspNetCore.Components.ComponentParameter},System.Collections.Generic.IList{System.Object})</property>
     </attribute>

--- a/src/Components/WebAssembly/WebAssembly/test/WebAssemblyHotReloadTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/WebAssemblyHotReloadTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.Extensions.HotReload;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
@@ -9,17 +11,22 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
     public class WebAssemblyHotReloadTest
     {
         [Fact]
-        public void WebAssemblyHotReload_DiscoversMetadataHandlers_FromComponentsAssembly()
+        public void WebAssemblyHotReload_DiscoversMetadataHandlers_FromHot()
         {
             // Arrange
-            var assemblies = new[] { typeof(Renderer).Assembly, };
+            var hotReloadManager = typeof(Renderer).Assembly.GetType("Microsoft.AspNetCore.Components.HotReload.HotReloadManager");
+            Assert.NotNull(hotReloadManager);
+
+            var handlerActions = new HotReloadAgent.UpdateHandlerActions();
+            var logs = new List<string>();
+            var hotReloadAgent = new HotReloadAgent(logs.Add);
 
             // Act
-            var (beforeUpdate, afterUpdate) = WebAssemblyHotReload.GetMetadataUpdateHandlerActions(assemblies);
+            hotReloadAgent.GetHandlerActions(handlerActions, hotReloadManager);
 
             // Assert
-            Assert.Empty(beforeUpdate);
-            Assert.Single(afterUpdate);
+            Assert.Empty(handlerActions.ClearCache);
+            Assert.Single(handlerActions.UpdateApplication);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <linker>
   <assembly fullname="Microsoft.JSInterop, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -12,6 +12,18 @@
       <argument>IL2026</argument>
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.JSInterop.Infrastructure.DotNetDispatcher.ParseArguments(Microsoft.JSInterop.JSRuntime,System.String,System.String,System.Type[])</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.JSInterop.JSRuntime.EndInvokeJS(System.Int64,System.Boolean,System.Text.Json.Utf8JsonReader@)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2026</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.JSInterop.JSRuntime.InvokeAsync``1(System.Int64,System.String,System.Threading.CancellationToken,System.Object[])</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
@@ -33,21 +45,9 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.JSInterop.JSRuntime.InvokeAsync``1(System.Int64,System.String,System.Threading.CancellationToken,System.Object[])</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
       <argument>IL2091</argument>
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.JSInterop.JSRuntime.&lt;InvokeAsync&gt;d__15`1.MoveNext</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.JSInterop.JSRuntime.EndInvokeJS(System.Int64,System.Boolean,System.Text.Json.Utf8JsonReader@)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>


### PR DESCRIPTION
* React to MetadataUpdateHandler renames

Contributes to https://github.com/dotnet/runtime/issues/51545

