### PR TITLE
Remove NotForwardedHttpHeaders in SpaServices.Extensions SpaProxy

### DIFF
--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -22,9 +22,6 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
         private const int DefaultWebSocketBufferSize = 4096;
         private const int StreamCopyBufferSize = 81920;
 
-        // https://github.com/dotnet/aspnetcore/issues/16797
-        private static readonly string[] NotForwardedHttpHeaders = new[] { "Connection" };
-
         // Don't forward User-Agent/Accept because of https://github.com/aspnet/JavaScriptServices/issues/1469
         // Others just aren't applicable in proxy scenarios
         private static readonly string[] NotForwardedWebSocketHeaders = new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" };
@@ -135,11 +132,6 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
             // Copy the request headers
             foreach (var header in request.Headers)
             {
-                if (NotForwardedHttpHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()) && requestMessage.Content != null)
                 {
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Remove NotForwardedHttpHeaders in SpaProxy


**PR Description**
Removes previously added code in SpaServices.Extensions that removes the Connection header being proxied back to webpack-dev-server/sockjs when using UseProxyToSpaDevelopmentServer on Windows.

Addresses #bugnumber (in this specific format)
#29478