### PR TITLE
[SPA] Typo in package.json causes new SPA projects to fail at startup

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/package.json
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/package.json
@@ -7,7 +7,7 @@
     "prestart": "node aspnetcore-https",
     "start": "run-script-os",
     "start:windows": "ng serve --port 5002 --ssl --ssl-cert %APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem --ssl-key %APPDATA%\\ASP.NET\\https\\%npm_package_name%.key",
-    "start:default": "ng serve --port 5002 --ssl --ssl-cert $HOME/.aspnet/https/%{npm_package_name}.pem --ssl-key $HOME/.aspnet/https/%{npm_package_name}.key",
+    "start:default": "ng serve --port 5002 --ssl --ssl-cert $HOME/.aspnet/https/${npm_package_name}.pem --ssl-key $HOME/.aspnet/https/${npm_package_name}.key",
 //#else
     "start": "ng serve --port 5002",
 //#endif


### PR DESCRIPTION
## Description
We have recently updated the SPA project templates to use the latest SPA framework versions and were using the wrong character to refer to environment variables on non windows operating systems.


## Customer Impact
Template will fail to launch after creation (**on Linux and Mac**)


## Regression?
- [x] Yes
- [ ] No

Yes, we broke this with our preview5 template update.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

This is a single character change which is verified manually.

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [x] No
- [ ] N/A


Addresses https://github.com/aspnet/AspNetCore-ManualTests/issues/637