### PR TITLE
Unquarantine Settings_MaxConcurrentStreamsGet_Server

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -1182,7 +1182,6 @@ namespace Interop.FunctionalTests
         // Nor does Kestrel yet support sending dynamic table updates, so there's nothing to test here. https://github.com/dotnet/aspnetcore/issues/4715
 
         [Theory]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27379")]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_MaxConcurrentStreamsGet_Server(string scheme)
         {


### PR DESCRIPTION
Passing for past 30 days and Runtime issue that was causing it has been fixed.
Fixes https://github.com/dotnet/aspnetcore/issues/27379
