### PR TITLE
SpaProxy: Don't forward HTTP/1.1 only headers

### DIFF
--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Http;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -23,14 +24,14 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
         private const int StreamCopyBufferSize = 81920;
 
         // https://github.com/dotnet/aspnetcore/issues/16797
-        private static readonly string[] NotForwardedHttpHeaders = new[] { "Connection" };
+        private static readonly HashSet<string> NotForwardedHttpHeaders = new HashSet<string> { "Connection" };
 
         // Don't forward User-Agent/Accept because of https://github.com/aspnet/JavaScriptServices/issues/1469
         // Others just aren't applicable in proxy scenarios
-        private static readonly string[] NotForwardedWebSocketHeaders = new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" };
+        private static readonly HashSet<string> NotForwardedWebSocketHeaders = new HashSet<string> { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" };
 
 		// In case the connection to the client is HTTP/2 or HTTP/3 and to the server HTTP/1.1 or less, let's get rid of the HTTP/1.1 only headers
-		private static readonly string[] InvalidH2H3Headers = new[] { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" };
+		private static readonly HashSet<string> InvalidH2H3Headers = new HashSet<string> { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" };
 
         public static HttpClient CreateHttpClientForProxy(TimeSpan requestTimeout)
         {

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -161,7 +161,8 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
             context.Response.StatusCode = (int)responseMessage.StatusCode;
             foreach (var header in responseMessage.Headers)
             {
-				if (context.Request.Protocol != "HTTP/1.1" && Http2NotForwardedResponseHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+				if ((HttpProtocol.IsHttp2(context.Request.Protocol) || HttpProtocol.IsHttp3(context.Request.Protocol))
+					&& Http2NotForwardedResponseHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
 				{
 					continue;
 				}

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -29,8 +29,8 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
         // Others just aren't applicable in proxy scenarios
         private static readonly string[] NotForwardedWebSocketHeaders = new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" };
 
-		// In case the connection to the client is HTTP/2 and to the server HTTP/1.1, let's get rid of the HTTP/1.1 only headers
-		private static readonly string[] Http2NotForwardedResponseHeaders = new[] { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" };
+		// In case the connection to the client is HTTP/2 or HTTP/3 and to the server HTTP/1.1 or less, let's get rid of the HTTP/1.1 only headers
+		private static readonly string[] InvalidH2H3Headers = new[] { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" };
 
         public static HttpClient CreateHttpClientForProxy(TimeSpan requestTimeout)
         {
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
             foreach (var header in responseMessage.Headers)
             {
 				if ((HttpProtocol.IsHttp2(context.Request.Protocol) || HttpProtocol.IsHttp3(context.Request.Protocol))
-					&& Http2NotForwardedResponseHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+					&& InvalidH2H3Headers.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
 				{
 					continue;
 				}

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -29,6 +29,9 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
         // Others just aren't applicable in proxy scenarios
         private static readonly string[] NotForwardedWebSocketHeaders = new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" };
 
+		// In case the connection to the client is HTTP/2 and to the server HTTP/1.1, let's get rid of the HTTP/1.1 only headers
+		private static readonly string[] Http2NotForwardedResponseHeaders = new[] { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" };
+
         public static HttpClient CreateHttpClientForProxy(TimeSpan requestTimeout)
         {
             var handler = new HttpClientHandler
@@ -158,6 +161,10 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
             context.Response.StatusCode = (int)responseMessage.StatusCode;
             foreach (var header in responseMessage.Headers)
             {
+				if (context.Request.Protocol != "HTTP/1.1" && Http2NotForwardedResponseHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+				{
+					continue;
+				}
                 context.Response.Headers[header.Key] = header.Value.ToArray();
             }
 

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -24,14 +24,23 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
         private const int StreamCopyBufferSize = 81920;
 
         // https://github.com/dotnet/aspnetcore/issues/16797
-        private static readonly HashSet<string> NotForwardedHttpHeaders = new HashSet<string> { "Connection" };
+		private static readonly HashSet<string> NotForwardedHttpHeaders = new HashSet<string>(
+			new[] { "Connection" },
+			StringComparer.OrdinalIgnoreCase
+		);
 
         // Don't forward User-Agent/Accept because of https://github.com/aspnet/JavaScriptServices/issues/1469
         // Others just aren't applicable in proxy scenarios
-        private static readonly HashSet<string> NotForwardedWebSocketHeaders = new HashSet<string> { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" };
+		private static readonly HashSet<string> NotForwardedWebSocketHeaders = new HashSet<string>(
+			new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" },
+			StringComparer.OrdinalIgnoreCase
+		);
 
 		// In case the connection to the client is HTTP/2 or HTTP/3 and to the server HTTP/1.1 or less, let's get rid of the HTTP/1.1 only headers
-		private static readonly HashSet<string> InvalidH2H3Headers = new HashSet<string> { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" };
+		private static readonly HashSet<string> InvalidH2H3Headers = new HashSet<string>(
+			new[] { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" },
+			StringComparer.OrdinalIgnoreCase
+		);
 
         public static HttpClient CreateHttpClientForProxy(TimeSpan requestTimeout)
         {
@@ -139,7 +148,7 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
             // Copy the request headers
             foreach (var header in request.Headers)
             {
-                if (NotForwardedHttpHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+                if (NotForwardedHttpHeaders.Contains(header.Key))
                 {
                     continue;
                 }
@@ -163,7 +172,7 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
             foreach (var header in responseMessage.Headers)
             {
 				if ((HttpProtocol.IsHttp2(context.Request.Protocol) || HttpProtocol.IsHttp3(context.Request.Protocol))
-					&& InvalidH2H3Headers.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+					&& InvalidH2H3Headers.Contains(header.Key))
 				{
 					continue;
 				}
@@ -224,7 +233,7 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
                 }
                 foreach (var headerEntry in context.Request.Headers)
                 {
-                    if (!NotForwardedWebSocketHeaders.Contains(headerEntry.Key, StringComparer.OrdinalIgnoreCase))
+                    if (!NotForwardedWebSocketHeaders.Contains(headerEntry.Key))
                     {
                         try
                         {

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/SpaProxy.cs
@@ -24,23 +24,23 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
         private const int StreamCopyBufferSize = 81920;
 
         // https://github.com/dotnet/aspnetcore/issues/16797
-		private static readonly HashSet<string> NotForwardedHttpHeaders = new HashSet<string>(
-			new[] { "Connection" },
-			StringComparer.OrdinalIgnoreCase
-		);
+        private static readonly HashSet<string> NotForwardedHttpHeaders = new HashSet<string>(
+            new[] { "Connection" },
+            StringComparer.OrdinalIgnoreCase
+        );
 
         // Don't forward User-Agent/Accept because of https://github.com/aspnet/JavaScriptServices/issues/1469
         // Others just aren't applicable in proxy scenarios
-		private static readonly HashSet<string> NotForwardedWebSocketHeaders = new HashSet<string>(
-			new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" },
-			StringComparer.OrdinalIgnoreCase
-		);
+        private static readonly HashSet<string> NotForwardedWebSocketHeaders = new HashSet<string>(
+            new[] { "Accept", "Connection", "Host", "User-Agent", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Protocol", "Sec-WebSocket-Version" },
+            StringComparer.OrdinalIgnoreCase
+        );
 
-		// In case the connection to the client is HTTP/2 or HTTP/3 and to the server HTTP/1.1 or less, let's get rid of the HTTP/1.1 only headers
-		private static readonly HashSet<string> InvalidH2H3Headers = new HashSet<string>(
-			new[] { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" },
-			StringComparer.OrdinalIgnoreCase
-		);
+        // In case the connection to the client is HTTP/2 or HTTP/3 and to the server HTTP/1.1 or less, let's get rid of the HTTP/1.1 only headers
+        private static readonly HashSet<string> InvalidH2H3Headers = new HashSet<string>(
+            new[] { "Connection", "Transfer-Encoding", "Keep-Alive", "Upgrade", "Proxy-Connection" },
+            StringComparer.OrdinalIgnoreCase
+        );
 
         public static HttpClient CreateHttpClientForProxy(TimeSpan requestTimeout)
         {
@@ -171,11 +171,11 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
             context.Response.StatusCode = (int)responseMessage.StatusCode;
             foreach (var header in responseMessage.Headers)
             {
-				if ((HttpProtocol.IsHttp2(context.Request.Protocol) || HttpProtocol.IsHttp3(context.Request.Protocol))
-					&& InvalidH2H3Headers.Contains(header.Key))
-				{
-					continue;
-				}
+                if ((HttpProtocol.IsHttp2(context.Request.Protocol) || HttpProtocol.IsHttp3(context.Request.Protocol))
+                    && InvalidH2H3Headers.Contains(header.Key))
+                {
+                    continue;
+                }
                 context.Response.Headers[header.Key] = header.Value.ToArray();
             }
 


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
SpaProxy: don't forward HTTP/1.1 only headers on HTTP/2 connections

**PR Description**
When using SpaServices.Extensions's SpaProxy with a development server using HTTP/1.1 and ASP.NET using HTTP/2, the console gets flooded with the following warning:
```
warn: Microsoft.AspNetCore.Server.Kestrel[41]
One or more of the following response headers have been removed because they are invalid for HTTP/2 and HTTP/3 responses: 'Connection', 'Transfer-Encoding', 'Keep-Alive', 'Upgrade' and 'Proxy-Connection'.
```
In case the connection to the client is using HTTP/2, don't forward the HTTP/1.1 only headers from the proxied response.

I tested the PR locally, it get's rid of the warnings.

Addresses #33501 
