### PR TITLE
Raise Change Events on data change in KeyPerFileConfigurationProvider

### DIFF
--- a/src/Configuration.KeyPerFile/src/KeyPerFileConfigurationProvider.cs
+++ b/src/Configuration.KeyPerFile/src/KeyPerFileConfigurationProvider.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile
                 if (Source.Optional || reload) // Always optional on reload
                 {
                     Data = data;
+                    OnReload();
                     return;
                 }
                 throw new DirectoryNotFoundException("The root directory for the FileProvider doesn't exist and is not optional.");
@@ -98,6 +99,7 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile
             }
 
             Data = data;
+            OnReload();
         }
 
         private string GetDirectoryName()

--- a/src/Configuration.KeyPerFile/src/KeyPerFileConfigurationProvider.cs
+++ b/src/Configuration.KeyPerFile/src/KeyPerFileConfigurationProvider.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile
                 if (Source.Optional || reload) // Always optional on reload
                 {
                     Data = data;
+                    OnReload();
                     return;
                 }
 

--- a/src/Configuration.KeyPerFile/test/KeyPerFileTests.cs
+++ b/src/Configuration.KeyPerFile/test/KeyPerFileTests.cs
@@ -358,6 +358,7 @@ namespace Microsoft.Extensions.Configuration.KeyPerFile.Test
                 {
                     o.FileProvider = testFileProvider;
                     o.ReloadOnChange = true;
+                    o.Optional = true;
                 }).Build();
 
             var changeToken = config.GetReloadToken();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Raise Change Events on data change in KeyPerFileConfigurationProvider

**PR Description**
KeyPerFileConfigurationProvider currently is not raising the on change event, which is problematic when trying to observe configuration changes through the file system when used in conjunction with  `IConfiguration.ChangeToken`.

This PR updates KeyPerFileConfigurationProvider to invoke `OnReload` on the branches where changes occur after initial load. 

Tests were updated to validate:
- Starting with missing directory and adding files triggers reloads
- Removing directory triggers reload
- Adding/removing files in directory triggers reload

Addresses #32836
