### PR TITLE
Improvements to IIS IO

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -33,9 +33,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
     internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPoolWorkItem, IDisposable
     {
         private const int MinAllocBufferSize = 2048;
-        private const int PauseWriterThreshold = 65536;
-        private const int ResumeWriterTheshold = PauseWriterThreshold / 2;
-
+        
         protected readonly NativeSafeHandle _requestNativeHandle;
 
         private readonly IISServerOptions _options;
@@ -92,6 +90,9 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
             ((IHttpBodyControlFeature)this).AllowSynchronousIO = _options.AllowSynchronousIO;
         }
+
+        private int PauseWriterThreshold => _options.MaxRequestBodyBufferSize;
+        private int ResumeWriterTheshold => PauseWriterThreshold / 2;
 
         public Version HttpVersion { get; set; } = default!;
         public string Scheme { get; set; } = default!;

--- a/src/Servers/IIS/IIS/src/IISServerOptions.cs
+++ b/src/Servers/IIS/IIS/src/IISServerOptions.cs
@@ -34,15 +34,18 @@ namespace Microsoft.AspNetCore.Builder
         public string? AuthenticationDisplayName { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum unconsumed incoming bytes the server will buffer for incoming request body.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to 1 MB.
+        /// </remarks>
+        public int MaxRequestBodyBufferSize { get; set; } = 1024 * 1024; // Matches kestrel (sorta)
+
+        /// <summary>
         /// Used to indicate if the authentication handler should be registered. This is only done if ANCM indicates
         /// IIS has a non-anonymous authentication enabled, or for back compat with ANCMs that did not provide this information.
         /// </summary>
         internal bool ForwardWindowsAuthentication { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets the maximum unconsumed incoming bytes the server will buffer for incoming request body.
-        /// </summary>
-        internal int MaxRequestBodyBufferSize { get; set; } = 1024 * 1024; // Matches kestrel (sorta)
 
         internal string[] ServerAddresses { get; set; } = default!; // Set by configuration.
 

--- a/src/Servers/IIS/IIS/src/IISServerOptions.cs
+++ b/src/Servers/IIS/IIS/src/IISServerOptions.cs
@@ -36,9 +36,9 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Gets or sets the maximum unconsumed incoming bytes the server will buffer for incoming request body.
         /// </summary>
-        /// <remarks>
+        /// <value>
         /// Defaults to 1 MB.
-        /// </remarks>
+        /// </value>
         public int MaxRequestBodyBufferSize { get; set; } = 1024 * 1024; // Matches kestrel (sorta)
 
         /// <summary>

--- a/src/Servers/IIS/IIS/src/IISServerOptions.cs
+++ b/src/Servers/IIS/IIS/src/IISServerOptions.cs
@@ -39,6 +39,11 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         internal bool ForwardWindowsAuthentication { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets the maximum unconsumed incoming bytes the server will buffer for incoming request body.
+        /// </summary>
+        internal int MaxRequestBodyBufferSize { get; set; } = 1024 * 1024; // Matches kestrel (sorta)
+
         internal string[] ServerAddresses { get; set; } = default!; // Set by configuration.
 
         // Matches the default maxAllowedContentLength in IIS (~28.6 MB)

--- a/src/Servers/IIS/IIS/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/IIS/IIS/src/PublicAPI.Unshipped.txt
@@ -13,6 +13,8 @@
 *REMOVED*~override Microsoft.AspNetCore.Server.IIS.Core.WriteOnlyStream.ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<int>
 *REMOVED*~static Microsoft.AspNetCore.Hosting.WebHostBuilderIISExtensions.UseIIS(this Microsoft.AspNetCore.Hosting.IWebHostBuilder hostBuilder) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder
 *REMOVED*~static Microsoft.AspNetCore.Server.IIS.HttpContextExtensions.GetIISServerVariable(this Microsoft.AspNetCore.Http.HttpContext context, string variableName) -> string
+Microsoft.AspNetCore.Builder.IISServerOptions.MaxRequestBodyBufferSize.get -> int
+Microsoft.AspNetCore.Builder.IISServerOptions.MaxRequestBodyBufferSize.set -> void
 Microsoft.AspNetCore.Http.Features.IServerVariablesFeature.this[string! variableName].get -> string? (forwarded, contained in Microsoft.AspNetCore.Http.Features)
 Microsoft.AspNetCore.Builder.IISServerOptions.AuthenticationDisplayName.get -> string?
 Microsoft.AspNetCore.Builder.IISServerOptions.AuthenticationDisplayName.set -> void


### PR DESCRIPTION
- Increase the IIS default pause threshold to 1MB by default. This matches kestrel. Today IIS only allows for 65K of slack for incoming request bodies. This affects the maximum size of the read possible when doing large uploads.
- ~Left the setting internal for now with the intent of exposing a public API in the future.~ Added a public API to configure the buffer size.
- ~Remove double thread pool dispatch. Today we dispatch continuations from the IIS thread to the thread pool thread. This resulted in 2 dispatches per read. These continuations are within our own managed code implementation so we can safely assume they don't block. Get rid of one of them.~ This was causing issues, so will revisit that later.

Improves https://github.com/dotnet/aspnetcore/issues/32467

Anecdotal performance improvements 3x for large uploads. 