### PR TITLE
Set DisplayName on ActionDescriptor

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -91,6 +91,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 RelativePath = routeEndpoint.RoutePattern.RawText?.TrimStart('/'),
                 ActionDescriptor = new ActionDescriptor
                 {
+                    DisplayName = routeEndpoint.DisplayName,
                     RouteValues =
                     {
                         ["controller"] = controllerName,

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -302,10 +302,19 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             Assert.Equal(BindingSource.Body, fromBodyParam.Source);
         }
 
+        [Fact]
+        public void AddsDisplayNameFromRouteEndpoint()
+        {
+            var apiDescription = GetApiDescription(() => "foo", displayName: "FOO");
+
+            Assert.Equal("FOO", apiDescription.ActionDescriptor.DisplayName);
+        }
+
         private IList<ApiDescription> GetApiDescriptions(
             Delegate action,
             string pattern = null,
-            IEnumerable<string> httpMethods = null)
+            IEnumerable<string> httpMethods = null,
+            string displayName = null)
         {
             var methodInfo = action.Method;
             var attributes = methodInfo.GetCustomAttributes();
@@ -316,7 +325,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             var endpointMetadata = new EndpointMetadataCollection(metadataItems.ToArray());
             var routePattern = RoutePatternFactory.Parse(pattern ?? "/");
 
-            var endpoint = new RouteEndpoint(httpContext => Task.CompletedTask, routePattern, 0, endpointMetadata, null);
+            var endpoint = new RouteEndpoint(httpContext => Task.CompletedTask, routePattern, 0, endpointMetadata, displayName);
             var endpointDataSource = new DefaultEndpointDataSource(endpoint);
             var hostEnvironment = new HostEnvironment
             {
@@ -331,8 +340,8 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             return context.Results;
         }
 
-        private ApiDescription GetApiDescription(Delegate action, string pattern = null) =>
-            Assert.Single(GetApiDescriptions(action, pattern));
+        private ApiDescription GetApiDescription(Delegate action, string pattern = null, string displayName = null) =>
+            Assert.Single(GetApiDescriptions(action, pattern, displayName: displayName));
 
         private static void TestAction()
         {


### PR DESCRIPTION
**PR Title**

Fix `ActionDescriptor.DisplayName` always being null with minimal actions.

**PR Description**

Copy the `DisplayName` from the route endpoint to the `ActionDescriptor`.

Fixes #34062.
