### PR TITLE
QueryStringEnumerable now works in terms of ReadOnlyMemory<char>

### DIFF
--- a/src/Http/Http/src/Features/QueryFeature.cs
+++ b/src/Http/Http/src/Features/QueryFeature.cs
@@ -110,10 +110,10 @@ namespace Microsoft.AspNetCore.Http.Features
             }
 
             var accumulator = new KvpAccumulator();
-            var enumerable = new QueryStringEnumerable(queryString.AsSpan());
+            var enumerable = new QueryStringEnumerable(queryString);
             foreach (var pair in enumerable)
             {
-                accumulator.Append(pair.DecodeName(), pair.DecodeValue());
+                accumulator.Append(pair.DecodeName().Span, pair.DecodeValue().Span);
             }
 
             return accumulator.HasValues

--- a/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
+++ b/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
@@ -4,15 +4,16 @@ Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream.MemoryThreshold.get ->
 Microsoft.AspNetCore.WebUtilities.FileBufferingWriteStream.MemoryThreshold.get -> int
 Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable
 Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair
-Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair.DecodeName() -> System.ReadOnlySpan<char>
-Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair.DecodeValue() -> System.ReadOnlySpan<char>
-Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair.EncodedName.get -> System.ReadOnlySpan<char>
-Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair.EncodedValue.get -> System.ReadOnlySpan<char>
+Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair.DecodeName() -> System.ReadOnlyMemory<char>
+Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair.DecodeValue() -> System.ReadOnlyMemory<char>
+Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair.EncodedName.get -> System.ReadOnlyMemory<char>
+Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair.EncodedValue.get -> System.ReadOnlyMemory<char>
 Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.Enumerator
 Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.Enumerator.Current.get -> Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.EncodedNameValuePair
 Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.Enumerator.MoveNext() -> bool
 Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.GetEnumerator() -> Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.Enumerator
-Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.QueryStringEnumerable(System.ReadOnlySpan<char> queryString) -> void
+Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.QueryStringEnumerable(System.ReadOnlyMemory<char> queryString) -> void
+Microsoft.AspNetCore.WebUtilities.QueryStringEnumerable.QueryStringEnumerable(string? queryString) -> void
 override Microsoft.AspNetCore.WebUtilities.BufferedReadStream.ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 override Microsoft.AspNetCore.WebUtilities.FileBufferingWriteStream.WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 static Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseNullableQuery(string? queryString) -> System.Collections.Generic.Dictionary<string!, Microsoft.Extensions.Primitives.StringValues>?

--- a/src/Shared/QueryStringEnumerable.cs
+++ b/src/Shared/QueryStringEnumerable.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Internal
         /// </summary>
         /// <param name="queryString">The query string.</param>
         public QueryStringEnumerable(string? queryString)
-            : this(MemoryExtensions.AsMemory(queryString))
+            : this(queryString.AsMemory())
         {
         }
 
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Internal
                 // then we can save some allocations.
                 return chars.Length < 16 && chars.Span.IndexOfAny('%', '+') < 0
                     ? chars
-                    : MemoryExtensions.AsMemory(Uri.UnescapeDataString(SpanHelper.ReplacePlusWithSpace(chars.Span)));
+                    : Uri.UnescapeDataString(SpanHelper.ReplacePlusWithSpace(chars.Span)).AsMemory();
             }
         }
 

--- a/src/Shared/QueryStringEnumerable.cs
+++ b/src/Shared/QueryStringEnumerable.cs
@@ -22,15 +22,24 @@ namespace Microsoft.AspNetCore.Internal
 #else
     internal
 #endif
-    readonly ref struct QueryStringEnumerable
+    readonly struct QueryStringEnumerable
     {
-        private readonly ReadOnlySpan<char> _queryString;
+        private readonly ReadOnlyMemory<char> _queryString;
 
         /// <summary>
         /// Constructs an instance of <see cref="QueryStringEnumerable"/>.
         /// </summary>
         /// <param name="queryString">The query string.</param>
-        public QueryStringEnumerable(ReadOnlySpan<char> queryString)
+        public QueryStringEnumerable(string? queryString)
+            : this(MemoryExtensions.AsMemory(queryString))
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance of <see cref="QueryStringEnumerable"/>.
+        /// </summary>
+        /// <param name="queryString">The query string.</param>
+        public QueryStringEnumerable(ReadOnlyMemory<char> queryString)
         {
             _queryString = queryString;
         }
@@ -45,21 +54,21 @@ namespace Microsoft.AspNetCore.Internal
         /// <summary>
         /// Represents a single name/value pair extracted from a query string during enumeration.
         /// </summary>
-        public readonly ref struct EncodedNameValuePair
+        public readonly struct EncodedNameValuePair
         {
             /// <summary>
             /// Gets the name from this name/value pair in its original encoded form.
             /// To get the decoded string, call <see cref="DecodeName"/>.
             /// </summary>
-            public readonly ReadOnlySpan<char> EncodedName { get; }
+            public readonly ReadOnlyMemory<char> EncodedName { get; }
 
             /// <summary>
             /// Gets the value from this name/value pair in its original encoded form.
             /// To get the decoded string, call <see cref="DecodeValue"/>.
             /// </summary>
-            public readonly ReadOnlySpan<char> EncodedValue { get; }
+            public readonly ReadOnlyMemory<char> EncodedValue { get; }
 
-            internal EncodedNameValuePair(ReadOnlySpan<char> encodedName, ReadOnlySpan<char> encodedValue)
+            internal EncodedNameValuePair(ReadOnlyMemory<char> encodedName, ReadOnlyMemory<char> encodedValue)
             {
                 EncodedName = encodedName;
                 EncodedValue = encodedValue;
@@ -69,37 +78,37 @@ namespace Microsoft.AspNetCore.Internal
             /// Decodes the name from this name/value pair.
             /// </summary>
             /// <returns>Characters representing the decoded name.</returns>
-            public ReadOnlySpan<char> DecodeName()
+            public ReadOnlyMemory<char> DecodeName()
                 => Decode(EncodedName);
 
             /// <summary>
             /// Decodes the value from this name/value pair.
             /// </summary>
             /// <returns>Characters representing the decoded value.</returns>
-            public ReadOnlySpan<char> DecodeValue()
+            public ReadOnlyMemory<char> DecodeValue()
                 => Decode(EncodedValue);
 
-            private static ReadOnlySpan<char> Decode(ReadOnlySpan<char> chars)
+            private static ReadOnlyMemory<char> Decode(ReadOnlyMemory<char> chars)
             {
                 // If the value is short, it's cheap to check up front if it really needs decoding. If it doesn't,
                 // then we can save some allocations.
-                return chars.Length < 16 && chars.IndexOfAny('%', '+') < 0
+                return chars.Length < 16 && chars.Span.IndexOfAny('%', '+') < 0
                     ? chars
-                    : Uri.UnescapeDataString(SpanHelper.ReplacePlusWithSpace(chars));
+                    : MemoryExtensions.AsMemory(Uri.UnescapeDataString(SpanHelper.ReplacePlusWithSpace(chars.Span)));
             }
         }
 
         /// <summary>
         /// An enumerator that supplies the name/value pairs from a URI query string.
         /// </summary>
-        public ref struct Enumerator
+        public struct Enumerator
         {
-            private ReadOnlySpan<char> _query;
+            private ReadOnlyMemory<char> _query;
 
-            internal Enumerator(ReadOnlySpan<char> query)
+            internal Enumerator(ReadOnlyMemory<char> query)
             {
                 Current = default;
-                _query = query.IsEmpty || query[0] != '?'
+                _query = query.IsEmpty || query.Span[0] != '?'
                     ? query
                     : query.Slice(1);
             }
@@ -118,8 +127,8 @@ namespace Microsoft.AspNetCore.Internal
                 while (!_query.IsEmpty)
                 {
                     // Chomp off the next segment
-                    ReadOnlySpan<char> segment;
-                    var delimiterIndex = _query.IndexOf('&');
+                    ReadOnlyMemory<char> segment;
+                    var delimiterIndex = _query.Span.IndexOf('&');
                     if (delimiterIndex >= 0)
                     {
                         segment = _query.Slice(0, delimiterIndex);
@@ -132,7 +141,7 @@ namespace Microsoft.AspNetCore.Internal
                     }
 
                     // If it's nonempty, emit it
-                    var equalIndex = segment.IndexOf('=');
+                    var equalIndex = segment.Span.IndexOf('=');
                     if (equalIndex >= 0)
                     {
                         Current = new EncodedNameValuePair(

--- a/src/Shared/test/Shared.Tests/QueryStringEnumerableTest.cs
+++ b/src/Shared/test/Shared.Tests/QueryStringEnumerableTest.cs
@@ -97,14 +97,12 @@ namespace Microsoft.AspNetCore.Internal
         }
 
         [Fact]
-        public void DecodingRetainsSpansIfDecodingNotNeeded()
+        public void DecodingReusesMemoryIfDecodingNotNeeded()
         {
             foreach (var kvp in new QueryStringEnumerable("?key=value"))
             {
-                Assert.True(MemoryExtensions.Overlaps(kvp.EncodedName, kvp.DecodeName(), out var nameOffset));
-                Assert.True(MemoryExtensions.Overlaps(kvp.EncodedValue, kvp.DecodeValue(), out var valueOffset));
-                Assert.Equal(0, nameOffset);
-                Assert.Equal(0, valueOffset);
+                Assert.True(kvp.EncodedName.Equals(kvp.DecodeName()));
+                Assert.True(kvp.EncodedValue.Equals(kvp.DecodeValue()));
             }
         }
 


### PR DESCRIPTION
While using the new `QueryStringEnumerable` to implement https://github.com/dotnet/aspnetcore/issues/33338, I realized it would be far more useful if the APIs were based around `ReadOnlyMemory<char>` instead of `ReadOnlySpan<char>`.

This doesn't incur any extra perf cost in realistic cases, because the querystring is basically always going to come from an actual `System.String` on the heap, so we can represent that as `ReadOnlyMemory<char>` without any further allocations.

The benefit is that, now:

* It's no longer a `ref struct`, because it doesn't need to be. Feel free to do normal things with it.
* The actual parsed values (e.g., `EncodedName`, `DecodeName()`, etc.) are no longer ref structs either, so you can do things like use them as keys or values in dictionaries, or store them on the heap for any other reason without having to allocate a new `string`.

I'm not aware of any drawbacks in realistic scenarios.