### PR TITLE
[release/6.0-preview5] Fix WebApplication to read environment specific logging configuration

### DIFF
--- a/src/DefaultBuilder/DefaultBuilder.slnf
+++ b/src/DefaultBuilder/DefaultBuilder.slnf
@@ -1,13 +1,24 @@
-﻿{
+{
   "solution": {
     "path": "..\\..\\AspNetCore.sln",
-    "projects" : [
+    "projects": [
       "src\\DefaultBuilder\\samples\\SampleApp\\DefaultBuilder.SampleApp.csproj",
-      "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.Tests\\Microsoft.AspNetCore.Tests.csproj",
-      "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.FunctionalTests\\Microsoft.AspNetCore.FunctionalTests.csproj",
       "src\\DefaultBuilder\\src\\Microsoft.AspNetCore.csproj",
+      "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.FunctionalTests\\Microsoft.AspNetCore.FunctionalTests.csproj",
+      "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.Tests\\Microsoft.AspNetCore.Tests.csproj",
+      "src\\Hosting\\Abstractions\\src\\Microsoft.AspNetCore.Hosting.Abstractions.csproj",
+      "src\\Hosting\\Hosting\\src\\Microsoft.AspNetCore.Hosting.csproj",
+      "src\\Hosting\\Server.Abstractions\\src\\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj",
       "src\\Hosting\\Server.IntegrationTesting\\src\\Microsoft.AspNetCore.Server.IntegrationTesting.csproj",
-      "src\\Middleware\\StaticFiles\\src\\Microsoft.AspNetCore.StaticFiles.csproj"
+      "src\\Http\\Features\\src\\Microsoft.Extensions.Features.csproj",
+      "src\\Http\\Headers\\src\\Microsoft.Net.Http.Headers.csproj",
+      "src\\Http\\Http.Abstractions\\src\\Microsoft.AspNetCore.Http.Abstractions.csproj",
+      "src\\Http\\Http.Extensions\\src\\Microsoft.AspNetCore.Http.Extensions.csproj",
+      "src\\Http\\Http.Features\\src\\Microsoft.AspNetCore.Http.Features.csproj",
+      "src\\Http\\Http\\src\\Microsoft.AspNetCore.Http.csproj",
+      "src\\Http\\WebUtilities\\src\\Microsoft.AspNetCore.WebUtilities.csproj",
+      "src\\Middleware\\StaticFiles\\src\\Microsoft.AspNetCore.StaticFiles.csproj",
+      "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj"
     ]
   }
 }

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -86,6 +86,9 @@ namespace Microsoft.AspNetCore.Hosting
                 configureHostAction(_configuration);
             }
 
+            // Configuration doesn't auto-update during the bootstrap phase to reduce I/O,
+            // but we do need to update between host and app configuration so the right environment is ussed.
+            _configuration.Update();
             _environment.ApplyConfigurationSettings(_configuration);
 
             foreach (var configureAppAction in _configureAppActions)
@@ -93,6 +96,7 @@ namespace Microsoft.AspNetCore.Hosting
                 configureAppAction(_context, _configuration);
             }
 
+            _configuration.Update();
             _environment.ApplyConfigurationSettings(_configuration);
         }
     }

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             configureDelegate(_context, _configuration);
             _environment.ApplyConfigurationSettings(_configuration);
-            _configuration.ChangeBasePath(_environment.ContentRootPath);
+            //_configuration.ChangeBasePath(_environment.ContentRootPath);
             return this;
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             configureDelegate(_configuration);
             _environment.ApplyConfigurationSettings(_configuration);
-            _configuration.ChangeBasePath(_environment.ContentRootPath);
+            //_configuration.ChangeBasePath(_environment.ContentRootPath);
             return this;
         }
 

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Hosting
     // This exists solely to bootstrap the configuration
     internal class BootstrapHostBuilder : IHostBuilder
     {
-        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
         private readonly HostBuilderContext _context;
         private readonly Configuration _configuration;
         private readonly WebHostEnvironment _environment;
@@ -28,6 +27,8 @@ namespace Microsoft.AspNetCore.Hosting
                 HostingEnvironment = webHostEnvironment
             };
         }
+
+        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
 
         public IHost Build()
         {

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -40,7 +40,6 @@ namespace Microsoft.AspNetCore.Hosting
         {
             configureDelegate(_context, _configuration);
             _environment.ApplyConfigurationSettings(_configuration);
-            //_configuration.ChangeBasePath(_environment.ContentRootPath);
             return this;
         }
 
@@ -55,7 +54,6 @@ namespace Microsoft.AspNetCore.Hosting
         {
             configureDelegate(_configuration);
             _environment.ApplyConfigurationSettings(_configuration);
-            //_configuration.ChangeBasePath(_environment.ContentRootPath);
             return this;
         }
 

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Hosting
             return this;
         }
 
-        internal void ExecuteActions()
+        internal void RunConfigurationCallbacks()
         {
             foreach (var configureHostAction in _configureHostActions)
             {
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Hosting
             }
 
             // Configuration doesn't auto-update during the bootstrap phase to reduce I/O,
-            // but we do need to update between host and app configuration so the right environment is ussed.
+            // but we do need to update between host and app configuration so the right environment is used.
             _configuration.Update();
             _environment.ApplyConfigurationSettings(_configuration);
 

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -13,18 +13,20 @@ namespace Microsoft.AspNetCore.Hosting
     // This exists solely to bootstrap the configuration
     internal class BootstrapHostBuilder : IHostBuilder
     {
-        private readonly HostBuilderContext _context;
         private readonly Configuration _configuration;
         private readonly WebHostEnvironment _environment;
 
-        private readonly List<Action<IConfigurationBuilder>> _configureHostActions = new List<Action<IConfigurationBuilder>>();
-        private readonly List<Action<HostBuilderContext, IConfigurationBuilder>> _configureAppActions = new List<Action<HostBuilderContext, IConfigurationBuilder>>();
+        private readonly HostBuilderContext _hostContext;
+
+        private readonly List<Action<IConfigurationBuilder>> _configureHostActions = new();
+        private readonly List<Action<HostBuilderContext, IConfigurationBuilder>> _configureAppActions = new();
 
         public BootstrapHostBuilder(Configuration configuration, WebHostEnvironment webHostEnvironment)
         {
             _configuration = configuration;
             _environment = webHostEnvironment;
-            _context = new HostBuilderContext(Properties)
+
+            _hostContext = new HostBuilderContext(Properties)
             {
                 Configuration = configuration,
                 HostingEnvironment = webHostEnvironment
@@ -56,6 +58,11 @@ namespace Microsoft.AspNetCore.Hosting
         {
             _configureHostActions.Add(configureDelegate ?? throw new ArgumentNullException(nameof(configureDelegate)));
             return this;
+        }
+
+        public string? GetSetting(string key)
+        {
+            return _configuration[key];
         }
 
         public IHostBuilder ConfigureServices(Action<HostBuilderContext, IServiceCollection> configureDelegate)
@@ -93,7 +100,7 @@ namespace Microsoft.AspNetCore.Hosting
 
             foreach (var configureAppAction in _configureAppActions)
             {
-                configureAppAction(_context, _configuration);
+                configureAppAction(_hostContext, _configuration);
             }
 
             _configuration.Update();

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
@@ -19,11 +18,28 @@ namespace Microsoft.AspNetCore.Builder
     public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder, IDisposable
     {
         private readonly ConfigurationSources _sources;
-        private readonly IDictionary<string, object> _properties;
         private ConfigurationRoot _configurationRoot;
 
         private ConfigurationReloadToken _changeToken = new();
         private IDisposable? _changeTokenRegistration;
+
+        /// <summary>
+        /// Creates an empty  mutable configuration object that is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
+        /// </summary>
+        public Configuration()
+        {
+            _sources = new ConfigurationSources(this);
+
+            // _configurationRoot is set by Update()
+            _configurationRoot = default!;
+            Update();
+        }
+
+        /// <summary>
+        /// Automatically update the <see cref="IConfiguration"/> on <see cref="IConfigurationBuilder"/> changes.
+        /// If <see langword="false"/>, <see cref="Update()"/> will manually update the <see cref="IConfiguration"/>.
+        /// </summary>
+        public bool AutoUpdateEnabled { get; set; }
 
         /// <inheritdoc />
         public string this[string key] { get => _configurationRoot[key]; set => _configurationRoot[key] = value; }
@@ -34,23 +50,28 @@ namespace Microsoft.AspNetCore.Builder
         /// <inheritdoc />
         public IEnumerable<IConfigurationSection> GetChildren() => GetChildrenImplementation(null);
 
-        IDictionary<string, object> IConfigurationBuilder.Properties => _properties;
+        IDictionary<string, object> IConfigurationBuilder.Properties { get; } = new Dictionary<string, object>();
 
         IList<IConfigurationSource> IConfigurationBuilder.Sources => _sources;
 
         IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => _configurationRoot.Providers;
 
         /// <summary>
-        /// Creates an empty  mutable configuration object that is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
+        /// Manually update the <see cref="IConfiguration"/> to reflect <see cref="IConfigurationBuilder"/> changes.
+        /// It is not necessary to call this if <see cref="AutoUpdateEnabled"/> is <see langword="true"/>.
         /// </summary>
-        public Configuration()
+        public void Update()
         {
-            _properties = new ConfigurationProperties(this);
-            _sources = new ConfigurationSources(this);
+            var newConfiguration = BuildConfigurationRoot();
+            var prevConfiguration = _configurationRoot;
 
-            // _configurationRoot is set by UpdateConfiguration()
-            _configurationRoot = default!;
-            UpdateConfiguration();
+            _configurationRoot = newConfiguration;
+
+            _changeTokenRegistration?.Dispose();
+            (prevConfiguration as IDisposable)?.Dispose();
+
+            _changeTokenRegistration = ChangeToken.OnChange(() => newConfiguration.GetReloadToken(), RaiseChanged);
+            RaiseChanged();
         }
 
         /// <inheritdoc />
@@ -72,20 +93,13 @@ namespace Microsoft.AspNetCore.Builder
 
         void IConfigurationRoot.Reload() => _configurationRoot.Reload();
 
-        private void UpdateConfiguration()
+        private void NotifySourcesChanged()
         {
-            var newConfiguration = BuildConfigurationRoot();
-            var prevConfiguration = _configurationRoot;
-
-            _configurationRoot = newConfiguration;
-
-            _changeTokenRegistration?.Dispose();
-            (prevConfiguration as IDisposable)?.Dispose();
-
-            _changeTokenRegistration = ChangeToken.OnChange(() => newConfiguration.GetReloadToken(), RaiseChanged);
-            RaiseChanged();
+            if (AutoUpdateEnabled)
+            {
+                Update();
+            }
         }
-
         private ConfigurationRoot BuildConfigurationRoot()
         {
             var providers = new List<IConfigurationProvider>();
@@ -120,12 +134,11 @@ namespace Microsoft.AspNetCore.Builder
 
         private class ConfigurationSources : IList<IConfigurationSource>
         {
-            private readonly IList<IConfigurationSource> _sources;
+            private readonly List<IConfigurationSource> _sources = new();
             private readonly Configuration _config;
 
             public ConfigurationSources(Configuration config)
             {
-                _sources = new List<IConfigurationSource>();
                 _config = config;
             }
 
@@ -135,24 +148,24 @@ namespace Microsoft.AspNetCore.Builder
                 set
                 {
                     _sources[index] = value;
-                    _config.UpdateConfiguration();
+                    _config.NotifySourcesChanged();
                 }
             }
 
             public int Count => _sources.Count;
 
-            public bool IsReadOnly => _sources.IsReadOnly;
+            public bool IsReadOnly => false;
 
             public void Add(IConfigurationSource item)
             {
                 _sources.Add(item);
-                _config.UpdateConfiguration();
+                _config.NotifySourcesChanged();
             }
 
             public void Clear()
             {
                 _sources.Clear();
-                _config.UpdateConfiguration();
+                _config.NotifySourcesChanged();
             }
 
             public bool Contains(IConfigurationSource item)
@@ -178,98 +191,26 @@ namespace Microsoft.AspNetCore.Builder
             public void Insert(int index, IConfigurationSource item)
             {
                 _sources.Insert(index, item);
-                _config.UpdateConfiguration();
+                _config.NotifySourcesChanged();
             }
 
             public bool Remove(IConfigurationSource item)
             {
                 var removed = _sources.Remove(item);
-                _config.UpdateConfiguration();
+                _config.NotifySourcesChanged();
                 return removed;
             }
 
             public void RemoveAt(int index)
             {
                 _sources.RemoveAt(index);
-                _config.UpdateConfiguration();
+                _config.NotifySourcesChanged();
             }
 
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
-        }
-
-        private class ConfigurationProperties : IDictionary<string, object>
-        {
-            private readonly IDictionary<string, object> _properties = new Dictionary<string, object>();
-            private readonly Configuration _config;
-
-            public ConfigurationProperties(Configuration config)
-            {
-                _config = config;
-            }
-
-            public object this[string key]
-            {
-                get => _properties[key];
-                set
-                {
-                    _properties[key] = value;
-                    _config.UpdateConfiguration();
-                }
-            }
-
-            public ICollection<string> Keys => _properties.Keys;
-
-            public ICollection<object> Values => _properties.Values;
-
-            public int Count => _properties.Count;
-
-            public bool IsReadOnly => false;
-
-            public void Add(string key, object value)
-            {
-                _properties.Add(key, value);
-                _config.UpdateConfiguration();
-            }
-
-            public void Add(KeyValuePair<string, object> item)
-            {
-                _properties.Add(item);
-                _config.UpdateConfiguration();
-            }
-
-            public void Clear()
-            {
-                _properties.Clear();
-                _config.UpdateConfiguration();
-            }
-
-            public bool Contains(KeyValuePair<string, object> item) => _properties.Contains(item);
-
-            public bool ContainsKey(string key) => _properties.ContainsKey(key);
-
-            public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) => _properties.CopyTo(array, arrayIndex);
-
-            public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _properties.GetEnumerator();
-
-            public bool Remove(string key)
-            {
-                var removed = _properties.Remove(key);
-                _config.UpdateConfiguration();
-                return removed;
-            }
-
-            public bool Remove(KeyValuePair<string, object> item)
-            {
-                var removed = _properties.Remove(item);
-                _config.UpdateConfiguration();
-                return removed;
-            }
-
-            public bool TryGetValue(string key, [MaybeNullWhen(false)] out object value) => _properties.TryGetValue(key, out value);
-            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_properties).GetEnumerator();
         }
     }
 }

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -9,208 +9,16 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Builder
 {
-    ///// <summary>
-    ///// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
-    ///// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
-    ///// </summary>
-    //public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder
-    //{
-    //    private readonly ConfigurationBuilder _builder = new();
-    //    private IConfigurationRoot _configuration;
-
-    //    /// <summary>
-    //    /// Gets or sets a configuration value.
-    //    /// </summary>
-    //    /// <param name="key">The configuration key.</param>
-    //    /// <returns>The configuration value.</returns>
-    //    public string this[string key] { get => _configuration[key]; set => _configuration[key] = value; }
-
-    //    /// <summary>
-    //    /// Gets a configuration sub-section with the specified key.
-    //    /// </summary>
-    //    /// <param name="key">The key of the configuration section.</param>
-    //    /// <returns>The <see cref="IConfigurationSection"/>.</returns>
-    //    /// <remarks>
-    //    ///     This method will never return <c>null</c>. If no matching sub-section is found with the specified key,
-    //    ///     an empty <see cref="IConfigurationSection"/> will be returned.
-    //    /// </remarks>
-    //    public IConfigurationSection GetSection(string key)
-    //    {
-    //        return _configuration.GetSection(key);
-    //    }
-
-    //    /// <summary>
-    //    /// Gets the immediate descendant configuration sub-sections.
-    //    /// </summary>
-    //    /// <returns>The configuration sub-sections.</returns>
-    //    public IEnumerable<IConfigurationSection> GetChildren() => _configuration.GetChildren();
-
-    //    IDictionary<string, object> IConfigurationBuilder.Properties => _builder.Properties;
-
-    //    IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
-
-    //    internal IList<IConfigurationSource> Sources { get; }
-
-    //    IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => _configuration.Providers;
-
-    //    /// <summary>
-    //    /// Creates a new <see cref="Configuration"/>.
-    //    /// </summary>
-    //    public Configuration()
-    //    {
-    //        _configuration = _builder.Build();
-    //        Sources = new ConfigurationSources(_builder.Sources, this);
-    //    }
-
-    //    internal void ChangeBasePath(string path)
-    //    {
-    //        this.SetBasePath(path);
-    //        UpdateConfiguration();
-    //    }
-
-    //    internal void ChangeFileProvider(IFileProvider fileProvider)
-    //    {
-    //        this.SetFileProvider(fileProvider);
-    //        UpdateConfiguration();
-    //    }
-
-    //    //private void AttachReloadToken()
-    //    //{
-    //    //    // We dispose the IConfigurationRoot every time we reattach so we don't bother tracking the registration.
-    //    //    _configuration.GetReloadToken().RegisterChangeCallback(static state =>
-    //    //        ((ConfigurationReloadToken)state).OnReload(), _reloadToken);
-    //    //}
-
-    //    private void UpdateConfiguration()
-    //    {
-    //        var current = _configuration;
-    //        if (current is IDisposable disposable)
-    //        {
-    //            disposable.Dispose();
-    //        }
-    //        _configuration = _builder.Build();
-    //    }
-
-    //    IConfigurationBuilder IConfigurationBuilder.Add(IConfigurationSource source)
-    //    {
-    //        Sources.Add(source);
-    //        return this;
-    //    }
-
-    //    IConfigurationRoot IConfigurationBuilder.Build()
-    //    {
-    //        // No more modification is expected after this final build
-    //        UpdateConfiguration();
-    //        return this;
-    //    }
-
-    //    IChangeToken IConfiguration.GetReloadToken()
-    //    {
-    //        return _configuration.GetReloadToken();
-    //    }
-
-    //    void IConfigurationRoot.Reload()
-    //    {
-    //        _configuration.Reload();
-    //        UpdateConfiguration();
-    //    }
-
-    //    // On source modifications, we rebuild configuration
-    //    private class ConfigurationSources : IList<IConfigurationSource>
-    //    {
-    //        private readonly IList<IConfigurationSource> _sources;
-    //        private readonly Configuration _config;
-
-    //        public ConfigurationSources(IList<IConfigurationSource> sources, Configuration config)
-    //        {
-    //            _sources = sources;
-    //            _config = config;
-    //        }
-
-    //        public IConfigurationSource this[int index]
-    //        {
-    //            get => _sources[index];
-    //            set
-    //            {
-    //                _sources[index] = value;
-    //                _config.UpdateConfiguration();
-    //            }
-    //        }
-
-    //        public int Count => _sources.Count;
-
-    //        public bool IsReadOnly => _sources.IsReadOnly;
-
-    //        public void Add(IConfigurationSource item)
-    //        {
-    //            _sources.Add(item);
-    //            _config.UpdateConfiguration();
-    //        }
-
-    //        public void Clear()
-    //        {
-    //            _sources.Clear();
-    //            _config.UpdateConfiguration();
-    //        }
-
-    //        public bool Contains(IConfigurationSource item)
-    //        {
-    //            return _sources.Contains(item);
-    //        }
-
-    //        public void CopyTo(IConfigurationSource[] array, int arrayIndex)
-    //        {
-    //            _sources.CopyTo(array, arrayIndex);
-    //        }
-
-    //        public IEnumerator<IConfigurationSource> GetEnumerator()
-    //        {
-    //            return _sources.GetEnumerator();
-    //        }
-
-    //        public int IndexOf(IConfigurationSource item)
-    //        {
-    //            return _sources.IndexOf(item);
-    //        }
-
-    //        public void Insert(int index, IConfigurationSource item)
-    //        {
-    //            _sources.Insert(index, item);
-    //            _config.UpdateConfiguration();
-    //        }
-
-    //        public bool Remove(IConfigurationSource item)
-    //        {
-    //            var removed = _sources.Remove(item);
-    //            _config.UpdateConfiguration();
-    //            return removed;
-    //        }
-
-    //        public void RemoveAt(int index)
-    //        {
-    //            _sources.RemoveAt(index);
-    //            _config.UpdateConfiguration();
-    //        }
-
-    //        IEnumerator IEnumerable.GetEnumerator()
-    //        {
-    //            return GetEnumerator();
-    //        }
-    //    }
-
     /// <summary>
     /// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
     /// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
     /// </summary>
     public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder, IDisposable
     {
-        // We start off dirty to ensure the first configuration root is built on demand
-        private bool _dirty = true;
         private ConfigurationRoot? _configurationRoot;
         private ConfigurationReloadToken _changeToken = new();
         private IDisposable? _changeTokenRegistration;
@@ -226,7 +34,7 @@ namespace Microsoft.AspNetCore.Builder
         {
             get
             {
-                EnsureFreshConfiguration();
+                UpdateConfiguration();
                 Debug.Assert(_configurationRoot is not null);
                 return _configurationRoot;
             }
@@ -269,20 +77,12 @@ namespace Microsoft.AspNetCore.Builder
 
         void IConfigurationRoot.Reload() => ConfigurationRoot.Reload();
 
-        private void MarkDirty() => _dirty = true;
-
-        private void EnsureFreshConfiguration()
+        private void UpdateConfiguration()
         {
-            if (!_dirty)
-            {
-                return;
-            }
-
             var newConfiguration = BuildConfigurationRoot();
             var prevConfiguration = _configurationRoot;
 
             _configurationRoot = newConfiguration;
-            _dirty = false;
 
             _changeTokenRegistration?.Dispose();
             (prevConfiguration as IDisposable)?.Dispose();
@@ -323,7 +123,6 @@ namespace Microsoft.AspNetCore.Builder
                 .Select(key => ConfigurationRoot.GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
         }
 
-        // On source modifications, we mark configuration as dirty
         private class ConfigurationSources : IList<IConfigurationSource>
         {
             private readonly IList<IConfigurationSource> _sources;
@@ -341,7 +140,7 @@ namespace Microsoft.AspNetCore.Builder
                 set
                 {
                     _sources[index] = value;
-                    _config.MarkDirty();
+                    _config.UpdateConfiguration();
                 }
             }
 
@@ -352,13 +151,13 @@ namespace Microsoft.AspNetCore.Builder
             public void Add(IConfigurationSource item)
             {
                 _sources.Add(item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public void Clear()
             {
                 _sources.Clear();
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public bool Contains(IConfigurationSource item)
@@ -384,20 +183,20 @@ namespace Microsoft.AspNetCore.Builder
             public void Insert(int index, IConfigurationSource item)
             {
                 _sources.Insert(index, item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public bool Remove(IConfigurationSource item)
             {
                 var removed = _sources.Remove(item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
                 return removed;
             }
 
             public void RemoveAt(int index)
             {
                 _sources.RemoveAt(index);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             IEnumerator IEnumerable.GetEnumerator()
@@ -406,7 +205,6 @@ namespace Microsoft.AspNetCore.Builder
             }
         }
 
-        // On property modifications we mark configuration as dirty.
         private class ConfigurationProperties : IDictionary<string, object>
         {
             private readonly IDictionary<string, object> _properties = new Dictionary<string, object>();
@@ -422,7 +220,7 @@ namespace Microsoft.AspNetCore.Builder
                 get => _properties[key];
                 set
                 {
-                    _config.MarkDirty();
+                    _config.UpdateConfiguration();
                     _properties[key] = value;
                 }
             }
@@ -438,19 +236,19 @@ namespace Microsoft.AspNetCore.Builder
             public void Add(string key, object value)
             {
                 _properties.Add(key, value);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public void Add(KeyValuePair<string, object> item)
             {
                 _properties.Add(item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public void Clear()
             {
                 _properties.Clear();
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
             }
 
             public bool Contains(KeyValuePair<string, object> item) => _properties.Contains(item);
@@ -464,14 +262,14 @@ namespace Microsoft.AspNetCore.Builder
             public bool Remove(string key)
             {
                 var removed = _properties.Remove(key);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
                 return removed;
             }
 
             public bool Remove(KeyValuePair<string, object> item)
             {
                 var removed = _properties.Remove(item);
-                _config.MarkDirty();
+                _config.UpdateConfiguration();
                 return removed;
             }
 

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -49,7 +49,6 @@ namespace Microsoft.AspNetCore.Builder
 
         IDictionary<string, object> IConfigurationBuilder.Properties => _builder.Properties;
 
-        // TODO: Handle modifications to Sources and keep the configuration root in sync
         IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
 
         internal IList<IConfigurationSource> Sources { get; }

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -4,125 +4,335 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 
-// TODO: Microsft.Extensions.Configuration API Proposal
 namespace Microsoft.AspNetCore.Builder
 {
+    ///// <summary>
+    ///// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
+    ///// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
+    ///// </summary>
+    //public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder
+    //{
+    //    private readonly ConfigurationBuilder _builder = new();
+    //    private IConfigurationRoot _configuration;
+
+    //    /// <summary>
+    //    /// Gets or sets a configuration value.
+    //    /// </summary>
+    //    /// <param name="key">The configuration key.</param>
+    //    /// <returns>The configuration value.</returns>
+    //    public string this[string key] { get => _configuration[key]; set => _configuration[key] = value; }
+
+    //    /// <summary>
+    //    /// Gets a configuration sub-section with the specified key.
+    //    /// </summary>
+    //    /// <param name="key">The key of the configuration section.</param>
+    //    /// <returns>The <see cref="IConfigurationSection"/>.</returns>
+    //    /// <remarks>
+    //    ///     This method will never return <c>null</c>. If no matching sub-section is found with the specified key,
+    //    ///     an empty <see cref="IConfigurationSection"/> will be returned.
+    //    /// </remarks>
+    //    public IConfigurationSection GetSection(string key)
+    //    {
+    //        return _configuration.GetSection(key);
+    //    }
+
+    //    /// <summary>
+    //    /// Gets the immediate descendant configuration sub-sections.
+    //    /// </summary>
+    //    /// <returns>The configuration sub-sections.</returns>
+    //    public IEnumerable<IConfigurationSection> GetChildren() => _configuration.GetChildren();
+
+    //    IDictionary<string, object> IConfigurationBuilder.Properties => _builder.Properties;
+
+    //    IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
+
+    //    internal IList<IConfigurationSource> Sources { get; }
+
+    //    IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => _configuration.Providers;
+
+    //    /// <summary>
+    //    /// Creates a new <see cref="Configuration"/>.
+    //    /// </summary>
+    //    public Configuration()
+    //    {
+    //        _configuration = _builder.Build();
+    //        Sources = new ConfigurationSources(_builder.Sources, this);
+    //    }
+
+    //    internal void ChangeBasePath(string path)
+    //    {
+    //        this.SetBasePath(path);
+    //        UpdateConfiguration();
+    //    }
+
+    //    internal void ChangeFileProvider(IFileProvider fileProvider)
+    //    {
+    //        this.SetFileProvider(fileProvider);
+    //        UpdateConfiguration();
+    //    }
+
+    //    //private void AttachReloadToken()
+    //    //{
+    //    //    // We dispose the IConfigurationRoot every time we reattach so we don't bother tracking the registration.
+    //    //    _configuration.GetReloadToken().RegisterChangeCallback(static state =>
+    //    //        ((ConfigurationReloadToken)state).OnReload(), _reloadToken);
+    //    //}
+
+    //    private void UpdateConfiguration()
+    //    {
+    //        var current = _configuration;
+    //        if (current is IDisposable disposable)
+    //        {
+    //            disposable.Dispose();
+    //        }
+    //        _configuration = _builder.Build();
+    //    }
+
+    //    IConfigurationBuilder IConfigurationBuilder.Add(IConfigurationSource source)
+    //    {
+    //        Sources.Add(source);
+    //        return this;
+    //    }
+
+    //    IConfigurationRoot IConfigurationBuilder.Build()
+    //    {
+    //        // No more modification is expected after this final build
+    //        UpdateConfiguration();
+    //        return this;
+    //    }
+
+    //    IChangeToken IConfiguration.GetReloadToken()
+    //    {
+    //        return _configuration.GetReloadToken();
+    //    }
+
+    //    void IConfigurationRoot.Reload()
+    //    {
+    //        _configuration.Reload();
+    //        UpdateConfiguration();
+    //    }
+
+    //    // On source modifications, we rebuild configuration
+    //    private class ConfigurationSources : IList<IConfigurationSource>
+    //    {
+    //        private readonly IList<IConfigurationSource> _sources;
+    //        private readonly Configuration _config;
+
+    //        public ConfigurationSources(IList<IConfigurationSource> sources, Configuration config)
+    //        {
+    //            _sources = sources;
+    //            _config = config;
+    //        }
+
+    //        public IConfigurationSource this[int index]
+    //        {
+    //            get => _sources[index];
+    //            set
+    //            {
+    //                _sources[index] = value;
+    //                _config.UpdateConfiguration();
+    //            }
+    //        }
+
+    //        public int Count => _sources.Count;
+
+    //        public bool IsReadOnly => _sources.IsReadOnly;
+
+    //        public void Add(IConfigurationSource item)
+    //        {
+    //            _sources.Add(item);
+    //            _config.UpdateConfiguration();
+    //        }
+
+    //        public void Clear()
+    //        {
+    //            _sources.Clear();
+    //            _config.UpdateConfiguration();
+    //        }
+
+    //        public bool Contains(IConfigurationSource item)
+    //        {
+    //            return _sources.Contains(item);
+    //        }
+
+    //        public void CopyTo(IConfigurationSource[] array, int arrayIndex)
+    //        {
+    //            _sources.CopyTo(array, arrayIndex);
+    //        }
+
+    //        public IEnumerator<IConfigurationSource> GetEnumerator()
+    //        {
+    //            return _sources.GetEnumerator();
+    //        }
+
+    //        public int IndexOf(IConfigurationSource item)
+    //        {
+    //            return _sources.IndexOf(item);
+    //        }
+
+    //        public void Insert(int index, IConfigurationSource item)
+    //        {
+    //            _sources.Insert(index, item);
+    //            _config.UpdateConfiguration();
+    //        }
+
+    //        public bool Remove(IConfigurationSource item)
+    //        {
+    //            var removed = _sources.Remove(item);
+    //            _config.UpdateConfiguration();
+    //            return removed;
+    //        }
+
+    //        public void RemoveAt(int index)
+    //        {
+    //            _sources.RemoveAt(index);
+    //            _config.UpdateConfiguration();
+    //        }
+
+    //        IEnumerator IEnumerable.GetEnumerator()
+    //        {
+    //            return GetEnumerator();
+    //        }
+    //    }
+
     /// <summary>
     /// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
     /// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
     /// </summary>
-    public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder
+    public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder, IDisposable
     {
-        private readonly ConfigurationBuilder _builder = new();
-        private IConfigurationRoot _configuration;
+        // We start off dirty to ensure the first configuration root is built on demand
+        private bool _dirty = true;
+        private ConfigurationRoot? _configurationRoot;
+        private ConfigurationReloadToken _changeToken = new();
+        private IDisposable? _changeTokenRegistration;
 
-        /// <summary>
-        /// Gets or sets a configuration value.
-        /// </summary>
-        /// <param name="key">The configuration key.</param>
-        /// <returns>The configuration value.</returns>
-        public string this[string key] { get => _configuration[key]; set => _configuration[key] = value; }
+        // Needs to be a separate field, as it is not possible to initialize an explicitly implemented property in the constructor
+        // and we pass an instance method to the constructor used to initialize it, so cannot use a field initializer.
+        // On the other hand, if this is a separate class (not an enhanced version of the existing ConfigurationBuilder class)
+        // then we probably do want `Properties` to be an explicit interface implementation, so users looking to read configuration values
+        // don't get confused by it. So explicit backing field it is!
+        private readonly IDictionary<string, object> _properties;
 
-        /// <summary>
-        /// Gets a configuration sub-section with the specified key.
-        /// </summary>
-        /// <param name="key">The key of the configuration section.</param>
-        /// <returns>The <see cref="IConfigurationSection"/>.</returns>
-        /// <remarks>
-        ///     This method will never return <c>null</c>. If no matching sub-section is found with the specified key,
-        ///     an empty <see cref="IConfigurationSection"/> will be returned.
-        /// </remarks>
-        public IConfigurationSection GetSection(string key)
+        private IConfigurationRoot ConfigurationRoot
         {
-            return _configuration.GetSection(key);
+            get
+            {
+                EnsureFreshConfiguration();
+                Debug.Assert(_configurationRoot is not null);
+                return _configurationRoot;
+            }
         }
 
-        /// <summary>
-        /// Gets the immediate descendant configuration sub-sections.
-        /// </summary>
-        /// <returns>The configuration sub-sections.</returns>
-        public IEnumerable<IConfigurationSection> GetChildren() => _configuration.GetChildren();
+        public string this[string key] { get => ConfigurationRoot[key]; set => ConfigurationRoot[key] = value; }
 
-        IDictionary<string, object> IConfigurationBuilder.Properties => _builder.Properties;
+        public IConfigurationSection GetSection(string key) => new ConfigurationSection(this, key);
 
-        IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
+        public IEnumerable<IConfigurationSection> GetChildren() => GetChildrenImplementation(null);
+
+        IDictionary<string, object> IConfigurationBuilder.Properties => _properties;
 
         internal IList<IConfigurationSource> Sources { get; }
+        IList<IConfigurationSource> IConfigurationBuilder.Sources => Sources;
 
-        IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => _configuration.Providers;
+        IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => ConfigurationRoot.Providers;
 
-        /// <summary>
-        /// Creates a new <see cref="Configuration"/>.
-        /// </summary>
         public Configuration()
         {
-            _configuration = _builder.Build();
-
-            var sources = new ConfigurationSources(_builder.Sources, UpdateConfigurationRoot);
-
-            Sources = sources;
+            _properties = new ConfigurationProperties(this);
+            Sources = new ConfigurationSources(this);
         }
 
-        internal void ChangeBasePath(string path)
+        public void Dispose()
         {
-            this.SetBasePath(path);
-            UpdateConfigurationRoot();
-        }
-
-        internal void ChangeFileProvider(IFileProvider fileProvider)
-        {
-            this.SetFileProvider(fileProvider);
-            UpdateConfigurationRoot();
-        }
-
-        private void UpdateConfigurationRoot()
-        {
-            var current = _configuration;
-            if (current is IDisposable disposable)
-            {
-                disposable.Dispose();
-            }
-            _configuration = _builder.Build();
+            _changeTokenRegistration?.Dispose();
+            _configurationRoot?.Dispose();
         }
 
         IConfigurationBuilder IConfigurationBuilder.Add(IConfigurationSource source)
         {
-            Sources.Add(source);
+            Sources.Add(source ?? throw new ArgumentNullException(nameof(source)));
             return this;
         }
 
-        IConfigurationRoot IConfigurationBuilder.Build()
+        IConfigurationRoot IConfigurationBuilder.Build() => BuildConfigurationRoot();
+
+        IChangeToken IConfiguration.GetReloadToken() => _changeToken;
+
+        void IConfigurationRoot.Reload() => ConfigurationRoot.Reload();
+
+        private void MarkDirty() => _dirty = true;
+
+        private void EnsureFreshConfiguration()
         {
-            // No more modification is expected after this final build
-            UpdateConfigurationRoot();
-            return this;
+            if (!_dirty)
+            {
+                return;
+            }
+
+            var newConfiguration = BuildConfigurationRoot();
+            var prevConfiguration = _configurationRoot;
+
+            _configurationRoot = newConfiguration;
+            _dirty = false;
+
+            _changeTokenRegistration?.Dispose();
+            (prevConfiguration as IDisposable)?.Dispose();
+
+            _changeTokenRegistration = ChangeToken.OnChange(() => newConfiguration.GetReloadToken(), RaiseChanged);
+            RaiseChanged();
         }
 
-        IChangeToken IConfiguration.GetReloadToken()
+        private ConfigurationRoot BuildConfigurationRoot()
         {
-            // REVIEW: Is this correct?
-            return _configuration.GetReloadToken();
+            var providers = new List<IConfigurationProvider>();
+            foreach (var source in Sources)
+            {
+                IConfigurationProvider provider = source.Build(this);
+                providers.Add(provider);
+            }
+            return new ConfigurationRoot(providers);
         }
 
-        void IConfigurationRoot.Reload()
+        private void RaiseChanged()
         {
-            _configuration.Reload();
+            ConfigurationReloadToken previousToken = Interlocked.Exchange(ref _changeToken, new ConfigurationReloadToken());
+            previousToken.OnReload();
         }
 
-        // On source modifications, we rebuild configuration
+        /// <summary>
+        /// Gets the immediate children sub-sections of configuration root based on key.
+        /// </summary>
+        /// <param name="path">Key of a section of which children to retrieve.</param>
+        /// <returns>Immediate children sub-sections of section specified by key.</returns>
+        private IEnumerable<IConfigurationSection> GetChildrenImplementation(string? path)
+        {
+            // From https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/libraries/Microsoft.Extensions.Configuration/src/InternalConfigurationRootExtensions.cs
+            return ConfigurationRoot.Providers
+                .Aggregate(Enumerable.Empty<string>(),
+                    (seed, source) => source.GetChildKeys(seed, path))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(key => ConfigurationRoot.GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
+        }
+
+        // On source modifications, we mark configuration as dirty
         private class ConfigurationSources : IList<IConfigurationSource>
         {
             private readonly IList<IConfigurationSource> _sources;
-            private readonly Action _sourcesModified;
+            private readonly Configuration _config;
 
-            public ConfigurationSources(IList<IConfigurationSource> sources, Action sourcesModified)
+            public ConfigurationSources(Configuration config)
             {
-                _sources = sources;
-                _sourcesModified = sourcesModified;
+                _sources = new List<IConfigurationSource>();
+                _config = config;
             }
 
             public IConfigurationSource this[int index]
@@ -131,7 +341,7 @@ namespace Microsoft.AspNetCore.Builder
                 set
                 {
                     _sources[index] = value;
-                    _sourcesModified();
+                    _config.MarkDirty();
                 }
             }
 
@@ -142,13 +352,13 @@ namespace Microsoft.AspNetCore.Builder
             public void Add(IConfigurationSource item)
             {
                 _sources.Add(item);
-                _sourcesModified();
+                _config.MarkDirty();
             }
 
             public void Clear()
             {
                 _sources.Clear();
-                _sourcesModified();
+                _config.MarkDirty();
             }
 
             public bool Contains(IConfigurationSource item)
@@ -174,26 +384,99 @@ namespace Microsoft.AspNetCore.Builder
             public void Insert(int index, IConfigurationSource item)
             {
                 _sources.Insert(index, item);
-                _sourcesModified();
+                _config.MarkDirty();
             }
 
             public bool Remove(IConfigurationSource item)
             {
                 var removed = _sources.Remove(item);
-                _sourcesModified();
+                _config.MarkDirty();
                 return removed;
             }
 
             public void RemoveAt(int index)
             {
                 _sources.RemoveAt(index);
-                _sourcesModified();
+                _config.MarkDirty();
             }
 
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return GetEnumerator();
             }
+        }
+
+        // On property modifications we mark configuration as dirty.
+        private class ConfigurationProperties : IDictionary<string, object>
+        {
+            private readonly IDictionary<string, object> _properties = new Dictionary<string, object>();
+            private readonly Configuration _config;
+
+            public ConfigurationProperties(Configuration config)
+            {
+                _config = config;
+            }
+
+            public object this[string key]
+            {
+                get => _properties[key];
+                set
+                {
+                    _config.MarkDirty();
+                    _properties[key] = value;
+                }
+            }
+
+            public ICollection<string> Keys => _properties.Keys;
+
+            public ICollection<object> Values => _properties.Values;
+
+            public int Count => _properties.Count;
+
+            public bool IsReadOnly => false;
+
+            public void Add(string key, object value)
+            {
+                _properties.Add(key, value);
+                _config.MarkDirty();
+            }
+
+            public void Add(KeyValuePair<string, object> item)
+            {
+                _properties.Add(item);
+                _config.MarkDirty();
+            }
+
+            public void Clear()
+            {
+                _properties.Clear();
+                _config.MarkDirty();
+            }
+
+            public bool Contains(KeyValuePair<string, object> item) => _properties.Contains(item);
+
+            public bool ContainsKey(string key) => _properties.ContainsKey(key);
+
+            public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) => _properties.CopyTo(array, arrayIndex);
+
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _properties.GetEnumerator();
+
+            public bool Remove(string key)
+            {
+                var removed = _properties.Remove(key);
+                _config.MarkDirty();
+                return removed;
+            }
+
+            public bool Remove(KeyValuePair<string, object> item)
+            {
+                var removed = _properties.Remove(item);
+                _config.MarkDirty();
+                return removed;
+            }
+
+            public bool TryGetValue(string key, [MaybeNullWhen(false)] out object value) => _properties.TryGetValue(key, out value);
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_properties).GetEnumerator();
         }
     }
 }

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Builder
             var providers = new List<IConfigurationProvider>();
             foreach (var source in _sources)
             {
-                IConfigurationProvider provider = source.Build(this);
+                var provider = source.Build(this);
                 providers.Add(provider);
             }
             return new ConfigurationRoot(providers);
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private void RaiseChanged()
         {
-            ConfigurationReloadToken previousToken = Interlocked.Exchange(ref _changeToken, new ConfigurationReloadToken());
+            var previousToken = Interlocked.Exchange(ref _changeToken, new ConfigurationReloadToken());
             previousToken.OnReload();
         }
 

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
@@ -33,8 +34,6 @@ namespace Microsoft.AspNetCore.Builder
             // Make sure there's some default storage since there are no default providers.
             this.AddInMemoryCollection();
 
-            // _configurationRoot is set by Update()
-            _configurationRoot = default!;
             Update();
         }
 
@@ -63,6 +62,7 @@ namespace Microsoft.AspNetCore.Builder
         /// Manually update the <see cref="IConfiguration"/> to reflect <see cref="IConfigurationBuilder"/> changes.
         /// It is not necessary to call this if <see cref="AutoUpdate"/> is <see langword="true"/>.
         /// </summary>
+        [MemberNotNull(nameof(_configurationRoot))]
         public void Update()
         {
             var newConfiguration = BuildConfigurationRoot();

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Builder
         /// Automatically update the <see cref="IConfiguration"/> on <see cref="IConfigurationBuilder"/> changes.
         /// If <see langword="false"/>, <see cref="Update()"/> will manually update the <see cref="IConfiguration"/>.
         /// </summary>
-        public bool AutoUpdate { get; set; } = true;
+        internal bool AutoUpdate { get; set; } = true;
 
         /// <inheritdoc />
         public string this[string key] { get => _configurationRoot[key]; set => _configurationRoot[key] = value; }
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         /// <inheritdoc />
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             _changeTokenRegistration?.Dispose();
             _configurationRoot?.Dispose();

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.AspNetCore.Builder
 {
     /// <summary>
-    /// Configuration is mutable configuration object. It is both a configuration builder and an IConfigurationRoot. 
+    /// Configuration is mutable configuration object. It is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
     /// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
     /// </summary>
     public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder, IDisposable
@@ -40,10 +40,13 @@ namespace Microsoft.AspNetCore.Builder
             }
         }
 
+        /// <inheritdoc />
         public string this[string key] { get => ConfigurationRoot[key]; set => ConfigurationRoot[key] = value; }
 
+        /// <inheritdoc />
         public IConfigurationSection GetSection(string key) => new ConfigurationSection(this, key);
 
+        /// <inheritdoc />
         public IEnumerable<IConfigurationSection> GetChildren() => GetChildrenImplementation(null);
 
         IDictionary<string, object> IConfigurationBuilder.Properties => _properties;
@@ -53,12 +56,16 @@ namespace Microsoft.AspNetCore.Builder
 
         IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => ConfigurationRoot.Providers;
 
+        /// <summary>
+        /// Creates an empty  mutable configuration object that is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
+        /// </summary>
         public Configuration()
         {
             _properties = new ConfigurationProperties(this);
             Sources = new ConfigurationSources(this);
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             _changeTokenRegistration?.Dispose();

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Builder
         /// It is not necessary to call this if <see cref="AutoUpdate"/> is <see langword="true"/>.
         /// </summary>
         [MemberNotNull(nameof(_configurationRoot))]
-        public void Update()
+        internal void Update()
         {
             var newConfiguration = BuildConfigurationRoot();
             var prevConfiguration = _configurationRoot;

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -30,6 +30,9 @@ namespace Microsoft.AspNetCore.Builder
         {
             _sources = new ConfigurationSources(this);
 
+            // Make sure there's some default storage since there are no default providers.
+            this.AddInMemoryCollection();
+
             // _configurationRoot is set by Update()
             _configurationRoot = default!;
             Update();
@@ -39,7 +42,7 @@ namespace Microsoft.AspNetCore.Builder
         /// Automatically update the <see cref="IConfiguration"/> on <see cref="IConfigurationBuilder"/> changes.
         /// If <see langword="false"/>, <see cref="Update()"/> will manually update the <see cref="IConfiguration"/>.
         /// </summary>
-        public bool AutoUpdateEnabled { get; set; }
+        public bool AutoUpdate { get; set; } = true;
 
         /// <inheritdoc />
         public string this[string key] { get => _configurationRoot[key]; set => _configurationRoot[key] = value; }
@@ -58,7 +61,7 @@ namespace Microsoft.AspNetCore.Builder
 
         /// <summary>
         /// Manually update the <see cref="IConfiguration"/> to reflect <see cref="IConfigurationBuilder"/> changes.
-        /// It is not necessary to call this if <see cref="AutoUpdateEnabled"/> is <see langword="true"/>.
+        /// It is not necessary to call this if <see cref="AutoUpdate"/> is <see langword="true"/>.
         /// </summary>
         public void Update()
         {
@@ -95,7 +98,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private void NotifySourcesChanged()
         {
-            if (AutoUpdateEnabled)
+            if (AutoUpdate)
             {
                 Update();
             }

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Builder
             configureDelegate(_hostConfiguration);
 
             _environment.ApplyConfigurationSettings(_hostConfiguration.Build());
-            Configuration.ChangeFileProvider(_environment.ContentRootFileProvider);
+            //Configuration.ChangeFileProvider(_environment.ContentRootFileProvider);
 
             return this;
         }

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -63,7 +63,6 @@ namespace Microsoft.AspNetCore.Builder
             _environment.ApplyConfigurationSettings(_hostConfiguration.Build());
             Configuration.ChangeFileProvider(_environment.ContentRootFileProvider);
 
-            _operations += b => b.ConfigureHostConfiguration(configureDelegate);
             return this;
         }
 

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Builder
             return this;
         }
 
-        internal void ExecuteActions(IHostBuilder hostBuilder)
+        internal void RunDeferredCallbacks(IHostBuilder hostBuilder)
         {
             foreach (var operation in _operations)
             {

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -61,7 +61,6 @@ namespace Microsoft.AspNetCore.Builder
             configureDelegate(_hostConfiguration);
 
             _environment.ApplyConfigurationSettings(_hostConfiguration.Build());
-            //Configuration.ChangeFileProvider(_environment.ContentRootFileProvider);
 
             return this;
         }

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Builder
                 _environment.ContentRootPath = value;
                 _environment.ResolveFileProviders(_configuration);
 
-                _configuration.ChangeBasePath(value);
+                //_configuration.ChangeBasePath(value);
             }
             else if (string.Equals(key, WebHostDefaults.EnvironmentKey, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -86,8 +86,6 @@ namespace Microsoft.AspNetCore.Builder
             {
                 _environment.ContentRootPath = value;
                 _environment.ResolveFileProviders(_configuration);
-
-                //_configuration.ChangeBasePath(value);
             }
             else if (string.Equals(key, WebHostDefaults.EnvironmentKey, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Builder
             return this;
         }
 
-        internal void ExecuteActions(IWebHostBuilder webHostBuilder)
+        internal void ApplySettings(IWebHostBuilder webHostBuilder)
         {
             foreach (var (key, value) in _settings)
             {

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,9 +1,6 @@
 #nullable enable
 Microsoft.AspNetCore.Builder.Configuration
-Microsoft.AspNetCore.Builder.Configuration.AutoUpdate.get -> bool
-Microsoft.AspNetCore.Builder.Configuration.AutoUpdate.set -> void
 Microsoft.AspNetCore.Builder.Configuration.Configuration() -> void
-Microsoft.AspNetCore.Builder.Configuration.Dispose() -> void
 Microsoft.AspNetCore.Builder.Configuration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!
 Microsoft.AspNetCore.Builder.Configuration.GetSection(string! key) -> Microsoft.Extensions.Configuration.IConfigurationSection!
 Microsoft.AspNetCore.Builder.Configuration.Update() -> void

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Builder.Configuration
-Microsoft.AspNetCore.Builder.Configuration.AutoUpdateEnabled.get -> bool
-Microsoft.AspNetCore.Builder.Configuration.AutoUpdateEnabled.set -> void
+Microsoft.AspNetCore.Builder.Configuration.AutoUpdate.get -> bool
+Microsoft.AspNetCore.Builder.Configuration.AutoUpdate.set -> void
 Microsoft.AspNetCore.Builder.Configuration.Configuration() -> void
 Microsoft.AspNetCore.Builder.Configuration.Dispose() -> void
 Microsoft.AspNetCore.Builder.Configuration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Builder.Configuration
 Microsoft.AspNetCore.Builder.Configuration.Configuration() -> void
+Microsoft.AspNetCore.Builder.Configuration.Dispose() -> void
 Microsoft.AspNetCore.Builder.Configuration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!
 Microsoft.AspNetCore.Builder.Configuration.GetSection(string! key) -> Microsoft.Extensions.Configuration.IConfigurationSection!
 Microsoft.AspNetCore.Builder.Configuration.this[string! key].get -> string!

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,9 +1,12 @@
 #nullable enable
 Microsoft.AspNetCore.Builder.Configuration
+Microsoft.AspNetCore.Builder.Configuration.AutoUpdateEnabled.get -> bool
+Microsoft.AspNetCore.Builder.Configuration.AutoUpdateEnabled.set -> void
 Microsoft.AspNetCore.Builder.Configuration.Configuration() -> void
 Microsoft.AspNetCore.Builder.Configuration.Dispose() -> void
 Microsoft.AspNetCore.Builder.Configuration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!
 Microsoft.AspNetCore.Builder.Configuration.GetSection(string! key) -> Microsoft.Extensions.Configuration.IConfigurationSection!
+Microsoft.AspNetCore.Builder.Configuration.Update() -> void
 Microsoft.AspNetCore.Builder.Configuration.this[string! key].get -> string!
 Microsoft.AspNetCore.Builder.Configuration.this[string! key].set -> void
 Microsoft.AspNetCore.Builder.ConfigureHostBuilder

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ Microsoft.AspNetCore.Builder.Configuration
 Microsoft.AspNetCore.Builder.Configuration.Configuration() -> void
 Microsoft.AspNetCore.Builder.Configuration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!
 Microsoft.AspNetCore.Builder.Configuration.GetSection(string! key) -> Microsoft.Extensions.Configuration.IConfigurationSection!
-Microsoft.AspNetCore.Builder.Configuration.Update() -> void
 Microsoft.AspNetCore.Builder.Configuration.this[string! key].get -> string!
 Microsoft.AspNetCore.Builder.Configuration.this[string! key].set -> void
 Microsoft.AspNetCore.Builder.ConfigureHostBuilder

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -61,13 +61,13 @@ namespace Microsoft.AspNetCore.Builder
         public Configuration Configuration { get; } = new();
 
         /// <summary>
-        /// A collection of logging providers for the applicaiton to compose. This is useful for adding new logging providers.
+        /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.
         /// </summary>
         public ILoggingBuilder Logging { get; }
 
         /// <summary>
         /// An <see cref="IHostBuilder"/> for configuring server specific properties, but not building.
-        /// To build after configuruation, call <see cref="Build"/>.
+        /// To build after configuration, call <see cref="Build"/>.
         /// </summary>
         public ConfigureWebHostBuilder WebHost { get; }
 

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -28,19 +28,22 @@ namespace Microsoft.AspNetCore.Builder
             // HACK: MVC and Identity do this horrible thing to get the hosting environment as an instance
             // from the service collection before it is built. That needs to be fixed...
             Environment = _environment = new WebHostEnvironment(callingAssembly);
+
             Services.AddSingleton(Environment);
 
             // Run methods to configure both generic and web host defaults early to populate config from appsettings.json
             // environment variables (both DOTNET_ and ASPNETCORE_ prefixed) and other possible default sources to prepopulate
             // the correct defaults.
             var bootstrapBuilder = new BootstrapHostBuilder(Configuration, _environment);
-            bootstrapBuilder.ConfigureDefaults(args);
             bootstrapBuilder.ConfigureWebHostDefaults(configure: _ => { });
+            bootstrapBuilder.ConfigureDefaults(args);
 
             Configuration.SetBasePath(_environment.ContentRootPath);
             Logging = new LoggingBuilder(Services);
             WebHost = _deferredWebHostBuilder = new ConfigureWebHostBuilder(Configuration, _environment, Services);
             Host = _deferredHostBuilder = new ConfigureHostBuilder(Configuration, _environment, Services);
+
+            Services.AddSingleton<IConfiguration>(Configuration);
 
             _deferredHostBuilder.ConfigureDefaults(args);
         }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Builder
             var bootstrapBuilder = new BootstrapHostBuilder(Configuration, _environment);
             bootstrapBuilder.ConfigureDefaults(args);
             bootstrapBuilder.ConfigureWebHostDefaults(configure: _ => { });
-            bootstrapBuilder.ExecuteActions();
+            bootstrapBuilder.RunConfigurationCallbacks();
 
             Logging = new LoggingBuilder(Services);
             WebHost = _deferredWebHostBuilder = new ConfigureWebHostBuilder(Configuration, _environment, Services);
@@ -218,8 +218,8 @@ namespace Microsoft.AspNetCore.Builder
 
             genericWebHostBuilder.Configure(ConfigureApplication);
 
-            _deferredHostBuilder.ExecuteActions(_hostBuilder);
-            _deferredWebHostBuilder.ExecuteActions(genericWebHostBuilder);
+            _deferredHostBuilder.RunDeferredCallbacks(_hostBuilder);
+            _deferredWebHostBuilder.ApplySettings(genericWebHostBuilder);
 
             _environment.ApplyEnvironmentSettings(genericWebHostBuilder);
         }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Builder
             _deferredHostBuilder.ConfigurationEnabled = true;
             // Now that consuming code can start modifying Configuration, we need to automatically rebuild on modification.
             // To this point, we've been manually calling Configuration.UpdateConfiguration() only when needed to reduce I/O.
-            Configuration.AutoUpdateEnabled = true;
+            Configuration.AutoUpdate = true;
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
         /// </summary>
-        public Configuration Configuration { get; } = new();
+        public Configuration Configuration { get; } = new() { AutoUpdate = false };
 
         /// <summary>
         /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -49,6 +49,15 @@ namespace Microsoft.AspNetCore.Builder
 
             // Add default services
             _deferredHostBuilder.ConfigureDefaults(args);
+            _deferredHostBuilder.ConfigureWebHostDefaults(configure: _ => { });
+
+            // This is important because GenericWebHostBuilder does the following and we want to preserve the WebHostBuilderContext:
+            // context.Properties[typeof(WebHostBuilderContext)] = webHostBuilderContext;
+            // context.Properties[typeof(WebHostOptions)] = options;
+            foreach (var (key, value) in _deferredHostBuilder.Properties)
+            {
+                _hostBuilder.Properties[key] = value;
+            }
 
             // Configuration changes made by ConfigureDefaults(args) were already picked up by the BootstrapHostBuilder,
             // so we ignore changes to config until ConfigureDefaults completes.
@@ -96,9 +105,11 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>A configured <see cref="WebApplication"/>.</returns>
         public WebApplication Build()
         {
+            // We call ConfigureWebHostDefaults AGAIN because config might be added like "ForwardedHeaders_Enabled"
+            // which can add even more services. If not for that, we probably call _hostBuilder.ConfigureWebHost(ConfigureWebHost)
+            // instead in order to avoid duplicate service registration.
             _hostBuilder.ConfigureWebHostDefaults(ConfigureWebHost);
-            _builtApplication = new WebApplication(_hostBuilder.Build());
-            return _builtApplication;
+            return _builtApplication = new WebApplication(_hostBuilder.Build());
         }
 
         private void ConfigureApplication(WebHostBuilderContext context, IApplicationBuilder app)
@@ -163,16 +174,23 @@ namespace Microsoft.AspNetCore.Builder
             {
                 app.Properties[item.Key] = item.Value;
             }
-
         }
 
         private void ConfigureWebHost(IWebHostBuilder genericWebHostBuilder)
         {
             _hostBuilder.ConfigureHostConfiguration(builder =>
             {
+                // TODO: Use a ChainedConfigurationSource instead.
+                // See EnvironmentSpecificLoggingConfigurationSectionPassedToLoggerByDefault in WebApplicationFuncationalTests.
+
                 // All the sources in builder.Sources should be in Configuration.Sources
                 // already thanks to the BootstrapHostBuilder.
                 builder.Sources.Clear();
+
+                foreach (var (key, value) in ((IConfigurationBuilder)Configuration).Properties)
+                {
+                    builder.Properties[key] = value;
+                }
 
                 foreach (var s in ((IConfigurationBuilder)Configuration).Sources)
                 {
@@ -180,8 +198,18 @@ namespace Microsoft.AspNetCore.Builder
                 }
             });
 
-            _hostBuilder.ConfigureServices((context, services) =>
+            genericWebHostBuilder.ConfigureServices((context, services) =>
             {
+                // We've only added services configured by the GenericWebHostBuilder and WebHost.ConfigureWebDefaults
+                // at this point. HostBuilder news up a new ServiceCollection in HostBuilder.Build() we haven't seen
+                // until now, so we cannot clear these services even though some are redundant because
+                // we called ConfigureWebHostDefaults on both the _deferredHostBuilder and _hostBuilder.
+
+                // Ideally, we'd only call _hostBuilder.ConfigureWebHost(ConfigureWebHost) instead of
+                // _hostBuilder.ConfigureWebHostDefaults(ConfigureWebHost) to avoid some duplicate service descriptors,
+                // but we want to add services in the WebApplicationBuilder constructor so code can inspect
+                // WebApplicationBuilder.Services. At the same time, we want to be able which services are loaded
+                // to react to config changes (e.g. ForwardedHeadersStartupFilter).
                 foreach (var s in Services)
                 {
                     services.Add(s);

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -174,7 +174,7 @@ namespace Microsoft.AspNetCore.Builder
                 // already thanks to the BootstrapHostBuilder.
                 builder.Sources.Clear();
 
-                foreach (var s in Configuration.Sources)
+                foreach (var s in ((IConfigurationBuilder)Configuration).Sources)
                 {
                     builder.Sources.Add(s);
                 }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -49,9 +49,13 @@ namespace Microsoft.AspNetCore.Builder
 
             // Add default services
             _deferredHostBuilder.ConfigureDefaults(args);
+
             // Configuration changes made by ConfigureDefaults(args) were already picked up by the BootstrapHostBuilder,
             // so we ignore changes to config until ConfigureDefaults completes.
             _deferredHostBuilder.ConfigurationEnabled = true;
+            // Now that consuming code can start modifying Configuration, we need to automatically rebuild on modification.
+            // To this point, we've been manually calling Configuration.UpdateConfiguration() only when needed to reduce I/O.
+            Configuration.AutoUpdateEnabled = true;
         }
 
         /// <summary>

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -167,6 +167,10 @@ namespace Microsoft.AspNetCore.Builder
 
             _hostBuilder.ConfigureAppConfiguration((hostContext, builder) =>
             {
+                // All the sources in builder.Sources should be in Configuration.Sources
+                // already thanks to the BootstrapHostBuilder.
+                builder.Sources.Clear();
+
                 foreach (var s in Configuration.Sources)
                 {
                     builder.Sources.Add(s);

--- a/src/DefaultBuilder/src/WebHostEnvironment.cs
+++ b/src/DefaultBuilder/src/WebHostEnvironment.cs
@@ -69,6 +69,23 @@ namespace Microsoft.AspNetCore.Builder
             genericWebHostBuilder.UseSetting(WebHostDefaults.EnvironmentKey, EnvironmentName);
             genericWebHostBuilder.UseSetting(WebHostDefaults.ContentRootKey, ContentRootPath);
             genericWebHostBuilder.UseSetting(WebHostDefaults.WebRootKey, WebRootPath);
+
+            genericWebHostBuilder.ConfigureAppConfiguration((context, builder) =>
+            {
+                CopyProperitesTo(context.HostingEnvironment);
+            });
+        }
+
+        internal void CopyProperitesTo(IWebHostEnvironment destination)
+        {
+            destination.ApplicationName = ApplicationName;
+            destination.EnvironmentName = EnvironmentName;
+
+            destination.ContentRootPath = ContentRootPath;
+            destination.ContentRootFileProvider = ContentRootFileProvider;
+
+            destination.WebRootPath = WebRootPath;
+            destination.WebRootFileProvider = WebRootFileProvider;
         }
 
         public void ResolveFileProviders(IConfiguration configuration)

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebApplicationFunctionalTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebApplicationFunctionalTests.cs
@@ -4,7 +4,6 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -68,6 +67,12 @@ namespace Microsoft.AspNetCore.Tests
 }");
 
                 var app = WebApplication.Create(new[] { "--environment", "Development" });
+
+                // TODO: Make this work! I think it should be possible if we register our Configuration
+                // as a ChainedConfigurationSource instead of copying over the bootstrapped IConfigurationSources.
+                //var builder = WebApplication.CreateBuilder();
+                //builder.Environment.EnvironmentName = "Development";
+                //await using var app = builder.Build();
 
                 var factory = (ILoggerFactory)app.Services.GetService(typeof(ILoggerFactory));
                 var logger = factory.CreateLogger("Test");

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigurationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigurationTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Tests
+{
+    public class ConfigurationTests
+    {
+        [Fact]
+        public void AutoUpdatesByDefault()
+        {
+            var config = new Configuration();
+
+            Assert.True(config.AutoUpdate);
+
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "TestKey", "TestValue" },
+            });
+
+            Assert.Equal("TestValue", config["TestKey"]);
+        }
+
+        [Fact]
+        public void AutoUpdateTriggersReloadTokenOnSourceModification()
+        {
+            var config = new Configuration();
+
+            var reloadToken = ((IConfiguration)config).GetReloadToken();
+
+            Assert.False(reloadToken.HasChanged);
+
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "TestKey", "TestValue" },
+            });
+
+            Assert.True(reloadToken.HasChanged);
+        }
+
+        [Fact]
+        public void DoesNotAutoUpdateWhenAutoUpdateDisabled()
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = false,
+            };
+
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "TestKey", "TestValue" },
+            });
+
+            Assert.Null(config["TestKey"]);
+
+            config.Update();
+
+            Assert.Equal("TestValue", config["TestKey"]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ManualUpdateTriggersReloadTokenWithOrWithoutAutoUpdate(bool autoUpdate)
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = autoUpdate,
+            };
+
+            var manualReloadToken = ((IConfiguration)config).GetReloadToken();
+
+            Assert.False(manualReloadToken.HasChanged);
+
+            config.Update();
+
+            Assert.True(manualReloadToken.HasChanged);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SettingValuesWorksWithOrWithoutAutoUpdate(bool autoUpdate)
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = autoUpdate,
+                ["TestKey"] = "TestValue",
+            };
+
+            Assert.Equal("TestValue", config["TestKey"]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SettingValuesDoesNotTriggerReloadTokenWithOrWithoutAutoUpdate(bool autoUpdate)
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = autoUpdate,
+            };
+
+            var reloadToken = ((IConfiguration)config).GetReloadToken();
+
+            config["TestKey"] = "TestValue";
+
+            Assert.Equal("TestValue", config["TestKey"]);
+
+            // ConfigurationRoot doesn't fire the token today when the setter is called. Maybe we should change that.
+            // At least you can manually call Configuration.Update() to fire a reload though this reloads all sources unnecessarily.
+            Assert.False(reloadToken.HasChanged);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SettingIConfigurationBuilderPropertiesWorksWithoutAutoUpdate(bool autoUpdate)
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = autoUpdate,
+            };
+
+            var configBuilder = (IConfigurationBuilder)config;
+
+            var reloadToken = ((IConfiguration)config).GetReloadToken();
+
+            configBuilder.Properties["TestKey"] = "TestValue";
+
+            Assert.Equal("TestValue", configBuilder.Properties["TestKey"]);
+
+            // Changing properties should not change config keys or fire reload token.
+            Assert.Null(config["TestKey"]);
+            Assert.False(reloadToken.HasChanged);
+        }
+    }
+}

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -179,7 +179,6 @@ namespace Microsoft.AspNetCore.Tests
             var envName = $"{nameof(WebApplicationTests)}_ENV";
 
             builder.WebHost.UseSetting("applicationname", nameof(WebApplicationTests));
-
             builder.WebHost.UseSetting("ENVIRONMENT", envName);
             builder.WebHost.UseSetting("CONTENTROOT", contentRoot);
             builder.WebHost.UseSetting("WEBROOT", webRoot);


### PR DESCRIPTION
Before this change, logging configuration like the following would not be respected if it was in an environment-specific config like `appsettings.Development.json` (as opposed to `appsettings.json`).

```
{
  "Logging": {
    "LogLevel": {
      "Default": "Information",
      "Microsoft": "Debug",
      "Microsoft.Hosting.Lifetime": "Information"
    }
  }
}
```

This also removes a ton of duplicate and conflicting configuration sources as noted previous closed PR: #32822

Loading less sources and not automatically reloading sources every time one is added during the "bootstrapping" of the default configuration results in far fewer file system checks leading to better startup performance.

Fixes #32383
Fixes #32432 

@Pilchie 