### PR TITLE
Preserve quote style when rendering markup content

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
@@ -327,12 +327,17 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
                     return;
                 }
 
-                Builder.Append("=\"");
+                // We examine the node.Prefix (e.g. " onfocus='" or " on focus=\"")
+                // to preserve the quote type that is used in the original markup.
+                var quoteType = node.Prefix.Contains("'") ? "'" : "\"";
+
+                Builder.Append('=');
+                Builder.Append(quoteType);
 
                 // Visit Children
                 base.VisitDefault(node);
 
-                Builder.Append('"');
+                Builder.Append(quoteType);
             }
 
             public override void VisitHtmlAttributeValue(HtmlAttributeValueIntermediateNode node)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
                 // We examine the node.Prefix (e.g. " onfocus='" or " on focus=\"")
                 // to preserve the quote type that is used in the original markup.
-                var quoteType = node.Prefix.Contains("'") ? "'" : "\"";
+                var quoteType = node.Prefix.EndsWith("'") ? "'" : "\"";
 
                 Builder.Append('=');
                 Builder.Append(quoteType);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
                 // We examine the node.Prefix (e.g. " onfocus='" or " on focus=\"")
                 // to preserve the quote type that is used in the original markup.
-                var quoteType = node.Prefix.EndsWith('\'') ? '\'' : '"';
+                var quoteType = node.Prefix.EndsWith("'", StringComparison.Ordinal) ? "'" : "\"";
 
                 Builder.Append('=');
                 Builder.Append(quoteType);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
                 // We examine the node.Prefix (e.g. " onfocus='" or " on focus=\"")
                 // to preserve the quote type that is used in the original markup.
-                var quoteType = node.Prefix.EndsWith("'") ? "'" : "\"";
+                var quoteType = node.Prefix.EndsWith("'", StringComparison.Ordinal) ? "'" : "\"";
 
                 Builder.Append('=');
                 Builder.Append(quoteType);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs
@@ -329,7 +329,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
                 // We examine the node.Prefix (e.g. " onfocus='" or " on focus=\"")
                 // to preserve the quote type that is used in the original markup.
-                var quoteType = node.Prefix.EndsWith("'", StringComparison.Ordinal) ? "'" : "\"";
+                var quoteType = node.Prefix.EndsWith('\'') ? '\'' : '"';
 
                 Builder.Append('=');
                 Builder.Append(quoteType);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Components/ComponentMarkupBlockPassTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/Components/ComponentMarkupBlockPassTest.cs
@@ -347,8 +347,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 </html>");
 
             var expected = NormalizeContent(@"
-<head cool=""beans""><option value=""1"">One</option>
-    <option selected value=""2"">Two</option></head>");
+<head cool=""beans""><option value='1'>One</option>
+    <option selected value='2'>Two</option></head>");
 
             var documentNode = Lower(document);
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -6674,6 +6674,9 @@ Welcome to your new app.
             // Act
             var generated = CompileToCSharp(@"
 <input onfocus='alert(""Test"");' />
+<input onfocus=""alert(""Test"");"" />
+<input onfocus=""alert('Test');"" />
+<p data-options='{direction: ""fromtop"", animation_duration: 25, direction: ""reverse""}'></p>
 ");
 
             // Assert

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.ir.txt
@@ -20,3 +20,32 @@ Document -
                             LazyIntermediateToken - (16:0,16 [14] x:\dir\subdir\Test\TestComponent.cshtml) - Html - alert("Test");
                 HtmlContent - (34:0,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     LazyIntermediateToken - (34:0,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                MarkupElement - (36:1,0 [34] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (42:1,6 [17] x:\dir\subdir\Test\TestComponent.cshtml) -  onfocus=" - "
+                        HtmlAttributeValue - (52:1,16 [6] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            LazyIntermediateToken - (52:1,16 [6] x:\dir\subdir\Test\TestComponent.cshtml) - Html - alert(
+                    HtmlAttribute - (59:1,23 [8] x:\dir\subdir\Test\TestComponent.cshtml) - Test");" - 
+                HtmlContent - (70:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    LazyIntermediateToken - (70:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                MarkupElement - (72:2,0 [34] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (78:2,6 [25] x:\dir\subdir\Test\TestComponent.cshtml) -  onfocus=" - "
+                        HtmlAttributeValue - (88:2,16 [14] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            LazyIntermediateToken - (88:2,16 [14] x:\dir\subdir\Test\TestComponent.cshtml) - Html - alert('Test');
+                HtmlContent - (106:2,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    LazyIntermediateToken - (106:2,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                MarkupElement - (108:3,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - p
+                    HtmlAttribute - (110:3,2 [84] x:\dir\subdir\Test\TestComponent.cshtml) -  data-options=' - '
+                        HtmlAttributeValue - (125:3,17 [11] x:\dir\subdir\Test\TestComponent.cshtml) - 
+                            LazyIntermediateToken - (125:3,17 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Html - {direction:
+                        HtmlAttributeValue - (136:3,28 [11] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            LazyIntermediateToken - (137:3,29 [10] x:\dir\subdir\Test\TestComponent.cshtml) - Html - "fromtop",
+                        HtmlAttributeValue - (147:3,39 [20] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            LazyIntermediateToken - (148:3,40 [19] x:\dir\subdir\Test\TestComponent.cshtml) - Html - animation_duration:
+                        HtmlAttributeValue - (167:3,59 [4] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            LazyIntermediateToken - (168:3,60 [3] x:\dir\subdir\Test\TestComponent.cshtml) - Html - 25,
+                        HtmlAttributeValue - (171:3,63 [11] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            LazyIntermediateToken - (172:3,64 [10] x:\dir\subdir\Test\TestComponent.cshtml) - Html - direction:
+                        HtmlAttributeValue - (182:3,74 [11] x:\dir\subdir\Test\TestComponent.cshtml) -  
+                            LazyIntermediateToken - (183:3,75 [10] x:\dir\subdir\Test\TestComponent.cshtml) - Html - "reverse"}
+                HtmlContent - (199:3,91 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    LazyIntermediateToken - (199:3,91 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
@@ -17,7 +17,7 @@ namespace Test
             __builder.AddAttribute(1, "MyAttr", "abc");
             __builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
                 __builder2.AddContent(3, "Some text");
-                __builder2.AddMarkupContent(4, "<some-child a=\"1\">Nested text</some-child>");
+                __builder2.AddMarkupContent(4, "<some-child a=\'1\'>Nested text</some-child>");
             }
             ));
             __builder.CloseComponent();

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
@@ -11,7 +11,7 @@ Document -
                     ComponentChildContent -  - ChildContent - context
                         HtmlContent - (26:0,26 [9] x:\dir\subdir\Test\TestComponent.cshtml)
                             LazyIntermediateToken - (26:0,26 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Some text
-                        MarkupBlock -  - <some-child a="1">Nested text</some-child>
+                        MarkupBlock -  - <some-child a='1'>Nested text</some-child>
                     ComponentAttribute - (21:0,21 [3] x:\dir\subdir\Test\TestComponent.cshtml) - MyAttr - MyAttr - AttributeStructure.DoubleQuotes
                         HtmlContent - (21:0,21 [3] x:\dir\subdir\Test\TestComponent.cshtml)
                             LazyIntermediateToken - (21:0,21 [3] x:\dir\subdir\Test\TestComponent.cshtml) - Html - abc

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.codegen.cs
@@ -13,7 +13,7 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.AddMarkupContent(0, "<input onfocus=\"alert(\"Test\");\">");
+            __builder.AddMarkupContent(0, "<input onfocus=\'alert(\"Test\");\'>\r\n<input onfocus=\"alert(\" Test\");\">\r\n<input onfocus=\"alert(\'Test\');\">\r\n<p data-options=\'{direction: \"fromtop\", animation_duration: 25, direction: \"reverse\"}\'></p>");
         }
         #pragma warning restore 1998
     }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandlerTagHelper_EscapeQuotes/TestComponent.ir.txt
@@ -7,4 +7,4 @@ Document -
         UsingDirective - (104:5,1 [39] ) - Microsoft.AspNetCore.Components
         ClassDeclaration -  - public partial - TestComponent - Microsoft.AspNetCore.Components.ComponentBase - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
-                MarkupBlock -  - <input onfocus="alert("Test");">
+                MarkupBlock -  - <input onfocus='alert("Test");'>\n<input onfocus="alert(" Test");">\n<input onfocus="alert('Test');">\n<p data-options='{direction: "fromtop", animation_duration: 25, direction: "reverse"}'></p>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/20950.

When a component renders static markup like:

```html
<input onfocus='alert(""Test"");' />
<input onfocus=""alert(""Test"");"" />
<input onfocus=""alert('Test');"" />
<p data-options='{direction: ""fromtop"", animation_duration: 25, direction: ""reverse""}'></p>
```

The Razor compiler interprets this collection of lines as a MarkupBlock. Unlike tag helper attributes, we don't store any information about what type of quote is used in the attributes (typically represented with an `AttributeStructure` enum). Instead, we indiscriminately use double quotes for all attributes on an HTML element within a markup block.

https://github.com/dotnet/aspnetcore/blob/3d1c0e30440dac0bdbd9ab6f64db35f2cc7b87ca/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMarkupBlockPass.cs#L330-L335

This causes issues in particular if a markup element like `<input onfocus='alert("Test");' />` is rendered because we produce the incorrectly quoted `<input onfocus="alert("Test");" />`. To resolve this, we add a check when constructing the attribute string to preserve the original quote style designated by the user.