### PR TITLE
Unescape query parameter name

### DIFF
--- a/src/Http/Http/src/Features/QueryFeature.cs
+++ b/src/Http/Http/src/Features/QueryFeature.cs
@@ -143,7 +143,9 @@ namespace Microsoft.AspNetCore.Http.Features
                 {
                     if (!querySegment.IsEmpty)
                     {
-                        accumulator.Append(querySegment);
+                        var name = SpanHelper.ReplacePlusWithSpace(querySegment);
+
+                        accumulator.Append(Uri.UnescapeDataString(name));
                     }
                 }
 

--- a/src/Http/Http/test/Features/QueryFeatureTests.cs
+++ b/src/Http/Http/test/Features/QueryFeatureTests.cs
@@ -150,5 +150,75 @@ namespace Microsoft.AspNetCore.Http.Features
 
             Assert.Empty(queryCollection);
         }
+
+        [Fact]
+        public void ParseQueryWithEncodedKeyWorks()
+        {
+            var features = new FeatureCollection();
+            features[typeof(IHttpRequestFeature)] = new HttpRequestFeature { QueryString = "?fields+%5BtodoItems%5D" };
+
+            var provider = new QueryFeature(features);
+
+            var queryCollection = provider.Query;
+
+            Assert.Single(queryCollection);
+            Assert.Equal("", queryCollection["fields [todoItems]"].FirstOrDefault());
+        }
+
+        [Fact]
+        public void ParseQueryWithEncodedValueWorks()
+        {
+            var features = new FeatureCollection();
+            features[typeof(IHttpRequestFeature)] = new HttpRequestFeature { QueryString = "?=fields+%5BtodoItems%5D" };
+
+            var provider = new QueryFeature(features);
+
+            var queryCollection = provider.Query;
+
+            Assert.Single(queryCollection);
+            Assert.Equal("fields [todoItems]", queryCollection[""].FirstOrDefault());
+        }
+
+        [Fact]
+        public void ParseQueryWithEncodedKeyEmptyValueWorks()
+        {
+            var features = new FeatureCollection();
+            features[typeof(IHttpRequestFeature)] = new HttpRequestFeature { QueryString = "?fields+%5BtodoItems%5D=" };
+
+            var provider = new QueryFeature(features);
+
+            var queryCollection = provider.Query;
+
+            Assert.Single(queryCollection);
+            Assert.Equal("", queryCollection["fields [todoItems]"].FirstOrDefault());
+        }
+
+        [Fact]
+        public void ParseQueryWithEncodedKeyEncodedValueWorks()
+        {
+            var features = new FeatureCollection();
+            features[typeof(IHttpRequestFeature)] = new HttpRequestFeature { QueryString = "?fields+%5BtodoItems%5D=%5B+1+%5D" };
+
+            var provider = new QueryFeature(features);
+
+            var queryCollection = provider.Query;
+
+            Assert.Single(queryCollection);
+            Assert.Equal("[ 1 ]", queryCollection["fields [todoItems]"].FirstOrDefault());
+        }
+
+        [Fact]
+        public void ParseQueryWithEncodedKeyEncodedValuesWorks()
+        {
+            var features = new FeatureCollection();
+            features[typeof(IHttpRequestFeature)] = new HttpRequestFeature { QueryString = "?fields+%5BtodoItems%5D=%5B+1+%5D&fields+%5BtodoItems%5D=%5B+2+%5D" };
+
+            var provider = new QueryFeature(features);
+
+            var queryCollection = provider.Query;
+
+            Assert.Single(queryCollection);
+            Assert.Equal(new[] { "[ 1 ]", "[ 2 ]" }, queryCollection["fields [todoItems]"]);
+        }
     }
 }

--- a/src/Http/WebUtilities/src/QueryHelpers.cs
+++ b/src/Http/WebUtilities/src/QueryHelpers.cs
@@ -218,7 +218,10 @@ namespace Microsoft.AspNetCore.WebUtilities
                 {
                     if (delimiterIndex > scanIndex)
                     {
-                        accumulator.Append(queryString.Substring(scanIndex, delimiterIndex - scanIndex), string.Empty);
+                        string name = queryString.Substring(scanIndex, delimiterIndex - scanIndex);
+                        accumulator.Append(
+                            Uri.UnescapeDataString(name.Replace('+', ' ')),
+                            string.Empty);
                     }
                 }
                 scanIndex = delimiterIndex + 1;

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -55,6 +55,14 @@ namespace Microsoft.AspNetCore.WebUtilities
             Assert.Equal(new[] { "value1", "" }, collection[""]);
         }
 
+        [Fact]
+        public void ParseQueryWithEncodedKeyWorks()
+        {
+            var collection = QueryHelpers.ParseQuery("?fields%5BtodoItems%5D");
+            Assert.Single(collection);
+            Assert.Equal("", collection["fields[todoItems]"].FirstOrDefault());
+        }
+
         [Theory]
         [InlineData("?")]
         [InlineData("")]

--- a/src/Http/WebUtilities/test/QueryHelpersTests.cs
+++ b/src/Http/WebUtilities/test/QueryHelpersTests.cs
@@ -58,9 +58,41 @@ namespace Microsoft.AspNetCore.WebUtilities
         [Fact]
         public void ParseQueryWithEncodedKeyWorks()
         {
-            var collection = QueryHelpers.ParseQuery("?fields%5BtodoItems%5D");
+            var collection = QueryHelpers.ParseQuery("?fields+%5BtodoItems%5D");
             Assert.Single(collection);
-            Assert.Equal("", collection["fields[todoItems]"].FirstOrDefault());
+            Assert.Equal("", collection["fields [todoItems]"].FirstOrDefault());
+        }
+
+        [Fact]
+        public void ParseQueryWithEncodedValueWorks()
+        {
+            var collection = QueryHelpers.ParseQuery("?=fields+%5BtodoItems%5D");
+            Assert.Single(collection);
+            Assert.Equal("fields [todoItems]", collection[""].FirstOrDefault());
+        }
+
+        [Fact]
+        public void ParseQueryWithEncodedKeyEmptyValueWorks()
+        {
+            var collection = QueryHelpers.ParseQuery("?fields+%5BtodoItems%5D=");
+            Assert.Single(collection);
+            Assert.Equal("", collection["fields [todoItems]"].FirstOrDefault());
+        }
+
+        [Fact]
+        public void ParseQueryWithEncodedKeyEncodedValueWorks()
+        {
+            var collection = QueryHelpers.ParseQuery("?fields+%5BtodoItems%5D=%5B+1+%5D");
+            Assert.Single(collection);
+            Assert.Equal("[ 1 ]", collection["fields [todoItems]"].FirstOrDefault());
+        }
+
+        [Fact]
+        public void ParseQueryWithEncodedKeyEncodedValuesWorks()
+        {
+            var collection = QueryHelpers.ParseQuery("?fields+%5BtodoItems%5D=%5B+1+%5D&fields+%5BtodoItems%5D=%5B+2+%5D");
+            Assert.Single(collection);
+            Assert.Equal(new[] { "[ 1 ]", "[ 2 ]" }, collection["fields [todoItems]"]);
         }
 
         [Theory]


### PR DESCRIPTION
**PR Title**
Unescape query parameter name in QueryHelpers

**PR Description**
Unescapes the query parameter name when there is no value. This is already done when there was a value.

There are currently no test in QueryHelpersTests for testing encoded keys / values, should I add some more?

Fixes #33394
