### PR TITLE
Don't add service parameters to an endpoint ApiDescriptions

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -104,6 +104,11 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             {
                 var parameterDescription = CreateApiParameterDescription(parameter, routeEndpoint.RoutePattern);
 
+                if (parameterDescription is null)
+                {
+                    continue;
+                }
+
                 if (parameterDescription.Source == BindingSource.Body)
                 {
                     hasJsonBody = true;
@@ -118,9 +123,15 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             return apiDescription;
         }
 
-        private ApiParameterDescription CreateApiParameterDescription(ParameterInfo parameter, RoutePattern pattern)
+        private ApiParameterDescription? CreateApiParameterDescription(ParameterInfo parameter, RoutePattern pattern)
         {
             var (source, name) = GetBindingSourceAndName(parameter, pattern);
+
+            // Services are ignored because they are not request parameters.
+            if (source == BindingSource.Services)
+            {
+                return null;
+            }
 
             return new ApiParameterDescription
             {

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -248,20 +248,12 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         }
 
         [Fact]
-        public void AddsFromServiceParameterAsService()
+        public void DoesNotAddFromServiceParameterAsService()
         {
-            static void AssertServiceParameter(ApiDescription apiDescription, Type expectedType)
-            {
-                var param = Assert.Single(apiDescription.ParameterDescriptions);
-                Assert.Equal(expectedType, param.Type);
-                Assert.Equal(expectedType, param.ModelMetadata.ModelType);
-                Assert.Equal(BindingSource.Services, param.Source);
-            }
-
-            AssertServiceParameter(GetApiDescription((IInferredServiceInterface foo) => { }), typeof(IInferredServiceInterface));
-            AssertServiceParameter(GetApiDescription(([FromServices] int foo) => { }), typeof(int));
-            AssertServiceParameter(GetApiDescription((HttpContext context) => { }), typeof(HttpContext));
-            AssertServiceParameter(GetApiDescription((CancellationToken token) => { }), typeof(CancellationToken));
+            Assert.Empty(GetApiDescription((IInferredServiceInterface foo) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription(([FromServices] int foo) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription((HttpContext context) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription((CancellationToken token) => { }).ParameterDescriptions);
         }
 
         [Fact]


### PR DESCRIPTION
Bug fix for #33433 which was recently merged. Service parameters do not belong in an endpoint's ApiDescription.

#### Before:

![image](https://user-images.githubusercontent.com/54385/122842477-5363e780-d2b2-11eb-9c83-36e1d3fbfb32.png)

#### After:

![image](https://user-images.githubusercontent.com/54385/122842485-56f76e80-d2b2-11eb-8526-61556175e4b0.png)

Addresses #33685