### PR TITLE
Adding `IResult` implementation for FileStreamResult and LocalRedirectResult

### DIFF
--- a/src/Mvc/Mvc.Core/src/FileContentResult.cs
+++ b/src/Mvc/Mvc.Core/src/FileContentResult.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Mvc
             }
 
             var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-            var logger = loggerFactory.CreateLogger<RedirectResult>();
+            var logger = loggerFactory.CreateLogger<FileContentResult>();
 
             var (range, rangeLength, serveBody) = FileResultExecutorBase.SetHeadersAndLog(
                 httpContext,

--- a/src/Mvc/Mvc.Core/src/FileStreamResult.cs
+++ b/src/Mvc/Mvc.Core/src/FileStreamResult.cs
@@ -106,7 +106,6 @@ namespace Microsoft.AspNetCore.Mvc
                     EntityTag,
                     logger!);
 
-
             await FileStreamResultExecutor.ExecuteAsyncInternal(
                 httpContext,
                 this,

--- a/src/Mvc/Mvc.Core/src/FileStreamResult.cs
+++ b/src/Mvc/Mvc.Core/src/FileStreamResult.cs
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Mvc
         async Task IResult.ExecuteAsync(HttpContext httpContext)
         {
             var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-            var logger = loggerFactory.CreateLogger<RedirectResult>();
+            var logger = loggerFactory.CreateLogger<FileStreamResult>();
 
             Task writeFileAsync(HttpContext httpContext, FileStreamResult result, RangeItemHeaderValue? range, long rangeLength)
                 => FileStreamResultExecutor.WriteFileAsyncInternal(httpContext, this, range, rangeLength, logger!);

--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileStreamResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileStreamResultExecutor.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 
@@ -77,9 +78,14 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
             RangeItemHeaderValue? range,
             long rangeLength)
         {
-            if (context == null)
+            return WriteFileAsyncInternal(context.HttpContext, result, range, rangeLength, Logger);
+        }
+
+        internal static Task WriteFileAsyncInternal(HttpContext httpContext, FileStreamResult result, RangeItemHeaderValue? range, long rangeLength, ILogger logger)
+        {
+            if (httpContext == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(httpContext));
             }
 
             if (result == null)
@@ -94,10 +100,10 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure
 
             if (range != null)
             {
-                Logger.WritingRangeToBody();
+                logger.WritingRangeToBody();
             }
 
-            return WriteFileAsync(context.HttpContext, result.FileStream, range, rangeLength);
+            return WriteFileAsync(httpContext, result.FileStream, range, rangeLength);
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/LocalRedirectResult.cs
+++ b/src/Mvc/Mvc.Core/src/LocalRedirectResult.cs
@@ -109,36 +109,15 @@ namespace Microsoft.AspNetCore.Mvc
 
         Task IResult.ExecuteAsync(HttpContext httpContext)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            // IsLocalUrl is called to handle  Urls starting with '~/'.
-            if (!UrlHelperBase.CheckIsLocalUrl(Url))
-            {
-                throw new InvalidOperationException(Resources.UrlNotLocal);
-            }
-
-            var destinationUrl = UrlHelperBase.Content(httpContext, Url);
-
             var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger<RedirectResult>();
-            logger.LocalRedirectResultExecuting(destinationUrl);
 
-            if (PreserveMethod)
-            {
-                httpContext.Response.StatusCode = Permanent
-                    ? StatusCodes.Status308PermanentRedirect
-                    : StatusCodes.Status307TemporaryRedirect;
-                httpContext.Response.Headers.Location = destinationUrl;
-            }
-            else
-            {
-                httpContext.Response.Redirect(destinationUrl, Permanent);
-            }
-
-            return Task.CompletedTask;
+            return LocalRedirectResultExecutor.ExecuteAsyncInternal(
+                httpContext,
+                this,
+                UrlHelperBase.CheckIsLocalUrl,
+                url => UrlHelperBase.Content(httpContext, Url),
+                logger);
         }
     }
 }

--- a/src/Mvc/Mvc.Core/src/LocalRedirectResult.cs
+++ b/src/Mvc/Mvc.Core/src/LocalRedirectResult.cs
@@ -110,7 +110,7 @@ namespace Microsoft.AspNetCore.Mvc
         Task IResult.ExecuteAsync(HttpContext httpContext)
         {
             var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-            var logger = loggerFactory.CreateLogger<RedirectResult>();
+            var logger = loggerFactory.CreateLogger<LocalRedirectResult>();
 
             return LocalRedirectResultExecutor.ExecuteAsyncInternal(
                 httpContext,

--- a/src/Mvc/Mvc.Core/src/PhysicalFileResult.cs
+++ b/src/Mvc/Mvc.Core/src/PhysicalFileResult.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Mvc
             long fileLength)
         {
             var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-            var logger = loggerFactory.CreateLogger<RedirectResult>();
+            var logger = loggerFactory.CreateLogger<PhysicalFileResult>();
 
             logger.ExecutingFileResult(result, result.FileName);
 

--- a/src/Mvc/Mvc.Core/src/VirtualFileResult.cs
+++ b/src/Mvc/Mvc.Core/src/VirtualFileResult.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Mvc
             }
 
             var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-            var logger = loggerFactory.CreateLogger<RedirectResult>();
+            var logger = loggerFactory.CreateLogger<VirtualFileResult>();
 
             var lastModified = LastModified ?? fileInfo.LastModified;
             var (range, rangeLength, serveBody) = FileResultExecutorBase.SetHeadersAndLog(

--- a/src/Mvc/Mvc.Core/test/BaseFileStreamResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/BaseFileStreamResultTest.cs
@@ -1,0 +1,584 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Net.Http.Headers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    public class BaseFileStreamResultTest
+    {
+        public static async Task WriteFileAsync_PreconditionStateShouldProcess_WritesRangeRequested<TContext>(
+            long? start,
+            long? end,
+            string expectedString,
+            long contentLength,
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var contentType = "text/plain";
+            var lastModified = new DateTimeOffset();
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("Hello World");
+            var readStream = new MemoryStream(byteArray);
+            readStream.SetLength(11);
+
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+                EnableRangeProcessing = true,
+            };
+
+            var httpContext = GetHttpContext();
+            var requestHeaders = httpContext.Request.GetTypedHeaders();
+            requestHeaders.Range = new RangeHeaderValue(start, end);
+            requestHeaders.IfMatch = new[]
+            {
+                new EntityTagHeaderValue("\"Etag\""),
+            };
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            start = start ?? 11 - end;
+            end = start + contentLength - 1;
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = streamReader.ReadToEndAsync().Result;
+            var contentRange = new ContentRangeHeaderValue(start.Value, end.Value, byteArray.Length);
+            Assert.Equal(lastModified.ToString("R"), httpResponse.Headers.LastModified);
+            Assert.Equal(entityTag.ToString(), httpResponse.Headers.ETag);
+            Assert.Equal(StatusCodes.Status206PartialContent, httpResponse.StatusCode);
+            Assert.Equal("bytes", httpResponse.Headers.AcceptRanges);
+            Assert.Equal(contentRange.ToString(), httpResponse.Headers.ContentRange);
+            Assert.Equal(contentLength, httpResponse.ContentLength);
+            Assert.Equal(expectedString, body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_IfRangeHeaderValid_WritesRequestedRange<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var contentType = "text/plain";
+            var lastModified = DateTimeOffset.MinValue;
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("Hello World");
+            var readStream = new MemoryStream(byteArray);
+            readStream.SetLength(11);
+
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+                EnableRangeProcessing = true,
+            };
+
+            var httpContext = GetHttpContext();
+            var requestHeaders = httpContext.Request.GetTypedHeaders();
+            requestHeaders.IfMatch = new[]
+            {
+                new EntityTagHeaderValue("\"Etag\""),
+            };
+            requestHeaders.Range = new RangeHeaderValue(0, 4);
+            requestHeaders.IfRange = new RangeConditionHeaderValue(new EntityTagHeaderValue("\"Etag\""));
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = streamReader.ReadToEndAsync().Result;
+            Assert.Equal(lastModified.ToString("R"), httpResponse.Headers.LastModified);
+            Assert.Equal(entityTag.ToString(), httpResponse.Headers.ETag);
+            var contentRange = new ContentRangeHeaderValue(0, 4, byteArray.Length);
+            Assert.Equal(StatusCodes.Status206PartialContent, httpResponse.StatusCode);
+            Assert.Equal("bytes", httpResponse.Headers.AcceptRanges);
+            Assert.Equal(contentRange.ToString(), httpResponse.Headers.ContentRange);
+            Assert.Equal(5, httpResponse.ContentLength);
+            Assert.Equal("Hello", body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_RangeProcessingNotEnabled_RangeRequestedIgnored<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var contentType = "text/plain";
+            var lastModified = DateTimeOffset.MinValue;
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("Hello World");
+            var readStream = new MemoryStream(byteArray);
+            readStream.SetLength(11);
+
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+            };
+
+            var httpContext = GetHttpContext();
+            var requestHeaders = httpContext.Request.GetTypedHeaders();
+            requestHeaders.IfMatch = new[]
+            {
+                new EntityTagHeaderValue("\"Etag\""),
+            };
+            requestHeaders.Range = new RangeHeaderValue(0, 4);
+            requestHeaders.IfRange = new RangeConditionHeaderValue(DateTimeOffset.MinValue);
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = streamReader.ReadToEndAsync().Result;
+            Assert.Equal(StatusCodes.Status200OK, httpResponse.StatusCode);
+            Assert.Equal(lastModified.ToString("R"), httpResponse.Headers.LastModified);
+            Assert.Equal(entityTag.ToString(), httpResponse.Headers.ETag);
+            Assert.Equal("Hello World", body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_IfRangeHeaderInvalid_RangeRequestedIgnored<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var contentType = "text/plain";
+            var lastModified = DateTimeOffset.MinValue.AddDays(1);
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("Hello World");
+            var readStream = new MemoryStream(byteArray);
+            readStream.SetLength(11);
+
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+                EnableRangeProcessing = true,
+            };
+
+            var httpContext = GetHttpContext();
+            var requestHeaders = httpContext.Request.GetTypedHeaders();
+            requestHeaders.IfMatch = new[]
+            {
+                new EntityTagHeaderValue("\"Etag\""),
+            };
+            requestHeaders.Range = new RangeHeaderValue(0, 4);
+            requestHeaders.IfRange = new RangeConditionHeaderValue(DateTimeOffset.MinValue);
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = streamReader.ReadToEndAsync().Result;
+            Assert.Equal(StatusCodes.Status200OK, httpResponse.StatusCode);
+            Assert.Equal(lastModified.ToString("R"), httpResponse.Headers.LastModified);
+            Assert.Equal(entityTag.ToString(), httpResponse.Headers.ETag);
+            Assert.Equal("Hello World", body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_PreconditionStateUnspecified_RangeRequestIgnored<TContext>(
+            string rangeString,
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange            
+            var contentType = "text/plain";
+            var lastModified = new DateTimeOffset();
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("Hello World");
+            var readStream = new MemoryStream(byteArray);
+
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+                EnableRangeProcessing = true,
+            };
+
+            var httpContext = GetHttpContext();
+            httpContext.Request.Headers.Range = rangeString;
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = streamReader.ReadToEndAsync().Result;
+            Assert.Empty(httpResponse.Headers.ContentRange);
+            Assert.Equal(StatusCodes.Status200OK, httpResponse.StatusCode);
+            Assert.Equal(lastModified.ToString("R"), httpResponse.Headers.LastModified);
+            Assert.Equal(entityTag.ToString(), httpResponse.Headers.ETag);
+            Assert.Equal("Hello World", body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_PreconditionStateUnspecified_RangeRequestedNotSatisfiable<TContext>(
+            string rangeString,
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange            
+            var contentType = "text/plain";
+            var lastModified = new DateTimeOffset();
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("Hello World");
+            var readStream = new MemoryStream(byteArray);
+
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+                EnableRangeProcessing = true,
+            };
+
+            var httpContext = GetHttpContext();
+            httpContext.Request.Headers.Range = rangeString;
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = streamReader.ReadToEndAsync().Result;
+            var contentRange = new ContentRangeHeaderValue(byteArray.Length);
+            Assert.Equal(lastModified.ToString("R"), httpResponse.Headers.LastModified);
+            Assert.Equal(entityTag.ToString(), httpResponse.Headers.ETag);
+            Assert.Equal(StatusCodes.Status416RangeNotSatisfiable, httpResponse.StatusCode);
+            Assert.Equal("bytes", httpResponse.Headers.AcceptRanges);
+            Assert.Equal(contentRange.ToString(), httpResponse.Headers.ContentRange);
+            Assert.Equal(0, httpResponse.ContentLength);
+            Assert.Empty(body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_RangeRequested_PreconditionFailed<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var contentType = "text/plain";
+            var lastModified = new DateTimeOffset();
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("Hello World");
+            var readStream = new MemoryStream(byteArray);
+
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+                EnableRangeProcessing = true,
+            };
+
+            var httpContext = GetHttpContext();
+            var requestHeaders = httpContext.Request.GetTypedHeaders();
+            requestHeaders.IfMatch = new[]
+            {
+                new EntityTagHeaderValue("\"NotEtag\""),
+            };
+            httpContext.Request.Headers.Range = "bytes = 0-6";
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = streamReader.ReadToEndAsync().Result;
+            Assert.Equal(StatusCodes.Status412PreconditionFailed, httpResponse.StatusCode);
+            Assert.Null(httpResponse.ContentLength);
+            Assert.Empty(httpResponse.Headers.ContentRange);
+            Assert.NotEmpty(httpResponse.Headers.LastModified);
+            Assert.Empty(body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_NotModified_RangeRequestedIgnored<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange       
+            var contentType = "text/plain";
+            var lastModified = new DateTimeOffset();
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("Hello World");
+            var readStream = new MemoryStream(byteArray);
+
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+                EnableRangeProcessing = true,
+            };
+
+            var httpContext = GetHttpContext();
+            var requestHeaders = httpContext.Request.GetTypedHeaders();
+            requestHeaders.IfNoneMatch = new[]
+            {
+                new EntityTagHeaderValue("\"Etag\""),
+            };
+            httpContext.Request.Headers.Range = "bytes = 0-6";
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = await streamReader.ReadToEndAsync();
+            Assert.Equal(StatusCodes.Status304NotModified, httpResponse.StatusCode);
+            Assert.Null(httpResponse.ContentLength);
+            Assert.Empty(httpResponse.Headers.ContentRange);            
+            Assert.False(httpResponse.Headers.ContainsKey(HeaderNames.ContentType));
+            Assert.NotEmpty(httpResponse.Headers.LastModified);
+            Assert.Empty(body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_RangeRequested_FileLengthZeroOrNull<TContext>(
+            long? fileLength,
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var contentType = "text/plain";
+            var lastModified = new DateTimeOffset();
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+            var byteArray = Encoding.ASCII.GetBytes("");
+            var readStream = new MemoryStream(byteArray);
+            fileLength = fileLength ?? 0L;
+            readStream.SetLength(fileLength.Value);
+            var result = new FileStreamResult(readStream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+                EnableRangeProcessing = true,
+            };
+
+            var httpContext = GetHttpContext();
+            var requestHeaders = httpContext.Request.GetTypedHeaders();
+            requestHeaders.Range = new RangeHeaderValue(0, 5);
+            requestHeaders.IfMatch = new[]
+            {
+                new EntityTagHeaderValue("\"Etag\""),
+            };
+            httpContext.Request.Method = HttpMethods.Get;
+            httpContext.Response.Body = new MemoryStream();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var httpResponse = actionContext.HttpContext.Response;
+            httpResponse.Body.Seek(0, SeekOrigin.Begin);
+            var streamReader = new StreamReader(httpResponse.Body);
+            var body = streamReader.ReadToEndAsync().Result;
+            Assert.Equal(lastModified.ToString("R"), httpResponse.Headers.LastModified);
+            Assert.Equal(entityTag.ToString(), httpResponse.Headers.ETag);
+            var contentRange = new ContentRangeHeaderValue(byteArray.Length);
+            Assert.Equal(StatusCodes.Status416RangeNotSatisfiable, httpResponse.StatusCode);
+            Assert.Equal("bytes", httpResponse.Headers.AcceptRanges);
+            Assert.Equal(contentRange.ToString(), httpResponse.Headers.ContentRange);
+            Assert.Equal(0, httpResponse.ContentLength);
+            Assert.Empty(body);
+            Assert.False(readStream.CanSeek);
+        }
+
+        public static async Task WriteFileAsync_WritesResponse_InChunksOfFourKilobytes<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var mockReadStream = new Mock<Stream>();
+            mockReadStream.SetupSequence(s => s.ReadAsync(It.IsAny<byte[]>(), 0, 0x1000, CancellationToken.None))
+                .Returns(Task.FromResult(0x1000))
+                .Returns(Task.FromResult(0x500))
+                .Returns(Task.FromResult(0));
+
+            var mockBodyStream = new Mock<Stream>();
+            mockBodyStream
+                .Setup(s => s.WriteAsync(It.IsAny<byte[]>(), 0, 0x1000, CancellationToken.None))
+                .Returns(Task.FromResult(0));
+
+            mockBodyStream
+                .Setup(s => s.WriteAsync(It.IsAny<byte[]>(), 0, 0x500, CancellationToken.None))
+                .Returns(Task.FromResult(0));
+
+            var result = new FileStreamResult(mockReadStream.Object, "text/plain");
+
+            var httpContext = GetHttpContext();
+            httpContext.Response.Body = mockBodyStream.Object;
+
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            mockReadStream.Verify();
+            mockBodyStream.Verify();
+        }
+
+        public static async Task WriteFileAsync_CopiesProvidedStream_ToOutputStream<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            // Generate an array of bytes with a predictable pattern
+            // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F, 10, 11, 12, 13
+            var originalBytes = Enumerable.Range(0, 0x1234)
+                .Select(b => (byte)(b % 20)).ToArray();
+
+            var originalStream = new MemoryStream(originalBytes);
+
+            var httpContext = GetHttpContext();
+            var outStream = new MemoryStream();
+            httpContext.Response.Body = outStream;
+
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            var result = new FileStreamResult(originalStream, "text/plain");
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var outBytes = outStream.ToArray();
+            Assert.True(originalBytes.SequenceEqual(outBytes));
+            Assert.False(originalStream.CanSeek);
+        }
+
+        public static async Task SetsSuppliedContentTypeAndEncoding<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var expectedContentType = "text/foo; charset=us-ascii";
+            // Generate an array of bytes with a predictable pattern
+            // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, A, B, C, D, E, F, 10, 11, 12, 13
+            var originalBytes = Enumerable.Range(0, 0x1234)
+                .Select(b => (byte)(b % 20)).ToArray();
+
+            var originalStream = new MemoryStream(originalBytes);
+
+            var httpContext = GetHttpContext();
+            var outStream = new MemoryStream();
+            httpContext.Response.Body = outStream;
+
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            var result = new FileStreamResult(originalStream, expectedContentType);
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            var outBytes = outStream.ToArray();
+            Assert.True(originalBytes.SequenceEqual(outBytes));
+            Assert.Equal(expectedContentType, httpContext.Response.ContentType);
+            Assert.False(originalStream.CanSeek);
+        }
+
+        public static async Task HeadRequest_DoesNotWriteToBody_AndClosesReadStream<TContext>(
+            Func<FileStreamResult, TContext, Task> function)
+        {
+            // Arrange
+            var readStream = new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!"));
+
+            var httpContext = GetHttpContext();
+            httpContext.Request.Method = "HEAD";
+            var outStream = new MemoryStream();
+            httpContext.Response.Body = outStream;
+
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            var result = new FileStreamResult(readStream, "text/plain");
+
+            // Act
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
+
+            // Assert
+            Assert.False(readStream.CanSeek);
+            Assert.Equal(200, httpContext.Response.StatusCode);
+            Assert.Equal(0, httpContext.Response.Body.Length);
+        }
+
+        private static IServiceCollection CreateServices()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IActionResultExecutor<FileStreamResult>, FileStreamResultExecutor>();
+            services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+            return services;
+        }
+
+        private static HttpContext GetHttpContext()
+        {
+            var services = CreateServices();
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.RequestServices = services.BuildServiceProvider();
+            return httpContext;
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/test/BaseLocalRedirectResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/BaseLocalRedirectResultTest.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    public class BaseLocalRedirectResultTest
+    {
+        public static async Task Execute_ReturnsExpectedValues<TContext>(
+            Func<LocalRedirectResult, TContext, Task> function)
+        {
+            // Arrange
+            var appRoot = "/";
+            var contentPath = "~/Home/About";
+            var expectedPath = "/Home/About";
+
+            var httpContext = GetHttpContext(appRoot);
+            var actionContext = GetActionContext(httpContext);
+            var result = new LocalRedirectResult(contentPath);
+
+            // Act
+            await result.ExecuteResultAsync(actionContext);
+
+            // Assert
+            Assert.Equal(expectedPath, httpContext.Response.Headers.Location.ToString());
+            Assert.Equal(StatusCodes.Status302Found, httpContext.Response.StatusCode);
+        }
+
+        public static async Task Execute_Throws_ForNonLocalUrl<TContext>(
+            string appRoot,
+            string contentPath,
+            Func<LocalRedirectResult, TContext, Task> function)
+        {
+            // Arrange
+            var httpContext = GetHttpContext(appRoot);
+            var actionContext = GetActionContext(httpContext);
+            var result = new LocalRedirectResult(contentPath);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => result.ExecuteResultAsync(actionContext));
+            Assert.Equal(
+                "The supplied URL is not local. A URL with an absolute path is considered local if it does not " +
+                "have a host/authority part. URLs using virtual paths ('~/') are also local.",
+                exception.Message);
+        }
+
+        public static async Task Execute_Throws_ForNonLocalUrlTilde<TContext>(
+            string appRoot,
+            string contentPath,
+            Func<LocalRedirectResult, TContext, Task> function)
+        {
+            // Arrange
+            var httpContext = GetHttpContext(appRoot);
+            var actionContext = GetActionContext(httpContext);
+            var result = new LocalRedirectResult(contentPath);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => result.ExecuteResultAsync(actionContext));
+            Assert.Equal(
+                "The supplied URL is not local. A URL with an absolute path is considered local if it does not " +
+                "have a host/authority part. URLs using virtual paths ('~/') are also local.",
+                exception.Message);
+        }
+
+        private static ActionContext GetActionContext(HttpContext httpContext)
+        {
+            var routeData = new RouteData();
+            routeData.Routers.Add(new Mock<IRouter>().Object);
+
+            return new ActionContext(httpContext, routeData, new ActionDescriptor());
+        }
+
+        private static IServiceProvider GetServiceProvider()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IActionResultExecutor<LocalRedirectResult>, LocalRedirectResultExecutor>();
+            serviceCollection.AddSingleton<IUrlHelperFactory, UrlHelperFactory>();
+            serviceCollection.AddTransient<ILoggerFactory, LoggerFactory>();
+            return serviceCollection.BuildServiceProvider();
+        }
+
+        private static HttpContext GetHttpContext(
+            string appRoot)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.RequestServices = GetServiceProvider();
+            httpContext.Request.PathBase = new PathString(appRoot);
+            return httpContext;
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/test/BaseLocalRedirectResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/BaseLocalRedirectResultTest.cs
@@ -30,7 +30,8 @@ namespace Microsoft.AspNetCore.Mvc
             var result = new LocalRedirectResult(contentPath);
 
             // Act
-            await result.ExecuteResultAsync(actionContext);
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            await function(result, (TContext)context);
 
             // Assert
             Assert.Equal(expectedPath, httpContext.Response.Headers.Location.ToString());
@@ -48,7 +49,8 @@ namespace Microsoft.AspNetCore.Mvc
             var result = new LocalRedirectResult(contentPath);
 
             // Act & Assert
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => result.ExecuteResultAsync(actionContext));
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => function(result, (TContext)context));
             Assert.Equal(
                 "The supplied URL is not local. A URL with an absolute path is considered local if it does not " +
                 "have a host/authority part. URLs using virtual paths ('~/') are also local.",
@@ -66,7 +68,9 @@ namespace Microsoft.AspNetCore.Mvc
             var result = new LocalRedirectResult(contentPath);
 
             // Act & Assert
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => result.ExecuteResultAsync(actionContext));
+            object context = typeof(TContext) == typeof(HttpContext) ? httpContext : actionContext;
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => function(result, (TContext)context));
             Assert.Equal(
                 "The supplied URL is not local. A URL with an absolute path is considered local if it does not " +
                 "have a host/authority part. URLs using virtual paths ('~/') are also local.",

--- a/src/Mvc/Mvc.Core/test/FileStreamActionResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/FileStreamActionResultTest.cs
@@ -4,14 +4,65 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
 {
-    public class FileStreamResultTest
+    public class FileStreamActionResultTest
     {
+        [Fact]
+        public void Constructor_SetsFileName()
+        {
+            // Arrange
+            var stream = Stream.Null;
+
+            // Act
+            var result = new FileStreamResult(stream, "text/plain");
+
+            // Assert
+            Assert.Equal(stream, result.FileStream);
+        }
+
+        [Fact]
+        public void Constructor_SetsContentTypeAndParameters()
+        {
+            // Arrange
+            var stream = Stream.Null;
+            var contentType = "text/plain; charset=us-ascii; p1=p1-value";
+            var expectedMediaType = contentType;
+
+            // Act
+            var result = new FileStreamResult(stream, contentType);
+
+            // Assert
+            Assert.Equal(stream, result.FileStream);
+            MediaTypeAssert.Equal(expectedMediaType, result.ContentType);
+        }
+
+        [Fact]
+        public void Constructor_SetsLastModifiedAndEtag()
+        {
+            // Arrange
+            var stream = Stream.Null;
+            var contentType = "text/plain";
+            var expectedMediaType = contentType;
+            var lastModified = new DateTimeOffset();
+            var entityTag = new EntityTagHeaderValue("\"Etag\"");
+
+            // Act
+            var result = new FileStreamResult(stream, contentType)
+            {
+                LastModified = lastModified,
+                EntityTag = entityTag,
+            };
+
+            // Assert
+            Assert.Equal(lastModified, result.LastModified);
+            Assert.Equal(entityTag, result.EntityTag);
+            MediaTypeAssert.Equal(expectedMediaType, result.ContentType);
+        }
+
         [Theory]
         [InlineData(0, 4, "Hello", 5)]
         [InlineData(6, 10, "World", 5)]
@@ -19,7 +70,7 @@ namespace Microsoft.AspNetCore.Mvc
         [InlineData(6, null, "World", 5)]
         public async Task WriteFileAsync_PreconditionStateShouldProcess_WritesRangeRequested(long? start, long? end, string expectedString, long contentLength)
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_PreconditionStateShouldProcess_WritesRangeRequested(
                 start,
@@ -32,7 +83,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task WriteFileAsync_IfRangeHeaderValid_WritesRequestedRange()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_IfRangeHeaderValid_WritesRequestedRange(action);
         }
@@ -40,7 +91,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task WriteFileAsync_RangeProcessingNotEnabled_RangeRequestedIgnored()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_RangeProcessingNotEnabled_RangeRequestedIgnored(action);
         }
@@ -48,7 +99,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task WriteFileAsync_IfRangeHeaderInvalid_RangeRequestedIgnored()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_IfRangeHeaderInvalid_RangeRequestedIgnored(action);
         }
@@ -59,7 +110,7 @@ namespace Microsoft.AspNetCore.Mvc
         [InlineData("bytes = 1-4, 5-11")]
         public async Task WriteFileAsync_PreconditionStateUnspecified_RangeRequestIgnored(string rangeString)
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_PreconditionStateUnspecified_RangeRequestIgnored(rangeString, action);
         }
@@ -69,7 +120,7 @@ namespace Microsoft.AspNetCore.Mvc
         [InlineData("bytes = -0")]
         public async Task WriteFileAsync_PreconditionStateUnspecified_RangeRequestedNotSatisfiable(string rangeString)
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_PreconditionStateUnspecified_RangeRequestedNotSatisfiable(rangeString, action);
         }
@@ -77,7 +128,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task WriteFileAsync_RangeRequested_PreconditionFailed()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_RangeRequested_PreconditionFailed(action);
         }
@@ -85,7 +136,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task WriteFileAsync_NotModified_RangeRequestedIgnored()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_NotModified_RangeRequestedIgnored(action);
         }
@@ -95,7 +146,7 @@ namespace Microsoft.AspNetCore.Mvc
         [InlineData(null)]
         public async Task WriteFileAsync_RangeRequested_FileLengthZeroOrNull(long? fileLength)
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_RangeRequested_FileLengthZeroOrNull(fileLength, action);
         }
@@ -103,7 +154,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task WriteFileAsync_WritesResponse_InChunksOfFourKilobytes()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_WritesResponse_InChunksOfFourKilobytes(action);
         }
@@ -111,7 +162,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task WriteFileAsync_CopiesProvidedStream_ToOutputStream()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.WriteFileAsync_CopiesProvidedStream_ToOutputStream(action);
         }
@@ -119,7 +170,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task SetsSuppliedContentTypeAndEncoding()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.SetsSuppliedContentTypeAndEncoding(action);
         }
@@ -127,7 +178,7 @@ namespace Microsoft.AspNetCore.Mvc
         [Fact]
         public async Task HeadRequest_DoesNotWriteToBody_AndClosesReadStream()
         {
-            var action = new Func<FileStreamResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
+            var action = new Func<FileStreamResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
 
             await BaseFileStreamResultTest.HeadRequest_DoesNotWriteToBody_AndClosesReadStream(action);
         }

--- a/src/Mvc/Mvc.Core/test/LocalRedirectActionResult.cs
+++ b/src/Mvc/Mvc.Core/test/LocalRedirectActionResult.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Mvc
+{
+    public class LocalRedirectActionResultTest
+    {
+        [Fact]
+        public void Constructor_WithParameterUrl_SetsResultUrlAndNotPermanentOrPreserveMethod()
+        {
+            // Arrange
+            var url = "/test/url";
+
+            // Act
+            var result = new LocalRedirectResult(url);
+
+            // Assert
+            Assert.False(result.PreserveMethod);
+            Assert.False(result.Permanent);
+            Assert.Same(url, result.Url);
+        }
+
+        [Fact]
+        public void Constructor_WithParameterUrlAndPermanent_SetsResultUrlAndPermanentNotPreserveMethod()
+        {
+            // Arrange
+            var url = "/test/url";
+
+            // Act
+            var result = new LocalRedirectResult(url, permanent: true);
+
+            // Assert
+            Assert.False(result.PreserveMethod);
+            Assert.True(result.Permanent);
+            Assert.Same(url, result.Url);
+        }
+
+        [Fact]
+        public void Constructor_WithParameterUrlAndPermanent_SetsResultUrlPermanentAndPreserveMethod()
+        {
+            // Arrange
+            var url = "/test/url";
+
+            // Act
+            var result = new LocalRedirectResult(url, permanent: true, preserveMethod: true);
+
+            // Assert
+            Assert.True(result.PreserveMethod);
+            Assert.True(result.Permanent);
+            Assert.Same(url, result.Url);
+        }
+
+        [Fact]
+        public async Task Execute_ReturnsExpectedValues()
+        {
+            var action = new Func<LocalRedirectResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
+
+            await BaseLocalRedirectResultTest.Execute_ReturnsExpectedValues(action);
+        }
+
+        [Theory]
+        [InlineData("", "//")]
+        [InlineData("", "/\\")]
+        [InlineData("", "//foo")]
+        [InlineData("", "/\\foo")]
+        [InlineData("", "Home/About")]
+        [InlineData("/myapproot", "http://www.example.com")]
+        public async Task Execute_Throws_ForNonLocalUrl(
+            string appRoot,
+            string contentPath)
+        {
+            var action = new Func<LocalRedirectResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
+
+            await BaseLocalRedirectResultTest.Execute_Throws_ForNonLocalUrl(appRoot, contentPath, action);
+        }
+
+        [Theory]
+        [InlineData("", "~//")]
+        [InlineData("", "~/\\")]
+        [InlineData("", "~//foo")]
+        [InlineData("", "~/\\foo")]
+        public async Task Execute_Throws_ForNonLocalUrlTilde(
+            string appRoot,
+            string contentPath)
+        {
+            var action = new Func<LocalRedirectResult, ActionContext, Task>(async (result, context) => await result.ExecuteResultAsync(context));
+
+            await BaseLocalRedirectResultTest.Execute_Throws_ForNonLocalUrlTilde(appRoot, contentPath, action);
+        }
+    }
+}

--- a/src/Mvc/Mvc.Core/test/LocalRedirectResultTest.cs
+++ b/src/Mvc/Mvc.Core/test/LocalRedirectResultTest.cs
@@ -4,15 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.Routing;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Net.Http.Headers;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc
@@ -20,68 +11,11 @@ namespace Microsoft.AspNetCore.Mvc
     public class LocalRedirectResultTest
     {
         [Fact]
-        public void Constructor_WithParameterUrl_SetsResultUrlAndNotPermanentOrPreserveMethod()
-        {
-            // Arrange
-            var url = "/test/url";
-
-            // Act
-            var result = new LocalRedirectResult(url);
-
-            // Assert
-            Assert.False(result.PreserveMethod);
-            Assert.False(result.Permanent);
-            Assert.Same(url, result.Url);
-        }
-
-        [Fact]
-        public void Constructor_WithParameterUrlAndPermanent_SetsResultUrlAndPermanentNotPreserveMethod()
-        {
-            // Arrange
-            var url = "/test/url";
-
-            // Act
-            var result = new LocalRedirectResult(url, permanent: true);
-
-            // Assert
-            Assert.False(result.PreserveMethod);
-            Assert.True(result.Permanent);
-            Assert.Same(url, result.Url);
-        }
-
-        [Fact]
-        public void Constructor_WithParameterUrlAndPermanent_SetsResultUrlPermanentAndPreserveMethod()
-        {
-            // Arrange
-            var url = "/test/url";
-
-            // Act
-            var result = new LocalRedirectResult(url, permanent: true, preserveMethod: true);
-
-            // Assert
-            Assert.True(result.PreserveMethod);
-            Assert.True(result.Permanent);
-            Assert.Same(url, result.Url);
-        }
-
-        [Fact]
         public async Task Execute_ReturnsExpectedValues()
         {
-            // Arrange
-            var appRoot = "/";
-            var contentPath = "~/Home/About";
-            var expectedPath = "/Home/About";
+            var action = new Func<LocalRedirectResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
 
-            var httpContext = GetHttpContext(appRoot);
-            var actionContext = GetActionContext(httpContext);
-            var result = new LocalRedirectResult(contentPath);
-
-            // Act
-            await result.ExecuteResultAsync(actionContext);
-
-            // Assert
-            Assert.Equal(expectedPath, httpContext.Response.Headers.Location.ToString());
-            Assert.Equal(StatusCodes.Status302Found, httpContext.Response.StatusCode);
+            await BaseLocalRedirectResultTest.Execute_ReturnsExpectedValues(action);
         }
 
         [Theory]
@@ -95,17 +29,9 @@ namespace Microsoft.AspNetCore.Mvc
             string appRoot,
             string contentPath)
         {
-            // Arrange
-            var httpContext = GetHttpContext(appRoot);
-            var actionContext = GetActionContext(httpContext);
-            var result = new LocalRedirectResult(contentPath);
+            var action = new Func<LocalRedirectResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
 
-            // Act & Assert
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => result.ExecuteResultAsync(actionContext));
-            Assert.Equal(
-                "The supplied URL is not local. A URL with an absolute path is considered local if it does not " +
-                "have a host/authority part. URLs using virtual paths ('~/') are also local.",
-                exception.Message);
+            await BaseLocalRedirectResultTest.Execute_Throws_ForNonLocalUrl(appRoot, contentPath, action);
         }
 
         [Theory]
@@ -117,43 +43,9 @@ namespace Microsoft.AspNetCore.Mvc
             string appRoot,
             string contentPath)
         {
-            // Arrange
-            var httpContext = GetHttpContext(appRoot);
-            var actionContext = GetActionContext(httpContext);
-            var result = new LocalRedirectResult(contentPath);
+            var action = new Func<LocalRedirectResult, HttpContext, Task>(async (result, context) => await ((IResult)result).ExecuteAsync(context));
 
-            // Act & Assert
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => result.ExecuteResultAsync(actionContext));
-            Assert.Equal(
-                "The supplied URL is not local. A URL with an absolute path is considered local if it does not " +
-                "have a host/authority part. URLs using virtual paths ('~/') are also local.",
-                exception.Message);
-        }
-
-        private static ActionContext GetActionContext(HttpContext httpContext)
-        {
-            var routeData = new RouteData();
-            routeData.Routers.Add(new Mock<IRouter>().Object);
-
-            return new ActionContext(httpContext, routeData, new ActionDescriptor());
-        }
-
-        private static IServiceProvider GetServiceProvider()
-        {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton<IActionResultExecutor<LocalRedirectResult>, LocalRedirectResultExecutor>();
-            serviceCollection.AddSingleton<IUrlHelperFactory, UrlHelperFactory>();
-            serviceCollection.AddTransient<ILoggerFactory, LoggerFactory>();
-            return serviceCollection.BuildServiceProvider();
-        }
-
-        private static HttpContext GetHttpContext(
-            string appRoot)
-        {
-            var httpContext = new DefaultHttpContext();
-            httpContext.RequestServices = GetServiceProvider();
-            httpContext.Request.PathBase = new PathString(appRoot);
-            return httpContext;
+            await BaseLocalRedirectResultTest.Execute_Throws_ForNonLocalUrlTilde(appRoot, contentPath, action);
         }
     }
 }


### PR DESCRIPTION
# Summary 
These changes add `IResult` implementation on `ActionResult`s that does not have it

# Details
The `ActionResult`s that are going to be worked on this PR are:

- [x] FileStreamResult
- [x] LocalRedirectResult

Task that needs to be done for this PR are:

- [x] Basic implementation for IResults
- [x] Add test suite to test the new IResults

Addresses part of #32565