### PR TITLE
Support Request, Response and User for minimal actions

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Metadata;
@@ -45,6 +46,7 @@ namespace Microsoft.AspNetCore.Http
         private static readonly MemberExpression HttpRequestExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.Request));
         private static readonly MemberExpression HttpResponseExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.Response));
         private static readonly MemberExpression RequestAbortedExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.RequestAborted));
+        private static readonly MemberExpression UserExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.User));
         private static readonly MemberExpression RouteValuesExpr = Expression.Property(HttpRequestExpr, nameof(HttpRequest.RouteValues));
         private static readonly MemberExpression QueryExpr = Expression.Property(HttpRequestExpr, nameof(HttpRequest.Query));
         private static readonly MemberExpression HeadersExpr = Expression.Property(HttpRequestExpr, nameof(HttpRequest.Headers));
@@ -220,6 +222,18 @@ namespace Microsoft.AspNetCore.Http
             else if (parameter.ParameterType == typeof(HttpContext))
             {
                 return HttpContextExpr;
+            }
+            else if (parameter.ParameterType == typeof(HttpRequest))
+            {
+                return HttpRequestExpr;
+            }
+            else if (parameter.ParameterType == typeof(HttpResponse))
+            {
+                return HttpResponseExpr;
+            }
+            else if (parameter.ParameterType == typeof(ClaimsPrincipal))
+            {
+                return UserExpr;
             }
             else if (parameter.ParameterType == typeof(CancellationToken))
             {

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -14,6 +14,7 @@ using System.Net.Sockets;
 using System.Numerics;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -96,7 +97,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             var httpContext = new DefaultHttpContext();
 
-            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -116,7 +117,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 BindingFlags.NonPublic | BindingFlags.Static,
                 new[] { typeof(HttpContext) });
 
-            var requestDelegate = RequestDelegateFactory.Create(methodInfo!, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(methodInfo!, new EmptyServiceProvider());
 
             var httpContext = new DefaultHttpContext();
 
@@ -162,7 +163,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 return new TestNonStaticActionClass(2);
             }
 
-            var requestDelegate = RequestDelegateFactory.Create(methodInfo!, new EmptyServiceProvdier(), _ => GetTarget());
+            var requestDelegate = RequestDelegateFactory.Create(methodInfo!, new EmptyServiceProvider(), _ => GetTarget());
 
             var httpContext = new DefaultHttpContext();
 
@@ -185,7 +186,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 BindingFlags.NonPublic | BindingFlags.Static,
                 new[] { typeof(HttpContext) });
 
-            var serviceProvider = new EmptyServiceProvdier();
+            var serviceProvider = new EmptyServiceProvider();
 
             var exNullAction = Assert.Throws<ArgumentNullException>(() => RequestDelegateFactory.Create(action: null!, serviceProvider));
             var exNullMethodInfo1 = Assert.Throws<ArgumentNullException>(() => RequestDelegateFactory.Create(methodInfo: null!, serviceProvider));
@@ -204,7 +205,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             const string paramName = "value";
             const int originalRouteParam = 42;
 
-            void TestAction(HttpContext httpContext, [FromRoute] int value)
+            static void TestAction(HttpContext httpContext, [FromRoute] int value)
             {
                 httpContext.Items.Add("input", value);
             }
@@ -212,7 +213,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = new DefaultHttpContext();
             httpContext.Request.RouteValues[paramName] = originalRouteParam.ToString(NumberFormatInfo.InvariantInfo);
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, int>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, int>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -239,7 +240,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             var httpContext = new DefaultHttpContext();
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, int>)TestOptional, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, int>)TestOptional, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -251,7 +252,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             var httpContext = new DefaultHttpContext();
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, int>)TestOptional, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, int>)TestOptional, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -263,7 +264,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             var httpContext = new DefaultHttpContext();
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, string>)TestOptionalString, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, string>)TestOptionalString, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -280,7 +281,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             httpContext.Request.RouteValues[paramName] = originalRouteParam.ToString(NumberFormatInfo.InvariantInfo);
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, int>)TestOptional, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext, int>)TestOptional, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -303,7 +304,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = new DefaultHttpContext();
             httpContext.Request.RouteValues[specifiedName] = originalRouteParam.ToString(NumberFormatInfo.InvariantInfo);
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<int>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<int>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -326,7 +327,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = new DefaultHttpContext();
             httpContext.Request.RouteValues[unmatchedName] = unmatchedRouteParam.ToString(NumberFormatInfo.InvariantInfo);
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<int>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<int>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -405,7 +406,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = new DefaultHttpContext();
             httpContext.Request.RouteValues["tryParsable"] = routeValue;
 
-            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -422,7 +423,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 ["tryParsable"] = routeValue
             });
 
-            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -445,7 +446,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             {
                 httpContext.Items["tryParsable"] = tryParsable;
             }),
-            new EmptyServiceProvdier());
+            new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -473,7 +474,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         [MemberData(nameof(DelegatesWithAttributesOnNotTryParsableParameters))]
         public void CreateThrowsInvalidOperationExceptionWhenAttributeRequiresTryParseMethodThatDoesNotExist(Delegate action)
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(action, new EmptyServiceProvdier()));
+            var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(action, new EmptyServiceProvider()));
             Assert.Equal("No public static bool Object.TryParse(string, out Object) method found for notTryParsable.", ex.Message);
         }
 
@@ -482,7 +483,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             var unnamedParameter = Expression.Parameter(typeof(int));
             var lambda = Expression.Lambda(Expression.Block(), unnamedParameter);
-            var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<int>)lambda.Compile(), new EmptyServiceProvdier()));
+            var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<int>)lambda.Compile(), new EmptyServiceProvider()));
             Assert.Equal("A parameter does not have a name! Was it generated? All parameters must be named.", ex.Message);
         }
 
@@ -505,7 +506,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             httpContext.Features.Set<IHttpRequestLifetimeFeature>(new TestHttpRequestLifetimeFeature());
             httpContext.RequestServices = serviceCollection.BuildServiceProvider();
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<int, int>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<int, int>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -547,7 +548,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Query = query;
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<int>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<int>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -570,7 +571,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers[customHeaderName] = originalHeaderParam.ToString(NumberFormatInfo.InvariantInfo);
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<int>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<int>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -634,7 +635,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             });
             httpContext.RequestServices = mock.Object;
 
-            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -651,7 +652,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             httpContext.Request.Headers["Content-Type"] = "application/json";
             httpContext.Request.Headers["Content-Length"] = "0";
 
-            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvider());
 
             await Assert.ThrowsAsync<JsonException>(() => requestDelegate(httpContext));
         }
@@ -670,7 +671,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             httpContext.Request.Headers["Content-Type"] = "application/json";
             httpContext.Request.Headers["Content-Length"] = "0";
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<Todo>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<Todo>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -694,7 +695,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             httpContext.Request.Headers["Content-Type"] = "application/json";
             httpContext.Request.Headers["Content-Length"] = "0";
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<BodyStruct>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<BodyStruct>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -721,7 +722,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             httpContext.Features.Set<IHttpRequestLifetimeFeature>(new TestHttpRequestLifetimeFeature());
             httpContext.RequestServices = serviceCollection.BuildServiceProvider();
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<Todo>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<Todo>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -754,7 +755,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             httpContext.Features.Set<IHttpRequestLifetimeFeature>(new TestHttpRequestLifetimeFeature());
             httpContext.RequestServices = serviceCollection.BuildServiceProvider();
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<Todo>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<Todo>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -775,9 +776,9 @@ namespace Microsoft.AspNetCore.Routing.Internal
             void TestInferredInvalidAction(Todo value1, Todo value2) { }
             void TestBothInvalidAction(Todo value1, [FromBody] int value2) { }
 
-            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<int, int>)TestAttributedInvalidAction, new EmptyServiceProvdier()));
-            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<Todo, Todo>)TestInferredInvalidAction, new EmptyServiceProvdier()));
-            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<Todo, int>)TestBothInvalidAction, new EmptyServiceProvdier()));
+            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<int, int>)TestAttributedInvalidAction, new EmptyServiceProvider()));
+            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<Todo, Todo>)TestInferredInvalidAction, new EmptyServiceProvider()));
+            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create((Action<Todo, int>)TestBothInvalidAction, new EmptyServiceProvider()));
         }
 
         public static object[][] FromServiceActions
@@ -849,9 +850,9 @@ namespace Microsoft.AspNetCore.Routing.Internal
         public async Task RequestDelegateRequiresServiceForAllFromServiceParameters(Delegate action)
         {
             var httpContext = new DefaultHttpContext();
-            httpContext.RequestServices = new EmptyServiceProvdier();
+            httpContext.RequestServices = new EmptyServiceProvider();
 
-            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(action, new EmptyServiceProvider());
 
             await Assert.ThrowsAsync<InvalidOperationException>(() => requestDelegate(httpContext));
         }
@@ -868,7 +869,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             var httpContext = new DefaultHttpContext();
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<HttpContext>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -876,7 +877,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Fact]
-        public async Task RequestDelegatePassHttpContextRequestAbortedAsCancelationToken()
+        public async Task RequestDelegatePassHttpContextRequestAbortedAsCancellationToken()
         {
             CancellationToken? cancellationTokenArgument = null;
 
@@ -891,11 +892,71 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 RequestAborted = cts.Token
             };
 
-            var requestDelegate = RequestDelegateFactory.Create((Action<CancellationToken>)TestAction, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create((Action<CancellationToken>)TestAction, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
             Assert.Equal(httpContext.RequestAborted, cancellationTokenArgument);
+        }
+
+        [Fact]
+        public async Task RequestDelegatePassHttpContextUserAsClaimsPrincipal()
+        {
+            ClaimsPrincipal? userArgument = null;
+
+            void TestAction(ClaimsPrincipal user)
+            {
+                userArgument = user;
+            }
+
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal()
+            };
+
+            var requestDelegate = RequestDelegateFactory.Create((Action<ClaimsPrincipal>)TestAction, new EmptyServiceProvider());
+
+            await requestDelegate(httpContext);
+
+            Assert.Equal(httpContext.User, userArgument);
+        }
+
+        [Fact]
+        public async Task RequestDelegatePassHttpContextRequestAsHttpRequest()
+        {
+            HttpRequest? httpRequestArgument = null;
+
+            void TestAction(HttpRequest httpRequest)
+            {
+                httpRequestArgument = httpRequest;
+            }
+
+            var httpContext = new DefaultHttpContext();
+
+            var requestDelegate = RequestDelegateFactory.Create((Action<HttpRequest>)TestAction, new EmptyServiceProvider());
+
+            await requestDelegate(httpContext);
+
+            Assert.Equal(httpContext.Request, httpRequestArgument);
+        }
+
+        [Fact]
+        public async Task RequestDelegatePassesHttpContextRresponseAsHttpResponse()
+        {
+            HttpResponse? httpResponseArgument = null;
+
+            void TestAction(HttpResponse httpResponse)
+            {
+                httpResponseArgument = httpResponse;
+            }
+
+            var httpContext = new DefaultHttpContext();
+
+            var requestDelegate = RequestDelegateFactory.Create((Action<HttpResponse>)TestAction, new EmptyServiceProvider());
+
+            await requestDelegate(httpContext);
+
+            Assert.Equal(httpContext.Response, httpResponseArgument);
         }
 
         public static IEnumerable<object[]> ComplexResult
@@ -935,7 +996,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var responseBodyStream = new MemoryStream();
             httpContext.Response.Body = responseBodyStream;
 
-            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -984,7 +1045,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var responseBodyStream = new MemoryStream();
             httpContext.Response.Body = responseBodyStream;
 
-            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -1027,7 +1088,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var responseBodyStream = new MemoryStream();
             httpContext.Response.Body = responseBodyStream;
 
-            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -1068,7 +1129,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var responseBodyStream = new MemoryStream();
             httpContext.Response.Body = responseBodyStream;
 
-            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -1109,7 +1170,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var responseBodyStream = new MemoryStream();
             httpContext.Response.Body = responseBodyStream;
 
-            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvdier());
+            var requestDelegate = RequestDelegateFactory.Create(@delegate, new EmptyServiceProvider());
 
             await requestDelegate(httpContext);
 
@@ -1227,7 +1288,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                         break;
                     }
 
-                    string property = reader.GetString()!;
+                    var property = reader.GetString()!;
                     reader.Read();
 
                     switch (property.ToLowerInvariant())
@@ -1352,13 +1413,13 @@ namespace Microsoft.AspNetCore.Routing.Internal
             }
         }
 
-        private class EmptyServiceProvdier : IServiceScope, IServiceProvider, IServiceScopeFactory
+        private class EmptyServiceProvider : IServiceScope, IServiceProvider, IServiceScopeFactory
         {
             public IServiceProvider ServiceProvider => this;
 
             public IServiceScope CreateScope()
             {
-                return new EmptyServiceProvdier();
+                return new EmptyServiceProvider();
             }
 
             public void Dispose()
@@ -1378,7 +1439,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
         private class TestHttpRequestLifetimeFeature : IHttpRequestLifetimeFeature
         {
-            private readonly CancellationTokenSource _requestAbortedCts = new CancellationTokenSource();
+            private readonly CancellationTokenSource _requestAbortedCts = new();
 
             public CancellationToken RequestAborted { get => _requestAbortedCts.Token; set => throw new NotImplementedException(); }
 


### PR DESCRIPTION
**PR Title**

Support Request, Response and User for minimal actions

**PR Description**

Adds support to minimal actions for parameters of type `HttpRequest`, `HttpResponse`, and `ClaimsPrincipal` to be bound to the values of the `Request`, `Response` and `User` properties of the `HttpContext` respectively.

Also cleans up some typos and IDE suggestions in the `RequestDelegateFactory` tests.

Fixes #33870
