### PR TITLE
Switch test projects to use Razor SDK (instead of Web)

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -388,6 +388,7 @@ stages:
         $(_BuildArgs)
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
+        -bl
       installNodeJs: false
       installJdk: false
       artifacts:
@@ -681,7 +682,7 @@ stages:
         agentOs: macOS
         timeoutInMinutes: 240
         isTestingJob: true
-        buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+        buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs) -bl
         beforeBuild:
         - bash: "./eng/scripts/install-nginx-mac.sh"
           displayName: Installing Nginx

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -388,7 +388,6 @@ stages:
         $(_BuildArgs)
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
-        -bl
       installNodeJs: false
       installJdk: false
       artifacts:
@@ -682,7 +681,7 @@ stages:
         agentOs: macOS
         timeoutInMinutes: 240
         isTestingJob: true
-        buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs) -bl
+        buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
         beforeBuild:
         - bash: "./eng/scripts/install-nginx-mac.sh"
           displayName: Installing Nginx

--- a/src/Components/test/testassets/LazyTestContentPackage/LazyTestContentPackage.csproj
+++ b/src/Components/test/testassets/LazyTestContentPackage/LazyTestContentPackage.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>

--- a/src/Components/test/testassets/TestContentPackage/TestContentPackage.csproj
+++ b/src/Components/test/testassets/TestContentPackage/TestContentPackage.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>


### PR DESCRIPTION
This makes them into RCLs, which is what they're intended to be.