### PR TITLE
Route parameter with urlencoded slash inconsistency between TestServer and Kestrel behavior

### DIFF
--- a/src/Http/Http.Abstractions/perf/Microbenchmarks/PathStringBenchmark.cs
+++ b/src/Http/Http.Abstractions/perf/Microbenchmarks/PathStringBenchmark.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Http.Abstractions.Microbenchmarks
+{
+    public class PathStringBenchmark
+    {
+        private const string TestPath = "/api/a%2Fb/c";
+        private const string LongTestPath = "/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a%20b";
+
+        public IEnumerable<object> TestPaths => new[] { TestPath, LongTestPath };
+
+        public IEnumerable<object> TestUris => new[] { new Uri($"https://localhost:5001/{TestPath}"), new Uri($"https://localhost:5001/{LongTestPath}") };
+
+        [Benchmark]
+        [ArgumentsSource(nameof(TestPaths))]
+        public string OnPathFromUriComponent(string testPath)
+        {
+            var pathString = PathString.FromUriComponent(testPath);
+            return pathString.Value;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(TestUris))]
+        public string OnUriFromUriComponent(Uri testUri)
+        {
+            var pathString = PathString.FromUriComponent(testUri);
+            return pathString.Value;
+        }
+    }
+}

--- a/src/Http/Http.Abstractions/perf/Microbenchmarks/PathStringBenchmark.cs
+++ b/src/Http/Http.Abstractions/perf/Microbenchmarks/PathStringBenchmark.cs
@@ -8,10 +8,11 @@ namespace Microsoft.AspNetCore.Http.Abstractions.Microbenchmarks
     {
         private const string TestPath = "/api/a%2Fb/c";
         private const string LongTestPath = "/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a%20b";
+        private const string LongTestPathEarlyPercent = "/t%20hisMustBeAVeryLongPath/SoLongButStillShorterToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeap/api/a%20b";
 
-        public IEnumerable<object> TestPaths => new[] { TestPath, LongTestPath };
+        public IEnumerable<object> TestPaths => new[] { TestPath, LongTestPath, LongTestPathEarlyPercent };
 
-        public IEnumerable<object> TestUris => new[] { new Uri($"https://localhost:5001/{TestPath}"), new Uri($"https://localhost:5001/{LongTestPath}") };
+        public IEnumerable<object> TestUris => new[] { new Uri($"https://localhost:5001/{TestPath}"), new Uri($"https://localhost:5001/{LongTestPath}"), new Uri($"https://localhost:5001/{LongTestPathEarlyPercent}") };
 
         [Benchmark]
         [ArgumentsSource(nameof(TestPaths))]

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -23,6 +23,7 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
     <Compile Include="$(SharedSourceRoot)ActivatorUtilities\*.cs" />
     <Compile Include="$(SharedSourceRoot)ParameterDefaultValue\*.cs" />
     <Compile Include="$(SharedSourceRoot)PropertyHelper\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)\UrlDecoder\UrlDecoder.cs" Link="UrlDecoder.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Abstractions/src/PathString.cs
+++ b/src/Http/Http.Abstractions/src/PathString.cs
@@ -175,9 +175,15 @@ namespace Microsoft.AspNetCore.Http
         /// <returns>The resulting PathString</returns>
         public static PathString FromUriComponent(string uriComponent)
         {
+            int position = uriComponent.IndexOf('%');
+            if (position == -1)
+            {
+                return new PathString(uriComponent);
+            }
             Span<char> pathBuffer = uriComponent.Length <= StackAllocThreshold ? stackalloc char[StackAllocThreshold] : new char[uriComponent.Length];
-            var length = UrlDecoder.DecodeRequestLine(uriComponent.AsSpan(), pathBuffer);
-            pathBuffer = pathBuffer.Slice(0, length);
+            uriComponent.CopyTo(pathBuffer);
+            var length = UrlDecoder.DecodeInPlace(pathBuffer.Slice(position, uriComponent.Length - position));
+            pathBuffer = pathBuffer.Slice(0, position + length);
             return new PathString(pathBuffer.ToString());
         }
 

--- a/src/Http/Http.Abstractions/src/PathString.cs
+++ b/src/Http/Http.Abstractions/src/PathString.cs
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.Http
         /// <returns>The resulting PathString</returns>
         public static PathString FromUriComponent(string uriComponent)
         {
-            Span<char> pathBuffer = uriComponent.Length <= StackAllocThreshold ? stackalloc char[uriComponent.Length] : new char[uriComponent.Length];
+            Span<char> pathBuffer = uriComponent.Length <= StackAllocThreshold ? stackalloc char[StackAllocThreshold] : new char[uriComponent.Length];
             var length = UrlDecoder.DecodeRequestLine(uriComponent.AsSpan(), pathBuffer, isFormEncoding: false);
             pathBuffer = pathBuffer.Slice(0, length);
             return new PathString(pathBuffer.ToString());
@@ -193,7 +193,7 @@ namespace Microsoft.AspNetCore.Http
                 throw new ArgumentNullException(nameof(uri));
             }
             var uriComponent = uri.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
-            Span<char> pathBuffer = uriComponent.Length <= StackAllocThreshold ? stackalloc char[uriComponent.Length + 1] : new char[uriComponent.Length + 1];
+            Span<char> pathBuffer = uriComponent.Length < StackAllocThreshold ? stackalloc char[StackAllocThreshold] : new char[uriComponent.Length + 1];
             pathBuffer[0] = '/';
             var length = UrlDecoder.DecodeRequestLine(uriComponent.AsSpan(), pathBuffer.Slice(1), isFormEncoding: false);
             pathBuffer = pathBuffer.Slice(0, length + 1);

--- a/src/Http/Http.Abstractions/src/PathString.cs
+++ b/src/Http/Http.Abstractions/src/PathString.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Http
     [TypeConverter(typeof(PathStringConverter))]
     public readonly struct PathString : IEquatable<PathString>
     {
-        private const int StackAllocThreshold = 128;
+        internal const int StackAllocThreshold = 128;
 
         /// <summary>
         /// Represents the empty path. This field is read-only.
@@ -176,7 +176,7 @@ namespace Microsoft.AspNetCore.Http
         public static PathString FromUriComponent(string uriComponent)
         {
             Span<char> pathBuffer = uriComponent.Length <= StackAllocThreshold ? stackalloc char[StackAllocThreshold] : new char[uriComponent.Length];
-            var length = UrlDecoder.DecodeRequestLine(uriComponent.AsSpan(), pathBuffer, isFormEncoding: false);
+            var length = UrlDecoder.DecodeRequestLine(uriComponent.AsSpan(), pathBuffer);
             pathBuffer = pathBuffer.Slice(0, length);
             return new PathString(pathBuffer.ToString());
         }
@@ -195,7 +195,7 @@ namespace Microsoft.AspNetCore.Http
             var uriComponent = uri.GetComponents(UriComponents.Path, UriFormat.UriEscaped);
             Span<char> pathBuffer = uriComponent.Length < StackAllocThreshold ? stackalloc char[StackAllocThreshold] : new char[uriComponent.Length + 1];
             pathBuffer[0] = '/';
-            var length = UrlDecoder.DecodeRequestLine(uriComponent.AsSpan(), pathBuffer.Slice(1), isFormEncoding: false);
+            var length = UrlDecoder.DecodeRequestLine(uriComponent.AsSpan(), pathBuffer.Slice(1));
             pathBuffer = pathBuffer.Slice(0, length + 1);
             return new PathString(pathBuffer.ToString());
         }

--- a/src/Http/Http.Abstractions/test/PathStringTests.cs
+++ b/src/Http/Http.Abstractions/test/PathStringTests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.AspNetCore.Http
         [InlineData("/a%20b", "/a b")]
         [InlineData("/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a%20b",
             "/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a b")]
-        public void StringFromUriComponentEscapes(string input, string expected)
+        public void StringFromUriComponentUnescapes(string input, string expected)
         {
             var sut = PathString.FromUriComponent(input);
             Assert.Equal(expected, sut.Value);
@@ -277,7 +277,7 @@ namespace Microsoft.AspNetCore.Http
         [InlineData("/a%20b", "/a b")]
         [InlineData("/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a%20b",
     "/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a b")]
-        public void UriFromUriComponentEscapes(string input, string expected)
+        public void UriFromUriComponentUnescapes(string input, string expected)
         {
             var uri = new Uri($"https://localhost:5001{input}");
             var sut = PathString.FromUriComponent(uri);

--- a/src/Http/Http.Abstractions/test/PathStringTests.cs
+++ b/src/Http/Http.Abstractions/test/PathStringTests.cs
@@ -308,6 +308,30 @@ namespace Microsoft.AspNetCore.Http
             Assert.Equal(expected, sut.Value);
         }
 
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ExercisingStringFromUriComponentOnStackAllocLimit(int offset)
+        {
+            var path = "/";
+            var testString = new string('a', PathString.StackAllocThreshold + offset - path.Length);
+            var sut = PathString.FromUriComponent(path + testString);
+            Assert.Equal(PathString.StackAllocThreshold + offset, sut.Value!.Length);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void ExercisingUriFromUriComponentOnStackAllocLimit(int offset)
+        {
+            var localhost = "https://localhost:5001/";
+            var testString = new string('a', PathString.StackAllocThreshold + offset);
+            var sut = PathString.FromUriComponent(new Uri(localhost + testString));
+            Assert.Equal(PathString.StackAllocThreshold + offset + 1, sut.Value!.Length);
+        }
+
         public static IEnumerable<object[]> CharsToUnescape
         {
             get

--- a/src/Http/Http.Abstractions/test/PathStringTests.cs
+++ b/src/Http/Http.Abstractions/test/PathStringTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
@@ -235,6 +238,70 @@ namespace Microsoft.AspNetCore.Http
             string s1 = p1;
             PathString p2 = s1;
             Assert.Equal(p1, p2);
+        }
+
+        [Theory]
+        [InlineData("/a%2Fb")]
+        [InlineData("/a%2F")]
+        [InlineData("/%2fb")]
+        [InlineData("/a%2Fb/c%2Fd/e")]
+        public void StringFromUriComponentLeavesForwardSlashEscaped(string input)
+        {
+            var sut = PathString.FromUriComponent(input);
+            Assert.Equal(input, sut.Value);
+        }
+
+        [Theory]
+        [InlineData("/a%2Fb")]
+        [InlineData("/a%2F")]
+        [InlineData("/%2fb")]
+        [InlineData("/a%2Fb/c%2Fd/e")]
+        public void UriFromUriComponentLeavesForwardSlashEscaped(string input)
+        {
+            var uri = new Uri($"https://localhost:5001{input}");
+            var sut = PathString.FromUriComponent(input);
+            Assert.Equal(input, sut.Value);
+        }
+
+        [Theory]
+        [InlineData("/a%2Fb")]
+        [InlineData("/a%2F")]
+        [InlineData("/%2fb")]
+        [InlineData("/%2Fb%20c")]
+        [InlineData("/a%2Fb%20c")]
+        [InlineData("/a%20b")]
+        [InlineData("/a%2Fb/c%2Fd/e%20f")]
+        [InlineData("/%E4%BD%A0%E5%A5%BD")]
+        public void FromUriComponentToUriComponent(string input)
+        {
+            var sut = PathString.FromUriComponent(input);
+            Assert.Equal(input, sut.ToUriComponent());
+        }
+
+        [Theory]
+        [MemberData(nameof(CharsToUnescape))]
+        [InlineData("/%E4%BD%A0%E5%A5%BD", "/你好")]
+        public void FromUriComponentUnescapesAllExceptForwardSlash(string input, string expected)
+        {
+            var sut = PathString.FromUriComponent(input);
+            Assert.Equal(expected, sut.Value);
+        }
+
+        public static IEnumerable<object[]> CharsToUnescape
+        {
+            get
+            {
+                foreach (var item in Enumerable.Range(1, 127))
+                {
+                    // %2F is '/' not escaped for paths
+                    if (item != 0x2f)
+                    {
+                        var hexEscapedValue = "%" + item.ToString("x2", CultureInfo.InvariantCulture);
+                        var expected = Uri.UnescapeDataString(hexEscapedValue);
+                        yield return new object[] { "/a" + hexEscapedValue, "/a" + expected };
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Http/Http.Abstractions/test/PathStringTests.cs
+++ b/src/Http/Http.Abstractions/test/PathStringTests.cs
@@ -259,8 +259,29 @@ namespace Microsoft.AspNetCore.Http
         public void UriFromUriComponentLeavesForwardSlashEscaped(string input)
         {
             var uri = new Uri($"https://localhost:5001{input}");
-            var sut = PathString.FromUriComponent(input);
+            var sut = PathString.FromUriComponent(uri);
             Assert.Equal(input, sut.Value);
+        }
+
+        [Theory]
+        [InlineData("/a%20b", "/a b")]
+        [InlineData("/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a%20b",
+            "/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a b")]
+        public void StringFromUriComponentEscapes(string input, string expected)
+        {
+            var sut = PathString.FromUriComponent(input);
+            Assert.Equal(expected, sut.Value);
+        }
+
+        [Theory]
+        [InlineData("/a%20b", "/a b")]
+        [InlineData("/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a%20b",
+    "/thisMustBeAVeryLongPath/SoLongThatItCouldActuallyBeLargerToTheStackAllocThresholdValue/PathsShorterToThisAllocateLessOnHeapByUsingStackAllocation/api/a b")]
+        public void UriFromUriComponentEscapes(string input, string expected)
+        {
+            var uri = new Uri($"https://localhost:5001{input}");
+            var sut = PathString.FromUriComponent(uri);
+            Assert.Equal(expected, sut.Value);
         }
 
         [Theory]

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamic.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamic.cs
@@ -61,7 +61,7 @@ namespace RoutingWebSite
                 var results = new RouteValueDictionary();
                 foreach (var kvp in kvps)
                 {
-                    var split = kvp.Split("=");
+                    var split = kvp.Replace("%2F", "/", StringComparison.OrdinalIgnoreCase).Split("=");
                     results[split[0]] = split[1];
                 }
 

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamicAndRazorPages.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamicAndRazorPages.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -50,7 +51,7 @@ namespace RoutingWebSite
                 var results = new RouteValueDictionary();
                 foreach (var kvp in kvps)
                 {
-                    var split = kvp.Split("=");
+                    var split = kvp.Replace("%2F", "/", StringComparison.OrdinalIgnoreCase).Split("=");
                     results[split[0]] = split[1];
                 }
 

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamicOrder.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupForDynamicOrder.cs
@@ -115,7 +115,7 @@ namespace RoutingWebSite
 
                 foreach (var kvp in kvps)
                 {
-                    var split = kvp.Split("=");
+                    var split = kvp.Replace("%2F", "/", StringComparison.OrdinalIgnoreCase).Split("=");
                     if (split.Length == 2)
                     {
                         results[split[0]] = split[1];

--- a/src/Shared/UrlDecoder/UrlDecoder.cs
+++ b/src/Shared/UrlDecoder/UrlDecoder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Internal
 
             // This requires the destination span to be larger or equal to source span
             source.CopyTo(destination);
-            return DecodeInPlace(destination, isFormEncoding);
+            return DecodeInPlace(destination.Slice(0, source.Length), isFormEncoding);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace Microsoft.AspNetCore.Internal
             return true;
         }
 
-        private static void Copy(int begin, int end, ref int writer, Span<byte> buffer)
+        private static void Copy<T>(int begin, int end, ref int writer, Span<T> buffer)
         {
             while (begin != end)
             {
@@ -289,7 +289,6 @@ namespace Microsoft.AspNetCore.Internal
             return (value1 << 4) + value2;
         }
 
-
         /// <summary>
         /// Read the next char and convert it into hexadecimal value.
         ///
@@ -344,6 +343,290 @@ namespace Microsoft.AspNetCore.Internal
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Unescape a URL path
+        /// </summary>
+        /// <param name="source">The char span represents a UTF8 encoded, escaped url path.</param>
+        /// <param name="destination">The char span where unescaped url path is copied to.</param>
+        /// <param name="isFormEncoding">Whether we are doing form encoding or not.</param>
+        /// <returns>The length of the char sequence of the unescaped url path.</returns>
+        public static int DecodeRequestLine(ReadOnlySpan<char> source, Span<char> destination, bool isFormEncoding)
+        {
+            if (destination.Length < source.Length)
+            {
+                throw new ArgumentException(
+                    "Length of the destination char span is less then the source.",
+                    nameof(destination));
+            }
+
+            // This requires the destination span to be larger or equal to source span
+            source.CopyTo(destination);
+            return DecodeInPlace(destination.Slice(0, source.Length), isFormEncoding);
+        }
+
+        /// <summary>
+        /// Unescape a URL path in place.
+        /// </summary>
+        /// <param name="buffer">The char span represents a UTF8 encoded, escaped url path.</param>
+        /// <param name="isFormEncoding">Whether we are doing form encoding or not.</param>
+        /// <returns>The number of the chars representing the result.</returns>
+        /// <remarks>
+        /// The unescape is done in place, which means after decoding the result is the subset of
+        /// the input span.
+        /// </remarks>
+        public static int DecodeInPlace(Span<char> buffer, bool isFormEncoding)
+        {
+            // the slot to read the input
+            var sourceIndex = 0;
+
+            // the slot to write the unescaped char
+            var destinationIndex = 0;
+
+            while (true)
+            {
+                if (sourceIndex == buffer.Length)
+                {
+                    break;
+                }
+
+                if (buffer[sourceIndex] == '+' && isFormEncoding)
+                {
+                    // Set it to ' ' when we are doing form encoding.
+                    buffer[sourceIndex] = ' ';
+                }
+                else if (buffer[sourceIndex] == '%')
+                {
+                    var decodeIndex = sourceIndex;
+
+                    // If decoding process succeeds, the writer iterator will be moved
+                    // to the next write-ready location. On the other hand if the scanned
+                    // percent-encodings cannot be interpreted as sequence of UTF-8 octets,
+                    // these chars should be copied to output as is.
+                    // The decodeReader iterator is always moved to the first char not yet
+                    // be scanned after the process. A failed decoding means the chars
+                    // between the reader and decodeReader can be copied to output untouched.
+                    if (!DecodeCore(ref decodeIndex, ref destinationIndex, buffer, isFormEncoding))
+                    {
+                        Copy(sourceIndex, decodeIndex, ref destinationIndex, buffer);
+                    }
+
+                    sourceIndex = decodeIndex;
+                }
+                else
+                {
+                    buffer[destinationIndex++] = buffer[sourceIndex++];
+                }
+            }
+
+            return destinationIndex;
+        }
+
+        /// <summary>
+        /// Unescape the percent-encodings
+        /// </summary>
+        /// <param name="sourceIndex">The iterator point to the first % char</param>
+        /// <param name="destinationIndex">The place to write to</param>
+        /// <param name="buffer">The char array</param>
+        /// <param name="isFormEncoding">Whether we are doing form encodoing</param>
+        private static bool DecodeCore(ref int sourceIndex, ref int destinationIndex, Span<char> buffer, bool isFormEncoding)
+        {
+            // preserves the original head. if the percent-encodings cannot be interpreted as sequence of UTF-8 octets,
+            // chars from this till the last scanned one will be copied to the memory pointed by writer.
+            var char1 = UnescapePercentEncoding(ref sourceIndex, buffer, isFormEncoding);
+            if (char1 == -1)
+            {
+                return false;
+            }
+
+            if (char1 == 0)
+            {
+                throw new InvalidOperationException("The path contains null characters.");
+            }
+
+            if (char1 <= 0x7F)
+            {
+                // first char < U+007f, it is a single char ASCII
+                buffer[destinationIndex++] = (char)char1;
+                return true;
+            }
+
+            // anticipate more chars
+            var currentDecodeBits = 0;
+            var charCount = 1;
+            var expectValueMin = 0;
+            if ((char1 & 0xE0) == 0xC0)
+            {
+                // 110x xxxx, expect one more char
+                currentDecodeBits = char1 & 0x1F;
+                charCount = 2;
+                expectValueMin = 0x80;
+            }
+            else if ((char1 & 0xF0) == 0xE0)
+            {
+                // 1110 xxxx, expect two more chars
+                currentDecodeBits = char1 & 0x0F;
+                charCount = 3;
+                expectValueMin = 0x800;
+            }
+            else if ((char1 & 0xF8) == 0xF0)
+            {
+                // 1111 0xxx, expect three more chars
+                currentDecodeBits = char1 & 0x07;
+                charCount = 4;
+                expectValueMin = 0x10000;
+            }
+            else
+            {
+                // invalid first char
+                return false;
+            }
+
+            var remainingChars = charCount - 1;
+            while (remainingChars > 0)
+            {
+                // read following three chars
+                if (sourceIndex == buffer.Length)
+                {
+                    return false;
+                }
+
+                var nextSourceIndex = sourceIndex;
+                var nextChar = UnescapePercentEncoding(ref nextSourceIndex, buffer, isFormEncoding);
+                if (nextChar == -1)
+                {
+                    return false;
+                }
+
+                if ((nextChar & 0xC0) != 0x80)
+                {
+                    // the follow up char is not in form of 10xx xxxx
+                    return false;
+                }
+
+                currentDecodeBits = (currentDecodeBits << 6) | (nextChar & 0x3F);
+                remainingChars--;
+
+                if (remainingChars == 1 && currentDecodeBits >= 0x360 && currentDecodeBits <= 0x37F)
+                {
+                    // this is going to end up in the range of 0xD800-0xDFFF UTF-16 surrogates that
+                    // are not allowed in UTF-8;
+                    return false;
+                }
+
+                if (remainingChars == 2 && currentDecodeBits >= 0x110)
+                {
+                    // this is going to be out of the upper Unicode bound 0x10FFFF.
+                    return false;
+                }
+
+                sourceIndex = nextSourceIndex;
+            }
+
+            if (currentDecodeBits < expectValueMin)
+            {
+                // overlong encoding
+                return false;
+            }
+
+            var rune = new System.Text.Rune(currentDecodeBits);
+            if (!rune.TryEncodeToUtf16(buffer.Slice(destinationIndex), out var charsWritten))
+            {
+                return false;
+            }
+            destinationIndex += charsWritten;
+            return true;
+        }
+
+        /// <summary>
+        /// Read the percent-encoding and try unescape it.
+        ///
+        /// The operation first peek at the character the <paramref name="scan"/>
+        /// iterator points at. If it is % the <paramref name="scan"/> is then
+        /// moved on to scan the following to characters. If the two following
+        /// characters are hexadecimal literals they will be unescaped and the
+        /// value will be returned.
+        ///
+        /// If the first character is not % the <paramref name="scan"/> iterator
+        /// will be removed beyond the location of % and -1 will be returned.
+        ///
+        /// If the following two characters can't be successfully unescaped the
+        /// <paramref name="scan"/> iterator will be move behind the % and -1
+        /// will be returned.
+        /// </summary>
+        /// <param name="scan">The value to read</param>
+        /// <param name="buffer">The char array</param>
+        /// <param name="isFormEncoding">Whether we are decoding a form or not. Will escape '/' if we are doing form encoding</param>
+        /// <returns>The unescaped char if success. Otherwise return -1.</returns>
+        private static int UnescapePercentEncoding(ref int scan, ReadOnlySpan<char> buffer, bool isFormEncoding)
+        {
+            if (buffer[scan++] != '%')
+            {
+                return -1;
+            }
+
+            var probe = scan;
+
+            var value1 = ReadHex(ref probe, buffer);
+            if (value1 == -1)
+            {
+                return -1;
+            }
+
+            var value2 = ReadHex(ref probe, buffer);
+            if (value2 == -1)
+            {
+                return -1;
+            }
+
+            if (SkipUnescape(value1, value2, isFormEncoding))
+            {
+                return -1;
+            }
+
+            scan = probe;
+            return (value1 << 4) + value2;
+        }
+
+        /// <summary>
+        /// Read the next char and convert it into hexadecimal value.
+        ///
+        /// The <paramref name="scan"/> index will be moved to the next
+        /// char no matter whether the operation successes.
+        /// </summary>
+        /// <param name="scan">The index of the char in the buffer to read</param>
+        /// <param name="buffer">The char span from which the hex to be read</param>
+        /// <returns>The hexadecimal value if successes, otherwise -1.</returns>
+        private static int ReadHex(ref int scan, ReadOnlySpan<char> buffer)
+        {
+            if (scan == buffer.Length)
+            {
+                return -1;
+            }
+
+            var value = buffer[scan++];
+            var isHead = ((value >= '0') && (value <= '9')) ||
+                         ((value >= 'A') && (value <= 'F')) ||
+                         ((value >= 'a') && (value <= 'f'));
+
+            if (!isHead)
+            {
+                return -1;
+            }
+
+            if (value <= '9')
+            {
+                return value - '0';
+            }
+            else if (value <= 'F')
+            {
+                return (value - 'A') + 10;
+            }
+            else // a - f
+            {
+                return (value - 'a') + 10;
+            }
         }
     }
 }

--- a/src/Shared/UrlDecoder/UrlDecoder.cs
+++ b/src/Shared/UrlDecoder/UrlDecoder.cs
@@ -306,11 +306,11 @@ namespace Microsoft.AspNetCore.Internal
             }
 
             var value = buffer[scan++];
-            var isHead = ((value >= '0') && (value <= '9')) ||
+            var isHex = ((value >= '0') && (value <= '9')) ||
                          ((value >= 'A') && (value <= 'F')) ||
                          ((value >= 'a') && (value <= 'f'));
 
-            if (!isHead)
+            if (!isHex)
             {
                 return -1;
             }
@@ -382,6 +382,9 @@ namespace Microsoft.AspNetCore.Internal
         /// </remarks>
         public static int DecodeInPlace(Span<char> buffer)
         {
+            // Compared to the byte overload implementation, this is a different
+            // by using the first occurrence of % as the starting position both
+            // for the source and the destination index.
             int position = buffer.IndexOf('%');
             if (position == -1)
             {
@@ -610,11 +613,11 @@ namespace Microsoft.AspNetCore.Internal
             }
 
             var value = buffer[scan++];
-            var isHead = ((value >= '0') && (value <= '9')) ||
+            var isHex = ((value >= '0') && (value <= '9')) ||
                          ((value >= 'A') && (value <= 'F')) ||
                          ((value >= 'a') && (value <= 'f'));
 
-            if (!isHead)
+            if (!isHex)
             {
                 return -1;
             }

--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework)</TargetFrameworks>
@@ -32,6 +32,7 @@
     <Compile Include="$(SharedSourceRoot)ValueStopwatch\**\*.cs" Link="Shared\ValueStopwatch\%(Filename)%(Extension)"/>
     <Compile Include="$(SharedSourceRoot)WebEncoders\**\*.cs" Link="Shared\WebEncoders\%(Filename)%(Extension)"/>
     <Compile Include="$(SharedSourceRoot)QueryStringEnumerable.cs" />
+    <Compile Include="$(SharedSourceRoot)UrlDecoder\**\*.cs" Link="Shared\UrlDecoder\%(Filename)%(Extension)"/>
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\*.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
   </ItemGroup>

--- a/src/Shared/test/Shared.Tests/UrlDecoderTests.cs
+++ b/src/Shared/test/Shared.Tests/UrlDecoderTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Shared.Tests
         public void StringDecodeRequestLine(string input, string expected)
         {
             var destination = new char[input.Length];
-            int length = UrlDecoder.DecodeRequestLine(input.AsSpan(), destination.AsSpan(), false);
+            int length = UrlDecoder.DecodeRequestLine(input.AsSpan(), destination.AsSpan());
             Assert.True(destination.AsSpan(0, length).SequenceEqual(expected.AsSpan()));
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Shared.Tests
         {
             var destination = new char[input.Length];
             input.CopyTo(destination);
-            int length = UrlDecoder.DecodeInPlace(destination.AsSpan(), false);
+            int length = UrlDecoder.DecodeInPlace(destination.AsSpan());
             Assert.True(destination.AsSpan(0, length).SequenceEqual(expected.AsSpan()));
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Shared.Tests
         public void StringDestinationShorterThanSourceDecodeRequestLineThrows()
         {
             var source = new char[2];
-            Assert.Throws<ArgumentException>(() => UrlDecoder.DecodeRequestLine(source.AsSpan(), source.AsSpan(0, 1), false));
+            Assert.Throws<ArgumentException>(() => UrlDecoder.DecodeRequestLine(source.AsSpan(), source.AsSpan(0, 1)));
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.Shared.Tests
         public void StringDestinationLargerThanSourceDecodeRequestLineReturnsCorrenctLenght()
         {
             var source = "/a%20b".ToCharArray();
-            var length = UrlDecoder.DecodeRequestLine(source.AsSpan(), new char[source.Length + 10], false);
+            var length = UrlDecoder.DecodeRequestLine(source.AsSpan(), new char[source.Length + 10]);
             Assert.Equal(4, length);
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Shared.Tests
         public void StringInputNullCharDecodeInPlaceThrows()
         {
             var source = "%00".ToCharArray();
-            Assert.Throws<InvalidOperationException>(() => UrlDecoder.DecodeInPlace(source.AsSpan(), false));
+            Assert.Throws<InvalidOperationException>(() => UrlDecoder.DecodeInPlace(source.AsSpan()));
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace Microsoft.AspNetCore.Shared.Tests
         public void StringInputNonHexDecodeInPlaceLeavesUnencoded(string input)
         {
             var source = input.ToCharArray();
-            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), false);
+            var length = UrlDecoder.DecodeInPlace(source.AsSpan());
             Assert.Equal(input.Length, length);
             Assert.True(source.AsSpan(0, length).SequenceEqual(input.AsSpan()));
         }
@@ -117,16 +117,6 @@ namespace Microsoft.AspNetCore.Shared.Tests
             var length = UrlDecoder.DecodeInPlace(source.AsSpan(), false);
             Assert.Equal(source.Length, length);
             Assert.True(source.AsSpan(0, length).SequenceEqual(Encoding.UTF8.GetBytes(input).AsSpan()));
-        }
-
-        [Theory]
-        [InlineData("%2F")]
-        public void StringFormsEncodingDecodeInPlaceDecodesPercent2F(string input)
-        {
-            var source = input.ToCharArray();
-            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), true);
-            Assert.Equal(1, length);
-            Assert.True(source.AsSpan(0, length).SequenceEqual("/".AsSpan()));
         }
 
         [Theory]
@@ -148,7 +138,7 @@ namespace Microsoft.AspNetCore.Shared.Tests
         public void StringOutOfUtf8RangeDecodeInPlaceLeavesUnencoded(string input)
         {
             var source = input.ToCharArray();
-            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), true);
+            var length = UrlDecoder.DecodeInPlace(source.AsSpan());
             Assert.Equal(input.Length, length);
             Assert.True(source.AsSpan(0, length).SequenceEqual(input.AsSpan()));
         }

--- a/src/Shared/test/Shared.Tests/UrlDecoderTests.cs
+++ b/src/Shared/test/Shared.Tests/UrlDecoderTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.AspNetCore.Internal;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Shared.Tests
+{
+    public class UrlDecoderTests
+    {
+        [Theory]
+        [MemberData(nameof(PathTestData))]
+        public void StringDecodeRequestLine(string input, string expected)
+        {
+            var destination = new char[input.Length];
+            int length = UrlDecoder.DecodeRequestLine(input.AsSpan(), destination.AsSpan(), false);
+            Assert.True(destination.AsSpan(0, length).SequenceEqual(expected.AsSpan()));
+        }
+
+        [Theory]
+        [MemberData(nameof(UriTestData))]
+        public void ByteDecodeRequestLine(byte[] input, byte[] expected)
+        {
+            var destination = new byte[input.Length];
+            int length = UrlDecoder.DecodeRequestLine(input.AsSpan(), destination.AsSpan(), false);
+            Assert.True(destination.AsSpan(0, length).SequenceEqual(expected.AsSpan()));
+        }
+
+        [Theory]
+        [MemberData(nameof(PathTestData))]
+        public void StringDecodeInPlace(string input, string expected)
+        {
+            var destination = new char[input.Length];
+            input.CopyTo(destination);
+            int length = UrlDecoder.DecodeInPlace(destination.AsSpan(), false);
+            Assert.True(destination.AsSpan(0, length).SequenceEqual(expected.AsSpan()));
+        }
+
+        [Theory]
+        [MemberData(nameof(UriTestData))]
+        public void ByteDecodeInPlace(byte[] input, byte[] expected)
+        {
+            var destination = new byte[input.Length];
+            input.AsSpan().CopyTo(destination);
+            int length = UrlDecoder.DecodeInPlace(destination.AsSpan(), false);
+            Assert.True(destination.AsSpan(0, length).SequenceEqual(expected.AsSpan()));
+        }
+
+        [Fact]
+        public void StringDestinationShorterThanSourceDecodeRequestLineThrows()
+        {
+            var source = new char[2];
+            Assert.Throws<ArgumentException>(() => UrlDecoder.DecodeRequestLine(source.AsSpan(), source.AsSpan(0, 1), false));
+        }
+
+        [Fact]
+        public void ByteDestinationShorterThanSourceDecodeRequestLineThrows()
+        {
+            var source = new byte[2];
+            Assert.Throws<ArgumentException>(() => UrlDecoder.DecodeRequestLine(source.AsSpan(), source.AsSpan(0, 1), false));
+        }
+
+        [Fact]
+        public void StringDestinationLargerThanSourceDecodeRequestLineReturnsCorrenctLenght()
+        {
+            var source = "/a%20b".ToCharArray();
+            var length = UrlDecoder.DecodeRequestLine(source.AsSpan(), new char[source.Length + 10], false);
+            Assert.Equal(4, length);
+        }
+
+        [Fact]
+        public void ByteDestinationLargerThanSourceDecodeRequestLineReturnsCorrenctLenght()
+        {
+            var source = Encoding.UTF8.GetBytes("/a%20b".ToCharArray());
+            var length = UrlDecoder.DecodeRequestLine(source.AsSpan(), new byte[source.Length + 10], false);
+            Assert.Equal(4, length);
+        }
+
+        [Fact]
+        public void StringInputNullCharDecodeInPlaceThrows()
+        {
+            var source = "%00".ToCharArray();
+            Assert.Throws<InvalidOperationException>(() => UrlDecoder.DecodeInPlace(source.AsSpan(), false));
+        }
+
+        [Fact]
+        public void ByteInputNullCharDecodeInPlaceThrows()
+        {
+            var source = Encoding.UTF8.GetBytes("%00");
+            Assert.Throws<InvalidOperationException>(() => UrlDecoder.DecodeInPlace(source.AsSpan(), false));
+        }
+
+        [Theory]
+        [InlineData("%$$")]
+        [InlineData("%1")]
+        [InlineData("%1$")]
+        [InlineData("%%1")]
+        [InlineData("%%1$")]
+        public void StringInputNonHexDecodeInPlaceLeavesUnencoded(string input)
+        {
+            var source = input.ToCharArray();
+            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), false);
+            Assert.Equal(input.Length, length);
+            Assert.True(source.AsSpan(0, length).SequenceEqual(input.AsSpan()));
+        }
+
+        [Theory]
+        [InlineData("%$$")]
+        [InlineData("%1")]
+        [InlineData("%1$")]
+        [InlineData("%%1")]
+        [InlineData("%%1$")]
+        public void ByteInputNonHexDecodeInPlaceLeavesUnencoded(string input)
+        {
+            var source = Encoding.UTF8.GetBytes(input.ToCharArray());
+            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), false);
+            Assert.Equal(source.Length, length);
+            Assert.True(source.AsSpan(0, length).SequenceEqual(Encoding.UTF8.GetBytes(input).AsSpan()));
+        }
+
+        [Theory]
+        [InlineData("%2F")]
+        public void StringFormsEncodingDecodeInPlaceDecodesPercent2F(string input)
+        {
+            var source = input.ToCharArray();
+            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), true);
+            Assert.Equal(1, length);
+            Assert.True(source.AsSpan(0, length).SequenceEqual("/".AsSpan()));
+        }
+
+        [Theory]
+        [InlineData("%2F")]
+        public void ByteFormsEncodingDecodeInPlaceDecodesPercent2F(string input)
+        {
+            var source = Encoding.UTF8.GetBytes(input.ToCharArray());
+            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), true);
+            Assert.Equal(1, length);
+            Assert.True(source.AsSpan(0, length).SequenceEqual(Encoding.UTF8.GetBytes("/").AsSpan()));
+        }
+
+        [Theory]
+        [InlineData("%FF%FF%FF%FF")] // FF invalid first byte
+        [InlineData("%F7%BF%BF%BF")] // beyond 0x10FFFF
+        [InlineData("%F7%C0")] // Following byte does not start with 10xx xxxx
+        [InlineData("%F0%81")] // Not enough bytes
+        [InlineData("%ED%A0%81")] // Invalid range 0xD800-0xDFFF
+        public void StringOutOfUtf8RangeDecodeInPlaceLeavesUnencoded(string input)
+        {
+            var source = input.ToCharArray();
+            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), true);
+            Assert.Equal(input.Length, length);
+            Assert.True(source.AsSpan(0, length).SequenceEqual(input.AsSpan()));
+        }
+
+        [Theory]
+        [InlineData("%FF%FF%FF%FF")] // FF invalid first byte
+        [InlineData("%F7%BF%BF%BF")] // beyond 0x10FFFF
+        [InlineData("%F7%C0")] // Following byte does not start with 10xx xxxx
+        [InlineData("%F0%81")] // Not enough bytes
+        [InlineData("%ED%A0%81")] // Invalid range 0xD800-0xDFFF
+        public void ByteOutOfUtf8RangeDecodeInPlaceLeavesUnencoded(string input)
+        {
+            var source = Encoding.UTF8.GetBytes(input.ToCharArray());
+            var length = UrlDecoder.DecodeInPlace(source.AsSpan(), true);
+            Assert.Equal(source.Length, length);
+            Assert.True(source.AsSpan(0, length).SequenceEqual(Encoding.UTF8.GetBytes(input).AsSpan()));
+        }
+
+        public static IEnumerable<object[]> PathTestData
+        {
+            get
+            {
+                return new List<object[]>()
+                {
+                    new[] { "hello", "hello" },
+                    new[] { "/", "/" },
+                    new[] { "http://localhost:5000/api", "http://localhost:5000/api" },
+                    new[] { "/api/abc", "/api/abc" },
+                    new[] { "/api/a%2Fb", "/api/a%2Fb" },
+                    new[] { "/a%20b", "/a b" },
+                    new[] { "/a%24b", "/a$b" },
+                    new[] { "/a%C2%A2b", "/a¢b" },
+                    new[] { "/a%E0%A4%B9b", "/aहb" },
+                    new[] { "/a%E2%82%ACb", "/a€b" },
+                    new[] { "/a%ED%95%9Cb", "/a한b" },
+                    new[] { "/a%F0%90%8D%88b", "/a𐍈b" },
+                    new[] { "/a%25b", "/a%b" },
+                    new[] { "/%E4%BD%A0%E5%A5%BD", "/你好" },
+                    new[] { "/a%%2Fb", "/a%%2Fb" },
+                    new[] { "/a%2Fb+c", "/a%2Fb+c" },
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> UriTestData
+        {
+            get
+            {
+                return PathTestData.Select(x =>
+                {
+                    var input = Encoding.UTF8.GetBytes((string)x[0]);
+                    var expected = Encoding.UTF8.GetBytes((string)x[1]);
+                    return new[] { input, expected };
+                });
+            }
+        }
+    }
+}

--- a/src/Shared/test/Shared.Tests/UrlDecoderTests.cs
+++ b/src/Shared/test/Shared.Tests/UrlDecoderTests.cs
@@ -179,6 +179,8 @@ namespace Microsoft.AspNetCore.Shared.Tests
                     new[] { "/%E4%BD%A0%E5%A5%BD", "/你好" },
                     new[] { "/a%%2Fb", "/a%%2Fb" },
                     new[] { "/a%2Fb+c", "/a%2Fb+c" },
+                    new[] { "/%C3%C3%A1", "/%C3á" },
+                    new[] { "/a%20%%b", "/a %%b" },
                 };
             }
         }


### PR DESCRIPTION
**Route parameter with urlencoded slash inconsistency between TestServer and Kestrel behavior**

Issue is that TestClient returns different value for the request Path compared to Kestrel.
TestClient uses `PathString.FromUriComponent` to set the path value
`PathString.FromUriComponent` (both overloads) url decode the %2F character for the path part of the URL. This is inconsistent with Kestrel (and generally with web servers), because that would result in an additional segment of path.


**Description**
* PathSting uses UrlDecoder to unescape the path string
* UrlDecoder not unescapes %2f which would be a forward slash
* Adding unit tests for PathString
* Adding tests for ClientHandler asserting the behavior change for TestClient

For the differences between the UrlDecoder and Url.Unescaped, please see conversation in #28965 

Addresses #28965
