### PR TITLE
Update comments in AddPolicyRegistry methods

### DIFF
--- a/src/HttpClientFactory/Polly/src/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/HttpClientFactory/Polly/src/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             // Create an empty registry, register and return it as an instance. This is the best way to get a
-            // single instance registered using both interfaces.
+            // single instance registered using all the interfaces.
             var registry = new PolicyRegistry();
 
             services.AddSingleton<IConcurrentPolicyRegistry<string>>(registry);
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             // Create an empty registry, configure it and register it as an instance.
-            // This is the best way to get a single instance registered using both interfaces.
+            // This is the best way to get a single instance registered using all the interfaces.
             services.AddSingleton(serviceProvider =>
             {
                 var registry = new PolicyRegistry();


### PR DESCRIPTION
**PR Title**

Update comments in `AddPolicyRegistry()` methods

**PR Description**

There's three interfaces now since #31708, not two, so _"both"_ is no longer correct.
