### PR TITLE
Fix a typo in XML docs of FallbackEndpointRouteBuilderExtensions

### DIFF
--- a/src/Http/Routing/src/Builder/FallbackEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/FallbackEndpointRouteBuilderExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Builder
         /// The order of the registered endpoint will be <c>int.MaxValue</c>.
         /// </para>
         /// <para>
-        /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route contraint
+        /// This overload will use the provided <paramref name="pattern"/> verbatim. Use the <c>:nonfile</c> route constraint
         /// to exclude requests for static files.
         /// </para>
         /// </remarks>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Fix a typo in XML docs of FallbackEndpointRouteBuilderExtensions

**PR Description**
This PR fixes a typo in XML documentation comments on `FallbackEndpointRouteBuilderExtensions.MapFallback()` method

Addresses #bugnumber (in this specific format)
