### PR TITLE
Add Bash scripts for launching VS Code with activated env

### DIFF
--- a/src/Antiforgery/startvscode.sh
+++ b/src/Antiforgery/startvscode.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/startvscode.sh" $DIR

--- a/src/Azure/startvscode.sh
+++ b/src/Azure/startvscode.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/startvscode.sh" $DIR

--- a/src/Caching/startvscode.sh
+++ b/src/Caching/startvscode.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/startvscode.sh" $DIR

--- a/src/Components/startvscode.sh
+++ b/src/Components/startvscode.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/startvscode.sh" $DIR

--- a/src/DataProtection/startvscode.sh
+++ b/src/DataProtection/startvscode.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/startvscode.sh" $DIR

--- a/src/Mvc/startvscode.sh
+++ b/src/Mvc/startvscode.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+repo_root="$DIR/../.."
+"$repo_root/startvscode.sh" $DIR

--- a/startvscode.sh
+++ b/startvscode.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This command launches a Visual Studio code with environment variables required to use a local version of the .NET Core SDK.
+
+# This tells .NET Core to use the same dotnet.exe that build scripts use
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export DOTNET_ROOT="$DIR/.dotnet"
+
+# This tells .NET Core not to go looking for .NET Core in other places
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+# Put our local dotnet on PATH first so Visual Studio knows which one to use
+export PATH="$DOTNET_ROOT:$PATH"
+
+# Sets TFW for Visual Studio Code usage
+export TARGET=net6.0
+
+if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
+    echo ".NET Core has not yet been installed. Run `./restore.sh` to install tools."
+    exit 1
+fi
+
+if [ $1 = "" ]; then
+  code .
+else
+  code $1
+fi
+
+exit 1


### PR DESCRIPTION
Adds a Bash version of the `startvscode` script to the repo and includes it in repos that currently have `startvscode.cmd` assets. Verified on `src/Mvc` area.