### PR TITLE
Increase KestrelServerLimits.KeepAliveTimeout to 130 seconds

### DIFF
--- a/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
@@ -33,8 +33,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         // Matches the default LimitRequestFields in Apache httpd.
         private int _maxRequestHeaderCount = 100;
 
-        // Matches the default http.sys connectionTimeout.
-        private TimeSpan _keepAliveTimeout = TimeSpan.FromMinutes(2);
+        // Slightly more than SocketHttpHandler's old PooledConnectionIdleTimeout of 2 minutes.
+        // https://github.com/dotnet/runtime/issues/52267
+        private TimeSpan _keepAliveTimeout = TimeSpan.FromSeconds(130);
 
         private TimeSpan _requestHeadersTimeout = TimeSpan.FromSeconds(30);
 
@@ -169,7 +170,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
         /// <summary>
         /// Gets or sets the keep-alive timeout.
-        /// Defaults to 2 minutes.
+        /// Defaults to 130 seconds.
         /// </summary>
         /// <remarks>
         /// </remarks>

--- a/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public void KeepAliveTimeoutDefault()
         {
-            Assert.Equal(TimeSpan.FromMinutes(2), new KestrelServerLimits().KeepAliveTimeout);
+            Assert.Equal(TimeSpan.FromSeconds(130), new KestrelServerLimits().KeepAliveTimeout);
         }
 
         [Theory]


### PR DESCRIPTION
HttpClient's SocketsHttpHandler also has a 120 second [PooledConnectionIdleTimeout](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler.pooledconnectionidletimeout?view=net-5.0) currently. Because Kestrel's KeepAliveTimeout does not exceed this, HttpClient can make a request right as Kestrel closes the connection due to the KeepAliveTimeout. This is one half of attempting to address that issue.

See https://github.com/dotnet/runtime/issues/52267#issuecomment-840140309

Similar issue for SocketsHttpHandler: https://github.com/dotnet/runtime/pull/52687