### PR TITLE
Accessibility: improve contrast tweaks

### DIFF
--- a/src/Identity/UI/src/wwwroot/V4/css/site.css
+++ b/src/Identity/UI/src/wwwroot/V4/css/site.css
@@ -12,6 +12,11 @@ a {
   color: #0366d6;
 }
 
+::selection {
+    color: #fff;
+    background-color: #333;
+}
+
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/Identity/UI/src/wwwroot/V4/css/site.css
+++ b/src/Identity/UI/src/wwwroot/V4/css/site.css
@@ -7,7 +7,6 @@ a.navbar-brand {
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background and black text */
 a {
   color: #0077cc;
 }
@@ -33,8 +32,6 @@ a {
   outline: black auto 1px;
 }
 
-/* Sticky footer styles
--------------------------------------------------- */
 html {
   font-size: 14px;
 }
@@ -68,15 +65,12 @@ button.accept-policy {
   line-height: inherit;
 }
 
-/* Sticky footer styles
--------------------------------------------------- */
 html {
   position: relative;
   min-height: 100%;
 }
 
 body {
-  /* Margin bottom by footer height */
   margin-bottom: 60px;
 }
 .footer {
@@ -85,5 +79,5 @@ body {
   width: 100%;
   overflow: scroll;
   white-space: nowrap;
-  line-height: 60px; /* Vertically center the text there */
+  line-height: 60px;
 }

--- a/src/Identity/UI/src/wwwroot/V4/css/site.css
+++ b/src/Identity/UI/src/wwwroot/V4/css/site.css
@@ -7,14 +7,14 @@ a.navbar-brand {
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background */
+/* Provide sufficient contrast against white background and black text */
 a {
-  color: #0366d6;
+  color: #0077cc;
 }
 
-::selection {
-    color: #fff;
-    background-color: #333;
+.form-control:focus {
+    border-color: #0077cc;
+    box-shadow: 0 0 0 0.2rem #0077cc;
 }
 
 .btn-primary {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -8,10 +8,6 @@ a, .btn-link {
     color: #0366d6;
 }
 
-::-moz-selection {
-    color: #fff;
-    background-color: #333;
-}
 ::selection {
     color: #fff;
     background-color: #333;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -8,6 +8,11 @@ a, .btn-link {
     color: #0077cc;
 }
 
+.form-control:focus {
+    border-color: #0077cc;
+    box-shadow: 0 0 0 0.2rem #0077cc;
+}
+
 .btn-primary {
     color: #fff;
     background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -5,12 +5,7 @@ html, body {
 }
 
 a, .btn-link {
-    color: #0366d6;
-}
-
-::selection {
-    color: #fff;
-    background-color: #333;
+    color: #0077cc;
 }
 
 .btn-primary {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -8,6 +8,15 @@ a, .btn-link {
     color: #0366d6;
 }
 
+::-moz-selection {
+    color: #fff;
+    background-color: #333;
+}
+::selection {
+    color: #fff;
+    background-color: #333;
+}
+
 .btn-primary {
     color: #fff;
     background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -8,11 +8,6 @@ a, .btn-link {
     color: #0077cc;
 }
 
-.form-control:focus {
-    border-color: #0077cc;
-    box-shadow: 0 0 0 0.2rem #0077cc;
-}
-
 .btn-primary {
     color: #fff;
     background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
@@ -8,10 +8,6 @@ a, .btn-link {
     color: #0366d6;
 }
 
-::-moz-selection {
-    color: #fff;
-    background-color: #333;
-}
 ::selection {
     color: #fff;
     background-color: #333;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
@@ -8,6 +8,11 @@ a, .btn-link {
     color: #0077cc;
 }
 
+.form-control:focus {
+    border-color: #0077cc;
+    box-shadow: 0 0 0 0.2rem #0077cc;
+}
+
 .btn-primary {
     color: #fff;
     background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
@@ -5,12 +5,7 @@ html, body {
 }
 
 a, .btn-link {
-    color: #0366d6;
-}
-
-::selection {
-    color: #fff;
-    background-color: #333;
+    color: #0077cc;
 }
 
 .btn-primary {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
@@ -8,6 +8,15 @@ a, .btn-link {
     color: #0366d6;
 }
 
+::-moz-selection {
+    color: #fff;
+    background-color: #333;
+}
+::selection {
+    color: #fff;
+    background-color: #333;
+}
+
 .btn-primary {
     color: #fff;
     background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
@@ -8,11 +8,6 @@ a, .btn-link {
     color: #0077cc;
 }
 
-.form-control:focus {
-    border-color: #0077cc;
-    box-shadow: 0 0 0 0.2rem #0077cc;
-}
-
 .btn-primary {
     color: #fff;
     background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -11,6 +11,11 @@ a {
   color: #0077cc;
 }
 
+.form-control:focus {
+    border-color: #0077cc;
+    box-shadow: 0 0 0 0.2rem #0077cc;
+}
+
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -12,10 +12,6 @@ a {
   color: #0366d6;
 }
 
-::-moz-selection {
-    color: #fff;
-    background-color: #333;
-}
 ::selection {
     color: #fff;
     background-color: #333;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -9,12 +9,7 @@ a.navbar-brand {
 
 /* Provide sufficient contrast against white background */
 a {
-  color: #0366d6;
-}
-
-::selection {
-    color: #fff;
-    background-color: #333;
+  color: #0077cc;
 }
 
 .btn-primary {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -7,7 +7,7 @@ a.navbar-brand {
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background */
+/* Provide sufficient contrast against white background and black text */
 a {
   color: #0077cc;
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -7,7 +7,6 @@ a.navbar-brand {
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background */
 a {
   color: #0077cc;
 }
@@ -24,8 +23,6 @@ a {
   border-color: #1861ac;
 }
 
-/* Sticky footer styles
--------------------------------------------------- */
 html {
   font-size: 14px;
 }
@@ -51,15 +48,12 @@ button.accept-policy {
   line-height: inherit;
 }
 
-/* Sticky footer styles
--------------------------------------------------- */
 html {
   position: relative;
   min-height: 100%;
 }
 
 body {
-  /* Margin bottom by footer height */
   margin-bottom: 60px;
 }
 .footer {
@@ -67,5 +61,5 @@ body {
   bottom: 0;
   width: 100%;
   white-space: nowrap;
-  line-height: 60px; /* Vertically center the text there */
+  line-height: 60px;
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -11,11 +11,6 @@ a {
   color: #0077cc;
 }
 
-.form-control:focus {
-    border-color: #0077cc;
-    box-shadow: 0 0 0 0.2rem #0077cc;
-}
-
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -12,6 +12,15 @@ a {
   color: #0366d6;
 }
 
+::-moz-selection {
+    color: #fff;
+    background-color: #333;
+}
+::selection {
+    color: #fff;
+    background-color: #333;
+}
+
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
@@ -11,6 +11,11 @@ a {
   color: #0077cc;
 }
 
+.form-control:focus {
+    border-color: #0077cc;
+    box-shadow: 0 0 0 0.2rem #0077cc;
+}
+
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
@@ -12,10 +12,6 @@ a {
   color: #0366d6;
 }
 
-::-moz-selection {
-    color: #fff;
-    background-color: #333;
-}
 ::selection {
     color: #fff;
     background-color: #333;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
@@ -7,14 +7,9 @@ a.navbar-brand {
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background */
+/* Provide sufficient contrast against white background and black text */
 a {
-  color: #0366d6;
-}
-
-::selection {
-    color: #fff;
-    background-color: #333;
+  color: #0077cc;
 }
 
 .btn-primary {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
@@ -7,7 +7,6 @@ a.navbar-brand {
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background and black text */
 a {
   color: #0077cc;
 }
@@ -24,8 +23,6 @@ a {
   border-color: #1861ac;
 }
 
-/* Sticky footer styles
--------------------------------------------------- */
 html {
   font-size: 14px;
 }
@@ -51,15 +48,12 @@ button.accept-policy {
   line-height: inherit;
 }
 
-/* Sticky footer styles
--------------------------------------------------- */
 html {
   position: relative;
   min-height: 100%;
 }
 
 body {
-  /* Margin bottom by footer height */
   margin-bottom: 60px;
 }
 .footer {
@@ -67,5 +61,5 @@ body {
   bottom: 0;
   width: 100%;
   white-space: nowrap;
-  line-height: 60px; /* Vertically center the text there */
+  line-height: 60px;
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
@@ -11,11 +11,6 @@ a {
   color: #0077cc;
 }
 
-.form-control:focus {
-    border-color: #0077cc;
-    box-shadow: 0 0 0 0.2rem #0077cc;
-}
-
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
@@ -12,6 +12,15 @@ a {
   color: #0366d6;
 }
 
+::-moz-selection {
+    color: #fff;
+    background-color: #333;
+}
+::selection {
+    color: #fff;
+    background-color: #333;
+}
+
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
@@ -11,6 +11,11 @@ a {
   color: #0077cc;
 }
 
+.form-control:focus {
+    border-color: #0077cc;
+    box-shadow: 0 0 0 0.2rem #0077cc;
+}
+
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
@@ -12,10 +12,6 @@ a {
   color: #0366d6;
 }
 
-::-moz-selection {
-    color: #fff;
-    background-color: #333;
-}
 ::selection {
     color: #fff;
     background-color: #333;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
@@ -7,14 +7,9 @@ a.navbar-brand {
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background */
+/* Provide sufficient contrast against white background and black text */
 a {
-  color: #0366d6;
-}
-
-::selection {
-    color: #fff;
-    background-color: #333;
+  color: #0077cc;
 }
 
 .btn-primary {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
@@ -7,7 +7,6 @@ a.navbar-brand {
   word-break: break-all;
 }
 
-/* Provide sufficient contrast against white background and black text */
 a {
   color: #0077cc;
 }
@@ -24,8 +23,6 @@ a {
   border-color: #1861ac;
 }
 
-/* Sticky footer styles
--------------------------------------------------- */
 html {
   font-size: 14px;
 }
@@ -51,15 +48,12 @@ button.accept-policy {
   line-height: inherit;
 }
 
-/* Sticky footer styles
--------------------------------------------------- */
 html {
   position: relative;
   min-height: 100%;
 }
 
 body {
-  /* Margin bottom by footer height */
   margin-bottom: 60px;
 }
 .footer {
@@ -67,5 +61,5 @@ body {
   bottom: 0;
   width: 100%;
   white-space: nowrap;
-  line-height: 60px; /* Vertically center the text there */
+  line-height: 60px;
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
@@ -11,11 +11,6 @@ a {
   color: #0077cc;
 }
 
-.form-control:focus {
-    border-color: #0077cc;
-    box-shadow: 0 0 0 0.2rem #0077cc;
-}
-
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
@@ -12,6 +12,15 @@ a {
   color: #0366d6;
 }
 
+::-moz-selection {
+    color: #fff;
+    background-color: #333;
+}
+::selection {
+    color: #fff;
+    background-color: #333;
+}
+
 .btn-primary {
   color: #fff;
   background-color: #1b6ec2;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/33341

Added to site.css to templates that support identity ui (register/login/manage UI focused/highlighted text cause this contrast failure)
```
::-moz-selection {
    color: #fff;
    background-color: #333;
}
::selection {
    color: #fff;
    background-color: #333;
}
```

After: (Passes contrast ratio of 12.634
![image](https://user-images.githubusercontent.com/6537861/124671271-17ac4e80-de6a-11eb-8d73-28c14a6a5b50.png)

Before: (Fails contrast ratio of 3.065 < 4.5)
![image](https://user-images.githubusercontent.com/6537861/124671386-3ca0c180-de6a-11eb-9be7-475102f4e15e.png)

