### PR TITLE
Remove Configuration.AutoUpdate and NotifySourcesChanged()

### DIFF
--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Hosting
     // This exists solely to bootstrap the configuration
     internal class BootstrapHostBuilder : IHostBuilder
     {
-        private readonly Configuration _configuration;
+        private readonly Config _configuration;
         private readonly WebHostEnvironment _environment;
 
         private readonly HostBuilderContext _hostContext;
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Hosting
         private readonly List<Action<IConfigurationBuilder>> _configureHostActions = new();
         private readonly List<Action<HostBuilderContext, IConfigurationBuilder>> _configureAppActions = new();
 
-        public BootstrapHostBuilder(Configuration configuration, WebHostEnvironment webHostEnvironment)
+        public BootstrapHostBuilder(Config configuration, WebHostEnvironment webHostEnvironment)
         {
             _configuration = configuration;
             _environment = webHostEnvironment;

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -95,7 +95,6 @@ namespace Microsoft.AspNetCore.Hosting
 
             // Configuration doesn't auto-update during the bootstrap phase to reduce I/O,
             // but we do need to update between host and app configuration so the right environment is used.
-            _configuration.Update();
             _environment.ApplyConfigurationSettings(_configuration);
 
             foreach (var configureAppAction in _configureAppActions)
@@ -103,7 +102,6 @@ namespace Microsoft.AspNetCore.Hosting
                 configureAppAction(_hostContext, _configuration);
             }
 
-            _configuration.Update();
             _environment.ApplyConfigurationSettings(_configuration);
         }
     }

--- a/src/DefaultBuilder/src/Config.cs
+++ b/src/DefaultBuilder/src/Config.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Builder
     /// Configuration is mutable configuration object. It is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
     /// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
     /// </summary>
-    public sealed class Configuration : IConfigurationRoot, IConfigurationBuilder, IDisposable
+    public sealed class Config : IConfigurationRoot, IConfigurationBuilder, IDisposable
     {
         private readonly ConfigurationSources _sources;
         private readonly ConfigurationBuilderProperties _properties;
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Creates an empty mutable configuration object that is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
         /// </summary>
-        public Configuration()
+        public Config()
         {
             _sources = new ConfigurationSources(this);
             _properties = new ConfigurationBuilderProperties(this);
@@ -206,9 +206,9 @@ namespace Microsoft.AspNetCore.Builder
         private class ConfigurationSources : IList<IConfigurationSource>
         {
             private readonly List<IConfigurationSource> _sources = new();
-            private readonly Configuration _config;
+            private readonly Config _config;
 
-            public ConfigurationSources(Configuration config)
+            public ConfigurationSources(Config config)
             {
                 _config = config;
             }
@@ -287,9 +287,9 @@ namespace Microsoft.AspNetCore.Builder
         private class ConfigurationBuilderProperties : IDictionary<string, object>
         {
             private readonly Dictionary<string, object> _properties = new();
-            private readonly Configuration _config;
+            private readonly Config _config;
 
-            public ConfigurationBuilderProperties(Configuration config)
+            public ConfigurationBuilderProperties(Config config)
             {
                 _config = config;
             }

--- a/src/DefaultBuilder/src/Configuration.cs
+++ b/src/DefaultBuilder/src/Configuration.cs
@@ -288,11 +288,8 @@ namespace Microsoft.AspNetCore.Builder
 
         private class ConfigurationBuilderProperties : IDictionary<string, object>
         {
-            private const string FileProviderKey = "FileProvider";
-
             private readonly Dictionary<string, object> _properties = new();
             private readonly Configuration _config;
-            private object? _fileProvider;
 
             public ConfigurationBuilderProperties(Configuration config)
             {
@@ -305,7 +302,7 @@ namespace Microsoft.AspNetCore.Builder
                 set
                 {
                     _properties[key] = value;
-                    CheckForFileProviderChange(key, value);
+                    _config.NotifySourcesChanged();
                 }
             }
 
@@ -320,19 +317,19 @@ namespace Microsoft.AspNetCore.Builder
             public void Add(string key, object value)
             {
                 _properties.Add(key, value);
-                CheckForFileProviderChange(key, value);
+                _config.NotifySourcesChanged();
             }
 
             public void Add(KeyValuePair<string, object> item)
             {
                 ((IDictionary<string, object>)_properties).Add(item);
-                CheckForFileProviderChange(item.Key, item.Value);
+                _config.NotifySourcesChanged();
             }
 
             public void Clear()
             {
                 _properties.Clear();
-                CheckForFileProviderChange(FileProviderKey, null);
+                _config.NotifySourcesChanged();
             }
 
             public bool Contains(KeyValuePair<string, object> item)
@@ -358,14 +355,14 @@ namespace Microsoft.AspNetCore.Builder
             public bool Remove(string key)
             {
                 var wasRemoved = _properties.Remove(key);
-                CheckForFileProviderChange(key, null);
+                _config.NotifySourcesChanged();
                 return wasRemoved;
             }
 
             public bool Remove(KeyValuePair<string, object> item)
             {
                 var wasRemoved = ((IDictionary<string, object>)_properties).Remove(item);
-                CheckForFileProviderChange(item.Key, null);
+                _config.NotifySourcesChanged();
                 return wasRemoved;
             }
 
@@ -377,16 +374,6 @@ namespace Microsoft.AspNetCore.Builder
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return _properties.GetEnumerator();
-            }
-
-            private void CheckForFileProviderChange(string key, object? value)
-            {
-                if (key == FileProviderKey && !ReferenceEquals(value, _fileProvider))
-                {
-                    _fileProvider = value;
-                    // Reload all the sources since the base path has likely changed.
-                    _config.NotifySourcesChanged();
-                }
             }
         }
     }

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -21,12 +21,12 @@ namespace Microsoft.AspNetCore.Builder
         public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
 
         private readonly WebHostEnvironment _environment;
-        private readonly Configuration _configuration;
+        private readonly Config _configuration;
         private readonly IServiceCollection _services;
 
         private readonly HostBuilderContext _context;
 
-        internal ConfigureHostBuilder(Configuration configuration, WebHostEnvironment environment, IServiceCollection services)
+        internal ConfigureHostBuilder(Config configuration, WebHostEnvironment environment, IServiceCollection services)
         {
             _configuration = configuration;
             _environment = environment;

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -16,13 +16,13 @@ namespace Microsoft.AspNetCore.Builder
     public sealed class ConfigureWebHostBuilder : IWebHostBuilder
     {
         private readonly WebHostEnvironment _environment;
-        private readonly Configuration _configuration;
+        private readonly Config _configuration;
         private readonly Dictionary<string, string?> _settings = new(StringComparer.OrdinalIgnoreCase);
         private readonly IServiceCollection _services;
 
         private readonly WebHostBuilderContext _context;
 
-        internal ConfigureWebHostBuilder(Configuration configuration, WebHostEnvironment environment, IServiceCollection services)
+        internal ConfigureWebHostBuilder(Config configuration, WebHostEnvironment environment, IServiceCollection services)
         {
             _configuration = configuration;
             _environment = environment;

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,11 +1,11 @@
 #nullable enable
-Microsoft.AspNetCore.Builder.Configuration
-Microsoft.AspNetCore.Builder.Configuration.Configuration() -> void
-Microsoft.AspNetCore.Builder.Configuration.Dispose() -> void
-Microsoft.AspNetCore.Builder.Configuration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!
-Microsoft.AspNetCore.Builder.Configuration.GetSection(string! key) -> Microsoft.Extensions.Configuration.IConfigurationSection!
-Microsoft.AspNetCore.Builder.Configuration.this[string! key].get -> string?
-Microsoft.AspNetCore.Builder.Configuration.this[string! key].set -> void
+Microsoft.AspNetCore.Builder.Config
+Microsoft.AspNetCore.Builder.Config.Config() -> void
+Microsoft.AspNetCore.Builder.Config.Dispose() -> void
+Microsoft.AspNetCore.Builder.Config.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!
+Microsoft.AspNetCore.Builder.Config.GetSection(string! key) -> Microsoft.Extensions.Configuration.IConfigurationSection!
+Microsoft.AspNetCore.Builder.Config.this[string! key].get -> string?
+Microsoft.AspNetCore.Builder.Config.this[string! key].set -> void
 Microsoft.AspNetCore.Builder.ConfigureHostBuilder
 Microsoft.AspNetCore.Builder.ConfigureHostBuilder.ConfigureAppConfiguration(System.Action<Microsoft.Extensions.Hosting.HostBuilderContext!, Microsoft.Extensions.Configuration.IConfigurationBuilder!>! configureDelegate) -> Microsoft.Extensions.Hosting.IHostBuilder!
 Microsoft.AspNetCore.Builder.ConfigureHostBuilder.ConfigureContainer<TContainerBuilder>(System.Action<Microsoft.Extensions.Hosting.HostBuilderContext!, TContainerBuilder>! configureDelegate) -> Microsoft.Extensions.Hosting.IHostBuilder!

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,9 +1,10 @@
 #nullable enable
 Microsoft.AspNetCore.Builder.Configuration
 Microsoft.AspNetCore.Builder.Configuration.Configuration() -> void
+Microsoft.AspNetCore.Builder.Configuration.Dispose() -> void
 Microsoft.AspNetCore.Builder.Configuration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Configuration.IConfigurationSection!>!
 Microsoft.AspNetCore.Builder.Configuration.GetSection(string! key) -> Microsoft.Extensions.Configuration.IConfigurationSection!
-Microsoft.AspNetCore.Builder.Configuration.this[string! key].get -> string!
+Microsoft.AspNetCore.Builder.Configuration.this[string! key].get -> string?
 Microsoft.AspNetCore.Builder.Configuration.this[string! key].set -> void
 Microsoft.AspNetCore.Builder.ConfigureHostBuilder
 Microsoft.AspNetCore.Builder.ConfigureHostBuilder.ConfigureAppConfiguration(System.Action<Microsoft.Extensions.Hosting.HostBuilderContext!, Microsoft.Extensions.Configuration.IConfigurationBuilder!>! configureDelegate) -> Microsoft.Extensions.Hosting.IHostBuilder!

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -62,10 +62,8 @@ namespace Microsoft.AspNetCore.Builder
             // Configuration changes made by ConfigureDefaults(args) were already picked up by the BootstrapHostBuilder,
             // so we ignore changes to config until ConfigureDefaults completes.
             _deferredHostBuilder.ConfigurationEnabled = true;
-            // Now that consuming code can start modifying Configuration, we need to automatically rebuild on modification.
-            // To this point, we've been manually calling Configuration.UpdateConfiguration() only when needed to reduce I/O.
-            Configuration.AutoUpdate = true;
         }
+
 
         /// <summary>
         /// Provides information about the web hosting environment an application is running.
@@ -80,7 +78,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
         /// </summary>
-        public Configuration Configuration { get; } = new() { AutoUpdate = false };
+        public Configuration Configuration { get; } = new();
 
         /// <summary>
         /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
         /// </summary>
-        public Configuration Configuration { get; } = new();
+        public Config Configuration { get; } = new();
 
         /// <summary>
         /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.

--- a/src/DefaultBuilder/src/WebHostEnvironment.cs
+++ b/src/DefaultBuilder/src/WebHostEnvironment.cs
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Builder
             ContentRootFileProvider = NullFileProvider;
             WebRootFileProvider = NullFileProvider;
 
-            ResolveFileProviders(new Configuration());
+            ResolveFileProviders(new Config());
         }
 
         // For testing

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigTests.cs
@@ -13,12 +13,12 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Tests
 {
-    public class ConfigurationTests
+    public class ConfigTests
     {
         [Fact]
         public void AutoUpdates()
         {
-            var config = new Configuration();
+            var config = new Config();
 
             config.AddInMemoryCollection(new Dictionary<string, string>
             {
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Tests
         [Fact]
         public void TriggersReloadTokenOnSourceAddition()
         {
-            var config = new Configuration();
+            var config = new Config();
 
             var reloadToken = ((IConfiguration)config).GetReloadToken();
 
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Tests
         [Fact]
         public void SettingValuesWorksWithoutManuallyAddingSource()
         {
-            var config = new Configuration
+            var config = new Config
             {
                 ["TestKey"] = "TestValue",
             };
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Tests
         [Fact]
         public void SettingConfigValuesDoesNotTriggerReloadToken()
         {
-            var config = new Configuration();
+            var config = new Config();
             var reloadToken = ((IConfiguration)config).GetReloadToken();
 
             config["TestKey"] = "TestValue";
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Tests
         [Fact]
         public void SettingIConfigurationBuilderPropertiesReloadsSources()
         {
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configBuilder = config;
 
             config["PreReloadTestConfigKey"] = "PreReloadTestConfigValue";
@@ -106,7 +106,7 @@ namespace Microsoft.AspNetCore.Tests
             var provider4 = new DisposableTestConfigurationProvider("qux", "qux-value");
             var provider5 = new DisposableTestConfigurationProvider("quux", "quux-value");
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder builder = config;
 
             builder.Add(new TestConfigurationSource(provider1));
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Tests
             var source4 = new TestConfigurationSource(provider4);
             var source5 = new TestConfigurationSource(provider5);
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder builder = config;
 
             builder.Add(source1);
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Tests
             var providerMock = new Mock<IConfigurationProvider>();
             providerMock.Setup(p => p.GetReloadToken()).Returns(changeToken);
 
-            var config = new Configuration();
+            var config = new Config();
 
             ((IConfigurationBuilder)config).Add(new TestConfigurationSource(providerMock.Object));
 
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.Tests
 
             var source = new TestConfigurationSource(providerMock.Object);
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder builder = config;
 
             builder.Add(source);
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Tests
                 provider
             });
 
-            var config = new Configuration();
+            var config = new Config();
 
             config.AddConfiguration(chainedConfig, shouldDisposeConfiguration: shouldDispose);
 
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
             var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             // Act
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
             var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             // Act
@@ -354,14 +354,14 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
             var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
 
-            var config1 = new Configuration();
+            var config1 = new Config();
             IConfigurationBuilder configurationBuilder = config1;
 
             // Act
             configurationBuilder.Add(memConfigSrc1);
             configurationBuilder.Add(memConfigSrc2);
 
-            var config2 = new Configuration();
+            var config2 = new Config();
 
             config2
                 .AddConfiguration(config1)
@@ -414,7 +414,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
             var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             // Act
@@ -468,7 +468,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
             var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             // Act
@@ -512,7 +512,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             // Act
@@ -556,7 +556,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new TestMemorySourceProvider(dict);
             var memConfigSrc3 = new TestMemorySourceProvider(dict);
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             configurationBuilder.Add(memConfigSrc1);
@@ -603,7 +603,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
             var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             configurationBuilder.Add(memConfigSrc1);
@@ -647,7 +647,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             configurationBuilder.Add(memConfigSrc1);
@@ -685,7 +685,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
             var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             configurationBuilder.Add(memConfigSrc1);
@@ -716,7 +716,7 @@ namespace Microsoft.AspNetCore.Tests
             var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dict };
             var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dict };
 
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder configurationBuilder = config;
 
             // Act
@@ -735,7 +735,7 @@ namespace Microsoft.AspNetCore.Tests
         public void SetValueThrowsExceptionNoSourceRegistered()
         {
             // Arrange
-            var config = new Configuration();
+            var config = new Config();
 
             // A MemoryConfigurationSource is added by default, so there will be no error unless we clear it
             config["Title"] = "Welcome";
@@ -755,7 +755,7 @@ namespace Microsoft.AspNetCore.Tests
         public void SameReloadTokenIsReturnedRepeatedly()
         {
             // Arrange
-            IConfiguration config = new Configuration();
+            IConfiguration config = new Config();
 
             // Act
             var token1 = config.GetReloadToken();
@@ -769,7 +769,7 @@ namespace Microsoft.AspNetCore.Tests
         public void DifferentReloadTokenReturnedAfterReloading()
         {
             // Arrange
-            IConfigurationRoot config = new Configuration();
+            IConfigurationRoot config = new Config();
 
             // Act
             var token1 = config.GetReloadToken();
@@ -788,7 +788,7 @@ namespace Microsoft.AspNetCore.Tests
         public void TokenTriggeredWhenReloadOccurs()
         {
             // Arrange
-            IConfigurationRoot config = new Configuration();
+            IConfigurationRoot config = new Config();
 
             // Act
             var token1 = config.GetReloadToken();
@@ -805,7 +805,7 @@ namespace Microsoft.AspNetCore.Tests
         public void MultipleCallbacksCanBeRegisteredToReload()
         {
             // Arrange
-            IConfigurationRoot config = new Configuration();
+            IConfigurationRoot config = new Config();
 
             // Act
             var token1 = config.GetReloadToken();
@@ -837,7 +837,7 @@ namespace Microsoft.AspNetCore.Tests
         public void NewTokenAfterReloadIsNotChanged()
         {
             // Arrange
-            IConfigurationRoot config = new Configuration();
+            IConfigurationRoot config = new Config();
 
             // Act
             var token1 = config.GetReloadToken();
@@ -886,7 +886,7 @@ namespace Microsoft.AspNetCore.Tests
                 ["Key1::Key3"] = "value"
             };
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             // Act
@@ -910,7 +910,7 @@ namespace Microsoft.AspNetCore.Tests
                 ["Key1:"] = "value"
             };
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             // Act
@@ -934,7 +934,7 @@ namespace Microsoft.AspNetCore.Tests
                 {"Mem1:KeyInMem1:Deep1", "ValueDeep1"}
             };
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             // Act
@@ -959,7 +959,7 @@ namespace Microsoft.AspNetCore.Tests
                 {"Mem1:KeyInMem1:Deep1", "ValueDeep1"}
             };
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             // Act
@@ -981,7 +981,7 @@ namespace Microsoft.AspNetCore.Tests
                 {"Mem1:Deep1", "Value1"},
             };
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             Assert.Throws<InvalidOperationException>(() => config.GetRequiredSection("Mem2"));
@@ -999,7 +999,7 @@ namespace Microsoft.AspNetCore.Tests
                 {"Mem2:KeyInMem2:Deep1", "ValueDeep2"}
             };
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             // Act
@@ -1024,7 +1024,7 @@ namespace Microsoft.AspNetCore.Tests
                 {"Mem1", value}
             };
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             // Act
@@ -1043,7 +1043,7 @@ namespace Microsoft.AspNetCore.Tests
                 {"Mem1", null}
             };
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             // Act
@@ -1067,7 +1067,7 @@ namespace Microsoft.AspNetCore.Tests
             };
 
 
-            var config = new Configuration();
+            var config = new Config();
             ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
 
             // Act
@@ -1081,7 +1081,7 @@ namespace Microsoft.AspNetCore.Tests
         public void ProviderWithNullReloadToken()
         {
             // Arrange
-            var config = new Configuration();
+            var config = new Config();
             IConfigurationBuilder builder = config;
 
             // Assert
@@ -1092,7 +1092,7 @@ namespace Microsoft.AspNetCore.Tests
         public void BuildReturnsThis()
         {
             // Arrange
-            var config = new Configuration();
+            var config = new Config();
 
             // Assert
             Assert.Same(config, ((IConfigurationBuilder)config).Build());

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigurationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigurationTests.cs
@@ -1,9 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.Primitives;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Tests
@@ -11,11 +16,9 @@ namespace Microsoft.AspNetCore.Tests
     public class ConfigurationTests
     {
         [Fact]
-        public void AutoUpdatesByDefault()
+        public void AutoUpdates()
         {
             var config = new Configuration();
-
-            Assert.True(config.AutoUpdate);
 
             config.AddInMemoryCollection(new Dictionary<string, string>
             {
@@ -26,7 +29,7 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
-        public void AutoUpdateTriggersReloadTokenOnSourceModification()
+        public void TriggersReloadTokenOnSourceAddition()
         {
             var config = new Configuration();
 
@@ -42,69 +45,22 @@ namespace Microsoft.AspNetCore.Tests
             Assert.True(reloadToken.HasChanged);
         }
 
+
         [Fact]
-        public void DoesNotAutoUpdateWhenAutoUpdateDisabled()
+        public void SettingValuesWorksWithoutManuallyAddingSource()
         {
             var config = new Configuration
             {
-                AutoUpdate = false,
-            };
-
-            config.AddInMemoryCollection(new Dictionary<string, string>
-            {
-                { "TestKey", "TestValue" },
-            });
-
-            Assert.Null(config["TestKey"]);
-
-            config.Update();
-
-            Assert.Equal("TestValue", config["TestKey"]);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ManualUpdateTriggersReloadTokenWithOrWithoutAutoUpdate(bool autoUpdate)
-        {
-            var config = new Configuration
-            {
-                AutoUpdate = autoUpdate,
-            };
-
-            var manualReloadToken = ((IConfiguration)config).GetReloadToken();
-
-            Assert.False(manualReloadToken.HasChanged);
-
-            config.Update();
-
-            Assert.True(manualReloadToken.HasChanged);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SettingValuesWorksWithOrWithoutAutoUpdate(bool autoUpdate)
-        {
-            var config = new Configuration
-            {
-                AutoUpdate = autoUpdate,
                 ["TestKey"] = "TestValue",
             };
 
             Assert.Equal("TestValue", config["TestKey"]);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SettingValuesDoesNotTriggerReloadTokenWithOrWithoutAutoUpdate(bool autoUpdate)
+        [Fact]
+        public void SettingValuesDoesNotTriggerReloadTokenWithOrWithoutAutoUpdate()
         {
-            var config = new Configuration
-            {
-                AutoUpdate = autoUpdate,
-            };
-
+            var config = new Configuration();
             var reloadToken = ((IConfiguration)config).GetReloadToken();
 
             config["TestKey"] = "TestValue";
@@ -116,15 +72,10 @@ namespace Microsoft.AspNetCore.Tests
             Assert.False(reloadToken.HasChanged);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SettingIConfigurationBuilderPropertiesWorksWithoutAutoUpdate(bool autoUpdate)
+        [Fact]
+        public void SettingIConfigurationBuilderPropertiesWorks()
         {
-            var config = new Configuration
-            {
-                AutoUpdate = autoUpdate,
-            };
+            var config = new Configuration();
 
             var configBuilder = (IConfigurationBuilder)config;
 
@@ -138,5 +89,1110 @@ namespace Microsoft.AspNetCore.Tests
             Assert.Null(config["TestKey"]);
             Assert.False(reloadToken.HasChanged);
         }
+
+        [Fact]
+        public void DisposesProvidersOnDispose()
+        {
+            var provider1 = new TestConfigurationProvider("foo", "foo-value");
+            var provider2 = new DisposableTestConfigurationProvider("bar", "bar-value");
+            var provider3 = new TestConfigurationProvider("baz", "baz-value");
+            var provider4 = new DisposableTestConfigurationProvider("qux", "qux-value");
+            var provider5 = new DisposableTestConfigurationProvider("quux", "quux-value");
+
+            var config = new Configuration();
+            IConfigurationBuilder builder = config;
+
+            builder.Add(new TestConfigurationSource(provider1));
+            builder.Add(new TestConfigurationSource(provider2));
+            builder.Add(new TestConfigurationSource(provider3));
+            builder.Add(new TestConfigurationSource(provider4));
+            builder.Add(new TestConfigurationSource(provider5));
+
+            Assert.Equal("foo-value", config["foo"]);
+            Assert.Equal("bar-value", config["bar"]);
+            Assert.Equal("baz-value", config["baz"]);
+            Assert.Equal("qux-value", config["qux"]);
+            Assert.Equal("quux-value", config["quux"]);
+
+            config.Dispose();
+
+            Assert.True(provider2.IsDisposed);
+            Assert.True(provider4.IsDisposed);
+            Assert.True(provider5.IsDisposed);
+        }
+
+        [Fact]
+        public void DisposesProvidersOnRemoval()
+        {
+            var provider1 = new TestConfigurationProvider("foo", "foo-value");
+            var provider2 = new DisposableTestConfigurationProvider("bar", "bar-value");
+            var provider3 = new TestConfigurationProvider("baz", "baz-value");
+            var provider4 = new DisposableTestConfigurationProvider("qux", "qux-value");
+            var provider5 = new DisposableTestConfigurationProvider("quux", "quux-value");
+
+            var source1 = new TestConfigurationSource(provider1);
+            var source2 = new TestConfigurationSource(provider2);
+            var source3 = new TestConfigurationSource(provider3);
+            var source4 = new TestConfigurationSource(provider4);
+            var source5 = new TestConfigurationSource(provider5);
+
+            var config = new Configuration();
+            IConfigurationBuilder builder = config;
+
+            builder.Add(source1);
+            builder.Add(source2);
+            builder.Add(source3);
+            builder.Add(source4);
+            builder.Add(source5);
+
+            Assert.Equal("foo-value", config["foo"]);
+            Assert.Equal("bar-value", config["bar"]);
+            Assert.Equal("baz-value", config["baz"]);
+            Assert.Equal("qux-value", config["qux"]);
+            Assert.Equal("quux-value", config["quux"]);
+
+            builder.Sources.Remove(source2);
+            builder.Sources.Remove(source4);
+
+            // While only provider2 and provider4 need to be disposed here, we do not assert provider5 is not disposed
+            // because even though it's unnecessary, Configuration disposes all providers on removal and rebuilds
+            // all the sources. While not optimal, this should be a pretty rare scenario.
+            Assert.True(provider2.IsDisposed);
+            Assert.True(provider4.IsDisposed);
+
+            config.Dispose();
+
+            Assert.True(provider2.IsDisposed);
+            Assert.True(provider4.IsDisposed);
+            Assert.True(provider5.IsDisposed);
+        }
+
+        [Fact]
+        public void DisposesChangeTokenRegistrationsOnDispose()
+        {
+            var changeToken = new TestChangeToken();
+            var providerMock = new Mock<IConfigurationProvider>();
+            providerMock.Setup(p => p.GetReloadToken()).Returns(changeToken);
+
+            var config = new Configuration();
+
+            ((IConfigurationBuilder)config).Add(new TestConfigurationSource(providerMock.Object));
+
+            Assert.NotEmpty(changeToken.Callbacks);
+
+            config.Dispose();
+
+            Assert.Empty(changeToken.Callbacks);
+        }
+
+        [Fact]
+        public void DisposesChangeTokenRegistrationsOnRemoval()
+        {
+            var changeToken = new TestChangeToken();
+            var providerMock = new Mock<IConfigurationProvider>();
+            providerMock.Setup(p => p.GetReloadToken()).Returns(changeToken);
+
+            var source = new TestConfigurationSource(providerMock.Object);
+
+            var config = new Configuration();
+            IConfigurationBuilder builder = config;
+
+            builder.Add(source);
+
+            Assert.NotEmpty(changeToken.Callbacks);
+
+            builder.Sources.Remove(source);
+
+            Assert.Empty(changeToken.Callbacks);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ChainedConfigurationIsDisposedOnDispose(bool shouldDispose)
+        {
+            var provider = new DisposableTestConfigurationProvider("foo", "foo-value");
+            var chainedConfig = new ConfigurationRoot(new IConfigurationProvider[] {
+                provider
+            });
+
+            var config = new Configuration();
+
+            config.AddConfiguration(chainedConfig, shouldDisposeConfiguration: shouldDispose);
+
+            Assert.False(provider.IsDisposed);
+
+            config.Dispose();
+
+            Assert.Equal(shouldDispose, provider.IsDisposed);
+        }
+
+        [Fact]
+        public void LoadAndCombineKeyValuePairsFromDifferentConfigurationProviders()
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+            {
+                {"Mem1:KeyInMem1", "ValueInMem1"}
+            };
+            var dic2 = new Dictionary<string, string>()
+            {
+                {"Mem2:KeyInMem2", "ValueInMem2"}
+            };
+            var dic3 = new Dictionary<string, string>()
+            {
+                {"Mem3:KeyInMem3", "ValueInMem3"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+            var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            // Act
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+            configurationBuilder.Add(memConfigSrc3);
+
+            var memVal1 = config["mem1:keyinmem1"];
+            var memVal2 = config["Mem2:KeyInMem2"];
+            var memVal3 = config["MEM3:KEYINMEM3"];
+
+            // Assert
+            Assert.Contains(memConfigSrc1, configurationBuilder.Sources);
+            Assert.Contains(memConfigSrc2, configurationBuilder.Sources);
+            Assert.Contains(memConfigSrc3, configurationBuilder.Sources);
+
+            Assert.Equal("ValueInMem1", memVal1);
+            Assert.Equal("ValueInMem2", memVal2);
+            Assert.Equal("ValueInMem3", memVal3);
+
+            Assert.Equal("ValueInMem1", config["mem1:keyinmem1"]);
+            Assert.Equal("ValueInMem2", config["Mem2:KeyInMem2"]);
+            Assert.Equal("ValueInMem3", config["MEM3:KEYINMEM3"]);
+            Assert.Null(config["NotExist"]);
+        }
+
+        [Fact]
+        public void CanChainConfiguration()
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+            {
+                {"Mem1:KeyInMem1", "ValueInMem1"}
+            };
+            var dic2 = new Dictionary<string, string>()
+            {
+                {"Mem2:KeyInMem2", "ValueInMem2"}
+            };
+            var dic3 = new Dictionary<string, string>()
+            {
+                {"Mem3:KeyInMem3", "ValueInMem3"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+            var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            // Act
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+            configurationBuilder.Add(memConfigSrc3);
+
+            var chained = new ConfigurationBuilder().AddConfiguration(config).Build();
+            var memVal1 = chained["mem1:keyinmem1"];
+            var memVal2 = chained["Mem2:KeyInMem2"];
+            var memVal3 = chained["MEM3:KEYINMEM3"];
+
+            // Assert
+
+            Assert.Equal("ValueInMem1", memVal1);
+            Assert.Equal("ValueInMem2", memVal2);
+            Assert.Equal("ValueInMem3", memVal3);
+
+            Assert.Null(chained["NotExist"]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ChainedAsEnumerateFlattensIntoDictionaryTest(bool removePath)
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+            {
+                {"Mem1", "Value1"},
+                {"Mem1:", "NoKeyValue1"},
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem1:KeyInMem1:Deep1", "ValueDeep1"}
+            };
+            var dic2 = new Dictionary<string, string>()
+            {
+                {"Mem2", "Value2"},
+                {"Mem2:", "NoKeyValue2"},
+                {"Mem2:KeyInMem2", "ValueInMem2"},
+                {"Mem2:KeyInMem2:Deep2", "ValueDeep2"}
+            };
+            var dic3 = new Dictionary<string, string>()
+            {
+                {"Mem3", "Value3"},
+                {"Mem3:", "NoKeyValue3"},
+                {"Mem3:KeyInMem3", "ValueInMem3"},
+                {"Mem3:KeyInMem3:Deep3", "ValueDeep3"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+            var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
+
+            var config1 = new Configuration();
+            IConfigurationBuilder configurationBuilder = config1;
+
+            // Act
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+
+            var config2 = new Configuration();
+
+            config2
+                .AddConfiguration(config1)
+                .Add(memConfigSrc3);
+
+            var dict = config2.AsEnumerable(makePathsRelative: removePath).ToDictionary(k => k.Key, v => v.Value);
+
+            // Assert
+            Assert.Equal("Value1", dict["Mem1"]);
+            Assert.Equal("NoKeyValue1", dict["Mem1:"]);
+            Assert.Equal("ValueDeep1", dict["Mem1:KeyInMem1:Deep1"]);
+            Assert.Equal("ValueInMem2", dict["Mem2:KeyInMem2"]);
+            Assert.Equal("Value2", dict["Mem2"]);
+            Assert.Equal("NoKeyValue2", dict["Mem2:"]);
+            Assert.Equal("ValueDeep2", dict["Mem2:KeyInMem2:Deep2"]);
+            Assert.Equal("Value3", dict["Mem3"]);
+            Assert.Equal("NoKeyValue3", dict["Mem3:"]);
+            Assert.Equal("ValueInMem3", dict["Mem3:KeyInMem3"]);
+            Assert.Equal("ValueDeep3", dict["Mem3:KeyInMem3:Deep3"]);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AsEnumerateFlattensIntoDictionaryTest(bool removePath)
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+            {
+                {"Mem1", "Value1"},
+                {"Mem1:", "NoKeyValue1"},
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem1:KeyInMem1:Deep1", "ValueDeep1"}
+            };
+            var dic2 = new Dictionary<string, string>()
+            {
+                {"Mem2", "Value2"},
+                {"Mem2:", "NoKeyValue2"},
+                {"Mem2:KeyInMem2", "ValueInMem2"},
+                {"Mem2:KeyInMem2:Deep2", "ValueDeep2"}
+            };
+            var dic3 = new Dictionary<string, string>()
+            {
+                {"Mem3", "Value3"},
+                {"Mem3:", "NoKeyValue3"},
+                {"Mem3:KeyInMem3", "ValueInMem3"},
+                {"Mem3:KeyInMem3:Deep3", "ValueDeep3"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+            var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            // Act
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+            configurationBuilder.Add(memConfigSrc3);
+            var dict = config.AsEnumerable(makePathsRelative: removePath).ToDictionary(k => k.Key, v => v.Value);
+
+            // Assert
+            Assert.Equal("Value1", dict["Mem1"]);
+            Assert.Equal("NoKeyValue1", dict["Mem1:"]);
+            Assert.Equal("ValueDeep1", dict["Mem1:KeyInMem1:Deep1"]);
+            Assert.Equal("ValueInMem2", dict["Mem2:KeyInMem2"]);
+            Assert.Equal("Value2", dict["Mem2"]);
+            Assert.Equal("NoKeyValue2", dict["Mem2:"]);
+            Assert.Equal("ValueDeep2", dict["Mem2:KeyInMem2:Deep2"]);
+            Assert.Equal("Value3", dict["Mem3"]);
+            Assert.Equal("NoKeyValue3", dict["Mem3:"]);
+            Assert.Equal("ValueInMem3", dict["Mem3:KeyInMem3"]);
+            Assert.Equal("ValueDeep3", dict["Mem3:KeyInMem3:Deep3"]);
+        }
+
+        [Fact]
+        public void AsEnumerateStripsKeyFromChildren()
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+            {
+                {"Mem1", "Value1"},
+                {"Mem1:", "NoKeyValue1"},
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem1:KeyInMem1:Deep1", "ValueDeep1"}
+            };
+            var dic2 = new Dictionary<string, string>()
+            {
+                {"Mem2", "Value2"},
+                {"Mem2:", "NoKeyValue2"},
+                {"Mem2:KeyInMem2", "ValueInMem2"},
+                {"Mem2:KeyInMem2:Deep2", "ValueDeep2"}
+            };
+            var dic3 = new Dictionary<string, string>()
+            {
+                {"Mem3", "Value3"},
+                {"Mem3:", "NoKeyValue3"},
+                {"Mem3:KeyInMem3", "ValueInMem3"},
+                {"Mem3:KeyInMem4", "ValueInMem4"},
+                {"Mem3:KeyInMem3:Deep3", "ValueDeep3"},
+                {"Mem3:KeyInMem3:Deep4", "ValueDeep4"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+            var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            // Act
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+            configurationBuilder.Add(memConfigSrc3);
+
+            var dict = config.GetSection("Mem1").AsEnumerable(makePathsRelative: true).ToDictionary(k => k.Key, v => v.Value);
+            Assert.Equal(3, dict.Count);
+            Assert.Equal("NoKeyValue1", dict[""]);
+            Assert.Equal("ValueInMem1", dict["KeyInMem1"]);
+            Assert.Equal("ValueDeep1", dict["KeyInMem1:Deep1"]);
+
+            var dict2 = config.GetSection("Mem2").AsEnumerable(makePathsRelative: true).ToDictionary(k => k.Key, v => v.Value);
+            Assert.Equal(3, dict2.Count);
+            Assert.Equal("NoKeyValue2", dict2[""]);
+            Assert.Equal("ValueInMem2", dict2["KeyInMem2"]);
+            Assert.Equal("ValueDeep2", dict2["KeyInMem2:Deep2"]);
+
+            var dict3 = config.GetSection("Mem3").AsEnumerable(makePathsRelative: true).ToDictionary(k => k.Key, v => v.Value);
+            Assert.Equal(5, dict3.Count);
+            Assert.Equal("NoKeyValue3", dict3[""]);
+            Assert.Equal("ValueInMem3", dict3["KeyInMem3"]);
+            Assert.Equal("ValueInMem4", dict3["KeyInMem4"]);
+            Assert.Equal("ValueDeep3", dict3["KeyInMem3:Deep3"]);
+            Assert.Equal("ValueDeep4", dict3["KeyInMem3:Deep4"]);
+        }
+
+        [Fact]
+        public void NewConfigurationProviderOverridesOldOneWhenKeyIsDuplicated()
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+                {
+                    {"Key1:Key2", "ValueInMem1"}
+                };
+            var dic2 = new Dictionary<string, string>()
+                {
+                    {"Key1:Key2", "ValueInMem2"}
+                };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            // Act
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+
+            // Assert
+            Assert.Equal("ValueInMem2", config["Key1:Key2"]);
+        }
+
+        [Fact]
+        public void NewConfigurationRootMayBeBuiltFromExistingWithDuplicateKeys()
+        {
+            var configurationRoot = new ConfigurationBuilder()
+                                    .AddInMemoryCollection(new Dictionary<string, string>
+                                        {
+                                            {"keya:keyb", "valueA"},
+                                        })
+                                    .AddInMemoryCollection(new Dictionary<string, string>
+                                        {
+                                            {"KEYA:KEYB", "valueB"}
+                                        })
+                                    .Build();
+            var newConfigurationRoot = new ConfigurationBuilder()
+                .AddInMemoryCollection(configurationRoot.AsEnumerable())
+                .Build();
+            Assert.Equal("valueB", newConfigurationRoot["keya:keyb"]);
+        }
+
+        [Fact]
+        public void SettingValueUpdatesAllConfigurationProviders()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Key1", "Value1"},
+                {"Key2", "Value2"}
+            };
+
+            var memConfigSrc1 = new TestMemorySourceProvider(dict);
+            var memConfigSrc2 = new TestMemorySourceProvider(dict);
+            var memConfigSrc3 = new TestMemorySourceProvider(dict);
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+            configurationBuilder.Add(memConfigSrc3);
+
+            // Act
+            config["Key1"] = "NewValue1";
+            config["Key2"] = "NewValue2";
+
+            var memConfigProvider1 = memConfigSrc1.Build(configurationBuilder);
+            var memConfigProvider2 = memConfigSrc2.Build(configurationBuilder);
+            var memConfigProvider3 = memConfigSrc3.Build(configurationBuilder);
+
+            // Assert
+            Assert.Equal("NewValue1", config["Key1"]);
+            Assert.Equal("NewValue1", Get(memConfigProvider1, "Key1"));
+            Assert.Equal("NewValue1", Get(memConfigProvider2, "Key1"));
+            Assert.Equal("NewValue1", Get(memConfigProvider3, "Key1"));
+            Assert.Equal("NewValue2", config["Key2"]);
+            Assert.Equal("NewValue2", Get(memConfigProvider1, "Key2"));
+            Assert.Equal("NewValue2", Get(memConfigProvider2, "Key2"));
+            Assert.Equal("NewValue2", Get(memConfigProvider3, "Key2"));
+        }
+
+        [Fact]
+        public void CanGetConfigurationSection()
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+            {
+                {"Data:DB1:Connection1", "MemVal1"},
+                {"Data:DB1:Connection2", "MemVal2"}
+            };
+            var dic2 = new Dictionary<string, string>()
+            {
+                {"DataSource:DB2:Connection", "MemVal3"}
+            };
+            var dic3 = new Dictionary<string, string>()
+            {
+                {"Data", "MemVal4"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+            var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+            configurationBuilder.Add(memConfigSrc3);
+
+            // Act
+            var configFocus = config.GetSection("Data");
+
+            var memVal1 = configFocus["DB1:Connection1"];
+            var memVal2 = configFocus["DB1:Connection2"];
+            var memVal3 = configFocus["DB2:Connection"];
+            var memVal4 = configFocus["Source:DB2:Connection"];
+            var memVal5 = configFocus.Value;
+
+            // Assert
+            Assert.Equal("MemVal1", memVal1);
+            Assert.Equal("MemVal2", memVal2);
+            Assert.Equal("MemVal4", memVal5);
+
+            Assert.Equal("MemVal1", configFocus["DB1:Connection1"]);
+            Assert.Equal("MemVal2", configFocus["DB1:Connection2"]);
+            Assert.Null(configFocus["DB2:Connection"]);
+            Assert.Null(configFocus["Source:DB2:Connection"]);
+            Assert.Equal("MemVal4", configFocus.Value);
+        }
+
+        [Fact]
+        public void CanGetConnectionStrings()
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+            {
+                {"ConnectionStrings:DB1:Connection1", "MemVal1"},
+                {"ConnectionStrings:DB1:Connection2", "MemVal2"}
+            };
+            var dic2 = new Dictionary<string, string>()
+            {
+                {"ConnectionStrings:DB2:Connection", "MemVal3"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+
+            // Act
+            var memVal1 = config.GetConnectionString("DB1:Connection1");
+            var memVal2 = config.GetConnectionString("DB1:Connection2");
+            var memVal3 = config.GetConnectionString("DB2:Connection");
+
+            // Assert
+            Assert.Equal("MemVal1", memVal1);
+            Assert.Equal("MemVal2", memVal2);
+            Assert.Equal("MemVal3", memVal3);
+        }
+
+        [Fact]
+        public void CanGetConfigurationChildren()
+        {
+            // Arrange
+            var dic1 = new Dictionary<string, string>()
+            {
+                {"Data:DB1:Connection1", "MemVal1"},
+                {"Data:DB1:Connection2", "MemVal2"}
+            };
+            var dic2 = new Dictionary<string, string>()
+            {
+                {"Data:DB2Connection", "MemVal3"}
+            };
+            var dic3 = new Dictionary<string, string>()
+            {
+                {"DataSource:DB3:Connection", "MemVal4"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dic1 };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dic2 };
+            var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dic3 };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+            configurationBuilder.Add(memConfigSrc3);
+
+            // Act
+            var configSections = config.GetSection("Data").GetChildren().ToList();
+
+            // Assert
+            Assert.Equal(2, configSections.Count());
+            Assert.Equal("MemVal1", configSections.FirstOrDefault(c => c.Key == "DB1")["Connection1"]);
+            Assert.Equal("MemVal2", configSections.FirstOrDefault(c => c.Key == "DB1")["Connection2"]);
+            Assert.Equal("MemVal3", configSections.FirstOrDefault(c => c.Key == "DB2Connection").Value);
+            Assert.False(configSections.Exists(c => c.Key == "DB3"));
+            Assert.False(configSections.Exists(c => c.Key == "DB3"));
+        }
+
+        [Fact]
+        public void SourcesReturnsAddedConfigurationProviders()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem:KeyInMem", "MemVal"}
+            };
+            var memConfigSrc1 = new MemoryConfigurationSource { InitialData = dict };
+            var memConfigSrc2 = new MemoryConfigurationSource { InitialData = dict };
+            var memConfigSrc3 = new MemoryConfigurationSource { InitialData = dict };
+
+            var config = new Configuration();
+            IConfigurationBuilder configurationBuilder = config;
+
+            // Act
+
+            // A MemoryConfigurationSource is added by default, so there will be no error unless we clear it
+            configurationBuilder.Sources.Clear();
+            configurationBuilder.Add(memConfigSrc1);
+            configurationBuilder.Add(memConfigSrc2);
+            configurationBuilder.Add(memConfigSrc3);
+
+            // Assert
+            Assert.Equal(new[] { memConfigSrc1, memConfigSrc2, memConfigSrc3 }, configurationBuilder.Sources);
+        }
+
+        [Fact]
+        public void SetValueThrowsExceptionNoSourceRegistered()
+        {
+            // Arrange
+            var config = new Configuration();
+
+            // A MemoryConfigurationSource is added by default, so there will be no error unless we clear it
+            config["Title"] = "Welcome";
+
+            ((IConfigurationBuilder)config).Sources.Clear();
+
+            var expectedMsg = "A configuration source is not registered. Please register one before setting a value.";
+
+            // Act
+            var ex = Assert.Throws<InvalidOperationException>(() => config["Title"] = "Welcome");
+
+            // Assert
+            Assert.Equal(expectedMsg, ex.Message);
+        }
+
+        [Fact]
+        public void SameReloadTokenIsReturnedRepeatedly()
+        {
+            // Arrange
+            IConfiguration config = new Configuration();
+
+            // Act
+            var token1 = config.GetReloadToken();
+            var token2 = config.GetReloadToken();
+
+            // Assert
+            Assert.Same(token1, token2);
+        }
+
+        [Fact]
+        public void DifferentReloadTokenReturnedAfterReloading()
+        {
+            // Arrange
+            IConfigurationRoot config = new Configuration();
+
+            // Act
+            var token1 = config.GetReloadToken();
+            var token2 = config.GetReloadToken();
+            config.Reload();
+            var token3 = config.GetReloadToken();
+            var token4 = config.GetReloadToken();
+
+            // Assert
+            Assert.Same(token1, token2);
+            Assert.Same(token3, token4);
+            Assert.NotSame(token1, token3);
+        }
+
+        [Fact]
+        public void TokenTriggeredWhenReloadOccurs()
+        {
+            // Arrange
+            IConfigurationRoot config = new Configuration();
+
+            // Act
+            var token1 = config.GetReloadToken();
+            var hasChanged1 = token1.HasChanged;
+            config.Reload();
+            var hasChanged2 = token1.HasChanged;
+
+            // Assert
+            Assert.False(hasChanged1);
+            Assert.True(hasChanged2);
+        }
+
+        [Fact]
+        public void MultipleCallbacksCanBeRegisteredToReload()
+        {
+            // Arrange
+            IConfigurationRoot config = new Configuration();
+
+            // Act
+            var token1 = config.GetReloadToken();
+            var called1 = 0;
+            token1.RegisterChangeCallback(_ => called1++, state: null);
+            var called2 = 0;
+            token1.RegisterChangeCallback(_ => called2++, state: null);
+
+            // Assert
+            Assert.Equal(0, called1);
+            Assert.Equal(0, called2);
+
+            config.Reload();
+            Assert.Equal(1, called1);
+            Assert.Equal(1, called2);
+
+            var token2 = config.GetReloadToken();
+            var cleanup1 = token2.RegisterChangeCallback(_ => called1++, state: null);
+            token2.RegisterChangeCallback(_ => called2++, state: null);
+
+            cleanup1.Dispose();
+
+            config.Reload();
+            Assert.Equal(1, called1);
+            Assert.Equal(2, called2);
+        }
+
+        [Fact]
+        public void NewTokenAfterReloadIsNotChanged()
+        {
+            // Arrange
+            IConfigurationRoot config = new Configuration();
+
+            // Act
+            var token1 = config.GetReloadToken();
+            var hasChanged1 = token1.HasChanged;
+            config.Reload();
+            var hasChanged2 = token1.HasChanged;
+            var token2 = config.GetReloadToken();
+            var hasChanged3 = token2.HasChanged;
+
+            // 
+            // Assert
+            Assert.False(hasChanged1);
+            Assert.True(hasChanged2);
+            Assert.False(hasChanged3);
+            Assert.NotSame(token1, token2);
+        }
+
+        [Fact]
+        public void KeyStartingWithColonMeansFirstSectionHasEmptyName()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                [":Key2"] = "value"
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dict);
+            var config = configurationBuilder.Build();
+
+            // Act
+            var children = config.GetChildren().ToArray();
+
+            // Assert
+            Assert.Single(children);
+            Assert.Equal(string.Empty, children.First().Key);
+            Assert.Single(children.First().GetChildren());
+            Assert.Equal("Key2", children.First().GetChildren().First().Key);
+        }
+
+        [Fact]
+        public void KeyWithDoubleColonHasSectionWithEmptyName()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                ["Key1::Key3"] = "value"
+            };
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var children = config.GetChildren().ToArray();
+
+            // Assert
+            Assert.Single(children);
+            Assert.Equal("Key1", children.First().Key);
+            Assert.Single(children.First().GetChildren());
+            Assert.Equal(string.Empty, children.First().GetChildren().First().Key);
+            Assert.Single(children.First().GetChildren().First().GetChildren());
+            Assert.Equal("Key3", children.First().GetChildren().First().GetChildren().First().Key);
+        }
+
+        [Fact]
+        public void KeyEndingWithColonMeansLastSectionHasEmptyName()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                ["Key1:"] = "value"
+            };
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var children = config.GetChildren().ToArray();
+
+            // Assert
+            Assert.Single(children);
+            Assert.Equal("Key1", children.First().Key);
+            Assert.Single(children.First().GetChildren());
+            Assert.Equal(string.Empty, children.First().GetChildren().First().Key);
+        }
+
+        [Fact]
+        public void SectionWithValueExists()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem1", "Value1"},
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem1:KeyInMem1:Deep1", "ValueDeep1"}
+            };
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var sectionExists1 = config.GetSection("Mem1").Exists();
+            var sectionExists2 = config.GetSection("Mem1:KeyInMem1").Exists();
+            var sectionNotExists = config.GetSection("Mem2").Exists();
+
+            // Assert
+            Assert.True(sectionExists1);
+            Assert.True(sectionExists2);
+            Assert.False(sectionNotExists);
+        }
+
+        [Fact]
+        public void SectionGetRequiredSectionSuccess()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem1", "Value1"},
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem1:KeyInMem1:Deep1", "ValueDeep1"}
+            };
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var sectionExists1 = config.GetRequiredSection("Mem1").Exists();
+            var sectionExists2 = config.GetRequiredSection("Mem1:KeyInMem1").Exists();
+
+            // Assert
+            Assert.True(sectionExists1);
+            Assert.True(sectionExists2);
+        }
+
+        [Fact]
+        public void SectionGetRequiredSectionMissingThrowException()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem1", "Value1"},
+                {"Mem1:Deep1", "Value1"},
+            };
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            Assert.Throws<InvalidOperationException>(() => config.GetRequiredSection("Mem2"));
+            Assert.Throws<InvalidOperationException>(() => config.GetRequiredSection("Mem1:Deep2"));
+        }
+
+        [Fact]
+        public void SectionWithChildrenExists()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+                {"Mem1:KeyInMem1:Deep1", "ValueDeep1"},
+                {"Mem2:KeyInMem2:Deep1", "ValueDeep2"}
+            };
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var sectionExists1 = config.GetSection("Mem1").Exists();
+            var sectionExists2 = config.GetSection("Mem2").Exists();
+            var sectionNotExists = config.GetSection("Mem3").Exists();
+
+            // Assert
+            Assert.True(sectionExists1);
+            Assert.True(sectionExists2);
+            Assert.False(sectionNotExists);
+        }
+
+        [Theory]
+        [InlineData("Value1")]
+        [InlineData("")]
+        public void KeyWithValueAndWithoutChildrenExistsAsSection(string value)
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem1", value}
+            };
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var sectionExists = config.GetSection("Mem1").Exists();
+
+            // Assert
+            Assert.True(sectionExists);
+        }
+
+        [Fact]
+        public void KeyWithNullValueAndWithoutChildrenIsASectionButNotExists()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem1", null}
+            };
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var sections = config.GetChildren();
+            var sectionExists = config.GetSection("Mem1").Exists();
+            var sectionChildren = config.GetSection("Mem1").GetChildren();
+
+            // Assert
+            Assert.Single(sections, section => section.Key == "Mem1");
+            Assert.False(sectionExists);
+            Assert.Empty(sectionChildren);
+        }
+
+        [Fact]
+        public void SectionWithChildrenHasNullValue()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>()
+            {
+                {"Mem1:KeyInMem1", "ValueInMem1"},
+            };
+
+
+            var config = new Configuration();
+            ((IConfigurationBuilder)config).AddInMemoryCollection(dict);
+
+            // Act
+            var sectionValue = config.GetSection("Mem1").Value;
+
+            // Assert
+            Assert.Null(sectionValue);
+        }
+
+        [Fact]
+        public void ProviderWithNullReloadToken()
+        {
+            // Arrange
+            var config = new Configuration();
+            IConfigurationBuilder builder = config;
+
+            // Assert
+            Assert.NotNull(builder.Build());
+        }
+
+        [Fact]
+        public void BuildReturnsThis()
+        {
+            // Arrange
+            var config = new Configuration();
+
+            // Assert
+            Assert.Same(config, ((IConfigurationBuilder)config).Build());
+        }
+
+
+        private static string Get(IConfigurationProvider provider, string key)
+        {
+            string value;
+
+            if (!provider.TryGet(key, out value))
+            {
+                throw new InvalidOperationException("Key not found");
+            }
+
+            return value;
+        }
+
+        private class TestConfigurationSource : IConfigurationSource
+        {
+            private readonly IConfigurationProvider _provider;
+
+            public TestConfigurationSource(IConfigurationProvider provider)
+            {
+                _provider = provider;
+            }
+
+            public IConfigurationProvider Build(IConfigurationBuilder builder)
+            {
+                return _provider;
+            }
+        }
+
+        private class TestConfigurationProvider : ConfigurationProvider
+        {
+            public TestConfigurationProvider(string key, string value)
+                => Data.Add(key, value);
+        }
+
+        private class DisposableTestConfigurationProvider : ConfigurationProvider, IDisposable
+        {
+            public bool IsDisposed { get; set; }
+
+            public DisposableTestConfigurationProvider(string key, string value)
+                => Data.Add(key, value);
+
+            public void Dispose()
+                => IsDisposed = true;
+        }
+
+        private class TestChangeToken : IChangeToken
+        {
+            public List<(Action<object>, object)> Callbacks { get; } = new List<(Action<object>, object)>();
+
+            public bool HasChanged => false;
+
+            public bool ActiveChangeCallbacks => true;
+
+            public IDisposable RegisterChangeCallback(Action<object> callback, object state)
+            {
+                var item = (callback, state);
+                Callbacks.Add(item);
+                return new DisposableAction(() => Callbacks.Remove(item));
+            }
+
+            private class DisposableAction : IDisposable
+            {
+                private Action _action;
+
+                public DisposableAction(Action action)
+                {
+                    _action = action;
+                }
+
+                public void Dispose()
+                {
+                    var a = _action;
+                    if (a != null)
+                    {
+                        _action = null;
+                        a();
+                    }
+                }
+            }
+        }
+
+        private class TestMemorySourceProvider : MemoryConfigurationProvider, IConfigurationSource
+        {
+            public TestMemorySourceProvider(Dictionary<string, string> initialData)
+                : base(new MemoryConfigurationSource { InitialData = initialData })
+            { }
+
+            public IConfigurationProvider Build(IConfigurationBuilder builder)
+            {
+                return this;
+            }
+        }
+
+        private class NullReloadTokenConfigSource : IConfigurationSource, IConfigurationProvider
+        {
+            public IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string parentPath) => throw new NotImplementedException();
+            public IChangeToken GetReloadToken() => null;
+            public void Load() { }
+            public void Set(string key, string value) => throw new NotImplementedException();
+            public bool TryGet(string key, out string value) => throw new NotImplementedException();
+            public IConfigurationProvider Build(IConfigurationBuilder builder) => this;
+        }
+
     }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigurationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/ConfigurationTests.cs
@@ -1091,7 +1091,6 @@ namespace Microsoft.AspNetCore.Tests
             Assert.Same(config, ((IConfigurationBuilder)config).Build());
         }
 
-
         private static string Get(IConfigurationProvider provider, string key)
         {
             string value;


### PR DESCRIPTION
This (hopefully) properly implements the combined IConfiguration/IConfigurationBuilder type proposed by https://github.com/dotnet/runtime/issues/51770 without the need to have an `AutoUpdate` property or internal `NotifySourcesChanged()`.

The new implementation essentially AutoUpdates always, so there's no need for a non-private `NotifySourcesChanged()` method. This relies on the assumption that adding sources is far more common than any other kind of modification of `IConfigurationBuilder.Sources`. Any other modification triggers a full rebuild like it did before in `AutoUpdate = true` case.

Fixes #33083
