### PR TITLE
Fixed startup timeout logging in ReactDevelopmentServerMiddleware

### DIFF
--- a/src/Middleware/Spa/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 // the first request times out, subsequent requests could still work.
                 var timeout = spaBuilder.Options.StartupTimeout;
                 var port = await portTask.WithTimeout(timeout, $"The create-react-app server did not start listening for requests " +
-                    $"within the timeout period of {timeout.Seconds} seconds. " +
+                    $"within the timeout period of {timeout.TotalSeconds} seconds. " +
                     $"Check the log output for error information.");
 
                 // Everything we proxy is hardcoded to target http://localhost because:


### PR DESCRIPTION
I've noticed that ReactDevelopmentServerMiddleware uses TimeSpan.Seconds property instead of TimeSpan.TotalSeconds to log startup timeout when exceeded. It can result in incorrect and confusing error message, for example when using full minutes:
"The create-react-app server did not start listening for requests within the timeout period of 0 seconds."
AngularCliMiddleware already uses correct property.