### PR TITLE
Add HTTP/0.9 to Microsoft.AspNetCore.Http.HttpProtocol

### DIFF
--- a/src/Http/Http.Abstractions/src/HttpProtocol.cs
+++ b/src/Http/Http.Abstractions/src/HttpProtocol.cs
@@ -20,6 +20,10 @@ namespace Microsoft.AspNetCore.Http
         // Please do NOT change these to 'const'
 
         /// <summary>
+        ///  HTTP protocol version 0.9.
+        /// </summary>
+        public static readonly string Http09 = "HTTP/0.9";
+        /// <summary>
         ///  HTTP protocol version 1.0.
         /// </summary>
         public static readonly string Http10 = "HTTP/1.0";
@@ -35,6 +39,18 @@ namespace Microsoft.AspNetCore.Http
         ///  HTTP protcol version 3.
         /// </summary>
         public static readonly string Http3 = "HTTP/3";
+
+        /// <summary>
+        /// Returns a value that indicates if the HTTP request protocol is HTTP/0.9.
+        /// </summary>
+        /// <param name="protocol">The HTTP request protocol.</param>
+        /// <returns>
+        /// <see langword="true" /> if the protocol is HTTP/0.9; otherwise, <see langword="false" />.
+        /// </returns>
+        public static bool IsHttp09(string protocol)
+        {
+            return object.ReferenceEquals(Http09, protocol) || StringComparer.OrdinalIgnoreCase.Equals(Http09, protocol);
+        }
 
         /// <summary>
         /// Returns a value that indicates if the HTTP request protocol is HTTP/1.0.
@@ -102,6 +118,7 @@ namespace Microsoft.AspNetCore.Http
                 { Major: 2, Minor: 0 } => Http2,
                 { Major: 1, Minor: 1 } => Http11,
                 { Major: 1, Minor: 0 } => Http10,
+                { Major: 0, Minor: 9 } => Http09,
                 _ => throw new ArgumentOutOfRangeException(nameof(version), "Version doesn't map to a known HTTP protocol.")
             };
         }

--- a/src/Http/Http.Abstractions/src/HttpProtocol.cs
+++ b/src/Http/Http.Abstractions/src/HttpProtocol.cs
@@ -23,18 +23,22 @@ namespace Microsoft.AspNetCore.Http
         ///  HTTP protocol version 0.9.
         /// </summary>
         public static readonly string Http09 = "HTTP/0.9";
+
         /// <summary>
         ///  HTTP protocol version 1.0.
         /// </summary>
         public static readonly string Http10 = "HTTP/1.0";
+
         /// <summary>
         ///  HTTP protocol version 1.1.
         /// </summary>
         public static readonly string Http11 = "HTTP/1.1";
+
         /// <summary>
         ///  HTTP protocol version 2.
         /// </summary>
         public static readonly string Http2 = "HTTP/2";
+
         /// <summary>
         ///  HTTP protcol version 3.
         /// </summary>

--- a/src/Http/Http.Abstractions/src/HttpProtocol.cs
+++ b/src/Http/Http.Abstractions/src/HttpProtocol.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Http
         ///  HTTP protocol version 0.9.
         /// </summary>
         public static readonly string Http09 = "HTTP/0.9";
-        
         /// <summary>
         ///  HTTP protocol version 1.0.
         /// </summary>

--- a/src/Http/Http.Abstractions/src/HttpProtocol.cs
+++ b/src/Http/Http.Abstractions/src/HttpProtocol.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Http
         ///  HTTP protocol version 0.9.
         /// </summary>
         public static readonly string Http09 = "HTTP/0.9";
+        
         /// <summary>
         ///  HTTP protocol version 1.0.
         /// </summary>

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ Microsoft.AspNetCore.Http.Metadata.IFromServiceMetadata
 Microsoft.AspNetCore.Http.Endpoint.Endpoint(Microsoft.AspNetCore.Http.RequestDelegate? requestDelegate, Microsoft.AspNetCore.Http.EndpointMetadataCollection? metadata, string? displayName) -> void
 Microsoft.AspNetCore.Http.Endpoint.RequestDelegate.get -> Microsoft.AspNetCore.Http.RequestDelegate?
 Microsoft.AspNetCore.Routing.RouteValueDictionary.TryAdd(string! key, object? value) -> bool
+static readonly Microsoft.AspNetCore.Http.HttpProtocol.Http09 -> string!
+static Microsoft.AspNetCore.Http.HttpProtocol.IsHttp09(string! protocol) -> bool
 abstract Microsoft.AspNetCore.Http.HttpRequest.ContentType.get -> string?
 static Microsoft.AspNetCore.Builder.UseExtensions.Use(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Func<Microsoft.AspNetCore.Http.HttpContext!, Microsoft.AspNetCore.Http.RequestDelegate!, System.Threading.Tasks.Task!>! middleware) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.UseMiddleware(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Type! middleware, params object?[]! args) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!

--- a/src/Http/Http.Abstractions/test/HttpProtocolTests.cs
+++ b/src/Http/Http.Abstractions/test/HttpProtocolTests.cs
@@ -84,12 +84,32 @@ namespace Microsoft.AspNetCore.Http.Abstractions
             Assert.Equal(match, HttpProtocol.IsHttp10(protocol));
         }
 
+        [Fact]
+        public void Http09_Success()
+        {
+            Assert.Equal("HTTP/0.9", HttpProtocol.Http09);
+        }
+
+        [Theory]
+        [InlineData("HTTP/0.9", true)]
+        [InlineData("http/0.9", true)]
+        [InlineData("HTTP/2", false)]
+        [InlineData("HTTP/1", false)]
+        [InlineData("HTTP/09", false)]
+        [InlineData(" HTTP/0.9", false)]
+        [InlineData("HTTP/0.9 ", false)]
+        public void IsHttp09_Success(string protocol, bool match)
+        {
+            Assert.Equal(match, HttpProtocol.IsHttp09(protocol));
+        }
+
         public static TheoryData<Version, string> s_ValidData = new TheoryData<Version, string>
         {
             { new Version(3, 0), "HTTP/3" },
             { new Version(2, 0), "HTTP/2" },
             { new Version(1, 1), "HTTP/1.1" },
-            { new Version(1, 0), "HTTP/1.0" }
+            { new Version(1, 0), "HTTP/1.0" },
+            { new Version(0, 9), "HTTP/0.9" }
         };
 
         [Theory]


### PR DESCRIPTION
Fixes #32775

### Description
This PR adds support for `HTTP\0.9` in `HttpProtocol`.

### Behaviour before the fix
Request
```GET /```
Response
```*Connection closed```
Logs
```
fail:
...
System.ArgumentOutOfRangeException: Version doesn't map to a known HTTP protocol. (Parameter 'version')
         at Microsoft.AspNetCore.Http.HttpProtocol.GetHttpProtocol(Version version) in Microsoft.AspNetCore.Http.Abstractions.dll:token 0x6000106+0x8b
         at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContext.Microsoft.AspNetCore.Http.Features.IHttpRequestFeature.get_Protocol() in Microsoft.AspNetCore.Server.IIS.dll:token 0x600033c+0x0...
```

### Behaviour after the fix
Request
``` GET /```
Response
```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
<HTML><HEAD><TITLE>Bad Request</TITLE>
<META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></ HEAD >
<BODY><h2>Bad Request - Invalid Hostname</h2>
<hr><p>HTTP Error 400. The request hostname is invalid.</p>
</BODY></HTML>
*Connection closed
```
Logs
```
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      Request starting HTTP/0.9 GET http:/// - -
info: Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware[3]
      HTTP/0.9 request rejected due to missing or empty host header.
info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/0.9 GET http:/// - - - 400 334 text/html 3.2967ms
```


