### PR TITLE
Remove dependency on Internal.AspNetCore.BuildTasks

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -297,6 +297,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>85a65ea1fca1d0867f699fed44d191358270bf6a</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="6.0.0-beta.21310.4">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>a565e0c890d0a325775882542cff7e775db8f8e6</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21304.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>85a65ea1fca1d0867f699fed44d191358270bf6a</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -137,6 +137,7 @@
     <MicrosoftEntityFrameworkCoreDesignVersion>6.0.0-preview.6.21308.13</MicrosoftEntityFrameworkCoreDesignVersion>
     <!-- Packages from dotnet/arcade -->
     <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.21304.1</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.21310.4</MicrosoftDotNetBuildTasksTemplatingVersion>
   </PropertyGroup>
   <!--
 
@@ -160,7 +161,6 @@
     <!-- DiagnosticAdapter package pinned temporarily until migrated/deprecated -->
     <MicrosoftExtensionsDiagnosticAdapterVersion>5.0.0-preview.4.20180.4</MicrosoftExtensionsDiagnosticAdapterVersion>
     <!-- Build tool dependencies -->
-    <InternalAspNetCoreBuildTasksVersion>3.0.0-build-20190530.3</InternalAspNetCoreBuildTasksVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.9.3032</MicrosoftVSSDKBuildToolsVersion>
     <!-- Stable dotnet/corefx packages no longer updated for .NET Core 3 -->
     <MicrosoftCSharpVersion>4.7.0</MicrosoftCSharpVersion>

--- a/eng/Workarounds.targets
+++ b/eng/Workarounds.targets
@@ -35,11 +35,6 @@
   <!-- Workaround https://github.com/dotnet/source-build/issues/1112. Source link is currently disabled in source build so define this dummy target which is required for pack. -->
   <Import Condition="'$(DotNetBuildFromSource)' == 'true'" Project="WorkaroundsImported.targets" />
 
-  <!-- Workaround for https://github.com/dotnet/arcade/issues/204, not needed in source build -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <PackageReference Include="Internal.AspNetCore.BuildTasks" PrivateAssets="All" Version="$(InternalAspNetCoreBuildTasksVersion)" IsImplicitlyDefined="true" />
-  </ItemGroup>
-
   <!-- Workaround for netstandard2.1 projects until we can get a preview 8 SDK containing https://github.com/dotnet/sdk/pull/3463 fix. -->
   <ItemGroup>
     <KnownFrameworkReference Update="NETStandard.Library">

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
   <!-- Update artifacts/bin/GenerateFiles/Directory.Build.* files. -->
   <Target Name="GenerateDirectoryBuildFiles">
     <PropertyGroup>

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
+
+    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!--  We include this here to ensure that the shared framework is built before we leverage it when running

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
+
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" IsImplicitlyDefined="true" AllowExplicitReference="true" />
   </ItemGroup>
 
   <!--  We include this here to ensure that the shared framework is built before we leverage it when running

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -21,8 +21,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
-
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!--  We include this here to ensure that the shared framework is built before we leverage it when running

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -22,7 +22,7 @@
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
 
-    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!--  We include this here to ensure that the shared framework is built before we leverage it when running

--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <Target Name="PrepareForBuild">

--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -11,6 +11,10 @@
     </DebBuildDependsOn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
   <Target Name="PrepareForBuild">
     <MakeDir Directories="$(IntermediateOutputPath);$(OutputPath)" />
 

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <Target Name="GetTargetPath" Returns="$(TargetPath)" />

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -9,6 +9,10 @@
     <RpmPackageInstallRoot Condition="'$(RpmPackageInstallRoot)' != '' AND !HasTrailingSlash('$(RpmPackageInstallRoot)')">$(RpmPackageInstallRoot)/</RpmPackageInstallRoot>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
   <Target Name="GetTargetPath" Returns="$(TargetPath)" />
 
   <Target Name="PrepareForBuild">

--- a/src/ProjectTemplates/GenerateContent.targets
+++ b/src/ProjectTemplates/GenerateContent.targets
@@ -51,8 +51,8 @@
       Properties="$(GeneratedContentProperties);%(GeneratedContent.AdditionalProperties)"
       OutputPath="%(GeneratedContent.OutputPath)">
 
-      <Output TaskParameter="OutputPath" ItemName="FileWrites" />
-      <Output TaskParameter="OutputPath" ItemName="Content" />
+      <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
+      <Output TaskParameter="ResolvedOutputPath" ItemName="Content" />
     </GenerateFileFromTemplate>
   </Target>
 </Project>

--- a/src/ProjectTemplates/GenerateContent.targets
+++ b/src/ProjectTemplates/GenerateContent.targets
@@ -12,6 +12,10 @@
     </GeneratedContentProperties>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
   <!--
     Generates content using MSBuild variables.
   -->

--- a/src/ProjectTemplates/GenerateContent.targets
+++ b/src/ProjectTemplates/GenerateContent.targets
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!--

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -18,10 +18,6 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
-  </ItemGroup>
-
   <Target Name="PrepareForTest" BeforeTargets="GetAssemblyAttributes" Condition="$(DesignTimeBuild) != true">
     <PropertyGroup>
       <TestTemplateCreationFolder>$([MSBuild]::NormalizePath('$(OutputPath)$(TestTemplateCreationFolder)'))</TestTemplateCreationFolder>

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -18,6 +18,10 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
   <Target Name="PrepareForTest" BeforeTargets="GetAssemblyAttributes" Condition="$(DesignTimeBuild) != true">
     <PropertyGroup>
       <TestTemplateCreationFolder>$([MSBuild]::NormalizePath('$(OutputPath)$(TestTemplateCreationFolder)'))</TestTemplateCreationFolder>

--- a/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <Target Name="PrepareForTest" BeforeTargets="GetAssemblyAttributes" Condition="$(DesignTimeBuild) != true">


### PR DESCRIPTION
Fixes: #32492 

Instead, use the Microsoft.DotNet.Build.Tasks.Templating package from dotnet/arcade https://github.com/dotnet/arcade/pull/7403.