### PR TITLE
Make trailers safer in TestHost

### DIFF
--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -184,12 +184,16 @@ namespace Microsoft.AspNetCore.TestHost
             // Copy trailers to the response message when the response stream is complete
             contextBuilder.RegisterResponseReadCompleteCallback(context =>
             {
-                var responseTrailersFeature = context.Features.Get<IHttpResponseTrailersFeature>()!;
+                var responseTrailersFeature = context.Features.Get<IHttpResponseTrailersFeature>();
 
-                foreach (var trailer in responseTrailersFeature.Trailers)
+                // Trailers collection is settable so double check the app hasn't set it to null.
+                if (responseTrailersFeature?.Trailers != null)
                 {
-                    bool success = response.TrailingHeaders.TryAddWithoutValidation(trailer.Key, (IEnumerable<string>)trailer.Value);
-                    Contract.Assert(success, "Bad trailer");
+                    foreach (var trailer in responseTrailersFeature.Trailers)
+                    {
+                        bool success = response.TrailingHeaders.TryAddWithoutValidation(trailer.Key, (IEnumerable<string>)trailer.Value);
+                        Contract.Assert(success, "Bad trailer");
+                    }
                 }
             });
 

--- a/src/Hosting/TestHost/src/HttpContextBuilder.cs
+++ b/src/Hosting/TestHost/src/HttpContextBuilder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.TestHost
             _requestPipe = new Pipe();
 
             var responsePipe = new Pipe();
-            _responseReaderStream = new ResponseBodyReaderStream(responsePipe, ClientInitiatedAbort, () => _responseReadCompleteCallback?.Invoke(_httpContext));
+            _responseReaderStream = new ResponseBodyReaderStream(responsePipe, ClientInitiatedAbort, ResponseBodyReadComplete);
             _responsePipeWriter = new ResponseBodyPipeWriter(responsePipe, ReturnResponseMessageAsync);
             _responseFeature.Body = new ResponseBodyWriterStream(_responsePipeWriter, () => AllowSynchronousIO);
             _responseFeature.BodyWriter = _responsePipeWriter;
@@ -178,6 +178,11 @@ namespace Microsoft.AspNetCore.TestHost
             // Cancel any pending request async activity when the client aborts a duplex
             // streaming scenario by disposing the HttpResponseMessage.
             CancelRequestBody();
+        }
+
+        private void ResponseBodyReadComplete()
+        {
+            _responseReadCompleteCallback?.Invoke(_httpContext);
         }
 
         private bool RequestBodyReadInProgress()


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/32561

I'm not sure this is a fix because I can't see where the problem is. But checking the trailers haven't been set to null should be done anyway for safety.