### PR TITLE
Some additional optimizations to ComponentDirectiveVisitor

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMetadata.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMetadata.cs
@@ -29,11 +29,6 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsMangledClass(StringSegment className)
         {
-            if (StringSegment.IsNullOrEmpty(className))
-            {
-                return false;
-            }
-
             return className.StartsWith(MangledClassNamePrefix, StringComparison.Ordinal);
         }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/TagHelperDescriptorExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/TagHelperDescriptorExtensions.cs
@@ -100,9 +100,16 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static bool IsChildContentTagHelper(this TagHelperDescriptor tagHelper)
         {
-            return
-                tagHelper.Metadata.TryGetValue(ComponentMetadata.SpecialKindKey, out var value) &&
-                string.Equals(value, ComponentMetadata.ChildContent.TagHelperKind, StringComparison.Ordinal);
+            if (tagHelper.IsChildContentTagHelperCache is bool value)
+            {
+                return value;
+            }
+
+            value = tagHelper.Metadata.TryGetValue(ComponentMetadata.SpecialKindKey, out var specialKey) &&
+                string.Equals(specialKey, ComponentMetadata.ChildContent.TagHelperKind, StringComparison.Ordinal);
+
+            tagHelper.IsChildContentTagHelperCache = value;
+            return value;
         }
 
         public static bool IsComponentTagHelper(this TagHelperDescriptor tagHelper)
@@ -146,9 +153,15 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
         /// <param name="tagHelper">The <see cref="TagHelperDescriptor"/>.</param>
         public static bool IsComponentFullyQualifiedNameMatch(this TagHelperDescriptor tagHelper)
         {
-            return
-                tagHelper.Metadata.TryGetValue(ComponentMetadata.Component.NameMatchKey, out var matchType) &&
+            if (tagHelper.IsComponentFullyQualifiedNameMatchCache is bool value)
+            {
+                return value;
+            }
+
+            value = tagHelper.Metadata.TryGetValue(ComponentMetadata.Component.NameMatchKey, out var matchType) &&
                 string.Equals(ComponentMetadata.Component.FullyQualifiedNameMatch, matchType);
+            tagHelper.IsComponentFullyQualifiedNameMatchCache = value;
+            return value;
         }
 
         public static string GetEventArgsType(this TagHelperDescriptor tagHelper)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultDocumentClassifierPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultDocumentClassifierPass.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             ClassDeclarationIntermediateNode @class,
             MethodDeclarationIntermediateNode method)
         {
-            var configuration = Engine.Features.OfType<DefaultDocumentClassifierPassFeature>().FirstOrDefault();
+            var configuration = Engine.GetFeature<DefaultDocumentClassifierPassFeature>();
             if (configuration != null)
             {
                 for (var i = 0; i < configuration.ConfigureClass.Count; i++)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperBinderPhase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperBinderPhase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                     return true;
                 }
 
-                return new StringSegment(descriptor.Name).StartsWith(new StringSegment(typePattern, 0, typePattern.Length - 1), StringComparison.Ordinal);
+               return new StringSegment(descriptor.Name).StartsWith(new StringSegment(typePattern, 0, typePattern.Length - 1), StringComparison.Ordinal);
             }
 
             return string.Equals(descriptor.Name, typePattern, StringComparison.Ordinal);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperBinderPhase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperBinderPhase.cs
@@ -251,7 +251,6 @@ namespace Microsoft.AspNetCore.Razor.Language
                         continue;
                     }
 
-
                     _notFullyQualifiedComponents ??= new();
                     _notFullyQualifiedComponents.Add(tagHelper);
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DocumentClassifierPassBase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DocumentClassifierPassBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,8 +17,8 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         protected override void OnInitialized()
         {
-            var feature = Engine.Features.OfType<IRazorTargetExtensionFeature>();
-            TargetExtensions = feature.FirstOrDefault()?.TargetExtensions.ToArray() ?? Array.Empty<ICodeTargetExtension>();
+            var feature = Engine.GetFeature<IRazorTargetExtensionFeature>();
+            TargetExtensions = feature?.TargetExtensions.ToArray() ?? Array.Empty<ICodeTargetExtension>();
         }
 
         protected sealed override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/MetadataAttributePass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Extensions/MetadataAttributePass.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Extensions
 
         protected override void OnInitialized()
         {
-            _identifierFeature = Engine.Features.OfType<IMetadataIdentifierFeature>().FirstOrDefault();
+            _identifierFeature = Engine.GetFeature<IMetadataIdentifierFeature>();
         }
 
         protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorEngine.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorEngine.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -144,6 +144,22 @@ namespace Microsoft.AspNetCore.Razor.Language
         public abstract IReadOnlyList<IRazorEnginePhase> Phases { get; }
 
         public abstract void Process(RazorCodeDocument document);
+
+#nullable enable
+        internal TFeature? GetFeature<TFeature>()
+        {
+            var count = Features.Count;
+            for (var i = 0; i < count; i++)
+            {
+                if (Features[i] is TFeature feature)
+                {
+                    return feature;
+                }
+            }
+
+            return default;
+        }
+#nullable disable
 
         #region Obsolete
         [Obsolete("This method is obsolete and will be removed in a future version.")]

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorEngineFeatureBase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorEngineFeatureBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new InvalidOperationException(Resources.FormatFeatureMustBeInitialized(nameof(Engine)));
             }
 
-            var feature = Engine.Features.OfType<TFeature>().FirstOrDefault();
+            var feature = Engine.GetFeature<TFeature>();
             ThrowForMissingFeatureDependency<TFeature>(feature);
 
             return feature;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -130,8 +130,10 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         private void Register(TagHelperDescriptor descriptor)
         {
-            foreach (var rule in descriptor.TagMatchingRules)
+            var count = descriptor.TagMatchingRules.Count;
+            for (var i = 0; i < count; i++)
             {
+                var rule = descriptor.TagMatchingRules[i];
                 var registrationKey =
                     string.Equals(rule.TagName, TagHelperMatchingConventions.ElementCatchAllName, StringComparison.Ordinal) ?
                     TagHelperMatchingConventions.ElementCatchAllName :

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
@@ -40,6 +40,12 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public IReadOnlyDictionary<string, string> Metadata { get; protected set; }
 
+        // Hoisted / cached metadata
+        private int? _hashCode;
+        internal bool? IsComponentFullyQualifiedNameMatchCache { get; set; }
+        internal bool? IsChildContentTagHelperCache { get; set; }
+        internal ParsedTypeInformation? ParsedTypeInfo { get; set; }
+
         public bool HasErrors
         {
             get
@@ -85,7 +91,23 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            return TagHelperDescriptorComparer.Default.GetHashCode(this);
+            // TagHelperDescriptors are immutable instances and it should be safe to cache it's hashes once.
+            _hashCode ??= TagHelperDescriptorComparer.Default.GetHashCode(this);
+            return _hashCode.Value;
+        }
+
+        internal readonly struct ParsedTypeInformation
+        {
+            public ParsedTypeInformation(bool success, StringSegment @namespace, StringSegment typeName)
+            {
+                Success = success;
+                Namespace = @namespace;
+                TypeName = typeName;
+            }
+
+            public bool Success { get; }
+            public StringSegment Namespace { get; }
+            public StringSegment TypeName { get; }
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptor.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 {
     public abstract class TagMatchingRuleDescriptor : IEquatable<TagMatchingRuleDescriptor>
     {
+        private int? _hashCode;
         private IEnumerable<RazorDiagnostic> _allDiagnostics;
 
         public string TagName { get; protected set; }
@@ -22,6 +23,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public bool CaseSensitive { get; protected set; }
 
         public IReadOnlyList<RazorDiagnostic> Diagnostics { get; protected set; }
+        
 
         public bool HasErrors
         {
@@ -58,7 +60,8 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            return TagMatchingRuleDescriptorComparer.Default.GetHashCode(this);
+            _hashCode ??= TagMatchingRuleDescriptorComparer.Default.GetHashCode(this);
+            return _hashCode.Value;
         }
     }
 }


### PR DESCRIPTION
* Cache frequently queried metadata on TagHelperDescriptors. Determining if a tag helper is in scope
  happens very frequently and some of it's partial results can be cached on the TagHelperDescriptor instance.
* Some hash codes on immutable types - TagHelperDescriptor / TagHelperRuleDescriptor can be cached
* Remove some Linq

Turns out the benchmarks weren't running on the right inputs (the file was treated as a MVC component and was missing tag helpers).
Updated it and here's a comparison of before / after with these changes.

|                             Method |        Mean |     Error |    StdDev |     Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |------------:|----------:|----------:|---------:|-------:|------:|------:|----------:|
| 'TagHelper Design Time Processing' | 2,578.76 us | 46.492 us | 43.488 us |    387.8 | 3.9063 |     - |     - | 752,148 B |
| 'TagHelper Design Time Processing' |    88.77 us |  0.708 us |  0.627 us | 11,265.2 |      - |     - |     - |     576 B |

|                             Method |        Mean |     Error |    StdDev |     Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |------------:|----------:|----------:|---------:|-------:|------:|------:|----------:|
| 'TagHelper Design Time Processing' | 2,330.11 us | 35.816 us | 33.503 us |    429.2 | 3.9063 |     - |     - | 736,220 B |
| 'TagHelper Design Time Processing' |    64.80 us |  0.634 us |  0.593 us | 15,431.6 |      - |     - |     - |     576 B |
