### PR TITLE
Honor RecursiveDir when used on packed items in framework packs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -676,35 +676,6 @@ stages:
     - template: jobs/default-build.yml
       parameters:
         condition: ne(variables['SkipTests'], 'true')
-        jobName: Windows_Templates_Test
-        jobDisplayName: "Test: Templates - Windows Server 2016 x64"
-        agentOs: Windows
-        isTestingJob: true
-        testRunTitle: Templates-$(AgentOsName)-$(BuildConfiguration)
-        steps:
-        - script: ./eng/build.cmd -ci -nobl -all -pack $(_InternalRuntimeDownloadArgs)
-          displayName: Build Repo
-        - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -pack -NoRestore -noBuildNative -NoBuilddeps "/p:RunTemplateTests=true"
-          displayName: Pack Templates
-        - script: ./src/ProjectTemplates/build.cmd -ci -nobl -noBuildRepoTasks -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true"
-          displayName: Test Templates
-        artifacts:
-        - name: Windows_Test_Templates_Dumps
-          path: artifacts/dumps/
-          publishOnError: true
-          includeForks: true
-        - name: Windows_Test_Templates_Logs
-          path: artifacts/log/
-          publishOnError: true
-          includeForks: true
-        - name: Windows_Test_Templates_Results
-          path: artifacts/TestResults/
-          publishOnError: true
-          includeForks: true
-
-    - template: jobs/default-build.yml
-      parameters:
-        condition: ne(variables['SkipTests'], 'true')
         jobName: MacOS_Test
         jobDisplayName: "Test: macOS 10.14"
         agentOs: macOS

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -86,10 +86,7 @@ jobs:
     steps:
     - powershell: "& ./eng/build.ps1 -CI -nobl -all -pack -NoBuildJava"
       displayName: Build
-    # The templates part can be removed when the Blazor Templates run on Helix
-    - script: ./src/ProjectTemplates/build.cmd -ci -nobl -pack -NoRestore -NoBuildNative -NoBuilddeps "/p:RunTemplateTests=true"
-      displayName: Pack Templates
-    - script: ./eng/build.cmd -ci -nobl -test -NoRestore -NoBuild -NoBuilddeps "/p:RunTemplateTests=true /p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true"
+    - script: ./eng/build.cmd -ci -nobl -test -NoRestore -NoBuild -NoBuilddeps "/p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true"
       displayName: Run Quarantined Tests
       continueOnError: true
     - task: PublishTestResults@2

--- a/eng/tools/RepoTasks/CreateFrameworkListFile.cs
+++ b/eng/tools/RepoTasks/CreateFrameworkListFile.cs
@@ -50,7 +50,7 @@ namespace RepoTasks
                     FileVersion = FileUtilities.GetFileVersion(item.ItemSpec),
                     IsNative = item.GetMetadata("IsNativeImage") == "true",
                     IsSymbolFile = item.GetMetadata("IsSymbolFile") == "true",
-                    PackagePath = item.GetMetadata("PackagePath")
+                    PackagePath = GetPackagePath(item)
                 })
                 .Where(f =>
                     !f.IsSymbolFile &&
@@ -125,5 +125,17 @@ namespace RepoTasks
 
             return !Log.HasLoggedErrors;
         }
+        private static string GetPackagePath(ITaskItem item)
+        {
+            string packagePath = item.GetMetadata("PackagePath");
+
+            // replicate the logic used by PackTask https://github.com/NuGet/NuGet.Client/blob/f24bad0668193ce21a1db8cabd1ce95ba509c7f0/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs#L644-L647
+            string recursiveDir = item.GetMetadata("RecursiveDir");
+            recursiveDir = string.IsNullOrEmpty(recursiveDir) ? item.GetMetadata("NuGetRecursiveDir") : recursiveDir;
+
+            return string.IsNullOrEmpty(recursiveDir) ? packagePath :
+                Path.Combine(packagePath, recursiveDir);
+        }
     }
+
 }

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -164,8 +164,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Include="@(AspNetCoreReferenceAssemblyPath->WithMetadataValue('ExternallyResolved', 'true')->'%(RootDir)%(Directory)%(Filename).xml')"
           Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
 
-      <_AnalyzerContent Include="$(PkgMicrosoft_AspNetCore_Internal_Transport)\$(AnalyzersPackagePath)**\*.*" />
-      <RefPackContent Include="@(_AnalyzerContent)" PackagePath="$(AnalyzersPackagePath)%(RecursiveDir)" />
+      <RefPackContent Include="$(PkgMicrosoft_AspNetCore_Internal_Transport)\$(AnalyzersPackagePath)**\*.*" PackagePath="$(AnalyzersPackagePath)" />
 
       <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
       <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -203,9 +203,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <Target Name="_BatchCopyToLayoutTargetDir"
           DependsOnTargets="_ResolveTargetingPackContent"
           Inputs="@(RefPackContent)"
-          Outputs="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(FileName)%(Extension)')">
+          Outputs="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')">
     <Copy SourceFiles="@(RefPackContent)"
-          DestinationFiles="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(FileName)%(Extension)')"
+          DestinationFiles="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
     <Message Importance="High" Text="$(MSBuildProjectName) -> $(LayoutTargetDir)" />
   </Target>
@@ -218,9 +218,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <Target Name="_InstallTargetingPackIntoLocalDotNet"
           DependsOnTargets="_ResolveTargetingPackContent"
           Inputs="@(RefPackContent)"
-          Outputs="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(FileName)%(Extension)')">
+          Outputs="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')">
     <Copy SourceFiles="@(RefPackContent)"
-          DestinationFiles="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(FileName)%(Extension)')"
+          DestinationFiles="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
     <Message Importance="High" Text="$(MSBuildProjectName) -> $(LocalInstallationOutputPath)" />
   </Target>

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -366,7 +366,7 @@ namespace Microsoft.AspNetCore
             });
         }
 
-        [Fact(Skip = "Skip until layout issues are resolved. See https://github.com/dotnet/aspnetcore/pull/34033")]
+        [Fact]
         public void FrameworkListListsContainsCorrectPaths()
         {
             if (!_isTargetingPackBuilding || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -10,7 +10,6 @@
 
     <RunTemplateTests Condition="'$(RunTemplateTests)' == ''" >true</RunTemplateTests>
     <SkipTests Condition="'$(RunTemplateTests)' != 'true'">true</SkipTests>
-    <BuildHelixPayload>false</BuildHelixPayload>
 
     <BaseOutputPath />
     <OutputPath />


### PR DESCRIPTION
When packaging Analyzers in the ref-pack we were setting PackagePath to the full path inside the package (by appending `%(RecursiveDir)`) then Nuget was appending `%(RecursiveDir)` again during pack.  Avoid this by removing the expansion in our own items and fixing the `CreateFrameworkList` task to append `%(RecurisveDir)` in a similar manner to NuGet.

Addresses #34272
