### PR TITLE
Further simplify empty project template

### DIFF
--- a/src/Http/samples/MinimalSample/Program.cs
+++ b/src/Http/samples/MinimalSample/Program.cs
@@ -2,7 +2,7 @@ using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
 
-await using var app = WebApplication.Create(args);
+var app = WebApplication.Create(args);
 
 if (app.Environment.IsDevelopment())
 {
@@ -18,4 +18,4 @@ app.MapGet("/json", (Func<object>)Json);
 string SayHello(string name) => $"Hello, {name}!";
 app.MapGet("/hello/{name}", (Func<string, string>)SayHello);
 
-await app.RunAsync();
+app.Run();

--- a/src/Http/samples/MinimalSampleFSharp/Program.fs
+++ b/src/Http/samples/MinimalSampleFSharp/Program.fs
@@ -4,7 +4,7 @@ open Microsoft.Extensions.Hosting
 
 [<EntryPoint>]
 let main args =
-    use app = WebApplication.Create(args)
+    let app = WebApplication.Create(args)
 
     if app.Environment.IsDevelopment() then
         app.UseDeveloperExceptionPage() |> ignore

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
-await using var app = builder.Build();
+var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
@@ -12,4 +12,4 @@ if (app.Environment.IsDevelopment())
 
 app.MapGet("/", (Func<string>)(() => "Hello World!"));
 
-await app.RunAsync();
+app.Run();

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Program.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Program.fs
@@ -5,7 +5,7 @@ open Microsoft.Extensions.Hosting
 [<EntryPoint>]
 let main args =
     let builder = WebApplication.CreateBuilder(args)
-    use app = builder.Build()
+    let app = builder.Build()
 
     if app.Environment.IsDevelopment() then
         app.UseDeveloperExceptionPage() |> ignore


### PR DESCRIPTION
The `await using` was unnecessary since `Run/RunAsync` dispose internally.

I'm less sure about changing the `await app.RunAsync()` to `app.Run()` , but it is less verbose this way and it's equivalent as long as there's no other `awaits` in the top-level statement. We could add an analyzer to suggest `RunAsync` if an `await` is added as a top-level statement. Worst case is one extra blocked thread for the lifetime of the application.

#32003 Was the PR started using WebApplication in the empty template.