### PR TITLE
Fewer static Sockets

### DIFF
--- a/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -52,11 +55,7 @@ namespace Sockets.BindTests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33206")]
         public async Task SocketTransportCallsCreateBoundListenSocketForFileHandleEndpoint()
         {
-            // file handle
-            // slightly messy but allows us to create a FileHandleEndPoint
-            // from the underlying OS handle used by the socket
-            using var fileHandleSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            fileHandleSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            using var fileHandleSocket = CreateBoundSocket();
             var endpoint = new FileHandleEndPoint((ulong)fileHandleSocket.Handle, FileHandleType.Auto);
 
             await VerifySocketTransportCallsCreateBoundListenSocketAsync(endpoint);
@@ -74,11 +73,7 @@ namespace Sockets.BindTests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33206")]
         public void CreateDefaultBoundListenSocket_PreservesLocalEndpointFromFileHandleEndpoint()
         {
-            // file handle
-            // slightly messy but allows us to create a FileHandleEndPoint
-            // from the underlying OS handle used by the socket
-            using var fileHandleSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            fileHandleSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            using var fileHandleSocket = CreateBoundSocket();
             var endpoint = new FileHandleEndPoint((ulong)fileHandleSocket.Handle, FileHandleType.Auto);
 
             using var listenSocket = SocketTransportOptions.CreateDefaultBoundListenSocket(endpoint);
@@ -103,6 +98,16 @@ namespace Sockets.BindTests
             }
 
             // TODO: other endpoint types?
+        }
+
+        private static Socket CreateBoundSocket()
+        {
+            // file handle
+            // slightly messy but allows us to create a FileHandleEndPoint
+            // from the underlying OS handle used by the socket
+            var fileHandleSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            fileHandleSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            return fileHandleSocket;
         }
 
         private IHost CreateWebHost(EndPoint endpoint, Action<SocketTransportOptions> configureSocketOptions) =>

--- a/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/SocketTransportOptionsTests.cs
@@ -18,9 +18,7 @@ namespace Sockets.BindTests
 {
     public class SocketTransportOptionsTests : LoggedTestBase
     {
-        [Theory]
-        [MemberData(nameof(GetEndpoints))]
-        public async Task SocketTransportCallsCreateBoundListenSocket(EndPoint endpointToTest)
+        private async Task VerifySocketTransportCallsCreateBoundListenSocketAsync(EndPoint endpointToTest)
         {
             var wasCalled = false;
 
@@ -45,15 +43,49 @@ namespace Sockets.BindTests
 
         [Theory]
         [MemberData(nameof(GetEndpoints))]
-        public void CreateDefaultBoundListenSocket_BindsForAllEndPoints(EndPoint endpoint)
+        public Task SocketTransportCallsCreateBoundListenSocketForNewEndpoints(EndPoint endpointToTest)
+        {
+            return VerifySocketTransportCallsCreateBoundListenSocketAsync(endpointToTest);
+        }
+
+        [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33206")]
+        public async Task SocketTransportCallsCreateBoundListenSocketForFileHandleEndpoint()
+        {
+            // file handle
+            // slightly messy but allows us to create a FileHandleEndPoint
+            // from the underlying OS handle used by the socket
+            using var fileHandleSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            fileHandleSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            var endpoint = new FileHandleEndPoint((ulong)fileHandleSocket.Handle, FileHandleType.Auto);
+
+            await VerifySocketTransportCallsCreateBoundListenSocketAsync(endpoint);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEndpoints))]
+        public void CreateDefaultBoundListenSocket_BindsForNewEndPoints(EndPoint endpoint)
         {
             using var listenSocket = SocketTransportOptions.CreateDefaultBoundListenSocket(endpoint);
             Assert.NotNull(listenSocket.LocalEndPoint);
         }
 
-        // static to ensure that the underlying handle doesn't get disposed
-        // when a local reference is GCed by the iterator in GetEndPoints
-        private static Socket _fileHandleSocket;
+        [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33206")]
+        public void CreateDefaultBoundListenSocket_PreservesLocalEndpointFromFileHandleEndpoint()
+        {
+            // file handle
+            // slightly messy but allows us to create a FileHandleEndPoint
+            // from the underlying OS handle used by the socket
+            using var fileHandleSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            fileHandleSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            var endpoint = new FileHandleEndPoint((ulong)fileHandleSocket.Handle, FileHandleType.Auto);
+
+            using var listenSocket = SocketTransportOptions.CreateDefaultBoundListenSocket(endpoint);
+
+            Assert.NotNull(fileHandleSocket.LocalEndPoint);
+            Assert.Equal(fileHandleSocket.LocalEndPoint, listenSocket.LocalEndPoint);
+        }
 
         public static IEnumerable<object[]> GetEndpoints()
         {
@@ -69,18 +101,6 @@ namespace Sockets.BindTests
                     new UnixDomainSocketEndPoint($"/tmp/{DateTime.UtcNow:yyyyMMddTHHmmss.fff}.sock")
                 };
             }
-
-            // file handle
-            // slightly messy but allows us to create a FileHandleEndPoint
-            // from the underlying OS handle used by the socket
-            _fileHandleSocket = new(
-                AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp
-            );
-            _fileHandleSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-            yield return new object[]
-            {
-                new FileHandleEndPoint((ulong) _fileHandleSocket.Handle, FileHandleType.Auto)
-            };
 
             // TODO: other endpoint types?
         }


### PR DESCRIPTION
This way we don't risk `_fileHandleSocket` getting finalized while the derived socket is still in use just because the member data was re-enumerated.

Addresses #33206.
