### PR TITLE
Add usings back to Blazor client Program.cs

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.cs
@@ -1,7 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
 #if (!NoAuth && Hosted)
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 #endif
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 #if (Hosted)
 using ComponentsWebAssembly_CSharp.Client;
 #else


### PR DESCRIPTION
BlazorWasm SDK hasn't got implicit global usings as yet so they need to be included for now.

Successfully ran the BlazorWasm template and ProjectTemplates.Tests passed locally.

@captainsafia @davidfowl 