### PR TITLE
Configure ALPN for callback scenarios 

### DIFF
--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -288,6 +288,8 @@ namespace Microsoft.AspNetCore.Hosting
             listenOptions.IsTls = true;
             listenOptions.Use(next =>
             {
+                // Set the list of protocols from listen options
+                callbackOptions.HttpProtocols = listenOptions.Protocols;
                 var middleware = new HttpsConnectionMiddleware(next, callbackOptions, loggerFactory);
                 return middleware.OnConnectionAsync;
             });

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -46,6 +46,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
         // The following fields are only set by TlsHandshakeCallbackOptions ctor.
         private readonly Func<TlsHandshakeCallbackContext, ValueTask<SslServerAuthenticationOptions>>? _tlsCallbackOptions;
         private readonly object? _tlsCallbackOptionsState;
+        private readonly HttpProtocols _httpProtocols;
 
         // Pool for cancellation tokens that cancel the handshake
         private readonly CancellationTokenSourcePool _ctsPool = new();
@@ -127,6 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
 
             _tlsCallbackOptions = tlsCallbackOptions.OnConnection;
             _tlsCallbackOptionsState = tlsCallbackOptions.OnConnectionState;
+            _httpProtocols = ValidateAndNormalizeHttpProtocols(tlsCallbackOptions.HttpProtocols, _logger);
             _sslStreamFactory = s => new SslStream(s);
         }
 
@@ -434,6 +436,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
             var sslOptions = await middleware._tlsCallbackOptions!(callbackContext);
             feature.AllowDelayedClientCertificateNegotation = callbackContext.AllowDelayedClientCertificateNegotation;
 
+            // The callback didn't set ALPN so we will.
+            if (sslOptions.ApplicationProtocols == null)
+            {
+                ConfigureAlpn(sslOptions, middleware._httpProtocols);
+            }
             KestrelEventSource.Log.TlsHandshakeStart(context, sslOptions);
 
             return sslOptions;

--- a/src/Servers/Kestrel/Core/src/TlsHandshakeCallbackOptions.cs
+++ b/src/Servers/Kestrel/Core/src/TlsHandshakeCallbackOptions.cs
@@ -42,5 +42,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
                 _handshakeTimeout = value != Timeout.InfiniteTimeSpan ? value : TimeSpan.MaxValue;
             }
         }
+
+        // Copied from the ListenOptions to enable ALPN
+        internal HttpProtocols HttpProtocols { get; set; }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -853,6 +853,39 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "ALPN not supported")]
+        public async Task TlsHandshakeCallbackOptionsOverload_EmptyAlpnList_DisablesAlpn()
+        {
+            static void ConfigureListenOptions(ListenOptions listenOptions)
+            {
+                listenOptions.UseHttps(new TlsHandshakeCallbackOptions()
+                {
+                    OnConnection = context =>
+                    {
+                        return ValueTask.FromResult(new SslServerAuthenticationOptions()
+                        {
+                            ServerCertificate = _x509Certificate2,
+                            ApplicationProtocols = new(),
+                        });
+                    }
+                });
+            }
+
+            await using var server = new TestServer(context => Task.CompletedTask,
+                new TestServiceContext(LoggerFactory), ConfigureListenOptions);
+
+            using var connection = server.CreateConnection();
+            var stream = OpenSslStream(connection.Stream);
+            await stream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions()
+            {
+                // Use a random host name to avoid the TLS session resumption cache.
+                TargetHost = Guid.NewGuid().ToString(),
+                ApplicationProtocols = new() { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11, },
+            });
+            Assert.Equal(default, stream.NegotiatedApplicationProtocol);
+        }
+
+        [ConditionalFact]
         [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
         public async Task CanRenegotiateForClientCertificateOnPostIfDrained()
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -794,6 +794,65 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "ALPN not supported")]
+        public async Task ServerOptionsSelectionCallback_SetsALPN()
+        {
+            static void ConfigureListenOptions(ListenOptions listenOptions)
+            {
+                listenOptions.UseHttps((_, _, _, _) =>
+                    ValueTask.FromResult(new SslServerAuthenticationOptions()
+                    {
+                        ServerCertificate = _x509Certificate2,
+                    }), state: null);
+            }
+
+            await using var server = new TestServer(context => Task.CompletedTask,
+                new TestServiceContext(LoggerFactory), ConfigureListenOptions);
+
+            using var connection = server.CreateConnection();
+            var stream = OpenSslStream(connection.Stream);
+            await stream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions()
+            {
+                // Use a random host name to avoid the TLS session resumption cache.
+                TargetHost = Guid.NewGuid().ToString(),
+                ApplicationProtocols = new() { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11, },
+            });
+            Assert.Equal(SslApplicationProtocol.Http2, stream.NegotiatedApplicationProtocol);
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "ALPN not supported")]
+        public async Task TlsHandshakeCallbackOptionsOverload_SetsALPN()
+        {
+            static void ConfigureListenOptions(ListenOptions listenOptions)
+            {
+                listenOptions.UseHttps(new TlsHandshakeCallbackOptions()
+                {
+                    OnConnection = context =>
+                    {
+                        return ValueTask.FromResult(new SslServerAuthenticationOptions()
+                        {
+                            ServerCertificate = _x509Certificate2,
+                        });
+                    }
+                });
+            }
+
+            await using var server = new TestServer(context => Task.CompletedTask,
+                new TestServiceContext(LoggerFactory), ConfigureListenOptions);
+
+            using var connection = server.CreateConnection();
+            var stream = OpenSslStream(connection.Stream);
+            await stream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions()
+            {
+                // Use a random host name to avoid the TLS session resumption cache.
+                TargetHost = Guid.NewGuid().ToString(),
+                ApplicationProtocols = new() { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11, },
+            });
+            Assert.Equal(SslApplicationProtocol.Http2, stream.NegotiatedApplicationProtocol);
+        }
+
+        [ConditionalFact]
         [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
         public async Task CanRenegotiateForClientCertificateOnPostIfDrained()
         {


### PR DESCRIPTION
Fixes #31303 by stashing HttpProtocols on TlsHandshakeCallbackOptions just like we did for HttpsConnectionAdapterOptions. If either of the callbacks don't supply ALPN settings then we will. ApplicationProtocols can be set to an empty list to disable ALPN.

Is this too magical?

Is it breaking for people that were using ServerOptionsSelectionCallback and suddenly HTTP/2 starts working?