### PR TITLE
Update Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
   <Import Project="eng\Common.props" />
 
   <PropertyGroup>
-    <!-- $(RepoRoot) is normally set globally and Arcade overrides it to ensure a trailing slash. -->
-    <RepoRoot Condition=" '$(RepoRoot)' == '' ">$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepoRoot>
+    <!-- Ensure that the $(RepoRoot) property has a trailing slash. -->
+    <RepoRoot>$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepoRoot>
 
     <RepositoryUrl>https://github.com/dotnet/aspnetcore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/32615.

The `RepoRoot` environment variable is set by the build scripts in each of the project areas. The value looks something like `src/Components/../..` without a trailing slash.

This ends up breaking the build locally after the user has run the local build scripts since we no longer override it with one that continues the trailing slash.

We should always set the property in MSBuild and not rely on the global property set in the build scripts.