### PR TITLE
Correct direct builds e.g. `msbuild`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,9 @@
   <Import Project="eng\Common.props" />
 
   <PropertyGroup>
-    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+    <!-- $(RepoRoot) is normally set globally and Arcade overrides it to ensure a trailing slash. -->
+    <RepoRoot Condition=" '$(RepoRoot)' == '' ">$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepoRoot>
+
     <RepositoryUrl>https://github.com/dotnet/aspnetcore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -73,7 +73,9 @@
   -->
   <Target Name="Helix">
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\helix\helix.proj"
-             Properties="ProjectToBuild=$(MSBuildProjectFullPath)" />
+             Properties="Configuration=$(Configuration);
+                         ProjectToBuild=$(MSBuildProjectFullPath);
+                         RepoRoot=$(RepoRoot)" />
   </Target>
 
   <!-- Build the actual helix work items to send to helix queues -->


### PR DESCRIPTION
- correct `$(RepoRoot)` fallback in Directory.Build.props
  - need trailing slash almost everywhere
- pass `$(RepoRoot)` and `$(Configuration)` properties into helix.proj
  - properties aren't always global and were missing when invoked from RunHelix.ps1