### PR TITLE
Mark directive types as static when necessary

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentConstrainedTypeParamDirective.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentConstrainedTypeParamDirective.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components
 {
-    internal class ComponentConstrainedTypeParamDirective
+    internal static class ComponentConstrainedTypeParamDirective
     {
         public static DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             "typeparam",

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentInjectDirective.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentInjectDirective.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
     // but this one outputs properties annotated for Components's property injector, plus it doesn't need to
     // support multiple CodeTargets.
 
-    internal class ComponentInjectDirective
+    internal static class ComponentInjectDirective
     {
         public static readonly DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             "inject",

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentTypeParamDirective.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentTypeParamDirective.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components
 {
-    internal class ComponentTypeParamDirective
+    internal static class ComponentTypeParamDirective
     {
         public static DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
             "typeparam",


### PR DESCRIPTION
Eh, turns out all the other classes were actually static as well. I thought I imagined they weren't but I was wrong.