### PR TITLE
Add barebones devcontainer setup for repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
+
+# [Choice] .NET version: 5.0, 3.1, 2.1
+ARG VARIANT="5.0"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
+{
+	"name": "C# (.NET)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
+			"VARIANT": "5.0",
+			// Options
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*"
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-dotnettools.csharp"
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",
+
+	// Add the locally installed dotnet to the path to ensure that it is activated
+	// This is needed so that things like the C# extension can resolve the correct SDK version
+	"remoteEnv": {
+		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
+		"DOTNET_MULTILEVEL_LOOKUP": "0",
+		"TARGET": "net6.0"
+	},
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/scripts/container-creation.sh
+++ b/.devcontainer/scripts/container-creation.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+# GitHub doesn't pull in submodules by default when mounting
+# the repo directory on the container so we do this post-create
+git submodule update --init --recursive
+# Run restore to install the SDK before the app starts
+./restore.sh

--- a/.devcontainer/scripts/container-creation.sh
+++ b/.devcontainer/scripts/container-creation.sh
@@ -5,5 +5,5 @@ set -e
 # GitHub doesn't pull in submodules by default when mounting
 # the repo directory on the container so we do this post-create
 git submodule update --init --recursive
-# Run restore to install the SDK before the app starts
-./restore.sh
+# Install SDK and tool dependencies before container starts
+./eng/build.sh --only-build-repo-tasks


### PR DESCRIPTION
Been using Codespaces a bit so dumping some config that has been helpful for me.

This is mostly here to:

- Make sure all the submodules are cloned
- Make sure that the version of dotnet specified in the `global.json` is installed
- Make sure that the $PATH includes the locally installed dotnet so that the integrated terminal and C# extension can pick up the right things

With this in place, you can launch Codespaces and be able to restore/run projects without any issues.