### PR TITLE
[SignalR TS] Ignore user errors from stream callbacks

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -544,7 +544,11 @@ export class HubConnection {
                             if (message.type === MessageType.Completion) {
                                 delete this._callbacks[message.invocationId];
                             }
-                            callback(message);
+                            try {
+                                callback(message);
+                            } catch (e) {
+                                this._logger.log(LogLevel.Error, `Stream callback threw error '${e}'.`);
+                            }
                         }
                         break;
                     }
@@ -830,7 +834,11 @@ export class HubConnection {
         Object.keys(callbacks)
             .forEach((key) => {
                 const callback = callbacks[key];
-                callback(null, error);
+                try {
+                    callback(null, error);
+                } catch (e) {
+                    this._logger.log(LogLevel.Error, `Stream 'error' callback called with '${error}' threw error '${e}'.`);
+                }
             });
     }
 

--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -8,7 +8,7 @@ import { ILogger, LogLevel } from "./ILogger";
 import { IRetryPolicy } from "./IRetryPolicy";
 import { IStreamResult } from "./Stream";
 import { Subject } from "./Subject";
-import { Arg } from "./Utils";
+import { Arg, getErrorString } from "./Utils";
 
 const DEFAULT_TIMEOUT_IN_MS: number = 30 * 1000;
 const DEFAULT_PING_INTERVAL_IN_MS: number = 15 * 1000;
@@ -547,7 +547,7 @@ export class HubConnection {
                             try {
                                 callback(message);
                             } catch (e) {
-                                this._logger.log(LogLevel.Error, `Stream callback threw error '${e}'.`);
+                                this._logger.log(LogLevel.Error, `Stream callback threw error: ${getErrorString(e)}`);
                             }
                         }
                         break;
@@ -837,7 +837,7 @@ export class HubConnection {
                 try {
                     callback(null, error);
                 } catch (e) {
-                    this._logger.log(LogLevel.Error, `Stream 'error' callback called with '${error}' threw error '${e}'.`);
+                    this._logger.log(LogLevel.Error, `Stream 'error' callback called with '${error}' threw error: ${getErrorString(e)}`);
                 }
             });
     }

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -266,3 +266,13 @@ function getRuntime(): string {
         return "Browser";
     }
 }
+
+/** @private */
+export function getErrorString(e: any): string {
+    if (e.stack) {
+        return e.stack;
+    } else if (e.message) {
+        return e.message;
+    }
+    return `${e}`;
+}

--- a/src/SignalR/clients/ts/signalr/tests/HubConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnection.test.ts
@@ -1215,8 +1215,8 @@ describe("HubConnection", () => {
                 } finally {
                     await hubConnection.stop();
                 }
-            }, "Stream callback threw error 'Error: from complete'.",
-            "Stream callback threw error 'Error: from next'.");
+            }, /Stream callback threw error: Error: from complete/,
+            /Stream callback threw error: Error: from next/);
         });
 
         it("ignores error from 'error' function", async () => {
@@ -1239,7 +1239,7 @@ describe("HubConnection", () => {
                 } finally {
                     await hubConnection.stop();
                 }
-            }, "Stream 'error' callback called with 'Error: Invocation canceled due to the underlying connection being closed.' threw error 'Error: from error'.");
+            }, /Stream 'error' callback called with 'Error: Invocation canceled due to the underlying connection being closed.' threw error: Error: from error/);
         });
     });
 


### PR DESCRIPTION
We do the same thing for `.on` and `.onclose`