### PR TITLE
Add UnsafePreferInlineScheduling to Http.sys server

### DIFF
--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -223,9 +223,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// Inline request processing instead of dispatching to the threadpool.
         /// </summary>
         /// <remarks>
-        /// This will run application code on the IO thread which is why this is unsafe.
-        /// This setting can make performance worse if there is expensive work that will end up holding onto the IO thread for longer than needed.
-        /// Test to make sure this setting helps performance.
+        /// Enabling this setting will run application code on the IO thread to reduce request processing latency. 
+        /// However, this will limit parallel request processing to <see cref="MaxAccepts"/>. This setting can make 
+        /// overall throughput worse if requests take long to process.
         /// </remarks>
         public bool UnsafePreferInlineScheduling { get; set; }
 

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -219,6 +219,16 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        /// <summary>
+        /// Inline request processing instead of dispatching to the threadpool.
+        /// </summary>
+        /// <remarks>
+        /// This will run application code on the IO thread which is why this is unsafe.
+        /// This setting can make performance worse if there is expensive work that will end up holding onto the IO thread for longer than needed.
+        /// Test to make sure this setting helps performance.
+        /// </remarks>
+        public bool UnsafePreferInlineScheduling { get; set; }
+
         // Not called when attaching to an existing queue.
         internal void Apply(UrlGroup urlGroup, RequestQueue requestQueue)
         {

--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -214,11 +214,18 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 }
                 try
                 {
-                    ThreadPool.UnsafeQueueUserWorkItem(requestContext, preferLocal: false);
+                    if (_options.UnsafePreferInlineScheduling)
+                    {
+                        await requestContext.ExecuteAsync();
+                    }
+                    else
+                    {
+                        ThreadPool.UnsafeQueueUserWorkItem(requestContext, preferLocal: false);
+                    }
                 }
                 catch (Exception ex)
                 {
-                    // Request processing failed to be queued in threadpool
+                    // Request processing failed
                     // Log the error message, release throttle and move on
                     Log.RequestListenerProcessError(_logger, ex);
                 }

--- a/src/Servers/HttpSys/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/HttpSys/src/PublicAPI.Unshipped.txt
@@ -39,6 +39,8 @@ Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.Authentication.get -> Microso
 Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.RequestQueueName.get -> string?
 Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.RequestQueueName.set -> void
 Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.Timeouts.get -> Microsoft.AspNetCore.Server.HttpSys.TimeoutManager!
+Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.UnsafePreferInlineScheduling.get -> bool
+Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.UnsafePreferInlineScheduling.set -> void
 Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.UrlPrefixes.get -> Microsoft.AspNetCore.Server.HttpSys.UrlPrefixCollection!
 Microsoft.AspNetCore.Server.HttpSys.IHttpSysRequestDelegationFeature.DelegateRequest(Microsoft.AspNetCore.Server.HttpSys.DelegationRule! destination) -> void
 Microsoft.AspNetCore.Server.HttpSys.IHttpSysRequestInfoFeature.RequestInfo.get -> System.Collections.Generic.IReadOnlyDictionary<int, System.ReadOnlyMemory<byte>>!

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -240,7 +240,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
-        protected virtual Task ExecuteAsync()
+        public virtual Task ExecuteAsync()
         {
             return Task.CompletedTask;
         }

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             _messagePump = messagePump;
         }
 
-        protected override async Task ExecuteAsync()
+        public override async Task ExecuteAsync()
         {
             var messagePump = _messagePump;
             var application = _application;

--- a/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ServerTests.cs
@@ -606,6 +606,24 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             Assert.Empty(attachedServer.Listener.Options.UrlPrefixes);
         }
 
+        [ConditionalFact]
+        public async Task Server_UnsafePreferInlineScheduling()
+        {
+            using var server = Utilities.CreateHttpServer(
+                out var address,
+                httpContext =>
+                {
+                    return httpContext.Response.WriteAsync("Hello World");
+                },
+                options =>
+                {
+                    options.UnsafePreferInlineScheduling = true;
+                });
+
+            string response = await SendRequestAsync(address);
+            Assert.Equal("Hello World", response);
+        }
+
         private async Task<string> SendRequestAsync(string uri)
         {
             using (HttpClient client = new HttpClient() { Timeout = Utilities.DefaultTimeout })


### PR DESCRIPTION
Fixes #30575

Adds a new property 'UnsafePreferInlineScheduling' to HttpSysOptions that when true, executes request on the IO callback thread instead of queuing the request to the thread pool.
