### PR TITLE
Add null check on Task, Task<IResult>, ValueTask, ValueTask<IResult>

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -679,6 +679,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteTask<T>(Task<T> task, HttpContext httpContext)
         {
+            EnsureRequestTaskResultNotNull(task);
             static async Task ExecuteAwaited(Task<T> task, HttpContext httpContext)
             {
                 await httpContext.Response.WriteAsJsonAsync(await task);
@@ -694,6 +695,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteTaskOfString(Task<string> task, HttpContext httpContext)
         {
+            EnsureRequestTaskResultNotNull(task);
             static async Task ExecuteAwaited(Task<string> task, HttpContext httpContext)
             {
                 await httpContext.Response.WriteAsync(await task);
@@ -709,6 +711,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteValueTask(ValueTask task)
         {
+            EnsureRequestValueTaskResultNotNull(task);
             static async Task ExecuteAwaited(ValueTask task)
             {
                 await task;
@@ -724,6 +727,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteValueTaskOfT<T>(ValueTask<T> task, HttpContext httpContext)
         {
+            EnsureRequestValueTaskResultNotNull(task);
             static async Task ExecuteAwaited(ValueTask<T> task, HttpContext httpContext)
             {
                 await httpContext.Response.WriteAsJsonAsync(await task);
@@ -739,6 +743,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteValueTaskOfString(ValueTask<string> task, HttpContext httpContext)
         {
+            EnsureRequestValueTaskResultNotNull(task);
             static async Task ExecuteAwaited(ValueTask<string> task, HttpContext httpContext)
             {
                 await httpContext.Response.WriteAsync(await task);
@@ -754,6 +759,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteValueTaskResult<T>(ValueTask<T> task, HttpContext httpContext) where T : IResult
         {
+            EnsureRequestValueTaskResultNotNull(task);
             static async Task ExecuteAwaited(ValueTask<T> task, HttpContext httpContext)
             {
                 await (await task).ExecuteAsync(httpContext);
@@ -769,6 +775,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static async Task ExecuteTaskResult<T>(Task<T> task, HttpContext httpContext) where T : IResult
         {
+            EnsureRequestTaskResultNotNull(task);
             await (await task).ExecuteAsync(httpContext);
         }
 
@@ -817,6 +824,30 @@ namespace Microsoft.AspNetCore.Http
             {
                 var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
                 return loggerFactory.CreateLogger(typeof(RequestDelegateFactory));
+            }
+        }
+
+        private static void EnsureRequestTaskResultNotNull<T>(Task<T> task)
+        {
+            if (task == null)
+            {
+                throw new InvalidOperationException("Task Result should not be null");
+            }
+        }
+
+        private static void EnsureRequestValueTaskResultNotNull<T>(ValueTask<T> task)
+        {
+            if (task.Equals(null))
+            {
+                throw new InvalidOperationException("Endpoint result should not be null");
+            }
+        }
+
+        private static void EnsureRequestValueTaskResultNotNull(ValueTask task)
+        {
+            if (task.Equals(null))
+            {
+                throw new InvalidOperationException("Endpoint result should not be null");
             }
         }
     }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -680,6 +680,7 @@ namespace Microsoft.AspNetCore.Http
         private static Task ExecuteTask<T>(Task<T> task, HttpContext httpContext)
         {
             EnsureRequestTaskOfNotNull(task);
+
             static async Task ExecuteAwaited(Task<T> task, HttpContext httpContext)
             {
                 await httpContext.Response.WriteAsJsonAsync(await task);

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -711,7 +711,6 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteValueTask(ValueTask task)
         {
-            EnsureRequestValueTaskResultNotNull(task);
             static async Task ExecuteAwaited(ValueTask task)
             {
                 await task;
@@ -727,7 +726,6 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteValueTaskOfT<T>(ValueTask<T> task, HttpContext httpContext)
         {
-            EnsureRequestValueTaskResultNotNull(task);
             static async Task ExecuteAwaited(ValueTask<T> task, HttpContext httpContext)
             {
                 await httpContext.Response.WriteAsJsonAsync(await task);
@@ -743,7 +741,6 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteValueTaskOfString(ValueTask<string> task, HttpContext httpContext)
         {
-            EnsureRequestValueTaskResultNotNull(task);
             static async Task ExecuteAwaited(ValueTask<string> task, HttpContext httpContext)
             {
                 await httpContext.Response.WriteAsync(await task);
@@ -759,7 +756,6 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteValueTaskResult<T>(ValueTask<T> task, HttpContext httpContext) where T : IResult
         {
-            EnsureRequestValueTaskResultNotNull(task);
             static async Task ExecuteAwaited(ValueTask<T> task, HttpContext httpContext)
             {
                 await (await task).ExecuteAsync(httpContext);
@@ -829,25 +825,9 @@ namespace Microsoft.AspNetCore.Http
 
         private static void EnsureRequestTaskResultNotNull<T>(Task<T> task)
         {
-            if (task == null)
+            if (task is null)
             {
                 throw new InvalidOperationException("Task Result should not be null");
-            }
-        }
-
-        private static void EnsureRequestValueTaskResultNotNull<T>(ValueTask<T> task)
-        {
-            if (task.Equals(null))
-            {
-                throw new InvalidOperationException("Endpoint result should not be null");
-            }
-        }
-
-        private static void EnsureRequestValueTaskResultNotNull(ValueTask task)
-        {
-            if (task.Equals(null))
-            {
-                throw new InvalidOperationException("Endpoint result should not be null");
             }
         }
     }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -741,7 +741,7 @@ namespace Microsoft.AspNetCore.Http
             return ExecuteAwaited(task, httpContext);
         }
 
-        private static Task ExecuteValueTaskOfString(ValueTask<string> task, HttpContext httpContext)
+        private static Task ExecuteValueTaskOfString(ValueTask<string?> task, HttpContext httpContext)
         {
             EnsureRequestValueTaskOfNotNull(task);
             static async Task ExecuteAwaited(ValueTask<string> task, HttpContext httpContext)
@@ -751,13 +751,13 @@ namespace Microsoft.AspNetCore.Http
 
             if (task.IsCompletedSuccessfully)
             {
-                return httpContext.Response.WriteAsync(task.GetAwaiter().GetResult());
+                return httpContext.Response.WriteAsync(task.GetAwaiter().GetResult()!);
             }
 
-            return ExecuteAwaited(task, httpContext);
+            return ExecuteAwaited(task!, httpContext);
         }
 
-        private static Task ExecuteValueTaskResult<T>(ValueTask<T> task, HttpContext httpContext) where T : IResult
+        private static Task ExecuteValueTaskResult<T>(ValueTask<T?> task, HttpContext httpContext) where T : IResult
         {
             EnsureRequestValueTaskOfNotNull(task);
             static async Task ExecuteAwaited(ValueTask<T> task, HttpContext httpContext)
@@ -767,16 +767,16 @@ namespace Microsoft.AspNetCore.Http
 
             if (task.IsCompletedSuccessfully)
             {
-                return task.GetAwaiter().GetResult().ExecuteAsync(httpContext);
+                return task.GetAwaiter().GetResult()!.ExecuteAsync(httpContext);
             }
 
-            return ExecuteAwaited(task, httpContext);
+            return ExecuteAwaited(task!, httpContext);
         }
 
-        private static async Task ExecuteTaskResult<T>(Task<T> task, HttpContext httpContext) where T : IResult
+        private static async Task ExecuteTaskResult<T>(Task<T?> task, HttpContext httpContext) where T : IResult
         {
             EnsureRequestTaskOfNotNull(task);
-            await (await task).ExecuteAsync(httpContext);
+            await (await task)!.ExecuteAsync(httpContext);
         }
 
         private static async Task ExecuteResultWriteResponse(IResult result, HttpContext httpContext)
@@ -851,7 +851,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static void EnsureRequestValueTaskOfNotNull<T>(ValueTask<T> task)
         {
-            if (task.Result is null)
+            if (task.Equals(default(ValueTask<T>)))
             {
                 throw new InvalidOperationException("ValueTask Result should not be null");
             }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1086,15 +1086,17 @@ namespace Microsoft.AspNetCore.Routing.Internal
             get
             {
                 IResult? TestAction() => null;
-                Task<IResult?>? TaskNullTestAction() => null;
+                Task<bool?>? TaskBoolAction() => null;
+                Task<IResult?>? TaskNullAction() => null;
                 Task<IResult?> TaskTestAction() => Task.FromResult<IResult?>(null);
                 ValueTask<IResult?> ValueTaskTestAction() => ValueTask.FromResult<IResult?>(null);
 
                 return new List<object[]>
                 {
                     new object[] { (Func<IResult?>)TestAction, "The IResult returned by the Delegate must not be null." },
-                    new object[] { (Func<Task<IResult?>?>)TaskNullTestAction, "The Task returned by the Delegate must not be null." },
-                    new object[] { (Func<Task<IResult?>>)TaskTestAction, "The IResult in Task<IResult> response must not be null." },
+                    new object[] { (Func<Task<IResult?>?>)TaskNullAction, "The IResult in Task<IResult> response must not be null." },
+                    new object[] { (Func<Task<bool?>?>)TaskBoolAction, "The Task returned by the Delegate must not be null." },
+                    new object[] { (Func<Task<IResult?>>)TaskTestAction, "The IResult returned by the Delegate must not be null." },
                     new object[] { (Func<ValueTask<IResult?>>)ValueTaskTestAction, "The IResult returned by the Delegate must not be null." },
                 };
             }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1116,6 +1116,54 @@ namespace Microsoft.AspNetCore.Routing.Internal
             Assert.Contains(message, exception.Message);
         }
 
+        public static IEnumerable<object[]> NullContentResult
+        {
+            get
+            {
+                bool? TestBoolAction() => null;
+                Task<bool?> TaskTestBoolAction() => Task.FromResult<bool?>(null);
+                ValueTask<bool?> ValueTaskTestBoolAction() => ValueTask.FromResult<bool?>(null);
+
+                int? TestIntAction() => null;
+                Task<int?> TaskTestIntAction() => Task.FromResult<int?>(null);
+                ValueTask<int?> ValueTaskTestIntAction() => ValueTask.FromResult<int?>(null);
+
+                Todo? TestTodoAction() => null;
+                Task<Todo?> TaskTestTodoAction() => Task.FromResult<Todo?>(null);
+                ValueTask<Todo?> ValueTaskTestTodoAction() => ValueTask.FromResult<Todo?>(null);
+
+                return new List<object[]>
+                {
+                    new object[] { (Func<bool?>)TestBoolAction },
+                    new object[] { (Func<Task<bool?>>)TaskTestBoolAction },
+                    new object[] { (Func<ValueTask<bool?>>)ValueTaskTestBoolAction },
+                    new object[] { (Func<int?>)TestIntAction },
+                    new object[] { (Func<Task<int?>>)TaskTestIntAction },
+                    new object[] { (Func<ValueTask<int?>>)ValueTaskTestIntAction },
+                    new object[] { (Func<Todo?>)TestTodoAction },
+                    new object[] { (Func<Task<Todo?>>)TaskTestTodoAction },
+                    new object[] { (Func<ValueTask<Todo?>>)ValueTaskTestTodoAction },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NullContentResult))]
+        public async Task RequestDelegateWritesNullReturnNullValue(Delegate @delegate)
+        {
+            var httpContext = new DefaultHttpContext();
+            var responseBodyStream = new MemoryStream();
+            httpContext.Response.Body = responseBodyStream;
+
+            var requestDelegate = RequestDelegateFactory.Create(@delegate);
+
+            await requestDelegate(httpContext);
+
+            var responseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+
+            Assert.Equal("null", responseBody);
+        }
+
         private class Todo
         {
             public int Id { get; set; }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1086,23 +1086,23 @@ namespace Microsoft.AspNetCore.Routing.Internal
             get
             {
                 IResult? TestAction() => null;
-                Task<bool?>? TestTaskBoolAction() => null;
+                Task<IResult?>? TaskNullTestAction() => null;
                 Task<IResult?> TaskTestAction() => Task.FromResult<IResult?>(null);
                 ValueTask<IResult?> ValueTaskTestAction() => ValueTask.FromResult<IResult?>(null);
 
                 return new List<object[]>
                 {
-                    new object[] { (Func<Task<bool?>?>)TestTaskBoolAction },
-                    new object[] { (Func<IResult?>)TestAction },
-                    new object[] { (Func<Task<IResult?>>)TaskTestAction },
-                    new object[] { (Func<ValueTask<IResult?>>)ValueTaskTestAction },
+                    new object[] { (Func<IResult?>)TestAction, "The IResult returned by the Delegate must not be null." },
+                    new object[] { (Func<Task<IResult?>?>)TaskNullTestAction, "The Task returned by the Delegate must not be null." },
+                    new object[] { (Func<Task<IResult?>>)TaskTestAction, "The IResult in Task<IResult> response must not be null." },
+                    new object[] { (Func<ValueTask<IResult?>>)ValueTaskTestAction, "The IResult returned by the Delegate must not be null." },
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(NullResult))]
-        public async Task RequestDelegateThrowsInvalidOperationExceptionOnNullDelegate(Delegate @delegate)
+        public async Task RequestDelegateThrowsInvalidOperationExceptionOnNullDelegate(Delegate @delegate, string message)
         {
             var httpContext = new DefaultHttpContext();
             var responseBodyStream = new MemoryStream();
@@ -1111,7 +1111,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var requestDelegate = RequestDelegateFactory.Create(@delegate);
 
             var exception = await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await requestDelegate(httpContext));
-            Assert.Contains("response should not be null", exception.Message);
+            Assert.Contains(message, exception.Message);
         }
 
         private class Todo


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Add null check on Task, Task<IResult>, ValueTask, ValueTask<IResult>

**PR Description**
Prevent returning null from **`Map{Verb}(string, Delegate)`**, adding a null check (that throw an exception) on **`Task, Task<IResult>, ValueTask, ValueTask<IResult>`**

https://github.com/wcontayon/AspNetCore/blob/cae7c582b6aec95c780897c089cc6d3e936842d7/src/Http/Http.Extensions/src/RequestDelegateFactory.cs#L830-L852

Fixes #32865
