### PR TITLE
Optimize [BLAZOR][WASM] project template for `PWA` applications.

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -4,7 +4,8 @@
   "classifications": [
     "Web",
     "Blazor",
-    "WebAssembly"
+    "WebAssembly",
+    "PWA"
   ],
   "name": "Blazor WebAssembly App",
   "defaultName": "BlazorApp",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/index.html
@@ -16,6 +16,7 @@
     <!--#if PWA -->
     <link href="manifest.json" rel="manifest" />
     <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
+    <link rel="apple-touch-icon" sizes="192x192" href="icon-192.png" />
     <!--#endif -->
 </head>
 


### PR DESCRIPTION
**PR Description**
Add `192x192` icon to PWA project template (Missing in [previous PR](https://github.com/dotnet/aspnetcore/pull/33469)) that is **required** for smaller _IOS_ devices. (ALSO Fixes #32904)
Add `PWA` classification to **BLAZOR WASM** project template.