### PR TITLE
Update runtime-sync.yml

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Send PR
       if: steps.check.outputs.changed == 'true'
       # https://github.com/marketplace/actions/create-pull-request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: .\aspnetcore

--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Send PR
       if: steps.check.outputs.changed == 'true'
       # https://github.com/marketplace/actions/create-pull-request
-      uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29
+      uses: dotnet/actions-create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: .\aspnetcore


### PR DESCRIPTION
Locking down github actions did break our sync script:
https://github.com/dotnet/aspnetcore/actions/runs/945644454
> peter-evans/create-pull-request@v3 is not allowed to be used in dotnet/aspnetcore. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub or match the following: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29.

This PR switches to that last option of referencing a specific commit.