### PR TITLE
Include platform in SharedFx bundle name

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
+++ b/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
@@ -66,8 +66,8 @@
 
     <BundleNameShort>Microsoft ASP.NET Core $(PackageBrandingVersion)</BundleNameShort>
     <BundleNameSub>Shared Framework</BundleNameSub>
-    <BundleName>$(BundleNameShort) - $(BundleNameSub)</BundleName>
-    <BundleNameFull>$(BundleName) ($(Platform))</BundleNameFull>
+    <BundleName>$(BundleNameShort) - $(BundleNameSub) ($(Platform))</BundleName>
+    <BundleNameFull>$(BundleName)</BundleNameFull>
     <BundleRegName>$(BundleNameFull)</BundleRegName>
 
     <BundleManufacturer>Microsoft Corporation</BundleManufacturer>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/32708

I'll use this PR as a guinea pig for the backport bot introduced by https://github.com/dotnet/aspnetcore/pull/32777

Internal build to grab installers for validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=1142108&view=results