### PR TITLE
Prevent JS interop after circuit disposal. Fixes #32808

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -174,6 +174,10 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
 
                 try
                 {
+                    // Prevent any further JS interop calls
+                    // Helps with scenarios like https://github.com/dotnet/aspnetcore/issues/32808
+                    JSRuntime.MarkPermanentlyDisconnected();
+
                     await Renderer.DisposeAsync();
 
                     // This cast is needed because it's possible the scope may not support async dispose.

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -89,8 +89,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 {
                     throw new InvalidOperationException(
                         "JavaScript interop calls cannot be issued at this time. This is because the component is being " +
-                        $"statically rendered. When prerendering is enabled, JavaScript interop calls can only be performed " +
-                        $"during the OnAfterRenderAsync lifecycle method.");
+                        "statically rendered. When prerendering is enabled, JavaScript interop calls can only be performed " +
+                        "during the OnAfterRenderAsync lifecycle method.");
                 }
             }
 

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -82,8 +82,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
                 if (_permanentlyDisconnected)
                 {
                     throw new JSDisconnectedException(
-                           "JavaScript interop calls cannot be issued at this time. This is because the circuit has disconnected " +
-                           "and is being disposed.");
+                   "JavaScript interop calls cannot be issued at this time. This is because the circuit has disconnected " +
+                   "and is being disposed.");
                 }
                 else
                 {

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -123,6 +123,38 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
         }
 
         [Fact]
+        public async Task DisposeAsync_MarksJSRuntimeAsDisconnectedBeforeDisposingRenderer()
+        {
+            // Arrange
+            var serviceScope = new Mock<IServiceScope>();
+            var remoteRenderer = GetRemoteRenderer();
+            var circuitHost = TestCircuitHost.Create(
+                serviceScope: serviceScope.Object,
+                remoteRenderer: remoteRenderer);
+
+            var component = new PerformJSInteropOnDisposeComponent(circuitHost.JSRuntime);
+            circuitHost.Renderer.AssignRootComponentId(component);
+
+            var circuitUnhandledExceptions = new List<UnhandledExceptionEventArgs>();
+            circuitHost.UnhandledException += (sender, eventArgs) =>
+            {
+                circuitUnhandledExceptions.Add(eventArgs);
+            };
+
+            // Act
+            await circuitHost.DisposeAsync();
+
+            // Assert: Component disposal logic sees the exception
+            var componentException = Assert.IsType<JSDisconnectedException>(component.ExceptionDuringDisposeAsync);
+
+            // Assert: Circuit host notifies about the exception
+            Assert.Collection(circuitUnhandledExceptions, eventArgs =>
+            {
+                Assert.Same(componentException, eventArgs.ExceptionObject);
+            });
+        }
+
+        [Fact]
         public async Task InitializeAsync_InvokesHandlers()
         {
             // Arrange
@@ -307,6 +339,38 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits
             {
                 DidCallDispose = true;
                 throw new InvalidFilterCriteriaException();
+            }
+        }
+
+        private class PerformJSInteropOnDisposeComponent : IComponent, IAsyncDisposable
+        {
+            private readonly IJSRuntime _js;
+
+            public PerformJSInteropOnDisposeComponent(IJSRuntime jsRuntime)
+            {
+                _js = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
+            }
+
+            public Exception ExceptionDuringDisposeAsync { get; private set; }
+
+            public void Attach(RenderHandle renderHandle)
+            {
+            }
+
+            public Task SetParametersAsync(ParameterView parameters)
+                => Task.CompletedTask;
+
+            public async ValueTask DisposeAsync()
+            {
+                try
+                {
+                    await _js.InvokeVoidAsync("SomeJsCleanupCode");
+                }
+                catch (Exception ex)
+                {
+                    ExceptionDuringDisposeAsync = ex;
+                    throw;
+                }
             }
         }
     }

--- a/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
+++ b/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
@@ -48,7 +48,14 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
         {
             if (_selfReference != null)
             {
-                await _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.dispose", _selfReference);
+                try
+                {
+                    await _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.dispose", _selfReference);
+                }
+                catch (JSDisconnectedException)
+                {
+                    // If the browser is gone, we don't need it to clean up any browser-side state
+                }
             }
         }
     }

--- a/src/JSInterop/Microsoft.JSInterop/src/JSDisconnectedException.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSDisconnectedException.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.JSInterop
+{
+    /// <summary>
+    /// Represents errors that occur during an interop call from .NET to JavaScript.
+    /// </summary>
+    public class JSDisconnectedException : Exception
+    {
+        /// <summary>
+        /// Constructs an instance of <see cref="JSDisconnectedException"/>.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        public JSDisconnectedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/JSInterop/Microsoft.JSInterop/src/JSDisconnectedException.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSDisconnectedException.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.JSInterop
 {
     /// <summary>
-    /// Represents errors that occur during an interop call from .NET to JavaScript.
+    /// Represents errors that occur during an interop call from .NET to JavaScript when the JavaScript runtime becomes disconnected.
     /// </summary>
     public sealed class JSDisconnectedException : Exception
     {

--- a/src/JSInterop/Microsoft.JSInterop/src/JSDisconnectedException.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSDisconnectedException.cs
@@ -8,7 +8,7 @@ namespace Microsoft.JSInterop
     /// <summary>
     /// Represents errors that occur during an interop call from .NET to JavaScript.
     /// </summary>
-    public class JSDisconnectedException : Exception
+    public sealed class JSDisconnectedException : Exception
     {
         /// <summary>
         /// Constructs an instance of <see cref="JSDisconnectedException"/>.

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -28,3 +28,5 @@ static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JS
 static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, System.TimeSpan timeout, params object?[]? args) -> System.Threading.Tasks.ValueTask
 *REMOVED*static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, params object![]! args) -> System.Threading.Tasks.ValueTask
 static Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(this Microsoft.JSInterop.IJSRuntime! jsRuntime, string! identifier, params object?[]? args) -> System.Threading.Tasks.ValueTask
+Microsoft.JSInterop.JSDisconnectedException
+Microsoft.JSInterop.JSDisconnectedException.JSDisconnectedException(string! message) -> void


### PR DESCRIPTION
See more details about the problem at https://github.com/dotnet/aspnetcore/issues/32808#issuecomment-845236683. In summary, any component that attempts JS interop during disposal (for example, `<Virtualize>`) would hang until the JS call times out, preventing cleanup of any scoped resources for that period.

This PR changes how JS interop works after a circuit has begun disposal (which typically means the user has closed their browser tab or navigated away):

 * Before: JS interop calls would not get any response from the browser, so they'd just hang for a minute and eventually time out with an exception
 * After: JS interop calls will throw immediately using a new exception type (`JSDisconnectedException`)

I think we can regard this as *not* a breaking change because the calls would have eventually thrown anyway, and still do. It now just completes this process faster. The advantages of this change are:

1. DI scopes no longer live for an extra minute before cleanup in this case (e.g., when you have an active `<Virtualize>` component and the user closes the tab). They now clean up immediately.
2. Component authors who want to treat this as not-an-error now have a specific exception type they can catch and suppress. This is now done inside `Virtualize` so it won't even get logged as an error. This makes sense in cases where you were only trying to do JS interop to clean up browser-side state, and obviously don't care about that if the browser is already gone.

If we wanted, we could consider more dramatic options like:

 * **Not treating JS interop calls as failing with exceptions if the browser is disconnected.** I think that's a bad idea because (1) it would be hugely breaking, and (2) semantically it doesn't make sense - we won't know if the developer actually requires some info back from the browser or wants to know for sure whether a void call was received and completed.
 * **Auto-suppressing `JSDisconnectedException` entirely from logs.** I think that's a bad idea because it likely prevents developers from discovering that one was even happening. And then if their disposal logic looked like `DoJsCleanUp(); DoDotNetCleanUp();`, they would not realise that the `DoDotNetCleanUp` part never executes. I think developers need to know this is an error and it's up to them to try/catch if they want to control how it's handled.
