### PR TITLE
Further attempt to fix CancelsOutdatedRefreshes_Async in CI

### DIFF
--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -169,12 +169,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25929")]
         public void CancelsOutdatedRefreshes_Async()
         {
             Browser.MountTestComponent<VirtualizationComponent>();
             var cancellationCount = Browser.Exists(By.Id("cancellation-count"));
             var finishLoadingButton = Browser.Exists(By.Id("finish-loading-button"));
+            var js = (IJavaScriptExecutor)Browser;
 
             // Load the initial set of items.
             finishLoadingButton.Click();
@@ -183,7 +183,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("0", () => cancellationCount.Text);
 
             // Validate that scrolling causes cancellations
-            Browser.ExecuteJavaScript("document.getElementById('async-container').scrollTo({ top:5000, behavior:'smooth' })");
+            for (var y = 1000; y <= 5000; y += 1000)
+            {
+                js.ExecuteScript($"document.getElementById('async-container').scrollTo({{ top: {y} }})");
+                Browser.Equal(y, () => (long)js.ExecuteScript("return document.getElementById('async-container').scrollTop"));
+            }
+
             Browser.True(() => int.Parse(cancellationCount.Text, CultureInfo.InvariantCulture) > 0);
         }
 


### PR DESCRIPTION
The previous attempt to fix this in https://github.com/dotnet/aspnetcore/pull/32869 actually made it worse. It went from being flaky in CI to failing 100% of the time in CI, even though it passes 100% of the time locally.

The implementation here is just a manual equivalent to the `behavior: 'smooth'` flag to see if that works better.

Sidenote: I'm increasingly thinking it may be a more fundamental aspect of the CI environment that makes anything based on human timescales for interactivity (which UI tests should and must be) unviable. Browsers aren't designed to operate in conditions where they're unable to execute code in response to events because of excessive resource contention. If that is the case we're going to have to set up a separate, dedicated environment for running E2E tests that is not in contention for resources with other build or test activities, or at least have a more sophisticated mechanism for retries. If the Playwright efforts prove this wrong then of course that would be better still, but as yet we haven't got there.