### PR TITLE
Fix incorrect Swagger return type when using IResult

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -265,7 +265,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     {
                         AddResponseContentTypes(apiResponseType.ApiResponseFormats, contentTypes);
                     }
-                    else if (CreateDefaultApiResponseFormat(responseType) is { } defaultResponseFormat)
+                    else if (CreateDefaultApiResponseFormat(apiResponseType.Type) is { } defaultResponseFormat)
                     {
                         apiResponseType.ApiResponseFormats.Add(defaultResponseFormat);
                     }

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         }
 
         [Fact]
-        public void AddsMultipleResponseFormatsFromMetadata()
+        public void AddsMultipleResponseFormatsFromMetadataWithPoco()
         {
             var apiDescription = GetApiDescription(
                 [ProducesResponseType(typeof(TimeSpan), StatusCodes.Status201Created)]
@@ -205,6 +205,34 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
             var badRequestResponseFormat = Assert.Single(badRequestResponseType.ApiResponseFormats);
             Assert.Equal("application/json", badRequestResponseFormat.MediaType);
+        }
+
+        [Fact]
+        public void AddsMultipleResponseFormatsFromMetadataWithIResult()
+        {
+            var apiDescription = GetApiDescription(
+                [ProducesResponseType(typeof(InferredJsonClass), StatusCodes.Status201Created)]
+                [ProducesResponseType(StatusCodes.Status400BadRequest)]
+                () => Results.Ok(new InferredJsonClass()));
+
+            Assert.Equal(2, apiDescription.SupportedResponseTypes.Count);
+
+            var createdResponseType = apiDescription.SupportedResponseTypes[0];
+
+            Assert.Equal(201, createdResponseType.StatusCode);
+            Assert.Equal(typeof(InferredJsonClass), createdResponseType.Type);
+            Assert.Equal(typeof(InferredJsonClass), createdResponseType.ModelMetadata.ModelType);
+
+            var createdResponseFormat = Assert.Single(createdResponseType.ApiResponseFormats);
+            Assert.Equal("application/json", createdResponseFormat.MediaType);
+
+            var badRequestResponseType = apiDescription.SupportedResponseTypes[1];
+
+            Assert.Equal(400, badRequestResponseType.StatusCode);
+            Assert.Equal(typeof(void), badRequestResponseType.Type);
+            Assert.Equal(typeof(void), badRequestResponseType.ModelMetadata.ModelType);
+
+            Assert.Empty(badRequestResponseType.ApiResponseFormats);
         }
 
         [Fact]

--- a/src/Mvc/Mvc.ApiExplorer/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test.csproj
+++ b/src/Mvc/Mvc.ApiExplorer/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Http.Results" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
     <Reference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <ProjectReference Include="..\..\shared\Mvc.Core.TestCommon\Microsoft.AspNetCore.Mvc.Core.TestCommon.csproj" />


### PR DESCRIPTION
**PR Title**

Fix incorrect Swagger return type when using IResult

**PR Description**

When a POCO is wrapped in an `IResult` with minimal actions, an incorrect return type is used to determine the default API response format, which results in the response being mapped incorrectly.

This then results in the metadata specified by an `[ProducesResponseType]` attribute not being used, resulting in the intended response type not being included in the Swagger documentation.

This change resolves this by using `apiResponseType` instead of `responseType` on line 268 as it is in the surrounding code:

https://github.com/dotnet/aspnetcore/blob/5577c0d128fd30d800f434e6a629978916f7d64e/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs#L262-L271

I discovered this in a sample project that was using the following code where the `ProducesStatusCode()` extension methods add an `ProducesResponseTypeAttribute` to the endpoint metadata:

```csharp
builder.MapGet("/api/items/{id}", async (
    [FromRoute] Guid id,
    ClaimsPrincipal user,
    ITodoService service,
    CancellationToken cancellationToken) =>
{
    var model = await service.GetAsync(user.GetUserId(), id, cancellationToken);
    return model is null ? Results.NotFound() : Results.Json(model);
})
.ProducesStatusCode(StatusCodes.Status200OK, typeof(TodoItemModel))
.ProducesStatusCode(StatusCodes.Status404NotFound)
.RequireAuthorization();
```

With the fix this results in the following JSON in the Swagger document:

```json
    "/api/items/{id}": {
      "get": {
        "tags": [
          "TodoApp"
        ],
        "parameters": [
          {
            "name": "id",
            "in": "path",
            "required": true,
            "schema": {
              "type": "string",
              "format": "uuid"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "Success",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/TodoItemModel"
                }
              }
            }
          },
          "404": {
            "description": "Not Found"
          }
        }
      },
    }
```

Without the change, the JSON is:

```json
    "/api/items/{id}": {
      "get": {
        "tags": [
          "TodoApp"
        ],
        "parameters": [
          {
            "name": "id",
            "in": "path",
            "required": true,
            "schema": {
              "type": "string",
              "format": "uuid"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "Success"
            }
          },
          "404": {
            "description": "Not Found"
          }
        }
      },
    }
```