### PR TITLE
Remove flaky extra wasm migration check

### DIFF
--- a/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
@@ -121,12 +121,6 @@ namespace Templates.Test
             Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", serverProject, migrationsResult));
             serverProject.AssertEmptyMigration("blazorwasm");
 
-            if (useLocalDb)
-            {
-                var dbUpdateResult = await serverProject.RunDotNetEfUpdateDatabaseAsync();
-                Assert.True(0 == dbUpdateResult.ExitCode, ErrorMessages.GetFailedProcessMessage("update database", serverProject, dbUpdateResult));
-            }
-
             return project;
         }
 


### PR DESCRIPTION
This should be the cause of the new wasm template test passing at only 18% it has extra logic none of the other templates do