### PR TITLE
Add support for customising the creation of Kestrel listen sockets

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -7,6 +7,6 @@ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.Bin
 ~Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.SocketTransportFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder, System.Action<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! configureOptions) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
-static Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateDefaultListenSocket(System.Net.EndPoint! endpoint) -> System.Net.Sockets.Socket!
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateListenSocket.get -> System.Func<System.Net.EndPoint!, System.Net.Sockets.Socket!>!
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateListenSocket.set -> void
+static Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateDefaultBoundListenSocket(System.Net.EndPoint! endpoint) -> System.Net.Sockets.Socket!
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateBoundListenSocket.get -> System.Func<System.Net.EndPoint!, System.Net.Sockets.Socket!>!
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateBoundListenSocket.set -> void

--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -7,3 +7,7 @@ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.Bin
 ~Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.SocketTransportFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder, System.Action<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! configureOptions) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureAcceptSocket.get -> System.Action<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureAcceptSocket.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureListenSocket.get -> System.Action<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureListenSocket.set -> void

--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -7,7 +7,7 @@ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.Bin
 ~Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.SocketTransportFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder, System.Action<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! configureOptions) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureAcceptSocket.get -> System.Action<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureAcceptSocket.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureAcceptedSocket.get -> System.Action<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureAcceptedSocket.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureListenSocket.get -> System.Action<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
 Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureListenSocket.set -> void

--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -8,5 +8,5 @@ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.Bin
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder, System.Action<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! configureOptions) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 static Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateDefaultListenSocket(System.Net.EndPoint! endpoint) -> System.Net.Sockets.Socket!
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateListenSocket.get -> System.Func<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateListenSocket.get -> System.Func<System.Net.EndPoint!, System.Net.Sockets.Socket!>!
 Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateListenSocket.set -> void

--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -7,7 +7,6 @@ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.Bin
 ~Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.SocketTransportFactory(Microsoft.Extensions.Options.IOptions<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! hostBuilder, System.Action<Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions!>! configureOptions) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureAcceptedSocket.get -> System.Action<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureAcceptedSocket.set -> void
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureListenSocket.get -> System.Action<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
-Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.ConfigureListenSocket.set -> void
+static Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateDefaultListenSocket(System.Net.EndPoint! endpoint) -> System.Net.Sockets.Socket!
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateListenSocket.get -> System.Func<System.Net.EndPoint!, System.Net.Sockets.Socket!>?
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateListenSocket.set -> void

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                         acceptSocket.NoDelay = _options.NoDelay;
                     }
 
-                    _options.ConfigureAcceptSocket?.Invoke(EndPoint, acceptSocket);
+                    _options.ConfigureAcceptedSocket?.Invoke(EndPoint, acceptSocket);
 
                     var setting = _settings[_settingsIndex];
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         private Socket? _listenSocket;
         private int _settingsIndex;
         private readonly SocketTransportOptions _options;
-        private SafeSocketHandle? _socketHandle;
 
         public EndPoint EndPoint { get; private set; }
 
@@ -91,42 +90,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 throw new InvalidOperationException(SocketsStrings.TransportAlreadyBound);
             }
 
-            Socket listenSocket;
-
-            switch (EndPoint)
-            {
-                case FileHandleEndPoint fileHandle:
-                    _socketHandle = new SafeSocketHandle((IntPtr)fileHandle.FileHandle, ownsHandle: true);
-                    listenSocket = new Socket(_socketHandle);
-                    ConfigureSocket();
-                    break;
-                case UnixDomainSocketEndPoint unix:
-                    listenSocket = new Socket(unix.AddressFamily, SocketType.Stream, ProtocolType.Unspecified);
-                    ConfigureSocket();
-                    BindSocket();
-                    break;
-                case IPEndPoint ip:
-                    listenSocket = new Socket(ip.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-
-                    // Kestrel expects IPv6Any to bind to both IPv6 and IPv4
-                    if (ip.Address == IPAddress.IPv6Any)
-                    {
-                        listenSocket.DualMode = true;
-                    }
-
-                    ConfigureSocket();
-                    BindSocket();
-                    break;
-                default:
-                    listenSocket = new Socket(EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-                    ConfigureSocket();
-                    BindSocket();
-                    break;
-            }
-
-            void ConfigureSocket() => _options.ConfigureListenSocket?.Invoke(EndPoint, listenSocket);
-
-            void BindSocket()
+            var listenSocketFactory = _options.CreateListenSocket ?? SocketTransportOptions.CreateDefaultListenSocket;
+            var listenSocket = listenSocketFactory(EndPoint);
+            // we only call Bind on sockets that were _not_ created
+            // using a file handle, otherwise underlying PAL call throws
+            if (!(EndPoint is FileHandleEndPoint))
             {
                 try
                 {
@@ -161,8 +129,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                     {
                         acceptSocket.NoDelay = _options.NoDelay;
                     }
-
-                    _options.ConfigureAcceptedSocket?.Invoke(EndPoint, acceptSocket);
 
                     var setting = _settings[_settingsIndex];
 
@@ -202,16 +168,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         public ValueTask UnbindAsync(CancellationToken cancellationToken = default)
         {
             _listenSocket?.Dispose();
-
-            _socketHandle?.Dispose();
             return default;
         }
 
         public ValueTask DisposeAsync()
         {
             _listenSocket?.Dispose();
-
-            _socketHandle?.Dispose();
 
             // Dispose the memory pool
             _memoryPool.Dispose();

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -89,9 +89,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             {
                 throw new InvalidOperationException(SocketsStrings.TransportAlreadyBound);
             }
-
-            var listenSocketFactory = _options.CreateListenSocket ?? SocketTransportOptions.CreateDefaultListenSocket;
-            var listenSocket = listenSocketFactory(EndPoint);
+            
+            var listenSocket = _options.CreateListenSocket(EndPoint);
             // we only call Bind on sockets that were _not_ created
             // using a file handle, otherwise underlying PAL call throws
             if (!(EndPoint is FileHandleEndPoint))

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -89,6 +89,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
             switch (endpoint)
             {
                 case FileHandleEndPoint fileHandle:
+                    // We're passing "ownsHandle: true" here even though we don't necessarily
+                    // own the handle because Socket.Dispose will clean-up everything safely.
+                    // If the handle was already closed or disposed then the socket will
+                    // be torn down gracefully, and if the caller never cleans up their handle
+                    // then we'll do it for them.
+                    //
+                    // If we don't do this then we run the risk of Kestrel hanging because the
+                    // the underlying socket is never closed and the transport manager can hang
+                    // when it attempts to stop.
                     return new Socket(
                         new SafeSocketHandle((IntPtr)fileHandle.FileHandle, ownsHandle: true)
                     );

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         public Action<EndPoint, Socket>? ConfigureListenSocket { get; set; }
 
         /// <summary>
-        /// An action used to configure an accepted socket before it's passed to the underlying connection.
+        /// An action used to configure an accepted socket before it's used.
         /// </summary>
         public Action<EndPoint, Socket>? ConfigureAcceptedSocket { get; set; }
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -73,9 +73,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         public Action<EndPoint, Socket>? ConfigureListenSocket { get; set; }
 
         /// <summary>
-        /// An action used to configure an accept socket before it's passed to the underlying connection.
+        /// An action used to configure an accepted socket before it's passed to the underlying connection.
         /// </summary>
-        public Action<EndPoint, Socket>? ConfigureAcceptSocket { get; set; }
+        public Action<EndPoint, Socket>? ConfigureAcceptedSocket { get; set; }
 
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.PinnedBlockMemoryPoolFactory.Create;
     }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Buffers;
+using System.Net;
+using System.Net.Sockets;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 {
@@ -64,6 +66,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         /// Test to make sure this setting helps performance.
         /// </remarks>
         public bool UnsafePreferInlineScheduling { get; set; }
+
+        /// <summary>
+        /// An action used to configure the listening socket before it is bound.
+        /// </summary>
+        public Action<EndPoint, Socket>? ConfigureListenSocket { get; set; }
+
+        /// <summary>
+        /// An action used to configure an accept socket before it's passed to the underlying connection.
+        /// </summary>
+        public Action<EndPoint, Socket>? ConfigureAcceptSocket { get; set; }
 
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.PinnedBlockMemoryPoolFactory.Create;
     }

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -70,9 +70,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 
         /// <summary>
         /// A function used to create a new <see cref="Socket"/> to listen with. If
-        /// not set, <see cref="CreateDefaultListenSocket" /> is called instead.
+        /// not set, <see cref="CreateDefaultListenSocket" /> is used.
         /// </summary>
-        public Func<EndPoint, Socket>? CreateListenSocket { get; set; }
+        public Func<EndPoint, Socket> CreateListenSocket { get; set; } = CreateDefaultListenSocket;
 
         /// <summary>
         /// Creates a default instance of <see cref="Socket"/> for the given <see cref="EndPoint"/>

--- a/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -60,7 +61,7 @@ namespace Sockets.BindTests
             {
                 yield return new object[]
                 {
-                    new UnixDomainSocketEndPoint($"/tmp/test.sock")
+                    new UnixDomainSocketEndPoint($"/tmp/{DateTime.UtcNow:yyyyMMddTHHmmss}.sock")
                 };
             }
 

--- a/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
@@ -36,20 +36,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(GetEndpoints))]
-        public async Task SocketTransportCallsConfigureAcceptSocket(EndPoint endpointToTest)
+        public async Task SocketTransportCallsConfigureAcceptedSocket(EndPoint endpointToTest)
         {
             var wasCalled = false;
-            void ConfigureAcceptSocket(EndPoint endpoint, Socket socket) => wasCalled = true;
+            void ConfigureAcceptedSocket(EndPoint endpoint, Socket socket) => wasCalled = true;
 
             using var host = CreateWebHost(
-                endpointToTest, options => options.ConfigureAcceptSocket = ConfigureAcceptSocket
+                endpointToTest, options => options.ConfigureAcceptedSocket = ConfigureAcceptedSocket
             );
             using var client = CreateHttpClient(endpointToTest);
             await host.StartAsync();
             var uri = host.GetUris().First();
             var response = await client.GetAsync(uri);
             response.EnsureSuccessStatusCode();
-            Assert.True(wasCalled, $"Expected {nameof(SocketTransportOptions.ConfigureAcceptSocket)} to be called.");
+            Assert.True(wasCalled, $"Expected {nameof(SocketTransportOptions.ConfigureAcceptedSocket)} to be called.");
             await host.StopAsync();
         }
 

--- a/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
+{
+    public class SocketTransportOptionsTests : LoggedTestBase
+    {
+        [Theory]
+        [MemberData(nameof(GetEndpoints))]
+        public async Task SocketTransportCallsConfigureListenSocket(EndPoint endpointToTest)
+        {
+            var wasCalled = false;
+            void ConfigureListenSocket(EndPoint endpoint, Socket socket) => wasCalled = true;
+
+            using var host = CreateWebHost(
+                endpointToTest, options => options.ConfigureListenSocket = ConfigureListenSocket
+            );
+            await host.StartAsync();
+            Assert.True(wasCalled, $"Expected {nameof(SocketTransportOptions.ConfigureListenSocket)} to be called.");
+            await host.StopAsync();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEndpoints))]
+        public async Task SocketTransportCallsConfigureAcceptSocket(EndPoint endpointToTest)
+        {
+            var wasCalled = false;
+            void ConfigureAcceptSocket(EndPoint endpoint, Socket socket) => wasCalled = true;
+
+            using var host = CreateWebHost(
+                endpointToTest, options => options.ConfigureAcceptSocket = ConfigureAcceptSocket
+            );
+            using var client = CreateHttpClient(endpointToTest);
+            await host.StartAsync();
+            var uri = host.GetUris().First();
+            var response = await client.GetAsync(uri);
+            response.EnsureSuccessStatusCode();
+            Assert.True(wasCalled, $"Expected {nameof(SocketTransportOptions.ConfigureAcceptSocket)} to be called.");
+            await host.StopAsync();
+        }
+
+        private static int _counter = 1;
+        public static IEnumerable<object[]> GetEndpoints()
+        {
+            // IPv4
+            yield return new object[] {new IPEndPoint(IPAddress.Loopback, 0)};
+            // IPv6
+            yield return new object[] {new IPEndPoint(IPAddress.IPv6Loopback, 0)};
+            // Unix sockets
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                yield return new object[]
+                {
+                    // NOTE
+                    // to avoid "address in use" errors need to ensure
+                    // the socket path is unique
+                    new UnixDomainSocketEndPoint(
+                        $"/tmp/test-{Interlocked.Increment(ref _counter)}.sock"
+                    )
+                };
+            }
+
+            // TODO: other endpoint types?
+        }
+
+        private IHost CreateWebHost(EndPoint endpoint, Action<SocketTransportOptions> configureSocketOptions) =>
+            TransportSelector.GetHostBuilder()
+                .ConfigureWebHost(
+                    webHostBuilder =>
+                    {
+                        webHostBuilder
+                            .UseSockets(configureSocketOptions)
+                            .UseKestrel(options => options.Listen(endpoint))
+                            .Configure(
+                                app => app.Run(ctx => ctx.Response.WriteAsync("Hello World"))
+                            );
+                    }
+                )
+                .ConfigureServices(AddTestLogging)
+                .Build();
+        private static HttpClient CreateHttpClient(EndPoint endpoint)
+        {
+            if (endpoint is UnixDomainSocketEndPoint)
+            {
+                // https://stackoverflow.com/a/67203488/871146
+                return new HttpClient(new SocketsHttpHandler
+                {
+                    ConnectCallback = async (_, _) =>
+                    {
+                        var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                        await socket.ConnectAsync(endpoint);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                });
+            }
+
+            return new HttpClient();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #32794. As mentioned in the issue it is currently not possible to configure the underlying listen socket used by Kestrel. In certain circumstances it is desirable to be able to configure socket options when the socket is created - a concrete case that I recently came across is setting the `SO_RECV_ANYIF` socket option on macOS so that Kestrel can listen on the `awdl0` interface (more details on that specific case [here](https://bakedbean.org.uk/posts/2021-05-airdrop-anywhere-part-3/)).

This change adds the API suggested by #32794 by adding a function that allows the caller to manage the creation of the listening socket - `Func<EndPoint, Socket> CreateListenSocket { get; set; }` allows the creation of the listen socket to be configured.

There's also some tests using IPv4, IPv6, unix domain sockets and file handles.

