### PR TITLE
Adding .mjs to list of known MIME types

### DIFF
--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -177,6 +177,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".mid", "audio/mid" },
                 { ".midi", "audio/mid" },
                 { ".mix", "application/octet-stream" },
+                { ".mjs", "text/javascript" },                
                 { ".mmf", "application/x-smaf" },
                 { ".mno", "text/xml" },
                 { ".mny", "application/x-msmoney" },

--- a/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
+++ b/src/Middleware/StaticFiles/src/FileExtensionContentTypeProvider.cs
@@ -177,7 +177,7 @@ namespace Microsoft.AspNetCore.StaticFiles
                 { ".mid", "audio/mid" },
                 { ".midi", "audio/mid" },
                 { ".mix", "application/octet-stream" },
-                { ".mjs", "text/javascript" },                
+                { ".mjs", "text/javascript" },
                 { ".mmf", "application/x-smaf" },
                 { ".mno", "text/xml" },
                 { ".mny", "application/x-msmoney" },


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/draft-ietf-dispatch-javascript-mjs has been submitted for publication to the IESG. We anticipate that browsers may start enforcing the correct `Content-Type` header for javascript modules prior to execution.

As an aside, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#aside_%E2%80%94_.mjs_versus_.js

👀 @MylesBorins
