### PR TITLE
Revert "Added endpoint API explorer to default webhost (#33800)"

### DIFF
--- a/src/DefaultBuilder/DefaultBuilder.slnf
+++ b/src/DefaultBuilder/DefaultBuilder.slnf
@@ -17,14 +17,8 @@
       "src\\Http\\Http.Features\\src\\Microsoft.AspNetCore.Http.Features.csproj",
       "src\\Http\\Http\\src\\Microsoft.AspNetCore.Http.csproj",
       "src\\Http\\WebUtilities\\src\\Microsoft.AspNetCore.WebUtilities.csproj",
-      "src\\Middleware\\ResponseCaching.Abstractions\\src\\Microsoft.AspNetCore.ResponseCaching.Abstractions.csproj",
       "src\\Middleware\\StaticFiles\\src\\Microsoft.AspNetCore.StaticFiles.csproj",
-      "src\\Mvc\\Mvc.Abstractions\\src\\Microsoft.AspNetCore.Mvc.Abstractions.csproj",
-      "src\\Mvc\\Mvc.ApiExplorer\\src\\Microsoft.AspNetCore.Mvc.ApiExplorer.csproj",
-      "src\\Mvc\\Mvc.Core\\src\\Microsoft.AspNetCore.Mvc.Core.csproj",
-      "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj",
-      "src\\Security\\Authentication\\Core\\src\\Microsoft.AspNetCore.Authentication.csproj",
-      "src\\Security\\Authorization\\Policy\\src\\Microsoft.AspNetCore.Authorization.Policy.csproj"
+      "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj"
     ]
   }
 }

--- a/src/DefaultBuilder/src/Microsoft.AspNetCore.csproj
+++ b/src/DefaultBuilder/src/Microsoft.AspNetCore.csproj
@@ -18,7 +18,6 @@
     <Reference Include="Microsoft.AspNetCore.Server.IIS" />
     <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
-    <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" />
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <Reference Include="Microsoft.Extensions.Configuration.FileExtensions" />
     <Reference Include="Microsoft.Extensions.Configuration.Json" />

--- a/src/DefaultBuilder/src/WebHost.cs
+++ b/src/DefaultBuilder/src/WebHost.cs
@@ -259,7 +259,6 @@ namespace Microsoft.AspNetCore
                 }
 
                 services.AddRouting();
-                services.AddEndpointsApiExplorer();
             })
             .UseIIS()
             .UseIISIntegration();

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.Testing;
@@ -268,14 +267,6 @@ namespace Microsoft.AspNetCore.Tests
             var app = WebApplication.Create();
             var linkGenerator = app.Services.GetService(typeof(LinkGenerator));
             Assert.NotNull(linkGenerator);
-        }
-
-        [Fact]
-        public void WebApplicationCreate_RegistersApiExplorerForEndpoints()
-        {
-            var app = WebApplication.Create();
-            var apiDescriptionProvider = app.Services.GetService(typeof(IApiDescriptionProvider));
-            Assert.NotNull(apiDescriptionProvider);
         }
 
         [Fact]

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebHostTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebHostTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.Testing;
@@ -98,17 +97,6 @@ namespace Microsoft.AspNetCore.Tests
 
             var linkGenerator = host.Services.GetService(typeof(LinkGenerator));
             Assert.NotNull(linkGenerator);
-        }
-
-        [Fact]
-        public void CreateDefaultBuilder_RegistersApiExplorer()
-        {
-            var host = WebHost.CreateDefaultBuilder()
-                .Configure(_ => { })
-                .Build();
-
-            var apiDescriptionProvider = host.Services.GetService(typeof(IApiDescriptionProvider));
-            Assert.NotNull(apiDescriptionProvider);
         }
 
         [Fact]


### PR DESCRIPTION
This reverts commit 2af293dc72625b865fa7fcad5aeb510df46386bd.

See https://github.com/dotnet/aspnetcore/issues/34208#issuecomment-877612044 for the explanation.

Fixes #34208

PS: Orchard will still fail if this service is added explicitly so I believe the ultimate fix is inside of orchard itself but reverting this for preview7 also unbreaks swashbuckle so it seems like the right short term decision.

@halter73 This takes the preview7 pressure off for https://github.com/dotnet/aspnetcore/issues/33934 so we can punt it to rc1 if need be.
