### PR TITLE
Try 3 retries on components tests

### DIFF
--- a/src/Components/test/E2ETest/AssemblyInfo.cs
+++ b/src/Components/test/E2ETest/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Testing;
+
+[assembly:Retry]


### PR DESCRIPTION
Use default 3 retries for components e2e tests to try and mitigate some of the e2e infrastructure flakiness