### PR TITLE
Refactor TLS result reporting

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -14,29 +15,111 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
     internal class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicationProtocolFeature, ITlsHandshakeFeature
     {
-        public X509Certificate2? ClientCertificate { get; set; }
+        private readonly SslStream _sslStream;
+        private X509Certificate2? _clientCert;
+        private ReadOnlyMemory<byte>? _applicationProtocol;
+        private SslProtocols? _protocol;
+        private CipherAlgorithmType? _cipherAlgorithm;
+        private int? _cipherStrength;
+        private HashAlgorithmType? _hashAlgorithm;
+        private int? _hashStrength;
+        private ExchangeAlgorithmType? _keyExchangeAlgorithm;
+        private int? _keyExchangeStrength;
 
+        public TlsConnectionFeature(SslStream sslStream)
+        {
+            if (sslStream is null)
+            {
+                throw new ArgumentNullException(nameof(sslStream));
+            }
+
+            _sslStream = sslStream;
+        }
+
+        public X509Certificate2? ClientCertificate
+        {
+            get
+            {
+                if (_clientCert is null)
+                {
+                    _clientCert = ConvertToX509Certificate2(_sslStream.RemoteCertificate);
+                }
+
+                return _clientCert;
+            }
+            set => _clientCert = value;
+        }
+
+        // Used for event source, not part of any of the feature interfaces.
         public string? HostName { get; set; }
 
-        public ReadOnlyMemory<byte> ApplicationProtocol { get; set; }
+        public ReadOnlyMemory<byte> ApplicationProtocol
+        {
+            get => _applicationProtocol ?? _sslStream.NegotiatedApplicationProtocol.Protocol;
+            set => _applicationProtocol = value;
+        }
 
-        public SslProtocols Protocol { get; set; }
+        public SslProtocols Protocol
+        {
+            get => _protocol ?? _sslStream.SslProtocol;
+            set => _protocol = value;
+        }
 
-        public CipherAlgorithmType CipherAlgorithm { get; set; }
+        // We don't store the values for these because they could be changed by a renegotiation.
+        public CipherAlgorithmType CipherAlgorithm
+        {
+            get => _cipherAlgorithm ?? _sslStream.CipherAlgorithm;
+            set => _cipherAlgorithm = value;
+        }
 
-        public int CipherStrength { get; set; }
+        public int CipherStrength
+        {
+            get => _cipherStrength ?? _sslStream.CipherStrength;
+            set => _cipherStrength = value;
+        }
 
-        public HashAlgorithmType HashAlgorithm { get; set; }
+        public HashAlgorithmType HashAlgorithm
+        {
+            get => _hashAlgorithm ?? _sslStream.HashAlgorithm;
+            set => _hashAlgorithm = value;
+        }
 
-        public int HashStrength { get; set; }
+        public int HashStrength
+        {
+            get => _hashStrength ?? _sslStream.HashStrength;
+            set => _hashStrength = value;
+        }
 
-        public ExchangeAlgorithmType KeyExchangeAlgorithm { get; set; }
+        public ExchangeAlgorithmType KeyExchangeAlgorithm
+        {
+            get => _keyExchangeAlgorithm ?? _sslStream.KeyExchangeAlgorithm;
+            set => _keyExchangeAlgorithm = value;
+        }
 
-        public int KeyExchangeStrength { get; set; }
+        public int KeyExchangeStrength
+        {
+            get => _keyExchangeStrength ?? _sslStream.KeyExchangeStrength;
+            set => _keyExchangeStrength = value;
+        }
 
         public Task<X509Certificate2?> GetClientCertificateAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(ClientCertificate);
+        }
+
+        private static X509Certificate2? ConvertToX509Certificate2(X509Certificate? certificate)
+        {
+            if (certificate == null)
+            {
+                return null;
+            }
+
+            if (certificate is X509Certificate2 cert2)
+            {
+                return cert2;
+            }
+
+            return new X509Certificate2(certificate);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -40,12 +40,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         {
             get
             {
-                if (_clientCert is null)
-                {
-                    _clientCert = ConvertToX509Certificate2(_sslStream.RemoteCertificate);
-                }
-
-                return _clientCert;
+                return _clientCert ??= ConvertToX509Certificate2(_sslStream.RemoteCertificate);
             }
             set => _clientCert = value;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -109,17 +109,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         private static X509Certificate2? ConvertToX509Certificate2(X509Certificate? certificate)
         {
-            if (certificate == null)
+            return certificate switch
             {
-                return null;
-            }
-
-            if (certificate is X509Certificate2 cert2)
-            {
-                return cert2;
-            }
-
-            return new X509Certificate2(certificate);
+                null => null,
+                X509Certificate2 cert2 => cert2,
+                _ => new X509Certificate2(certificate),
+            };
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -142,14 +142,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
                 return;
             }
 
-            var feature = new Core.Internal.TlsConnectionFeature();
-            context.Features.Set<ITlsConnectionFeature>(feature);
-            context.Features.Set<ITlsHandshakeFeature>(feature);
-
             var sslDuplexPipe = CreateSslDuplexPipe(
                 context.Transport,
                 context.Features.Get<IMemoryPoolFeature>()?.MemoryPool ?? MemoryPool<byte>.Shared);
             var sslStream = sslDuplexPipe.Stream;
+
+            var feature = new Core.Internal.TlsConnectionFeature(sslStream);
+            context.Features.Set<ITlsConnectionFeature>(feature);
+            context.Features.Set<ITlsHandshakeFeature>(feature);
+            context.Features.Set<ITlsApplicationProtocolFeature>(feature);
 
             try
             {
@@ -195,17 +196,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
                 return;
             }
 
-            feature.ApplicationProtocol = sslStream.NegotiatedApplicationProtocol.Protocol;
-            context.Features.Set<ITlsApplicationProtocolFeature>(feature);
-
-            feature.ClientCertificate = ConvertToX509Certificate2(sslStream.RemoteCertificate);
-            feature.CipherAlgorithm = sslStream.CipherAlgorithm;
-            feature.CipherStrength = sslStream.CipherStrength;
-            feature.HashAlgorithm = sslStream.HashAlgorithm;
-            feature.HashStrength = sslStream.HashStrength;
-            feature.KeyExchangeAlgorithm = sslStream.KeyExchangeAlgorithm;
-            feature.KeyExchangeStrength = sslStream.KeyExchangeStrength;
-            feature.Protocol = sslStream.SslProtocol;
 
             KestrelEventSource.Log.TlsHandshakeStop(context, feature);
 


### PR DESCRIPTION
Contributes to #23948

This is some initial refactoring to enable client cert renegotiation. After this we should only need to modify the GetClientCertificateAsync method (that part's still blocked on https://github.com/dotnet/runtime/pull/51905).