### PR TITLE
Apply copyOnly to CSS assets only

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -55,7 +55,7 @@
         ".template.config/**"
       ],
       "copyOnly": [
-        "**/wwwroot/**"
+        "**/wwwroot/css/**"
       ],
       "modifiers": [
         {


### PR DESCRIPTION
`wwwroot` directory for WASM projects contains `appsettings.json` and `index.html` files that need variable interpolation so we only need to apply CSS to the wwwroot directory.