### PR TITLE
Fix WebApplication to read environment specific logging configuration

### DIFF
--- a/src/DefaultBuilder/DefaultBuilder.slnf
+++ b/src/DefaultBuilder/DefaultBuilder.slnf
@@ -1,13 +1,24 @@
-﻿{
+{
   "solution": {
     "path": "..\\..\\AspNetCore.sln",
-    "projects" : [
+    "projects": [
       "src\\DefaultBuilder\\samples\\SampleApp\\DefaultBuilder.SampleApp.csproj",
-      "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.Tests\\Microsoft.AspNetCore.Tests.csproj",
-      "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.FunctionalTests\\Microsoft.AspNetCore.FunctionalTests.csproj",
       "src\\DefaultBuilder\\src\\Microsoft.AspNetCore.csproj",
+      "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.FunctionalTests\\Microsoft.AspNetCore.FunctionalTests.csproj",
+      "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.Tests\\Microsoft.AspNetCore.Tests.csproj",
+      "src\\Hosting\\Abstractions\\src\\Microsoft.AspNetCore.Hosting.Abstractions.csproj",
+      "src\\Hosting\\Hosting\\src\\Microsoft.AspNetCore.Hosting.csproj",
+      "src\\Hosting\\Server.Abstractions\\src\\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj",
       "src\\Hosting\\Server.IntegrationTesting\\src\\Microsoft.AspNetCore.Server.IntegrationTesting.csproj",
-      "src\\Middleware\\StaticFiles\\src\\Microsoft.AspNetCore.StaticFiles.csproj"
+      "src\\Http\\Features\\src\\Microsoft.Extensions.Features.csproj",
+      "src\\Http\\Headers\\src\\Microsoft.Net.Http.Headers.csproj",
+      "src\\Http\\Http.Abstractions\\src\\Microsoft.AspNetCore.Http.Abstractions.csproj",
+      "src\\Http\\Http.Extensions\\src\\Microsoft.AspNetCore.Http.Extensions.csproj",
+      "src\\Http\\Http.Features\\src\\Microsoft.AspNetCore.Http.Features.csproj",
+      "src\\Http\\Http\\src\\Microsoft.AspNetCore.Http.csproj",
+      "src\\Http\\WebUtilities\\src\\Microsoft.AspNetCore.WebUtilities.csproj",
+      "src\\Middleware\\StaticFiles\\src\\Microsoft.AspNetCore.StaticFiles.csproj",
+      "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj"
     ]
   }
 }

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Builder
         private IDisposable? _changeTokenRegistration;
 
         /// <summary>
-        /// Creates an empty  mutable configuration object that is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
+        /// Creates an empty mutable configuration object that is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
         /// </summary>
         public Configuration()
         {
@@ -103,6 +103,7 @@ namespace Microsoft.AspNetCore.Builder
                 Update();
             }
         }
+
         private ConfigurationRoot BuildConfigurationRoot()
         {
             var providers = new List<IConfigurationProvider>();

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -15,18 +15,24 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public sealed class ConfigureWebHostBuilder : IWebHostBuilder
     {
-        private Action<IWebHostBuilder>? _operations;
-
         private readonly WebHostEnvironment _environment;
         private readonly Configuration _configuration;
         private readonly Dictionary<string, string?> _settings = new(StringComparer.OrdinalIgnoreCase);
         private readonly IServiceCollection _services;
+
+        private readonly WebHostBuilderContext _context;
 
         internal ConfigureWebHostBuilder(Configuration configuration, WebHostEnvironment environment, IServiceCollection services)
         {
             _configuration = configuration;
             _environment = environment;
             _services = services;
+
+            _context = new WebHostBuilderContext
+            {
+                Configuration = _configuration,
+                HostingEnvironment = _environment
+            };
         }
 
         IWebHost IWebHostBuilder.Build()
@@ -37,19 +43,17 @@ namespace Microsoft.AspNetCore.Builder
         /// <inheritdoc />
         public IWebHostBuilder ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate)
         {
-            _operations += b => b.ConfigureAppConfiguration(configureDelegate);
+            // Run these immediately so that they are observable by the imperative code
+            configureDelegate(_context, _configuration);
+            _environment.ApplyConfigurationSettings(_configuration);
             return this;
         }
 
         /// <inheritdoc />
         public IWebHostBuilder ConfigureServices(Action<WebHostBuilderContext, IServiceCollection> configureServices)
         {
-            configureServices(new WebHostBuilderContext
-            {
-                Configuration = _configuration,
-                HostingEnvironment = _environment
-            },
-            _services);
+            // Run these immediately so that they are observable by the imperative code
+            configureServices(_context, _services);
             return this;
         }
 
@@ -70,7 +74,6 @@ namespace Microsoft.AspNetCore.Builder
         public IWebHostBuilder UseSetting(string key, string? value)
         {
             _settings[key] = value;
-            _operations += b => b.UseSetting(key, value);
 
             // All properties on IWebHostEnvironment are non-nullable.
             if (value is null)
@@ -86,8 +89,6 @@ namespace Microsoft.AspNetCore.Builder
             {
                 _environment.ContentRootPath = value;
                 _environment.ResolveFileProviders(_configuration);
-
-                _configuration.ChangeBasePath(value);
             }
             else if (string.Equals(key, WebHostDefaults.EnvironmentKey, StringComparison.OrdinalIgnoreCase))
             {
@@ -102,9 +103,12 @@ namespace Microsoft.AspNetCore.Builder
             return this;
         }
 
-        internal void ExecuteActions(IWebHostBuilder webHostBuilder)
+        internal void ApplySettings(IWebHostBuilder webHostBuilder)
         {
-            _operations?.Invoke(webHostBuilder);
+            foreach (var (key, value) in _settings)
+            {
+                webHostBuilder.UseSetting(key, value);
+            }
         }
     }
 }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -28,6 +28,8 @@ namespace Microsoft.AspNetCore.Builder
             // HACK: MVC and Identity do this horrible thing to get the hosting environment as an instance
             // from the service collection before it is built. That needs to be fixed...
             Environment = _environment = new WebHostEnvironment(callingAssembly);
+
+            Configuration.SetBasePath(_environment.ContentRootPath);
             Services.AddSingleton(Environment);
 
             // Run methods to configure both generic and web host defaults early to populate config from appsettings.json
@@ -36,13 +38,33 @@ namespace Microsoft.AspNetCore.Builder
             var bootstrapBuilder = new BootstrapHostBuilder(Configuration, _environment);
             bootstrapBuilder.ConfigureDefaults(args);
             bootstrapBuilder.ConfigureWebHostDefaults(configure: _ => { });
+            bootstrapBuilder.RunConfigurationCallbacks();
 
-            Configuration.SetBasePath(_environment.ContentRootPath);
             Logging = new LoggingBuilder(Services);
             WebHost = _deferredWebHostBuilder = new ConfigureWebHostBuilder(Configuration, _environment, Services);
             Host = _deferredHostBuilder = new ConfigureHostBuilder(Configuration, _environment, Services);
 
+            // Register Configuration as IConfiguration so updates can be observed even after the WebApplication is built.
+            Services.AddSingleton<IConfiguration>(Configuration);
+
+            // Add default services
             _deferredHostBuilder.ConfigureDefaults(args);
+            _deferredHostBuilder.ConfigureWebHostDefaults(configure: _ => { });
+
+            // This is important because GenericWebHostBuilder does the following and we want to preserve the WebHostBuilderContext:
+            // context.Properties[typeof(WebHostBuilderContext)] = webHostBuilderContext;
+            // context.Properties[typeof(WebHostOptions)] = options;
+            foreach (var (key, value) in _deferredHostBuilder.Properties)
+            {
+                _hostBuilder.Properties[key] = value;
+            }
+
+            // Configuration changes made by ConfigureDefaults(args) were already picked up by the BootstrapHostBuilder,
+            // so we ignore changes to config until ConfigureDefaults completes.
+            _deferredHostBuilder.ConfigurationEnabled = true;
+            // Now that consuming code can start modifying Configuration, we need to automatically rebuild on modification.
+            // To this point, we've been manually calling Configuration.UpdateConfiguration() only when needed to reduce I/O.
+            Configuration.AutoUpdate = true;
         }
 
         /// <summary>
@@ -58,16 +80,16 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
         /// </summary>
-        public Configuration Configuration { get; } = new();
+        public Configuration Configuration { get; } = new() { AutoUpdate = false };
 
         /// <summary>
-        /// A collection of logging providers for the applicaiton to compose. This is useful for adding new logging providers.
+        /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.
         /// </summary>
         public ILoggingBuilder Logging { get; }
 
         /// <summary>
         /// An <see cref="IHostBuilder"/> for configuring server specific properties, but not building.
-        /// To build after configuruation, call <see cref="Build"/>.
+        /// To build after configuration, call <see cref="Build"/>.
         /// </summary>
         public ConfigureWebHostBuilder WebHost { get; }
 
@@ -83,9 +105,11 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>A configured <see cref="WebApplication"/>.</returns>
         public WebApplication Build()
         {
+            // We call ConfigureWebHostDefaults AGAIN because config might be added like "ForwardedHeaders_Enabled"
+            // which can add even more services. If not for that, we probably call _hostBuilder.ConfigureWebHost(ConfigureWebHost)
+            // instead in order to avoid duplicate service registration.
             _hostBuilder.ConfigureWebHostDefaults(ConfigureWebHost);
-            _builtApplication = new WebApplication(_hostBuilder.Build());
-            return _builtApplication;
+            return _builtApplication = new WebApplication(_hostBuilder.Build());
         }
 
         private void ConfigureApplication(WebHostBuilderContext context, IApplicationBuilder app)
@@ -150,31 +174,52 @@ namespace Microsoft.AspNetCore.Builder
             {
                 app.Properties[item.Key] = item.Value;
             }
-
         }
 
         private void ConfigureWebHost(IWebHostBuilder genericWebHostBuilder)
         {
-            genericWebHostBuilder.Configure(ConfigureApplication);
-
-            _hostBuilder.ConfigureServices((context, services) =>
+            _hostBuilder.ConfigureHostConfiguration(builder =>
             {
+                // TODO: Use a ChainedConfigurationSource instead.
+                // See EnvironmentSpecificLoggingConfigurationSectionPassedToLoggerByDefault in WebApplicationFuncationalTests.
+
+                // All the sources in builder.Sources should be in Configuration.Sources
+                // already thanks to the BootstrapHostBuilder.
+                builder.Sources.Clear();
+
+                foreach (var (key, value) in ((IConfigurationBuilder)Configuration).Properties)
+                {
+                    builder.Properties[key] = value;
+                }
+
+                foreach (var s in ((IConfigurationBuilder)Configuration).Sources)
+                {
+                    builder.Sources.Add(s);
+                }
+            });
+
+            genericWebHostBuilder.ConfigureServices((context, services) =>
+            {
+                // We've only added services configured by the GenericWebHostBuilder and WebHost.ConfigureWebDefaults
+                // at this point. HostBuilder news up a new ServiceCollection in HostBuilder.Build() we haven't seen
+                // until now, so we cannot clear these services even though some are redundant because
+                // we called ConfigureWebHostDefaults on both the _deferredHostBuilder and _hostBuilder.
+
+                // Ideally, we'd only call _hostBuilder.ConfigureWebHost(ConfigureWebHost) instead of
+                // _hostBuilder.ConfigureWebHostDefaults(ConfigureWebHost) to avoid some duplicate service descriptors,
+                // but we want to add services in the WebApplicationBuilder constructor so code can inspect
+                // WebApplicationBuilder.Services. At the same time, we want to be able which services are loaded
+                // to react to config changes (e.g. ForwardedHeadersStartupFilter).
                 foreach (var s in Services)
                 {
                     services.Add(s);
                 }
             });
 
-            _hostBuilder.ConfigureAppConfiguration((hostContext, builder) =>
-            {
-                foreach (var s in Configuration.Sources)
-                {
-                    builder.Sources.Add(s);
-                }
-            });
+            genericWebHostBuilder.Configure(ConfigureApplication);
 
-            _deferredHostBuilder.ExecuteActions(_hostBuilder);
-            _deferredWebHostBuilder.ExecuteActions(genericWebHostBuilder);
+            _deferredHostBuilder.RunDeferredCallbacks(_hostBuilder);
+            _deferredWebHostBuilder.ApplySettings(genericWebHostBuilder);
 
             _environment.ApplyEnvironmentSettings(genericWebHostBuilder);
         }

--- a/src/DefaultBuilder/src/WebHostEnvironment.cs
+++ b/src/DefaultBuilder/src/WebHostEnvironment.cs
@@ -69,6 +69,23 @@ namespace Microsoft.AspNetCore.Builder
             genericWebHostBuilder.UseSetting(WebHostDefaults.EnvironmentKey, EnvironmentName);
             genericWebHostBuilder.UseSetting(WebHostDefaults.ContentRootKey, ContentRootPath);
             genericWebHostBuilder.UseSetting(WebHostDefaults.WebRootKey, WebRootPath);
+
+            genericWebHostBuilder.ConfigureAppConfiguration((context, builder) =>
+            {
+                CopyProperitesTo(context.HostingEnvironment);
+            });
+        }
+
+        internal void CopyProperitesTo(IWebHostEnvironment destination)
+        {
+            destination.ApplicationName = ApplicationName;
+            destination.EnvironmentName = EnvironmentName;
+
+            destination.ContentRootPath = ContentRootPath;
+            destination.ContentRootFileProvider = ContentRootFileProvider;
+
+            destination.WebRootPath = WebRootPath;
+            destination.WebRootFileProvider = WebRootFileProvider;
         }
 
         public void ResolveFileProviders(IConfiguration configuration)

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebApplicationFunctionalTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebApplicationFunctionalTests.cs
@@ -51,5 +51,52 @@ namespace Microsoft.AspNetCore.Tests
                 File.Delete("appsettings.json");
             }
         }
+
+        [Fact]
+        public async Task EnvironmentSpecificLoggingConfigurationSectionPassedToLoggerByDefault()
+        {
+            try
+            {
+                await File.WriteAllTextAsync("appsettings.Development.json", @"
+{
+    ""Logging"": {
+        ""LogLevel"": {
+            ""Default"": ""Warning""
+        }
+    }
+}");
+
+                var app = WebApplication.Create(new[] { "--environment", "Development" });
+
+                // TODO: Make this work! I think it should be possible if we register our Configuration
+                // as a ChainedConfigurationSource instead of copying over the bootstrapped IConfigurationSources.
+                //var builder = WebApplication.CreateBuilder();
+                //builder.Environment.EnvironmentName = "Development";
+                //await using var app = builder.Build();
+
+                var factory = (ILoggerFactory)app.Services.GetService(typeof(ILoggerFactory));
+                var logger = factory.CreateLogger("Test");
+
+                logger.Log(LogLevel.Information, 0, "Message", null, (s, e) =>
+                {
+                    Assert.True(false);
+                    return string.Empty;
+                });
+
+                var logWritten = false;
+                logger.Log(LogLevel.Warning, 0, "Message", null, (s, e) =>
+                {
+                    logWritten = true;
+                    return string.Empty;
+                });
+
+                Assert.True(logWritten);
+            }
+            finally
+            {
+                File.Delete("appsettings.json");
+            }
+        }
+
     }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigurationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigurationTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Tests
+{
+    public class ConfigurationTests
+    {
+        [Fact]
+        public void AutoUpdatesByDefault()
+        {
+            var config = new Configuration();
+
+            Assert.True(config.AutoUpdate);
+
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "TestKey", "TestValue" },
+            });
+
+            Assert.Equal("TestValue", config["TestKey"]);
+        }
+
+        [Fact]
+        public void AutoUpdateTriggersReloadTokenOnSourceModification()
+        {
+            var config = new Configuration();
+
+            var reloadToken = ((IConfiguration)config).GetReloadToken();
+
+            Assert.False(reloadToken.HasChanged);
+
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "TestKey", "TestValue" },
+            });
+
+            Assert.True(reloadToken.HasChanged);
+        }
+
+        [Fact]
+        public void DoesNotAutoUpdateWhenAutoUpdateDisabled()
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = false,
+            };
+
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "TestKey", "TestValue" },
+            });
+
+            Assert.Null(config["TestKey"]);
+
+            config.Update();
+
+            Assert.Equal("TestValue", config["TestKey"]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ManualUpdateTriggersReloadTokenWithOrWithoutAutoUpdate(bool autoUpdate)
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = autoUpdate,
+            };
+
+            var manualReloadToken = ((IConfiguration)config).GetReloadToken();
+
+            Assert.False(manualReloadToken.HasChanged);
+
+            config.Update();
+
+            Assert.True(manualReloadToken.HasChanged);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SettingValuesWorksWithOrWithoutAutoUpdate(bool autoUpdate)
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = autoUpdate,
+                ["TestKey"] = "TestValue",
+            };
+
+            Assert.Equal("TestValue", config["TestKey"]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SettingValuesDoesNotTriggerReloadTokenWithOrWithoutAutoUpdate(bool autoUpdate)
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = autoUpdate,
+            };
+
+            var reloadToken = ((IConfiguration)config).GetReloadToken();
+
+            config["TestKey"] = "TestValue";
+
+            Assert.Equal("TestValue", config["TestKey"]);
+
+            // ConfigurationRoot doesn't fire the token today when the setter is called. Maybe we should change that.
+            // At least you can manually call Configuration.Update() to fire a reload though this reloads all sources unnecessarily.
+            Assert.False(reloadToken.HasChanged);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SettingIConfigurationBuilderPropertiesWorksWithoutAutoUpdate(bool autoUpdate)
+        {
+            var config = new Configuration
+            {
+                AutoUpdate = autoUpdate,
+            };
+
+            var configBuilder = (IConfigurationBuilder)config;
+
+            var reloadToken = ((IConfiguration)config).GetReloadToken();
+
+            configBuilder.Properties["TestKey"] = "TestValue";
+
+            Assert.Equal("TestValue", configBuilder.Properties["TestKey"]);
+
+            // Changing properties should not change config keys or fire reload token.
+            Assert.Null(config["TestKey"]);
+            Assert.False(reloadToken.HasChanged);
+        }
+    }
+}

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -179,7 +179,6 @@ namespace Microsoft.AspNetCore.Tests
             var envName = $"{nameof(WebApplicationTests)}_ENV";
 
             builder.WebHost.UseSetting("applicationname", nameof(WebApplicationTests));
-
             builder.WebHost.UseSetting("ENVIRONMENT", envName);
             builder.WebHost.UseSetting("CONTENTROOT", contentRoot);
             builder.WebHost.UseSetting("WEBROOT", webRoot);


### PR DESCRIPTION
- Apply host config before app config
- Avoid duplicate config sources
- Reduce I/O reloading config while bootstrapping
- Reduce duplicate services

Before this change, logging configuration like the following would not be respected if it was in an environment-specific config like `appsettings.Development.json` (as opposed to `appsettings.json`).

```
{
  "Logging": {
    "LogLevel": {
      "Default": "Information",
      "Microsoft": "Debug",
      "Microsoft.Hosting.Lifetime": "Information"
    }
  }
}
```

This also removes a ton of duplicate and conflicting configuration sources as noted previous closed PR: #32822

Loading less sources and not automatically reloading sources every time one is added during the "bootstrapping" of the default configuration results in far fewer file system checks leading to better startup performance.

Fixes #32383
Fixes #32432 

This is the same as #32926 but targets main.
