### PR TITLE
HTTP/3: Fix flakey Http3StreamTests.ContentLength_Received_NoDataFrames_Reset

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportFactory.cs
@@ -19,8 +19,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic
     /// </summary>
     internal class QuicTransportFactory : IMultiplexedConnectionListenerFactory
     {
-        private QuicTrace _log;
-        private QuicTransportOptions _options;
+        private readonly QuicTrace _log;
+        private readonly QuicTransportOptions _options;
 
         public QuicTransportFactory(ILoggerFactory loggerFactory, IOptions<QuicTransportOptions> options)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/33760

I couldn't repo the situation, but I think this is caused by a race where frame data and end stream are read separately in Kestrel. Prospective fix is to use `CompleteAsync()` to flush the final frame instead of FlushAsync+CompleteAsync.