### PR TITLE
Revert "Skip component governance (#30125)"

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -261,8 +261,7 @@ jobs:
         condition: always()
 
     # Run component detection after all successful Build:* jobs unless overridden e.g. for Alpine build.
-    # Disabled for now because detector limits some error handling to the auto-injected task. Will re-enable once fixed.
-    - ${{ if and(startsWith(parameters.jobDisplayName, 'Build:'), eq(parameters.agentOs, 'NotARealOperatingSystem'), ne(variables['skipComponentGovernanceDetection'], 'true'), ne(parameters.skipComponentGovernanceDetection, 'true'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if and(startsWith(parameters.jobDisplayName, 'Build:'), ne(variables['skipComponentGovernanceDetection'], 'true'), ne(parameters.skipComponentGovernanceDetection, 'true'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
         condition: and(succeeded(), ne(variables['CG_RAN'], 'true'))
         displayName: 'Component Detection'


### PR DESCRIPTION
@- see if CG still times out when not auto-injected
- enables CG in all jobs named "Build..." except the Linux MUSL job

This reverts commit 6fcebd4196e6


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Summary of the changes (Less than 80 chars)

**PR Description**
Detail 1
Detail 2

Addresses #bugnumber (in this specific format)
