### PR TITLE
Remove inner `<RepoRoot/>` element

### DIFF
--- a/src/Testing/src/build/Microsoft.AspNetCore.Testing.props
+++ b/src/Testing/src/build/Microsoft.AspNetCore.Testing.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <RepoRoot
-        Condition=" '$(RepoRoot)' == '' OR !HasTrailingSlash('$(RepoRoot)') "><RepoRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..', '..', '..'))</RepoRoot></RepoRoot>
+        Condition=" '$(RepoRoot)' == '' OR !HasTrailingSlash('$(RepoRoot)') ">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..', '..', '..'))</RepoRoot>
 
     <!-- Priority: LoggingTestingDisableFileLogging > LoggingTestingFileLoggingDirectory > ASPNETCORE_TEST_LOG_DIR > Default location -->
     <LoggingTestingFileLoggingDirectory


### PR DESCRIPTION
- typo introduced in #32664
- see discussion at https://github.com/dotnet/aspnetcore/pull/32664#discussion_r632633610