### PR TITLE
Surrogate pairs encoding handling in ContentDispositionHeaderValue

### DIFF
--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Net.Http.Headers
         private const string ModificationDateString = "modification-date";
         private const string ReadDateString = "read-date";
         private const string SizeString = "size";
-        private const int MaxStackSize = 256;
+        private const int MaxStackAllocSizeBytes = 256;
         private static readonly char[] QuestionMark = new char[] { '?' };
         private static readonly char[] SingleQuote = new char[] { '\'' };
         private static readonly char[] EscapeChars = new char[] { '\\', '"' };
@@ -551,8 +551,8 @@ namespace Microsoft.Net.Http.Headers
                 Base64.GetMaxEncodedToUtf8Length(Encoding.UTF8.GetByteCount(input.AsSpan())) +
                 MimeSuffix.Length;
             byte[]? bufferFromPool = null;
-            Span<byte> buffer = requiredLength <= MaxStackSize
-                ? stackalloc byte[MaxStackSize]
+            Span<byte> buffer = requiredLength <= MaxStackAllocSizeBytes
+                ? stackalloc byte[MaxStackAllocSizeBytes]
                 : bufferFromPool = ArrayPool<byte>.Shared.Rent(requiredLength);
             buffer = buffer[..requiredLength];
 
@@ -625,8 +625,8 @@ namespace Microsoft.Net.Http.Headers
 
             var maxInputBytes = Encoding.UTF8.GetMaxByteCount(input.Length);
             byte[]? bufferFromPool = null;
-            Span<byte> inputBytes = maxInputBytes <= MaxStackSize
-                ? stackalloc byte[MaxStackSize]
+            Span<byte> inputBytes = maxInputBytes <= MaxStackAllocSizeBytes
+                ? stackalloc byte[MaxStackAllocSizeBytes]
                 : bufferFromPool = ArrayPool<byte>.Shared.Rent(maxInputBytes);
 
             var bytesWritten = Encoding.UTF8.GetBytes(input, inputBytes);

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -617,7 +617,14 @@ namespace Microsoft.Net.Http.Headers
                 //      ; token except ( "*" / "'" / "%" )
                 if (c > 0x7F) // Encodes as multiple utf-8 bytes
                 {
-                    var bytes = Encoding.UTF8.GetBytes(c.ToString());
+                    var startPos = i;
+                    while (i + 1 < input.Length && input[i + 1] > 0x7F)
+                    {
+                        i++;
+                    }
+
+                    var unicodePart = input.Value.Substring(startPos, i - startPos + 1);
+                    var bytes = Encoding.UTF8.GetBytes(unicodePart);
                     foreach (byte b in bytes)
                     {
                         HexEscape(builder, (char)b);

--- a/src/Http/Headers/src/Microsoft.Net.Http.Headers.csproj
+++ b/src/Http/Headers/src/Microsoft.Net.Http.Headers.csproj
@@ -8,6 +8,7 @@
     <PackageTags>http</PackageTags>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Http/Headers/test/ContentDispositionHeaderValueTest.cs
+++ b/src/Http/Headers/test/ContentDispositionHeaderValueTest.cs
@@ -600,6 +600,17 @@ namespace Microsoft.Net.Http.Headers
             Assert.Equal(expectedFileName, result.FileName);
         }
 
+        [Fact]
+        public void FileNameWithSurrogatePairs_EncodedCorrectly()
+        {
+            var contentDisposition = new ContentDispositionHeaderValue("attachment");
+
+            contentDisposition.SetHttpFileName("File 🤩 name.txt");
+            Assert.Equal("File __ name.txt", contentDisposition.FileName);
+            Assert.Equal(2, contentDisposition.Parameters.Count);
+            Assert.Equal("UTF-8\'\'File%20%F0%9F%A4%A9%20name.txt", contentDisposition.Parameters[1].Value);
+        }
+
         public class ContentDispositionValue
         {
             public ContentDispositionValue(string value, string description, bool valid)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Surrogate pairs encoding handling in ContentDispositionHeaderValue

**PR Description**
Encoding multiple consecutive Unicode symbols at once to correctly handle the surrogate pairs case.

Addresses #33912
