### PR TITLE
Quarantine ComponentDiscovery_CanFindComponent_WithTypeParameter

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiscoveryIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiscoveryIntegrationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
@@ -83,6 +84,7 @@ namespace Test.AnotherNamespace
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/32592")]
         public void ComponentDiscovery_CanFindComponent_WithTypeParameter()
         {
             // Arrange


### PR DESCRIPTION
/sadness

This generic params bug is appearing in the codegen tests which indicates there might be some funkiness in M.A.R.L going on. 