### PR TITLE
Apply diagnostic and fix for API1000 and API1001 to expression-bodied methods

### DIFF
--- a/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadata.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadata.cs
@@ -11,21 +11,21 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
     {
         private readonly int? _statusCode;
 
-        public ActualApiResponseMetadata(ReturnStatementSyntax returnStatement, ITypeSymbol returnType)
+        public ActualApiResponseMetadata(ExpressionSyntax returnExpression, ITypeSymbol returnType)
         {
-            ReturnStatement = returnStatement;
+            ReturnExpression = returnExpression;
             ReturnType = returnType;
             _statusCode = null;
         }
 
-        public ActualApiResponseMetadata(ReturnStatementSyntax returnStatement, int statusCode, ITypeSymbol? returnType)
+        public ActualApiResponseMetadata(ExpressionSyntax returnExpression, int statusCode, ITypeSymbol? returnType)
         {
-            ReturnStatement = returnStatement;
+            ReturnExpression = returnExpression;
             _statusCode = statusCode;
             ReturnType = returnType;
         }
 
-        public ReturnStatementSyntax ReturnStatement { get; }
+        public ExpressionSyntax ReturnExpression { get; }
 
         public int StatusCode => _statusCode ?? throw new ArgumentException("Status code is not available when IsDefaultResponse is true");
 

--- a/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadata.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadata.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {
@@ -11,21 +11,21 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
     {
         private readonly int? _statusCode;
 
-        public ActualApiResponseMetadata(ExpressionSyntax returnExpression, ITypeSymbol returnType)
+        public ActualApiResponseMetadata(IReturnOperation returnExpression, ITypeSymbol returnType)
         {
-            ReturnExpression = returnExpression;
+            ReturnOperation = returnExpression;
             ReturnType = returnType;
             _statusCode = null;
         }
 
-        public ActualApiResponseMetadata(ExpressionSyntax returnExpression, int statusCode, ITypeSymbol? returnType)
+        public ActualApiResponseMetadata(IReturnOperation returnExpression, int statusCode, ITypeSymbol? returnType)
         {
-            ReturnExpression = returnExpression;
+            ReturnOperation = returnExpression;
             _statusCode = statusCode;
             ReturnType = returnType;
         }
 
-        public ExpressionSyntax ReturnExpression { get; }
+        public IReturnOperation ReturnOperation { get; }
 
         public int StatusCode => _statusCode ?? throw new ArgumentException("Status code is not available when IsDefaultResponse is true");
 

--- a/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadataFactory.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadataFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 var responseMetadata = InspectReturnStatementSyntax(
                     symbolCache,
                     semanticModel,
-                    returnStatementSyntax,
+                    returnStatementSyntax.Expression,
                     cancellationToken);
 
                 if (responseMetadata != null)
@@ -64,10 +64,9 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         internal static ActualApiResponseMetadata? InspectReturnStatementSyntax(
             in ApiControllerSymbolCache symbolCache,
             SemanticModel semanticModel,
-            ReturnStatementSyntax returnStatementSyntax,
+            ExpressionSyntax returnExpression,
             CancellationToken cancellationToken)
         {
-            var returnExpression = returnStatementSyntax.Expression;
             var typeInfo = semanticModel.GetTypeInfo(returnExpression, cancellationToken);
             if (typeInfo.Type == null || typeInfo.Type.TypeKind == TypeKind.Error)
             {
@@ -79,7 +78,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
             if (!symbolCache.IActionResult.IsAssignableFrom(statementReturnType))
             {
                 // Return expression is not an instance of IActionResult. Must be returning the "model".
-                return new ActualApiResponseMetadata(returnStatementSyntax, statementReturnType);
+                return new ActualApiResponseMetadata(returnExpression, statementReturnType);
             }
 
             var defaultStatusCodeAttribute = statementReturnType
@@ -124,7 +123,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 return null;
             }
 
-            return new ActualApiResponseMetadata(returnStatementSyntax, statusCode.Value, returnType);
+            return new ActualApiResponseMetadata(returnExpression, statusCode.Value, returnType);
         }
 
         private static (int? statusCode, ITypeSymbol? returnType) InspectInitializers(

--- a/src/Mvc/Mvc.Api.Analyzers/src/AddResponseTypeAttributeCodeFixAction.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/AddResponseTypeAttributeCodeFixAction.cs
@@ -139,8 +139,8 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
             }
 
             var semanticModel = await _document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var methodReturnStatement = (ReturnStatementSyntax)root.FindNode(_diagnostic.Location.SourceSpan);
-            var methodSyntax = methodReturnStatement.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+            var diagnosticNode = root.FindNode(_diagnostic.Location.SourceSpan);
+            var methodSyntax = diagnosticNode.FirstAncestorOrSelf<MethodDeclarationSyntax>();
             var method = semanticModel.GetDeclaredSymbol(methodSyntax, cancellationToken);
 
             if (semanticModel == null)

--- a/src/Mvc/Mvc.Api.Analyzers/src/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzer.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzer.cs
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 var actualMetadata = ActualApiResponseMetadataFactory.InspectReturnStatementSyntax(
                     symbolCache,
                     semanticModel,
-                    returnStatementSyntax,
+                    returnStatementSyntax.Expression,
                     operationAnalysisContext.CancellationToken);
 
                 if (actualMetadata == null || actualMetadata.Value.StatusCode != 400)

--- a/src/Mvc/Mvc.Api.Analyzers/src/ApiConventionAnalyzer.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ApiConventionAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 var hasUndocumentedStatusCodes = false;
                 foreach (var actualMetadata in actualResponseMetadata)
                 {
-                    var location = actualMetadata.ReturnStatement.GetLocation();
+                    var location = actualMetadata.ReturnExpression.GetLocation();
 
                     if (!DeclaredApiResponseMetadata.Contains(declaredResponseMetadata, actualMetadata))
                     {

--- a/src/Mvc/Mvc.Api.Analyzers/test/ActualApiResponseMetadataFactoryTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/ActualApiResponseMetadataFactoryTest.cs
@@ -298,6 +298,27 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 });
         }
 
+        [Fact]
+        public async Task TryGetActualResponseMetadata_ActionWithActionResultOfTReturningOkResultExpression()
+        {
+            // Arrange
+            var typeName = typeof(TryGetActualResponseMetadataController).FullName;
+            var methodName = nameof(TryGetActualResponseMetadataController.ActionWithActionResultOfTReturningOkResultExpression);
+
+            // Act
+            var (success, responseMetadatas, _) = await TryGetActualResponseMetadata(typeName, methodName);
+
+            // Assert
+            Assert.True(success);
+            Assert.Collection(
+                responseMetadatas,
+                metadata =>
+                {
+                    Assert.False(metadata.IsDefaultResponse);
+                    Assert.Equal(200, metadata.StatusCode);
+                });
+        }
+
         private async Task<(bool result, IList<ActualApiResponseMetadata> responseMetadatas, TestSource testSource)> TryGetActualResponseMetadata(string typeName, string methodName)
         {
             var testSource = MvcTestSource.Read(GetType().Name, "TryGetActualResponseMetadataTests");

--- a/src/Mvc/Mvc.Api.Analyzers/test/ActualApiResponseMetadataFactoryTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/ActualApiResponseMetadataFactoryTest.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
             var actualResponseMetadata = ActualApiResponseMetadataFactory.InspectReturnStatementSyntax(
                 symbolCache,
                 compilation.GetSemanticModel(syntaxTree),
-                returnStatement,
+                returnStatement.Expression,
                 CancellationToken.None);
 
             // Assert
@@ -288,13 +288,13 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 {
                     Assert.False(metadata.IsDefaultResponse);
                     Assert.Equal(204, metadata.StatusCode);
-                    AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], metadata.ReturnStatement.GetLocation());
+                    AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], metadata.ReturnExpression.GetLocation());
 
                 },
                 metadata =>
                 {
                     Assert.True(metadata.IsDefaultResponse);
-                    AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM2"], metadata.ReturnStatement.GetLocation());
+                    AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM2"], metadata.ReturnExpression.GetLocation());
                 });
         }
 
@@ -334,7 +334,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
             return ActualApiResponseMetadataFactory.InspectReturnStatementSyntax(
                 symbolCache,
                 compilation.GetSemanticModel(syntaxTree),
-                returnStatement,
+                returnStatement.Expression,
                 CancellationToken.None);
         }
 
@@ -354,7 +354,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
             return ActualApiResponseMetadataFactory.InspectReturnStatementSyntax(
                 symbolCache,
                 compilation.GetSemanticModel(syntaxTree),
-                returnStatement,
+                returnStatement.Expression,
                 CancellationToken.None);
         }
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/AddResponseTypeAttributeCodeFixProviderIntegrationTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/AddResponseTypeAttributeCodeFixProviderIntegrationTest.cs
@@ -54,6 +54,9 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         [Fact]
         public Task CodeFixWorksWhenMultipleIdenticalStatusCodesAreInError() => RunTest();
 
+        [Fact]
+        public Task CodeFixWorksOnExpressionBodiedMethod() => RunTest();
+
         private async Task RunTest([CallerMemberName] string testMethod = "")
         {
             // Arrange

--- a/src/Mvc/Mvc.Api.Analyzers/test/ApiConventionAnalyzerIntegrationTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/ApiConventionAnalyzerIntegrationTest.cs
@@ -60,7 +60,7 @@ namespace Test
         {
             if (id == 0)
             {
-                /*MM*/return NotFound();
+                return /*MM*/NotFound();
             }
 
             return;

--- a/src/Mvc/Mvc.Api.Analyzers/test/DeclaredApiResponseMetadataTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/DeclaredApiResponseMetadataTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 {
     public class DeclaredApiResponseMetadataTest
     {
-        private readonly ReturnStatementSyntax ReturnStatement = SyntaxFactory.ReturnStatement();
+        private readonly ExpressionSyntax ReturnExpression = SyntaxFactory.ThisExpression();
         private readonly AttributeData AttributeData = new TestAttributeData();
 
         [Fact]
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ImplicitResponse;
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ImplicitResponse;
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, 200, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, 200, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ForProducesResponseType(200, AttributeData, Mock.Of<IMethodSymbol>());
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ForProducesResponseType(201, AttributeData, Mock.Of<IMethodSymbol>());
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ForProducesResponseType(201, AttributeData, Mock.Of<IMethodSymbol>());
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, 200, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, 200, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ForProducesResponseType(302, AttributeData, Mock.Of<IMethodSymbol>());
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, 302, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, 302, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ForProducesDefaultResponse(AttributeData, Mock.Of<IMethodSymbol>());
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, actualStatusCode, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, actualStatusCode, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ForProducesDefaultResponse(AttributeData, Mock.Of<IMethodSymbol>());
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, 204, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, 204, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             // Arrange
             var declaredMetadata = DeclaredApiResponseMetadata.ForProducesDefaultResponse(AttributeData, Mock.Of<IMethodSymbol>());
-            var actualMetadata = new ActualApiResponseMetadata(ReturnStatement, null);
+            var actualMetadata = new ActualApiResponseMetadata(ReturnExpression, null);
 
             // Act
             var matches = declaredMetadata.Matches(actualMetadata);

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/TryGetActualResponseMetadataTests.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/TryGetActualResponseMetadataTests.cs
@@ -27,10 +27,10 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ActualApiResponseMeta
 
             if (id == 0)
             {
-                /*MM1*/return NoContent();
+                return /*MM1*/NoContent();
             }
 
-            /*MM2*/return new TryGetActualResponseMetadataModel();
+            return /*MM2*/new TryGetActualResponseMetadataModel();
         }
     }
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/TryGetActualResponseMetadataTests.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ActualApiResponseMetadataFactoryTest/TryGetActualResponseMetadataTests.cs
@@ -32,6 +32,8 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers.TestFiles.ActualApiResponseMeta
 
             return /*MM2*/new TryGetActualResponseMetadataModel();
         }
+
+        public IActionResult ActionWithActionResultOfTReturningOkResultExpression() => Ok();
     }
 
     public class TryGetActualResponseMetadataModel { }

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksOnExpressionBodiedMethod.Input.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksOnExpressionBodiedMethod.Input.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._INPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixWorksOnExpressionBodiedMethodController : ControllerBase
+    {
+        public IActionResult GetItem() => NotFound();
+    }
+}

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksOnExpressionBodiedMethod.Output.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/AddResponseTypeAttributeCodeFixProviderIntegrationTest/CodeFixWorksOnExpressionBodiedMethod.Output.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers._OUTPUT_
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class CodeFixWorksOnExpressionBodiedMethodController : ControllerBase
+    {
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesDefaultResponseType]
+        public IActionResult GetItem() => NotFound();
+    }
+}

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForActionResultOfTReturningMethodWithoutAnyAttributes.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForActionResultOfTReturningMethodWithoutAnyAttributes.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             if (id == null)
             {
-                /*MM*/return NotFound();
+                return /*MM*/NotFound();
             }
 
             return "Hello world";

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForActionResultOfTReturningMethodWithoutSomeAttributes.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForActionResultOfTReturningMethodWithoutSomeAttributes.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
 
             if (!ModelState.IsValid)
             {
-                /*MM*/return UnprocessableEntity();
+                return /*MM*/UnprocessableEntity();
             }
 
             return Ok();

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForControllerWithCustomConvention.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_ForControllerWithCustomConvention.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             if (id < 0)
             {
-                /*MM*/return BadRequest();
+                return /*MM*/BadRequest();
             }
 
             try

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfAsyncMethodReturningValueTaskWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfAsyncMethodReturningValueTaskWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 return NotFound();
             }
 
-            /*MM*/return Ok();
+            return /*MM*/Ok();
         }
     }
 }

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfAsyncMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfAsyncMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
             await Task.Yield();
             if (id == 0)
             {
-                /*MM*/return NotFound();
+                return /*MM*/NotFound();
             }
 
             return Ok();

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithApiConventionMethod_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithApiConventionMethod_ReturnsUndocumentedStatusCode.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         [ApiConventionMethod(typeof(DefaultApiConventions), nameof(DefaultApiConventions.Post))]
         public IActionResult Get(int id)
         {
-            /*MM*/return Accepted();
+            return /*MM*/Accepted();
         }
     }
 }

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttributeAsynchronouslyReturnsValue_WithoutDocumentation.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttributeAsynchronouslyReturnsValue_WithoutDocumentation.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 return NotFound();
             }
 
-            /*MM*/return new DiagnosticsAreReturned_IfMethodWithAttributeAsynchronouslyReturnsValue_WithoutDocumentationModel();
+            return /*MM*/new DiagnosticsAreReturned_IfMethodWithAttributeAsynchronouslyReturnsValue_WithoutDocumentationModel();
         }
     }
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttributeReturnsValue_WithoutDocumentation.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttributeReturnsValue_WithoutDocumentation.cs
@@ -11,7 +11,7 @@
                 return NotFound();
             }
 
-            /*MM*/return new DiagnosticsAreReturned_IfMethodWithAttributeReturnsValue_WithoutDocumentationModel();
+            return /*MM*/new DiagnosticsAreReturned_IfMethodWithAttributeReturnsValue_WithoutDocumentationModel();
         }
     }
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttribute_ReturnsDerivedType.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithAttribute_ReturnsDerivedType.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
                 return NotFound();
             }
 
-            /*MM*/return new DiagnosticsAreReturned_IfMethodWithAttribute_ReturnsDerivedTypeDerived();
+            return /*MM*/new DiagnosticsAreReturned_IfMethodWithAttribute_ReturnsDerivedTypeDerived();
         }
     }
 

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithConvention_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithConvention_ReturnsUndocumentedStatusCode.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Mvc.Api.Analyzers
         {
             if (id < 0)
             {
-                /*MM*/return BadRequest();
+                return /*MM*/BadRequest();
             }
 
             if (id == 0)

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/DiagnosticsAreReturned_IfMethodWithProducesResponseTypeAttribute_ReturnsUndocumentedStatusCode.cs
@@ -8,7 +8,7 @@
         {
             if (id == 0)
             {
-                /*MM*/return NotFound();
+                return /*MM*/NotFound();
             }
 
             return Ok();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Apply diagnostic and fix for API1000 and API1001 to expression-bodied methods

**PR Description**

NOTE: this also has the observable effect of modifying the diagnostic location for return statements for API1000 and API1001, and the secondary location for API1003, to the start of the expression being returned instead of the return statement itself; this can be seen clearly in the diffs for "DiagnosticsAreReturned_*.cs" test files. I believe this is a desirable change, as not only does it make return diagnostics more consistent with expression-bodied diagnostics, but that would be magnified if [diagnostics for conditional expressions](#33105) are implemented.

However, if this observable effect is unacceptable or undesirable, the goal of reporting diagnostics on expression-bodied members can still be achieved, at the cost of some additional complication in `ActualApiResponseMetadataFactory`/`ActualApiResponseMetadata`.


Addresses #33091
