### PR TITLE
Revert to last known good SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.7.21324.2"
+    "version": "6.0.100-preview.6.21313.2"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.7.21324.2",
+    "dotnet": "6.0.100-preview.6.21313.2",
     "runtimes": {
       "dotnet/x64": [
         "2.1.27",

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.7.21327.2"
+    "version": "6.0.100-preview.7.21324.2"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.7.21327.2",
+    "dotnet": "6.0.100-preview.7.21324.2",
     "runtimes": {
       "dotnet/x64": [
         "2.1.27",

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
@@ -8,7 +8,6 @@
       Clien caching isn't part of our performance measurement, so we'll skip it.
     -->
     <BlazorCacheBootResources>false</BlazorCacheBootResources>
-    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
+++ b/src/Components/benchmarkapps/Wasm.Performance/TestApp/Wasm.Performance.TestApp.csproj
@@ -8,6 +8,7 @@
       Clien caching isn't part of our performance measurement, so we'll skip it.
     -->
     <BlazorCacheBootResources>false</BlazorCacheBootResources>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
+++ b/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
@@ -11,6 +11,7 @@
 
     <!-- Project supports more than one language -->
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestTrimmedApps)' == 'true'">


### PR DESCRIPTION
This undoes less than #33920, so I plan to merge this instead of the internal build passes.

@captainsafia Should I still be adding the `<UseRazorSourceGenerator>false</UseRazorSourceGenerator>` back?