### PR TITLE
Set copyOnly on static resources in Blazor templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
@@ -25,6 +25,14 @@
   ],
   "sources": [
     {
+      "source": "./",
+      "target": "./",
+      "exclude": [
+        ".template.config/**"
+      ],
+      "copyOnly": [
+        "wwwroot/**"
+      ],
       "modifiers": [
         {
           "condition": "(!IndividualLocalAuth || UseLocalDB)",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -54,6 +54,9 @@
       "exclude": [
         ".template.config/**"
       ],
+      "copyOnly": [
+        "**/wwwroot/**"
+      ],
       "modifiers": [
         {
           "condition": "(!Hosted)",


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/33738.

Due to a downstream bug (see https://github.com/dotnet/templating/issues/3325), the templating engine can copy malformed versions of static assets, like images or styles, to the app repo. As a result, fonts/styles/etc won't appear on the functional application without replacing these assets with working versions.

The workaround is to use the `copyOnly` property to indicate that the assets should be copied without modification.

Also, this change isn't just a workaround for the problem at hand. It's the right thing to do for assets that don't need to run through the templating engines variable replacement in order to function. We already do this for `wwwroot` in other templates but missed it in Blazor somewhow.