### PR TITLE
Clean out Ubuntu 16.04 testing

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -105,10 +105,10 @@ jobs:
         ${{ if eq(parameters.useHostedUbuntu, false) }}:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCorePublic-Pool
-            queue: BuildPool.Ubuntu.1604.Amd64.Open
+            queue: BuildPool.Ubuntu.1804.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCoreInternal-Pool
-            queue: BuildPool.Ubuntu.1604.Amd64
+            queue: BuildPool.Ubuntu.1804.Amd64
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCorePublic-Pool

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -149,7 +149,7 @@ jobs:
 - template: jobs/default-build.yml
   parameters:
     jobName: Linux_Quarantined_Test
-    jobDisplayName: "Tests: Ubuntu 16.04 x64"
+    jobDisplayName: "Tests: Ubuntu 18.04 x64"
     agentOs: Linux
     timeoutInMinutes: 60
     isTestingJob: true

--- a/docs/Helix.md
+++ b/docs/Helix.md
@@ -18,8 +18,8 @@ This will restore, and then publish all the test project including some bootstra
 
 ## Overview of the helix usage in our pipelines
 
-- Required queues: Windows10, OSX, Ubuntu1604
-- Full queue matrix: Windows[7, 81, 10], Ubuntu[1604, 1804, 2004], Centos7, Debian9, Redhat7, Fedora28, Arm64 (Win10, Debian9)
+- Required queues: Windows10, OSX, Ubuntu1804
+- Full queue matrix: Windows[7, 81, 10], Ubuntu[1804, 2004], Debian9, Redhat7, Arm64 (Win10, Debian9)
 - The queues are defined in [Helix.Common.props](https://github.com/dotnet/aspnetcore/blob/main/eng/targets/Helix.Common.props)
 
 [aspnetcore-ci](https://dev.azure.com/dnceng/public/_build?definitionId=278) runs non quarantined tests against the required helix queues as a required PR check and all builds on all branches.

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -8,13 +8,12 @@
 .PARAMETER HelixQueues
     Set the Helix queues to use. The list is '+' or ';'-separated.
     Some supported queues:
-    Ubuntu.1604.Amd64.Open
     Ubuntu.1804.Amd64.Open
-    Windows.10.Amd64.Open
+    Ubuntu.2004.Amd64.Open
+    Windows.10.Amd64.Server20H2.Open
     Windows.81.Amd64.Open
     Windows.7.Amd64.Open
     OSX.1014.Amd64.Open
-    Centos.7.Amd64.Open
     Debian.9.Amd64.Open
     Redhat.7.Amd64.Open
 .PARAMETER RunQuarantinedTests
@@ -29,7 +28,7 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$Project,
 
-    [string]$HelixQueues = "Windows.10.Amd64.Open",
+    [string]$HelixQueues = "Windows.10.Amd64.Server20H2.Open",
     [switch]$RunQuarantinedTests,
 
     [ValidateSet('x64', 'x86', 'arm', 'arm64')]

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -14,13 +14,13 @@
   <ItemGroup Condition="'$(IsRequiredCheck)' == 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(_UseHelixOpenQueues)' == 'true'">
     <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Windows.10.Amd64.Server20H2.Open" Platform="Windows" />
-    <HelixAvailableTargetQueue Include="OSX.1014.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="OSX.1014.Amd64.Open" Platform="OSX" />
   </ItemGroup>
 
   <!-- queues for helix-matrix.yml pipeline -->
   <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
     <HelixAvailableTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Fedora.33.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-helix-20210120000908-a9df267" Platform="Linux" />

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -19,13 +19,12 @@
 
   <!-- queues for helix-matrix.yml pipeline -->
   <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
-    <HelixAvailableTargetQueue Include="Ubuntu.1604.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="(Fedora.33.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-helix-20210120000908-a9df267" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="(Alpine.312.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="(Fedora.33.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-helix-20210120000908-a9df267" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="(Alpine.312.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673" Platform="Linux" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true'">
     <!-- TODO Re-enable Win-7 queue when dotnet restore are fixed. https://github.com/dotnet/aspnetcore/issues/32683 -->

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -10,16 +10,13 @@
 
   <PropertyGroup Condition="'$(TestDependsOnPlaywright)' == 'true'">
     <SkipHelixQueues>
-      Windows.7.Amd64.Open;
-      Windows.81.Amd64.Open;
-      Redhat.7.Amd64.Open;
-      Redhat.7.Amd64;
-      Debian.9.Amd64.Open;
-      Debian.9.Amd64;
-      Ubuntu.2004.Amd64.Open;
-      Ubuntu.2004.Amd64;
       (Alpine.312.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673;
       (Fedora.33.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-helix-20210120000908-a9df267
+      Debian.9.Amd64.Open;
+      Redhat.7.Amd64.Open;
+      Ubuntu.2004.Amd64.Open;
+      Windows.7.Amd64.Open;
+      Windows.81.Amd64.Open;
     </SkipHelixQueues>
     <SkipHelixArm>true</SkipHelixArm>
   </PropertyGroup>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -9,7 +9,18 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TestDependsOnPlaywright)' == 'true'">
-    <SkipHelixQueues>Windows.7.Amd64.Open;Windows.81.Amd64.Open;Redhat.7.Amd64.Open;Redhat.7.Amd64;Debian.9.Amd64.Open;Debian.9.Amd64.Open;Ubuntu.2004.Amd64.Open;Ubuntu.2004.Amd64;Ubuntu.1604.Amd64.Open;Ubuntu.1604.Amd64;Alpine.312.Amd64.Open;(Alpine.312.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673;(Fedora.33.Amd64.Open)Ubuntu.1604.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-helix-20210120000908-a9df267</SkipHelixQueues>
+    <SkipHelixQueues>
+      Windows.7.Amd64.Open;
+      Windows.81.Amd64.Open;
+      Redhat.7.Amd64.Open;
+      Redhat.7.Amd64;
+      Debian.9.Amd64.Open;
+      Debian.9.Amd64;
+      Ubuntu.2004.Amd64.Open;
+      Ubuntu.2004.Amd64;
+      (Alpine.312.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673;
+      (Fedora.33.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-helix-20210120000908-a9df267
+    </SkipHelixQueues>
     <SkipHelixArm>true</SkipHelixArm>
   </PropertyGroup>
 

--- a/src/Identity/test/Identity.Test/IdentityUIScriptsTest.cs
+++ b/src/Identity/test/Identity.Test/IdentityUIScriptsTest.cs
@@ -79,9 +79,6 @@ namespace Microsoft.AspNetCore.Identity.Test
 
         [Theory]
         [MemberData(nameof(ScriptWithFallbackSrcData))]
-        // Ubuntu 16 uses an old version of OpenSSL that doesn't work well when an intermediate CA is expired.
-        // We've decided to not run these tests against that OS anymore and will run on newer versions of Ubuntu.
-        [SkipOnHelix("Skip on Ubuntu 16", Queues = "Ubuntu.1604.Amd64.Open;Ubuntu.1604.Amd64")]
         public async Task IdentityUI_ScriptTags_FallbackSourceContent_Matches_CDNContent(ScriptTag scriptTag)
         {
             var wwwrootDir = Path.Combine(GetProjectBasePath(), "wwwroot", scriptTag.Version);


### PR DESCRIPTION
- use Ubuntu 18.04 agents for testing in Docker containers on Helix

nit: clean up a few old mentions of Centos and Fedora testing