### PR TITLE
Further reduce string allocations

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/NamespaceDirective.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/NamespaceDirective.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>ASP.NET Core design time hosting infrastructure for the Razor view engine.</Description>
@@ -13,6 +13,7 @@
     <Compile Include="..\..\Microsoft.AspNetCore.Razor.Language\src\CodeGeneration\CodeWriterExtensions.cs" Link="Shared\CodeWriterExtensions.cs" />
     <Compile Include="..\..\Microsoft.AspNetCore.Razor.Language\src\CSharpIdentifier.cs" Link="Shared\CSharpIdentifier.cs" />
     <Compile Include="..\..\Microsoft.AspNetCore.Razor.Language\src\Checksum.cs" Link="Shared\Checksum.cs" />
+    <Compile Include="..\..\Microsoft.AspNetCore.Razor.Language\src\StringSegment.cs" Link="Shared\Checksum.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/MvcViewDocumentClassifierPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/MvcViewDocumentClassifierPass.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
@@ -46,7 +47,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 // It's possible for a Razor document to not have a file path.
                 // Eg. When we try to generate code for an in memory document like default imports.
                 var checksum = Checksum.BytesToString(codeDocument.Source.GetChecksum());
-                @class.ClassName = $"AspNetCore_{checksum}";
+                @class.ClassName = "AspNetCore_" + checksum;
             }
             else
             {
@@ -94,12 +95,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 return path;
             }
 
+            var pathSegment = new StringSegment(path);
             if (path.EndsWith(cshtmlExtension, StringComparison.OrdinalIgnoreCase))
             {
-                path = path.Substring(0, path.Length - cshtmlExtension.Length);
+                pathSegment = pathSegment.Subsegment(0, path.Length - cshtmlExtension.Length);
             }
 
-            return CSharpIdentifier.SanitizeIdentifier(path);
+            return CSharpIdentifier.SanitizeIdentifier(pathSegment);
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/RazorPageDocumentClassifierPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/RazorPageDocumentClassifierPass.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
@@ -187,12 +188,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 return path;
             }
 
+            var pathSegment = new StringSegment(path);
             if (path.EndsWith(cshtmlExtension, StringComparison.OrdinalIgnoreCase))
             {
-                path = path.Substring(0, path.Length - cshtmlExtension.Length);
+                pathSegment = pathSegment.Subsegment(0, path.Length - cshtmlExtension.Length);
             }
 
-            return CSharpIdentifier.SanitizeIdentifier(path);
+            return CSharpIdentifier.SanitizeIdentifier(pathSegment);
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/CSharpIdentifier.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/CSharpIdentifier.cs
@@ -33,15 +33,32 @@ namespace Microsoft.AspNetCore.Razor.Language
                 category == UnicodeCategory.Format; // Cf
         }
 
-        public static string SanitizeIdentifier(string inputName)
+        public static string SanitizeIdentifier(StringSegment inputName)
         {
-            if (string.IsNullOrEmpty(inputName))
+            if (StringSegment.IsNullOrEmpty(inputName))
             {
-                return inputName;
+                return string.Empty;
             }
 
-            var builder = new StringBuilder(inputName.Length);
-            AppendSanitized(builder, inputName);
+            var length = inputName.Length;
+            var prependUnderscore = false;
+            if (!IsIdentifierStart(inputName[0]) && IsIdentifierPart(inputName[0]))
+            {
+                length++;
+                prependUnderscore = true;
+            }
+
+            var builder = new StringBuilder(length);
+            if (prependUnderscore)
+            {
+                builder.Append('_');
+            }
+
+            for (var i = 0; i < inputName.Length; i++)
+            {
+                var ch = inputName[i];
+                builder.Append(IsIdentifierPart(ch) ? ch : '_');
+            }
 
             return builder.ToString();
         }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/CSharpIdentifier.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/CSharpIdentifier.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Globalization;
@@ -40,19 +40,24 @@ namespace Microsoft.AspNetCore.Razor.Language
                 return inputName;
             }
 
+            var builder = new StringBuilder(inputName.Length);
+            AppendSanitized(builder, inputName);
+
+            return builder.ToString();
+        }
+
+        public static void AppendSanitized(StringBuilder builder, StringSegment inputName)
+        {
             if (!IsIdentifierStart(inputName[0]) && IsIdentifierPart(inputName[0]))
             {
-                inputName = "_" + inputName;
+                builder.Append('_');
             }
 
-            var builder = new StringBuilder(inputName.Length);
             for (var i = 0; i < inputName.Length; i++)
             {
                 var ch = inputName[i];
                 builder.Append(IsIdentifierPart(ch) ? ch : '_');
             }
-
-            return builder.ToString();
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/CodeWriter.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/CodeWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
@@ -114,6 +115,11 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
             return Write(value, 0, value.Length);
         }
 
+        internal CodeWriter Write(StringSegment value)
+        {
+            return WriteCore(value.Buffer, value.Offset, value.Length);
+        }
+
         public CodeWriter Write(string value, int startIndex, int count)
         {
             if (value == null)
@@ -136,6 +142,12 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
             }
 
+            return WriteCore(value, startIndex, count);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal CodeWriter WriteCore(string value, int startIndex, int count)
+        {
             if (count == 0)
             {
                 return this;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentBindLoweringPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentBindLoweringPass.cs
@@ -518,7 +518,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             out BoundAttributeDescriptor changeAttribute,
             out BoundAttributeDescriptor expressionAttribute)
         {
-            valueAttributeName = null;
             changeAttributeName = null;
             expressionAttributeName = null;
             changeAttributeNode = null;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDesignTimeNodeWriter.cs
@@ -660,7 +660,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                     context.CodeWriter.Write(".");
                     context.CodeWriter.Write(ComponentsApi.EventCallbackFactory.CreateMethod);
 
-                    if (node.TryParseEventCallbackTypeArgument(out var argument))
+                    if (node.TryParseEventCallbackTypeArgument(out StringSegment argument))
                     {
                         context.CodeWriter.Write("<");
                         context.CodeWriter.Write(argument);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupEncodingPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupEncodingPass.cs
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
                         // `entity` is guaranteed to be of the format &#****;
                         var entityValue = entity.Substring(2, entity.Length - 3);
-                        var codePoint = -1;
+                        int codePoint;
                         if (!int.TryParse(entityValue, out codePoint))
                         {
                             // If it is not an integer, check if it is hexadecimal like 0x00CD

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentPageDirectivePass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentPageDirectivePass.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                     routeToken.Content[1] == '/' &&
                     routeToken.Content[routeToken.Content.Length - 1] == '\"')
                 {
-                    var template = routeToken.Content.Substring(1, routeToken.Content.Length - 2);
+                    var template = new StringSegment(routeToken.Content, 1, routeToken.Content.Length - 2);
                     @namespace.Children.Insert(index++, new RouteAttributeExtensionNode(template));
                 }
                 else

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
@@ -614,7 +614,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                     context.CodeWriter.Write(".");
                     context.CodeWriter.Write(ComponentsApi.EventCallbackFactory.CreateMethod);
 
-                    if (node.TryParseEventCallbackTypeArgument(out var argument))
+                    if (node.TryParseEventCallbackTypeArgument(out StringSegment argument))
                     {
                         context.CodeWriter.Write("<");
                         context.CodeWriter.Write(argument);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/RouteAttributeExtensionNode.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/RouteAttributeExtensionNode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
@@ -6,14 +6,14 @@ using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components
 {
-    internal class RouteAttributeExtensionNode : ExtensionIntermediateNode
+    internal sealed class RouteAttributeExtensionNode : ExtensionIntermediateNode
     {
-        public RouteAttributeExtensionNode(string template)
+        public RouteAttributeExtensionNode(StringSegment template)
         {
             Template = template;
         }
 
-        public string Template { get; }
+        public StringSegment Template { get; }
 
         public override IntermediateNodeCollection Children => IntermediateNodeCollection.ReadOnly;
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
@@ -186,10 +186,10 @@ namespace Microsoft.AspNetCore.Razor.Language
                     yield return diagnostic;
                 }
 
-                var name = Name;
+                StringSegment name = Name;
                 if (isDirectiveAttribute && name.StartsWith("@", StringComparison.Ordinal))
                 {
-                    name = name.Substring(1);
+                    name = name.Subsegment(1);
                 }
                 else if (isDirectiveAttribute)
                 {
@@ -201,14 +201,15 @@ namespace Microsoft.AspNetCore.Razor.Language
                     yield return diagnostic;
                 }
 
-                foreach (var character in name)
+                for (var i = 0; i < name.Length; i++)
                 {
+                    var character = name[i];
                     if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
                     {
                         var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidBoundAttributeName(
                             _parent.GetDisplayName(),
                             GetDisplayName(),
-                            name,
+                            name.Value,
                             character);
 
                         yield return diagnostic;
@@ -237,29 +238,30 @@ namespace Microsoft.AspNetCore.Razor.Language
                 }
                 else
                 {
-                    var indexerPrefix = IndexerAttributeNamePrefix;
+                    StringSegment indexerPrefix = IndexerAttributeNamePrefix;
                     if (isDirectiveAttribute && indexerPrefix.StartsWith("@", StringComparison.Ordinal))
                     {
-                        indexerPrefix = indexerPrefix.Substring(1);
+                        indexerPrefix = indexerPrefix.Subsegment(1);
                     }
                     else if (isDirectiveAttribute)
                     {
                         var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidBoundDirectiveAttributePrefix(
                             _parent.GetDisplayName(),
                             GetDisplayName(),
-                            indexerPrefix);
+                            indexerPrefix.Value);
 
                         yield return diagnostic;
                     }
 
-                    foreach (var character in indexerPrefix)
+                    for (var i = 0; i < indexerPrefix.Length; i++)
                     {
+                        var character = indexerPrefix[i];
                         if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
                         {
                             var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidBoundAttributePrefix(
                                 _parent.GetDisplayName(),
                                 GetDisplayName(),
-                                indexerPrefix,
+                                indexerPrefix.Value,
                                 character);
 
                             yield return diagnostic;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1774,7 +1774,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
                             IntermediateNode attributeNode;
                             if (parameterMatch &&
-                                TagHelperMatchingConventions.TryGetBoundAttributeParameter(actualAttributeName, out var attributeNameWithoutParameter, out _))
+                                TagHelperMatchingConventions.TryGetBoundAttributeParameter(actualAttributeName, out var attributeNameWithoutParameter))
                             {
                                 var expectsBooleanValue = associatedAttributeParameterDescriptor.IsBooleanProperty;
                                 if (!expectsBooleanValue)
@@ -1786,7 +1786,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                                 attributeNode = new TagHelperDirectiveAttributeParameterIntermediateNode()
                                 {
                                     AttributeName = actualAttributeName,
-                                    AttributeNameWithoutParameter = attributeNameWithoutParameter,
+                                    AttributeNameWithoutParameter = attributeNameWithoutParameter.Value,
                                     OriginalAttributeName = attributeName,
                                     BoundAttributeParameter = associatedAttributeParameterDescriptor,
                                     BoundAttribute = associatedAttributeDescriptor,
@@ -1912,12 +1912,12 @@ namespace Microsoft.AspNetCore.Razor.Language
 
                             IntermediateNode attributeNode;
                             if (parameterMatch &&
-                                TagHelperMatchingConventions.TryGetBoundAttributeParameter(actualAttributeName, out var attributeNameWithoutParameter, out _))
+                                TagHelperMatchingConventions.TryGetBoundAttributeParameter(actualAttributeName, out var attributeNameWithoutParameter))
                             {
                                 attributeNode = new TagHelperDirectiveAttributeParameterIntermediateNode()
                                 {
                                     AttributeName = actualAttributeName,
-                                    AttributeNameWithoutParameter = attributeNameWithoutParameter,
+                                    AttributeNameWithoutParameter = attributeNameWithoutParameter.Value,
                                     OriginalAttributeName = attributeName,
                                     BoundAttributeParameter = associatedAttributeParameterDescriptor,
                                     BoundAttribute = associatedAttributeDescriptor,

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/DefaultTagHelperTargetExtension.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/DefaultTagHelperTargetExtension.cs
@@ -493,7 +493,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
             if (!context.Options.DesignTime)
             {
                 context.CodeWriter.WriteField(FieldUnusedModifiers, PrivateModifiers, "string", StringValueBufferVariableName);
-             
+
                 var backedScopeManageVariableName = "__backed" + ScopeManagerVariableName;
                 context.CodeWriter
                     .Write("private ")
@@ -650,7 +650,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
         private static string GetPropertyAccessor(DefaultTagHelperPropertyIntermediateNode node)
         {
-            var propertyAccessor = string.Concat(node.FieldName, '.', node.PropertyName);
+            var propertyAccessor = node.FieldName + "." + node.PropertyName;
 
             if (node.IsIndexerNameMatch)
             {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/DefaultTagHelperTargetExtension.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/DefaultTagHelperTargetExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -650,7 +650,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
         private static string GetPropertyAccessor(DefaultTagHelperPropertyIntermediateNode node)
         {
-            var propertyAccessor = $"{node.FieldName}.{node.PropertyName}";
+            var propertyAccessor = string.Concat(node.FieldName, '.', node.PropertyName);
 
             if (node.IsIndexerNameMatch)
             {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/PreallocatedAttributeTargetExtension.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/PreallocatedAttributeTargetExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Intermediate/ComponentAttributeIntermediateNode.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Intermediate/ComponentAttributeIntermediateNode.cs
@@ -160,6 +160,18 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
 
         public bool TryParseEventCallbackTypeArgument(out string argument)
         {
+            if (TryParseEventCallbackTypeArgument(out StringSegment stringSegment))
+            {
+                argument = stringSegment.Value;
+                return true;
+            }
+
+            argument = null;
+            return false;
+        }
+
+        internal bool TryParseEventCallbackTypeArgument(out StringSegment argument)
+        {
             // This is ugly and ad-hoc, but for various layering reasons we can't just use Roslyn APIs
             // to parse this. We need to parse this just before we write it out to the code generator,
             // so we can't compute it up front either.
@@ -172,11 +184,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             if (string.Equals(TypeName, ComponentsApi.EventCallback.FullTypeName, StringComparison.Ordinal))
             {
                 // Non-Generic
-                argument = null;
+                argument = default;
                 return false;
             }
 
-            if (TypeName != null && 
+            if (TypeName != null &&
                 TypeName.Length > ComponentsApi.EventCallback.FullTypeName.Length + "<>".Length &&
                 TypeName.StartsWith(ComponentsApi.EventCallback.FullTypeName, StringComparison.Ordinal) &&
                 TypeName[ComponentsApi.EventCallback.FullTypeName.Length] == '<' &&
@@ -185,13 +197,13 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
                 // OK this is promising.
                 //
                 // Chop off leading `...EventCallback<` and let the length so the ending `>` is cut off as well.
-                argument = TypeName.Substring(ComponentsApi.EventCallback.FullTypeName.Length + 1, TypeName.Length - (ComponentsApi.EventCallback.FullTypeName.Length + "<>".Length));
+                argument = new StringSegment(TypeName, ComponentsApi.EventCallback.FullTypeName.Length + 1, TypeName.Length - (ComponentsApi.EventCallback.FullTypeName.Length + "<>".Length));
                 return true;
             }
 
             // If we get here this is a failure. This should only happen if someone manages to mangle the name with extensibility.
             // We don't really want to crash though.
-            argument = null;
+            argument = default;
             return false;
         }
     }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Intermediate/IntermediateNodeFormatterBase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Intermediate/IntermediateNodeFormatterBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -120,12 +120,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Intermediate
             _properties.Clear();
         }
 
-        private string GetShortName(IntermediateNode node)
+        private StringSegment GetShortName(IntermediateNode node)
         {
             var typeName = node.GetType().Name;
             return
                 typeName.EndsWith(nameof(IntermediateNode), StringComparison.Ordinal) ?
-                typeName.Substring(0, typeName.Length - nameof(IntermediateNode).Length) :
+                new StringSegment(typeName, 0, typeName.Length - nameof(IntermediateNode).Length) :
                 typeName;
         }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlMarkupParser.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlMarkupParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -2026,8 +2026,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                 CurrentToken.Content[position] == sequence[0] &&
                 position + sequence.Length <= CurrentToken.Content.Length)
             {
-                var possibleStart = CurrentToken.Content.Substring(position, sequence.Length);
-                if (string.Equals(possibleStart, sequence, Comparison))
+                var possibleStart = new StringSegment(CurrentToken.Content, position, sequence.Length);
+                if (possibleStart.Equals(sequence, Comparison))
                 {
                     // Capture the current token and "put it back" (really we just want to clear CurrentToken)
                     var bookmark = CurrentStart;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/ImplicitExpressionEditHandler.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/ImplicitExpressionEditHandler.cs
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             }
 
             var relativePosition = changeStart - target.Position;
-            var deletionContent = target.GetContent().Substring(relativePosition, changeLength);
+            var deletionContent = new StringSegment(target.GetContent(), relativePosition, changeLength);
 
             if (deletionContent.IndexOfAny(new[] { '(', ')' }) >= 0)
             {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/SourceLocationTracker.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/SourceLocationTracker.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
-    internal class SourceLocationTracker
+    internal sealed class SourceLocationTracker
     {
         private int _absoluteIndex;
         private int _characterIndex;
@@ -52,10 +52,32 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
             return tracker.CurrentLocation;
         }
 
+        public static SourceLocation Advance(SourceLocation location, StringSegment text)
+        {
+            var tracker = new SourceLocationTracker(location);
+            tracker.UpdateLocation(text);
+            return tracker.CurrentLocation;
+        }
+
         public void UpdateLocation(char characterRead, char nextCharacter)
         {
             UpdateCharacterCore(characterRead, nextCharacter);
             RecalculateSourceLocation();
+        }
+
+        public SourceLocationTracker UpdateLocation(StringSegment content)
+        {
+            for (var i = 0; i < content.Length; i++)
+            {
+                var nextCharacter = '\0';
+                if (i < content.Length - 1)
+                {
+                    nextCharacter = content[i + 1];
+                }
+                UpdateCharacterCore(content[i], nextCharacter);
+            }
+            RecalculateSourceLocation();
+            return this;
         }
 
         public SourceLocationTracker UpdateLocation(string content)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
@@ -553,7 +553,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
                         if (!string.IsNullOrWhiteSpace(content))
                         {
                             var trimmedStart = content.TrimStart();
-                            var whitespace = content.Substring(0, content.Length - trimmedStart.Length);
+                            var whitespace = new StringSegment(content, 0, content.Length - trimmedStart.Length);
                             var errorStart = SourceLocationTracker.Advance(child.GetSourceLocation(_source), whitespace);
                             var length = trimmedStart.TrimEnd().Length;
                             var allowedChildren = CurrentTagHelperTracker.AllowedChildren;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeDocumentExtensions.cs
@@ -250,14 +250,12 @@ namespace Microsoft.AspNetCore.Razor.Language
             }
 
             var filePath = document.Source.FilePath;
-            var relativePath = document.Source.RelativePath;
-            if (filePath == null || relativePath == null || filePath.Length < relativePath.Length)
+            if (filePath == null || document.Source.RelativePath == null || filePath.Length < document.Source.RelativePath.Length)
             {
                 @namespace = null;
                 return false;
             }
 
-            relativePath = NormalizePath(relativePath);
             // If the document or it's imports contains a @namespace directive, we want to use that over the root namespace.
             var baseNamespace = string.Empty;
             var appendSuffix = true;
@@ -284,6 +282,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                 lastNamespaceLocation = namespaceLocation;
             }
 
+            StringSegment relativePath = document.Source.RelativePath;
+
             // If there are multiple @namespace directives in the heirarchy,
             // we want to pick the closest one to the current document.
             if (!string.IsNullOrEmpty(lastNamespaceContent))
@@ -291,9 +291,10 @@ namespace Microsoft.AspNetCore.Razor.Language
                 baseNamespace = lastNamespaceContent;
                 var directiveLocationDirectory = NormalizeDirectory(lastNamespaceLocation.FilePath);
 
+                var sourceFilePath = new StringSegment(document.Source.FilePath);
                 // We're specifically using OrdinalIgnoreCase here because Razor treats all paths as case-insensitive.
-                if (!document.Source.FilePath.StartsWith(directiveLocationDirectory, StringComparison.OrdinalIgnoreCase) ||
-                    document.Source.FilePath.Length <= directiveLocationDirectory.Length)
+                if (!sourceFilePath.StartsWith(directiveLocationDirectory, StringComparison.OrdinalIgnoreCase) ||
+                    sourceFilePath.Length <= directiveLocationDirectory.Length)
                 {
                     // The most relevant directive is not from the directory hierarchy, can't compute a suffix.
                     appendSuffix = false;
@@ -302,7 +303,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     // We know that the document containing the namespace directive is in the current document's heirarchy.
                     // Let's compute the actual relative path that we'll use to compute the namespace suffix.
-                    relativePath = document.Source.FilePath.Substring(directiveLocationDirectory.Length);
+                    relativePath = sourceFilePath.Subsegment(directiveLocationDirectory.Length);
                 }
             }
             else if (fallbackToRootNamespace)
@@ -322,25 +323,48 @@ namespace Microsoft.AspNetCore.Razor.Language
             var builder = new StringBuilder();
 
             // Sanitize the base namespace, but leave the dots.
-            var segments = baseNamespace.Split(NamespaceSeparators, StringSplitOptions.RemoveEmptyEntries);
-            builder.Append(CSharpIdentifier.SanitizeIdentifier(segments[0]));
-            for (var i = 1; i < segments.Length; i++)
+            var segments = new StringTokenizer(baseNamespace, NamespaceSeparators);
+            var first = true;
+            foreach (var token in segments)
             {
-                builder.Append('.');
-                builder.Append(CSharpIdentifier.SanitizeIdentifier(segments[i]));
+                if (token.IsEmpty)
+                {
+                    continue;
+                }
+
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    builder.Append('.');
+                }
+
+                CSharpIdentifier.AppendSanitized(builder, token);
+
             }
 
             if (appendSuffix)
             {
                 // If we get here, we already have a base namespace and the relative path that should be used as the namespace suffix.
-                segments = relativePath.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries);
-
-                // Skip the last segment because it's the FileName.
-                for (var i = 0; i < segments.Length - 1; i++)
+                segments = new StringTokenizer(relativePath, PathSeparators);
+                var previousLength = builder.Length;
+                foreach (var token in segments)
                 {
+                    if (token.IsEmpty)
+                    {
+                        continue;
+                    }
+
+                    previousLength = builder.Length;
+
                     builder.Append('.');
-                    builder.Append(CSharpIdentifier.SanitizeIdentifier(segments[i]));
+                    CSharpIdentifier.AppendSanitized(builder, token);
                 }
+
+                // Trim the last segment because it's the FileName.
+                builder.Length = previousLength;
             }
 
             @namespace = builder.ToString();
@@ -356,30 +380,22 @@ namespace Microsoft.AspNetCore.Razor.Language
             // We also don't normalize the separators here. We expect that all documents are using a consistent style of path.
             // 
             // If we can't normalize the path, we just return null so it will be ignored.
-            string NormalizeDirectory(string path)
+            StringSegment NormalizeDirectory(string path)
             {
-                char[] Separators = new char[] { '\\', '/' };
                 if (string.IsNullOrEmpty(path))
                 {
-                    return null;
+                    return default;
                 }
 
-                var lastSeparator = path.LastIndexOfAny(Separators);
+                var lastSeparator = path.LastIndexOfAny(PathSeparators);
                 if (lastSeparator == -1)
                 {
-                    return null;
+                    return default;
                 }
 
                 // Includes the separator
-                return path.Substring(0, lastSeparator + 1);
+                return new StringSegment(path, 0, lastSeparator + 1);
             }
-        }
-
-        private static string NormalizePath(string path)
-        {
-            path = path.Replace('\\', '/');
-
-            return path;
         }
 
         private class ImportSyntaxTreesHolder

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StreamSourceDocument.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StreamSourceDocument.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
-    internal class StreamSourceDocument : RazorSourceDocument
+    internal sealed class StreamSourceDocument : RazorSourceDocument
     {
         // Internal for testing
         internal readonly RazorSourceDocument _innerSourceDocument;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
@@ -305,6 +305,33 @@ namespace Microsoft.AspNetCore.Razor
             return IndexOf(c, 0, Length);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int IndexOfAny(char[] anyOf, int startIndex, int count)
+        {
+            var index = -1;
+
+            if (HasValue)
+            {
+                index = Buffer.IndexOfAny(anyOf, Offset + startIndex, count);
+                if (index != -1)
+                {
+                    index -= Offset;
+                }
+            }
+
+            return index;
+        }
+
+        public int IndexOfAny(char[] anyOf, int startIndex)
+        {
+            return IndexOfAny(anyOf, startIndex, Length - startIndex);
+        }
+
+        public int IndexOfAny(char[] anyOf)
+        {
+            return IndexOfAny(anyOf, 0, Length);
+        }
+
         /// <summary>
         /// Indicates whether the specified StringSegment is null or an Empty string.
         /// </summary>

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
@@ -10,6 +10,10 @@ namespace Microsoft.AspNetCore.Razor
 {
     /// <summary>
     /// An optimized representation of a substring.
+    /// <p>
+    /// We're using our own copy of StringSegment rather than using Span or StringSegment from M.Extensions.Primitives
+    /// to avoid cross-compiling this project to support source build and to avoid adding new dependencies to the IDE.
+    /// </p>
     /// </summary>
     internal readonly struct StringSegment : IEquatable<StringSegment>, IEquatable<string>
     {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringTokenizer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringTokenizer.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+    internal readonly struct StringTokenizer
+    {
+        private readonly StringSegment _value;
+        private readonly char[] _separators;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="StringTokenizer"/>.
+        /// </summary>
+        /// <param name="value">The <see cref="string"/> to tokenize.</param>
+        /// <param name="separators">The characters to tokenize by.</param>
+        public StringTokenizer(string value, char[] separators)
+        {
+            _value = value;
+            _separators = separators;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="StringTokenizer"/>.
+        /// </summary>
+        /// <param name="value">The <see cref="StringSegment"/> to tokenize.</param>
+        /// <param name="separators">The characters to tokenize by.</param>
+        public StringTokenizer(StringSegment value, char[] separators)
+        {
+            _value = value;
+            _separators = separators;
+        }
+
+        public Enumerator GetEnumerator() => new Enumerator(in _value, _separators);
+
+        public struct Enumerator
+        {
+            private readonly StringSegment _value;
+            private readonly char[] _separators;
+            private int _index;
+
+            internal Enumerator(in StringSegment value, char[] separators)
+            {
+                _value = value;
+                _separators = separators;
+                Current = default;
+                _index = 0;
+            }
+
+            public Enumerator(ref StringTokenizer tokenizer)
+            {
+                _value = tokenizer._value;
+                _separators = tokenizer._separators;
+                Current = default(StringSegment);
+                _index = 0;
+            }
+
+            public StringSegment Current { get; private set; }
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                if (!_value.HasValue || _index > _value.Length)
+                {
+                    Current = default(StringSegment);
+                    return false;
+                }
+
+                int next = _value.IndexOfAny(_separators, _index);
+                if (next == -1)
+                {
+                    // No separator found. Consume the remainder of the string.
+                    next = _value.Length;
+                }
+
+                Current = _value.Subsegment(_index, next - _index);
+                _index = next + 1;
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Legacy/SourceLocationTrackerTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Legacy/SourceLocationTrackerTest.cs
@@ -8,20 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
     public class SourceLocationTrackerTest
     {
         private static readonly SourceLocation TestStartLocation = new SourceLocation(10, 42, 45);
-
-        [Fact]
-        public void ConstructorSetsCurrentLocationToZero()
-        {
-            Assert.Equal(SourceLocation.Zero, new SourceLocationTracker().CurrentLocation);
-        }
-
-        [Fact]
-        public void ConstructorWithSourceLocationSetsCurrentLocationToSpecifiedValue()
-        {
-            var loc = new SourceLocation(10, 42, 4);
-            Assert.Equal(loc, new SourceLocationTracker(loc).CurrentLocation);
-        }
-
+       
         [Theory]
         [InlineData(null)]
         [InlineData("path-to-file")]
@@ -44,171 +31,171 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         public void UpdateLocationAdvancesCorrectlyForMultiLineString()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation("foo\nbar\rbaz\r\nbox");
+            var currentLocation = SourceLocationTracker.Advance(location, "foo\nbar\rbaz\r\nbox");
 
             // Assert
-            Assert.Equal(26, tracker.CurrentLocation.AbsoluteIndex);
-            Assert.Equal(45, tracker.CurrentLocation.LineIndex);
-            Assert.Equal(3, tracker.CurrentLocation.CharacterIndex);
+            Assert.Equal(26, currentLocation.AbsoluteIndex);
+            Assert.Equal(45, currentLocation.LineIndex);
+            Assert.Equal(3, currentLocation.CharacterIndex);
         }
-
-        [Fact]
-        public void UpdateLocationAdvancesAbsoluteIndexOnNonNewlineCharacter()
-        {
-            // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
-
-            // Act
-            tracker.UpdateLocation('f', 'o');
-
-            // Assert
-            Assert.Equal(11, tracker.CurrentLocation.AbsoluteIndex);
-        }
+        
 
         [Fact]
         public void UpdateLocationAdvancesCharacterIndexOnNonNewlineCharacter()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('f', 'o');
+            var currentLocation = UpdateLocation(location, 'f', 'o');
 
             // Assert
-            Assert.Equal(46, tracker.CurrentLocation.CharacterIndex);
+            Assert.Equal(46, currentLocation.CharacterIndex);
         }
+
 
         [Fact]
         public void UpdateLocationDoesNotAdvanceLineIndexOnNonNewlineCharacter()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('f', 'o');
+            var currentLocation = UpdateLocation(location, 'f', 'o');
 
             // Assert
-            Assert.Equal(42, tracker.CurrentLocation.LineIndex);
+            Assert.Equal(42, currentLocation.LineIndex);
         }
 
         [Fact]
         public void UpdateLocationAdvancesLineIndexOnSlashN()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\n', 'o');
+            var currentLocation = UpdateLocation(location, '\n', 'o');
 
             // Assert
-            Assert.Equal(43, tracker.CurrentLocation.LineIndex);
+            Assert.Equal(43, currentLocation.LineIndex);
         }
 
         [Fact]
         public void UpdateLocationAdvancesAbsoluteIndexOnSlashN()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\n', 'o');
+            var currentLocation = UpdateLocation(location, '\n', 'o');
 
             // Assert
-            Assert.Equal(11, tracker.CurrentLocation.AbsoluteIndex);
+            Assert.Equal(11, currentLocation.AbsoluteIndex);
         }
 
         [Fact]
         public void UpdateLocationResetsCharacterIndexOnSlashN()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\n', 'o');
+            var currentLocation = UpdateLocation(location, '\n', 'o');
 
             // Assert
-            Assert.Equal(0, tracker.CurrentLocation.CharacterIndex);
+            Assert.Equal(0, currentLocation.CharacterIndex);
         }
 
         [Fact]
         public void UpdateLocationAdvancesLineIndexOnSlashRFollowedByNonNewlineCharacter()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\r', 'o');
+            var currentLocation = UpdateLocation(location, '\r', 'o');
 
             // Assert
-            Assert.Equal(43, tracker.CurrentLocation.LineIndex);
+            Assert.Equal(43, currentLocation.LineIndex);
         }
 
         [Fact]
         public void UpdateLocationAdvancesAbsoluteIndexOnSlashRFollowedByNonNewlineCharacter()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\r', 'o');
+            var currentLocation = UpdateLocation(location, '\r', 'o');
 
             // Assert
-            Assert.Equal(11, tracker.CurrentLocation.AbsoluteIndex);
+            Assert.Equal(11, currentLocation.AbsoluteIndex);
         }
 
         [Fact]
         public void UpdateLocationResetsCharacterIndexOnSlashRFollowedByNonNewlineCharacter()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\r', 'o');
+            var currentLocation = UpdateLocation(location, '\r', 'o');
 
             // Assert
-            Assert.Equal(0, tracker.CurrentLocation.CharacterIndex);
+            Assert.Equal(0, currentLocation.CharacterIndex);
         }
 
         [Fact]
         public void UpdateLocationDoesNotAdvanceLineIndexOnSlashRFollowedBySlashN()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\r', '\n');
+            var currentLocation = UpdateLocation(location, '\r', '\n');
 
             // Assert
-            Assert.Equal(42, tracker.CurrentLocation.LineIndex);
+            Assert.Equal(42, currentLocation.LineIndex);
         }
 
         [Fact]
         public void UpdateLocationAdvancesAbsoluteIndexOnSlashRFollowedBySlashN()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\r', '\n');
+            var currentLocation = UpdateLocation(location, '\r', '\n');
 
             // Assert
-            Assert.Equal(11, tracker.CurrentLocation.AbsoluteIndex);
+            Assert.Equal(11, currentLocation.AbsoluteIndex);
         }
 
         [Fact]
         public void UpdateLocationAdvancesCharacterIndexOnSlashRFollowedBySlashN()
         {
             // Arrange
-            var tracker = new SourceLocationTracker(TestStartLocation);
+            var location = TestStartLocation;
 
             // Act
-            tracker.UpdateLocation('\r', '\n');
+            var currentLocation = UpdateLocation(location, '\r', '\n');
 
             // Assert
-            Assert.Equal(46, tracker.CurrentLocation.CharacterIndex);
+            Assert.Equal(46, currentLocation.CharacterIndex);
+        }
+
+        private static SourceLocation UpdateLocation(SourceLocation location, char v1, char v2)
+        {
+            var absoluteIndex = location.AbsoluteIndex;
+            var lineIndex = location.LineIndex;
+            var characterIndex = location.CharacterIndex;
+
+            SourceLocationTracker.UpdateCharacterCore(v1, v2, ref absoluteIndex, ref lineIndex, ref characterIndex);
+
+            return new SourceLocation(location.FilePath, absoluteIndex, lineIndex, characterIndex);
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringSegmentTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringSegmentTest.cs
@@ -568,6 +568,60 @@ namespace Microsoft.AspNetCore.Razor.Language
             Assert.Equal(-1, result);
         }
 
+        [Fact]
+        public void IndexOfAny_ComputesIndex_RelativeToTheCurrentSegment()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 10);
+
+            // Act
+            var result = segment.IndexOfAny(new[] { ',' });
+
+            // Assert
+            Assert.Equal(4, result);
+        }
+
+        [Fact]
+        public void IndexOfAny_ReturnsMinusOne_IfElementNotInSegment()
+        {
+            // Arrange
+            var segment = new StringSegment("Hello, World!", 1, 3);
+
+            // Act
+            var result = segment.IndexOfAny(new[] { ',' });
+
+            // Assert
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public void IndexOfAny_SkipsANumberOfCaracters_IfStartIsProvided()
+        {
+            // Arrange
+            const string buffer = "Hello, World!, Hello people!";
+            var segment = new StringSegment(buffer, 3, buffer.Length - 3);
+
+            // Act
+            var result = segment.IndexOfAny(new[] { '!' }, 15);
+
+            // Assert
+            Assert.Equal(buffer.Length - 4, result);
+        }
+
+        [Fact]
+        public void IndexOfAny_SearchOnlyInsideTheRange_IfStartAndCountAreProvided()
+        {
+            // Arrange
+            const string buffer = "Hello, World!, Hello people!";
+            var segment = new StringSegment(buffer, 3, buffer.Length - 3);
+
+            // Act
+            var result = segment.IndexOfAny(new[] { '!' }, 15, 5);
+
+            // Assert
+            Assert.Equal(-1, result);
+        }
+
 
         [Fact]
         public void Value_DoesNotAllocateANewString_IfTheSegmentContainsTheWholeBuffer()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringTokenizerTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringTokenizerTest.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language
+{
+
+    public class StringTokenizerTest
+    {
+        [Fact]
+        public void TokenizerReturnsEmptySequenceForNullValues()
+        {
+            // Arrange
+            var stringTokenizer = new StringTokenizer();
+            var enumerator = stringTokenizer.GetEnumerator();
+
+            // Act
+            var next = enumerator.MoveNext();
+
+            // Assert
+            Assert.False(next);
+        }
+
+        [Theory]
+        [InlineData("", new[] { "" })]
+        [InlineData("a", new[] { "a" })]
+        [InlineData("abc", new[] { "abc" })]
+        [InlineData("a,b", new[] { "a", "b" })]
+        [InlineData("a,,b", new[] { "a", "", "b" })]
+        [InlineData(",a,b", new[] { "", "a", "b" })]
+        [InlineData(",,a,b", new[] { "", "", "a", "b" })]
+        [InlineData("a,b,", new[] { "a", "b", "" })]
+        [InlineData("a,b,,", new[] { "a", "b", "", "" })]
+        [InlineData("ab,cde,efgh", new[] { "ab", "cde", "efgh" })]
+        public void Tokenizer_ReturnsSequenceOfValues(string value, string[] expected)
+        {
+            // Arrange
+            var tokenizer = new StringTokenizer(value, new[] { ',' });
+
+            // Act
+            var result = Enumerate(tokenizer);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("", new[] { "" })]
+        [InlineData("a", new[] { "a" })]
+        [InlineData("abc", new[] { "abc" })]
+        [InlineData("a.b", new[] { "a", "b" })]
+        [InlineData("a,b", new[] { "a", "b" })]
+        [InlineData("a.b,c", new[] { "a", "b", "c" })]
+        [InlineData("a,b.c", new[] { "a", "b", "c" })]
+        [InlineData("ab.cd,ef", new[] { "ab", "cd", "ef" })]
+        [InlineData("ab,cd.ef", new[] { "ab", "cd", "ef" })]
+        [InlineData(",a.b", new[] { "", "a", "b" })]
+        [InlineData(".a,b", new[] { "", "a", "b" })]
+        [InlineData(".,a.b", new[] { "", "", "a", "b" })]
+        [InlineData(",.a,b", new[] { "", "", "a", "b" })]
+        [InlineData("a.b,", new[] { "a", "b", "" })]
+        [InlineData("a,b.", new[] { "a", "b", "" })]
+        [InlineData("a.b,.", new[] { "a", "b", "", "" })]
+        [InlineData("a,b.,", new[] { "a", "b", "", "" })]
+        public void Tokenizer_SupportsMultipleSeparators(string value, string[] expected)
+        {
+            // Arrange
+            var tokenizer = new StringTokenizer(value, new[] { '.', ',' });
+
+            // Act
+            var result = Enumerate(tokenizer);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        private static string[] Enumerate(StringTokenizer tokenizer)
+        {
+            var items = new List<string>();
+            foreach (var token in tokenizer)
+            {
+                items.Add(token.Value);
+            }
+
+            return items.ToArray();
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntermediateNodeWriter.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntermediateNodeWriter.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
         void IExtensionIntermediateNodeVisitor<RouteAttributeExtensionNode>.VisitExtension(RouteAttributeExtensionNode node)
         {
-            WriteContentNode(node, node.Template);
+            WriteContentNode(node, node.Template.Value);
         }
 
         public override void VisitExtension(ExtensionIntermediateNode node)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/SyntaxTreeVerifier.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/SyntaxTreeVerifier.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -67,28 +67,28 @@ $@"Could not locate Syntax Node owner at position '{i}':
 
         private class Verifier : SyntaxWalker
         {
-            private readonly SourceLocationTracker _tracker;
             private readonly RazorSourceDocument _source;
+            private SourceLocation _currentLocation;
 
             public Verifier(RazorSourceDocument source)
             {
-                _tracker = new SourceLocationTracker(new SourceLocation(source.FilePath, 0, 0, 0));
+                _currentLocation = new SourceLocation(source.FilePath, 0, 0, 0);
                 _source = source;
             }
 
-            public SourceLocationTracker SourceLocationTracker => _tracker;
+            // public SourceLocationTracker SourceLocationTracker => _tracker;
 
             public override void VisitToken(SyntaxToken token)
             {
                 if (token != null && !token.IsMissing && token.Kind != SyntaxKind.Marker)
                 {
                     var start = token.GetSourceLocation(_source);
-                    if (!start.Equals(_tracker.CurrentLocation))
+                    if (!start.Equals(_currentLocation))
                     {
-                        throw new InvalidOperationException($"Token starting at {start} should start at {_tracker.CurrentLocation} - {token} ");
+                        throw new InvalidOperationException($"Token starting at {start} should start at {_currentLocation} - {token} ");
                     }
 
-                    _tracker.UpdateLocation(token.Content);
+                    _currentLocation = SourceLocationTracker.Advance(_currentLocation, token.Content);
                 }
 
                 base.VisitToken(token);


### PR DESCRIPTION
Found a bunch of places that performed Substring and Split and replaced them with StringSegment. Didn't make a dent in the micro-benchmark but this feels like a low cost fix to consider.