### PR TITLE
Add support for DI in Hub methods

### DIFF
--- a/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -33,7 +33,7 @@ public class DefaultHubDispatcherBenchmark
             serviceScopeFactory,
             new HubContext<TestHub>(new DefaultHubLifetimeManager<TestHub>(NullLogger<DefaultHubLifetimeManager<TestHub>>.Instance)),
             enableDetailedErrors: false,
-            enableInferredFromServiceParameters: false,
+            disableImplicitFromServiceParameters: true,
             new Logger<DefaultHubDispatcher<TestHub>>(NullLoggerFactory.Instance),
             hubFilters: null);
 

--- a/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/DefaultHubDispatcherBenchmark.cs
@@ -33,6 +33,7 @@ public class DefaultHubDispatcherBenchmark
             serviceScopeFactory,
             new HubContext<TestHub>(new DefaultHubLifetimeManager<TestHub>(NullLogger<DefaultHubLifetimeManager<TestHub>>.Instance)),
             enableDetailedErrors: false,
+            enableInferredFromServiceParameters: false,
             new Logger<DefaultHubDispatcher<TestHub>>(NullLoggerFactory.Instance),
             hubFilters: null);
 

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -62,7 +62,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
         _userIdProvider = userIdProvider;
 
         _enableDetailedErrors = false;
-        bool enableInferredFromServiceParameters;
+        bool disableImplicitFromServiceParameters;
 
         List<IHubFilter>? hubFilters = null;
         if (_hubOptions.UserHasSetValues)
@@ -70,7 +70,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _maximumMessageSize = _hubOptions.MaximumReceiveMessageSize;
             _enableDetailedErrors = _hubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _hubOptions.MaximumParallelInvocationsPerClient;
-            enableInferredFromServiceParameters = _hubOptions.EnableInferredFromServiceParameters;
+            disableImplicitFromServiceParameters = _hubOptions.DisableImplicitFromServiceParameters;
 
             if (_hubOptions.HubFilters != null)
             {
@@ -82,7 +82,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _maximumMessageSize = _globalHubOptions.MaximumReceiveMessageSize;
             _enableDetailedErrors = _globalHubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _globalHubOptions.MaximumParallelInvocationsPerClient;
-            enableInferredFromServiceParameters = _globalHubOptions.EnableInferredFromServiceParameters;
+            disableImplicitFromServiceParameters = _globalHubOptions.DisableImplicitFromServiceParameters;
 
             if (_globalHubOptions.HubFilters != null)
             {
@@ -94,7 +94,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             serviceScopeFactory,
             new HubContext<THub>(lifetimeManager),
             _enableDetailedErrors,
-            enableInferredFromServiceParameters,
+            disableImplicitFromServiceParameters,
             new Logger<DefaultHubDispatcher<THub>>(loggerFactory),
             hubFilters);
     }

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -62,6 +62,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
         _userIdProvider = userIdProvider;
 
         _enableDetailedErrors = false;
+        bool enableInferredFromServiceParameters;
 
         List<IHubFilter>? hubFilters = null;
         if (_hubOptions.UserHasSetValues)
@@ -69,6 +70,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _maximumMessageSize = _hubOptions.MaximumReceiveMessageSize;
             _enableDetailedErrors = _hubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _hubOptions.MaximumParallelInvocationsPerClient;
+            enableInferredFromServiceParameters = _hubOptions.EnableInferredFromServiceParameters;
 
             if (_hubOptions.HubFilters != null)
             {
@@ -80,6 +82,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _maximumMessageSize = _globalHubOptions.MaximumReceiveMessageSize;
             _enableDetailedErrors = _globalHubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _globalHubOptions.MaximumParallelInvocationsPerClient;
+            enableInferredFromServiceParameters = _globalHubOptions.EnableInferredFromServiceParameters;
 
             if (_globalHubOptions.HubFilters != null)
             {
@@ -91,6 +94,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             serviceScopeFactory,
             new HubContext<THub>(lifetimeManager),
             _enableDetailedErrors,
+            enableInferredFromServiceParameters,
             new Logger<DefaultHubDispatcher<THub>>(loggerFactory),
             hubFilters);
     }

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Microsoft.AspNetCore.SignalR;
 
 /// <summary>
@@ -70,4 +73,13 @@ public class HubOptions
             _maximumParallelInvocationsPerClient = value;
         }
     }
+
+    /// <summary>
+    /// When enabled, will use <see cref="IServiceProviderIsService"/> to guess if a Hub method parameter can be injected from the DI container.
+    /// Parameters can be explicitly marked with an attribute that implements <see cref="IFromServiceMetadata"/> with or without this option enabled.
+    /// </summary>
+    /// <remarks>
+    /// Disabled by default.
+    /// </remarks>
+    public bool EnableInferredFromServiceParameters { get; set; }
 }

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -75,7 +75,7 @@ public class HubOptions
     }
 
     /// <summary>
-    /// Will use <see cref="IServiceProviderIsService"/> to guess if a Hub method parameter can be injected from the DI container.
+    /// When <see langword="false"/>, <see cref="IServiceProviderIsService"/> determines if a Hub method parameter will be injected from the DI container.
     /// Parameters can be explicitly marked with an attribute that implements <see cref="IFromServiceMetadata"/> with or without this option set.
     /// </summary>
     /// <remarks>

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -75,11 +75,11 @@ public class HubOptions
     }
 
     /// <summary>
-    /// When enabled, will use <see cref="IServiceProviderIsService"/> to guess if a Hub method parameter can be injected from the DI container.
-    /// Parameters can be explicitly marked with an attribute that implements <see cref="IFromServiceMetadata"/> with or without this option enabled.
+    /// Will use <see cref="IServiceProviderIsService"/> to guess if a Hub method parameter can be injected from the DI container.
+    /// Parameters can be explicitly marked with an attribute that implements <see cref="IFromServiceMetadata"/> with or without this option set.
     /// </summary>
     /// <remarks>
-    /// Disabled by default.
+    /// False by default. Hub method arguments will be resolved from a DI container if possible.
     /// </remarks>
-    public bool EnableInferredFromServiceParameters { get; set; }
+    public bool DisableImplicitFromServiceParameters { get; set; }
 }

--- a/src/SignalR/server/Core/src/HubOptionsSetup`T.cs
+++ b/src/SignalR/server/Core/src/HubOptionsSetup`T.cs
@@ -37,7 +37,7 @@ public class HubOptionsSetup<THub> : IConfigureOptions<HubOptions<THub>> where T
         options.MaximumReceiveMessageSize = _hubOptions.MaximumReceiveMessageSize;
         options.StreamBufferCapacity = _hubOptions.StreamBufferCapacity;
         options.MaximumParallelInvocationsPerClient = _hubOptions.MaximumParallelInvocationsPerClient;
-        options.EnableInferredFromServiceParameters = _hubOptions.EnableInferredFromServiceParameters;
+        options.DisableImplicitFromServiceParameters = _hubOptions.DisableImplicitFromServiceParameters;
 
         options.UserHasSetValues = true;
 

--- a/src/SignalR/server/Core/src/HubOptionsSetup`T.cs
+++ b/src/SignalR/server/Core/src/HubOptionsSetup`T.cs
@@ -37,6 +37,7 @@ public class HubOptionsSetup<THub> : IConfigureOptions<HubOptions<THub>> where T
         options.MaximumReceiveMessageSize = _hubOptions.MaximumReceiveMessageSize;
         options.StreamBufferCapacity = _hubOptions.StreamBufferCapacity;
         options.MaximumParallelInvocationsPerClient = _hubOptions.MaximumParallelInvocationsPerClient;
+        options.EnableInferredFromServiceParameters = _hubOptions.EnableInferredFromServiceParameters;
 
         options.UserHasSetValues = true;
 

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -28,13 +28,13 @@ internal partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> where TH
     private readonly Func<HubLifetimeContext, Exception?, Task>? _onDisconnectedMiddleware;
 
     public DefaultHubDispatcher(IServiceScopeFactory serviceScopeFactory, IHubContext<THub> hubContext, bool enableDetailedErrors,
-        bool enableInferredFromServiceParameters, ILogger<DefaultHubDispatcher<THub>> logger, List<IHubFilter>? hubFilters)
+        bool disableImplicitFromServiceParameters, ILogger<DefaultHubDispatcher<THub>> logger, List<IHubFilter>? hubFilters)
     {
         _serviceScopeFactory = serviceScopeFactory;
         _hubContext = hubContext;
         _enableDetailedErrors = enableDetailedErrors;
         _logger = logger;
-        DiscoverHubMethods(enableInferredFromServiceParameters);
+        DiscoverHubMethods(disableImplicitFromServiceParameters);
 
         var count = hubFilters?.Count ?? 0;
         if (count != 0)
@@ -648,7 +648,7 @@ internal partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> where TH
         }
     }
 
-    private void DiscoverHubMethods(bool enableInferredFromServiceParameters)
+    private void DiscoverHubMethods(bool disableImplicitFromServiceParameters)
     {
         var hubType = typeof(THub);
         var hubTypeInfo = hubType.GetTypeInfo();
@@ -657,7 +657,7 @@ internal partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> where TH
         using var scope = _serviceScopeFactory.CreateScope();
 
         IServiceProviderIsService? serviceProviderIsService = null;
-        if (enableInferredFromServiceParameters)
+        if (!disableImplicitFromServiceParameters)
         {
             serviceProviderIsService = scope.ServiceProvider.GetService<IServiceProviderIsService>();
         }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -654,8 +654,6 @@ internal partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> where TH
         var hubTypeInfo = hubType.GetTypeInfo();
         var hubName = hubType.Name;
 
-        using var scope = _serviceScopeFactory.CreateScope();
-
         foreach (var methodInfo in HubReflectionHelper.GetHubMethods(hubType))
         {
             if (methodInfo.IsGenericMethod)

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -655,7 +655,6 @@ internal partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> where TH
         var hubName = hubType.Name;
 
         using var scope = _serviceScopeFactory.CreateScope();
-        IServiceProviderIsService? serviceProviderIsService = scope.ServiceProvider.GetService<IServiceProviderIsService>();
 
         foreach (var methodInfo in HubReflectionHelper.GetHubMethods(hubType))
         {
@@ -675,7 +674,7 @@ internal partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> where TH
 
             var executor = ObjectMethodExecutor.Create(methodInfo, hubTypeInfo);
             var authorizeAttributes = methodInfo.GetCustomAttributes<AuthorizeAttribute>(inherit: true);
-            _methods[methodName] = new HubMethodDescriptor(executor, serviceProviderIsService, authorizeAttributes);
+            _methods[methodName] = new HubMethodDescriptor(executor, authorizeAttributes);
 
             Log.HubMethodBound(_logger, hubName, methodName);
         }

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Metadata;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.SignalR.Internal;

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -23,8 +23,8 @@ internal class HubMethodDescriptor
 
     private readonly MethodInfo? _makeCancelableEnumeratorMethodInfo;
     private Func<object, CancellationToken, IAsyncEnumerator<object>>? _makeCancelableEnumerator;
-    // bitset to store which parameters come from DI
-    private int _isServiceArgument;
+    // bitset to store which parameters come from DI up to 64 arguments
+    private ulong _isServiceArgument;
 
     public HubMethodDescriptor(ObjectMethodExecutor methodExecutor, IEnumerable<IAuthorizeData> policies)
     {
@@ -80,12 +80,12 @@ internal class HubMethodDescriptor
             }
             else if (p.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)))
             {
-                if (index >= 32)
+                if (index >= 64)
                 {
                     throw new InvalidOperationException(
-                        "Hub methods can't use services from DI in the parameters after the 32nd parameter.");
+                        "Hub methods can't use services from DI in the parameters after the 64th parameter.");
                 }
-                _isServiceArgument |= (1 << index);
+                _isServiceArgument |= (1UL << index);
                 HasSyntheticArguments = true;
                 return false;
             }
@@ -120,7 +120,7 @@ internal class HubMethodDescriptor
 
     public bool IsServiceArgument(int argumentIndex)
     {
-        return (_isServiceArgument & (1 << argumentIndex)) != 0;
+        return (_isServiceArgument & (1UL << argumentIndex)) != 0;
     }
 
     public IAsyncEnumerator<object> FromReturnedStream(object stream, CancellationToken cancellationToken)

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.SignalR.Internal;
@@ -26,7 +27,7 @@ internal class HubMethodDescriptor
     // bitset to store which parameters come from DI up to 64 arguments
     private ulong _isServiceArgument;
 
-    public HubMethodDescriptor(ObjectMethodExecutor methodExecutor, IEnumerable<IAuthorizeData> policies)
+    public HubMethodDescriptor(ObjectMethodExecutor methodExecutor, IServiceProviderIsService? serviceProviderIsService, IEnumerable<IAuthorizeData> policies)
     {
         MethodExecutor = methodExecutor;
 
@@ -78,7 +79,8 @@ internal class HubMethodDescriptor
                 HasSyntheticArguments = true;
                 return false;
             }
-            else if (p.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)))
+            else if (p.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)) ||
+                serviceProviderIsService?.IsService(p.ParameterType) == true)
             {
                 if (index >= 64)
                 {

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -24,6 +24,7 @@ internal class HubMethodDescriptor
 
     private readonly MethodInfo? _makeCancelableEnumeratorMethodInfo;
     private Func<object, CancellationToken, IAsyncEnumerator<object>>? _makeCancelableEnumerator;
+        // bitset to store which parameters come from DI
         private int _isServiceArgument;
 
     public HubMethodDescriptor(ObjectMethodExecutor methodExecutor, IServiceProviderIsService? serviceProviderIsService, IEnumerable<IAuthorizeData> policies)

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -1,12 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 
@@ -24,10 +24,10 @@ internal class HubMethodDescriptor
 
     private readonly MethodInfo? _makeCancelableEnumeratorMethodInfo;
     private Func<object, CancellationToken, IAsyncEnumerator<object>>? _makeCancelableEnumerator;
-        // bitset to store which parameters come from DI
-        private int _isServiceArgument;
+    // bitset to store which parameters come from DI
+    private int _isServiceArgument;
 
-    public HubMethodDescriptor(ObjectMethodExecutor methodExecutor, IServiceProviderIsService? serviceProviderIsService, IEnumerable<IAuthorizeData> policies)
+    public HubMethodDescriptor(ObjectMethodExecutor methodExecutor, IEnumerable<IAuthorizeData> policies)
     {
         MethodExecutor = methodExecutor;
 
@@ -79,7 +79,7 @@ internal class HubMethodDescriptor
                 HasSyntheticArguments = true;
                 return false;
             }
-            else if (serviceProviderIsService?.IsService(p.ParameterType) == true)
+            else if (p.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)))
             {
                 if (index >= 32)
                 {

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.SignalR.HubOptions.EnableInferredFromServiceParameters.get -> bool
-Microsoft.AspNetCore.SignalR.HubOptions.EnableInferredFromServiceParameters.set -> void
+Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServiceParameters.get -> bool
+Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServiceParameters.set -> void

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.SignalR.HubOptions.EnableInferredFromServiceParameters.get -> bool
+Microsoft.AspNetCore.SignalR.HubOptions.EnableInferredFromServiceParameters.set -> void

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -111,6 +111,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Equal(globalHubOptions.SupportedProtocols, hubOptions.SupportedProtocols);
             Assert.Equal(globalHubOptions.ClientTimeoutInterval, hubOptions.ClientTimeoutInterval);
             Assert.Equal(globalHubOptions.MaximumParallelInvocationsPerClient, hubOptions.MaximumParallelInvocationsPerClient);
+            Assert.Equal(globalHubOptions.EnableInferredFromServiceParameters, hubOptions.EnableInferredFromServiceParameters);
             Assert.True(hubOptions.UserHasSetValues);
         }
 
@@ -145,6 +146,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 options.SupportedProtocols = null;
                 options.ClientTimeoutInterval = TimeSpan.FromSeconds(1);
                 options.MaximumParallelInvocationsPerClient = 3;
+                options.EnableInferredFromServiceParameters = true;
             });
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -158,6 +160,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Null(globalOptions.SupportedProtocols);
             Assert.Equal(3, globalOptions.MaximumParallelInvocationsPerClient);
             Assert.Equal(TimeSpan.FromSeconds(1), globalOptions.ClientTimeoutInterval);
+            Assert.True(globalOptions.EnableInferredFromServiceParameters);
         }
 
         [Fact]

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Equal(globalHubOptions.SupportedProtocols, hubOptions.SupportedProtocols);
             Assert.Equal(globalHubOptions.ClientTimeoutInterval, hubOptions.ClientTimeoutInterval);
             Assert.Equal(globalHubOptions.MaximumParallelInvocationsPerClient, hubOptions.MaximumParallelInvocationsPerClient);
-            Assert.Equal(globalHubOptions.EnableInferredFromServiceParameters, hubOptions.EnableInferredFromServiceParameters);
+            Assert.Equal(globalHubOptions.DisableImplicitFromServiceParameters, hubOptions.DisableImplicitFromServiceParameters);
             Assert.True(hubOptions.UserHasSetValues);
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 options.SupportedProtocols = null;
                 options.ClientTimeoutInterval = TimeSpan.FromSeconds(1);
                 options.MaximumParallelInvocationsPerClient = 3;
-                options.EnableInferredFromServiceParameters = true;
+                options.DisableImplicitFromServiceParameters = true;
             });
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -160,7 +160,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Null(globalOptions.SupportedProtocols);
             Assert.Equal(3, globalOptions.MaximumParallelInvocationsPerClient);
             Assert.Equal(TimeSpan.FromSeconds(1), globalOptions.ClientTimeoutInterval);
-            Assert.True(globalOptions.EnableInferredFromServiceParameters);
+            Assert.True(globalOptions.DisableImplicitFromServiceParameters);
         }
 
         [Fact]

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1294,6 +1294,6 @@ public class TooManyParamsHub : Hub
 {
     public void ManyParams(int a, string b, bool c, float d, string e, int f, int g, int h, int i, int j, int k,
         int l, int m, int n, int o, int p, int q, int r, int s, int t, int u, int v, int w, int x, int y, int z,
-        int aa, int ab, int ac, int ad, int ae, int af, Service1 service)
+        int aa, int ab, int ac, int ad, int ae, int af, [FromService] Service1 service)
     { }
 }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1246,4 +1246,42 @@ public class CallerService
     {
         Caller = caller;
     }
+
+    public class Service1
+    { }
+    public class Service2
+    { }
+    public class Service3
+    { }
+
+    public class ServicesHub : TestHub
+    {
+        public bool SingleService(Service1 service)
+        {
+            return true;
+        }
+
+        public bool MultipleServices(Service1 service, Service2 service2, Service3 service3)
+        {
+            return true;
+        }
+
+        public async Task<int> ServicesAndParams(int value, Service1 service, ChannelReader<int> channelReader, Service2 service2, bool value2)
+        {
+            int total = 0;
+            while (await channelReader.WaitToReadAsync())
+            {
+                total += await channelReader.ReadAsync();
+            }
+            return total + value;
+        }
+
+        public async Task Stream(ChannelReader<int> channelReader)
+        {
+            while (await channelReader.WaitToReadAsync())
+            {
+                await channelReader.ReadAsync();
+            }
+        }
+    }
 }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1292,8 +1292,11 @@ public class ServicesHub : TestHub
 
 public class TooManyParamsHub : Hub
 {
-    public void ManyParams(int a, string b, bool c, float d, string e, int f, int g, int h, int i, int j, int k,
-        int l, int m, int n, int o, int p, int q, int r, int s, int t, int u, int v, int w, int x, int y, int z,
-        int aa, int ab, int ac, int ad, int ae, int af, [FromService] Service1 service)
+    public void ManyParams(int a1, string a2, bool a3, float a4, string a5, int a6, int a7, int a8, int a9, int a10, int a11,
+        int a12, int a13, int a14, int a15, int a16, int a17, int a18, int a19, int a20, int a21, int a22, int a23, int a24,
+        int a25, int a26, int a27, int a28, int a29, int a30, int a31, int a32, int a33, int a34, int a35, int a36, int a37,
+        int a38, int a39, int a40, int a41, int a42, int a43, int a44, int a45, int a46, int a47, int a48, int a49, int a50,
+        int a51, int a52, int a53, int a54, int a55, int a56, int a57, int a58, int a59, int a60, int a61, int a62, int a63,
+        int a64, [FromService] Service1 service)
     { }
 }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1284,4 +1284,12 @@ public class CallerService
             }
         }
     }
+
+    public class TooManyParamsHub : Hub
+    {
+        public void ManyParams(int a, string b, bool c, float d, string e, int f, int g, int h, int i, int j, int k,
+            int l, int m, int n, int o, int p, int q, int r, int s, int t, int u, int v, int w, int x, int y, int z,
+            int aa, int ab, int ac, int ad, int ae, int af, Service1 service)
+        { }
+    }
 }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1281,6 +1281,11 @@ public class ServicesHub : TestHub
         return 1;
     }
 
+    public int ServiceWithAndWithoutAttribute(Service1 service, [FromService] Service2 service2)
+    {
+        return 1;
+    }
+
     public async Task Stream(ChannelReader<int> channelReader)
     {
         while (await channelReader.WaitToReadAsync())

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1,16 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading;
 using System.Threading.Channels;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Metadata;
 using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.AspNetCore.SignalR.Tests;
@@ -1246,50 +1242,58 @@ public class CallerService
     {
         Caller = caller;
     }
+}
 
-    public class Service1
-    { }
-    public class Service2
-    { }
-    public class Service3
-    { }
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+public class FromService : Attribute, IFromServiceMetadata
+{ }
+public class Service1
+{ }
+public class Service2
+{ }
+public class Service3
+{ }
 
-    public class ServicesHub : TestHub
+public class ServicesHub : TestHub
+{
+    public bool SingleService([FromService] Service1 service)
     {
-        public bool SingleService(Service1 service)
-        {
-            return true;
-        }
-
-        public bool MultipleServices(Service1 service, Service2 service2, Service3 service3)
-        {
-            return true;
-        }
-
-        public async Task<int> ServicesAndParams(int value, Service1 service, ChannelReader<int> channelReader, Service2 service2, bool value2)
-        {
-            int total = 0;
-            while (await channelReader.WaitToReadAsync())
-            {
-                total += await channelReader.ReadAsync();
-            }
-            return total + value;
-        }
-
-        public async Task Stream(ChannelReader<int> channelReader)
-        {
-            while (await channelReader.WaitToReadAsync())
-            {
-                await channelReader.ReadAsync();
-            }
-        }
+        return true;
     }
 
-    public class TooManyParamsHub : Hub
+    public bool MultipleServices([FromService] Service1 service, [FromService] Service2 service2, [FromService] Service3 service3)
     {
-        public void ManyParams(int a, string b, bool c, float d, string e, int f, int g, int h, int i, int j, int k,
-            int l, int m, int n, int o, int p, int q, int r, int s, int t, int u, int v, int w, int x, int y, int z,
-            int aa, int ab, int ac, int ad, int ae, int af, Service1 service)
-        { }
+        return true;
     }
+
+    public async Task<int> ServicesAndParams(int value, [FromService] Service1 service, ChannelReader<int> channelReader, [FromService] Service2 service2, bool value2)
+    {
+        int total = 0;
+        while (await channelReader.WaitToReadAsync())
+        {
+            total += await channelReader.ReadAsync();
+        }
+        return total + value;
+    }
+
+    public int ServiceWithoutAttribute(Service1 service)
+    {
+        return 1;
+    }
+
+    public async Task Stream(ChannelReader<int> channelReader)
+    {
+        while (await channelReader.WaitToReadAsync())
+        {
+            await channelReader.ReadAsync();
+        }
+    }
+}
+
+public class TooManyParamsHub : Hub
+{
+    public void ManyParams(int a, string b, bool c, float d, string e, int f, int g, int h, int i, int j, int k,
+        int l, int m, int n, int o, int p, int q, int r, int s, int t, int u, int v, int w, int x, int y, int z,
+        int aa, int ab, int ac, int ad, int ae, int af, Service1 service)
+    { }
 }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using MessagePack;
 using MessagePack.Formatters;
@@ -4594,6 +4595,103 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
             Assert.Single(invocation.Arguments);
             Assert.Equal("test", invocation.Arguments[0]);
             Assert.Equal("Send", invocation.Target);
+        }
+    }
+
+    [Fact]
+    public async Task HubMethodFailsIfServiceNotFound()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSignalR(o => o.EnableDetailedErrors = true);
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(ServicesHub.SingleService)).DefaultTimeout();
+            Assert.Equal("Failed to invoke 'SingleService' due to an error on the server. InvalidDataException: Invocation provides 0 argument(s) but target expects 1.", res.Error);
+        }
+    }
+
+    [Fact]
+    public async Task HubMethodCanInjectService()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSingleton<Service1>();
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(ServicesHub.SingleService)).DefaultTimeout();
+            Assert.True(Assert.IsType<bool>(res.Result));
+        }
+    }
+
+    [Fact]
+    public async Task HubMethodCanInjectMultipleServices()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSingleton<Service1>();
+            provider.AddSingleton<Service2>();
+            provider.AddSingleton<Service3>();
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(ServicesHub.MultipleServices)).DefaultTimeout();
+            Assert.True(Assert.IsType<bool>(res.Result));
+        }
+    }
+
+    [Fact]
+    public async Task HubMethodCanInjectServicesWithOtherParameters()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSingleton<Service1>();
+            provider.AddSingleton<Service2>();
+            provider.AddSingleton<Service3>();
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            await client.BeginUploadStreamAsync("0", nameof(ServicesHub.ServicesAndParams), new string[] { "1" }, 10, true).DefaultTimeout();
+
+            await client.SendHubMessageAsync(new StreamItemMessage("1", 1)).DefaultTimeout();
+            await client.SendHubMessageAsync(new StreamItemMessage("1", 14)).DefaultTimeout();
+
+            await client.SendHubMessageAsync(CompletionMessage.Empty("1")).DefaultTimeout();
+
+            var response = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+            Assert.Equal(25L, response.Result);
+        }
+    }
+
+    [Fact]
+    public async Task StreamFromServiceDoesNotWork()
+    {
+        var channel = Channel.CreateBounded<int>(10);
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSingleton(channel.Reader);
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(ServicesHub.Stream)).DefaultTimeout();
+            Assert.Equal("An unexpected error occurred invoking 'Stream' on the server. HubException: Client sent 0 stream(s), Hub method expects 1.", res.Error);
         }
     }
 

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -4695,6 +4695,17 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
         }
     }
 
+    [Fact]
+    public void TooManyParametersWithServiceThrows()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSingleton<Service1>();
+        });
+        Assert.Throws<InvalidOperationException>(
+            () => serviceProvider.GetService<HubConnectionHandler<TooManyParamsHub>>());
+    }
+
     private class CustomHubActivator<THub> : IHubActivator<THub> where THub : Hub
     {
         public int ReleaseCount;

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -4689,13 +4689,14 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
     }
 
     [Fact]
-    public async Task ServiceNotResolvedWithoutAttribute()
+    public async Task ServiceNotResolvedWithoutAttribute_WithSettingDisabledGlobally()
     {
         var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
         {
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
+                options.DisableImplicitFromServiceParameters = true;
             });
             provider.AddSingleton<Service1>();
         });
@@ -4710,14 +4711,13 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
     }
 
     [Fact]
-    public async Task ServiceResolvedWithoutAttribute_WithSettingEnabledGlobally()
+    public async Task ServiceResolvedWithoutAttribute()
     {
         var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
         {
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
-                options.EnableInferredFromServiceParameters = true;
             });
             provider.AddSingleton<Service1>();
         });
@@ -4739,9 +4739,10 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
+                options.DisableImplicitFromServiceParameters = true;
             }).AddHubOptions<ServicesHub>(options =>
             {
-                options.EnableInferredFromServiceParameters = true;
+                options.DisableImplicitFromServiceParameters = false;
             });
             provider.AddSingleton<Service1>();
         });
@@ -4756,13 +4757,14 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
     }
 
     [Fact]
-    public async Task ServiceNotResolvedWithAndWithoutAttribute()
+    public async Task ServiceNotResolvedWithAndWithoutAttribute_WithOptionDisabled()
     {
         var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
         {
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
+                options.DisableImplicitFromServiceParameters = true;
             });
             provider.AddSingleton<Service1>();
             provider.AddSingleton<Service2>();
@@ -4778,14 +4780,13 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
     }
 
     [Fact]
-    public async Task ServiceResolvedWithAndWithoutAttribute_WithOptionEnabled()
+    public async Task ServiceResolvedWithAndWithoutAttribute()
     {
         var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
         {
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
-                options.EnableInferredFromServiceParameters = true;
             });
             provider.AddSingleton<Service1>();
             provider.AddSingleton<Service2>();
@@ -4801,14 +4802,13 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
     }
 
     [Fact]
-    public async Task ServiceNotResolvedIfNotInDI_WithOptionEnabled()
+    public async Task ServiceNotResolvedIfNotInDI()
     {
         var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
         {
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
-                options.EnableInferredFromServiceParameters = true;
             });
         });
         var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -4604,7 +4604,7 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
         {
             var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
             var res = await client.InvokeAsync(nameof(ServicesHub.SingleService)).DefaultTimeout();
-            Assert.Equal("Failed to invoke 'SingleService' due to an error on the server. InvalidDataException: Invocation provides 0 argument(s) but target expects 1.", res.Error);
+            Assert.Equal("An unexpected error occurred invoking 'SingleService' on the server. InvalidOperationException: No service for type 'Microsoft.AspNetCore.SignalR.Tests.Service1' has been registered.", res.Error);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/16686

~~The issue talks about having a `[FromServices]` attribute, that isn't addressed in the current form of this PR.~~
Using `IFromServiceMetadata` like we do for Minimal APIs to check if a parameter should be resolved from a service. This makes the feature opt-in and less likely for us to accidentally mess something up.

Source generator wont be able to do anything special about hub methods with services, but that might just be something we don't care about and developers should design their interfaces with that in mind.

Currently using a mask (ulong) to store indices for service positions in Hub methods which limits hub methods to 64 arguments, I think this is fine though 😄  

### API

```diff
public class HubOptions
{
+    public bool DisableImplicitFromServiceParameters { get; set; }
}
```