### PR TITLE
Remove Utf8EncodingSealed from Kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         private const ulong _http10VersionLong = 3471766442030158920; // GetAsciiStringAsLong("HTTP/1.0"); const results in better codegen
         private const ulong _http11VersionLong = 3543824036068086856; // GetAsciiStringAsLong("HTTP/1.1"); const results in better codegen
 
-        private static readonly UTF8EncodingSealed DefaultRequestHeaderEncoding = new UTF8EncodingSealed();
+        private static readonly UTF8Encoding DefaultRequestHeaderEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
         private static readonly SpanAction<char, IntPtr> s_getHeaderName = GetHeaderName;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -523,14 +523,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 // Cast to uint to change negative numbers to large numbers
                 // Check if less than 6 representing chars 'a' - 'f'
                 || (uint)((ch | 32) - 'a') < 6u;
-        }
-
-        // Allow for de-virtualization (see https://github.com/dotnet/coreclr/pull/9230)
-        private sealed class UTF8EncodingSealed : UTF8Encoding
-        {
-            public UTF8EncodingSealed() : base(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true) { }
-
-            public override byte[] GetPreamble() => Array.Empty<byte>();
         }
     }
 }


### PR DESCRIPTION
**PR Description**
1. Remove `UTF8EncodingSealed` class used for devirtualization
2. Update `DefaultRequestHeaderEncoding` variable to use default `UTF8Encoding()` 

Addresses ##33713
