### PR TITLE
Renderer support for removing root components or updating parameters on them

### DIFF
--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -41,6 +41,7 @@ Microsoft.AspNetCore.Components.NavigationOptions.NavigationOptions() -> void
 Microsoft.AspNetCore.Components.NavigationOptions.ReplaceHistoryEntry.get -> bool
 Microsoft.AspNetCore.Components.NavigationOptions.ReplaceHistoryEntry.init -> void
 Microsoft.AspNetCore.Components.RenderHandle.IsRenderingOnMetadataUpdate.get -> bool
+Microsoft.AspNetCore.Components.RenderTree.Renderer.RemoveRootComponent(int componentId) -> void
 Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.Dispose() -> void
 Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.get -> bool
 Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.set -> void

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             // Currently there's no known scenario where we need to support calling RemoveRootComponentAsync
             // during a batch, but if a scenario emerges we can add support.
             _batchBuilder.ComponentDisposalQueue.Enqueue(componentId);
-            if (HotReloadFeature.IsSupported)
+            if (TestableMetadataUpdate.IsSupported)
             {
                 _rootComponentsLatestParameters?.Remove(componentId);
             }

--- a/src/Components/Components/test/EventCallbackFactoryBinderExtensionsTest.cs
+++ b/src/Components/Components/test/EventCallbackFactoryBinderExtensionsTest.cs
@@ -396,7 +396,7 @@ namespace Microsoft.AspNetCore.Components
             var expectedValue = new DateTime(2018, 3, 4, 1, 2, 3);
 
             // Act
-            await binder.InvokeAsync(new ChangeEventArgs() { Value = expectedValue.ToString(CultureInfo.InvariantCulture), });
+            await binder.InvokeAsync(new ChangeEventArgs() { Value = expectedValue.ToString(CultureInfo.CurrentCulture), });
 
             Assert.Equal(expectedValue, value);
             Assert.Equal(1, component.Count);
@@ -415,7 +415,7 @@ namespace Microsoft.AspNetCore.Components
             var expectedValue = new DateTime(2018, 3, 4, 1, 2, 3);
 
             // Act
-            await binder.InvokeAsync(new ChangeEventArgs() { Value = expectedValue.ToString(CultureInfo.InvariantCulture), });
+            await binder.InvokeAsync(new ChangeEventArgs() { Value = expectedValue.ToString(CultureInfo.CurrentCulture), });
 
             Assert.Equal(expectedValue, value);
             Assert.Equal(1, component.Count);
@@ -474,7 +474,7 @@ namespace Microsoft.AspNetCore.Components
             var expectedValue = new DateTime(2018, 3, 4, 1, 2, 3);
 
             // Act
-            await binder.InvokeAsync(new ChangeEventArgs() { Value = expectedValue.ToString(CultureInfo.InvariantCulture), });
+            await binder.InvokeAsync(new ChangeEventArgs() { Value = expectedValue.ToString(CultureInfo.CurrentCulture), });
 
             Assert.Equal(expectedValue, value);
             Assert.Equal(1, component.Count);
@@ -493,7 +493,7 @@ namespace Microsoft.AspNetCore.Components
             var expectedValue = new DateTime(2018, 3, 4, 1, 2, 3);
 
             // Act
-            await binder.InvokeAsync(new ChangeEventArgs() { Value = expectedValue.ToString(CultureInfo.InvariantCulture), });
+            await binder.InvokeAsync(new ChangeEventArgs() { Value = expectedValue.ToString(CultureInfo.CurrentCulture), });
 
             Assert.Equal(expectedValue, value);
             Assert.Equal(1, component.Count);

--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -208,12 +208,12 @@ namespace Microsoft.AspNetCore.Components.Web.Rendering
                 .Returns<string, object[], CancellationToken>((n, v, t) => (long)v[1] == 2 ? firstBatchTCS.Task : secondBatchTCS.Task);
 
             // This produces the initial batch (id = 2)
-            await renderer.RenderComponentAsync<AutoParameterTestComponent>(
-            ParameterView.FromDictionary(new Dictionary<string, object>
-            {
-                [nameof(AutoParameterTestComponent.Content)] = initialContent,
-                [nameof(AutoParameterTestComponent.Trigger)] = trigger
-            }));
+            await renderer.Dispatcher.InvokeAsync(() => renderer.RenderComponentAsync<AutoParameterTestComponent>(
+                ParameterView.FromDictionary(new Dictionary<string, object>
+                {
+                    [nameof(AutoParameterTestComponent.Content)] = initialContent,
+                    [nameof(AutoParameterTestComponent.Trigger)] = trigger
+                })));
             trigger.Component.Content = (builder) =>
             {
                 builder.OpenElement(0, "offline element");
@@ -271,12 +271,12 @@ namespace Microsoft.AspNetCore.Components.Web.Rendering
                 .Returns<string, object[], CancellationToken>((n, v, t) => (long)v[1] == 2 ? firstBatchTCS.Task : secondBatchTCS.Task);
 
             // This produces the initial batch (id = 2)
-            await renderer.RenderComponentAsync<AutoParameterTestComponent>(
-            ParameterView.FromDictionary(new Dictionary<string, object>
-            {
-                [nameof(AutoParameterTestComponent.Content)] = initialContent,
-                [nameof(AutoParameterTestComponent.Trigger)] = trigger
-            }));
+            await renderer.Dispatcher.InvokeAsync(() => renderer.RenderComponentAsync<AutoParameterTestComponent>(
+                ParameterView.FromDictionary(new Dictionary<string, object>
+                {
+                    [nameof(AutoParameterTestComponent.Content)] = initialContent,
+                    [nameof(AutoParameterTestComponent.Trigger)] = trigger
+                })));
             trigger.Component.Content = (builder) =>
             {
                 builder.OpenElement(0, "offline element");
@@ -334,12 +334,12 @@ namespace Microsoft.AspNetCore.Components.Web.Rendering
             var trigger = new Trigger();
 
             // This produces the initial batch (id = 2)
-            await renderer.RenderComponentAsync<AutoParameterTestComponent>(
-            ParameterView.FromDictionary(new Dictionary<string, object>
-            {
-                [nameof(AutoParameterTestComponent.Content)] = initialContent,
-                [nameof(AutoParameterTestComponent.Trigger)] = trigger
-            }));
+            await renderer.Dispatcher.InvokeAsync(() => renderer.RenderComponentAsync<AutoParameterTestComponent>(
+                ParameterView.FromDictionary(new Dictionary<string, object>
+                {
+                    [nameof(AutoParameterTestComponent.Content)] = initialContent,
+                    [nameof(AutoParameterTestComponent.Trigger)] = trigger
+                })));
             trigger.Component.Content = (builder) =>
             {
                 builder.OpenElement(0, "offline element");
@@ -391,12 +391,12 @@ namespace Microsoft.AspNetCore.Components.Web.Rendering
             var trigger = new Trigger();
 
             // This produces the initial batch (id = 2)
-            await renderer.RenderComponentAsync<AutoParameterTestComponent>(
-            ParameterView.FromDictionary(new Dictionary<string, object>
-            {
-                [nameof(AutoParameterTestComponent.Content)] = initialContent,
-                [nameof(AutoParameterTestComponent.Trigger)] = trigger
-            }));
+            await renderer.Dispatcher.InvokeAsync(() => renderer.RenderComponentAsync<AutoParameterTestComponent>(
+                ParameterView.FromDictionary(new Dictionary<string, object>
+                {
+                    [nameof(AutoParameterTestComponent.Content)] = initialContent,
+                    [nameof(AutoParameterTestComponent.Trigger)] = trigger
+                })));
             trigger.Component.Content = (builder) =>
             {
                 builder.OpenElement(0, "offline element");

--- a/src/Components/Shared/test/TestRenderer.cs
+++ b/src/Components/Shared/test/TestRenderer.cs
@@ -55,6 +55,9 @@ namespace Microsoft.AspNetCore.Components.Test.Helpers
         public new int AssignRootComponentId(IComponent component)
             => base.AssignRootComponentId(component);
 
+        public new void RemoveRootComponent(int componentId)
+            => base.RemoveRootComponent(componentId);
+
         public new ArrayRange<RenderTreeFrame> GetCurrentRenderTreeFrames(int componentId)
             => base.GetCurrentRenderTreeFrames(componentId);
 


### PR DESCRIPTION
This is needed as part of #27574 

The core `Renderer` needs to have APIs for being told to:

 * Remove root components, clearing up properly and running all the correct disposal flows
 * Supply new parameters to root components, whether or not the rendering system is currently quiescent, and return a task that completes when we do reach quiescence

It's not necessary to add a new API for "supply new parameters" because the existing `RenderRootComponentAsync` actually does that already. The one thing it didn't support was being called while the system was not yet quiescent, so that's what I've added. It just involves juggling the tasks a little differently.