### PR TITLE
Fix installPlaywright variable in runtests.cmd

### DIFF
--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -14,7 +14,7 @@ REM Batch only supports up to 9 arguments using the %# syntax, need to shift to 
 
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 set DOTNET_MULTILEVEL_LOOKUP=0
-set InstallPlaywright=%installPlaywright%
+set InstallPlaywright=%$installPlaywright%
 set PLAYWRIGHT_BROWSERS_PATH=%CD%\ms-playwright
 set PLAYWRIGHT_DRIVER_PATH=%CD%\.playwright\win-x64\native\playwright.cmd
 


### PR DESCRIPTION
Update to runtests broke pw install logic (all tests are quarantined, so didn't notice immediately)