### PR TITLE
Make the duplicate usings warnings go away

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -111,6 +111,7 @@
   <PropertyGroup>
     <!-- Ensure API docs are available. -->
     <NoWarn>$(NoWarn.Replace('1591', ''))</NoWarn>
+    <NoWarn>$(NoWarn),0105</NoWarn>
 
     <!-- For local builds, don't make missing XML docs a fatal build error, but still surface so we have visibility into undocumented APIs. -->
     <WarningsNotAsErrors Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>


### PR DESCRIPTION
- The value is low and they clash in vs 2019 16.10/11
- We can remove this when vs 2022 ships
