### PR TITLE
Bump the SDK back up again

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -213,13 +213,25 @@ stages:
                 -buildInstallers
                 -noBuildNative
                 /p:DotNetSignType=$(_SignType)
-                /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
                 $(_BuildArgs)
-                $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
-                /p:PublishInstallerBaseVersion=true
                 $(WindowsInstallersLogArgs)
         displayName: Build Installers
+
+      - script: ./eng/build.cmd
+               -ci
+               -noBuildRepoTasks
+               -noBuildNative
+               -noBuild
+               -noRestore
+               -projects eng/empty.proj
+               $(_BuildArgs)
+               $(_InternalRuntimeDownloadArgs)
+               $(_PublishArgs)
+               /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
+               /p:PublishInstallerBaseVersion=true
+               /bl:artifacts/log/Release/Build.Publish.binlog
+        displayName: Publish
 
       # A few files must also go to the VS package feed.
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:

--- a/AspNetCore.sln
+++ b/AspNetCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30204.135
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31324.12
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "eng", "eng", "{C28A32F6-8314-412E-9F3B-CBD31C23E878}"
 EndProject
@@ -1606,7 +1606,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testassets", "testassets", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfTestApp", "src\Components\WebView\Platforms\Wpf\testassets\WpfTestApp\WpfTestApp.csproj", "{036C6BDA-7B69-4E8C-A921-822DA5972A56}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebviewAppShared", "src\Components\WebView\Samples\WebviewAppShared\WebviewAppShared.csproj", "{64C3BAC8-C4F8-466A-9E84-0400EE54B25A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebviewAppShared", "src\Components\WebView\Samples\WebviewAppShared\WebviewAppShared.csproj", "{64C3BAC8-C4F8-466A-9E84-0400EE54B25A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestStartupAssembly1", "src\Hosting\test\testassets\TestStartupAssembly1\TestStartupAssembly1.csproj", "{262FF30C-34B4-462D-B5E2-0DABB9196E40}"
 EndProject
@@ -1641,6 +1641,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Features", "src\Http\Features\src\Microsoft.Extensions.Features.csproj", "{A07D3B13-388B-444F-9E37-DDC0787C4690}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Features.Tests", "src\Http\Features\test\Microsoft.Extensions.Features.Tests.csproj", "{09FFBC53-3EFF-45C4-9822-5D66089CD6AD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Components.Migration.E2ETests", "src\Components\test\E2ETestMigration\Microsoft.AspNetCore.Components.Migration.E2ETests.csproj", "{A1D02CE6-1077-410A-81CB-D4BD500FD765}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -7797,6 +7799,18 @@ Global
 		{09FFBC53-3EFF-45C4-9822-5D66089CD6AD}.Release|x64.Build.0 = Release|Any CPU
 		{09FFBC53-3EFF-45C4-9822-5D66089CD6AD}.Release|x86.ActiveCfg = Release|Any CPU
 		{09FFBC53-3EFF-45C4-9822-5D66089CD6AD}.Release|x86.Build.0 = Release|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Debug|x86.Build.0 = Debug|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Release|x64.Build.0 = Release|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -8610,6 +8624,7 @@ Global
 		{17F28812-983E-4415-A55D-842DD7EC6887} = {627BE8B3-59E6-4F1D-8C9C-76B804D41724}
 		{A07D3B13-388B-444F-9E37-DDC0787C4690} = {17F28812-983E-4415-A55D-842DD7EC6887}
 		{09FFBC53-3EFF-45C4-9822-5D66089CD6AD} = {17F28812-983E-4415-A55D-842DD7EC6887}
+		{A1D02CE6-1077-410A-81CB-D4BD500FD765} = {0508E463-0269-40C9-B5C2-3B600FB2A28B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3E8720B3-DBDD-498C-B383-2CC32A054E8F}

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -51,10 +51,10 @@
                       $(RepoRoot)src\Components\WebView\Samples\BlazorWinFormsApp\**\*.csproj;
                       $(RepoRoot)src\Components\WebView\Samples\BlazorWpfApp\**\*.csproj;
                       " />
-    
-    <!-- Skipping due to build race conditions for now -->
+
+    <!-- Skipping due to build unreliability with current SDK et cetera. -->
     <ProjectToExclude Include="
-                      $(RepoRoot)src/Components/test/E2ETestMigration/Microsoft.AspNetCore.Components.Migration.E2ETests.csproj" />    
+                      $(RepoRoot)src/Components/test/E2ETestMigration/Microsoft.AspNetCore.Components.Migration.E2ETests.csproj" />
   </ItemGroup>
 
   <Choose>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -51,11 +51,8 @@
                       $(RepoRoot)src\Components\WebView\Samples\BlazorWinFormsApp\**\*.csproj;
                       $(RepoRoot)src\Components\WebView\Samples\BlazorWpfApp\**\*.csproj;
                       " />
-
-    <!-- Projects won't build consistently. An SDK newer than 6.0.100-preview.5.21230.2 should fix the first.
-         See https://github.com/dotnet/aspnetcore/pull/32428 and https://github.com/dotnet/aspnetcore/issues/32788. -->
-    <ProjectToExclude Include="
-                      $(RepoRoot)src\Components\benchmarkapps\Wasm.Performance\TestApp\Wasm.Performance.TestApp.csproj" />
+    
+    <!-- Skipping due to build race conditions for now -->
     <ProjectToExclude Include="
                       $(RepoRoot)src/Components/test/E2ETestMigration/Microsoft.AspNetCore.Components.Migration.E2ETests.csproj" />    
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.5.21230.2"
+    "version": "6.0.100-preview.5.21264.3"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.5.21230.2",
+    "dotnet": "6.0.100-preview.5.21264.3",
     "runtimes": {
       "dotnet/x64": [
         "2.1.27",

--- a/src/Components/Authorization/src/CascadingAuthenticationState.razor
+++ b/src/Components/Authorization/src/CascadingAuthenticationState.razor
@@ -1,7 +1,7 @@
 ﻿@implements IDisposable
 @inject AuthenticationStateProvider AuthenticationStateProvider
 
-<CascadingValue TValue="Task<AuthenticationState>" Value="@_currentAuthenticationStateTask" ChildContent="@((RenderFragment)ChildContent!)" />
+<CascadingValue TValue="Task<AuthenticationState>" Value="@_currentAuthenticationStateTask" ChildContent="@ChildContent" />
 
 @code {
     private Task<AuthenticationState>? _currentAuthenticationStateTask;

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -47,11 +47,10 @@
     <ProjectReference Include="..\testassets\TestServer\Components.TestServer.csproj" />
     <ProjectReference Include="..\..\WebAssembly\testassets\Wasm.Authentication.Server\Wasm.Authentication.Server.csproj" />
 
-    <!-- TODO - turn this back on once the SDK is higher than 6.0.100-preview.5.21230.2: https://github.com/dotnet/aspnetcore/issues/32788
     <ProjectReference Include="..\..\benchmarkapps\Wasm.Performance\TestApp\Wasm.Performance.TestApp.csproj"
       Targets="Publish"
       Properties="TestTrimmedApps=true;PublishDir=$(MSBuildThisFileDirectory)$(OutputPath)trimmed\Wasm.Performance.TestApp\"
-      Condition="'$(TestTrimmedApps)' == 'true'" /> -->
+      Condition="'$(TestTrimmedApps)' == 'true'" />
 
     <ProjectReference
       Include="..\testassets\BasicTestApp\BasicTestApp.csproj"

--- a/src/Components/test/E2ETest/Tests/PerformanceTest.cs
+++ b/src/Components/test/E2ETest/Tests/PerformanceTest.cs
@@ -33,14 +33,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public override Task InitializeAsync() => base.InitializeAsync(Guid.NewGuid().ToString());
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/32788")]
         public void HasTitle()
         {
             Assert.Equal("E2EPerformance", Browser.Title);
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/32788")]
         public void BenchmarksRunWithoutError()
         {
             // In CI, we only verify that the benchmarks run without throwing any


### PR DESCRIPTION
Publish in a separate step
- Publishing.props executes the `_GetPackageVersionInfo` target in Microsoft.AspNetCore.App.Runtime.csproj
- that target currently fails when using a new SDK and desktop `msbuild`

Revert "Revert SDK update (#32785)"
- take us back to the 6.0.100-preview.5.21264.3 SDK

This reverts commit 57b9c132a28f1bb2af2b3d4a7d97bc5c6291c6b9.

Reword a comment