### PR TITLE
Clean up `$(RepoRoot)` consistently

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- $(RepoRoot) is normally set globally and Arcade overrides it to ensure a trailing slash. -->
-    <RepoRoot Condition=" '$(RepoRoot)' == '' ">$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepoRoot>
+    <RepoRoot Condition=" '$(RepoRoot)' == '' OR !HasTrailingSlash('$(RepoRoot)') ">$(MSBuildThisFileDirectory)</RepoRoot>
 
     <RepositoryUrl>https://github.com/dotnet/aspnetcore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/eng/CodeGen.proj
+++ b/eng/CodeGen.proj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <BuildManaged>true</BuildManaged>
-    <RepoRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..'))</RepoRoot>
+    <RepoRoot
+        Condition=" '$(RepoRoot)' == '' OR !HasTrailingSlash('$(RepoRoot)') ">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..'))</RepoRoot>
     <BuildMainlyReferenceProviders>true</BuildMainlyReferenceProviders>
   </PropertyGroup>
 

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -22,12 +22,12 @@
     <MakeDir Directories="$(BaseOutputPath)" />
 
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $(BaseOutputPath)Directory.Build.props" />
-    <GenerateFileFromTemplate TemplateFile="$(MSBuildProjectDirectory)\Directory.Build.props.in"
+    <GenerateFileFromTemplate TemplateFile="$(MSBuildThisFileDirectory)Directory.Build.props.in"
       Properties="$(_TemplateProperties)"
       OutputPath="$(BaseOutputPath)Directory.Build.props" />
 
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $(BaseOutputPath)Directory.Build.targets" />
-    <GenerateFileFromTemplate TemplateFile="$(MSBuildProjectDirectory)\Directory.Build.targets.in"
+    <GenerateFileFromTemplate TemplateFile="$(MSBuildThisFileDirectory)Directory.Build.targets.in"
       Properties="$(_TemplateProperties)"
       OutputPath="$(BaseOutputPath)Directory.Build.targets" />
   </Target>

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -49,25 +49,25 @@
 
     <ProjectReference Include="..\..\benchmarkapps\Wasm.Performance\TestApp\Wasm.Performance.TestApp.csproj"
       Targets="Publish"
-      Properties="TestTrimmedApps=true;PublishDir=$(MSBuildProjectDirectory)\$(OutputPath)trimmed\Wasm.Performance.TestApp\"
+      Properties="TestTrimmedApps=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed\Wasm.Performance.TestApp\"
       Condition="'$(TestTrimmedApps)' == 'true'" />
 
     <ProjectReference
       Include="..\testassets\BasicTestApp\BasicTestApp.csproj"
       Targets="Publish"
-      Properties="TestTrimmedApps=true;PublishDir=$(MSBuildProjectDirectory)\$(OutputPath)trimmed\BasicTestApp\"
+      Properties="TestTrimmedApps=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed\BasicTestApp\"
       Condition="'$(TestTrimmedApps)' == 'true'" />
 
     <ProjectReference
       Include="..\testassets\GlobalizationWasmApp\GlobalizationWasmApp.csproj"
       Targets="Publish"
-      Properties="TestTrimmedApps=true;PublishDir=$(MSBuildProjectDirectory)\$(OutputPath)trimmed\GlobalizationWasmApp\;"
+      Properties="TestTrimmedApps=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed\GlobalizationWasmApp\;"
       Condition="'$(TestTrimmedApps)' == 'true'" />
 
     <ProjectReference
       Include="..\..\WebAssembly\testassets\StandaloneApp\StandaloneApp.csproj"
       Targets="Publish"
-      Properties="TestTrimmedApps=true;PublishDir=$(MSBuildProjectDirectory)\$(OutputPath)trimmed\StandaloneApp\;"
+      Properties="TestTrimmedApps=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed\StandaloneApp\;"
       Condition="'$(TestTrimmedApps)' == 'true'" />
   </ItemGroup>
 

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
@@ -31,7 +31,7 @@
     <!-- Skip the "inner" test run when we're running DailyTests -->
     <Yarn Command="run test:inner --no-color --configuration $(Configuration)"
           Condition="'$(DailyTests)' != 'true'"
-          WorkingDirectory="$(RepoRoot)src/SignalR/clients/ts/FunctionalTests" />
+          WorkingDirectory="$(MSBuildThisFileDirectory)" />
 
     <PropertyGroup>
       <BrowserTestHostName Condition="'$(ContinuousIntegrationBuild)' == 'true'">sauce.local</BrowserTestHostName>
@@ -41,7 +41,7 @@
     <Message Text="test:sauce Args = $(_TestSauceArgs)" Importance="high" />
     <Yarn Command="run test:sauce $(_TestSauceArgs)"
           Condition="'$(DailyTests)' == 'true'"
-          WorkingDirectory="$(RepoRoot)src/SignalR/clients/ts/FunctionalTests" />
+          WorkingDirectory="$(MSBuildThisFileDirectory)" />
   </Target>
 
   <Target Name="ClientBuild" AfterTargets="Build">
@@ -49,15 +49,15 @@
       <JasmineFiles Include="$(MSBuildThisFileDirectory)node_modules/jasmine-core/lib/jasmine-core/*.js" />
       <JasmineFiles Include="$(MSBuildThisFileDirectory)node_modules/jasmine-core/lib/jasmine-core/*.css" />
     </ItemGroup>
-    <Copy SourceFiles="@(JasmineFiles)" DestinationFolder="$(MSBuildProjectDirectory)/wwwroot/lib/jasmine" />
+    <Copy SourceFiles="@(JasmineFiles)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot/lib/jasmine" />
 
     <ItemGroup>
       <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr/dist/browser/*" />
       <SignalRJSBrowserClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr-protocol-msgpack/dist/browser/*" />
       <SignalRJSWebWorkerClientFiles Include="$(MSBuildThisFileDirectory)node_modules/@microsoft/signalr/dist/webworker/*" />
     </ItemGroup>
-    <Copy SourceFiles="@(SignalRJSBrowserClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)/wwwroot/lib/signalr" />
-    <Copy SourceFiles="@(SignalRJSWebWorkerClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)/wwwroot/lib/signalr-webworker" />
+    <Copy SourceFiles="@(SignalRJSBrowserClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot/lib/signalr" />
+    <Copy SourceFiles="@(SignalRJSWebWorkerClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot/lib/signalr-webworker" />
   </Target>
 
 </Project>

--- a/src/SiteExtensions/Sdk/SiteExtension.targets
+++ b/src/SiteExtensions/Sdk/SiteExtension.targets
@@ -41,7 +41,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <_TemplateFiles Include="$(MSBuildThisFileDirectory)\HostingStartup\*.cs*" />
+      <_TemplateFiles Include="$(MSBuildThisFileDirectory)HostingStartup\*.cs*" />
       <!--
         Always use Major.Minor.0 so that if we have to produce a new SiteExtension during a patch build it will still work for non-patch runtimes.
         i.e. 3.0.0 dotnet will search for 3.0.0 and below and wouldn't find a 3.0.1 folder path

--- a/src/Testing/src/build/Microsoft.AspNetCore.Testing.props
+++ b/src/Testing/src/build/Microsoft.AspNetCore.Testing.props
@@ -1,9 +1,13 @@
 ﻿<Project>
   <PropertyGroup>
+    <RepoRoot
+        Condition=" '$(RepoRoot)' == '' OR !HasTrailingSlash('$(RepoRoot)') "><RepoRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..', '..', '..'))</RepoRoot></RepoRoot>
+
     <!-- Priority: LoggingTestingDisableFileLogging > LoggingTestingFileLoggingDirectory > ASPNETCORE_TEST_LOG_DIR > Default location -->
-    <RepoRoot Condition="'$(RepoRoot)' == ''">$(RepositoryRoot)</RepoRoot>
-    <LoggingTestingFileLoggingDirectory Condition="'$(LoggingTestingFileLoggingDirectory)' == ''">$(ASPNETCORE_TEST_LOG_DIR)</LoggingTestingFileLoggingDirectory>
-    <LoggingTestingFileLoggingDirectory Condition="'$(LoggingTestingFileLoggingDirectory)' == '' AND '$(RepoRoot)' != ''">$(RepoRoot)artifacts\log\</LoggingTestingFileLoggingDirectory>
+    <LoggingTestingFileLoggingDirectory
+        Condition=" '$(LoggingTestingFileLoggingDirectory)' == '' AND '$(ASPNETCORE_TEST_LOG_DIR)' != '' ">$(ASPNETCORE_TEST_LOG_DIR)</LoggingTestingFileLoggingDirectory>
+    <LoggingTestingFileLoggingDirectory
+        Condition=" '$(LoggingTestingFileLoggingDirectory)' == ''">$(RepoRoot)artifacts\log\</LoggingTestingFileLoggingDirectory>
   </PropertyGroup>
 
   <Target Name="SetLoggingTestingAssemblyAttributes"

--- a/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.props
+++ b/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
   <PropertyGroup>
-    <_ApiDescriptionClientAssemblyPath>$(MSBuildThisFileDirectory)/../tasks/netstandard2.0/Microsoft.Extensions.ApiDescription.Client.dll</_ApiDescriptionClientAssemblyPath>
+    <_ApiDescriptionClientAssemblyPath>$(MSBuildThisFileDirectory)../tasks/netstandard2.0/Microsoft.Extensions.ApiDescription.Client.dll</_ApiDescriptionClientAssemblyPath>
   </PropertyGroup>
   <UsingTask TaskName="GetCurrentOpenApiReference" AssemblyFile="$(_ApiDescriptionClientAssemblyPath)" />
   <UsingTask TaskName="GetOpenApiReferenceMetadata" AssemblyFile="$(_ApiDescriptionClientAssemblyPath)" />

--- a/src/Tools/Extensions.ApiDescription.Client/test/Microsoft.Extensions.ApiDescription.Client.Tests.csproj
+++ b/src/Tools/Extensions.ApiDescription.Client/test/Microsoft.Extensions.ApiDescription.Client.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(MSBuildProjectDirectory)\..\src\build\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="build" />
-    <Content Include="$(MSBuildProjectDirectory)\..\src\buildMultiTargeting\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="buildMultiTargeting" />
+    <Content Include="$(MSBuildThisFileDirectory)..\src\build\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="build" />
+    <Content Include="$(MSBuildThisFileDirectory)..\src\buildMultiTargeting\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="buildMultiTargeting" />
     <Content Include="TestProjects\**\*" CopyToOutputDirectory="PreserveNewest" />
 
     <Reference Include="Microsoft.Extensions.ApiDescription.Client" />

--- a/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
+++ b/src/Tools/Extensions.ApiDescription.Server/src/build/Microsoft.Extensions.ApiDescription.Server.targets
@@ -51,7 +51,7 @@
         Text="OpenAPI document generation is not supported when targeting netcoreapp2.0 or earlier. Disable the feature or move to a later target framework." />
 
     <PropertyGroup>
-      <_Command>dotnet "$(MSBuildThisFileDirectory)/../tools/dotnet-getdocument.dll" --assembly "$(TargetPath)"</_Command>
+      <_Command>dotnet "$(MSBuildThisFileDirectory)../tools/dotnet-getdocument.dll" --assembly "$(TargetPath)"</_Command>
       <_Command>$(_Command) --file-list "$(_OpenApiDocumentsCache)" --framework "$(TargetFrameworkMoniker)"</_Command>
       <_Command>$(_Command) --output "$(OpenApiDocumentsDirectory.TrimEnd('\'))" --project "$(MSBuildProjectName)"</_Command>
       <_Command Condition=" '$(ProjectAssetsFile)' != '' ">$(_Command) --assets-file "$(ProjectAssetsFile)"</_Command>


### PR DESCRIPTION
- don't override correct values but fix incorrect ones

nits:
- don't use `$(MSBuildProjectDirectory)` in project files
  - inconsistent w/ `$(MSBuildThisFileDirectory)` and harder to grok
- don't add unnecessary slashes after `$(MSBuildThisFileDirectory)`
- clean up Microsoft.AspNetCore.Testing.props
  - used only from eng/targets/CSharp.Common.props but fallback settings may help