### PR TITLE
.NET-to-JS stream proof of concept

### DIFF
--- a/src/Components/Samples/BlazorServerApp/Pages/Index.razor
+++ b/src/Components/Samples/BlazorServerApp/Pages/Index.razor
@@ -1,5 +1,17 @@
 ﻿@page "/"
+@inject IJSRuntime JS 
 
 <h1>Hello, world!</h1>
 
 Welcome to your new app.
+
+<button @onclick="SendStream">Send stream</button>
+
+@code {
+    async Task SendStream()
+    {
+        using var data = new System.IO.MemoryStream(new byte[10 * 1024 * 1024]);
+        using var streamRef = new DotNetStreamReference(data);
+        await JS.InvokeVoidAsync("getTheStream", streamRef);
+    }
+} 

--- a/src/Components/Samples/BlazorServerApp/Pages/Index.razor
+++ b/src/Components/Samples/BlazorServerApp/Pages/Index.razor
@@ -7,6 +7,8 @@ Welcome to your new app.
 
 <button @onclick="SendStream">Send stream</button>
 
+<button onclick="getFileData()">Get file data (as return value)</button>
+
 @code {
     async Task SendStream()
     {

--- a/src/Components/Samples/BlazorServerApp/Pages/_Host.cshtml
+++ b/src/Components/Samples/BlazorServerApp/Pages/_Host.cshtml
@@ -29,6 +29,12 @@
             const data = await streamRef.arrayBuffer();
             console.log(data.byteLength);
         }
+
+        async function getFileData() {
+            const streamRef = await DotNet.invokeMethodAsync('BlazorServerApp', 'GetFileData');
+            const data = await streamRef.arrayBuffer();
+            console.log(data.byteLength);
+        }
     </script>
 </body>
 </html>

--- a/src/Components/Samples/BlazorServerApp/Pages/_Host.cshtml
+++ b/src/Components/Samples/BlazorServerApp/Pages/_Host.cshtml
@@ -24,5 +24,11 @@
             });
         })()
     </script>
+    <script>
+        async function getTheStream(streamRef) {
+            const data = await streamRef.arrayBuffer();
+            console.log(data.byteLength);
+        }
+    </script>
 </body>
 </html>

--- a/src/Components/Samples/BlazorServerApp/Program.cs
+++ b/src/Components/Samples/BlazorServerApp/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
 
 namespace BlazorServerApp
 {
@@ -24,5 +25,12 @@ namespace BlazorServerApp
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+
+        [JSInvokable]
+        public static DotNetStreamReference GetFileData()
+        {
+            var arbitraryFilename = typeof(Program).Assembly.Location;
+            return new DotNetStreamReference(File.OpenRead(arbitraryFilename));
+        }
     }
 }

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -238,9 +238,11 @@ namespace Microsoft.AspNetCore.Components.Server
                 }
                 finally
                 {
-
                     // TODO: Don't send the exception to the client if detailed errors is off.
-                    // In that case, log detailed error info on the server only.
+                    // In that case, log detailed error info on the server only. From experiments it
+                    // doesn't seem like SignalR sends the actual exception info anyway, which is a
+                    // bit awkward because in development we would like it to show up. Maybe if we're
+                    // logging the detailed error info on the .NET side anyway that might be enough.
                     writer.Complete(localException);
                 }
             }

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetStreamReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetStreamReference.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.JSInterop
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed class DotNetStreamReference : IDisposable
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="leaveOpen"></param>
+        public DotNetStreamReference(Stream stream, bool leaveOpen = false)
+        {
+            Stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            LeaveOpen = leaveOpen;
+        }
+
+        internal Stream Stream { get; }
+
+        internal bool LeaveOpen { get; }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (!LeaveOpen)
+            {
+                Stream.Dispose();
+            }
+        }
+    }
+}

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetStreamReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetStreamReferenceJsonConverter.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.JSInterop.Infrastructure
+{
+    internal sealed class DotNetStreamReferenceJsonConverter : JsonConverter<DotNetStreamReference>
+    {
+        public DotNetStreamReferenceJsonConverter(JSRuntime jsRuntime)
+        {
+            JSRuntime = jsRuntime;
+        }
+
+        private readonly static JsonEncodedText DotNetStreamRefKey = JsonEncodedText.Encode("__dotNetStream");
+
+        public JSRuntime JSRuntime { get; }
+
+        public override DotNetStreamReference Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => throw new NotSupportedException($"{nameof(DotNetStreamReference)} cannot be supplied from JavaScript to .NET because the stream is released after being sent.");
+
+        public override void Write(Utf8JsonWriter writer, DotNetStreamReference value, JsonSerializerOptions options)
+        {
+            // We only serialize a DotNetStreamReference using this converter when we're supplying that info
+            // to JS. We want to transmit the stream immediately as part of this process, so that the .NET side
+            // doesn't have to hold onto the stream waiting for JS to request it. If a developer doesn't really
+            // want to send the data, they shouldn't include the DotNetStreamReference in the object graph
+            // they are sending to the JS side.
+            var id = JSRuntime.BeginTransmittingStream(value);
+            writer.WriteStartObject();
+            writer.WriteNumber(DotNetStreamRefKey, id);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Microsoft.JSInterop.DotNetStreamReference
+Microsoft.JSInterop.DotNetStreamReference.Dispose() -> void
+Microsoft.JSInterop.DotNetStreamReference.DotNetStreamReference(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.JSInterop.Implementation.JSObjectReferenceJsonWorker
 Microsoft.JSInterop.Infrastructure.DotNetInvocationResult.ResultJson.get -> string?
 static Microsoft.JSInterop.Implementation.JSObjectReferenceJsonWorker.ReadJSObjectReferenceIdentifier(ref System.Text.Json.Utf8JsonReader reader) -> long
@@ -28,3 +31,4 @@ static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JS
 static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, System.TimeSpan timeout, params object?[]? args) -> System.Threading.Tasks.ValueTask
 *REMOVED*static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, params object![]! args) -> System.Threading.Tasks.ValueTask
 static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, params object?[]? args) -> System.Threading.Tasks.ValueTask
+virtual Microsoft.JSInterop.JSRuntime.BeginTransmittingStream(long streamId, System.IO.Stream! stream, bool leaveOpen) -> void


### PR DESCRIPTION
This is just an exploration, not a real PR. I think it may be @TanayParikh doing the real implementation, but I'm not sure if that's confirmed yet.

It is a bit complicated, but hopefully achieves what we need in terms of not pinning things in memory indefinitely on the .NET side. It's also very flexible on the JS side, as you can receive a `ReadableStream` which you can then easily convert asynchronously into an `ArrayBuffer` or you can convert into a `Blob` to be used as a response (e.g., for image contents).

The sequence of operations is:

1. Developer creates a `DotNetStreamReference` to wrap some `Stream`
2. Developer uses this as a param in .NET-to-JS interop, or a return value in JS-to-.NET interop. As soon as it's serialized into the JSON with some auto-generated ID, the `JSRuntime` base class instructs the hosting platform to supply the `Stream` to JS code under the same ID, by calling a protected virtual method `BeginTransmittingStream`.
3. Within this method, the hosting platform is responsible for somehow sending a representation of that stream into JS, and calling `DotNet.jsCallDispatcher.supplyDotNetStream(streamId, readableStream)`. The details of the transport, chunking, multiplexing, etc. are all left up to the hosting platform.
4. The developer's JS-side code receives the `DotNetStreamReference` as an instance of a JS class that has a function `stream()` that returns a `Promise<ReadableStream>`, whose value is given by what is supplied in step 3 above

As you see, there's nothing on the .NET side that has to hold onto anything.

The way that step 3 works depends on the hosting platform. The most complex one is Blazor Server, which is what I've prototyped in this PR. Since SignalR only allows streaming to be initiated from the JS side, what it does is:

1. Sends a message to JS saying *Please request stream [id]*.
    * Since this is async, it has to stash the stream in .NET memory until that request arrives
    * We allow a maximum of just 10 seconds for the JS side to begin requesting the stream. If the JS side fails to do so fast enough, we remove the stream from the temporary in-memory dictionary and dispose it - this is an error case that shouldn't occur in normal apps.
2. On the JS side, the code does SignalR stream-returning call, asking for that stream. It generates a JS `ReadableStream` instance and wires up the SignalR stream response to provide content for it. This becomes the stream instance returned to user code from step 4 above.
3. Back on the .NET side, assuming the stream instance hasn't been evicted yet (i.e., as long as steps 1 and 2 completed in under 10 seconds), we then pump the `Stream` contents into the SignalR stream response as fast as we're allowed (which can take arbitrarily long), then finally closes it.

### Open questions

 * Do we believe this is secure against hostile clients? What goes wrong if they try to slow down the transfer to a trickle - can they do so through backpressure? Is there any problem with stashing the stream for 10 seconds before disposing it if the client never actually requests it?
 * Is the error handling/reporting correct, given all the moving parts?
 * Do we need to do anything about infinite streams? As it stands, the .NET side would continue pumping the contents as fast as it can until the circuit eventually disconnects (which can take arbitrarily long).

### Alternative considered

If we wanted, we could change the flow so that the .NET side pumps the *entire* stream contents across before the JS-side invocation occurs. Then the JS-side code could receive an `ArrayBuffer` instead of a stream.

TBH I'm not convinced that actually solves any of the tricky things here, and it loses the ability to actually read the stream data incrementally in JS.

Or even more aggressively, we could just pump out the entire stream as a `byte[]` in the initial SignalR message. This might simplify a lot of the moving parts, but would massively reduce the usefulness of this because (I think) it would no longer multiplex at all and would block the entire circuit from being interactive until the whole transfer completes.