### PR TITLE
Cleanup Helix infrastructure slightly

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -11,7 +11,7 @@
   <Import Project="..\targets\Helix.Common.props" />
   <Import Project="..\Build.props" />
   <Import Project="..\Versions.props" />
-  
+
   <!-- Microsoft.DotNet.Helix.Sdk.MultiQueue.targets splits $(HelixTargetQueues) into @(HelixTargetQueue) items. -->
   <ItemGroup Condition=" '$(HelixTargetQueues)' == '' ">
     <HelixTargetQueue Condition="'$(_UseHelixOpenQueues)' == 'true'" Include="@(HelixAvailableTargetQueue)" />
@@ -26,13 +26,11 @@
     <HelixAccessToken Condition="'$(_UseHelixOpenQueues)' != 'true'">$(HelixApiAccessToken)</HelixAccessToken>
     <IncludeDotNetCli>true</IncludeDotNetCli>
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
-    <DotNetCliVersion>$(NETCoreSdkVersion)</DotNetCliVersion>    
+    <DotNetCliVersion>$(NETCoreSdkVersion)</DotNetCliVersion>
     <DotNetCliChannel>Current</DotNetCliChannel>
 
-    <!-- Copied from Microsoft.NET.DefaultOutputPaths.targets in the .NET SDK. The Helix SDK contains nothing similar. -->
-    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">bin\</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseOutputPath)$(Configuration)\</OutputPath>
-    <OutputPath Condition="'$(OutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseOutputPath)$(PlatformName)\$(Configuration)\</OutputPath>
+    <!-- Similar to ProjectLayout.props in the Arcade SDK. The Helix SDK contains nothing similar. -->
+    <OutputPath Condition=" '$(OutputPath)' == '' ">$(RepoRoot)artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
 
   <!-- Specify the runtime we need which will be included as a correlation payload -->
@@ -44,7 +42,7 @@
       <PackageType>runtime</PackageType>
     </AdditionalDotNetPackage>
   </ItemGroup>
-  
+
   <PropertyGroup Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">
     <HelixType>ci</HelixType>
     <!-- Creator is not valid for internal queues -->
@@ -86,30 +84,35 @@
 
     <PropertyGroup>
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
-    </PropertyGroup>    
-    
+    </PropertyGroup>
+
+    <!-- Use package because .dotnet/ folder doesn't contain RuntimeList.xml file and SharedFxTests checks that. -->
     <Unzip Condition="Exists('$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Runtime.$(TargetRuntimeIdentifier).$(SharedFxVersion).nupkg')"
-       SourceFiles="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Runtime.$(TargetRuntimeIdentifier).$(SharedFxVersion).nupkg" 
-       DestinationFolder="$(OutputPath)\AspNetCoreAppRuntimeHelixRaw" />
+       SourceFiles="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Runtime.$(TargetRuntimeIdentifier).$(SharedFxVersion).nupkg"
+       DestinationFolder="$(OutputPath)\SharedFx.Unzip" />
     <ItemGroup>
-      <_appRuntimeFiles Include="$(OutputPath)\AspNetCoreAppRuntimeHelixRaw\**\*.txt" />
-      <_appRuntimeFiles Include="$(OutputPath)\AspNetCoreAppRuntimeHelixRaw\**\*.json" />
-      <_appRuntimeFiles Include="$(OutputPath)\AspNetCoreAppRuntimeHelixRaw\**\*.dll" />
-      <_appRuntimeFiles Include="$(OutputPath)\AspNetCoreAppRuntimeHelixRaw\**\*.xml" />
+      <_appRuntimeFiles Include="$(OutputPath)\SharedFx.Unzip\**\*.txt" />
+      <_appRuntimeFiles Include="$(OutputPath)\SharedFx.Unzip\**\*.json" />
+      <_appRuntimeFiles Include="$(OutputPath)\SharedFx.Unzip\**\*.dll" />
+      <_appRuntimeFiles Include="$(OutputPath)\SharedFx.Unzip\**\RuntimeList.xml" />
     </ItemGroup>
-    <Copy SourceFiles="@(_appRuntimeFiles)" DestinationFolder="$(OutputPath)\AspNetCoreAppRuntimeHelix\shared\Microsoft.AspNetCore.App\$(SharedFxVersion)" />
-    <Unzip Condition="Exists('$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg')" 
-      SourceFiles="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg" 
-      DestinationFolder="$(OutputPath)\AspNetCoreAppRuntimeHelix\packs\Microsoft.AspNetCore.App.Ref\$(SharedFxVersion)" />
-    <ZipDirectory Condition="Exists('$(OutputPath)\AspNetCoreAppRuntimeHelix')"
-      SourceDirectory="$(OutputPath)\AspNetCoreAppRuntimeHelix" 
-      DestinationFile="$(OutputPath)\AspNetCoreAppRuntimeHelix.zip" Overwrite="true" />
-    
+    <Copy SourceFiles="@(_appRuntimeFiles)"
+        DestinationFolder="$(OutputPath)\SharedFx.Layout\shared\Microsoft.AspNetCore.App\$(SharedFxVersion)" />
+    <Copy SourceFiles="$(OutputPath)\SharedFx.Unzip\Microsoft.AspNetCore.App.versions.txt"
+        DestinationFiles="$(OutputPath)\SharedFx.Layout\shared\Microsoft.AspNetCore.App\$(SharedFxVersion)\.version" />
+
+    <Unzip Condition="Exists('$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg')"
+      SourceFiles="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg"
+      DestinationFolder="$(OutputPath)\SharedFx.Layout\packs\Microsoft.AspNetCore.App.Ref\$(SharedFxVersion)" />
+    <ZipDirectory Condition="Exists('$(OutputPath)\SharedFx.Layout')"
+      SourceDirectory="$(OutputPath)\SharedFx.Layout"
+      DestinationFile="$(OutputPath)\SharedFx.Layout.zip" Overwrite="true" />
+
     <ItemGroup>
-      <HelixCorrelationPayload Include="$(OutputPath)\AspNetCoreAppRuntimeHelix.zip" Destination="$(DotNetCliDestination)" />
+      <HelixCorrelationPayload Include="$(OutputPath)\SharedFx.Layout.zip" Destination="$(DotNetCliDestination)" />
     </ItemGroup>
   </Target>
-  
+
   <Target Name="Gather" BeforeTargets="Build">
     <MSBuild Projects="@(ProjectToBuild)"
               Targets="CreateHelixPayload"

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -19,14 +19,27 @@
     Redhat.7.Amd64.Open
 .PARAMETER RunQuarantinedTests
     By default quarantined tests are not run. Set this to $true to run only the quarantined tests.
+.PARAMETER TargetArchitecture
+    The CPU architecture to build for (x64, x86, arm). Default=x64
+.PARAMETER MSBuildArguments
+    Additional MSBuild arguments to be passed through.
 #>
+[CmdletBinding(PositionalBinding = $false)]
 param(
     [Parameter(Mandatory=$true)]
     [string]$Project,
+
     [string]$HelixQueues = "Windows.10.Amd64.Open",
+    [switch]$RunQuarantinedTests,
+
+    [ValidateSet('x64', 'x86', 'arm', 'arm64')]
     [string]$TargetArchitecture = "x64",
-    [bool]$RunQuarantinedTests = $false
+
+    # Capture the rest
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$MSBuildArguments
 )
+
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue' # Workaround PowerShell/PowerShell#2138
 
@@ -43,4 +56,5 @@ Write-Host -ForegroundColor Yellow "And if packing for a different platform, add
 $HelixQueues = $HelixQueues -replace ";", "%3B"
 dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" /p:IsRequiredCheck=true `
     /p:IsHelixDaily=true /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests `
-    /p:_UseHelixOpenQueues=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+    /p:_UseHelixOpenQueues=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log `
+    @MSBuildArguments

--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -19,7 +19,6 @@
     <IsMacHelixQueue>false</IsMacHelixQueue>
     <IsMacHelixQueue Condition="$(HelixTargetQueue.Contains('OSX')) or $(HelixTargetQueue.Contains('macOs'))">true</IsMacHelixQueue>
     <HelixTestName>$(MSBuildProjectName)--$(TargetFramework)</HelixTestName>
-    <HelixUseArchive>false</HelixUseArchive>
     <LoggingTestingDisableFileLogging Condition="'$(IsHelixJob)' == 'true'">false</LoggingTestingDisableFileLogging>
     <NodeVersion>10.15.3</NodeVersion>
     <TestDependsOnAspNetPackages>false</TestDependsOnAspNetPackages>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -120,11 +120,6 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_PublishHelixArchive" DependsOnTargets="Publish" >
-    <ZipDirectory Condition="'$(HelixUseArchive)' == 'true'" SourceDirectory="$(PublishDir)" DestinationFile="$(PublishDir)../$(HelixTestName).zip" Overwrite="true" />
-    <RemoveDir Condition="'$(HelixUseArchive)' == 'true'" Directories="$(PublishDir)" />
-  </Target>
-
   <Target Name="_CreateHelixWorkItem" Condition="$(BuildHelixPayload)">
     <PropertyGroup>
       <!-- Extract the effective queue name from this format "(name)host@dockerimage". This is sometimes used in test code to skip tests.  -->
@@ -133,7 +128,7 @@
     </PropertyGroup>
 
     <!-- Important: If HelixTargetQueue is not removed here, then Publish will occur for every single queue type. And since Publish shouldn't depend on the queue we can just publish once -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_PublishHelixArchive" RemoveProperties="HelixTargetQueue;TestRunId" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" RemoveProperties="HelixTargetQueue;TestRunId" />
 
     <!-- Isolate Helix tests from whatever happens to be in a parent directory. -->
     <Copy SourceFiles="$(RepoRoot)eng\helix\content\Directory.Build.empty.in"
@@ -176,8 +171,7 @@
     </ConvertToAbsolutePath>
     <ItemGroup>
       <HelixWorkItem Include="$(HelixTestName)">
-        <PayloadArchive Condition="'$(HelixUseArchive)' == 'true'">$(PublishAbsoluteDir)../$(HelixTestName).zip</PayloadArchive>
-        <PayloadDirectory Condition="'$(HelixUseArchive)' == 'false'">$(PublishAbsoluteDir)</PayloadDirectory>
+        <PayloadDirectory>$(PublishAbsoluteDir)</PayloadDirectory>
         <TestAssembly>$(TargetFileName)</TestAssembly>
         <PreCommands>@(HelixPreCommand)</PreCommands>
         <PostCommands>@(HelixPostCommand)</PostCommands>


### PR DESCRIPTION
- remove unused `$(HelixUseArchive)` property
- move helix.proj output into artifacts/bin/helix/
  - remove `$(Configuration)` and `$(PlatformName)` from output path
    - other layouts aren't that specific
    - properties weren't available anyhow in some cases

  nits:
  - provide the .version file expected in .dotnet/shared/&hellip;
  - rename `AspNetCoreAppRuntimeHelix/` -> `SharedFx.Layout/`; same for the correlation payload archive
  - rename `AspNetCoreAppRuntimeHelixRaw/` -> `SharedFx.Unzip/`
- support added `msbuild` arguments in RunHelix.ps1
  nit: use `[switch]` instead of `[bool]`