### PR TITLE
Remove usings from templates implicitly added by the SDK

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Areas/Identity/RevalidatingIdentityAuthenticationStateProvider.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Areas/Identity/RevalidatingIdentityAuthenticationStateProvider.cs
@@ -1,13 +1,8 @@
-using System;
 using System.Security.Claims;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace BlazorServerWeb_CSharp.Areas.Identity

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Data/ApplicationDbContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace BlazorServerWeb_CSharp.Data

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Data/WeatherForecast.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Data/WeatherForecast.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace BlazorServerWeb_CSharp.Data
 {
     public class WeatherForecast

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Data/WeatherForecastService.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Data/WeatherForecastService.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace BlazorServerWeb_CSharp.Data
 {
     public class WeatherForecastService

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/Error.cshtml.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/Error.cshtml.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Logging;
 
 namespace BlazorServerWeb_CSharp.Pages
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Program.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -14,23 +10,18 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 #endif
 using Microsoft.AspNetCore.Authorization;
 #endif
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components;
 #if (IndividualLocalAuth)
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI;
 #endif
-using Microsoft.AspNetCore.Hosting;
 #if (OrganizationalAuth)
 using Microsoft.AspNetCore.Mvc.Authorization;
 #endif
 #if (IndividualLocalAuth)
 using Microsoft.EntityFrameworkCore;
 #endif
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 #if (GenerateGraph)
 using Graph = Microsoft.Graph;
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.cs
@@ -1,15 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 #if (!NoAuth && Hosted)
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 #endif
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 #if (Hosted)
 using ComponentsWebAssembly_CSharp.Client;
 #else

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/OidcConfigurationController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/OidcConfigurationController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 
 namespace ComponentsWebAssembly_CSharp.Server.Controllers
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-#if (!NoAuth)
+﻿#if (!NoAuth)
 using Microsoft.AspNetCore.Authorization;
 #endif
 #if (GenerateApi)
-using Microsoft.Extensions.Configuration;
 using Microsoft.Identity.Web;
 using System.Net;
-using System.Net.Http;
 #endif
 #if (GenerateGraph)
 using Microsoft.Graph;
 #endif
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.Identity.Web.Resource;
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Data/ApplicationDbContext.cs
@@ -1,12 +1,8 @@
-﻿using ComponentsWebAssembly_CSharp.Server.Models;
-using IdentityServer4.EntityFramework.Options;
-using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
+﻿using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using IdentityServer4.EntityFramework.Options;
+using ComponentsWebAssembly_CSharp.Server.Models;
 
 namespace ComponentsWebAssembly_CSharp.Server.Data
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Models/ApplicationUser.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Models/ApplicationUser.cs
@@ -1,8 +1,4 @@
 ﻿using Microsoft.AspNetCore.Identity;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ComponentsWebAssembly_CSharp.Server.Models
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Pages/Error.cshtml.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Pages/Error.cshtml.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Logging;
 
 namespace ComponentsWebAssembly_CSharp.Server.Pages
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Program.cs
@@ -1,19 +1,13 @@
-﻿using System.Linq;
-#if (OrganizationalAuth || IndividualB2CAuth || IndividualLocalAuth)
+﻿#if (OrganizationalAuth || IndividualB2CAuth || IndividualLocalAuth)
 using Microsoft.AspNetCore.Authentication;
 #endif
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 #endif
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.ResponseCompression;
 #if (IndividualLocalAuth)
 using Microsoft.EntityFrameworkCore;
 #endif
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 #if (GenerateGraph)
 using Graph = Microsoft.Graph;
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Shared/WeatherForecast.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Shared/WeatherForecast.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ComponentsWebAssembly_CSharp.Shared
+﻿namespace ComponentsWebAssembly_CSharp.Shared
 {
     public class WeatherForecast
     {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/Program.cs
@@ -1,7 +1,3 @@
-using System;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Hosting;
-
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.cs
@@ -1,12 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using GrpcService_CSharp.Services;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Services/GreeterService.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Services/GreeterService.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Grpc.Core;
-using Microsoft.Extensions.Logging;
 using GrpcService_CSharp;
 
 namespace GrpcService_CSharp.Services

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/Areas/MyFeature/Pages/Page1.cshtml.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/Areas/MyFeature/Pages/Page1.cshtml.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Company.RazorClassLibrary1.MyFeature.Pages

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/ExampleJsInterop.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
 namespace Company.RazorClassLibrary1

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Data/ApplicationDbContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Company.WebApplication1.Data

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Error.cshtml.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Error.cshtml.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Logging;
 
 namespace Company.WebApplication1.Pages
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Index.cshtml.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Index.cshtml.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-#if (GenerateApiOrGraph)
-using Microsoft.Extensions.Configuration;
-using Microsoft.Identity.Web;
+﻿#if (GenerateApiOrGraph)
 using System.Net;
-using System.Net.Http;
-#endif
-#if (GenerateGraph)
-using Microsoft.Graph;
 #endif
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Logging;
+#if (GenerateGraph)
+using Microsoft.Graph;
+#endif
+#if (GenerateApiOrGraph)
+using Microsoft.Identity.Web;
+#endif
 
 namespace Company.WebApplication1.Pages
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Privacy.cshtml.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Privacy.cshtml.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Logging;
 
 namespace Company.WebApplication1.Pages
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Program.cs
@@ -1,16 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.Identity.Web;
-using Microsoft.Identity.Web.UI;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 #endif
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 #if (IndividualLocalAuth)
 using Microsoft.AspNetCore.Identity;
 #endif
@@ -20,10 +12,10 @@ using Microsoft.AspNetCore.Mvc.Authorization;
 #if (IndividualLocalAuth)
 using Microsoft.EntityFrameworkCore;
 #endif
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+#if (OrganizationalAuth || IndividualB2CAuth)
+using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.UI;
+#endif
 #if (MultiOrgAuth)
 using Microsoft.IdentityModel.Tokens;
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Controllers/HomeController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Controllers/HomeController.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
+#if (GenerateApiOrGraph)
+using System.Net;
+#endif
 #if (OrganizationalAuth)
 using Microsoft.AspNetCore.Authorization;
 #endif
-#if (GenerateApiOrGraph)
-using Microsoft.Extensions.Configuration;
-using Microsoft.Identity.Web;
-using System.Net;
-using System.Net.Http;
-#endif
+using Microsoft.AspNetCore.Mvc;
 #if (GenerateGraph)
 using Microsoft.Graph;
 #endif
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
+#if (GenerateApiOrGraph)
+using Microsoft.Identity.Web;
+#endif
 using Company.WebApplication1.Models;
 
 namespace Company.WebApplication1.Controllers

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Data/ApplicationDbContext.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Data/ApplicationDbContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Company.WebApplication1.Data

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Models/ErrorViewModel.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Company.WebApplication1.Models
 {
     public class ErrorViewModel

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Program.cs
@@ -1,16 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.Identity.Web;
-using Microsoft.Identity.Web.UI;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 #endif
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 #if (IndividualLocalAuth)
 using Microsoft.AspNetCore.Identity;
 #endif
@@ -20,10 +12,10 @@ using Microsoft.AspNetCore.Mvc.Authorization;
 #if (IndividualLocalAuth)
 using Microsoft.EntityFrameworkCore;
 #endif
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+#if (OrganizationalAuth || IndividualB2CAuth)
+using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.UI;
+#endif
 #if (MultiOrgAuth)
 using Microsoft.IdentityModel.Tokens;
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Controllers/WeatherForecastController.cs
@@ -1,23 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿#if (GenerateApi)
+using System.Net.Http;
+#endif
 #if (!NoAuth)
 using Microsoft.AspNetCore.Authorization;
 #endif
+using Microsoft.AspNetCore.Mvc;
 #if (GenerateApi)
-using Microsoft.Extensions.Configuration;
 using Microsoft.Identity.Web;
-using System.Net;
-using System.Net.Http;
+#endif
+#if (OrganizationalAuth || IndividualB2CAuth)
+using Microsoft.Identity.Web.Resource;
 #endif
 #if (GenerateGraph)
 using Microsoft.Graph;
-#endif
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-#if (OrganizationalAuth || IndividualB2CAuth)
-using Microsoft.Identity.Web.Resource;
 #endif
 
 namespace Company.WebApplication1.Controllers

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
@@ -1,17 +1,12 @@
-using System;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.Identity.Web;
 #endif
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 #if (GenerateGraph)
 using Graph = Microsoft.Graph;
+#endif
+#if (OrganizationalAuth || IndividualB2CAuth)
+using Microsoft.Identity.Web;
 #endif
 #if (EnableOpenAPI)
 using Microsoft.OpenApi.Models;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/WeatherForecast.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/WeatherForecast.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Company.WebApplication1
 {
     public class WeatherForecast

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Company.Application1;
 
 IHost host = Host.CreateDefaultBuilder(args)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Worker.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Worker.cs
@@ -1,11 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-
 namespace Company.Application1
 {
     public class Worker : BackgroundService


### PR DESCRIPTION
- Depends on dotnet/sdk#18459 flowing to dotnet/aspnetcore repo before we can merge this
- There's a couple of places we could remove usings from .razor files but need to verify the global usings flow into Razor compiler (#34217)
- Reordered usings in some places to ensure they get emitted in alphabetical order (modulo `System.*` & `Microsoft.*` coming before any others)

Contributes to #33947 #33948