### PR TITLE
Add Quality parameter to BrowserFileExtensions.RequestImageFileAsync

### DIFF
--- a/src/Components/Web.JS/src/InputFile.ts
+++ b/src/Components/Web.JS/src/InputFile.ts
@@ -56,7 +56,7 @@ function init(callbackWrapper: any, elem: InputElement): void {
   });
 }
 
-async function toImageFile(elem: InputElement, fileId: number, format: string, maxWidth: number, maxHeight: number): Promise<BrowserFile> {
+async function toImageFile(elem: InputElement, fileId: number, format: string, maxWidth: number, maxHeight: number, quality?: number): Promise<BrowserFile> {
   const originalFile = getFileById(elem, fileId);
 
   const loadedImage = await new Promise(function(resolve: (loadedImage: HTMLImageElement) => void): void {
@@ -76,7 +76,7 @@ async function toImageFile(elem: InputElement, fileId: number, format: string, m
     canvas.width = Math.round(loadedImage.width * chosenSizeRatio);
     canvas.height = Math.round(loadedImage.height * chosenSizeRatio);
     canvas.getContext('2d')?.drawImage(loadedImage, 0, 0, canvas.width, canvas.height);
-    canvas.toBlob(resolve, format);
+    canvas.toBlob(resolve, format, quality);
   });
   const result: BrowserFile = {
     id: ++elem._blazorInputFileNextFileId,

--- a/src/Components/Web/src/Forms/InputFile.cs
+++ b/src/Components/Web/src/Forms/InputFile.cs
@@ -86,9 +86,9 @@ namespace Microsoft.AspNetCore.Components.Forms
                 (Stream)new SharedBrowserFileStream(JSRuntime, _jsUnmarshalledRuntime, _inputFileElement, file) :
                 new RemoteBrowserFileStream(JSRuntime, _inputFileElement, file, Options.Value, cancellationToken);
 
-        internal async ValueTask<IBrowserFile> ConvertToImageFileAsync(BrowserFile file, string format, int maxWidth, int maxHeight)
+        internal async ValueTask<IBrowserFile> ConvertToImageFileAsync(BrowserFile file, string format, int maxWidth, int maxHeight, double? quality = null)
         {
-            var imageFile = await JSRuntime.InvokeAsync<BrowserFile>(InputFileInterop.ToImageFile, _inputFileElement, file.Id, format, maxWidth, maxHeight);
+            var imageFile = await JSRuntime.InvokeAsync<BrowserFile>(InputFileInterop.ToImageFile, _inputFileElement, file.Id, format, maxWidth, maxHeight, quality);
 
             if (imageFile is null)
             {

--- a/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
+++ b/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
@@ -26,12 +26,13 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <param name="format">The new image format.</param>
         /// <param name="maxWidth">The maximum image width.</param>
         /// <param name="maxHeight">The maximum image height</param>
+        /// <param name="quality">The quality of the image</param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        public static ValueTask<IBrowserFile> RequestImageFileAsync(this IBrowserFile browserFile, string format, int maxWidth, int maxHeight)
+        public static ValueTask<IBrowserFile> RequestImageFileAsync(this IBrowserFile browserFile, string format, int maxWidth, int maxHeight, double? quality = null)
         {
             if (browserFile is BrowserFile browserFileInternal)
             {
-                return browserFileInternal.Owner.ConvertToImageFileAsync(browserFileInternal, format, maxWidth, maxHeight);
+                return browserFileInternal.Owner.ConvertToImageFileAsync(browserFileInternal, format, maxWidth, maxHeight, quality);
             }
 
             throw new InvalidOperationException($"Cannot perform this operation on custom {typeof(IBrowserFile)} implementations.");

--- a/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
+++ b/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// Contains helper methods for <see cref="IBrowserFile"/>.
     /// </summary>
     public static class BrowserFileExtensions
-    {        
+    {
         /// <summary>
         /// Attempts to convert the current image file to a new one of the specified file type and maximum file dimensions.
         /// <para>

--- a/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
+++ b/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <param name="browserFile">The <see cref="IBrowserFile"/> to convert to a new image file.</param>
         /// <param name="format">The new image format.</param>
         /// <param name="maxWidth">The maximum image width.</param>
-        /// <param name="maxHeight">The maximum image height</param>
+        /// <param name="maxHeight">The maximum image height.</param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
         public static ValueTask<IBrowserFile> RequestImageFileAsync(this IBrowserFile browserFile, string format, int maxWidth, int maxHeight)
         {
@@ -47,8 +47,12 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <param name="browserFile">The <see cref="IBrowserFile"/> to convert to a new image file.</param>
         /// <param name="format">The new image format.</param>
         /// <param name="maxWidth">The maximum image width.</param>
-        /// <param name="maxHeight">The maximum image height</param>
-        /// <param name="quality">The quality of the image</param>
+        /// <param name="maxHeight">The maximum image height.</param>
+        /// <param name="quality">
+        /// A Number between 0 and 1 indicating the image quality to be used when creating images using file formats that support 
+        /// lossy compression (such as image/jpeg or image/webp). A user agent will use its default quality value if this option is not specified, 
+        /// or if the number is outside the allowed range.
+        /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
         public static ValueTask<IBrowserFile> RequestImageFileAsync(this IBrowserFile browserFile, string format, int maxWidth, int maxHeight, double? quality)
         {

--- a/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
+++ b/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <param name="maxWidth">The maximum image width.</param>
         /// <param name="maxHeight">The maximum image height.</param>
         /// <param name="quality">
-        /// A Number between 0 and 1 indicating the image quality to be used when creating images using file formats that support 
+        /// A number between 0 and 1 indicating the image quality to be used when creating images using file formats that support 
         /// lossy compression (such as image/jpeg or image/webp). A user agent will use its default quality value if this option is not specified, 
         /// or if the number is outside the allowed range.
         /// </param>

--- a/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
+++ b/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
         public static ValueTask<IBrowserFile> RequestImageFileAsync(this IBrowserFile browserFile, string format, int maxWidth, int maxHeight)
         {
-            return browserFile.RequestImageFileAsync(format, maxWidth, maxHeight, null);
+            return browserFile.RequestImageFileAsync(format, maxWidth, maxHeight, quality: null);
         }
         
         /// <summary>

--- a/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
+++ b/src/Components/Web/src/Forms/InputFile/BrowserFileExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// Contains helper methods for <see cref="IBrowserFile"/>.
     /// </summary>
     public static class BrowserFileExtensions
-    {
+    {        
         /// <summary>
         /// Attempts to convert the current image file to a new one of the specified file type and maximum file dimensions.
         /// <para>
@@ -26,9 +26,31 @@ namespace Microsoft.AspNetCore.Components.Forms
         /// <param name="format">The new image format.</param>
         /// <param name="maxWidth">The maximum image width.</param>
         /// <param name="maxHeight">The maximum image height</param>
+        /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
+        public static ValueTask<IBrowserFile> RequestImageFileAsync(this IBrowserFile browserFile, string format, int maxWidth, int maxHeight)
+        {
+            return browserFile.RequestImageFileAsync(format, maxWidth, maxHeight, null);
+        }
+        
+        /// <summary>
+        /// Attempts to convert the current image file to a new one of the specified file type and maximum file dimensions.
+        /// <para>
+        /// Caution: there is no guarantee that the file will be converted, or will even be a valid image file at all, either
+        /// before or after conversion. The conversion is requested within the browser before it is transferred to .NET
+        /// code, so the resulting data should be treated as untrusted.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// The image will be scaled to fit the specified dimensions while preserving the original aspect ratio.
+        /// The quality parameter is not supported on all browsers, especially mobile browsers.
+        /// </remarks>
+        /// <param name="browserFile">The <see cref="IBrowserFile"/> to convert to a new image file.</param>
+        /// <param name="format">The new image format.</param>
+        /// <param name="maxWidth">The maximum image width.</param>
+        /// <param name="maxHeight">The maximum image height</param>
         /// <param name="quality">The quality of the image</param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        public static ValueTask<IBrowserFile> RequestImageFileAsync(this IBrowserFile browserFile, string format, int maxWidth, int maxHeight, double? quality = null)
+        public static ValueTask<IBrowserFile> RequestImageFileAsync(this IBrowserFile browserFile, string format, int maxWidth, int maxHeight, double? quality)
         {
             if (browserFile is BrowserFile browserFileInternal)
             {


### PR DESCRIPTION
**Add Quality parameter to BrowserFileExtensions.RequestImageFileAsync**
This adds a quality parameter to the `BrowserFileExtensions.RequestImageFileAsync` method to choose the quality of the resized image.

Addresses #32769