### PR TITLE
Revert part of "Add base interface for IHubContext (#33443)"

### DIFF
--- a/src/SignalR/server/Core/src/IHubContext.cs
+++ b/src/SignalR/server/Core/src/IHubContext.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.SignalR
     /// <summary>
     /// A context abstraction for a hub.
     /// </summary>
-    public interface IHubContext<THub> where THub : Hub
+    public interface IHubContext<out THub> where THub : Hub
     {
         /// <summary>
         /// Gets a <see cref="IHubClients"/> that can be used to invoke methods on clients connected to the hub.

--- a/src/SignalR/server/Core/src/IHubContext.cs
+++ b/src/SignalR/server/Core/src/IHubContext.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.SignalR
     /// <summary>
     /// A context abstraction for a hub.
     /// </summary>
-    public interface IHubContext
+    public interface IHubContext<THub> where THub : Hub
     {
         /// <summary>
         /// Gets a <see cref="IHubClients"/> that can be used to invoke methods on clients connected to the hub.
@@ -17,12 +17,5 @@ namespace Microsoft.AspNetCore.SignalR
         /// Gets a <see cref="IGroupManager"/> that can be used to add and remove connections to named groups.
         /// </summary>
         IGroupManager Groups { get; }
-    }
-
-    /// <summary>
-    /// A context abstraction for a hub.
-    /// </summary>
-    public interface IHubContext<out THub> : IHubContext where THub : Hub
-    {
     }
 }

--- a/src/SignalR/server/Core/src/IHubContext.cs
+++ b/src/SignalR/server/Core/src/IHubContext.cs
@@ -6,6 +6,22 @@ namespace Microsoft.AspNetCore.SignalR
     /// <summary>
     /// A context abstraction for a hub.
     /// </summary>
+    public interface IHubContext
+    {
+        /// <summary>
+        /// Gets a <see cref="IHubClients"/> that can be used to invoke methods on clients connected to the hub.
+        /// </summary>
+        IHubClients Clients { get; }
+
+        /// <summary>
+        /// Gets a <see cref="IGroupManager"/> that can be used to add and remove connections to named groups.
+        /// </summary>
+        IGroupManager Groups { get; }
+    }
+
+    /// <summary>
+    /// A context abstraction for a hub.
+    /// </summary>
     public interface IHubContext<out THub> where THub : Hub
     {
         /// <summary>

--- a/src/SignalR/server/Core/src/Internal/HubContext.cs
+++ b/src/SignalR/server/Core/src/Internal/HubContext.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.SignalR.Internal
 {
-    internal class HubContext<THub> : IHubContext<THub> where THub : Hub
+    internal class HubContext<THub> : IHubContext, IHubContext<THub> where THub : Hub
     {
         private readonly HubLifetimeManager<THub> _lifetimeManager;
         private readonly IHubClients _clients;

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -21,6 +21,9 @@
 *REMOVED*abstract Microsoft.AspNetCore.SignalR.HubLifetimeManager<THub>.SendUsersAsync(System.Collections.Generic.IReadOnlyList<string!>! userIds, string! methodName, object?[]? args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.AspNetCore.SignalR.IClientProxy.SendCoreAsync(string! method, object?[]? args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*virtual Microsoft.AspNetCore.SignalR.HubConnectionContext.User.get -> System.Security.Claims.ClaimsPrincipal?
+Microsoft.AspNetCore.SignalR.IHubContext
+Microsoft.AspNetCore.SignalR.IHubContext.Clients.get -> Microsoft.AspNetCore.SignalR.IHubClients!
+Microsoft.AspNetCore.SignalR.IHubContext.Groups.get -> Microsoft.AspNetCore.SignalR.IGroupManager!
 virtual Microsoft.AspNetCore.SignalR.HubConnectionContext.User.get -> System.Security.Claims.ClaimsPrincipal!
 override Microsoft.AspNetCore.SignalR.DefaultHubLifetimeManager<THub>.SendAllAsync(string! methodName, object?[]! args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.SignalR.DefaultHubLifetimeManager<THub>.SendAllExceptAsync(string! methodName, object?[]! args, System.Collections.Generic.IReadOnlyList<string!>! excludedConnectionIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -21,11 +21,6 @@
 *REMOVED*abstract Microsoft.AspNetCore.SignalR.HubLifetimeManager<THub>.SendUsersAsync(System.Collections.Generic.IReadOnlyList<string!>! userIds, string! methodName, object?[]? args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.AspNetCore.SignalR.IClientProxy.SendCoreAsync(string! method, object?[]? args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 *REMOVED*virtual Microsoft.AspNetCore.SignalR.HubConnectionContext.User.get -> System.Security.Claims.ClaimsPrincipal?
-*REMOVED*Microsoft.AspNetCore.SignalR.IHubContext<THub>.Clients.get -> Microsoft.AspNetCore.SignalR.IHubClients!
-*REMOVED*Microsoft.AspNetCore.SignalR.IHubContext<THub>.Groups.get -> Microsoft.AspNetCore.SignalR.IGroupManager!
-Microsoft.AspNetCore.SignalR.IHubContext
-Microsoft.AspNetCore.SignalR.IHubContext.Clients.get -> Microsoft.AspNetCore.SignalR.IHubClients!
-Microsoft.AspNetCore.SignalR.IHubContext.Groups.get -> Microsoft.AspNetCore.SignalR.IGroupManager!
 virtual Microsoft.AspNetCore.SignalR.HubConnectionContext.User.get -> System.Security.Claims.ClaimsPrincipal!
 override Microsoft.AspNetCore.SignalR.DefaultHubLifetimeManager<THub>.SendAllAsync(string! methodName, object?[]! args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.SignalR.DefaultHubLifetimeManager<THub>.SendAllExceptAsync(string! methodName, object?[]! args, System.Collections.Generic.IReadOnlyList<string!>! excludedConnectionIds, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -4500,60 +4500,6 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
         }
 
-        [Fact]
-        public async Task CanSendThroughIHubContext()
-        {
-            using (StartVerifiableLog())
-            {
-                var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(null, LoggerFactory);
-                var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
-
-                using var client = new TestClient();
-
-                var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
-
-                // Wait for a connection, or for the endpoint to fail.
-                await client.Connected.OrThrowIfOtherFails(connectionHandlerTask).DefaultTimeout();
-
-                IHubContext context = serviceProvider.GetRequiredService<IHubContext<MethodHub>>();
-                await context.Clients.All.SendAsync("Send", "test");
-
-                var message = await client.ReadAsync().DefaultTimeout();
-                var invocation = Assert.IsType<InvocationMessage>(message);
-
-                Assert.Single(invocation.Arguments);
-                Assert.Equal("test", invocation.Arguments[0]);
-                Assert.Equal("Send", invocation.Target);
-            }
-        }
-
-        [Fact]
-        public async Task CanSendThroughIHubContextBaseHub()
-        {
-            using (StartVerifiableLog())
-            {
-                var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(null, LoggerFactory);
-                var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
-
-                using var client = new TestClient();
-
-                var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
-
-                // Wait for a connection, or for the endpoint to fail.
-                await client.Connected.OrThrowIfOtherFails(connectionHandlerTask).DefaultTimeout();
-
-                IHubContext<TestHub> context = serviceProvider.GetRequiredService<IHubContext<MethodHub>>();
-                await context.Clients.All.SendAsync("Send", "test");
-
-                var message = await client.ReadAsync().DefaultTimeout();
-                var invocation = Assert.IsType<InvocationMessage>(message);
-
-                Assert.Single(invocation.Arguments);
-                Assert.Equal("test", invocation.Arguments[0]);
-                Assert.Equal("Send", invocation.Target);
-            }
-        }
-
         private class CustomHubActivator<THub> : IHubActivator<THub> where THub : Hub
         {
             public int ReleaseCount;

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -4500,6 +4500,33 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             }
         }
 
+        [Fact]
+        public async Task CanSendThroughIHubContextBaseHub()
+        {
+            using (StartVerifiableLog())
+            {
+                var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(null, LoggerFactory);
+                var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+                using var client = new TestClient();
+
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler);
+
+                // Wait for a connection, or for the endpoint to fail.
+                await client.Connected.OrThrowIfOtherFails(connectionHandlerTask).DefaultTimeout();
+
+                IHubContext<TestHub> context = serviceProvider.GetRequiredService<IHubContext<MethodHub>>();
+                await context.Clients.All.SendAsync("Send", "test");
+
+                var message = await client.ReadAsync().DefaultTimeout();
+                var invocation = Assert.IsType<InvocationMessage>(message);
+
+                Assert.Single(invocation.Arguments);
+                Assert.Equal("test", invocation.Arguments[0]);
+                Assert.Equal("Send", invocation.Target);
+            }
+        }
+
         private class CustomHubActivator<THub> : IHubActivator<THub> where THub : Hub
         {
             public int ReleaseCount;


### PR DESCRIPTION
Original change https://github.com/dotnet/aspnetcore/pull/33443

The change is a breaking change:
> ❌ DISALLOWED: Adding an interface to the set of base types of an interface

Apps rolling forward from a 5.0 runtime to a 6.0 runtime would break (if using SignalR obviously)

**Keeping** the `out THub` change as it isn't a binary breaking change I believe. It can be a behavior breaking change in extremely rare scenarios that no one is doing probably.
```csharp
class BaseHub : Hub
{}

class DerivedHub : BaseHub
{}

if (x is IHubContext<BaseHub>)
{
    // now matches for IHubContext<DerivedHub>
}
else if (x is IHubContext<DerivedHub>)
{
}
```