### PR TITLE
Fix root directory not being considered by UseSolutionRelativeContentRoot()

### DIFF
--- a/src/Hosting/TestHost/src/WebHostBuilderExtensions.cs
+++ b/src/Hosting/TestHost/src/WebHostBuilderExtensions.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.TestHost
 
                 directoryInfo = directoryInfo.Parent;
             }
-            while (directoryInfo!.Parent != null);
+            while (directoryInfo is not null);
 
             throw new InvalidOperationException($"Solution root could not be located using application root {applicationBasePath}.");
         }

--- a/src/Hosting/TestHost/src/WebHostBuilderExtensions.cs
+++ b/src/Hosting/TestHost/src/WebHostBuilderExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.TestHost
                 throw new ArgumentNullException(nameof(servicesConfiguration));
             }
 
-            if (webHostBuilder.GetType().Name.Equals("GenericWebHostBuilder"))
+            if (webHostBuilder.GetType().Name.Equals("GenericWebHostBuilder", StringComparison.Ordinal))
             {
                 // Generic host doesn't need to do anything special here since there's only one container.
                 webHostBuilder.ConfigureServices(servicesConfiguration);


### PR DESCRIPTION
**PR Title**

Fix root directory not being used by `UseSolutionRelativeContentRoot`

**PR Description**

* Fix the root directory of a drive not being considered to find the solution.
* Resolve CA1309 warning be specifying `StringComparison.Ordinal`.

As noted in the original issue, this requires a specific file layout on disk and the code doesn't support using a mock file system, so there is no new unit test associated with the fix.

Addresses #33363
