### PR TITLE
Allow base64 encoded strings to be deserialized as byte arrays in JSI…

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/ByteArrayJsonConverterTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/ByteArrayJsonConverterTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.JSInterop.Infrastructure
 
             // Act & Assert
             var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte[]>(json, JsonSerializerOptions));
-            Assert.Equal("ByteArraysToBeRevived is empty.", ex.Message);
+            Assert.Equal("JSON serialization is attempting to deserialize an unexpected byte array.", ex.Message);
         }
 
         [Fact]
@@ -64,6 +64,33 @@ namespace Microsoft.JSInterop.Infrastructure
             // Act & Assert
             var ex = Record.Exception(() => JsonSerializer.Deserialize<byte[]>(json, JsonSerializerOptions));
             Assert.IsAssignableFrom<JsonException>(ex);
+        }
+
+        [Fact]
+        public void Read_ReadsBase64EncodedStrings()
+        {
+            // Arrange
+            var expected = new byte[] { 1, 5, 8 };
+            var json = JsonSerializer.Serialize(expected);
+
+            // Act
+            var deserialized = JsonSerializer.Deserialize<byte[]>(json, JsonSerializerOptions)!;
+
+            // Assert
+            Assert.Equal(expected, deserialized);
+        }
+
+        [Fact]
+        public void Read_ThrowsIfTheInputIsNotAValidBase64String()
+        {
+            // Arrange
+            var json = "\"Hello world\"";
+
+            // Act
+            var ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte[]>(json, JsonSerializerOptions));
+
+            // Assert
+            Assert.Equal("JSON serialization is attempting to deserialize an unexpected byte array.", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
…nterop

### Description
As part of https://github.com/dotnet/announcements/issues/187, JSInterop required
byte arrays to be written as `Uint8Array` JS arrays and read using a new JS API.
This change intentionally broke support for sending byte arrays as base64 strings.

Through testing, we found at least one use case (dotnet-watch) that currently passes a base64 string via JSInterop. We can
trivially support both formats to retain back-compat in this one case.

### Customer impact
This reduces the extent of the breaking change by allowing base-64 encoded strings to be sent from JS to .NET.

### Risk
Low. The change is specific to reading byte arrays via JSInterop and does not have any broad impact outside of this.

* [x] Automated
* [x] Manual (using dotnet-watch)

