### PR TITLE
New UseHttps overload with per connection callback 

### DIFF
--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -93,7 +93,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         public Action<ConnectionContext, SslServerAuthenticationOptions>? OnAuthenticate { get; set; }
 
         /// <summary>
-        /// Specifies the maximum amount of time allowed for the TLS/SSL handshake. This must be positive and finite. Defaults to 10 seconds.
+        /// Specifies the maximum amount of time allowed for the TLS/SSL handshake. This must be positive
+        /// or <see cref="Timeout.InfiniteTimeSpan"/>. Defaults to 10 seconds.
         /// </summary>
         public TimeSpan HandshakeTimeout
         {

--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -176,11 +176,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             return (sslOptions, sniOptions.ClientCertificateMode);
         }
 
-        public static ValueTask<(SslServerAuthenticationOptions, ClientCertificateMode)> OptionsCallback(ConnectionContext connection, SslStream stream, SslClientHelloInfo clientHelloInfo, object state, CancellationToken cancellationToken)
+        public static ValueTask<SslServerAuthenticationOptions> OptionsCallback(TlsHandshakeCallbackContext callbackContext)
         {
-            var sniOptionsSelector = (SniOptionsSelector)state;
-            var (options, clientCertificateMode) = sniOptionsSelector.GetOptions(connection, clientHelloInfo.ServerName);
-            return new ValueTask<(SslServerAuthenticationOptions, ClientCertificateMode)>((options, clientCertificateMode));
+            var sniOptionsSelector = (SniOptionsSelector)callbackContext.State!;
+            var (options, clientCertificateMode) = sniOptionsSelector.GetOptions(callbackContext.Connection, callbackContext.ClientHelloInfo.ServerName);
+            callbackContext.AllowDelayedClientCertificateNegotation = clientCertificateMode == ClientCertificateMode.DelayCertificate;
+            return new ValueTask<SslServerAuthenticationOptions>(options);
         }
 
         internal static SslServerAuthenticationOptions CloneSslOptions(SslServerAuthenticationOptions sslOptions) =>

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             _sslStream = sslStream;
         }
 
-        internal ClientCertificateMode ClientCertificateMode { get; set; }
+        internal bool AllowDelayedClientCertificateNegotation { get; set; }
 
         public X509Certificate2? ClientCertificate
         {
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             }
 
             if (ClientCertificate != null
-                || ClientCertificateMode != ClientCertificateMode.DelayCertificate
+                || !AllowDelayedClientCertificateNegotation
                 // Delayed client cert negotiation is not allowed on HTTP/2 (or HTTP/3, but that's implemented elsewhere).
                 || _sslStream.NegotiatedApplicationProtocol == SslApplicationProtocol.Http2)
             {

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -400,8 +400,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel
                     }
                     else
                     {
-                        var sniOptionsSelector = new SniOptionsSelector(endpoint.Name, endpoint.Sni, CertificateConfigLoader, httpsOptions, listenOptions.Protocols, HttpsLogger);
-                        listenOptions.UseHttps(SniOptionsSelector.OptionsCallback, sniOptionsSelector, httpsOptions.HandshakeTimeout);
+                        var sniOptionsSelector = new SniOptionsSelector(endpoint.Name, endpoint.Sni, CertificateConfigLoader,
+                            httpsOptions, listenOptions.Protocols, HttpsLogger);
+                        var tlsCallbackOptions = new TlsHandshakeCallbackOptions()
+                        {
+                            OnConnection = SniOptionsSelector.OptionsCallback,
+                            HandshakeTimeout = httpsOptions.HandshakeTimeout,
+                            OnConnectionState = sniOptionsSelector,
+                        };
+
+                        listenOptions.UseHttps(tlsCallbackOptions);
                     }
                 }
 

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -100,7 +100,25 @@ Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowAlternateSche
 Microsoft.AspNetCore.Server.Kestrel.Https.ClientCertificateMode.DelayCertificate = 3 -> Microsoft.AspNetCore.Server.Kestrel.Https.ClientCertificateMode
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ResponseHeaderEncodingSelector.get -> System.Func<string!, System.Text.Encoding?>!
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ResponseHeaderEncodingSelector.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.AllowDelayedClientCertificateNegotation.get -> bool
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.AllowDelayedClientCertificateNegotation.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.CancellationToken.get -> System.Threading.CancellationToken
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.ClientHelloInfo.get -> System.Net.Security.SslClientHelloInfo
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.Connection.get -> Microsoft.AspNetCore.Connections.ConnectionContext!
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.SslStream.get -> System.Net.Security.SslStream!
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.State.get -> object?
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.TlsHandshakeCallbackContext() -> void
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions.HandshakeTimeout.get -> System.TimeSpan
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions.HandshakeTimeout.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions.OnConnection.get -> System.Func<Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext!, System.Threading.Tasks.ValueTask<System.Net.Security.SslServerAuthenticationOptions!>>!
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions.OnConnection.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions.OnConnectionState.get -> object?
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions.OnConnectionState.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions.TlsHandshakeCallbackOptions() -> void
 static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions! httpsOptions) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!
+static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions! callbackOptions) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!
 static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, System.Action<Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions!>! configureOptions) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!
 static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, System.Net.Security.ServerOptionsSelectionCallback! serverOptionsSelectionCallback, object! state) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!
 static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, System.Net.Security.ServerOptionsSelectionCallback! serverOptionsSelectionCallback, object! state, System.TimeSpan handshakeTimeout) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!

--- a/src/Servers/Kestrel/Core/src/TlsHandshakeCallbackContext.cs
+++ b/src/Servers/Kestrel/Core/src/TlsHandshakeCallbackContext.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Security;
+using System.Threading;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Https
+{
+    /// <summary>
+    /// Per connection state used to determine the TLS options.
+    /// </summary>
+    public class TlsHandshakeCallbackContext
+    {
+        // ServerOptionsSelectionCallback parameters
+
+        /// <summary>
+        /// The TLS stream on which the authentication happens.
+        /// </summary>
+        public SslStream SslStream { get; internal set; } = default!;
+
+        /// <summary>
+        /// Information from the Client Hello message.
+        /// </summary>
+        public SslClientHelloInfo ClientHelloInfo { get; internal set; }
+
+        /// <summary>
+        /// The information that was passed when registering the callback.
+        /// </summary>
+        public object? State { get; internal set; }
+
+        /// <summary>
+        /// The token to monitor for cancellation requests.
+        /// </summary>
+        public CancellationToken CancellationToken { get; internal set; }
+
+        // Kestrel specific
+
+        /// <summary>
+        /// Information about an individual connection.
+        /// </summary>
+        public ConnectionContext Connection { get; internal set; } = default!;
+
+        /// <summary>
+        /// Indicates if the application is allowed to request a client certificate after the handshake has completed.
+        /// The default is false. See <see cref="ITlsConnectionFeature.GetClientCertificateAsync"/>
+        /// </summary>
+        public bool AllowDelayedClientCertificateNegotation { get; set; }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/TlsHandshakeCallbackOptions.cs
+++ b/src/Servers/Kestrel/Core/src/TlsHandshakeCallbackOptions.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Https
+{
+    /// <summary>
+    /// Options used to configure a per connection callback for TLS configuration.
+    /// </summary>
+    public class TlsHandshakeCallbackOptions
+    {
+        private TimeSpan _handshakeTimeout = HttpsConnectionAdapterOptions.DefaultHandshakeTimeout;
+
+        /// <summary>
+        /// The callback to invoke per connection. This property is required.
+        /// </summary>
+        public Func<TlsHandshakeCallbackContext, ValueTask<SslServerAuthenticationOptions>> OnConnection { get; set; } = default!;
+
+        /// <summary>
+        /// Optional application state to flow to the <see cref="OnConnection"/> callback.
+        /// </summary>
+        public object? OnConnectionState { get; set; }
+
+        /// <summary>
+        /// Specifies the maximum amount of time allowed for the TLS/SSL handshake. This must be positive
+        /// or <see cref="Timeout.InfiniteTimeSpan"/>. Defaults to 10 seconds.
+        /// </summary>
+        public TimeSpan HandshakeTimeout
+        {
+            get => _handshakeTimeout;
+            set
+            {
+                if (value <= TimeSpan.Zero && value != Timeout.InfiniteTimeSpan)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), CoreStrings.PositiveTimeSpanRequired);
+                }
+                _handshakeTimeout = value != Timeout.InfiniteTimeSpan ? value : TimeSpan.MaxValue;
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -705,14 +705,62 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
+        // TLS 1.2 and lower have to renegotiate the whole connection to get a client cert, and if that hits an error
+        // then the connection is aborted.
         [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
-        public async Task RenegotiateForClientCertificateOnPostWithoutBufferingThrows()
+        public async Task RenegotiateForClientCertificateOnPostWithoutBufferingThrows_TLS12()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
             {
                 listenOptions.Protocols = HttpProtocols.Http1;
                 listenOptions.UseHttps(options =>
                 {
+                    options.SslProtocols = SslProtocols.Tls12;
+                    options.ServerCertificate = _x509Certificate2;
+                    options.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
+                    options.AllowAnyClientCertificate();
+                });
+            }
+
+            // Under 4kb can sometimes work because it fits into Kestrel's header parsing buffer.
+            var expectedBody = new string('a', 1024 * 4);
+
+            await using var server = new TestServer(async context =>
+            {
+                var tlsFeature = context.Features.Get<ITlsConnectionFeature>();
+                Assert.NotNull(tlsFeature);
+                Assert.Null(tlsFeature.ClientCertificate);
+                Assert.Null(context.Connection.ClientCertificate);
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Connection.GetClientCertificateAsync());
+                Assert.Equal("Received data during renegotiation.", ex.Message);
+                Assert.Null(tlsFeature.ClientCertificate);
+                Assert.Null(context.Connection.ClientCertificate);
+            }, new TestServiceContext(LoggerFactory), ConfigureListenOptions);
+
+            using var connection = server.CreateConnection();
+            // SslStream is used to ensure the certificate is actually passed to the server
+            // HttpClient might not send the certificate because it is invalid or it doesn't match any
+            // of the certificate authorities sent by the server in the SSL handshake.
+            // Use a random host name to avoid the TLS session resumption cache.
+            var stream = OpenSslStreamWithCert(connection.Stream);
+            await stream.AuthenticateAsClientAsync(Guid.NewGuid().ToString());
+            await AssertConnectionResult(stream, false, expectedBody);
+        }
+
+        [ConditionalFact]
+        // TLS 1.3 uses a new client cert negotiation extension that doesn't cause the connection to abort
+        // for this error.
+        [MinimumOSVersion(OperatingSystems.Windows, "10.0.20145")] // Needs a preview version with TLS 1.3 enabled.
+        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
+        public async Task RenegotiateForClientCertificateOnPostWithoutBufferingThrows_TLS13()
+        {
+            void ConfigureListenOptions(ListenOptions listenOptions)
+            {
+                listenOptions.Protocols = HttpProtocols.Http1;
+                listenOptions.UseHttps(options =>
+                {
+                    options.SslProtocols = SslProtocols.Tls13;
                     options.ServerCertificate = _x509Certificate2;
                     options.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
                     options.AllowAnyClientCertificate();


### PR DESCRIPTION
Fixes #33452, contributes to #33264 (delayed client certs).

There is no new functionality here, this takes an internal API and makes it public (and more user friendly). Customers wanted this in order to A) get access to the ConnectionContext for information like the IPs, and B) to configure delayed client cert negotiation per connection.

~~@dotnet/aspnet-api-review having to pass the callback to the TlsHandshakeCallbackOptions constructor is inconvenient usage compared to assigning it as a property. This pattern was recommended because the callback is required. I recommend we instead validate the property is set inside the UseHttps method that takes the TlsHandshakeCallbackOptions.~~ I removed the constructor.

~~Open question: Should the ServerOptionsSelectionCallback still default to AllowDelayedClientCertificateNegotation = true (new in preview6)? Or should people that want delayed client certs move to the new API?~~ Removed. The new API will be required to opt into delayed client certs. 