### PR TITLE
RedirectHandler follows HTTP status code 303 See other

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Handlers/RedirectHandler.cs
+++ b/src/Mvc/Mvc.Testing/src/Handlers/RedirectHandler.cs
@@ -173,6 +173,7 @@ namespace Microsoft.AspNetCore.Mvc.Testing.Handlers
         private bool IsRedirect(HttpResponseMessage response) =>
             response.StatusCode == HttpStatusCode.MovedPermanently ||
                 response.StatusCode == HttpStatusCode.Redirect ||
+                response.StatusCode == HttpStatusCode.RedirectMethod ||
                 response.StatusCode == HttpStatusCode.RedirectKeepVerb ||
                 (int)response.StatusCode == 308;
     }

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureTests.cs
@@ -115,6 +115,20 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [Fact]
+        public async Task TestingInfrastructure_RedirectHandlerFollowsStatusCode303()
+        {
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, "Testing/RedirectHandler/Redirect303");
+            var client = Factory.CreateDefaultClient(
+                new RedirectHandler());
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Test", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
         public async Task TestingInfrastructure_PostRedirectGetWorksWithCookies()
         {
             // Act

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/TestingController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/TestingController.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using System.Net;
 
 namespace BasicWebSite.Controllers
 {
@@ -60,6 +61,30 @@ namespace BasicWebSite.Controllers
             else
             {
                 return Content("false");
+            }
+        }
+
+        [HttpGet("Testing/RedirectHandler/Redirect303")]
+        public IActionResult RedirectHandlerStatusCode303()
+        {
+            return new RedirectUsingStatusCode("Testing/Builder", HttpStatusCode.SeeOther);
+        }
+
+        public class RedirectUsingStatusCode : ActionResult
+        {
+            private string _url;
+            private HttpStatusCode _statusCode;
+
+            public RedirectUsingStatusCode(string url, HttpStatusCode statusCode)
+            {
+                _url = url;
+                _statusCode = statusCode;
+            }
+
+            public override void ExecuteResult(ActionContext context)
+            {
+                context.HttpContext.Response.Redirect(_url);
+                context.HttpContext.Response.StatusCode = (int)_statusCode;
             }
         }
 

--- a/src/Mvc/test/WebSites/GenericHostWebSite/Controllers/TestingController.cs
+++ b/src/Mvc/test/WebSites/GenericHostWebSite/Controllers/TestingController.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using System.Net;
 
 namespace GenericHostWebSite.Controllers
 {
@@ -60,6 +61,30 @@ namespace GenericHostWebSite.Controllers
             else
             {
                 return Content("false");
+            }
+        }
+
+        [HttpGet("Testing/RedirectHandler/Redirect303")]
+        public IActionResult RedirectHandlerStatusCode303()
+        {
+            return new RedirectUsingStatusCode("Testing/Builder", HttpStatusCode.SeeOther);
+        }
+
+        public class RedirectUsingStatusCode : ActionResult
+        {
+            private string _url;
+            private HttpStatusCode _statusCode;
+
+            public RedirectUsingStatusCode(string url, HttpStatusCode statusCode)
+            {
+                _url = url;
+                _statusCode = statusCode;
+            }
+
+            public override void ExecuteResult(ActionContext context)
+            {
+                context.HttpContext.Response.Redirect(_url);
+                context.HttpContext.Response.StatusCode = (int)_statusCode;
             }
         }
 


### PR DESCRIPTION
Addresses #33218.

The HttpClient created by a WebApplicationFactory uses RedirectHandler object to handle the HTTP redirections.
But RedirectHandler didn't recognize status code 303 as the redirection status so the result of the HttpClient request was the redirection itself instead of the redirected content.

Missing HTTP status code for 303 See other was added.