### PR TITLE
Add support for packaging analyzers into ref-pack

### DIFF
--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -57,12 +57,34 @@ namespace RepoTasks
                     (f.Filename.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || f.IsNative))
                 .OrderBy(f => f.Filename, StringComparer.Ordinal))
             {
-                var element = new XElement(
-                    "File",
-                    new XAttribute("Type", f.IsNative ? "Native" : "Managed"),
-                    new XAttribute(
-                        "Path",
-                        Path.Combine(f.PackagePath, f.Filename).Replace('\\', '/')));
+                string path = Path.Combine(f.PackagePath, f.Filename).Replace('\\', '/');
+                string type = f.IsNative ? "Native" : "Managed";
+                var element = new XElement("File", new XAttribute("Path", path));
+
+                if (path.StartsWith("analyzers/"))
+                {
+                    type = "Analyzer";
+
+                    if (path.EndsWith(".resources.dll"))
+                    {
+                        // omit analyzer resources
+                        continue;
+                    }
+
+                    var pathParts = path.Split('/');
+
+                    if (pathParts.Length < 3 || !pathParts[1].Equals("dotnet", StringComparison.Ordinal) || pathParts.Length > 4)
+                    {
+                        Log.LogError($"Unexpected analyzer path format {path}.  Expected  'analyzers/dotnet(/language)/analyzer.dll");
+                    }
+
+                    if (pathParts.Length > 3)
+                    {
+                        element.Add(new XAttribute("Language", pathParts[2]));
+                    }
+                }
+
+                element.Add(new XAttribute("Type", type));
 
                 if (f.AssemblyName != null)
                 {

--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -61,11 +61,11 @@ namespace RepoTasks
                 string type = f.IsNative ? "Native" : "Managed";
                 var element = new XElement("File", new XAttribute("Path", path));
 
-                if (path.StartsWith("analyzers/"))
+                if (path.StartsWith("analyzers/", StringComparison.Ordinal))
                 {
                     type = "Analyzer";
 
-                    if (path.EndsWith(".resources.dll"))
+                    if (path.EndsWith(".resources.dll", StringComparison.Ordinal))
                     {
                         // omit analyzer resources
                         continue;
@@ -78,6 +78,7 @@ namespace RepoTasks
                         Log.LogError($"Unexpected analyzer path format {path}.  Expected  'analyzers/dotnet(/language)/analyzer.dll");
                     }
 
+                    // Check if we have enough parts for language directory and include it
                     if (pathParts.Length > 3)
                     {
                         element.Add(new XAttribute("Language", pathParts[2]));

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -165,7 +165,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
 
       <_AnalyzerContent Include="$(PkgMicrosoft_AspNetCore_Internal_Transport)\$(AnalyzersPackagePath)**\*.*" />
-      <RefPackContent Include="@(_AnalyzerContent)" TargetPath="$(AnalyzersPackagePath)%(RecursiveDir)" />
+      <RefPackContent Include="@(_AnalyzerContent)" PackagePath="$(AnalyzersPackagePath)%(RecursiveDir)" />
 
       <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -164,6 +164,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Include="@(AspNetCoreReferenceAssemblyPath->WithMetadataValue('ExternallyResolved', 'true')->'%(RootDir)%(Directory)%(Filename).xml')"
           Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
 
+      <_AnalyzerContent Include="$(PkgMicrosoft_AspNetCore_Internal_Transport)\$(AnalyzersPackagePath)**\*.*" />
+      <RefPackContent Include="@(_AnalyzerContent)" TargetPath="$(AnalyzersPackagePath)%(RecursiveDir)" />
+
       <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="$(ReferencePackageOverridesPath)" PackagePath="$(ManifestsPackagePath)" />

--- a/src/Framework/Directory.Build.props
+++ b/src/Framework/Directory.Build.props
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <ManifestsPackagePath>data/</ManifestsPackagePath>
+    <AnalyzersPackagePath>analyzers/</AnalyzersPackagePath>
     <!-- Shared between targeting pack and runtime build. -->
     <PlatformManifestFileName>PlatformManifest.txt</PlatformManifestFileName>
     <PlatformManifestOutputPath>$(ArtifactsObjDir)$(PlatformManifestFileName)</PlatformManifestOutputPath>

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -315,11 +315,13 @@ namespace Microsoft.AspNetCore
             var managedEntries = frameworkListEntries.Where(i => i.Attribute("Type").Value.Equals("Managed", StringComparison.Ordinal));
             var analyzerEntries = frameworkListEntries.Where(i => i.Attribute("Type").Value.Equals("Analyzer", StringComparison.Ordinal));
 
-            var expectedAnalyzers = Directory.GetFiles(
-                Path.Combine(_targetingPackRoot, "analyzers"), "*.dll", SearchOption.AllDirectories)
+            var analyzersDir = Path.Combine(_targetingPackRoot, "analyzers");
+            var expectedAnalyzers = Directory.Exists(analyzersDir) ?
+                Directory.GetFiles(analyzersDir, "*.dll", SearchOption.AllDirectories)
                 .Select(p => Path.GetFileNameWithoutExtension(p))
                 .Where(f => !f.EndsWith(".resources", StringComparison.OrdinalIgnoreCase))
-                .ToHashSet();
+                .ToHashSet() :
+                new HashSet<string>();
 
             CompareFrameworkElements(expectedAssemblies, managedEntries, "managed");
             CompareFrameworkElements(expectedAnalyzers, analyzerEntries, "analyzer");


### PR DESCRIPTION
Related: https://github.com/dotnet/runtime/issues/54687
Spec: https://github.com/dotnet/designs/blob/main/accepted/2021/InboxSourceGenerators.md

We'll start flowing source-generators through the transport package in https://github.com/dotnet/runtime/pull/54950.  This will pick them up and include them in the ASP.NET refpack.

The framework list change is a port of https://github.com/dotnet/arcade/pull/7561.

