### PR TITLE
Flow ReadAtLeast calls to underlying PipeReader

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ChunkedEncodingMessageBody.cs
@@ -59,6 +59,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return boolResult;
         }
 
+        public override async ValueTask<ReadResult> ReadAtLeastAsyncInternal(int minimumSize, CancellationToken cancellationToken = default)
+        {
+            await TryStartAsync();
+
+            try
+            {
+                var readAwaitable = _requestBodyPipe.Reader.ReadAtLeastAsync(minimumSize, cancellationToken);
+
+                _readResult = await StartTimingReadAsync(readAwaitable, cancellationToken);
+            }
+            catch (ConnectionAbortedException ex)
+            {
+                throw new TaskCanceledException("The request was aborted", ex);
+            }
+
+            StopTimingRead(_readResult.Buffer.Length);
+
+            if (_readResult.IsCompleted)
+            {
+                TryStop();
+            }
+
+            return _readResult;
+        }
+
         public override async ValueTask<ReadResult> ReadAsyncInternal(CancellationToken cancellationToken = default)
         {
             await TryStartAsync();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -30,7 +30,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return ReadAsyncInternal(cancellationToken);
         }
 
+        public override ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, CancellationToken cancellationToken = default)
+        {
+            ThrowIfReaderCompleted();
+            return ReadAtLeastAsyncInternal(minimumSize, cancellationToken);
+        }
+
         public abstract ValueTask<ReadResult> ReadAsyncInternal(CancellationToken cancellationToken = default);
+
+        public abstract ValueTask<ReadResult> ReadAtLeastAsyncInternal(int minimumSize, CancellationToken cancellationToken = default);
 
         public override bool TryRead(out ReadResult readResult)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1UpgradeMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1UpgradeMessageBody.cs
@@ -72,6 +72,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return true;
         }
 
+        public override ValueTask<ReadResult> ReadAtLeastAsyncInternal(int minimumSize, CancellationToken cancellationToken = default)
+        {
+            ReadResult readResult;
+
+            // Ignore the canceled readResult unless it was canceled by the user.
+            do
+            {
+                var readTask = _context.Input.ReadAtLeastAsync(minimumSize, cancellationToken);
+
+                if (!readTask.IsCompletedSuccessfully)
+                {
+                    return Awaited(this, readTask, minimumSize, cancellationToken);
+                }
+
+                readResult = readTask.GetAwaiter().GetResult();
+            } while (readResult.IsCanceled && Interlocked.Exchange(ref _userCanceled, 0) == 0);
+
+            return new ValueTask<ReadResult>(readResult);
+
+            static async ValueTask<ReadResult> Awaited(Http1UpgradeMessageBody body, ValueTask<ReadResult> readTask, int minimumSize, CancellationToken cancellationToken = default)
+            {
+                var readResult = await readTask;
+
+                // Ignore the canceled readResult unless it was canceled by the user.
+                while (readResult.IsCanceled && Interlocked.Exchange(ref body._userCanceled, 0) == 0)
+                {
+                    readResult = await body._context.Input.ReadAtLeastAsync(minimumSize, cancellationToken);
+                }
+
+                return readResult;
+            }
+        }
+
         public override ValueTask<ReadResult> ReadAsyncInternal(CancellationToken cancellationToken = default)
         {
             ReadResult readResult;
@@ -83,26 +116,26 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
                 if (!readTask.IsCompletedSuccessfully)
                 {
-                    return ReadAsyncInternalAwaited(readTask, cancellationToken);
+                    return Awaited(this, readTask, cancellationToken);
                 }
 
                 readResult = readTask.GetAwaiter().GetResult();
             } while (readResult.IsCanceled && Interlocked.Exchange(ref _userCanceled, 0) == 0);
 
             return new ValueTask<ReadResult>(readResult);
-        }
 
-        private async ValueTask<ReadResult> ReadAsyncInternalAwaited(ValueTask<ReadResult> readTask, CancellationToken cancellationToken = default)
-        {
-            var readResult = await readTask;
-
-            // Ignore the canceled readResult unless it was canceled by the user.
-            while (readResult.IsCanceled && Interlocked.Exchange(ref _userCanceled, 0) == 0)
+            static async ValueTask<ReadResult> Awaited(Http1UpgradeMessageBody body, ValueTask<ReadResult> readTask, CancellationToken cancellationToken = default)
             {
-                readResult = await _context.Input.ReadAsync(cancellationToken);
-            }
+                var readResult = await readTask;
 
-            return readResult;
+                // Ignore the canceled readResult unless it was canceled by the user.
+                while (readResult.IsCanceled && Interlocked.Exchange(ref body._userCanceled, 0) == 0)
+                {
+                    readResult = await body._context.Input.ReadAsync(cancellationToken);
+                }
+
+                return readResult;
+            }
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestPipeReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestPipeReader.cs
@@ -66,6 +66,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return _body!.ReadAsync(cancellationToken);
         }
 
+        protected override ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumSize, CancellationToken cancellationToken)
+        {
+            ValidateState(cancellationToken);
+
+            return _body!.ReadAtLeastAsync(minimumSize, cancellationToken);
+        }
+
         public override bool TryRead(out ReadResult result)
         {
             ValidateState();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
@@ -46,6 +46,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public abstract ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default);
 
+        public abstract ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, CancellationToken cancellationToken = default);
+
         public abstract bool TryRead(out ReadResult readResult);
 
         public void AdvanceTo(SequencePosition consumed)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/ZeroContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/ZeroContentLengthMessageBody.cs
@@ -20,6 +20,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default) => new ValueTask<ReadResult>(new ReadResult(default, isCanceled: false, isCompleted: true));
 
+        public override ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, CancellationToken cancellationToken = default) => new ValueTask<ReadResult>(new ReadResult(default, isCanceled: false, isCompleted: true));
+
         public override Task ConsumeAsync() => Task.CompletedTask;
 
         public override ValueTask StopAsync() => default;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3MessageBody.cs
@@ -68,6 +68,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             return hasResult;
         }
 
+        public override async ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, CancellationToken cancellationToken = default)
+        {
+            await TryStartAsync();
+
+            try
+            {
+                var readAwaitable = _context.RequestBodyPipe.Reader.ReadAtLeastAsync(minimumSize, cancellationToken);
+
+                _readResult = await StartTimingReadAsync(readAwaitable, cancellationToken);
+            }
+            catch (ConnectionAbortedException ex)
+            {
+                throw new TaskCanceledException("The request was aborted", ex);
+            }
+
+            StopTimingRead(_readResult.Buffer.Length);
+
+            if (_readResult.IsCompleted)
+            {
+                TryStop();
+            }
+
+            return _readResult;
+        }
+
         public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
         {
             await TryStartAsync();

--- a/src/Servers/Kestrel/Core/test/BodyControlTests.cs
+++ b/src/Servers/Kestrel/Core/test/BodyControlTests.cs
@@ -166,6 +166,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 throw new NotImplementedException();
             }
 
+            public override ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
             public override bool TryRead(out ReadResult readResult)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
- Flows ReadAtLeast calls to underlying PipeReader through the layers of Kestrel abstractions.
- There's some code duplication as a result. This can be reduced though.

Fixes #32536 

TODO Add tests