### PR TITLE
Recommend checking the logs for errors #33055

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/Pages/Error.cshtml
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/Pages/Error.cshtml
@@ -14,6 +14,11 @@
     </p>
 }
 
+<h3>Server Logs</h3>
+<p>
+    Check the server logs to see the error details. For intructions see the <a href="https://docs.microsoft.com/aspnet/core/fundamentals/logging/">documentation</a>.
+</p>
+
 <h3>Development Mode</h3>
 <p>
     Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.


### PR DESCRIPTION
Fixes #33055

The error page says to enable development mode if you want to see the error, but it does not say what to do in production. In both environments we should recommend checking the server logs before enabling development mode.

Draft until:
- We confirm we like the text (@danroth27?)
- We get an aka link for the docs (@danroth27?)
- I copy it to the other templates