### PR TITLE
Revert multiple SDK updates.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.7.21324.2"
+    "version": "6.0.100-preview.6.21313.2"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.7.21324.2",
+    "dotnet": "6.0.100-preview.6.21313.2",
     "runtimes": {
       "dotnet/x64": [
         "2.1.27",

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.7.21327.2"
+    "version": "6.0.100-preview.7.21324.2"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.7.21327.2",
+    "dotnet": "6.0.100-preview.7.21324.2",
     "runtimes": {
       "dotnet/x64": [
         "2.1.27",

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
@@ -8,6 +8,7 @@
       Clien caching isn't part of our performance measurement, so we'll skip it.
     -->
     <BlazorCacheBootResources>false</BlazorCacheBootResources>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
+++ b/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
@@ -11,6 +11,7 @@
 
     <!-- Project supports more than one language -->
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestTrimmedApps)' == 'true'">

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -109,6 +109,8 @@ namespace Templates.Test.Helpers
                     Directory.Delete(TemplateOutputDir, recursive: true);
                 }
                 
+                // Temporary while investigating why this process occasionally never runs or exits on Debian 9
+                environmentVariables.Add("COREHOST_TRACE", "1");
                 using var execution = ProcessEx.Run(Output, AppContext.BaseDirectory, DotNetMuxer.MuxerPathOrDefault(), argString, environmentVariables);
                 await execution.Exited;
                 return new ProcessResult(execution);

--- a/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
+++ b/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
@@ -128,8 +128,8 @@ namespace Templates.Test.Helpers
 
         private static async Task VerifyCanFindTemplate(ITestOutputHelper output, string templateName)
         {
-            var proc = await RunDotNetNew(output, $"--list");
-            if (!(proc.Output.Contains($" {templateName} ") || proc.Output.Contains($",{templateName}") || proc.Output.Contains($"{templateName},")))
+            var proc = await RunDotNetNew(output, $"");
+            if (!proc.Output.Contains($" {templateName} "))
             {
                 throw new InvalidOperationException($"Couldn't find {templateName} as an option in {proc.Output}.");
             }


### PR DESCRIPTION
This seems to fix multiple internal builds and avoids the following error when building in VS.

```
Error    CS8032    An instance of analyzer Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator cannot be created from C:\github\aspnetcore\.dotnet\sdk\6.0.100-preview.7.21327.2\Sdks\Microsoft.NET.Sdk.Razor\source-generators\Microsoft.NET.Sdk.Razor.SourceGenerators.dll : Could not load type 'Microsoft.CodeAnalysis.IIncrementalGenerator' from assembly 'Microsoft.CodeAnalysis, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
```