### PR TITLE
Don't infer interfaces as services anymore

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Http
 
             var factoryContext = new FactoryContext()
             {
-                ServiceProvider = serviceProvider
+                ServiceProviderIsService = serviceProvider?.GetService<IServiceProviderIsService>()
             };
 
             var arguments = CreateArguments(methodInfo.GetParameters(), factoryContext);
@@ -229,13 +229,9 @@ namespace Microsoft.AspNetCore.Http
             {
                 return BindParameterFromRouteValueOrQueryString(parameter, parameter.Name, factoryContext);
             }
-            else if (parameter.ParameterType.IsInterface)
-            {
-                return Expression.Call(GetRequiredServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
-            }
             else
             {
-                if (factoryContext.ServiceProvider?.GetService<IServiceProviderIsService>() is IServiceProviderIsService serviceProviderIsService)
+                if (factoryContext.ServiceProviderIsService is IServiceProviderIsService serviceProviderIsService)
                 {
                     // If the parameter resolves as a service then get it from services
                     if (serviceProviderIsService.IsService(parameter.ParameterType))
@@ -732,7 +728,7 @@ namespace Microsoft.AspNetCore.Http
         {
             public Type? JsonRequestBodyType { get; set; }
             public bool AllowEmptyRequestBody { get; set; }
-            public IServiceProvider? ServiceProvider { get; init; }
+            public IServiceProviderIsService? ServiceProviderIsService { get; init; }
 
             public bool UsingTempSourceString { get; set; }
             public List<(ParameterExpression, Expression)> TryParseParams { get; } = new();

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -16,15 +16,19 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Routing.Internal
@@ -587,10 +591,16 @@ namespace Microsoft.AspNetCore.Routing.Internal
                     httpContext.Items.Add("body", myService);
                 }
 
+                void TestImpliedFromBodyInterface(HttpContext httpContext, ITodo myService)
+                {
+                    httpContext.Items.Add("body", myService);
+                }
+
                 return new[]
                 {
                     new[] { (Action<HttpContext, Todo>)TestExplicitFromBody },
                     new[] { (Action<HttpContext, Todo>)TestImpliedFromBody },
+                    new[] { (Action<HttpContext, ITodo>)TestImpliedFromBodyInterface },
                 };
             }
         }
@@ -609,6 +619,20 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             var requestBodyBytes = JsonSerializer.SerializeToUtf8Bytes(originalTodo);
             httpContext.Request.Body = new MemoryStream(requestBodyBytes);
+
+            var jsonOptions = new JsonOptions();
+            jsonOptions.SerializerOptions.Converters.Add(new TodoJsonConverter());
+
+            var mock = new Mock<IServiceProvider>();
+            mock.Setup(m => m.GetService(It.IsAny<Type>())).Returns<Type>(t =>
+            {
+                if (t == typeof(IOptions<JsonOptions>))
+                {
+                    return Options.Create(jsonOptions);
+                }
+                return null;
+            });
+            httpContext.RequestServices = mock.Object;
 
             var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvdier());
 
@@ -1177,11 +1201,58 @@ namespace Microsoft.AspNetCore.Routing.Internal
             Assert.Equal("null", responseBody);
         }
 
-        private class Todo
+        private class Todo : ITodo
         {
             public int Id { get; set; }
             public string? Name { get; set; } = "Todo";
             public bool IsComplete { get; set; }
+        }
+
+        private interface ITodo
+        {
+            public int Id { get; }
+            public string? Name { get; }
+            public bool IsComplete { get; }
+        }
+
+        class TodoJsonConverter : JsonConverter<ITodo>
+        {
+            public override ITodo? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                var todo = new Todo();
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                    {
+                        break;
+                    }
+
+                    string property = reader.GetString()!;
+                    reader.Read();
+
+                    switch (property.ToLowerInvariant())
+                    {
+                        case "id":
+                            todo.Id = reader.GetInt32();
+                            break;
+                        case "name":
+                            todo.Name = reader.GetString();
+                            break;
+                        case "iscomplete":
+                            todo.IsComplete = reader.GetBoolean();
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                return todo;
+            }
+
+            public override void Write(Utf8JsonWriter writer, ITodo value, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private struct BodyStruct


### PR DESCRIPTION
- Now that we can detect from the `IServiceProvider` if a type is a service, there's no need to prefer interfaces as services. It also makes room for polymorphic JSON deserialization work since we don't assume the interface is a service.
