### PR TITLE
Allow POST/PUT without Content-Length or chunked

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -162,9 +162,6 @@
   <data name="BadRequest_InvalidRequestTarget_Detail" xml:space="preserve">
     <value>Invalid request target: '{detail}'</value>
   </data>
-  <data name="BadRequest_LengthRequired" xml:space="preserve">
-    <value>{detail} request contains no Content-Length or Transfer-Encoding header.</value>
-  </data>
   <data name="BadRequest_LengthRequiredHttp10" xml:space="preserve">
     <value>{detail} request contains no Content-Length header.</value>
   </data>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -180,11 +180,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
 
             // If we got here, request contains no Content-Length or Transfer-Encoding header.
-            // Reject with 411 Length Required.
-            if (context.Method == HttpMethod.Post || context.Method == HttpMethod.Put)
+            // Reject with Length Required for HTTP 1.0.
+            if (httpVersion == HttpVersion.Http10 && (context.Method == HttpMethod.Post || context.Method == HttpMethod.Put))
             {
-                var requestRejectionReason = httpVersion == HttpVersion.Http11 ? RequestRejectionReason.LengthRequired : RequestRejectionReason.LengthRequiredHttp10;
-                KestrelBadHttpRequestException.Throw(requestRejectionReason, context.Method);
+                KestrelBadHttpRequestException.Throw(RequestRejectionReason.LengthRequiredHttp10, context.Method);
             }
 
             context.OnTrailersComplete(); // No trailers for these.

--- a/src/Servers/Kestrel/Core/src/Internal/Http/RequestRejectionReason.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/RequestRejectionReason.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         RequestHeadersTimeout,
         RequestBodyTimeout,
         FinalTransferCodingNotChunked,
-        LengthRequired,
         LengthRequiredHttp10,
         OptionsMethodRequired,
         ConnectMethodRequired,

--- a/src/Servers/Kestrel/Core/src/KestrelBadHttpRequestException.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelBadHttpRequestException.cs
@@ -133,9 +133,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 case RequestRejectionReason.FinalTransferCodingNotChunked:
                     ex = new BadHttpRequestException(CoreStrings.FormatBadRequest_FinalTransferCodingNotChunked(detail), StatusCodes.Status400BadRequest, reason);
                     break;
-                case RequestRejectionReason.LengthRequired:
-                    ex = new BadHttpRequestException(CoreStrings.FormatBadRequest_LengthRequired(detail), StatusCodes.Status411LengthRequired, reason);
-                    break;
                 case RequestRejectionReason.LengthRequiredHttp10:
                     ex = new BadHttpRequestException(CoreStrings.FormatBadRequest_LengthRequiredHttp10(detail), StatusCodes.Status400BadRequest, reason);
                     break;

--- a/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
+++ b/src/Servers/Kestrel/Core/test/MessageBodyTests.cs
@@ -559,19 +559,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Theory]
         [InlineData((int)HttpMethod.Post)]
         [InlineData((int)HttpMethod.Put)]
-        public void ForThrowsWhenMethodRequiresLengthButNoContentLengthOrTransferEncodingIsSet(int intMethod)
+        public void ForReturnsZeroLengthWhenNoContentLengthOrTransferEncodingIsSetHttp11(int intMethod)
         {
             var method = (HttpMethod)intMethod;
             using (var input = new TestInput())
             {
                 input.Http1Connection.Method = method;
-#pragma warning disable CS0618 // Type or member is obsolete
-                var ex = Assert.Throws<BadHttpRequestException>(() =>
-#pragma warning restore CS0618 // Type or member is obsolete
-                    Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection));
+                var result = Http1MessageBody.For(HttpVersion.Http11, new HttpRequestHeaders(), input.Http1Connection);
 
-                Assert.Equal(StatusCodes.Status411LengthRequired, ex.StatusCode);
-                Assert.Equal(CoreStrings.FormatBadRequest_LengthRequired(((IHttpRequestFeature)input.Http1Connection).Method), ex.Message);
+                Assert.Same(MessageBody.ZeroContentLengthKeepAlive, result);
             }
         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -81,17 +81,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [Theory]
         [InlineData("POST")]
         [InlineData("PUT")]
-        public Task BadRequestIfMethodRequiresLengthButNoContentLengthOrTransferEncodingInRequest(string method)
-        {
-            return TestBadRequest(
-                $"{method} / HTTP/1.1\r\nHost:\r\n\r\n",
-                "411 Length Required",
-                CoreStrings.FormatBadRequest_LengthRequired(method));
-        }
-
-        [Theory]
-        [InlineData("POST")]
-        [InlineData("PUT")]
         public Task BadRequestIfMethodRequiresLengthButNoContentLengthInHttp10Request(string method)
         {
             return TestBadRequest(


### PR DESCRIPTION
**Allow POST/PUT without Content-Length or chunked**

If I understand HTTP 1.0 rfc1945#section-8.3 PUT and POST should return 400. In contrast to HTTP 1.1 and the referenced rfc7230#section-3.3.3 which may return 411. As this class (referenced above) seems to be used for request, response sections of above RFC-s fall out of consideration.

The following changes made:

- Updating MessageBody's For method to reject when no Content-Length *only* for HTTP 1.0
- Removing LengthRequired reject reason, which is internal and not used elsewhere
- Updating unit tests

Fixes #29398
