### PR TITLE
Unquarantine CanUseViewportAsContainer test

### DIFF
--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -193,7 +193,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/24922")]
         public void CanUseViewportAsContainer()
         {
             Browser.MountTestComponent<VirtualizationComponent>();


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/24922.

This test was originally fixed in https://github.com/dotnet/aspnetcore/pull/26904. The quarantine ticket was opened due to an unrelated failure with Selenium that hasn't reproed.

In any case, it's been passing for 30 days now.

<img width="1392" alt="Screen Shot 2021-06-30 at 9 16 10 PM" src="https://user-images.githubusercontent.com/1857993/124063743-6d0ada80-d9e8-11eb-9984-4ac0c408d47d.png">
