### PR TITLE
Fix WebApplicationBuilder to read environment specific config for logging

### DIFF
--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             configureDelegate(_context, _configuration);
             _environment.ApplyConfigurationSettings(_configuration);
-            _configuration.ChangeBasePath(_environment.ContentRootPath);
+            //_configuration.ChangeBasePath(_environment.ContentRootPath);
             return this;
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             configureDelegate(_configuration);
             _environment.ApplyConfigurationSettings(_configuration);
-            _configuration.ChangeBasePath(_environment.ContentRootPath);
+            //_configuration.ChangeBasePath(_environment.ContentRootPath);
             return this;
         }
 

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Hosting
     // This exists solely to bootstrap the configuration
     internal class BootstrapHostBuilder : IHostBuilder
     {
-        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
         private readonly HostBuilderContext _context;
         private readonly Configuration _configuration;
         private readonly WebHostEnvironment _environment;
@@ -28,6 +27,8 @@ namespace Microsoft.AspNetCore.Hosting
                 HostingEnvironment = webHostEnvironment
             };
         }
+
+        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
 
         public IHost Build()
         {

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -40,7 +40,6 @@ namespace Microsoft.AspNetCore.Hosting
         {
             configureDelegate(_context, _configuration);
             _environment.ApplyConfigurationSettings(_configuration);
-            //_configuration.ChangeBasePath(_environment.ContentRootPath);
             return this;
         }
 
@@ -55,7 +54,6 @@ namespace Microsoft.AspNetCore.Hosting
         {
             configureDelegate(_configuration);
             _environment.ApplyConfigurationSettings(_configuration);
-            //_configuration.ChangeBasePath(_environment.ContentRootPath);
             return this;
         }
 

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -9,208 +9,16 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Builder
 {
-    ///// <summary>
-    ///// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
-    ///// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
-    ///// </summary>
-    //public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder
-    //{
-    //    private readonly ConfigurationBuilder _builder = new();
-    //    private IConfigurationRoot _configuration;
-
-    //    /// <summary>
-    //    /// Gets or sets a configuration value.
-    //    /// </summary>
-    //    /// <param name="key">The configuration key.</param>
-    //    /// <returns>The configuration value.</returns>
-    //    public string this[string key] { get => _configuration[key]; set => _configuration[key] = value; }
-
-    //    /// <summary>
-    //    /// Gets a configuration sub-section with the specified key.
-    //    /// </summary>
-    //    /// <param name="key">The key of the configuration section.</param>
-    //    /// <returns>The <see cref="IConfigurationSection"/>.</returns>
-    //    /// <remarks>
-    //    ///     This method will never return <c>null</c>. If no matching sub-section is found with the specified key,
-    //    ///     an empty <see cref="IConfigurationSection"/> will be returned.
-    //    /// </remarks>
-    //    public IConfigurationSection GetSection(string key)
-    //    {
-    //        return _configuration.GetSection(key);
-    //    }
-
-    //    /// <summary>
-    //    /// Gets the immediate descendant configuration sub-sections.
-    //    /// </summary>
-    //    /// <returns>The configuration sub-sections.</returns>
-    //    public IEnumerable<IConfigurationSection> GetChildren() => _configuration.GetChildren();
-
-    //    IDictionary<string, object> IConfigurationBuilder.Properties => _builder.Properties;
-
-    //    IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
-
-    //    internal IList<IConfigurationSource> Sources { get; }
-
-    //    IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => _configuration.Providers;
-
-    //    /// <summary>
-    //    /// Creates a new <see cref="Configuration"/>.
-    //    /// </summary>
-    //    public Configuration()
-    //    {
-    //        _configuration = _builder.Build();
-    //        Sources = new ConfigurationSources(_builder.Sources, this);
-    //    }
-
-    //    internal void ChangeBasePath(string path)
-    //    {
-    //        this.SetBasePath(path);
-    //        UpdateConfiguration();
-    //    }
-
-    //    internal void ChangeFileProvider(IFileProvider fileProvider)
-    //    {
-    //        this.SetFileProvider(fileProvider);
-    //        UpdateConfiguration();
-    //    }
-
-    //    //private void AttachReloadToken()
-    //    //{
-    //    //    // We dispose the IConfigurationRoot every time we reattach so we don't bother tracking the registration.
-    //    //    _configuration.GetReloadToken().RegisterChangeCallback(static state =>
-    //    //        ((ConfigurationReloadToken)state).OnReload(), _reloadToken);
-    //    //}
-
-    //    private void UpdateConfiguration()
-    //    {
-    //        var current = _configuration;
-    //        if (current is IDisposable disposable)
-    //        {
-    //            disposable.Dispose();
-    //        }
-    //        _configuration = _builder.Build();
-    //    }
-
-    //    IConfigurationBuilder IConfigurationBuilder.Add(IConfigurationSource source)
-    //    {
-    //        Sources.Add(source);
-    //        return this;
-    //    }
-
-    //    IConfigurationRoot IConfigurationBuilder.Build()
-    //    {
-    //        // No more modification is expected after this final build
-    //        UpdateConfiguration();
-    //        return this;
-    //    }
-
-    //    IChangeToken IConfiguration.GetReloadToken()
-    //    {
-    //        return _configuration.GetReloadToken();
-    //    }
-
-    //    void IConfigurationRoot.Reload()
-    //    {
-    //        _configuration.Reload();
-    //        UpdateConfiguration();
-    //    }
-
-    //    // On source modifications, we rebuild configuration
-    //    private class ConfigurationSources : IList<IConfigurationSource>
-    //    {
-    //        private readonly IList<IConfigurationSource> _sources;
-    //        private readonly Configuration _config;
-
-    //        public ConfigurationSources(IList<IConfigurationSource> sources, Configuration config)
-    //        {
-    //            _sources = sources;
-    //            _config = config;
-    //        }
-
-    //        public IConfigurationSource this[int index]
-    //        {
-    //            get => _sources[index];
-    //            set
-    //            {
-    //                _sources[index] = value;
-    //                _config.UpdateConfiguration();
-    //            }
-    //        }
-
-    //        public int Count => _sources.Count;
-
-    //        public bool IsReadOnly => _sources.IsReadOnly;
-
-    //        public void Add(IConfigurationSource item)
-    //        {
-    //            _sources.Add(item);
-    //            _config.UpdateConfiguration();
-    //        }
-
-    //        public void Clear()
-    //        {
-    //            _sources.Clear();
-    //            _config.UpdateConfiguration();
-    //        }
-
-    //        public bool Contains(IConfigurationSource item)
-    //        {
-    //            return _sources.Contains(item);
-    //        }
-
-    //        public void CopyTo(IConfigurationSource[] array, int arrayIndex)
-    //        {
-    //            _sources.CopyTo(array, arrayIndex);
-    //        }
-
-    //        public IEnumerator<IConfigurationSource> GetEnumerator()
-    //        {
-    //            return _sources.GetEnumerator();
-    //        }
-
-    //        public int IndexOf(IConfigurationSource item)
-    //        {
-    //            return _sources.IndexOf(item);
-    //        }
-
-    //        public void Insert(int index, IConfigurationSource item)
-    //        {
-    //            _sources.Insert(index, item);
-    //            _config.UpdateConfiguration();
-    //        }
-
-    //        public bool Remove(IConfigurationSource item)
-    //        {
-    //            var removed = _sources.Remove(item);
-    //            _config.UpdateConfiguration();
-    //            return removed;
-    //        }
-
-    //        public void RemoveAt(int index)
-    //        {
-    //            _sources.RemoveAt(index);
-    //            _config.UpdateConfiguration();
-    //        }
-
-    //        IEnumerator IEnumerable.GetEnumerator()
-    //        {
-    //            return GetEnumerator();
-    //        }
-    //    }
-
     /// <summary>
     /// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
     /// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
     /// </summary>
     public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder, IDisposable
     {
-        // We start off dirty to ensure the first configuration root is built on demand
-        private bool _dirty = true;
         private ConfigurationRoot? _configurationRoot;
         private ConfigurationReloadToken _changeToken = new();
         private IDisposable? _changeTokenRegistration;
@@ -226,7 +34,7 @@ namespace Microsoft.AspNetCore.Builder
         {
             get
             {
-                EnsureFreshConfiguration();
+                UpdateConfiguration();
                 Debug.Assert(_configurationRoot is not null);
                 return _configurationRoot;
             }
@@ -269,20 +77,12 @@ namespace Microsoft.AspNetCore.Builder
 
         void IConfigurationRoot.Reload() => ConfigurationRoot.Reload();
 
-        private void MarkDirty() => _dirty = true;
-
-        private void EnsureFreshConfiguration()
+        private void UpdateConfiguration()
         {
-            if (!_dirty)
-            {
-                return;
-            }
-
             var newConfiguration = BuildConfigurationRoot();
             var prevConfiguration = _configurationRoot;
 
             _configurationRoot = newConfiguration;
-            _dirty = false;
 
             _changeTokenRegistration?.Dispose();
             (prevConfiguration as IDisposable)?.Dispose();
@@ -323,7 +123,6 @@ namespace Microsoft.AspNetCore.Builder
                 .Select(key => ConfigurationRoot.GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
         }
 
-        // On source modifications, we mark configuration as dirty
         private class ConfigurationSources : IList<IConfigurationSource>
         {
             private readonly IList<IConfigurationSource> _sources;
@@ -341,7 +140,7 @@ namespace Microsoft.AspNetCore.Builder
                 set
                 {
                     _sources[index] = value;
-                    _config.MarkDirty();
+                    _config.UpdateConfiguration();
                 }
             }
 
@@ -352,13 +151,13 @@ namespace Microsoft.AspNetCore.Builder
             public void Add(IConfigurationSource item)
             {
                 _sources.Add(item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public void Clear()
             {
                 _sources.Clear();
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public bool Contains(IConfigurationSource item)
@@ -384,20 +183,20 @@ namespace Microsoft.AspNetCore.Builder
             public void Insert(int index, IConfigurationSource item)
             {
                 _sources.Insert(index, item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public bool Remove(IConfigurationSource item)
             {
                 var removed = _sources.Remove(item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
                 return removed;
             }
 
             public void RemoveAt(int index)
             {
                 _sources.RemoveAt(index);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             IEnumerator IEnumerable.GetEnumerator()
@@ -406,7 +205,6 @@ namespace Microsoft.AspNetCore.Builder
             }
         }
 
-        // On property modifications we mark configuration as dirty.
         private class ConfigurationProperties : IDictionary<string, object>
         {
             private readonly IDictionary<string, object> _properties = new Dictionary<string, object>();
@@ -422,7 +220,7 @@ namespace Microsoft.AspNetCore.Builder
                 get => _properties[key];
                 set
                 {
-                    _config.MarkDirty();
+                    _config.UpdateConfiguration();
                     _properties[key] = value;
                 }
             }
@@ -438,19 +236,19 @@ namespace Microsoft.AspNetCore.Builder
             public void Add(string key, object value)
             {
                 _properties.Add(key, value);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public void Add(KeyValuePair<string, object> item)
             {
                 _properties.Add(item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public void Clear()
             {
                 _properties.Clear();
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public bool Contains(KeyValuePair<string, object> item) => _properties.Contains(item);
@@ -464,14 +262,14 @@ namespace Microsoft.AspNetCore.Builder
             public bool Remove(string key)
             {
                 var removed = _properties.Remove(key);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
                 return removed;
             }
 
             public bool Remove(KeyValuePair<string, object> item)
             {
                 var removed = _properties.Remove(item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
                 return removed;
             }
 

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -49,7 +49,6 @@ namespace Microsoft.AspNetCore.Builder
 
         IDictionary<string, object> IConfigurationBuilder.Properties => _builder.Properties;
 
-        // TODO: Handle modifications to Sources and keep the configuration root in sync
         IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
 
         internal IList<IConfigurationSource> Sources { get; }

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -4,125 +4,335 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 
-// TODO: Microsft.Extensions.Configuration API Proposal
 namespace Microsoft.AspNetCore.Builder
 {
+    ///// <summary>
+    ///// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
+    ///// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
+    ///// </summary>
+    //public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder
+    //{
+    //    private readonly ConfigurationBuilder _builder = new();
+    //    private IConfigurationRoot _configuration;
+
+    //    /// <summary>
+    //    /// Gets or sets a configuration value.
+    //    /// </summary>
+    //    /// <param name="key">The configuration key.</param>
+    //    /// <returns>The configuration value.</returns>
+    //    public string this[string key] { get => _configuration[key]; set => _configuration[key] = value; }
+
+    //    /// <summary>
+    //    /// Gets a configuration sub-section with the specified key.
+    //    /// </summary>
+    //    /// <param name="key">The key of the configuration section.</param>
+    //    /// <returns>The <see cref="IConfigurationSection"/>.</returns>
+    //    /// <remarks>
+    //    ///     This method will never return <c>null</c>. If no matching sub-section is found with the specified key,
+    //    ///     an empty <see cref="IConfigurationSection"/> will be returned.
+    //    /// </remarks>
+    //    public IConfigurationSection GetSection(string key)
+    //    {
+    //        return _configuration.GetSection(key);
+    //    }
+
+    //    /// <summary>
+    //    /// Gets the immediate descendant configuration sub-sections.
+    //    /// </summary>
+    //    /// <returns>The configuration sub-sections.</returns>
+    //    public IEnumerable<IConfigurationSection> GetChildren() => _configuration.GetChildren();
+
+    //    IDictionary<string, object> IConfigurationBuilder.Properties => _builder.Properties;
+
+    //    IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
+
+    //    internal IList<IConfigurationSource> Sources { get; }
+
+    //    IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => _configuration.Providers;
+
+    //    /// <summary>
+    //    /// Creates a new <see cref="Configuration"/>.
+    //    /// </summary>
+    //    public Configuration()
+    //    {
+    //        _configuration = _builder.Build();
+    //        Sources = new ConfigurationSources(_builder.Sources, this);
+    //    }
+
+    //    internal void ChangeBasePath(string path)
+    //    {
+    //        this.SetBasePath(path);
+    //        UpdateConfiguration();
+    //    }
+
+    //    internal void ChangeFileProvider(IFileProvider fileProvider)
+    //    {
+    //        this.SetFileProvider(fileProvider);
+    //        UpdateConfiguration();
+    //    }
+
+    //    //private void AttachReloadToken()
+    //    //{
+    //    //    // We dispose the IConfigurationRoot every time we reattach so we don't bother tracking the registration.
+    //    //    _configuration.GetReloadToken().RegisterChangeCallback(static state =>
+    //    //        ((ConfigurationReloadToken)state).OnReload(), _reloadToken);
+    //    //}
+
+    //    private void UpdateConfiguration()
+    //    {
+    //        var current = _configuration;
+    //        if (current is IDisposable disposable)
+    //        {
+    //            disposable.Dispose();
+    //        }
+    //        _configuration = _builder.Build();
+    //    }
+
+    //    IConfigurationBuilder IConfigurationBuilder.Add(IConfigurationSource source)
+    //    {
+    //        Sources.Add(source);
+    //        return this;
+    //    }
+
+    //    IConfigurationRoot IConfigurationBuilder.Build()
+    //    {
+    //        // No more modification is expected after this final build
+    //        UpdateConfiguration();
+    //        return this;
+    //    }
+
+    //    IChangeToken IConfiguration.GetReloadToken()
+    //    {
+    //        return _configuration.GetReloadToken();
+    //    }
+
+    //    void IConfigurationRoot.Reload()
+    //    {
+    //        _configuration.Reload();
+    //        UpdateConfiguration();
+    //    }
+
+    //    // On source modifications, we rebuild configuration
+    //    private class ConfigurationSources : IList<IConfigurationSource>
+    //    {
+    //        private readonly IList<IConfigurationSource> _sources;
+    //        private readonly Configuration _config;
+
+    //        public ConfigurationSources(IList<IConfigurationSource> sources, Configuration config)
+    //        {
+    //            _sources = sources;
+    //            _config = config;
+    //        }
+
+    //        public IConfigurationSource this[int index]
+    //        {
+    //            get => _sources[index];
+    //            set
+    //            {
+    //                _sources[index] = value;
+    //                _config.UpdateConfiguration();
+    //            }
+    //        }
+
+    //        public int Count => _sources.Count;
+
+    //        public bool IsReadOnly => _sources.IsReadOnly;
+
+    //        public void Add(IConfigurationSource item)
+    //        {
+    //            _sources.Add(item);
+    //            _config.UpdateConfiguration();
+    //        }
+
+    //        public void Clear()
+    //        {
+    //            _sources.Clear();
+    //            _config.UpdateConfiguration();
+    //        }
+
+    //        public bool Contains(IConfigurationSource item)
+    //        {
+    //            return _sources.Contains(item);
+    //        }
+
+    //        public void CopyTo(IConfigurationSource[] array, int arrayIndex)
+    //        {
+    //            _sources.CopyTo(array, arrayIndex);
+    //        }
+
+    //        public IEnumerator<IConfigurationSource> GetEnumerator()
+    //        {
+    //            return _sources.GetEnumerator();
+    //        }
+
+    //        public int IndexOf(IConfigurationSource item)
+    //        {
+    //            return _sources.IndexOf(item);
+    //        }
+
+    //        public void Insert(int index, IConfigurationSource item)
+    //        {
+    //            _sources.Insert(index, item);
+    //            _config.UpdateConfiguration();
+    //        }
+
+    //        public bool Remove(IConfigurationSource item)
+    //        {
+    //            var removed = _sources.Remove(item);
+    //            _config.UpdateConfiguration();
+    //            return removed;
+    //        }
+
+    //        public void RemoveAt(int index)
+    //        {
+    //            _sources.RemoveAt(index);
+    //            _config.UpdateConfiguration();
+    //        }
+
+    //        IEnumerator IEnumerable.GetEnumerator()
+    //        {
+    //            return GetEnumerator();
+    //        }
+    //    }
+
     /// <summary>
     /// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
     /// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
     /// </summary>
-    public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder
+    public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder, IDisposable
     {
-        private readonly ConfigurationBuilder _builder = new();
-        private IConfigurationRoot _configuration;
+        // We start off dirty to ensure the first configuration root is built on demand
+        private bool _dirty = true;
+        private ConfigurationRoot? _configurationRoot;
+        private ConfigurationReloadToken _changeToken = new();
+        private IDisposable? _changeTokenRegistration;
 
-        /// <summary>
-        /// Gets or sets a configuration value.
-        /// </summary>
-        /// <param name="key">The configuration key.</param>
-        /// <returns>The configuration value.</returns>
-        public string this[string key] { get => _configuration[key]; set => _configuration[key] = value; }
+        // Needs to be a separate field, as it is not possible to initialize an explicitly implemented property in the constructor
+        // and we pass an instance method to the constructor used to initialize it, so cannot use a field initializer.
+        // On the other hand, if this is a separate class (not an enhanced version of the existing ConfigurationBuilder class)
+        // then we probably do want `Properties` to be an explicit interface implementation, so users looking to read configuration values
+        // don't get confused by it. So explicit backing field it is!
+        private readonly IDictionary<string, object> _properties;
 
-        /// <summary>
-        /// Gets a configuration sub-section with the specified key.
-        /// </summary>
-        /// <param name="key">The key of the configuration section.</param>
-        /// <returns>The <see cref="IConfigurationSection"/>.</returns>
-        /// <remarks>
-        ///     This method will never return <c>null</c>. If no matching sub-section is found with the specified key,
-        ///     an empty <see cref="IConfigurationSection"/> will be returned.
-        /// </remarks>
-        public IConfigurationSection GetSection(string key)
+        private IConfigurationRoot ConfigurationRoot
         {
-            return _configuration.GetSection(key);
+            get
+            {
+                EnsureFreshConfiguration();
+                Debug.Assert(_configurationRoot is not null);
+                return _configurationRoot;
+            }
         }
 
-        /// <summary>
-        /// Gets the immediate descendant configuration sub-sections.
-        /// </summary>
-        /// <returns>The configuration sub-sections.</returns>
-        public IEnumerable<IConfigurationSection> GetChildren() => _configuration.GetChildren();
+        public string this[string key] { get => ConfigurationRoot[key]; set => ConfigurationRoot[key] = value; }
 
-        IDictionary<string, object> IConfigurationBuilder.Properties => _builder.Properties;
+        public IConfigurationSection GetSection(string key) => new ConfigurationSection(this, key);
 
-        IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
+        public IEnumerable<IConfigurationSection> GetChildren() => GetChildrenImplementation(null);
+
+        IDictionary<string, object> IConfigurationBuilder.Properties => _properties;
 
         internal IList<IConfigurationSource> Sources { get; }
+        IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
 
-        IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => _configuration.Providers;
+        IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => ConfigurationRoot.Providers;
 
-        /// <summary>
-        /// Creates a new <see cref="Configuration"/>.
-        /// </summary>
         public Configuration()
         {
-            _configuration = _builder.Build();
-
-            var sources = new ConfigurationSources(_builder.Sources, UpdateConfigurationRoot);
-
-            Sources = sources;
+            _properties = new ConfigurationProperties(this);
+            Sources = new ConfigurationSources(this);
         }
 
-        internal void ChangeBasePath(string path)
+        public void Dispose()
         {
-            this.SetBasePath(path);
-            UpdateConfigurationRoot();
-        }
-
-        internal void ChangeFileProvider(IFileProvider fileProvider)
-        {
-            this.SetFileProvider(fileProvider);
-            UpdateConfigurationRoot();
-        }
-
-        private void UpdateConfigurationRoot()
-        {
-            var current = _configuration;
-            if (current is IDisposable disposable)
-            {
-                disposable.Dispose();
-            }
-            _configuration = _builder.Build();
+            _changeTokenRegistration?.Dispose();
+            _configurationRoot?.Dispose();
         }
 
         IConfigurationBuilder IConfigurationBuilder.Add(IConfigurationSource source)
         {
-            Sources.Add(source);
+            Sources.Add(source ?? throw new ArgumentNullException(nameof(source)));
             return this;
         }
 
-        IConfigurationRoot IConfigurationBuilder.Build()
+        IConfigurationRoot IConfigurationBuilder.Build() => BuildConfigurationRoot();
+
+        IChangeToken IConfiguration.GetReloadToken() => _changeToken;
+
+        void IConfigurationRoot.Reload() => ConfigurationRoot.Reload();
+
+        private void MarkDirty() => _dirty = true;
+
+        private void EnsureFreshConfiguration()
         {
-            // No more modification is expected after this final build
-            UpdateConfigurationRoot();
-            return this;
+            if (!_dirty)
+            {
+                return;
+            }
+
+            var newConfiguration = BuildConfigurationRoot();
+            var prevConfiguration = _configurationRoot;
+
+            _configurationRoot = newConfiguration;
+            _dirty = false;
+
+            _changeTokenRegistration?.Dispose();
+            (prevConfiguration as IDisposable)?.Dispose();
+
+            _changeTokenRegistration = ChangeToken.OnChange(() => newConfiguration.GetReloadToken(), RaiseChanged);
+            RaiseChanged();
         }
 
-        IChangeToken IConfiguration.GetReloadToken()
+        private ConfigurationRoot BuildConfigurationRoot()
         {
-            // REVIEW: Is this correct?
-            return _configuration.GetReloadToken();
+            var providers = new List<IConfigurationProvider>();
+            foreach (var source in Sources)
+            {
+                IConfigurationProvider provider = source.Build(this);
+                providers.Add(provider);
+            }
+            return new ConfigurationRoot(providers);
         }
 
-        void IConfigurationRoot.Reload()
+        private void RaiseChanged()
         {
-            _configuration.Reload();
+            ConfigurationReloadToken previousToken = Interlocked.Exchange(ref _changeToken, new ConfigurationReloadToken());
+            previousToken.OnReload();
         }
 
-        // On source modifications, we rebuild configuration
+        /// <summary>
+        /// Gets the immediate children sub-sections of configuration root based on key.
+        /// </summary>
+        /// <param name="path">Key of a section of which children to retrieve.</param>
+        /// <returns>Immediate children sub-sections of section specified by key.</returns>
+        private IEnumerable<IConfigurationSection> GetChildrenImplementation(string? path)
+        {
+            // From https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/libraries/Microsoft.Extensions.Configuration/src/InternalConfigurationRootExtensions.cs
+            return ConfigurationRoot.Providers
+                .Aggregate(Enumerable.Empty<string>(),
+                    (seed, source) => source.GetChildKeys(seed, path))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(key => ConfigurationRoot.GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
+        }
+
+        // On source modifications, we mark configuration as dirty
         private class ConfigurationSources : IList<IConfigurationSource>
         {
             private readonly IList<IConfigurationSource> _sources;
-            private readonly Action _sourcesModified;
+            private readonly Configuration _config;
 
-            public ConfigurationSources(IList<IConfigurationSource> sources, Action sourcesModified)
+            public ConfigurationSources(Configuration config)
             {
-                _sources = sources;
-                _sourcesModified = sourcesModified;
+                _sources = new List<IConfigurationSource>();
+                _config = config;
             }
 
             public IConfigurationSource this[int index]
@@ -131,7 +341,7 @@ namespace Microsoft.AspNetCore.Builder
                 set
                 {
                     _sources[index] = value;
-                    _sourcesModified();
+                    _config.MarkDirty();
                 }
             }
 
@@ -142,13 +352,13 @@ namespace Microsoft.AspNetCore.Builder
             public void Add(IConfigurationSource item)
             {
                 _sources.Add(item);
-                _sourcesModified();
+                _config.MarkDirty();
             }
 
             public void Clear()
             {
                 _sources.Clear();
-                _sourcesModified();
+                _config.MarkDirty();
             }
 
             public bool Contains(IConfigurationSource item)
@@ -174,26 +384,99 @@ namespace Microsoft.AspNetCore.Builder
             public void Insert(int index, IConfigurationSource item)
             {
                 _sources.Insert(index, item);
-                _sourcesModified();
+                _config.MarkDirty();
             }
 
             public bool Remove(IConfigurationSource item)
             {
                 var removed = _sources.Remove(item);
-                _sourcesModified();
+                _config.MarkDirty();
                 return removed;
             }
 
             public void RemoveAt(int index)
             {
                 _sources.RemoveAt(index);
-                _sourcesModified();
+                _config.MarkDirty();
             }
 
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
+        }
+
+        // On property modifications we mark configuration as dirty.
+        private class ConfigurationProperties : IDictionary<string, object>
+        {
+            private readonly IDictionary<string, object> _properties = new Dictionary<string, object>();
+            private readonly Configuration _config;
+
+            public ConfigurationProperties(Configuration config)
+            {
+                _config = config;
+            }
+
+            public object this[string key]
+            {
+                get => _properties[key];
+                set
+                {
+                    _config.MarkDirty();
+                    _properties[key] = value;
+                }
+            }
+
+            public ICollection<string> Keys => _properties.Keys;
+
+            public ICollection<object> Values => _properties.Values;
+
+            public int Count => _properties.Count;
+
+            public bool IsReadOnly => false;
+
+            public void Add(string key, object value)
+            {
+                _properties.Add(key, value);
+                _config.MarkDirty();
+            }
+
+            public void Add(KeyValuePair<string, object> item)
+            {
+                _properties.Add(item);
+                _config.MarkDirty();
+            }
+
+            public void Clear()
+            {
+                _properties.Clear();
+                _config.MarkDirty();
+            }
+
+            public bool Contains(KeyValuePair<string, object> item) => _properties.Contains(item);
+
+            public bool ContainsKey(string key) => _properties.ContainsKey(key);
+
+            public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) => _properties.CopyTo(array, arrayIndex);
+
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _properties.GetEnumerator();
+
+            public bool Remove(string key)
+            {
+                var removed = _properties.Remove(key);
+                _config.MarkDirty();
+                return removed;
+            }
+
+            public bool Remove(KeyValuePair<string, object> item)
+            {
+                var removed = _properties.Remove(item);
+                _config.MarkDirty();
+                return removed;
+            }
+
+            public bool TryGetValue(string key, [MaybeNullWhen(false)] out object value) => _properties.TryGetValue(key, out value);
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_properties).GetEnumerator();
         }
     }
 }

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Builder
             var providers = new List<IConfigurationProvider>();
             foreach (var source in _sources)
             {
-                IConfigurationProvider provider = source.Build(this);
+                var provider = source.Build(this);
                 providers.Add(provider);
             }
             return new ConfigurationRoot(providers);
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private void RaiseChanged()
         {
-            ConfigurationReloadToken previousToken = Interlocked.Exchange(ref _changeToken, new ConfigurationReloadToken());
+            var previousToken = Interlocked.Exchange(ref _changeToken, new ConfigurationReloadToken());
             previousToken.OnReload();
         }
 

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.AspNetCore.Builder
 {
     /// <summary>
-    /// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
+    /// Configuration is mutable configuration object. It is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
     /// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
     /// </summary>
     public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder, IDisposable
@@ -40,10 +40,13 @@ namespace Microsoft.AspNetCore.Builder
             }
         }
 
+        /// <inheritdoc />
         public string this[string key] { get => ConfigurationRoot[key]; set => ConfigurationRoot[key] = value; }
 
+        /// <inheritdoc />
         public IConfigurationSection GetSection(string key) => new ConfigurationSection(this, key);
 
+        /// <inheritdoc />
         public IEnumerable<IConfigurationSection> GetChildren() => GetChildrenImplementation(null);
 
         IDictionary<string, object> IConfigurationBuilder.Properties => _properties;
@@ -53,12 +56,16 @@ namespace Microsoft.AspNetCore.Builder
 
         IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => ConfigurationRoot.Providers;
 
+        /// <summary>
+        /// Creates an empty  mutable configuration object that is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
+        /// </summary>
         public Configuration()
         {
             _properties = new ConfigurationProperties(this);
             Sources = new ConfigurationSources(this);
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             _changeTokenRegistration?.Dispose();

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Builder
             configureDelegate(_hostConfiguration);
 
             _environment.ApplyConfigurationSettings(_hostConfiguration.Build());
-            Configuration.ChangeFileProvider(_environment.ContentRootFileProvider);
+            //Configuration.ChangeFileProvider(_environment.ContentRootFileProvider);
 
             return this;
         }

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -63,7 +63,6 @@ namespace Microsoft.AspNetCore.Builder
             _environment.ApplyConfigurationSettings(_hostConfiguration.Build());
             Configuration.ChangeFileProvider(_environment.ContentRootFileProvider);
 
-            _operations += b => b.ConfigureHostConfiguration(configureDelegate);
             return this;
         }
 

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -61,7 +61,6 @@ namespace Microsoft.AspNetCore.Builder
             configureDelegate(_hostConfiguration);
 
             _environment.ApplyConfigurationSettings(_hostConfiguration.Build());
-            //Configuration.ChangeFileProvider(_environment.ContentRootFileProvider);
 
             return this;
         }

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Builder
                 _environment.ContentRootPath = value;
                 _environment.ResolveFileProviders(_configuration);
 
-                _configuration.ChangeBasePath(value);
+                //_configuration.ChangeBasePath(value);
             }
             else if (string.Equals(key, WebHostDefaults.EnvironmentKey, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -86,8 +86,6 @@ namespace Microsoft.AspNetCore.Builder
             {
                 _environment.ContentRootPath = value;
                 _environment.ResolveFileProviders(_configuration);
-
-                //_configuration.ChangeBasePath(value);
             }
             else if (string.Equals(key, WebHostDefaults.EnvironmentKey, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Builder.Configuration
 Microsoft.AspNetCore.Builder.Configuration.Configuration() -> void
+Microsoft.AspNetCore.Builder.Configuration.Dispose() -> void
 Microsoft.AspNetCore.Builder.Configuration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!
 Microsoft.AspNetCore.Builder.Configuration.GetSection(string! key) -> Microsoft.Extensions.Configuration.IConfigurationSection!
 Microsoft.AspNetCore.Builder.Configuration.this[string! key].get -> string!

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -61,13 +61,13 @@ namespace Microsoft.AspNetCore.Builder
         public Configuration Configuration { get; } = new();
 
         /// <summary>
-        /// A collection of logging providers for the applicaiton to compose. This is useful for adding new logging providers.
+        /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.
         /// </summary>
         public ILoggingBuilder Logging { get; }
 
         /// <summary>
         /// An <see cref="IHostBuilder"/> for configuring server specific properties, but not building.
-        /// To build after configuruation, call <see cref="Build"/>.
+        /// To build after configuration, call <see cref="Build"/>.
         /// </summary>
         public ConfigureWebHostBuilder WebHost { get; }
 

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -28,19 +28,22 @@ namespace Microsoft.AspNetCore.Builder
             // HACK: MVC and Identity do this horrible thing to get the hosting environment as an instance
             // from the service collection before it is built. That needs to be fixed...
             Environment = _environment = new WebHostEnvironment(callingAssembly);
+
             Services.AddSingleton(Environment);
 
             // Run methods to configure both generic and web host defaults early to populate config from appsettings.json
             // environment variables (both DOTNET_ and ASPNETCORE_ prefixed) and other possible default sources to prepopulate
             // the correct defaults.
             var bootstrapBuilder = new BootstrapHostBuilder(Configuration, _environment);
-            bootstrapBuilder.ConfigureDefaults(args);
             bootstrapBuilder.ConfigureWebHostDefaults(configure: _ => { });
+            bootstrapBuilder.ConfigureDefaults(args);
 
             Configuration.SetBasePath(_environment.ContentRootPath);
             Logging = new LoggingBuilder(Services);
             WebHost = _deferredWebHostBuilder = new ConfigureWebHostBuilder(Configuration, _environment, Services);
             Host = _deferredHostBuilder = new ConfigureHostBuilder(Configuration, _environment, Services);
+
+            Services.AddSingleton<IConfiguration>(Configuration);
 
             _deferredHostBuilder.ConfigureDefaults(args);
         }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Builder
                 // already thanks to the BootstrapHostBuilder.
                 builder.Sources.Clear();
 
-                foreach (var s in Configuration.Sources)
+                foreach (var s in ((IConfigurationBuilder)Configuration).Sources)
                 {
                     builder.Sources.Add(s);
                 }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -167,6 +167,10 @@ namespace Microsoft.AspNetCore.Builder
 
             _hostBuilder.ConfigureAppConfiguration((hostContext, builder) =>
             {
+                // All the sources in builder.Sources should be in Configuration.Sources
+                // already thanks to the BootstrapHostBuilder.
+                builder.Sources.Clear();
+
                 foreach (var s in Configuration.Sources)
                 {
                     builder.Sources.Add(s);


### PR DESCRIPTION
### Before

![old-webapplicationbuilder-loggingconfiguration](https://user-images.githubusercontent.com/54385/118707674-a9cf9900-b7cf-11eb-8c30-dd069e16c430.png)

### After

![new-webapplicationbuilder-loggingconfiguration](https://user-images.githubusercontent.com/54385/118707707-b2c06a80-b7cf-11eb-906e-7824a611e99c.png)

### CreateDefaultBuilder/ConfigureWebHostDefaults

![default-generic-host-loggingconfiguration](https://user-images.githubusercontent.com/54385/118707773-c79cfe00-b7cf-11eb-9afd-2de29b572d07.png)

Fixes #32383

Thanks to @KevinCathcart for https://github.com/dotnet/runtime/issues/51770#issuecomment-828915774

TODO: Add tests
