### PR TITLE
Fix HeadFile_HeadersButNotBodyServed

### DIFF
--- a/src/Middleware/StaticFiles/test/FunctionalTests/StaticFileMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/FunctionalTests/StaticFileMiddlewareTests.cs
@@ -191,6 +191,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                     webHostBuilder
                     .ConfigureServices(services => services.AddSingleton(LoggerFactory))
                     .UseKestrel()
+                    .UseUrls(TestUrlHelper.GetTestUrl(ServerType.Kestrel))
                     .UseWebRoot(Path.Combine(AppContext.BaseDirectory, baseDir))
                     .Configure(app => app.UseStaticFiles(new StaticFileOptions
                     {


### PR DESCRIPTION
All of the tests in this file use http and a random port. This test forgot to specify that so it uses the defaults (https://localhost:5001;http://localhost:5001). It hit an issue with the dev cert and hung.

Fix: Specify http and a random port.

Build: https://dev.azure.com/dnceng/public/_build/results?buildId=1186665&view=results

Log:
```
[0.114s] [Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer] [Warning] The application is trying to access the ASP.NET Core developer certificate key. A prompt might appear to ask for permission to access the key. When that happens, select 'Always Allow' to grant 'dotnet' access to the certificate key in the future.
```

https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-aspnetcore-refs-heads-dougbu-enablecg-031ea90195364fac85/Microsoft.AspNetCore.StaticFiles.FunctionalTests--net6.0/console.883ea48b.log?sv=2019-07-07&se=2021-07-04T20:05:40Z&sr=c&sp=rl&sig=GaiMryAu3KJLnlJ%2BLSwhbmFs5UohFi6s2k6Bfa%2FKddo%3D
```
[xUnit.net 00:01:06.84] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:01:05
[xUnit.net 00:02:06.86] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:02:05
[xUnit.net 00:03:06.89] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:03:05
[xUnit.net 00:04:06.91] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:04:05
[xUnit.net 00:05:06.93] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:05:05
[xUnit.net 00:06:06.95] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:06:05
[xUnit.net 00:07:06.97] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:07:05
[xUnit.net 00:08:06.99] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:08:05
[xUnit.net 00:09:07.01] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:09:05
[xUnit.net 00:10:07.03] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:10:05
[xUnit.net 00:11:07.05] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:11:05
[xUnit.net 00:12:07.07] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:12:05
[xUnit.net 00:13:07.09] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:13:05
[xUnit.net 00:14:07.11] Microsoft.AspNetCore.StaticFiles.FunctionalTests: [Long Running Test] 'Microsoft.AspNetCore.StaticFiles.StaticFileMiddlewareTests.HeadFile_HeadersButNotBodyServed(baseUrl: "", baseDir: "SubFolder", requestUrl: "/ranges.txt")', Elapsed: 00:14:05
Blame: Dumping 38715 - dotnet
Gathering state for process 38715 
Writing full dump to file /cores/dotnet_38715_20210614T132440_hangdump.dmp
Written 1643655624 bytes (401283 pages) to core file
Dump successfully written
The active test run was aborted. Reason: Test host process crashed
```
