### PR TITLE
Fix API Explorer for HTTP Request, Response and User

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Security.Claims;
 using System.Threading;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
@@ -168,6 +169,9 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             }
             else if (parameter.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)) ||
                      parameter.ParameterType == typeof(HttpContext) ||
+                     parameter.ParameterType == typeof(HttpRequest) ||
+                     parameter.ParameterType == typeof(HttpResponse) ||
+                     parameter.ParameterType == typeof(ClaimsPrincipal) ||
                      parameter.ParameterType == typeof(CancellationToken) ||
                      _serviceProviderIsService?.IsService(parameter.ParameterType) == true)
             {

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -253,6 +254,9 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             Assert.Empty(GetApiDescription((IInferredServiceInterface foo) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription(([FromServices] int foo) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription((HttpContext context) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription((HttpRequest request) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription((HttpResponse response) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription((ClaimsPrincipal user) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription((CancellationToken token) => { }).ParameterDescriptions);
         }
 


### PR DESCRIPTION
**PR Title**

Fix API Explorer for HTTP Request, Response and User

**PR Description**

Fix minimal actions parameters for `HttpRequest`, `HttpResponse` and `ClaimsPrincipal` being marked as body parameters by API Explorer.

Addresses https://github.com/dotnet/aspnetcore/pull/33883#issuecomment-875302429

/cc @davidfowl 