### PR TITLE
Make HttpSys client certificate behavior consistent 

### DIFF
--- a/src/Servers/HttpSys/Directory.Build.props
+++ b/src/Servers/HttpSys/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
+  <PropertyGroup>
+    <KestrelSharedSourceRoot>$(MSBuildThisFileDirectory)..\Kestrel\shared\</KestrelSharedSourceRoot>
+  </PropertyGroup>
+</Project>

--- a/src/Servers/HttpSys/HttpSysServer.slnf
+++ b/src/Servers/HttpSys/HttpSysServer.slnf
@@ -8,10 +8,10 @@
       "src\\Hosting\\Server.Abstractions\\src\\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj",
       "src\\Http\\Authentication.Abstractions\\src\\Microsoft.AspNetCore.Authentication.Abstractions.csproj",
       "src\\Http\\Authentication.Core\\src\\Microsoft.AspNetCore.Authentication.Core.csproj",
+      "src\\Http\\Features\\src\\Microsoft.Extensions.Features.csproj",
       "src\\Http\\Headers\\src\\Microsoft.Net.Http.Headers.csproj",
       "src\\Http\\Http.Abstractions\\src\\Microsoft.AspNetCore.Http.Abstractions.csproj",
       "src\\Http\\Http.Extensions\\src\\Microsoft.AspNetCore.Http.Extensions.csproj",
-      "src\\Http\\Features\\src\\Microsoft.Extensions.Features.csproj",
       "src\\Http\\Http.Features\\src\\Microsoft.AspNetCore.Http.Features.csproj",
       "src\\Http\\Http\\src\\Microsoft.AspNetCore.Http.csproj",
       "src\\Http\\Metadata\\src\\Microsoft.AspNetCore.Metadata.csproj",
@@ -25,8 +25,8 @@
       "src\\Servers\\HttpSys\\src\\Microsoft.AspNetCore.Server.HttpSys.csproj",
       "src\\Servers\\HttpSys\\test\\FunctionalTests\\Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj",
       "src\\Servers\\HttpSys\\test\\Tests\\Microsoft.AspNetCore.Server.HttpSys.Tests.csproj",
-      "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj",
       "src\\Servers\\IIS\\IIS\\src\\Microsoft.AspNetCore.Server.IIS.csproj",
+      "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj",
       "src\\Testing\\src\\Microsoft.AspNetCore.Testing.csproj"
     ]
   }

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -62,6 +62,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         private string? _connectionId;
         private string? _traceIdentitfier;
         private X509Certificate2? _clientCert;
+        private Task<X509Certificate2?>? _clientCertTask;
         private ClaimsPrincipal? _user;
         private Stream _responseStream = default!;
         private PipeWriter? _pipeWriter;
@@ -318,15 +319,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 if (IsNotInitialized(Fields.ClientCertificate))
                 {
                     var method = Server.Options.ClientCertificateMethod;
-                    if (method == ClientCertificateMethod.AllowCertificate)
+                    if (method != ClientCertificateMethod.NoCertificate)
                     {
                         _clientCert = Request.ClientCertificate;
                     }
-                    else if (method == ClientCertificateMethod.AllowRenegotation)
-                    {
-                        _clientCert = Request.GetClientCertificateAsync().Result; // TODO: Sync over async;
-                    }
-                    // else if (method == ClientCertificateMethod.NoCertificate) // No-op
 
                     SetInitialized(Fields.ClientCertificate);
                 }
@@ -335,29 +331,34 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             set
             {
                 _clientCert = value;
+                _clientCertTask = Task.FromResult(value);
                 SetInitialized(Fields.ClientCertificate);
             }
         }
 
-        async Task<X509Certificate2?> ITlsConnectionFeature.GetClientCertificateAsync(CancellationToken cancellationToken)
+        Task<X509Certificate2?> ITlsConnectionFeature.GetClientCertificateAsync(CancellationToken cancellationToken)
         {
-            if (IsNotInitialized(Fields.ClientCertificate))
+            if (_clientCertTask != null)
             {
-                var method = Server.Options.ClientCertificateMethod;
-                if (method != ClientCertificateMethod.NoCertificate)
-                {
-                    // Check if a cert was already available on the connection.
-                    _clientCert = Request.ClientCertificate;
-                }
-
-                if (_clientCert == null && method == ClientCertificateMethod.AllowRenegotation)
-                {
-                    _clientCert = await Request.GetClientCertificateAsync(cancellationToken);
-                }
-
-                SetInitialized(Fields.ClientCertificate);
+                return _clientCertTask;
             }
-            return _clientCert;
+
+            var tlsFeature = (ITlsConnectionFeature)this;
+            var clientCert = tlsFeature.ClientCertificate; // Lazy initialized
+            if (clientCert != null
+                || Server.Options.ClientCertificateMethod != ClientCertificateMethod.AllowRenegotation
+                // Delayed client cert negotiation is not allowed on HTTP/2.
+                || Request.ProtocolVersion >= HttpVersion.Version20)
+            {
+                return _clientCertTask = Task.FromResult(clientCert);
+            }
+
+            return _clientCertTask = GetCertificateAsync(cancellationToken);
+
+            async Task<X509Certificate2?> GetCertificateAsync(CancellationToken cancellation)
+            {
+                return _clientCert = await Request.GetClientCertificateAsync(cancellation);
+            }
         }
 
         internal ITlsConnectionFeature? GetTlsConnectionFeature()

--- a/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
+++ b/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
@@ -15,6 +15,8 @@
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Remove="$(SharedSourceRoot)ServerInfrastructure\StringUtilities.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" LinkBase="shared" />
+    <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -46,7 +46,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             {
                 return _clientCert ??= ConvertToX509Certificate2(_sslStream.RemoteCertificate);
             }
-            set => _clientCert = value;
+            set
+            {
+                _clientCert = value;
+                _clientCertTask = Task.FromResult(value);
+            }
         }
 
         // Used for event source, not part of any of the feature interfaces.


### PR DESCRIPTION
Fixes #33586 Now that we know more about the expected usage of the client cert APIs from our work on kestrel, this change brings HttpSys into alignment. The biggest change is that HttpSys' ClientCertificate property used to trigger a sync-over-async renegotiation. In a prior release we made renegotiation opt-in for both the property and the GetClientCertificateAsync method, and this change now removes it entirely for the ClientCertificate property. Anyone that wants renegotiation must opt in and use the GetClientCertificateAsync API. This enables the following usage pattern:
```
if (feature.ClientCertificate == null)
{
  await BufferRequestBodyAsync();
  await feature.GetClientCertificateAsync();
}
```

I also borrowed the test certificates from Kestrel so we could enable these tests on the CI.