### PR TITLE
Blazor Desktop: Call ServiceScope.DisposeAsync() instead of Dispose()

### DIFF
--- a/src/Components/WebView/WebView/src/PageContext.cs
+++ b/src/Components/WebView/WebView/src/PageContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebView.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -17,7 +18,7 @@ namespace Microsoft.AspNetCore.Components.WebView
     /// for web views, the IPC channel is outside the page context, whereas in Blazor Server,
     /// the IPC channel is within the circuit.
     /// </summary>
-    internal class PageContext : IDisposable
+    internal class PageContext : IAsyncDisposable
     {
         private readonly AsyncServiceScope _serviceScope;
 
@@ -45,10 +46,10 @@ namespace Microsoft.AspNetCore.Components.WebView
             Renderer = new WebViewRenderer(services, dispatcher, ipcSender, loggerFactory, JSRuntime.ElementReferenceContext);
         }
 
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
             Renderer.Dispose();
-            _serviceScope.Dispose();
+            return _serviceScope.DisposeAsync();
         }
     }
 }

--- a/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
@@ -2,7 +2,7 @@
 Microsoft.AspNetCore.Components.WebView.WebViewManager
 Microsoft.AspNetCore.Components.WebView.WebViewManager.AddRootComponentAsync(System.Type! componentType, string! selector, Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.WebView.WebViewManager.Dispatcher.get -> Microsoft.AspNetCore.Components.Dispatcher!
-Microsoft.AspNetCore.Components.WebView.WebViewManager.Dispose() -> void
+Microsoft.AspNetCore.Components.WebView.WebViewManager.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Microsoft.AspNetCore.Components.WebView.WebViewManager.MessageReceived(System.Uri! sourceUri, string! message) -> void
 Microsoft.AspNetCore.Components.WebView.WebViewManager.Navigate(string! url) -> void
 Microsoft.AspNetCore.Components.WebView.WebViewManager.RemoveRootComponentAsync(string! selector) -> System.Threading.Tasks.Task!
@@ -12,4 +12,4 @@ Microsoft.Extensions.DependencyInjection.ComponentsWebViewServiceCollectionExten
 abstract Microsoft.AspNetCore.Components.WebView.WebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
 abstract Microsoft.AspNetCore.Components.WebView.WebViewManager.SendMessage(string! message) -> void
 static Microsoft.Extensions.DependencyInjection.ComponentsWebViewServiceCollectionExtensions.AddBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-virtual Microsoft.AspNetCore.Components.WebView.WebViewManager.Dispose(bool disposing) -> void
+virtual Microsoft.AspNetCore.Components.WebView.WebViewManager.DisposeAsync(bool disposing) -> System.Threading.Tasks.ValueTask

--- a/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
@@ -12,4 +12,4 @@ Microsoft.Extensions.DependencyInjection.ComponentsWebViewServiceCollectionExten
 abstract Microsoft.AspNetCore.Components.WebView.WebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
 abstract Microsoft.AspNetCore.Components.WebView.WebViewManager.SendMessage(string! message) -> void
 static Microsoft.Extensions.DependencyInjection.ComponentsWebViewServiceCollectionExtensions.AddBlazorWebView(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-virtual Microsoft.AspNetCore.Components.WebView.WebViewManager.DisposeAsync(bool disposing) -> System.Threading.Tasks.ValueTask
+virtual Microsoft.AspNetCore.Components.WebView.WebViewManager.DisposeAsyncCore() -> System.Threading.Tasks.ValueTask

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -16,7 +15,7 @@ namespace Microsoft.AspNetCore.Components.WebView
     /// should subclass this to wire up the abstract and protected methods to the APIs of
     /// the platform's web view.
     /// </summary>
-    public abstract class WebViewManager : IDisposable
+    public abstract class WebViewManager : IAsyncDisposable
     {
         // These services are not DI services, because their lifetime isn't limited to a single
         // per-page-load scope. Instead, their lifetime matches the webview itself.
@@ -176,7 +175,10 @@ namespace Microsoft.AspNetCore.Components.WebView
             // If there was some previous attached page, dispose all its resources. We're not eagerly disposing
             // page contexts when the user navigates away, because we don't get notified about that. We could
             // change this if any important reason emerges.
-            _currentPageContext?.Dispose();
+            if (_currentPageContext != null)
+            {
+                await _currentPageContext.DisposeAsync();
+            }
 
             var serviceScope = _provider.CreateAsyncScope();
             _currentPageContext = new PageContext(_dispatcher, serviceScope, _ipcSender, baseUrl, startUrl);
@@ -204,13 +206,16 @@ namespace Microsoft.AspNetCore.Components.WebView
         /// Disposes the current <see cref="WebViewManager"/> instance.
         /// </summary>
         /// <param name="disposing"><c>true</c> when dispose was called explicitly; <c>false</c> when it is called as part of the finalizer.</param>
-        protected virtual void Dispose(bool disposing)
+        protected virtual async ValueTask DisposeAsync(bool disposing)
         {
             if (!_disposed)
             {
                 if (disposing)
                 {
-                    _currentPageContext?.Dispose();
+                    if (_currentPageContext != null)
+                    {
+                        await _currentPageContext.DisposeAsync();
+                    }
                 }
 
                 _disposed = true;
@@ -218,11 +223,12 @@ namespace Microsoft.AspNetCore.Components.WebView
         }
 
         /// <inheritdoc/>
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
+            // Do not change this code. Put cleanup code in 'DisposeAsync(bool disposing)' method
+            var task = DisposeAsync(disposing: true);
             GC.SuppressFinalize(this);
+            return task;
         }
     }
 }

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -205,19 +205,15 @@ namespace Microsoft.AspNetCore.Components.WebView
         /// <summary>
         /// Disposes the current <see cref="WebViewManager"/> instance.
         /// </summary>
-        /// <param name="disposing"><c>true</c> when dispose was called explicitly; <c>false</c> when it is called as part of the finalizer.</param>
-        protected virtual async ValueTask DisposeAsync(bool disposing)
+        protected virtual async ValueTask DisposeAsyncCore()
         {
             if (!_disposed)
             {
                 _disposed = true;
 
-                if (disposing)
+                if (_currentPageContext != null)
                 {
-                    if (_currentPageContext != null)
-                    {
-                        await _currentPageContext.DisposeAsync();
-                    }
+                    await _currentPageContext.DisposeAsync();
                 }
             }
         }
@@ -227,7 +223,7 @@ namespace Microsoft.AspNetCore.Components.WebView
         {
             // Do not change this code. Put cleanup code in 'DisposeAsync(bool disposing)' method
             GC.SuppressFinalize(this);
-            await DisposeAsync(disposing: true);
+            await DisposeAsyncCore();
         }
     }
 }

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -210,6 +210,8 @@ namespace Microsoft.AspNetCore.Components.WebView
         {
             if (!_disposed)
             {
+                _disposed = true;
+
                 if (disposing)
                 {
                     if (_currentPageContext != null)
@@ -217,18 +219,15 @@ namespace Microsoft.AspNetCore.Components.WebView
                         await _currentPageContext.DisposeAsync();
                     }
                 }
-
-                _disposed = true;
             }
         }
 
         /// <inheritdoc/>
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             // Do not change this code. Put cleanup code in 'DisposeAsync(bool disposing)' method
-            var task = DisposeAsync(disposing: true);
+            await DisposeAsync(disposing: true);
             GC.SuppressFinalize(this);
-            return task;
         }
     }
 }

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -226,8 +226,8 @@ namespace Microsoft.AspNetCore.Components.WebView
         public async ValueTask DisposeAsync()
         {
             // Do not change this code. Put cleanup code in 'DisposeAsync(bool disposing)' method
-            await DisposeAsync(disposing: true);
             GC.SuppressFinalize(this);
+            await DisposeAsync(disposing: true);
         }
     }
 }


### PR DESCRIPTION
If you call Dispose() and there are IAsyncDisposable scoped services registered, it throws. Instead it needs to call DisposeAsync() that supports both sync and async disposable services.

Partial fix for #31112. The rest of this fix will be in the MAUI repo: https://github.com/dotnet/maui/issues/1280