### PR TITLE
HTTP/3: Complete outbound control stream with connection

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ConnectionErrorException.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ConnectionErrorException.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
     internal class Http3ConnectionErrorException : Exception
     {
         public Http3ConnectionErrorException(string message, Http3ErrorCode errorCode)
-            : base($"HTTP/3 connection error ({errorCode}): {message}")
+            : base($"HTTP/3 connection error ({Http3Formatting.ToFormattedErrorCode(errorCode)}): {message}")
         {
             ErrorCode = errorCode;
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -160,7 +160,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public async Task ControlStream_ServerToClient_ErrorInitializing_ConnectionError()
         {
-            OnCreateServerControlStream = () => throw new Exception();
+            OnCreateServerControlStream = () =>
+            {
+                var controlStream = new Http3ControlStream(this, StreamInitiator.Server);
+
+                // Make server connection error when trying to write to control stream.
+                controlStream.StreamContext.Transport.Output.Complete();
+
+                return controlStream;
+            };
 
             await InitializeConnectionAsync(_noopApplication);
 


### PR DESCRIPTION
Ensure that the outbound control stream is completed when the connection is completed.

(right now it is completed via Stream.Abort, future issue will cover graceful shutdown)