### PR TITLE
Update to public UseRazorSourceGenerator property

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
@@ -8,7 +8,7 @@
       Clien caching isn't part of our performance measurement, so we'll skip it.
     -->
     <BlazorCacheBootResources>false</BlazorCacheBootResources>
-    <_UseRazorSourceGenerator>false</_UseRazorSourceGenerator>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
+++ b/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
@@ -11,7 +11,7 @@
 
     <!-- Project supports more than one language -->
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-    <_UseRazorSourceGenerator>false</_UseRazorSourceGenerator>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestTrimmedApps)' == 'true'">


### PR DESCRIPTION
We moved to a public facing `UseRazorSourceGenerator` property recently but missed updating our use of it when we updated the SDK recently.