### PR TITLE
Fix AdaptiveCapacityDictionary assert with 11 elements 

### DIFF
--- a/src/Http/Http/perf/Microbenchmarks/AdaptiveCapacityDictionaryBenchmark.cs
+++ b/src/Http/Http/perf/Microbenchmarks/AdaptiveCapacityDictionaryBenchmark.cs
@@ -40,7 +40,11 @@ namespace Microsoft.AspNetCore.Http
 
             _smallCapDict = new AdaptiveCapacityDictionary<string, string>(capacity: 1, StringComparer.OrdinalIgnoreCase);
             _smallCapDictTen = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
-            _filledSmallDictionary = new AdaptiveCapacityDictionary<string, string>(_tenValues, capacity: 10, StringComparer.OrdinalIgnoreCase);
+            _filledSmallDictionary = new AdaptiveCapacityDictionary<string, string>(capacity: 10, StringComparer.OrdinalIgnoreCase);
+            foreach (var a in _tenValues)
+            {
+                _filledSmallDictionary[a.Key] = a.Value;
+            }
 
             _dict = new Dictionary<string, string>(1, StringComparer.OrdinalIgnoreCase);
             _dictTen = new Dictionary<string, string>(10, StringComparer.OrdinalIgnoreCase);

--- a/src/Http/Http/src/Internal/RequestCookieCollection.cs
+++ b/src/Http/Http/src/Internal/RequestCookieCollection.cs
@@ -70,7 +70,9 @@ namespace Microsoft.AspNetCore.Http
             {
                 return Empty;
             }
-            var collection = new RequestCookieCollection(values.Count);
+
+            // Do not set the collection capacity based on StringValues.Count, the Cookie header is supposed to be a single combine value.
+            var collection = new RequestCookieCollection();
             var store = collection.Store!;
 
             if (CookieHeaderParserShared.TryParseValues(values, store, enableCookieNameEncoding, supportsMultipleValues: true))

--- a/src/Http/Http/src/Internal/RequestCookieCollection.cs
+++ b/src/Http/Http/src/Internal/RequestCookieCollection.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Http
                 return Empty;
             }
 
-            // Do not set the collection capacity based on StringValues.Count, the Cookie header is supposed to be a single combine value.
+            // Do not set the collection capacity based on StringValues.Count, the Cookie header is supposed to be a single combined value.
             var collection = new RequestCookieCollection();
             var store = collection.Store!;
 

--- a/src/Http/Http/test/RequestCookiesCollectionTests.cs
+++ b/src/Http/Http/test/RequestCookiesCollectionTests.cs
@@ -38,5 +38,13 @@ namespace Microsoft.AspNetCore.Http.Tests
             Assert.Equal(expectedKey, cookies.Keys.Single());
             Assert.Equal(expectedValue, cookies[expectedKey]);
         }
+
+        [Fact]
+        public void ParseManyCookies()
+        {
+            var cookies = RequestCookieCollection.Parse(new StringValues(new[] { "a=a", "b=b", "c=c", "d=d", "e=e", "f=f", "g=g", "h=h", "i=i", "j=j", "k=k", "l=l" }));
+
+            Assert.Equal(12, cookies.Count);
+        }
     }
 }

--- a/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
+++ b/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
@@ -77,7 +77,6 @@ namespace Microsoft.AspNetCore.Internal
             else
             {
                 _dictionaryStorage = new Dictionary<TKey, TValue>(capacity);
-                _arrayStorage = Array.Empty<KeyValuePair<TKey, TValue>>();
             }
         }
 
@@ -95,6 +94,7 @@ namespace Microsoft.AspNetCore.Internal
         {
             _comparer = comparer ?? EqualityComparer<TKey>.Default;
 
+            Debug.Assert(capacity <= DefaultArrayThreshold);
             _arrayStorage = new KeyValuePair<TKey, TValue>[capacity];
 
             foreach (var kvp in values)

--- a/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
+++ b/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
@@ -81,29 +81,6 @@ namespace Microsoft.AspNetCore.Internal
         }
 
         /// <summary>
-        /// Creates a <see cref="AdaptiveCapacityDictionary{TKey, TValue}"/> initialized with the specified <paramref name="values"/>.
-        /// </summary>
-        /// <param name="values">An object to initialize the dictionary. The value can be of type
-        /// <see cref="IDictionary{TKey, TValue}"/> or <see cref="IReadOnlyDictionary{TKey, TValue}"/>
-        /// or an object with public properties as key-value pairs.
-        /// </param>
-        /// <remarks>This constructor is unoptimized and primarily used for tests.</remarks>
-        /// <param name="comparer">Equality comparison.</param>
-        /// <param name="capacity">Initial capacity.</param>
-        internal AdaptiveCapacityDictionary(IEnumerable<KeyValuePair<TKey, TValue>> values, int capacity, IEqualityComparer<TKey> comparer)
-        {
-            _comparer = comparer ?? EqualityComparer<TKey>.Default;
-
-            Debug.Assert(capacity <= DefaultArrayThreshold);
-            _arrayStorage = new KeyValuePair<TKey, TValue>[capacity];
-
-            foreach (var kvp in values)
-            {
-                Add(kvp.Key, kvp.Value);
-            }
-        }
-
-        /// <summary>
         /// Creates a <see cref="AdaptiveCapacityDictionary{TKey, TValue}"/> initialized with the specified <paramref name="dict"/>.
         /// </summary>
         /// <param name="dict">A dictionary to use.

--- a/src/Shared/test/Shared.Tests/AdaptiveCapacityDictionaryTests.cs
+++ b/src/Shared/test/Shared.Tests/AdaptiveCapacityDictionaryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Testing;
@@ -98,6 +99,25 @@ namespace Microsoft.AspNetCore.Internal.Tests
                 kvp => { Assert.Equal("First Name", kvp.Key); Assert.Equal("James", kvp.Value); },
                 kvp => { Assert.Equal("Last Name", kvp.Key); Assert.Equal("Henrik", kvp.Value); },
                 kvp => { Assert.Equal("Middle Name", kvp.Key); Assert.Equal("Bob", kvp.Value); });
+        }
+
+        [Fact]
+        public void CreateWithCapacityOverDefaultLimit()
+        {
+            // The default threshold between array and dictionary is 10. If we created one over that limit it should go directly to a dictionary.
+            var dict = new AdaptiveCapacityDictionary<string, string>(capacity: 12, StringComparer.OrdinalIgnoreCase);
+
+            Assert.Null(dict._arrayStorage);
+            Assert.NotNull(dict._dictionaryStorage);
+
+            for (var i = 0; i < 12; i++)
+            {
+                dict[i.ToString(CultureInfo.InvariantCulture)] = i.ToString(CultureInfo.InvariantCulture);
+            }
+
+            Assert.Null(dict._arrayStorage);
+            Assert.NotNull(dict._dictionaryStorage);
+            Assert.Equal(12, dict.Count);
         }
 
         [Fact]

--- a/src/Shared/test/Shared.Tests/AdaptiveCapacityDictionaryTests.cs
+++ b/src/Shared/test/Shared.Tests/AdaptiveCapacityDictionaryTests.cs
@@ -39,68 +39,6 @@ namespace Microsoft.AspNetCore.Internal.Tests
             Assert.Null(dict._dictionaryStorage);
         }
 
-        public static KeyValuePair<string, object>[] IEnumerableKeyValuePairData
-        {
-            get
-            {
-                return new[]
-                {
-                    new KeyValuePair<string, object?>("Name", "James"),
-                    new KeyValuePair<string, object?>("Age", 30),
-                    new KeyValuePair<string, object?>("Address", new Address() { City = "Redmond", State = "WA" })
-                };
-            }
-        }
-
-        public static KeyValuePair<string, string>[] IEnumerableStringValuePairData
-        {
-            get
-            {
-                return new[]
-                {
-                    new KeyValuePair<string, string>("First Name", "James"),
-                    new KeyValuePair<string, string>("Last Name", "Henrik"),
-                    new KeyValuePair<string, string>("Middle Name", "Bob")
-                };
-            }
-        }
-
-        [Fact]
-        public void CreateFromIEnumerableKeyValuePair_CopiesValues()
-        {
-            // Arrange & Act
-            var dict = new AdaptiveCapacityDictionary<string, object?>(IEnumerableKeyValuePairData, capacity: IEnumerableKeyValuePairData.Length, EqualityComparer<string>.Default);
-
-            // Assert
-            Assert.IsType<KeyValuePair<string, object?>[]>(dict._arrayStorage);
-            Assert.Collection(
-                dict.OrderBy(kvp => kvp.Key),
-                kvp =>
-                {
-                    Assert.Equal("Address", kvp.Key);
-                    var address = Assert.IsType<Address>(kvp.Value);
-                    Assert.Equal("Redmond", address.City);
-                    Assert.Equal("WA", address.State);
-                },
-                kvp => { Assert.Equal("Age", kvp.Key); Assert.Equal(30, kvp.Value); },
-                kvp => { Assert.Equal("Name", kvp.Key); Assert.Equal("James", kvp.Value); });
-        }
-
-        [Fact]
-        public void CreateFromIEnumerableStringValuePair_CopiesValues()
-        {
-            // Arrange & Act
-            var dict = new AdaptiveCapacityDictionary<string, string>(IEnumerableStringValuePairData, capacity: 3, StringComparer.OrdinalIgnoreCase);
-
-            // Assert
-            Assert.IsType<KeyValuePair<string, string>[]>(dict._arrayStorage);
-            Assert.Collection(
-                dict.OrderBy(kvp => kvp.Key),
-                kvp => { Assert.Equal("First Name", kvp.Key); Assert.Equal("James", kvp.Value); },
-                kvp => { Assert.Equal("Last Name", kvp.Key); Assert.Equal("Henrik", kvp.Value); },
-                kvp => { Assert.Equal("Middle Name", kvp.Key); Assert.Equal("Bob", kvp.Value); });
-        }
-
         [Fact]
         public void CreateWithCapacityOverDefaultLimit()
         {
@@ -132,23 +70,6 @@ namespace Microsoft.AspNetCore.Internal.Tests
                 },
                 "key",
                 $"An element with the key 'Name' already exists in the {nameof(AdaptiveCapacityDictionary<string, object?>)}.");
-        }
-
-        [Fact]
-        public void CreateFromIEnumerableStringValuePair_ThrowsExceptionForDuplicateKey()
-        {
-            // Arrange
-            var values = new List<KeyValuePair<string, string>>()
-            {
-                new KeyValuePair<string, string>("name", "Billy"),
-                new KeyValuePair<string, string>("Name", "Joey"),
-            };
-
-            // Act & Assert
-            ExceptionAssert.ThrowsArgument(
-                () => new AdaptiveCapacityDictionary<string, string>(values, capacity: 3, StringComparer.OrdinalIgnoreCase),
-                "key",
-                $"An element with the key 'Name' already exists in the {nameof(AdaptiveCapacityDictionary<string, object>)}.");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #34307 

AdaptiveCapacityDictionary starts with an Array and then transitions to a Dictionary after 10 elements. It uses null checks on these fields to figure out which mode it's in. However, one constructor was initializing both fields and put the object in an invalid state.

This is a Debug.Assert failure that Hao noticed when manually testing something. It's a 6.0 regression introduced with the new AdaptiveCapacityDictionary. Neither of us saw any incorrect product behavior related to the bug, but there's potential for it given the invalid state the object is in.

Related: the cookie parser shouldn't be assuming that the StringValues.Count is the cookie count. The Cookie header is supposed to be a single value so StringValues.Count would normally be 0 or 1. There is a Kestrel Http/2 bug (#26461) where you can get more values, which is how Hao ran into this issue.