### PR TITLE
Use PeriodicTimer instead of TimerAwaitable on the server

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -10,8 +10,8 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Net.WebSockets;
 using System.Security.Cryptography;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Internal;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         private readonly ConcurrentDictionary<string, (HttpConnectionContext Connection, ValueStopwatch Timer)> _connections =
             new ConcurrentDictionary<string, (HttpConnectionContext Connection, ValueStopwatch Timer)>(StringComparer.Ordinal);
-        private readonly TimerAwaitable _nextHeartbeat;
+        private readonly PeriodicTimer _nextHeartbeat;
         private readonly ILogger<HttpConnectionManager> _logger;
         private readonly ILogger<HttpConnectionContext> _connectionLogger;
         private readonly TimeSpan _disconnectTimeout;
@@ -35,7 +35,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         {
             _logger = loggerFactory.CreateLogger<HttpConnectionManager>();
             _connectionLogger = loggerFactory.CreateLogger<HttpConnectionContext>();
-            _nextHeartbeat = new TimerAwaitable(_heartbeatTickRate, _heartbeatTickRate);
+            _nextHeartbeat = new PeriodicTimer(_heartbeatTickRate);
             _disconnectTimeout = connectionOptions.Value.DisconnectTimeout ?? ConnectionOptionsSetup.DefaultDisconectTimeout;
 
             // Register these last as the callbacks could run immediately
@@ -45,8 +45,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         public void Start()
         {
-            _nextHeartbeat.Start();
-
             // Start the timer loop
             _ = ExecuteTimerLoop();
         }
@@ -122,7 +120,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             using (_nextHeartbeat)
             {
                 // The TimerAwaitable will return true until Stop is called
-                while (await _nextHeartbeat)
+                while (await _nextHeartbeat.WaitForNextTickAsync())
                 {
                     try
                     {
@@ -176,7 +174,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         public void CloseConnections()
         {
             // Stop firing the timer
-            _nextHeartbeat.Stop();
+            _nextHeartbeat.Dispose();
 
             var tasks = new List<Task>(_connections.Count);
 

--- a/src/SignalR/common/Http.Connections/src/Microsoft.AspNetCore.Http.Connections.csproj
+++ b/src/SignalR/common/Http.Connections/src/Microsoft.AspNetCore.Http.Connections.csproj
@@ -13,7 +13,6 @@
     <Compile Include="$(SignalRSharedSourceRoot)AwaitableThreadPool.cs" Link="AwaitableThreadPool.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)MemoryBufferWriter.cs" Link="MemoryBufferWriter.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)PipeWriterStream.cs" Link="PipeWriterStream.cs" />
-    <Compile Include="$(SignalRSharedSourceRoot)TimerAwaitable.cs" Link="Internal\TimerAwaitable.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)WebSocketExtensions.cs" Link="WebSocketExtensions.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)StreamExtensions.cs" Link="StreamExtensions.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)DuplexPipe.cs" Link="DuplexPipe.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/34117

Can't replace the client side usage because we run on net461 and netstandard2.0/2.1.

cc @stephentoub 