### PR TITLE
Iterate on Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,14 @@ updates:
     allow:
       - dependency-type: "all"
     assignees:
-      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "juntaoluo"
+      - "wtgodbe"
+    commit-message:
+      prefix: "[main] "
+      include: scope
     labels:
       - area-infrastructure
-      - dependencies
 
   # Keep submodules up to date in 'release/*' branches. (Unfortunately Dependabot security PRs can't target these.)
   - package-ecosystem: "gitsubmodule"
@@ -23,10 +27,14 @@ updates:
     allow:
       - dependency-type: "all"
     assignees:
-      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "juntaoluo"
+      - "wtgodbe"
+    commit-message:
+      prefix: "[release/2.1] "
+      include: scope
     labels:
       - area-infrastructure
-      - dependencies
     target-branch: "release/2.1"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
@@ -36,10 +44,14 @@ updates:
     allow:
       - dependency-type: "all"
     assignees:
-      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "juntaoluo"
+      - "wtgodbe"
+    commit-message:
+      prefix: "[release/3.1] "
+      include: scope
     labels:
       - area-infrastructure
-      - dependencies
     target-branch: "release/3.1"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
@@ -49,8 +61,12 @@ updates:
     allow:
       - dependency-type: "all"
     assignees:
-      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "juntaoluo"
+      - "wtgodbe"
+    commit-message:
+      prefix: "[release/5.0] "
+      include: scope
     labels:
       - area-infrastructure
-      - dependencies
     target-branch: "release/5.0"


### PR DESCRIPTION
- remove mention of non-existant `dependencies` label
- don't attempt to assign PRs to a group
- make target branch more obvious in commit and PR titles