### PR TITLE
Add a feature for accessing the AuthenticateResult

### DIFF
--- a/src/Http/Authentication.Abstractions/src/IAuthenticateResultFeature.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticateResultFeature.cs
@@ -14,6 +14,6 @@ namespace Microsoft.AspNetCore.Authentication
         /// The <see cref="AuthenticateResult"/> from the authorization middleware.
         /// Set to null if the <see cref="IHttpAuthenticationFeature.User"/> property is set after the authorization middleware.
         /// </summary>
-        AuthenticateResult? Result { get; set; }
+        AuthenticateResult? AuthenticateResult { get; set; }
     }
 }

--- a/src/Http/Authentication.Abstractions/src/IAuthenticateResultFeature.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticateResultFeature.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Authentication
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public interface IAuthenticateResultFeature
+    {
+        /// <summary>
+        /// TODO
+        /// </summary>
+        AuthenticateResult Result { get; set; }
+    }
+}

--- a/src/Http/Authentication.Abstractions/src/IAuthenticateResultFeature.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticateResultFeature.cs
@@ -11,6 +11,6 @@ namespace Microsoft.AspNetCore.Authentication
         /// <summary>
         /// TODO
         /// </summary>
-        AuthenticateResult Result { get; set; }
+        AuthenticateResult? Result { get; set; }
     }
 }

--- a/src/Http/Authentication.Abstractions/src/IAuthenticateResultFeature.cs
+++ b/src/Http/Authentication.Abstractions/src/IAuthenticateResultFeature.cs
@@ -1,15 +1,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Http.Features.Authentication;
+
 namespace Microsoft.AspNetCore.Authentication
 {
     /// <summary>
-    /// TODO
+    /// Used to capture the <see cref="AuthenticateResult"/> from the authorization middleware.
     /// </summary>
     public interface IAuthenticateResultFeature
     {
         /// <summary>
-        /// TODO
+        /// The <see cref="AuthenticateResult"/> from the authorization middleware.
+        /// Set to null if the <see cref="IHttpAuthenticationFeature.User"/> property is set after the authorization middleware.
         /// </summary>
         AuthenticateResult? Result { get; set; }
     }

--- a/src/Http/Authentication.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Authentication.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature
+Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.Result.get -> Microsoft.AspNetCore.Authentication.AuthenticateResult!
+Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.Result.set -> void

--- a/src/Http/Authentication.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Authentication.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature
-Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.Result.get -> Microsoft.AspNetCore.Authentication.AuthenticateResult?
-Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.Result.set -> void
+Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.AuthenticateResult.get -> Microsoft.AspNetCore.Authentication.AuthenticateResult?
+Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.AuthenticateResult.set -> void

--- a/src/Http/Authentication.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Authentication.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
 Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature
-Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.Result.get -> Microsoft.AspNetCore.Authentication.AuthenticateResult!
+Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.Result.get -> Microsoft.AspNetCore.Authentication.AuthenticateResult?
 Microsoft.AspNetCore.Authentication.IAuthenticateResultFeature.Result.set -> void

--- a/src/Security/Authentication/Core/src/AuthenticationFeatures.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationFeatures.cs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Security.Claims;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 
-namespace Microsoft.AspNetCore.Authorization.Policy
+namespace Microsoft.AspNetCore.Authentication
 {
     /// <summary>
     /// Keeps the User and AuthenticationResult consistent with each other

--- a/src/Security/Authentication/Core/src/AuthenticationMiddleware.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationMiddleware.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Authentication
@@ -70,6 +71,12 @@ namespace Microsoft.AspNetCore.Authentication
                 if (result?.Principal != null)
                 {
                     context.User = result.Principal;
+                }
+                if (result?.Succeeded ?? false)
+                {
+                    var authFeatures = new AuthenticationFeatures(result);
+                    context.Features.Set<IHttpAuthenticationFeature>(authFeatures);
+                    context.Features.Set<IAuthenticateResultFeature>(authFeatures);
                 }
             }
 

--- a/src/Security/Authentication/test/AuthenticationMiddlewareTests.cs
+++ b/src/Security/Authentication/test/AuthenticationMiddlewareTests.cs
@@ -3,12 +3,15 @@
 using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Authentication
@@ -54,6 +57,126 @@ namespace Microsoft.AspNetCore.Authentication
             Assert.Equal(607, (int)response.StatusCode);
         }
 
+        [Fact]
+        public async Task IAuthenticateResultFeature_SetOnSuccessfulAuthenticate()
+        {
+            var authenticationService = new Mock<IAuthenticationService>();
+            authenticationService.Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), "custom"))));
+            var schemeProvider = new Mock<IAuthenticationSchemeProvider>();
+            schemeProvider.Setup(p => p.GetDefaultAuthenticateSchemeAsync())
+                .Returns(Task.FromResult(new AuthenticationScheme("custom", "custom", typeof(JwtBearerHandler))));
+            var middleware = new AuthenticationMiddleware(c => Task.CompletedTask, schemeProvider.Object);
+            var context = GetHttpContext(authenticationService: authenticationService.Object);
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.NotNull(authenticateResultFeature);
+            Assert.NotNull(authenticateResultFeature.AuthenticateResult);
+            Assert.True(authenticateResultFeature.AuthenticateResult.Succeeded);
+            Assert.Same(context.User, authenticateResultFeature.AuthenticateResult.Principal);
+        }
+
+        [Fact]
+        public async Task IAuthenticateResultFeature_NotSetOnUnsuccessfulAuthenticate()
+        {
+            var authenticationService = new Mock<IAuthenticationService>();
+            authenticationService.Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(AuthenticateResult.Fail("not authenticated")));
+            var schemeProvider = new Mock<IAuthenticationSchemeProvider>();
+            schemeProvider.Setup(p => p.GetDefaultAuthenticateSchemeAsync())
+                .Returns(Task.FromResult(new AuthenticationScheme("custom", "custom", typeof(JwtBearerHandler))));
+            var middleware = new AuthenticationMiddleware(c => Task.CompletedTask, schemeProvider.Object);
+            var context = GetHttpContext(authenticationService: authenticationService.Object);
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.Null(authenticateResultFeature);
+        }
+
+        [Fact]
+        public async Task IAuthenticateResultFeature_NullResultWhenUserSetAfter()
+        {
+            var authenticationService = new Mock<IAuthenticationService>();
+            authenticationService.Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), "custom"))));
+            var schemeProvider = new Mock<IAuthenticationSchemeProvider>();
+            schemeProvider.Setup(p => p.GetDefaultAuthenticateSchemeAsync())
+                .Returns(Task.FromResult(new AuthenticationScheme("custom", "custom", typeof(JwtBearerHandler))));
+            var middleware = new AuthenticationMiddleware(c => Task.CompletedTask, schemeProvider.Object);
+            var context = GetHttpContext(authenticationService: authenticationService.Object);
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.NotNull(authenticateResultFeature);
+            Assert.NotNull(authenticateResultFeature.AuthenticateResult);
+            Assert.True(authenticateResultFeature.AuthenticateResult.Succeeded);
+            Assert.Same(context.User, authenticateResultFeature.AuthenticateResult.Principal);
+
+            context.User = new ClaimsPrincipal();
+            Assert.Null(authenticateResultFeature.AuthenticateResult);
+        }
+
+        [Fact]
+        public async Task IAuthenticateResultFeature_SettingResultSetsUser()
+        {
+            var authenticationService = new Mock<IAuthenticationService>();
+            authenticationService.Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(), "custom"))));
+            var schemeProvider = new Mock<IAuthenticationSchemeProvider>();
+            schemeProvider.Setup(p => p.GetDefaultAuthenticateSchemeAsync())
+                .Returns(Task.FromResult(new AuthenticationScheme("custom", "custom", typeof(JwtBearerHandler))));
+            var middleware = new AuthenticationMiddleware(c => Task.CompletedTask, schemeProvider.Object);
+            var context = GetHttpContext(authenticationService: authenticationService.Object);
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.NotNull(authenticateResultFeature);
+            Assert.NotNull(authenticateResultFeature.AuthenticateResult);
+            Assert.True(authenticateResultFeature.AuthenticateResult.Succeeded);
+            Assert.Same(context.User, authenticateResultFeature.AuthenticateResult.Principal);
+
+            var newTicket = new AuthenticationTicket(new ClaimsPrincipal(), "");
+            authenticateResultFeature.AuthenticateResult = AuthenticateResult.Success(newTicket);
+            Assert.Same(context.User, newTicket.Principal);
+        }
+
+        private HttpContext GetHttpContext(
+            Action<IServiceCollection> registerServices = null,
+            IAuthenticationService authenticationService = null)
+        {
+            // ServiceProvider
+            var serviceCollection = new ServiceCollection();
+
+            authenticationService = authenticationService ?? Mock.Of<IAuthenticationService>();
+
+            serviceCollection.AddSingleton(authenticationService);
+            serviceCollection.AddOptions();
+            serviceCollection.AddLogging();
+            serviceCollection.AddAuthentication();
+            registerServices?.Invoke(serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            //// HttpContext
+            var httpContext = new DefaultHttpContext();
+            httpContext.RequestServices = serviceProvider;
+
+            return httpContext;
+        }
+
         private class ThreeOhFiveHandler : StatusCodeHandler {
             public ThreeOhFiveHandler() : base(305) { }
         }
@@ -77,7 +200,7 @@ namespace Microsoft.AspNetCore.Authentication
             {
                 _code = code;
             }
-            
+
             public Task<AuthenticateResult> AuthenticateAsync()
             {
                 throw new NotImplementedException();

--- a/src/Security/Authorization/Policy/src/AuthenticationFeatures.cs
+++ b/src/Security/Authorization/Policy/src/AuthenticationFeatures.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Authorization.Policy
     /// <summary>
     /// Keeps the User and AuthenticationResult consistent with each other
     /// </summary>
-    internal class AuthenticationFeatures : IAuthenticateResultFeature, IHttpAuthenticationFeature
+    internal sealed class AuthenticationFeatures : IAuthenticateResultFeature, IHttpAuthenticationFeature
     {
         private ClaimsPrincipal? _user;
         private AuthenticateResult? _result;

--- a/src/Security/Authorization/Policy/src/AuthenticationFeatures.cs
+++ b/src/Security/Authorization/Policy/src/AuthenticationFeatures.cs
@@ -1,12 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 
-namespace Microsoft.AspNetCore.Authorization.Policy.Internal
+namespace Microsoft.AspNetCore.Authorization.Policy
 {
     /// <summary>
     /// Keeps the User and AuthenticationResult consistent with each other
@@ -37,7 +36,7 @@ namespace Microsoft.AspNetCore.Authorization.Policy.Internal
             set
             {
                 _user = value;
-                Result = null;
+                _result = null;
             }
         }
     }

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization.Policy;
-using Microsoft.AspNetCore.Authorization.Policy.Internal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,7 +71,7 @@ namespace Microsoft.AspNetCore.Authorization
 
             var authenticateResult = await policyEvaluator.AuthenticateAsync(policy, context);
 
-            if (authenticateResult.Succeeded)
+            if (authenticateResult?.Succeeded ?? false)
             {
                 var authFeatures = new AuthenticationFeatures(authenticateResult);
                 context.Features.Set<IHttpAuthenticationFeature>(authFeatures);

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
@@ -73,9 +73,16 @@ namespace Microsoft.AspNetCore.Authorization
 
             if (authenticateResult?.Succeeded ?? false)
             {
-                var authFeatures = new AuthenticationFeatures(authenticateResult);
-                context.Features.Set<IHttpAuthenticationFeature>(authFeatures);
-                context.Features.Set<IAuthenticateResultFeature>(authFeatures);
+                if (context.Features.Get<IAuthenticateResultFeature>() is IAuthenticateResultFeature authenticateResultFeature)
+                {
+                    authenticateResultFeature.AuthenticateResult = authenticateResult;
+                }
+                else
+                {
+                    var authFeatures = new AuthenticationFeatures(authenticateResult);
+                    context.Features.Set<IHttpAuthenticationFeature>(authFeatures);
+                    context.Features.Set<IAuthenticateResultFeature>(authFeatures);
+                }
             }
 
             // Allow Anonymous still wants to run authorization to populate the User but skips any failure/challenge handling

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Authorization
                 resource = context;
             }
 
-            var authorizeResult = await policyEvaluator.AuthorizeAsync(policy, authenticateResult, context, resource);
+            var authorizeResult = await policyEvaluator.AuthorizeAsync(policy, authenticateResult!, context, resource);
             var authorizationMiddlewareResultHandler = context.RequestServices.GetRequiredService<IAuthorizationMiddlewareResultHandler>();
             await authorizationMiddlewareResultHandler.HandleAsync(_next, context, policy, authorizeResult);
         }

--- a/src/Security/Authorization/Policy/src/Internal/AuthenticationFeatures.cs
+++ b/src/Security/Authorization/Policy/src/Internal/AuthenticationFeatures.cs
@@ -1,0 +1,41 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http.Features.Authentication;
+
+namespace Microsoft.AspNetCore.Authorization.Policy.Internal
+{
+    /// <summary>
+    /// Keeps the User and AuthenticationResult consistent with each other
+    /// </summary>
+    internal class AuthenticationFeatures : IAuthenticateResultFeature, IHttpAuthenticationFeature
+    {
+        public AuthenticationFeatures(AuthenticateResult result)
+        {
+            Result = result;
+        }
+
+        public AuthenticateResult Result { get; set; }
+
+        public ClaimsPrincipal? User
+        {
+            get => Result.Principal;
+            set
+            {
+                if (value is not null)
+                {
+                    Result = AuthenticateResult.Success(
+                        new AuthenticationTicket(value, Result.Ticket!.Properties, Result.Ticket.AuthenticationScheme));
+                }
+                else
+                {
+                    // REVIEW: Make Result nullable and null it out here?
+                    throw new ArgumentNullException(nameof(User));
+                }
+            }
+        }
+    }
+}

--- a/src/Security/Authorization/Policy/src/Internal/AuthenticationFeatures.cs
+++ b/src/Security/Authorization/Policy/src/Internal/AuthenticationFeatures.cs
@@ -13,28 +13,31 @@ namespace Microsoft.AspNetCore.Authorization.Policy.Internal
     /// </summary>
     internal class AuthenticationFeatures : IAuthenticateResultFeature, IHttpAuthenticationFeature
     {
+        private ClaimsPrincipal? _user;
+        private AuthenticateResult? _result;
+
         public AuthenticationFeatures(AuthenticateResult result)
         {
             Result = result;
         }
 
-        public AuthenticateResult Result { get; set; }
+        public AuthenticateResult? Result
+        {
+            get => _result;
+            set
+            {
+                _result = value;
+                _user = _result?.Principal;
+            }
+        }
 
         public ClaimsPrincipal? User
         {
-            get => Result.Principal;
+            get => _user;
             set
             {
-                if (value is not null)
-                {
-                    Result = AuthenticateResult.Success(
-                        new AuthenticationTicket(value, Result.Ticket!.Properties, Result.Ticket.AuthenticationScheme));
-                }
-                else
-                {
-                    // REVIEW: Make Result nullable and null it out here?
-                    throw new ArgumentNullException(nameof(User));
-                }
+                _user = value;
+                Result = null;
             }
         }
     }

--- a/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
+++ b/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
@@ -57,6 +57,8 @@ namespace Microsoft.AspNetCore.Authorization.Policy
                 {
                     context.User = newPrincipal;
                     var ticket = new AuthenticationTicket(newPrincipal, string.Join(";", policy.AuthenticationSchemes));
+                    // ExpiresUtc is the easiest property to reason about when dealing with multiple schemese
+                    // SignalR will use this property to evaluate auth expiration for long running connections
                     ticket.Properties.ExpiresUtc = minExpiresUtc;
                     return AuthenticateResult.Success(ticket);
                 }

--- a/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
+++ b/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Authorization.Policy
                 {
                     context.User = newPrincipal;
                     var ticket = new AuthenticationTicket(newPrincipal, string.Join(";", policy.AuthenticationSchemes));
-                    // ExpiresUtc is the easiest property to reason about when dealing with multiple schemese
+                    // ExpiresUtc is the easiest property to reason about when dealing with multiple schemes
                     // SignalR will use this property to evaluate auth expiration for long running connections
                     ticket.Properties.ExpiresUtc = minExpiresUtc;
                     return AuthenticateResult.Success(ticket);

--- a/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
+++ b/src/Security/Authorization/Policy/src/PolicyEvaluator.cs
@@ -38,19 +38,27 @@ namespace Microsoft.AspNetCore.Authorization.Policy
             if (policy.AuthenticationSchemes != null && policy.AuthenticationSchemes.Count > 0)
             {
                 ClaimsPrincipal? newPrincipal = null;
+                DateTimeOffset? minExpiresUtc = null;
                 foreach (var scheme in policy.AuthenticationSchemes)
                 {
                     var result = await context.AuthenticateAsync(scheme);
                     if (result != null && result.Succeeded)
                     {
                         newPrincipal = SecurityHelper.MergeUserPrincipal(newPrincipal, result.Principal);
+
+                        if (minExpiresUtc is null || result.Properties?.ExpiresUtc < minExpiresUtc)
+                        {
+                            minExpiresUtc = result.Properties?.ExpiresUtc;
+                        }
                     }
                 }
 
                 if (newPrincipal != null)
                 {
                     context.User = newPrincipal;
-                    return AuthenticateResult.Success(new AuthenticationTicket(newPrincipal, string.Join(";", policy.AuthenticationSchemes)));
+                    var ticket = new AuthenticationTicket(newPrincipal, string.Join(";", policy.AuthenticationSchemes));
+                    ticket.Properties.ExpiresUtc = minExpiresUtc;
+                    return AuthenticateResult.Success(ticket);
                 }
                 else
                 {

--- a/src/Security/Authorization/test/AuthorizationMiddlewareTests.cs
+++ b/src/Security/Authorization/test/AuthorizationMiddlewareTests.cs
@@ -581,7 +581,7 @@ namespace Microsoft.AspNetCore.Authorization.Test
         }
 
         [Fact]
-        public async Task IAuthenticateResultFeature_ReplacesExistingFeature()
+        public async Task IAuthenticateResultFeature_UsesExistingFeature()
         {
             // Arrange
             var policy = new AuthorizationPolicyBuilder().RequireClaim("Permission", "CanViewPage").Build();
@@ -604,7 +604,7 @@ namespace Microsoft.AspNetCore.Authorization.Test
             var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
             Assert.NotNull(authenticateResultFeature);
             Assert.NotNull(authenticateResultFeature.AuthenticateResult);
-            Assert.NotSame(testAuthenticateResultFeature, authenticateResultFeature);
+            Assert.Same(testAuthenticateResultFeature, authenticateResultFeature);
             Assert.NotSame(authenticateResult, authenticateResultFeature.AuthenticateResult);
         }
 

--- a/src/Security/Authorization/test/AuthorizationMiddlewareTests.cs
+++ b/src/Security/Authorization/test/AuthorizationMiddlewareTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -9,7 +10,6 @@ using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.AspNetCore.Authorization.Test.TestObjects;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Authorization.Test
             // Assert
             Assert.False(next.Called);
         }
-        
+
         [Fact]
         public async Task HasEndpointWithoutAuth_AnonymousUser_Allows()
         {
@@ -156,7 +156,7 @@ namespace Microsoft.AspNetCore.Authorization.Test
             Assert.False(next.Called);
             Assert.True(authenticationService.ChallengeCalled);
         }
-        
+
         [Fact]
         public async Task HasEndpointWithAuth_AnonymousUser_ChallengePerScheme()
         {
@@ -367,7 +367,7 @@ namespace Microsoft.AspNetCore.Authorization.Test
             // Assert
             Assert.Equal(endpoint, resource);
         }
-        
+
         [Fact]
         public async Task Invoke_RequireUnknownRoleShouldForbid()
         {
@@ -433,6 +433,146 @@ namespace Microsoft.AspNetCore.Authorization.Test
             Assert.False(next.Called);
             Assert.False(authenticationService.ChallengeCalled);
             Assert.True(authenticationService.ForbidCalled);
+        }
+
+        [Fact]
+        public async Task IAuthenticateResultFeature_SetOnSuccessfulAuthorize()
+        {
+            // Arrange
+            var policy = new AuthorizationPolicyBuilder().RequireClaim("Permission", "CanViewPage").Build();
+            var policyProvider = new Mock<IAuthorizationPolicyProvider>();
+            policyProvider.Setup(p => p.GetDefaultPolicyAsync()).ReturnsAsync(policy);
+            var next = new TestRequestDelegate();
+
+            var middleware = CreateMiddleware(next.Invoke, policyProvider.Object);
+            var context = GetHttpContext(endpoint: CreateEndpoint(new AuthorizeAttribute()));
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            Assert.True(next.Called);
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.NotNull(authenticateResultFeature);
+            Assert.NotNull(authenticateResultFeature.Result);
+            Assert.Same(context.User, authenticateResultFeature.Result.Principal);
+        }
+
+        [Fact]
+        public async Task IAuthenticateResultFeature_NotSetOnUnsuccessfulAuthorize()
+        {
+            // Arrange
+            var policy = new AuthorizationPolicyBuilder().RequireRole("Wut").AddAuthenticationSchemes("NotImplemented").Build();
+            var policyProvider = new Mock<IAuthorizationPolicyProvider>();
+            policyProvider.Setup(p => p.GetDefaultPolicyAsync()).ReturnsAsync(policy);
+            var next = new TestRequestDelegate();
+            var authenticationService = new TestAuthenticationService();
+
+            var middleware = CreateMiddleware(next.Invoke, policyProvider.Object);
+            var context = GetHttpContext(endpoint: CreateEndpoint(new AuthorizeAttribute(), new AllowAnonymousAttribute()), authenticationService: authenticationService);
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            Assert.True(next.Called);
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.Null(authenticateResultFeature);
+            Assert.True(authenticationService.AuthenticateCalled);
+        }
+
+        [Fact]
+        public async Task IAuthenticateResultFeature_ContainsLowestExpiration()
+        {
+            // Arrange
+            var policy = new AuthorizationPolicyBuilder().RequireRole("Wut").AddAuthenticationSchemes("Basic", "Bearer").Build();
+            var policyProvider = new Mock<IAuthorizationPolicyProvider>();
+            policyProvider.Setup(p => p.GetDefaultPolicyAsync()).ReturnsAsync(policy);
+            var next = new TestRequestDelegate();
+
+            var firstExpiration = new DateTimeOffset(2021, 5, 12, 2, 3, 4, TimeSpan.Zero);
+            var secondExpiration = new DateTimeOffset(2021, 5, 11, 2, 3, 4, TimeSpan.Zero);
+            var authenticationService = new Mock<IAuthenticationService>();
+            authenticationService.Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), "Basic"))
+                .ReturnsAsync((HttpContext c, string scheme) =>
+                {
+                    var res = AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(c.User.Identities.FirstOrDefault(i => i.AuthenticationType == scheme)), scheme));
+                    res.Properties.ExpiresUtc = firstExpiration;
+                    return res;
+                });
+            authenticationService.Setup(s => s.AuthenticateAsync(It.IsAny<HttpContext>(), "Bearer"))
+                .ReturnsAsync((HttpContext c, string scheme) =>
+                {
+                    var res = AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(c.User.Identities.FirstOrDefault(i => i.AuthenticationType == scheme)), scheme));
+                    res.Properties.ExpiresUtc = secondExpiration;
+                    return res;
+                });
+
+            var middleware = CreateMiddleware(next.Invoke, policyProvider.Object);
+            var context = GetHttpContext(endpoint: CreateEndpoint(new AuthorizeAttribute()), authenticationService: authenticationService.Object);
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.NotNull(authenticateResultFeature);
+            Assert.NotNull(authenticateResultFeature.Result);
+            Assert.Same(context.User, authenticateResultFeature.Result.Principal);
+            Assert.Equal(secondExpiration, authenticateResultFeature.Result?.Properties?.ExpiresUtc);
+        }
+
+        [Fact]
+        public async Task IAuthenticateResultFeature_NullResultWhenUserSetAfter()
+        {
+            // Arrange
+            var policy = new AuthorizationPolicyBuilder().RequireClaim("Permission", "CanViewPage").Build();
+            var policyProvider = new Mock<IAuthorizationPolicyProvider>();
+            policyProvider.Setup(p => p.GetDefaultPolicyAsync()).ReturnsAsync(policy);
+            var next = new TestRequestDelegate();
+
+            var middleware = CreateMiddleware(next.Invoke, policyProvider.Object);
+            var context = GetHttpContext(endpoint: CreateEndpoint(new AuthorizeAttribute()));
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            Assert.True(next.Called);
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.NotNull(authenticateResultFeature);
+            Assert.NotNull(authenticateResultFeature.Result);
+            Assert.Same(context.User, authenticateResultFeature.Result.Principal);
+
+            context.User = new ClaimsPrincipal();
+            Assert.Null(authenticateResultFeature.Result);
+        }
+
+        [Fact]
+        public async Task IAuthenticateResultFeature_SettingResultSetsUser()
+        {
+            // Arrange
+            var policy = new AuthorizationPolicyBuilder().RequireClaim("Permission", "CanViewPage").Build();
+            var policyProvider = new Mock<IAuthorizationPolicyProvider>();
+            policyProvider.Setup(p => p.GetDefaultPolicyAsync()).ReturnsAsync(policy);
+            var next = new TestRequestDelegate();
+
+            var middleware = CreateMiddleware(next.Invoke, policyProvider.Object);
+            var context = GetHttpContext(endpoint: CreateEndpoint(new AuthorizeAttribute()));
+
+            // Act
+            await middleware.Invoke(context);
+
+            // Assert
+            Assert.True(next.Called);
+            var authenticateResultFeature = context.Features.Get<IAuthenticateResultFeature>();
+            Assert.NotNull(authenticateResultFeature);
+            Assert.NotNull(authenticateResultFeature.Result);
+            Assert.Same(context.User, authenticateResultFeature.Result.Principal);
+
+            var newTicket = new AuthenticationTicket(new ClaimsPrincipal(), "");
+            authenticateResultFeature.Result = AuthenticateResult.Success(newTicket);
+            Assert.Same(context.User, newTicket.Principal);
         }
 
         private AuthorizationMiddleware CreateMiddleware(RequestDelegate requestDelegate = null, IAuthorizationPolicyProvider policyProvider = null)


### PR DESCRIPTION
* Add the `IAuthenticateResult` feature
* Add a class to keep `User` and `AuthenticateResult` consistent
* Add `ExpiresUtc` value to ticket properties (easiest property to reason about with multiple schemes)

~~TODO: Add tests~~

Fixes https://github.com/dotnet/aspnetcore/issues/20847

```c#
Authentication.Abstractions package

namespace Microsoft.AspNetCore.Authentication
{
    public interface IAuthenticateResultFeature
    {
        AuthenticateResult? AuthenticateResult { get; set; }
    }
}
```