### PR TITLE
Ensure @typeparam directive descriptor is always set

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentConstrainedTypeParamDirective.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentConstrainedTypeParamDirective.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components
 {
-    internal class ComponentTypeParamDirective
+    internal class ComponentConstrainedTypeParamDirective
     {
         public static DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             "typeparam",
@@ -13,6 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             builder =>
             {
                 builder.AddMemberToken(ComponentResources.TypeParamDirective_Token_Name, ComponentResources.TypeParamDirective_Token_Description);
+                builder.AddOptionalGenericTypeConstraintToken(ComponentResources.TypeParamDirective_Constraint_Name, ComponentResources.TypeParamDirective_Constraint_Description);
                 builder.Usage = DirectiveUsage.FileScopedMultipleOccurring;
                 builder.Description = ComponentResources.TypeParamDirective_Description;
             });

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDocumentClassifierPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDocumentClassifierPass.cs
@@ -100,7 +100,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             {
                 @class.BaseType = ComponentsApi.ComponentBase.FullTypeName;
 
-                var typeParamReferences = documentNode.FindDirectiveReferences(ComponentTypeParamDirective.Directive);
+                var razorLanguageVersion = codeDocument.GetParserOptions().Version;
+                // Constrained type parameters are support in Razor language versions v6.0
+                var directiveType = razorLanguageVersion.CompareTo(RazorLanguageVersion.Version_6_0) >= 0
+                    ? ComponentConstrainedTypeParamDirective.Directive
+                    : ComponentTypeParamDirective.Directive;
+                var typeParamReferences = documentNode.FindDirectiveReferences(directiveType);
                 for (var i = 0; i < typeParamReferences.Count; i++)
                 {
                     var typeParamNode = (DirectiveIntermediateNode)typeParamReferences[i].Node;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDocumentClassifierPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDocumentClassifierPass.cs
@@ -100,8 +100,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
             {
                 @class.BaseType = ComponentsApi.ComponentBase.FullTypeName;
 
-                var razorLanguageVersion = codeDocument.GetParserOptions().Version;
-                // Constrained type parameters are support in Razor language versions v6.0
+                // Constrained type parameters are only supported in Razor language versions v6.0
+                var razorLanguageVersion = codeDocument.GetParserOptions()?.Version ?? RazorLanguageVersion.Latest;
                 var directiveType = razorLanguageVersion.CompareTo(RazorLanguageVersion.Version_6_0) >= 0
                     ? ComponentConstrainedTypeParamDirective.Directive
                     : ComponentTypeParamDirective.Directive;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
@@ -222,12 +222,16 @@ namespace Microsoft.AspNetCore.Razor.Language
             ComponentLayoutDirective.Register(builder);
             ComponentPageDirective.Register(builder);
 
-            // Unconditionally enable the feature for the time being until we flow the SDK with the flow version
-            // into the repository.
-            ComponentTypeParamDirective.Register(
-                builder,
-                supportConstraints: true);
-                //supportConstraints: razorLanguageVersion.CompareTo(RazorLanguageVersion.Version_6_0) >= 0);
+
+
+            if (razorLanguageVersion.CompareTo(RazorLanguageVersion.Version_6_0) >= 0)
+            {
+                ComponentConstrainedTypeParamDirective.Register(builder);
+            }
+            else
+            {
+                ComponentTypeParamDirective.Register(builder);
+            }
 
             if (razorLanguageVersion.CompareTo(RazorLanguageVersion.Version_5_0) >= 0)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/32592 and fixes https://github.com/dotnet/aspnetcore/issues/32193 and probably also fixes https://github.com/dotnet/aspnetcore/issues/32237.

The way the `TypeParamDirective` was instantiated before ran the risk of having an undefined `Directive` property if multiple project engines are instantiated. This is more likely to happen in tests that run in parallel and in our compilation flow.

I've cleaned this up so that the correct `TypeParamDirective` construct is produced depending on the language version.