### PR TITLE
Fix script/link tests

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -135,10 +135,9 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             }
         }
 
-        [ConditionalTheory]
+        [Theory]
         [InlineData("Link", null)]
         [InlineData("Script", null)]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/10423")]
         public Task HtmlGenerationWebSite_GeneratesExpectedResultsNotReadyForHelix(string action, string antiforgeryPath)
             => HtmlGenerationWebSite_GeneratesExpectedResults(action, antiforgeryPath);
 

--- a/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -52,6 +52,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                     { "Customer", "/Customer/HtmlGeneration_Customer" },
                     { "Index", null },
                     { "Product", null },
+                    { "Link", null },
+                    { "Script", null },
                     // Testing attribute values with boolean and null values
                     { "AttributesWithBooleanValues", null },
                     // Testing SelectTagHelper with Html.BeginForm
@@ -134,12 +136,6 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
                 }
             }
         }
-
-        [Theory]
-        [InlineData("Link", null)]
-        [InlineData("Script", null)]
-        public Task HtmlGenerationWebSite_GeneratesExpectedResultsNotReadyForHelix(string action, string antiforgeryPath)
-            => HtmlGenerationWebSite_GeneratesExpectedResults(action, antiforgeryPath);
 
         [Fact]
         public async Task HtmlGenerationWebSite_GeneratesExpectedResults_WithImageData()

--- a/src/Mvc/test/Mvc.FunctionalTests/TagHelpersTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TagHelpersTest.cs
@@ -38,7 +38,6 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         [Theory]
         [InlineData("Index")]
         [InlineData("About")]
-        [InlineData("GlobbingTagHelpers")]
         [InlineData("Help")]
         [InlineData("UnboundDynamicAttributes")]
         public async Task CanRenderViewsWithTagHelpers(string action)
@@ -62,6 +61,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [ConditionalTheory]
+        [InlineData("GlobbingTagHelpers")]
         [InlineData("ViewComponentTagHelpers")]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/10423")]
         public Task CanRenderViewsWithTagHelpersNotReadyForHelix(string action) => CanRenderViewsWithTagHelpers(action);

--- a/src/Mvc/test/Mvc.FunctionalTests/TagHelpersTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TagHelpersTest.cs
@@ -38,8 +38,8 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         [Theory]
         [InlineData("Index")]
         [InlineData("About")]
-        [InlineData("Help")]
         [InlineData("GlobbingTagHelpers")]
+        [InlineData("Help")]
         [InlineData("UnboundDynamicAttributes")]
         public async Task CanRenderViewsWithTagHelpers(string action)
         {

--- a/src/Mvc/test/Mvc.FunctionalTests/TagHelpersTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TagHelpersTest.cs
@@ -39,6 +39,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         [InlineData("Index")]
         [InlineData("About")]
         [InlineData("Help")]
+        [InlineData("GlobbingTagHelpers")]
         [InlineData("UnboundDynamicAttributes")]
         public async Task CanRenderViewsWithTagHelpers(string action)
         {
@@ -61,11 +62,9 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [ConditionalTheory]
-        [InlineData("GlobbingTagHelpers")]
         [InlineData("ViewComponentTagHelpers")]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/10423")]
-        public Task CanRenderViewsWithTagHelpersNotReadyForHelix(string action)
-            => CanRenderViewsWithTagHelpers(action);
+        public Task CanRenderViewsWithTagHelpersNotReadyForHelix(string action) => CanRenderViewsWithTagHelpers(action);
 
         [Fact]
         public async Task GivesCorrectCallstackForSyncronousCalls()

--- a/src/Mvc/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Link.cshtml
+++ b/src/Mvc/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Link.cshtml
@@ -10,13 +10,13 @@
     <link href="~/styles/site.css" rel="stylesheet" title="&lt;the title>" />
 
     <!-- Globbed link tag with existing file -->
-    <link asp-href-include="**/site.css" rel="stylesheet" title="&lt;the title>" />
+    <link asp-href-include="**/styles/site.css" rel="stylesheet" title="&lt;the title>" />
 
     <!-- Globbed link tag with comma separated pattern -->
     <link asp-href-include="~/styles/*.css, ~/styles/sub/*.css" rel="stylesheet" title="&lt;the title" />
 
     <!-- Globbed link tag with existing file and exclude -->
-    <link asp-href-include=" **/*.css" asp-href-exclude="**/site3*.css" rel="stylesheet" title='"the" title' />
+    <link asp-href-include=" **/styles/**/*.css" asp-href-exclude="**/site3*.css" rel="stylesheet" title='"the" title' />
 
     <!-- Globbed link tag missing include -->
     <link asp-href-exclude="**/site2.css" rel="stylesheet">
@@ -37,7 +37,7 @@
     <link href="~/styles/site.css" asp-href-include="**/site2.css" rel="stylesheet" />
 
     <!-- Globbed link tag with existing file and static href should dedupe -->
-    <link href="~/styles/site.css" asp-href-include="**/site.css" rel="stylesheet" />
+    <link href="~/styles/site.css" asp-href-include="**/styles/site.css" rel="stylesheet" />
 
     <!-- Fallback to static href -->
     <link href="~/styles/site.min.css?a=b&c=d" rel="stylesheet" data-extra="test" title='"the" title'
@@ -127,7 +127,7 @@
 
     <!-- Fallback to globbed href -->
     <link href="~/styles/site.min.css" rel="stylesheet" data-extra="test"
-          asp-fallback-href-include="**/site.css"
+          asp-fallback-href-include="**/styles/site.css"
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden" />
@@ -143,7 +143,7 @@
     <!-- Fallback to static and globbed href should dedupe -->
     <link href="~/styles/site.min.css" rel="stylesheet" data-extra="test"
           asp-fallback-href="~/styles/site.css"
-          asp-fallback-href-include="**/site.css"
+          asp-fallback-href-include="**/styles/site.css"
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden" />
@@ -151,7 +151,7 @@
     <!-- Fallback to static and globbed href with exclude -->
     <link href="~/styles/site.min.css" rel="stylesheet" data-extra="test"
           asp-fallback-href="~/styles/site.css"
-          asp-fallback-href-include="**/*.css"
+          asp-fallback-href-include="**/styles/**/*.css"
           asp-fallback-href-exclude="**/site3*.css"
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
@@ -159,21 +159,21 @@
 
     <!-- Fallback from globbed href to globbed href -->
     <link asp-href-include="styles/site.min.css" rel="stylesheet" data-extra="test"
-          asp-fallback-href-include="**/site.css"
+          asp-fallback-href-include="**/styles/site.css"
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden" />
 
     <!-- Fallback from globbed href with exclude to globbed href -->
     <link asp-href-include="**/*.min.css" asp-href-exclude="**/site3.min.css" rel="stylesheet" data-extra="test"
-          asp-fallback-href-include="**/site.css"
+          asp-fallback-href-include="**/styles/site.css"
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden" />
 
     <!-- Fallback from globbed and static href to globbed href -->
     <link href="styles/site.min.css" asp-href-include="styles/site.css" rel="stylesheet" data-extra="test"
-          asp-fallback-href-include="**/site.css"
+          asp-fallback-href-include="**/styles/site.css"
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden" />
@@ -181,7 +181,7 @@
     <!-- Fallback from globbed and static href with exclude to globbed href -->
     <link href="styles/site.min.css" asp-href-include="**/*.min.css" asp-href-exclude="**/site3.min.css"
           rel="stylesheet" data-extra="test"
-          asp-fallback-href-include="**/site.css"
+          asp-fallback-href-include="**/styles/site.css"
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
           asp-fallback-test-value="hidden">
@@ -190,7 +190,7 @@
     <link href="styles/site.min.css" asp-href-include="**/*.min.css" asp-href-exclude="**/site3.min.css"
           rel="stylesheet" data-extra="test"
           asp-fallback-href="~/styles/site.css"
-          asp-fallback-href-include="**/*.css"
+          asp-fallback-href-include="**/styles/**/*.css"
           asp-fallback-href-exclude="**/site3*.css"
           asp-fallback-test-class="hidden"
           asp-fallback-test-property="visibility"
@@ -232,7 +232,7 @@
     <link href="~/styles/site.css" rel="stylesheet" asp-append-version="true" />
 
     <!-- Globbed link tag with existing file and file version -->
-    <link asp-href-include="**/site.css" rel="stylesheet" asp-append-version="true" />
+    <link asp-href-include="**/styles/site.css" rel="stylesheet" asp-append-version="true" />
 
     <!-- Fallback with file version -->
     <link href="~/styles/site.min.css" rel="stylesheet" data-extra="test"
@@ -243,7 +243,7 @@
           asp-append-version="true">
 
     <!-- Globbed link tag with existing file, static href and file version -->
-    <link href="~/styles/site.css" asp-href-include="**/*.css" rel="stylesheet" asp-append-version="true" />
+    <link href="~/styles/site.css" asp-href-include="**/styles/**/*.css" rel="stylesheet" asp-append-version="true" />
 </head>
 <body>
 

--- a/src/Mvc/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Script.cshtml
+++ b/src/Mvc/test/WebSites/HtmlGenerationWebSite/Views/HtmlGeneration_Home/Script.cshtml
@@ -51,7 +51,7 @@
     </script>
 
     <script src="~/blank.js"
-            asp-fallback-src-include="**/*.js"
+            asp-fallback-src-include="**/styles/**/*.js"
             asp-fallback-src-exclude="**/site3.js"
             asp-fallback-test="false">
         // Fallback to globbed src with exclude
@@ -104,7 +104,7 @@
     </script>
 
     <!-- Globbed script tag with existing file and exclude -->
-    <script asp-src-include="**/*.js" asp-src-exclude="**/site3.js">
+    <script asp-src-include="**/styles/**/*.js" asp-src-exclude="**/site3.js">
         // This comment shouldn't be emitted
     </script>
 
@@ -149,12 +149,12 @@
     </script>
 
     <!-- Globbed script tag with existing files and version -->
-    <script asp-src-include="**/*.js" asp-append-version="true">
+    <script asp-src-include="**/styles/**/*.js" asp-append-version="true">
         // This comment shouldn't be emitted
     </script>
 
     <!-- Globbed script tag with existing file, exclude and version -->
-    <script asp-src-include="**/*.js" asp-src-exclude="**/site3.js" asp-append-version="true">
+    <script asp-src-include="**/styles/**/*.js" asp-src-exclude="**/site3.js" asp-append-version="true">
         // This comment shouldn't be emitted
     </script>
 </body>

--- a/src/Mvc/test/WebSites/TagHelpersWebSite/Views/Home/GlobbingTagHelpers.cshtml
+++ b/src/Mvc/test/WebSites/TagHelpersWebSite/Views/Home/GlobbingTagHelpers.cshtml
@@ -10,10 +10,10 @@
     <!-- RazorClassLib folder wildcard -->
     <script asp-src-include="/_content/RazorPagesClassLibrary/**/file.js"></script>
     <!-- RazorClassLib deep wildcard -->
-    <script asp-src-include="/**/*.js"></script>
+    <script asp-src-include="/**/*.js" asp-src-exclude="/styles/**/*.js,/razorlib/*.js,/lib/**/*.js" ></script>
     <!-- RazorClassLib Exclude local -->
-    <script asp-src-exclude="/js/dist/*.js" asp-src-include="**/*.js"></script>
+    <script asp-src-exclude="/js/dist/*.js,/styles/**/*.js,/razorlib/*.js,/lib/**/*.js" asp-src-include="**/*.js"></script>
     <!-- local Exclude lib-->
-    <script asp-src-exclude="/_content/**/*.js" asp-src-include="**/*.js"></script>
+    <script asp-src-exclude="/_content/**/*.js,/styles/**/*.js,/razorlib/*.js,/lib/**/*.js" asp-src-include="**/*.js"></script>
 }
 Globbing


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/29597

Moving to helix merged the websites so there are additional css/js files, more tightly scoping the globs avoids the additional js/css files