### PR TITLE
Reduce some allocations in Razor

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMetadata.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMetadata.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
     // Metadata used for Components interactions with the tag helper system
     internal static class ComponentMetadata
     {
-        private const string MangledClassNamePrefix = "__generated__";
+        private static readonly StringSegment MangledClassNamePrefix = "__generated__";
 
         // There's a bug in the 15.7 preview 1 Razor that prevents 'Kind' from being serialized
         // this affects both tooling and build. For now our workaround is to ignore 'Kind' and
@@ -27,9 +27,9 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             return MangledClassNamePrefix + className;
         }
 
-        public static bool IsMangledClass(string className)
+        public static bool IsMangledClass(StringSegment className)
         {
-            if (string.IsNullOrEmpty(className))
+            if (StringSegment.IsNullOrEmpty(className))
             {
                 return false;
             }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/TagHelperBoundAttributeDescriptorExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/TagHelperBoundAttributeDescriptorExtensions.cs
@@ -9,11 +9,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
     {
         public static bool IsDelegateProperty(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
             var key = ComponentMetadata.Component.DelegateSignatureKey;
             return 
                 attribute.Metadata.TryGetValue(key, out var value) &&
@@ -28,11 +23,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns><c>true</c> if the attribute is an event callback, otherwise <c>false</c>.</returns>
         public static bool IsEventCallbackProperty(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
             var key = ComponentMetadata.Component.EventCallbackKey;
             return
                 attribute.Metadata.TryGetValue(key, out var value) &&
@@ -41,11 +31,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsGenericTypedProperty(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-            
             return
                 attribute.Metadata.TryGetValue(ComponentMetadata.Component.GenericTypedKey, out var value) &&
                 string.Equals(value, bool.TrueString);
@@ -53,35 +38,20 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsTypeParameterProperty(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
-            return
+             return
                 attribute.Metadata.TryGetValue(ComponentMetadata.Component.TypeParameterKey, out var value) &&
                 string.Equals(value, bool.TrueString);
         }
 
         public static bool IsCascadingTypeParameterProperty(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
-            return
+              return
                 attribute.Metadata.TryGetValue(ComponentMetadata.Component.TypeParameterIsCascadingKey, out var value) &&
                 string.Equals(value, bool.TrueString);
         }
 
         public static bool IsWeaklyTyped(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
             var key = ComponentMetadata.Component.WeaklyTypedKey;
             return
                 attribute.Metadata.TryGetValue(key, out var value) &&
@@ -96,11 +66,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns>Returns <c>true</c> if the property is child content, otherwise <c>false</c>.</returns>
         public static bool IsChildContentProperty(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
             var key = ComponentMetadata.Component.ChildContentKey;
             return
                 attribute.Metadata.TryGetValue(key, out var value) &&
@@ -115,11 +80,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns>Returns <c>true</c> if the property is child content, otherwise <c>false</c>.</returns>
         public static bool IsChildContentProperty(this BoundAttributeDescriptorBuilder attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
             var key = ComponentMetadata.Component.ChildContentKey;
             return
                 attribute.Metadata.TryGetValue(key, out var value) &&
@@ -134,11 +94,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns>Returns <c>true</c> if the property is parameterized child content, otherwise <c>false</c>.</returns>
         public static bool IsParameterizedChildContentProperty(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
             return attribute.IsChildContentProperty() &&
                 !string.Equals(attribute.TypeName, ComponentsApi.RenderFragment.FullTypeName, StringComparison.Ordinal);
         }
@@ -151,11 +106,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns>Returns <c>true</c> if the property is parameterized child content, otherwise <c>false</c>.</returns>
         public static bool IsParameterizedChildContentProperty(this BoundAttributeDescriptorBuilder attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
             return attribute.IsChildContentProperty() &&
                 !string.Equals(attribute.TypeName, ComponentsApi.RenderFragment.FullTypeName, StringComparison.Ordinal);
         }
@@ -171,11 +121,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// </returns>
         public static bool IsChildContentParameterNameProperty(this BoundAttributeDescriptor attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
-
             var key = ComponentMetadata.Component.ChildContentParameterNameKey;
             return
                 attribute.Metadata.TryGetValue(key, out var value) &&

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/TagHelperDescriptorExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/TagHelperDescriptorExtensions.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components
 {
@@ -13,21 +12,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
     {
         public static bool IsAnyComponentDocumentTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return tagHelper.IsComponentTagHelper() || tagHelper.Metadata.ContainsKey(ComponentMetadata.SpecialKindKey);
         }
 
         public static bool IsBindTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-            
             return 
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.SpecialKindKey, out var kind) && 
                 string.Equals(ComponentMetadata.Bind.TagHelperKind, kind);
@@ -35,11 +24,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsFallbackBindTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.IsBindTagHelper() &&
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.Bind.FallbackKey, out var fallback) &&
@@ -48,11 +32,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsGenericTypedComponent(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 IsComponentTagHelper(tagHelper) &&
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.Component.GenericTypedKey, out var value) &&
@@ -61,11 +40,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsInputElementBindTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.IsBindTagHelper() &&
                 tagHelper.TagMatchingRules.Count == 1 &&
@@ -74,11 +48,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsInputElementFallbackBindTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.IsInputElementBindTagHelper() &&
                 !tagHelper.Metadata.ContainsKey(ComponentMetadata.Bind.TypeAttribute);
@@ -86,33 +55,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static string GetValueAttributeName(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             tagHelper.Metadata.TryGetValue(ComponentMetadata.Bind.ValueAttribute, out var result);
             return result;
         }
 
         public static string GetChangeAttributeName(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             tagHelper.Metadata.TryGetValue(ComponentMetadata.Bind.ChangeAttribute, out var result);
             return result;
         }
 
         public static string GetExpressionAttributeName(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             tagHelper.Metadata.TryGetValue(ComponentMetadata.Bind.ExpressionAttribute, out var result);
             return result;
         }
@@ -127,11 +81,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// </returns>
         public static bool IsInvariantCultureBindTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.Bind.IsInvariantCulture, out var text) &&
                 bool.TryParse(text, out var result) &&
@@ -145,22 +94,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns>The format, or <c>null</c>.</returns>
         public static string GetFormat(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             tagHelper.Metadata.TryGetValue(ComponentMetadata.Bind.Format, out var result);
             return result;
         }
 
         public static bool IsChildContentTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.SpecialKindKey, out var value) &&
                 string.Equals(value, ComponentMetadata.ChildContent.TagHelperKind, StringComparison.Ordinal);
@@ -168,11 +107,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsComponentTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 string.Equals(tagHelper.Kind, ComponentMetadata.Component.TagHelperKind) &&
                 !tagHelper.Metadata.ContainsKey(ComponentMetadata.SpecialKindKey);
@@ -180,11 +114,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsEventHandlerTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.SpecialKindKey, out var kind) &&
                 string.Equals(ComponentMetadata.EventHandler.TagHelperKind, kind);
@@ -192,11 +121,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsKeyTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.SpecialKindKey, out var kind) &&
                 string.Equals(ComponentMetadata.Key.TagHelperKind, kind);
@@ -204,11 +128,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsSplatTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.SpecialKindKey, out var kind) &&
                 string.Equals(ComponentMetadata.Splat.TagHelperKind, kind);
@@ -216,11 +135,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsRefTagHelper(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.SpecialKindKey, out var kind) &&
                 string.Equals(ComponentMetadata.Ref.TagHelperKind, kind);
@@ -232,11 +146,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <param name="tagHelper">The <see cref="TagHelperDescriptor"/>.</param>
         public static bool IsComponentFullyQualifiedNameMatch(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             return
                 tagHelper.Metadata.TryGetValue(ComponentMetadata.Component.NameMatchKey, out var matchType) &&
                 string.Equals(ComponentMetadata.Component.FullyQualifiedNameMatch, matchType);
@@ -244,11 +153,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static string GetEventArgsType(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             tagHelper.Metadata.TryGetValue(ComponentMetadata.EventHandler.EventArgsType, out var result);
             return result;
         }
@@ -260,11 +164,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns>The child content attributes</returns>
         public static IEnumerable<BoundAttributeDescriptor> GetChildContentProperties(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             for (var i = 0; i < tagHelper.BoundAttributes.Count; i++)
             {
                 var attribute = tagHelper.BoundAttributes[i];
@@ -282,11 +181,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns>The type parameter attributes</returns>
         public static IEnumerable<BoundAttributeDescriptor> GetTypeParameters(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
-            {
-                throw new ArgumentNullException(nameof(tagHelper));
-            }
-
             for (var i = 0; i < tagHelper.BoundAttributes.Count; i++)
             {
                 var attribute = tagHelper.BoundAttributes[i];
@@ -305,12 +199,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <returns>True if it does supply one or more generic type parameters to descendants; false otherwise.</returns>
         public static bool SuppliesCascadingGenericParameters(this TagHelperDescriptor tagHelper)
         {
-            if (tagHelper == null)
+            for (var i = 0; i < tagHelper.BoundAttributes.Count; i++)
             {
-                throw new ArgumentNullException(nameof(tagHelper));
+                var attribute = tagHelper.BoundAttributes[i];
+                if (attribute.IsCascadingTypeParameterProperty())
+                {
+                    return true;
+                }
             }
 
-            return tagHelper.BoundAttributes.Any(a => a.IsCascadingTypeParameterProperty());
+            return false;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultDirectiveSyntaxTreePass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultDirectiveSyntaxTreePass.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -14,16 +14,12 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public RazorSyntaxTree Execute(RazorCodeDocument codeDocument, RazorSyntaxTree syntaxTree)
         {
-            if (codeDocument == null)
+            if (FileKinds.IsComponent(codeDocument.GetFileKind()))
             {
-                throw new ArgumentNullException(nameof(codeDocument));
+                // Nothing to do here.
+                return syntaxTree;
             }
 
-            if (syntaxTree == null)
-            {
-                throw new ArgumentNullException(nameof(syntaxTree));
-            }
-            
             var sectionVerifier = new NestedSectionVerifier(syntaxTree);
             return sectionVerifier.Verify();
         }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/LegacySyntaxNodeExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/LegacySyntaxNodeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -48,11 +48,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public static SpanContext GetSpanContext(this SyntaxNode node)
         {
-            if (node == null)
-            {
-                throw new ArgumentNullException(nameof(node));
-            }
-
             var context = node.GetAnnotationValue(SyntaxConstants.SpanContextKind);
 
             return context is SpanContext ? (SpanContext)context : null;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
-    internal class TagHelperParseTreeRewriter
+    internal static class TagHelperParseTreeRewriter
     {
         public static RazorSyntaxTree Rewrite(RazorSyntaxTree syntaxTree, string tagHelperPrefix, IEnumerable<TagHelperDescriptor> descriptors)
         {
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         }
 
         // Internal for testing.
-        internal class Rewriter : SyntaxRewriter
+        internal sealed class Rewriter : SyntaxRewriter
         {
             // Internal for testing.
             // Null characters are invalid markup for HTML attribute values.

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
@@ -1,0 +1,327 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor
+{
+    /// <summary>
+    /// An optimized representation of a substring.
+    /// </summary>
+    internal readonly struct StringSegment : IEquatable<StringSegment>, IEquatable<string>
+    {
+        /// <summary>
+        /// A <see cref="StringSegment"/> for <see cref="string.Empty"/>.
+        /// </summary>
+        public static readonly StringSegment Empty = string.Empty;
+
+        public StringSegment(string buffer)
+        {
+            Buffer = buffer;
+            Offset = 0;
+            Length = buffer?.Length ?? 0;
+        }
+
+        public StringSegment(string buffer, int offset)
+        {
+            Debug.Assert(buffer != null);
+            Buffer = buffer;
+            Offset = offset;
+            Length = buffer.Length - offset;
+        }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="StringSegment"/> struct.
+        /// </summary>
+        /// <param name="buffer">The original <see cref="string"/> used as buffer.</param>
+        /// <param name="offset">The offset of the segment within the <paramref name="buffer"/>.</param>
+        /// <param name="length">The length of the segment.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public StringSegment(string buffer, int offset, int length)
+        {
+            Debug.Assert(buffer != null);
+            Buffer = buffer;
+            Offset = offset;
+            Length = length;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="string"/> buffer for this <see cref="StringSegment"/>.
+        /// </summary>
+        public string Buffer { get; }
+
+        /// <summary>
+        /// Gets the offset within the buffer for this <see cref="StringSegment"/>.
+        /// </summary>
+        public int Offset { get; }
+
+        /// <summary>
+        /// Gets the length of this <see cref="StringSegment"/>.
+        /// </summary>
+        public int Length { get; }
+
+        /// <summary>
+        /// Gets the value of this segment as a <see cref="string"/>.
+        /// </summary>
+        public string Value => HasValue ? Buffer.Substring(Offset, Length) : null;
+
+        public bool IsEmpty => Length == 0;
+
+        public bool HasValue => Buffer != null;
+
+        /// <summary>
+        /// Gets the <see cref="char"/> at a specified position in the current <see cref="StringSegment"/>.
+        /// </summary>
+        /// <param name="index">The offset into the <see cref="StringSegment"/></param>
+        /// <returns>The <see cref="char"/> at a specified position.</returns>
+        public char this[int index]
+        {
+            get
+            {
+                return Buffer[Offset + index];
+            }
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            return obj is StringSegment segment && Equals(segment);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns><code>true</code> if the current object is equal to the other parameter; otherwise, <code>false</code>.</returns>
+        public bool Equals(StringSegment other)
+        {
+            return Equals(other, StringComparison.Ordinal);
+        }
+
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
+        /// <returns><code>true</code> if the current object is equal to the other parameter; otherwise, <code>false</code>.</returns>
+        public bool Equals(StringSegment other, StringComparison comparisonType)
+        {
+            var textLength = other.Length;
+            if (Length != textLength)
+            {
+                return false;
+            }
+
+            return string.Compare(Buffer, Offset, other.Buffer, other.Offset, textLength, comparisonType) == 0;
+        }
+
+        // This handles StringSegment.Equals(string, StringSegment, StringComparison) and StringSegment.Equals(StringSegment, string, StringComparison)
+        // via the implicit type converter
+        /// <summary>
+        /// Determines whether two specified StringSegment objects have the same value. A parameter specifies the culture, case, and
+        /// sort rules used in the comparison.
+        /// </summary>
+        /// <param name="a">The first StringSegment to compare.</param>
+        /// <param name="b">The second StringSegment to compare.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies the rules for the comparison.</param>
+        /// <returns><code>true</code> if the objects are equal; otherwise, <code>false</code>.</returns>
+        public static bool Equals(StringSegment a, StringSegment b, StringComparison comparisonType)
+        {
+            return a.Equals(b, comparisonType);
+        }
+
+        /// <summary>
+        /// Checks if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>.
+        /// </summary>
+        /// <param name="text">The <see cref="string"/> to compare with the current <see cref="StringSegment"/>.</param>
+        /// <returns><code>true</code> if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
+        public bool Equals(string text)
+        {
+            return Equals(text, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Checks if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>.
+        /// </summary>
+        /// <param name="text">The <see cref="string"/> to compare with the current <see cref="StringSegment"/>.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
+        /// <returns><code>true</code> if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
+        public bool Equals(string text, StringComparison comparisonType)
+        {
+            var textLength = text.Length;
+            if (!HasValue || Length != textLength)
+            {
+                return false;
+            }
+
+            return string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            if (!HasValue)
+            {
+                return 0;
+            }
+
+            if (Offset == 0 && Length == Buffer.Length)
+            {
+                return Buffer.GetHashCode();
+            }
+
+            return Value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Checks if two specified <see cref="StringSegment"/> have the same value.
+        /// </summary>
+        /// <param name="left">The first <see cref="StringSegment"/> to compare, or <code>null</code>.</param>
+        /// <param name="right">The second <see cref="StringSegment"/> to compare, or <code>null</code>.</param>
+        /// <returns><code>true</code> if the value of <paramref name="left"/> is the same as the value of <paramref name="right"/>; otherwise, <code>false</code>.</returns>
+        public static bool operator ==(StringSegment left, StringSegment right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Checks if two specified <see cref="StringSegment"/> have different values.
+        /// </summary>
+        /// <param name="left">The first <see cref="StringSegment"/> to compare, or <code>null</code>.</param>
+        /// <param name="right">The second <see cref="StringSegment"/> to compare, or <code>null</code>.</param>
+        /// <returns><code>true</code> if the value of <paramref name="left"/> is different from the value of <paramref name="right"/>; otherwise, <code>false</code>.</returns>
+        public static bool operator !=(StringSegment left, StringSegment right)
+        {
+            return !left.Equals(right);
+        }
+
+        // PERF: Do NOT add a implicit converter from StringSegment to String. That would negate most of the perf safety.
+        /// <summary>
+        /// Creates a new <see cref="StringSegment"/> from the given <see cref="string"/>.
+        /// </summary>
+        /// <param name="value">The <see cref="string"/> to convert to a <see cref="StringSegment"/></param>
+        public static implicit operator StringSegment(string value)
+        {
+            return new StringSegment(value);
+        }
+
+        /// <summary>
+        /// Checks if the beginning of this <see cref="StringSegment"/> matches the specified <see cref="string"/> when compared using the specified <paramref name="comparisonType"/>.
+        /// </summary>
+        /// <param name="text">The <see cref="string"/>to compare.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
+        /// <returns><code>true</code> if <paramref name="text"/> matches the beginning of this <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
+        public bool StartsWith(string text, StringComparison comparisonType)
+        {
+            var textLength = text.Length;
+            return string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
+        }
+
+        public bool StartsWith(StringSegment text, StringComparison comparisonType)
+        {
+            var textLength = text.Length;
+            if (!HasValue || Length < text.Length)
+            {
+                return false;
+            }
+
+            return string.Compare(Buffer, Offset, text.Buffer, text.Offset, textLength, comparisonType) == 0;
+
+        }
+
+        /// <summary>
+        /// Retrieves a <see cref="StringSegment"/> that represents a substring from this <see cref="StringSegment"/>.
+        /// The <see cref="StringSegment"/> starts at the position specified by <paramref name="offset"/>.
+        /// </summary>
+        /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
+        /// <returns>A <see cref="StringSegment"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/>
+        /// whose length is the remainder.</returns>
+        public StringSegment Subsegment(int offset)
+        {
+            return Subsegment(offset, Length - offset);
+        }
+
+        /// <summary>
+        /// Retrieves a <see cref="StringSegment"/> that represents a substring from this <see cref="StringSegment"/>.
+        /// The <see cref="StringSegment"/> starts at the position specified by <paramref name="offset"/> and has the specified <paramref name="length"/>.
+        /// </summary>
+        /// <param name="offset">The zero-based starting character position of a substring in this <see cref="StringSegment"/>.</param>
+        /// <param name="length">The number of characters in the substring.</param>
+        /// <returns>A <see cref="StringSegment"/> that is equivalent to the substring of length <paramref name="length"/> that begins at <paramref name="offset"/> in this <see cref="StringSegment"/></returns>
+        public StringSegment Subsegment(int offset, int length)
+        {
+            return new StringSegment(Buffer, Offset + offset, length);
+        }
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the character <paramref name="c"/> in this <see cref="StringSegment"/>.
+        /// The search starts at <paramref name="start"/> and examines a specified number of <paramref name="count"/> character positions.
+        /// </summary>
+        /// <param name="c">The Unicode character to seek.</param>
+        /// <param name="start">The zero-based index position at which the search starts. </param>
+        /// <param name="count">The number of characters to examine.</param>
+        /// <returns>The zero-based index position of <paramref name="c"/> from the beginning of the <see cref="StringSegment"/> if that character is found, or -1 if it is not.</returns>
+        public int IndexOf(char c, int start, int count)
+        {
+            var index = Buffer.IndexOf(c, start + Offset, count);
+            if (index != -1)
+            {
+                return index - Offset;
+            }
+            else
+            {
+                return index;
+            }
+        }
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the character <paramref name="c"/> in this <see cref="StringSegment"/>.
+        /// The search starts at <paramref name="start"/>.
+        /// </summary>
+        /// <param name="c">The Unicode character to seek.</param>
+        /// <param name="start">The zero-based index position at which the search starts. </param>
+        /// <returns>The zero-based index position of <paramref name="c"/> from the beginning of the <see cref="StringSegment"/> if that character is found, or -1 if it is not.</returns>
+        public int IndexOf(char c, int start)
+        {
+            return IndexOf(c, start, Length - start);
+        }
+
+        /// <summary>
+        /// Gets the zero-based index of the first occurrence of the character <paramref name="c"/> in this <see cref="StringSegment"/>.
+        /// </summary>
+        /// <param name="c">The Unicode character to seek.</param>
+        /// <returns>The zero-based index position of <paramref name="c"/> from the beginning of the <see cref="StringSegment"/> if that character is found, or -1 if it is not.</returns>
+        public int IndexOf(char c)
+        {
+            return IndexOf(c, 0, Length);
+        }
+
+        /// <summary>
+        /// Indicates whether the specified StringSegment is null or an Empty string.
+        /// </summary>
+        /// <param name="value">The StringSegment to test.</param>
+        /// <returns></returns>
+        public static bool IsNullOrEmpty(StringSegment value)
+        {
+            return !value.HasValue || value.Length == 0;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="string"/> represented by this <see cref="StringSegment"/> or <code>String.Empty</code> if the <see cref="StringSegment"/> does not contain a value.
+        /// </summary>
+        /// <returns>The <see cref="string"/> represented by this <see cref="StringSegment"/> or <code>String.Empty</code> if the <see cref="StringSegment"/> does not contain a value.</returns>
+        public override string ToString()
+        {
+            return Value ?? string.Empty;
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -10,9 +10,9 @@ namespace Microsoft.AspNetCore.Razor.Language
     /// <summary>
     /// Enables retrieval of <see cref="TagHelperBinding"/>'s.
     /// </summary>
-    internal class TagHelperBinder
+    internal sealed class TagHelperBinder
     {
-        private IDictionary<string, HashSet<TagHelperDescriptor>> _registrations;
+        private readonly Dictionary<string, HashSet<TagHelperDescriptor>> _registrations;
         private readonly string _tagHelperPrefix;
 
         /// <summary>
@@ -75,11 +75,11 @@ namespace Microsoft.AspNetCore.Razor.Language
                 descriptors = matchingDescriptors.Concat(descriptors);
             }
 
-            var tagNameWithoutPrefix = _tagHelperPrefix != null ? tagName.Substring(_tagHelperPrefix.Length) : tagName;
-            var parentTagNameWithoutPrefix = parentTagName;
+            var tagNameWithoutPrefix = _tagHelperPrefix != null ? new StringSegment(tagName, _tagHelperPrefix.Length) : tagName;
+            StringSegment parentTagNameWithoutPrefix = parentTagName;
             if (_tagHelperPrefix != null && parentIsTagHelper)
             {
-                parentTagNameWithoutPrefix = parentTagName.Substring(_tagHelperPrefix.Length);
+                parentTagNameWithoutPrefix = new StringSegment(parentTagName, _tagHelperPrefix.Length);
             }
 
             Dictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> applicableDescriptorMappings = null;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -23,6 +23,16 @@ namespace Microsoft.AspNetCore.Razor.Language
             return new DefaultTagHelperDocumentContext(prefix, tagHelpers.ToArray());
         }
 
+        internal static TagHelperDocumentContext Create(string prefix, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        {
+            if (tagHelpers == null)
+            {
+                throw new ArgumentNullException(nameof(tagHelpers));
+            }
+
+            return new DefaultTagHelperDocumentContext(prefix, tagHelpers);
+        }
+
         public abstract string Prefix { get; }
 
         public abstract IReadOnlyList<TagHelperDescriptor> TagHelpers { get; }
@@ -30,9 +40,9 @@ namespace Microsoft.AspNetCore.Razor.Language
         private class DefaultTagHelperDocumentContext : TagHelperDocumentContext
         {
             private readonly string _prefix;
-            private readonly TagHelperDescriptor[] _tagHelpers;
+            private readonly IReadOnlyList<TagHelperDescriptor> _tagHelpers;
 
-            public DefaultTagHelperDocumentContext(string prefix, TagHelperDescriptor[] tagHelpers)
+            public DefaultTagHelperDocumentContext(string prefix, IReadOnlyList<TagHelperDescriptor> tagHelpers)
             {
                 _prefix = prefix;
                 _tagHelpers = tagHelpers;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1359,8 +1359,8 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Assert
             Assert.Equal(expectedResult, result);
-            Assert.Equal(expectedNamespace, DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(@namespace, fullTypeName));
-            Assert.Equal(expectedTypeName, DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(typeName, fullTypeName));
+            Assert.True(new StringSegment(expectedNamespace).Equals(DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(@namespace, fullTypeName), StringComparison.Ordinal));
+            Assert.True(new StringSegment(expectedTypeName).Equals(DefaultRazorTagHelperBinderPhase.ComponentDirectiveVisitor.GetTextSpanContent(typeName, fullTypeName), StringComparison.Ordinal));
         }
 
         private static RazorSourceDocument CreateComponentTestSourceDocument(string content, string filePath = null)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringSegmentTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringSegmentTest.cs
@@ -1,0 +1,596 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    public class StringSegmentTest
+    {
+        [Fact]
+        public void StringSegment_Empty()
+        {
+            // Arrange & Act
+            var segment = StringSegment.Empty;
+
+            // Assert
+            Assert.True(segment.HasValue);
+            Assert.Same(string.Empty, segment.Value);
+            Assert.Equal(0, segment.Offset);
+            Assert.Equal(0, segment.Length);
+        }
+
+        [Fact]
+        public void StringSegment_ImplicitConvertFromString()
+        {
+            StringSegment segment = "Hello";
+
+            Assert.True(segment.HasValue);
+            Assert.Equal(0, segment.Offset);
+            Assert.Equal(5, segment.Length);
+            Assert.Equal("Hello", segment.Value);
+        }
+
+        [Fact]
+        public void StringSegment_StringCtor_AllowsNullBuffers()
+        {
+            // Arrange & Act
+            var segment = new StringSegment(null);
+
+            // Assert
+            Assert.False(segment.HasValue);
+            Assert.Equal(0, segment.Offset);
+            Assert.Equal(0, segment.Length);
+        }
+
+        [Theory]
+        [InlineData("", 0, 0)]
+        [InlineData("abc", 2, 0)]
+        public void StringSegmentConstructor_AllowsEmptyBuffers(string text, int offset, int length)
+        {
+            // Arrange & Act
+            var segment = new StringSegment(text, offset, length);
+
+            // Assert
+            Assert.True(segment.HasValue);
+            Assert.Equal(offset, segment.Offset);
+            Assert.Equal(length, segment.Length);
+        }
+
+        [Fact]
+        public void StringSegment_StringCtor_InitializesValuesCorrectly()
+        {
+            // Arrange
+            var buffer = "Hello world!";
+
+            // Act
+            var segment = new StringSegment(buffer);
+
+            // Assert
+            Assert.True(segment.HasValue);
+            Assert.Equal(0, segment.Offset);
+            Assert.Equal(buffer.Length, segment.Length);
+        }
+
+        [Fact]
+        public void StringSegment_Value_Valid()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 4);
+
+            // Act
+            var value = segment.Value;
+
+            // Assert
+            Assert.Equal("ello", value);
+        }
+
+        [Fact]
+        public void StringSegment_Value_Invalid()
+        {
+            // Arrange
+            var segment = new StringSegment();
+
+            // Act
+            var value = segment.Value;
+
+            // Assert
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void StringSegment_HasValue_Valid()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 4);
+
+            // Act
+            var hasValue = segment.HasValue;
+
+            // Assert
+            Assert.True(hasValue);
+        }
+
+        [Fact]
+        public void StringSegment_HasValue_Invalid()
+        {
+            // Arrange
+            var segment = new StringSegment();
+
+            // Act
+            var hasValue = segment.HasValue;
+
+            // Assert
+            Assert.False(hasValue);
+        }
+
+        [Theory]
+        [InlineData("a", 0, 1, 0, 'a')]
+        [InlineData("abc", 1, 1, 0, 'b')]
+        [InlineData("abcdef", 1, 4, 0, 'b')]
+        [InlineData("abcdef", 1, 4, 1, 'c')]
+        [InlineData("abcdef", 1, 4, 2, 'd')]
+        [InlineData("abcdef", 1, 4, 3, 'e')]
+        public void StringSegment_Indexer_InRange(string value, int offset, int length, int index, char expected)
+        {
+            var segment = new StringSegment(value, offset, length);
+
+            var result = segment[index];
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("", 0, 0, 0)]
+        [InlineData("a", 0, 1, -1)]
+        [InlineData("a", 0, 1, 1)]
+        public void StringSegment_Indexer_OutOfRangeThrows(string value, int offset, int length, int index)
+        {
+            var segment = new StringSegment(value, offset, length);
+
+            Assert.Throws<IndexOutOfRangeException>(() => segment[index]);
+        }
+
+        public static TheoryData<string, StringComparison, bool> EndsWithData
+        {
+            get
+            {
+                // candidate / comparer / expected result
+                return new TheoryData<string, StringComparison, bool>()
+                {
+                    { "Hello", StringComparison.Ordinal, false },
+                    { "ello ", StringComparison.Ordinal, false },
+                    { "ll", StringComparison.Ordinal, false },
+                    { "ello", StringComparison.Ordinal, true },
+                    { "llo", StringComparison.Ordinal, true },
+                    { "lo", StringComparison.Ordinal, true },
+                    { "o", StringComparison.Ordinal, true },
+                    { string.Empty, StringComparison.Ordinal, true },
+                    { "eLLo", StringComparison.Ordinal, false },
+                    { "eLLo", StringComparison.OrdinalIgnoreCase, true },
+                };
+            }
+        }
+
+        public static TheoryData<string, StringComparison, bool> StartsWithData
+        {
+            get
+            {
+                // candidate / comparer / expected result
+                return new TheoryData<string, StringComparison, bool>()
+                {
+                    { "Hello", StringComparison.Ordinal, false },
+                    { "ello ", StringComparison.Ordinal, false },
+                    { "ll", StringComparison.Ordinal, false },
+                    { "ello", StringComparison.Ordinal, true },
+                    { "ell", StringComparison.Ordinal, true },
+                    { "el", StringComparison.Ordinal, true },
+                    { "e", StringComparison.Ordinal, true },
+                    { string.Empty, StringComparison.Ordinal, true },
+                    { "eLLo", StringComparison.Ordinal, false },
+                    { "eLLo", StringComparison.OrdinalIgnoreCase, true },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(StartsWithData))]
+        public void StringSegment_StartsWith_Valid(string candidate, StringComparison comparison, bool expectedResult)
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 4);
+
+            // Act
+            var result = segment.StartsWith(candidate, comparison);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void StringSegment_StartsWith_Invalid()
+        {
+            // Arrange
+            var segment = new StringSegment();
+
+            // Act
+            var result = segment.StartsWith(string.Empty, StringComparison.Ordinal);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        public static TheoryData<string, StringComparison, bool> EqualsStringData
+        {
+            get
+            {
+                // candidate / comparer / expected result
+                return new TheoryData<string, StringComparison, bool>()
+                {
+                    { "eLLo", StringComparison.OrdinalIgnoreCase, true },
+                    { "eLLo", StringComparison.Ordinal, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EqualsStringData))]
+        public void StringSegment_Equals_String_Valid(string candidate, StringComparison comparison, bool expectedResult)
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 4);
+
+            // Act
+            var result = segment.Equals(candidate, comparison);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void StringSegment_StaticEquals_Valid()
+        {
+            var segment1 = new StringSegment("My Car Is Cool", 3, 3);
+            var segment2 = new StringSegment("Your Carport is blue", 5, 3);
+
+            Assert.True(StringSegment.Equals(segment1, segment2));
+        }
+
+        [Fact]
+        public void StringSegment_StaticEquals_Invalid()
+        {
+            var segment1 = new StringSegment("My Car Is Cool", 3, 4);
+            var segment2 = new StringSegment("Your Carport is blue", 5, 4);
+
+            Assert.False(StringSegment.Equals(segment1, segment2));
+        }
+
+        [Fact]
+        public void StringSegment_IsNullOrEmpty_Valid()
+        {
+            Assert.True(StringSegment.IsNullOrEmpty(null));
+            Assert.True(StringSegment.IsNullOrEmpty(string.Empty));
+            Assert.True(StringSegment.IsNullOrEmpty(new StringSegment(null)));
+            Assert.True(StringSegment.IsNullOrEmpty(new StringSegment(string.Empty)));
+            Assert.True(StringSegment.IsNullOrEmpty(StringSegment.Empty));
+            Assert.True(StringSegment.IsNullOrEmpty(new StringSegment(string.Empty, 0, 0)));
+            Assert.True(StringSegment.IsNullOrEmpty(new StringSegment("Hello", 0, 0)));
+            Assert.True(StringSegment.IsNullOrEmpty(new StringSegment("Hello", 3, 0)));
+        }
+
+        [Fact]
+        public void StringSegment_IsNullOrEmpty_Invalid()
+        {
+            Assert.False(StringSegment.IsNullOrEmpty("A"));
+            Assert.False(StringSegment.IsNullOrEmpty("ABCDefg"));
+            Assert.False(StringSegment.IsNullOrEmpty(new StringSegment("A", 0, 1)));
+            Assert.False(StringSegment.IsNullOrEmpty(new StringSegment("ABCDefg", 3, 2)));
+        }
+
+        public static TheoryData GetHashCode_ReturnsSameValueForEqualSubstringsData
+        {
+            get
+            {
+                return new TheoryData<StringSegment, StringSegment>
+                {
+                    { default(StringSegment), default(StringSegment) },
+                    { default(StringSegment), new StringSegment() },
+                    { new StringSegment("Test123", 0, 0), new StringSegment(string.Empty) },
+                    { new StringSegment("C`est si bon", 2, 3), new StringSegment("Yesterday", 1, 3) },
+                    { new StringSegment("Hello", 1, 4), new StringSegment("Hello world", 1, 4) },
+                    { new StringSegment("Hello"), new StringSegment("Hello", 0, 5) },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHashCode_ReturnsSameValueForEqualSubstringsData))]
+        public void GetHashCode_ReturnsSameValueForEqualSubstrings(object segment1, object segment2)
+        {
+            // Act
+            var hashCode1 = ((StringSegment)segment1).GetHashCode();
+            var hashCode2 = ((StringSegment)segment2).GetHashCode();
+
+            // Assert
+            Assert.Equal(hashCode1, hashCode2);
+        }
+
+        public static TheoryData GetHashCode_ReturnsDifferentValuesForInequalSubstringsData
+        {
+            get
+            {
+                var testString = "Test123";
+                return new TheoryData<StringSegment, StringSegment>
+                {
+                    { new StringSegment(testString, 0, 1), new StringSegment(string.Empty) },
+                    { new StringSegment(testString, 0, 1), new StringSegment(testString, 1, 1) },
+                    { new StringSegment(testString, 1, 2), new StringSegment(testString, 1, 3) },
+                    { new StringSegment(testString, 0, 4), new StringSegment("TEST123", 0, 4) },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHashCode_ReturnsDifferentValuesForInequalSubstringsData))]
+        public void GetHashCode_ReturnsDifferentValuesForInequalSubstrings(
+            object segment1,
+            object segment2)
+        {
+            // Act
+            var hashCode1 = segment1.GetHashCode();
+            var hashCode2 = segment2.GetHashCode();
+
+            // Assert
+            Assert.NotEqual(hashCode1, hashCode2);
+        }
+
+        [Fact]
+        public void StringSegment_EqualsString_Invalid()
+        {
+            // Arrange
+            var segment = new StringSegment();
+
+            // Act
+            var result = segment.Equals(string.Empty, StringComparison.Ordinal);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        public static TheoryData<object> DefaultStringSegmentEqualsStringSegmentData
+        {
+            get
+            {
+                // candidate
+                return new TheoryData<object>()
+                {
+                    { default(StringSegment) },
+                    { new StringSegment() },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultStringSegmentEqualsStringSegmentData))]
+        public void DefaultStringSegment_EqualsStringSegment(object candidate)
+        {
+            // Arrange
+            var segment = default(StringSegment);
+
+            // Act
+            var result = segment.Equals((StringSegment)candidate, StringComparison.Ordinal);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        public static TheoryData<object> DefaultStringSegmentDoesNotEqualStringSegmentData
+        {
+            get
+            {
+                // candidate
+                return new TheoryData<object>()
+                {
+                    { new StringSegment("Hello, World!", 1, 4) },
+                    { new StringSegment("Hello", 1, 0) },
+                    { new StringSegment(string.Empty) },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultStringSegmentDoesNotEqualStringSegmentData))]
+        public void DefaultStringSegment_DoesNotEqualStringSegment(object candidate)
+        {
+            // Arrange
+            var segment = default(StringSegment);
+
+            // Act
+            var result = segment.Equals((StringSegment)candidate, StringComparison.Ordinal);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        public static TheoryData<string> DefaultStringSegmentDoesNotEqualStringData
+        {
+            get
+            {
+                // candidate
+                return new TheoryData<string>()
+                {
+                    { string.Empty },
+                    { "Hello, World!" },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultStringSegmentDoesNotEqualStringData))]
+        public void DefaultStringSegment_DoesNotEqualString(string candidate)
+        {
+            // Arrange
+            var segment = default(StringSegment);
+
+            // Act
+            var result = segment.Equals(candidate, StringComparison.Ordinal);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        public static TheoryData<object, object, bool> EqualsStringSegmentData
+        {
+            get
+            {
+                // candidate / comparer / expected result
+                return new TheoryData<object, object, bool>()
+                {
+                    { new StringSegment("Hello, World!", 1, 4), StringComparison.Ordinal, true },
+                    { new StringSegment("HELlo, World!", 1, 4), StringComparison.Ordinal, false },
+                    { new StringSegment("HELlo, World!", 1, 4), StringComparison.OrdinalIgnoreCase, true },
+                    { new StringSegment("ello, World!", 0, 4), StringComparison.Ordinal, true },
+                    { new StringSegment("ello, World!", 0, 3), StringComparison.Ordinal, false },
+                    { new StringSegment("ello, World!", 1, 3), StringComparison.Ordinal, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EqualsStringSegmentData))]
+        public void StringSegment_Equals_StringSegment_Valid(object candidate, StringComparison comparison, bool expectedResult)
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 4);
+
+            // Act
+            var result = segment.Equals((StringSegment)candidate, comparison);
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void StringSegment_EqualsStringSegment_Invalid()
+        {
+            // Arrange
+            var segment = new StringSegment();
+            var candidate = new StringSegment("Hello, World!", 3, 2);
+
+            // Act
+            var result = segment.Equals(candidate, StringComparison.Ordinal);
+
+            // Assert
+            Assert.False(result);
+        }
+
+
+        [Fact]
+        public void StringSegment_SubsegmentOffset_Valid()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 4);
+
+            // Act
+            var result = segment.Subsegment(offset: 1);
+
+            // Assert
+            Assert.Equal(new StringSegment("Hello, World!", 2, 3), result);
+            Assert.Equal("llo", result.Value);
+        }
+
+        [Fact]
+        public void StringSegment_Subsegment_Valid()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 4);
+
+            // Act
+            var result = segment.Subsegment(offset: 1, length: 2);
+
+            // Assert
+            Assert.Equal(new StringSegment("Hello, World!", 2, 2), result);
+            Assert.Equal("ll", result.Value);
+        }
+
+        [Fact]
+        public void IndexOf_ComputesIndex_RelativeToTheCurrentSegment()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 10);
+
+            // Act
+            var result = segment.IndexOf(',');
+
+            // Assert
+            Assert.Equal(4, result);
+        }
+
+        [Fact]
+        public void IndexOf_ReturnsMinusOne_IfElementNotInSegment()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 3);
+
+            // Act
+            var result = segment.IndexOf(',');
+
+            // Assert
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public void IndexOf_SkipsANumberOfCaracters_IfStartIsProvided()
+        {
+            // Arrange
+            const string buffer = "Hello, World!, Hello people!";
+            var segment = new StringSegment(buffer, 3, buffer.Length - 3);
+
+            // Act
+            var result = segment.IndexOf('!', 15);
+
+            // Assert
+            Assert.Equal(buffer.Length - 4, result);
+        }
+
+        [Fact]
+        public void IndexOf_SearchOnlyInsideTheRange_IfStartAndCountAreProvided()
+        {
+            // Arrange
+            const string buffer = "Hello, World!, Hello people!";
+            var segment = new StringSegment(buffer, 3, buffer.Length - 3);
+
+            // Act
+            var result = segment.IndexOf('!', 15, 5);
+
+            // Assert
+            Assert.Equal(-1, result);
+        }
+
+
+        [Fact]
+        public void Value_DoesNotAllocateANewString_IfTheSegmentContainsTheWholeBuffer()
+        {
+            // Arrange
+            const string buffer = "Hello, World!";
+            var segment = new StringSegment(buffer);
+
+            // Act
+            var result = segment.Value;
+
+            // Assert
+            Assert.Same(buffer, result);
+        }
+
+        [Fact]
+        public void StringSegment_CreateEmptySegment()
+        {
+            // Arrange
+            var segment = new StringSegment("//", 1, 0);
+
+            // Assert
+            Assert.True(segment.HasValue);
+        }
+    }
+}


### PR DESCRIPTION
Nothing particularly dramatic, just some low hanging fruits that remove string allocations
in TagHelperMatchingConvention. VS ships with a copy of System.Memory, so we're not the first to
introduce this dependency over there.

Some before and after benchmarks because there was a convenient scenario set up for this:

// * Summary *

BenchmarkDotNet=v0.12.1.1466-nightly, OS=Windows 10.0.19043
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.100-preview.5.21230.2
  [Host]     : .NET Core 2.1.27 (CoreCLR 4.6.29916.01, CoreFX 4.6.29916.03), X64 RyuJIT
  Job-GISAGT : .NET Core 2.1.27 (CoreCLR 4.6.29916.01, CoreFX 4.6.29916.03), X64 RyuJIT

Server=True  Toolchain=.NET Core 2.1  RunStrategy=Throughput

Before:
|                                  Method |        Mean |     Error |    StdDev |     Op/s |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|---------------------------------------- |------------:|----------:|----------:|---------:|-------:|-------:|-------:|----------:|
|      'TagHelper Design Time Processing' | 2,313.36 us | 25.477 us | 21.275 us |    432.3 | 7.8125 | 3.9063 | 3.9063 |    986 KB |
| 'TagHelper Component Directive Parsing' |    93.52 us |  1.408 us |  1.100 us | 10,693.5 |      - |      - |      - |      3 KB |

Ater:
|                                  Method |        Mean |     Error |    StdDev |     Op/s |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|---------------------------------------- |------------:|----------:|----------:|---------:|-------:|-------:|-------:|----------:|
|      'TagHelper Design Time Processing' | 2,205.42 us | 28.353 us | 26.522 us |    453.4 | 7.8125 | 3.9063 | 3.9063 | 963 KB |
| 'TagHelper Component Directive Parsing' |    85.89 us |  0.724 us |  0.565 us | 11,643.1 |      - |      - |      - | 288 B |

Also some minor cleanup of Linq operations and null-ref checks in internal code

