### PR TITLE
Delete multiple cookie with same-key when Path is different but Domain is specified

### DIFF
--- a/src/Http/Http/src/Internal/ResponseCookies.cs
+++ b/src/Http/Http/src/Internal/ResponseCookies.cs
@@ -154,25 +154,24 @@ namespace Microsoft.AspNetCore.Http
             }
 
             var encodedKeyPlusEquals = (_enableCookieNameEncoding ? Uri.EscapeDataString(key) : key) + "=";
-            bool domainAndPathHasValue = !string.IsNullOrEmpty(options.Domain) && !string.IsNullOrEmpty(options.Path);
-            bool domainOnlyHasValue = !string.IsNullOrEmpty(options.Domain) && string.IsNullOrEmpty(options.Path);
-            bool pathOnlyHasValue = !string.IsNullOrEmpty(options.Path) && string.IsNullOrEmpty(options.Domain);
+            bool domainHasValue = !string.IsNullOrEmpty(options.Domain);
+            bool pathHasValue = !string.IsNullOrEmpty(options.Path);
 
             Func<string, string, CookieOptions, bool> rejectPredicate;
-            if (domainAndPathHasValue)
+            if (domainHasValue && pathHasValue)
             {
                 rejectPredicate = (value, encKeyPlusEquals, opts) =>
                     value.StartsWith(encKeyPlusEquals, StringComparison.OrdinalIgnoreCase) &&
                         value.IndexOf($"domain={opts.Domain}", StringComparison.OrdinalIgnoreCase) != -1 &&
                         value.IndexOf($"path={opts.Path}", StringComparison.OrdinalIgnoreCase) != -1;
             }
-            else if (domainOnlyHasValue)
+            else if (domainHasValue)
             {
                 rejectPredicate = (value, encKeyPlusEquals, opts) =>
                     value.StartsWith(encKeyPlusEquals, StringComparison.OrdinalIgnoreCase) &&
                         value.IndexOf($"domain={opts.Domain}", StringComparison.OrdinalIgnoreCase) != -1;
             }
-            else if (pathOnlyHasValue)
+            else if (pathHasValue)
             {
                 rejectPredicate = (value, encKeyPlusEquals, opts) =>
                     value.StartsWith(encKeyPlusEquals, StringComparison.OrdinalIgnoreCase) &&

--- a/src/Http/Http/test/ResponseCookiesTest.cs
+++ b/src/Http/Http/test/ResponseCookiesTest.cs
@@ -75,6 +75,32 @@ namespace Microsoft.AspNetCore.Http.Tests
         }
 
         [Fact]
+        public void DeleteCookieWithDomainAndPathShouldSetDefaultPath()
+        {
+            var headers = (IHeaderDictionary)new HeaderDictionary();
+            var features = MakeFeatures(headers);
+            var responseCookies = new ResponseCookies(features);
+
+            var testCookies = new (string key, string path, string domaine)[]
+            {
+                new ("key1", "/", null),
+                new ("key1", "/test/", null),
+                new ("key2", "/", "localhost"),
+                new ("key2", "/test/", "localhost"),
+            };
+
+            foreach (var cookie in testCookies)
+            {
+                responseCookies.Delete(cookie.key, new CookieOptions() { Domain = cookie.domaine, Path = cookie.path });
+            }
+
+            var cookieHeaderValues = headers.SetCookie.ToArray();
+            Assert.True(cookieHeaderValues.Length == testCookies.Length);
+            Assert.All(cookieHeaderValues, cookie => Assert.Contains("path=/", cookie));
+            Assert.All(cookieHeaderValues, cookie => Assert.Contains("expires=Thu, 01 Jan 1970 00:00:00 GMT", cookie));
+        }
+
+        [Fact]
         public void DeleteCookieWithCookieOptionsShouldKeepPropertiesOfCookieOptions()
         {
             var headers = (IHeaderDictionary)new HeaderDictionary();

--- a/src/Http/Http/test/ResponseCookiesTest.cs
+++ b/src/Http/Http/test/ResponseCookiesTest.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Http.Tests
         }
 
         [Fact]
-        public void DeleteCookieWithDomainAndPathShouldSetDefaultPath()
+        public void DeleteCookieWithDomainAndPathDeletesPriorMatchingCookies()
         {
             var headers = (IHeaderDictionary)new HeaderDictionary();
             var features = MakeFeatures(headers);
@@ -84,10 +84,10 @@ namespace Microsoft.AspNetCore.Http.Tests
 
             var testCookies = new (string Key, string Path, string Domain)[]
             {
-                new ("key1", "/", null),
-                new ("key1", "/test/", null),
-                new ("key2", "/", "localhost"),
-                new ("key2", "/test/", "localhost"),
+                new ("key1", "/path1/", null),
+                new ("key1", "/path2/", null),
+                new ("key2", "/path1/", "localhost"),
+                new ("key2", "/path2/", "localhost"),
             };
 
             foreach (var cookie in testCookies)
@@ -99,10 +99,10 @@ namespace Microsoft.AspNetCore.Http.Tests
             Assert.Equal(testCookies.Length, cookieHeaderValues.Length);
 
             var deletedCookies = cookieHeaderValues.ToArray();
-            Assert.Contains(deletedCookies, cookie => cookie.StartsWith("key1", StringComparison.InvariantCulture) && cookie.Contains("path=/"));
-            Assert.Contains(deletedCookies, cookie => cookie.StartsWith("key1", StringComparison.InvariantCulture) && cookie.Contains("path=/test/"));
-            Assert.Contains(deletedCookies, cookie => cookie.StartsWith("key2", StringComparison.InvariantCulture) && cookie.Contains("path=/") && cookie.Contains("domain=localhost"));
-            Assert.Contains(deletedCookies, cookie => cookie.StartsWith("key2", StringComparison.InvariantCulture) && cookie.Contains("path=/test/") && cookie.Contains("domain=localhost"));
+            Assert.Single(deletedCookies, cookie => cookie.StartsWith("key1", StringComparison.InvariantCulture) && cookie.Contains("path=/path1/"));
+            Assert.Single(deletedCookies, cookie => cookie.StartsWith("key1", StringComparison.InvariantCulture) && cookie.Contains("path=/path2/"));
+            Assert.Single(deletedCookies, cookie => cookie.StartsWith("key2", StringComparison.InvariantCulture) && cookie.Contains("path=/path1/") && cookie.Contains("domain=localhost"));
+            Assert.Single(deletedCookies, cookie => cookie.StartsWith("key2", StringComparison.InvariantCulture) && cookie.Contains("path=/path2/") && cookie.Contains("domain=localhost"));
             Assert.All(cookieHeaderValues, cookie => Assert.Contains("expires=Thu, 01 Jan 1970 00:00:00 GMT", cookie));
         }
 

--- a/src/Http/Http/test/ResponseCookiesTest.cs
+++ b/src/Http/Http/test/ResponseCookiesTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -91,12 +92,17 @@ namespace Microsoft.AspNetCore.Http.Tests
 
             foreach (var cookie in testCookies)
             {
-                responseCookies.Delete(cookie.key, new CookieOptions() { Domain = cookie.domaine, Path = cookie.path });
+                responseCookies.Delete(cookie.Key, new CookieOptions() { Domain = cookie.Domain, Path = cookie.Path });
             }
 
             var cookieHeaderValues = headers.SetCookie.ToArray();
-            Assert.True(cookieHeaderValues.Length == testCookies.Length);
-            Assert.All(cookieHeaderValues, cookie => Assert.Contains("path=/", cookie));
+            Assert.Equal(testCookies.Length, cookieHeaderValues.Length);
+
+            var deletedCookies = cookieHeaderValues.ToArray();
+            Assert.Contains(deletedCookies, cookie => cookie.StartsWith("key1", StringComparison.InvariantCulture) && cookie.Contains("path=/"));
+            Assert.Contains(deletedCookies, cookie => cookie.StartsWith("key1", StringComparison.InvariantCulture) && cookie.Contains("path=/test/"));
+            Assert.Contains(deletedCookies, cookie => cookie.StartsWith("key2", StringComparison.InvariantCulture) && cookie.Contains("path=/") && cookie.Contains("domain=localhost"));
+            Assert.Contains(deletedCookies, cookie => cookie.StartsWith("key2", StringComparison.InvariantCulture) && cookie.Contains("path=/test/") && cookie.Contains("domain=localhost"));
             Assert.All(cookieHeaderValues, cookie => Assert.Contains("expires=Thu, 01 Jan 1970 00:00:00 GMT", cookie));
         }
 

--- a/src/Http/Http/test/ResponseCookiesTest.cs
+++ b/src/Http/Http/test/ResponseCookiesTest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Http.Tests
             var features = MakeFeatures(headers);
             var responseCookies = new ResponseCookies(features);
 
-            var testCookies = new (string key, string path, string domaine)[]
+            var testCookies = new (string Key, string Path, string Domain)[]
             {
                 new ("key1", "/", null),
                 new ("key1", "/test/", null),


### PR DESCRIPTION
- [x] You've read the Contributor Guide and Code of Conduct.
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

**PR Title**
Fix multiple cookies deletion with same-key when Path is different but Domain is specified

**PR Description**
Update the cookie reject predicate to add a new condition that take into account the domain and the path.

(https://github.com/wcontayon/AspNetCore/blob/038557748532e6cc0eeff304ab5cbd7f147f7e72/src/Http/Http/src/Internal/ResponseCookies.cs#L162-L168)

Addresses #30579 
