### PR TITLE
Fix `SignalRClientWorksWithLongPolling`

### DIFF
--- a/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
@@ -44,6 +44,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public override Task InitializeAsync() => base.InitializeAsync(Guid.NewGuid().ToString());
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27156")]
         public void SignalRClientWorksWithLongPolling()
         {
             Browser.Exists(By.Id("hub-url")).SendKeys(

--- a/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
@@ -40,8 +40,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Exists(By.Id("signalr-client"));
         }
 
+        public override Task InitializeAsync() => base.InitializeAsync(Guid.NewGuid().ToString());
+
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27156")]
         public void SignalRClientWorksWithLongPolling()
         {
             Browser.Exists(By.Id("hub-url")).SendKeys(

--- a/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/SignalRClientTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;


### PR DESCRIPTION
Failure seems to be due to the same resource sharing issues seen in https://github.com/dotnet/aspnetcore/pull/32281

Confirmed that the test has a steady pass rate in the quarantine env (4 failures are un-related).

![image](https://user-images.githubusercontent.com/14852843/118701867-0d09fd00-b7c9-11eb-98fa-dde72f45f1fb.png)
