### PR TITLE
[SPA] Fix start script on Linux/Mac

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/package.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/package.json
@@ -7,7 +7,7 @@
     "prestart": "node aspnetcore-https",
     "start": "run-script-os",
     "start:windows": "ng serve --port 5002 --ssl --ssl-cert %APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem --ssl-key %APPDATA%\\ASP.NET\\https\\%npm_package_name%.key",
-    "start:default": "ng serve --port 5002 --ssl --ssl-cert $HOME/.aspnet/https/%{npm_package_name}.pem --ssl-key $HOME/.aspnet/https/%{npm_package_name}.key",
+    "start:default": "ng serve --port 5002 --ssl --ssl-cert $HOME/.aspnet/https/${npm_package_name}.pem --ssl-key $HOME/.aspnet/https/${npm_package_name}.key",
 //#else
     "start": "ng serve --port 5002",
 //#endif


### PR DESCRIPTION
It was using % instead of $ to prefix the environment variable.
