### PR TITLE
HTTP/3: Support large response header section

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -689,4 +689,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http3ControlStreamErrorUnsupportedType" xml:space="preserve">
     <value>Stream type {type} is unsupported.</value>
   </data>
+  <data name="Http3ControlStreamErrorInitializingOutbound" xml:space="preserve">
+    <value>Error initializing outbound control stream.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private readonly TimingPipeFlusher _flusher;
 
         // HTTP/3 doesn't have a max frame size (peer can optionally specify a size).
-        // Write headers a buffer that can grow. Possible performance improvement
+        // Write headers to a buffer that can grow. Possible performance improvement
         // by writing directly to output writer (difficult as frame length is prefixed).
         private readonly ArrayBufferWriter<byte> _headerEncodingBuffer;
         private IEnumerator<KeyValuePair<string, string>>? _headersEnumerator;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
@@ -21,6 +21,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
     internal class Http3FrameWriter
     {
+        // Size based on HTTP/2 default frame size
+        private const int MaxDataFrameSize = 16 * 1024;
+        private const int HeaderBufferSize = 16 * 1024;
+
         private readonly object _writeLock = new object();
 
         private readonly int _maxTotalHeaderSize;
@@ -36,16 +40,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private readonly Http3RawFrame _outgoingFrame;
         private readonly TimingPipeFlusher _flusher;
 
+        // HTTP/3 doesn't have a max frame size (peer can optionally specify a size).
+        // Write headers a buffer that can grow. Possible performance improvement
+        // by writing directly to output writer (difficult as frame length is prefixed).
+        private readonly ArrayBufferWriter<byte> _headerEncodingBuffer;
         private IEnumerator<KeyValuePair<string, string>>? _headersEnumerator;
         private int _headersTotalSize;
-        // TODO update max frame size
-        private uint _maxFrameSize = 10000; //Http3PeerSettings.MinAllowedMaxFrameSize;
-        private byte[] _headerEncodingBuffer;
+
         private long _unflushedBytes;
         private bool _completed;
         private bool _aborted;
-
-        //private int _unflushedBytes;
 
         public Http3FrameWriter(PipeWriter output, ConnectionContext connectionContext, ITimeoutControl timeoutControl, MinDataRate? minResponseDataRate, string connectionId, MemoryPool<byte> memoryPool, IKestrelTrace log, IStreamIdFeature streamIdFeature, Http3PeerSettings clientPeerSettings, IHttp3Stream http3Stream)
         {
@@ -60,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             _http3Stream = http3Stream;
             _outgoingFrame = new Http3RawFrame();
             _flusher = new TimingPipeFlusher(_outputWriter, timeoutControl, log);
-            _headerEncodingBuffer = new byte[_maxFrameSize];
+            _headerEncodingBuffer = new ArrayBufferWriter<byte>(HeaderBufferSize);
 
             // Note that max total header size value doesn't react to settings change during a stream.
             // Unlikely to be a problem in practice:
@@ -69,18 +73,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             _maxTotalHeaderSize = clientPeerSettings.MaxRequestHeaderFieldSectionSize > int.MaxValue
                 ? int.MaxValue
                 : (int)clientPeerSettings.MaxRequestHeaderFieldSectionSize;
-        }
-
-        public void UpdateMaxFrameSize(uint maxFrameSize)
-        {
-            lock (_writeLock)
-            {
-                if (_maxFrameSize != maxFrameSize)
-                {
-                    _maxFrameSize = maxFrameSize;
-                    _headerEncodingBuffer = new byte[_maxFrameSize];
-                }
-            }
         }
 
         internal Task WriteSettingsAsync(List<Http3PeerSetting> settings)
@@ -172,7 +164,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             _outgoingFrame.PrepareData();
 
-            if (dataLength > _maxFrameSize)
+            if (dataLength > MaxDataFrameSize)
             {
                 SplitAndWriteDataUnsynchronized(in data, dataLength);
                 return;
@@ -193,7 +185,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             {
                 Debug.Assert(dataLength == data.Length);
 
-                var dataPayloadLength = (int)_maxFrameSize;
+                var dataPayloadLength = (int)MaxDataFrameSize;
 
                 Debug.Assert(dataLength > dataPayloadLength);
 
@@ -281,9 +273,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 {
                     _headersEnumerator = EnumerateHeaders(headers).GetEnumerator();
                     _headersTotalSize = 0;
+                    _headerEncodingBuffer.Clear();
 
                     _outgoingFrame.PrepareHeaders();
-                    var buffer = _headerEncodingBuffer.AsSpan();
+                    var buffer = _headerEncodingBuffer.GetSpan(HeaderBufferSize);
                     var done = QPackHeaderWriter.BeginEncode(_headersEnumerator, buffer, ref _headersTotalSize, out var payloadLength);
                     FinishWritingHeaders(payloadLength, done);
                 }
@@ -335,7 +328,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     _headersEnumerator = EnumerateHeaders(headers).GetEnumerator();
 
                     _outgoingFrame.PrepareHeaders();
-                    var buffer = _headerEncodingBuffer.AsSpan();
+                    var buffer = _headerEncodingBuffer.GetSpan(HeaderBufferSize);
                     var done = QPackHeaderWriter.BeginEncode(statusCode, _headersEnumerator, buffer, ref _headersTotalSize, out var payloadLength);
                     FinishWritingHeaders(payloadLength, done);
                 }
@@ -349,25 +342,30 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private void FinishWritingHeaders(int payloadLength, bool done)
         {
-            var buffer = _headerEncodingBuffer.AsSpan();
-            _outgoingFrame.Length = payloadLength;
-
-            WriteHeaderUnsynchronized();
-            _outputWriter.Write(buffer.Slice(0, payloadLength));
+            _headerEncodingBuffer.Advance(payloadLength);
 
             while (!done)
             {
-                done = QPackHeaderWriter.Encode(_headersEnumerator!, buffer, ref _headersTotalSize, out payloadLength);
-                _outgoingFrame.Length = payloadLength;
+                ValidateHeadersTotalSize();
 
-                WriteHeaderUnsynchronized();
-                _outputWriter.Write(buffer.Slice(0, payloadLength));
+                var buffer = _headerEncodingBuffer.GetSpan(HeaderBufferSize);
+                done = QPackHeaderWriter.Encode(_headersEnumerator!, buffer, ref _headersTotalSize, out payloadLength);
+                _headerEncodingBuffer.Advance(payloadLength);
             }
 
-            // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.3
-            if (_headersTotalSize > _maxTotalHeaderSize)
+            ValidateHeadersTotalSize();
+
+            _outgoingFrame.Length = _headerEncodingBuffer.WrittenCount;
+            WriteHeaderUnsynchronized();
+            _outputWriter.Write(_headerEncodingBuffer.WrittenSpan);
+
+            void ValidateHeadersTotalSize()
             {
-                throw new QPackEncodingException($"The encoded HTTP headers length exceeds the limit specified by the peer of {_maxTotalHeaderSize} bytes.");
+                // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.1.3
+                if (_headersTotalSize > _maxTotalHeaderSize)
+                {
+                    throw new QPackEncodingException($"The encoded HTTP headers length exceeds the limit specified by the peer of {_maxTotalHeaderSize} bytes.");
+                }
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -97,5 +97,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         void QPackDecodingError(string connectionId, long streamId, QPackDecodingException ex);
 
         void QPackEncodingError(string connectionId, long streamId, QPackEncodingException ex);
+
+        void Http3OutboundControlStreamError(string connectionId, Exception ex);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -157,8 +157,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 @"Connection id ""{ConnectionId}"": QPACK decoding error while decoding headers for stream ID {StreamId}.");
 
         private static readonly Action<ILogger, string, long, Exception> _qpackEncodingError =
-            LoggerMessage.Define<string, long>(LogLevel.Information, new EventId(49, "QPackEncodingError"),
+            LoggerMessage.Define<string, long>(LogLevel.Debug, new EventId(49, "QPackEncodingError"),
                 @"Connection id ""{ConnectionId}"": QPACK encoding error while encoding headers for stream ID {StreamId}.");
+
+        private static readonly Action<ILogger, string, Exception> _http3OutboundControlStreamError =
+            LoggerMessage.Define<string>(LogLevel.Debug, new EventId(50, "Http3OutboundControlStreamError"),
+                @"Connection id ""{ConnectionId}"": Unexpected error when initializing outbound control stream.");
 
         protected readonly ILogger _generalLogger;
         protected readonly ILogger _badRequestsLogger;
@@ -399,6 +403,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public virtual void QPackEncodingError(string connectionId, long streamId, QPackEncodingException ex)
         {
             _qpackEncodingError(_http3Logger, connectionId, streamId, ex);
+        }
+
+        public void Http3OutboundControlStreamError(string connectionId, Exception ex)
+        {
+            _http3OutboundControlStreamError(_http3Logger, connectionId, ex);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -157,7 +157,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 @"Connection id ""{ConnectionId}"": QPACK decoding error while decoding headers for stream ID {StreamId}.");
 
         private static readonly Action<ILogger, string, long, Exception> _qpackEncodingError =
-            LoggerMessage.Define<string, long>(LogLevel.Debug, new EventId(49, "QPackEncodingError"),
+            LoggerMessage.Define<string, long>(LogLevel.Information, new EventId(49, "QPackEncodingError"),
                 @"Connection id ""{ConnectionId}"": QPACK encoding error while encoding headers for stream ID {StreamId}.");
 
         private static readonly Action<ILogger, string, Exception> _http3OutboundControlStreamError =

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
@@ -69,5 +69,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public void Http3FrameSending(string connectionId, long streamId, Http3RawFrame frame) { }
         public void QPackDecodingError(string connectionId, long streamId, QPackDecodingException ex) { }
         public void QPackEncodingError(string connectionId, long streamId, QPackEncodingException ex) { }
+        public void Http3OutboundControlStreamError(string connectionId, Exception ex) { }
     }
 }

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -293,5 +293,11 @@ namespace Microsoft.AspNetCore.Testing
             _trace1.QPackEncodingError(connectionId, streamId, ex);
             _trace2.QPackEncodingError(connectionId, streamId, ex);
         }
+
+        public void Http3OutboundControlStreamError(string connectionId, Exception ex)
+        {
+            _trace1.Http3OutboundControlStreamError(connectionId, ex);
+            _trace2.Http3OutboundControlStreamError(connectionId, ex);
+        }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData(nameof(Http3FrameType.Data))]
         [InlineData(nameof(Http3FrameType.Headers))]
         [InlineData(nameof(Http3FrameType.PushPromise))]
-        public async Task ControlStream_UnexpectedFrameType_ConnectionError(string frameType)
+        public async Task ControlStream_ClientToServer_UnexpectedFrameType_ConnectionError(string frameType)
         {
             await InitializeConnectionAsync(_noopApplication);
 
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        public async Task ControlStream_ClientCloses_ConnectionError()
+        public async Task ControlStream_ClientToServer_ClientCloses_ConnectionError()
         {
             await InitializeConnectionAsync(_noopApplication);
 
@@ -155,6 +155,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 expectedLastStreamId: 0,
                 expectedErrorCode: Http3ErrorCode.ClosedCriticalStream,
                 expectedErrorMessage: CoreStrings.Http3ErrorControlStreamClientClosedInbound);
+        }
+
+        [Fact]
+        public async Task ControlStream_ServerToClient_ErrorInitializing_ConnectionError()
+        {
+            OnCreateServerControlStream = () => throw new Exception();
+
+            await InitializeConnectionAsync(_noopApplication);
+
+            AssertConnectionError<Http3ConnectionErrorException>(
+                expectedErrorCode: Http3ErrorCode.ClosedCriticalStream,
+                expectedErrorMessage: CoreStrings.Http3ControlStreamErrorInitializingOutbound);
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -62,6 +62,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected readonly RequestDelegate _echoPath;
         protected readonly RequestDelegate _echoHost;
 
+        protected Func<Http3ControlStream> OnCreateServerControlStream;
         private Http3ControlStream _inboundControlStream;
         private long _currentStreamId;
 
@@ -229,6 +230,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 VerifyGoAway(frame, expectedLastStreamId.GetValueOrDefault());
             }
 
+            AssertConnectionError<TException>(expectedErrorCode, expectedErrorMessage);
+        }
+
+        internal void AssertConnectionError<TException>(Http3ErrorCode expectedErrorCode, params string[] expectedErrorMessage) where TException : Exception
+        {
             Assert.Equal((Http3ErrorCode)expectedErrorCode, (Http3ErrorCode)MultiplexedConnectionContext.Error);
 
             if (expectedErrorMessage?.Length > 0)
@@ -883,6 +889,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             public override void Abort(ConnectionAbortedException abortReason)
             {
                 ToServerAcceptQueue.Writer.TryComplete();
+                ToClientAcceptQueue.Writer.TryComplete();
             }
 
             public override async ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
@@ -900,7 +907,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             public override ValueTask<ConnectionContext> ConnectAsync(IFeatureCollection features = null, CancellationToken cancellationToken = default)
             {
-                var stream = new Http3ControlStream(_testBase, StreamInitiator.Server);
+                var stream = _testBase.OnCreateServerControlStream?.Invoke() ?? new Http3ControlStream(_testBase, StreamInitiator.Server);
                 ToClientAcceptQueue.Writer.WriteAsync(stream);
                 return new ValueTask<ConnectionContext>(stream.StreamContext);
             }


### PR DESCRIPTION
Two things:
* Catch error from outbound control stream initialization and abort the connection
* Support large response header sections