### PR TITLE
Make image file upload test wait for image to load before trying to read it

### DIFF
--- a/src/Components/test/E2ETest/Tests/InputFileTest.cs
+++ b/src/Components/test/E2ETest/Tests/InputFileTest.cs
@@ -131,7 +131,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25929")]
         public void CanUploadAndConvertImageFile()
         {
             var sourceImageId = "image-source";

--- a/src/Components/test/E2ETest/Tests/InputFileTest.cs
+++ b/src/Components/test/E2ETest/Tests/InputFileTest.cs
@@ -135,6 +135,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public void CanUploadAndConvertImageFile()
         {
             var sourceImageId = "image-source";
+            var imageStatus = Browser.Exists(By.Id("image-status"));
+            Browser.Equal("ready", () => imageStatus.Text);
 
             // Get the source image base64
             var base64 = Browser.ExecuteJavaScript<string>($@"

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -169,7 +169,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25929")]
         public void CancelsOutdatedRefreshes_Async()
         {
             Browser.MountTestComponent<VirtualizationComponent>();

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -169,6 +169,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25929")]
         public void CancelsOutdatedRefreshes_Async()
         {
             Browser.MountTestComponent<VirtualizationComponent>();

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/InputFileComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/InputFileComponent.razor
@@ -50,7 +50,8 @@ Max allowed files:
 
 <p>
     Source image:<br />
-    <img id="image-source" src="images/blazor_logo_1000x.png" />
+    <img id="image-source" src="images/blazor_logo_1000x.png" onload="document.getElementById('image-status').textContent = 'ready'" />
+    <span id="image-status"></span>
 </p>
 
 @code {


### PR DESCRIPTION
Possibly helps with https://github.com/dotnet/aspnetcore/issues/25929

I don't know whether this is actually going to make a difference. Running locally this test *always* fails for me on Blazor Server, and the change in this PR fixes that. Running in CI though, it virtually always passes on Server and occasionally fails on WebAssembly.

Since this is the only thing I can guess might be going wrong, let's try fixing that.