### PR TITLE
Add AcceptSocketAsync to SocketTransportOptions

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -10,3 +10,6 @@ static Microsoft.AspNetCore.Hosting.WebHostBuilderSocketExtensions.UseSockets(th
 static Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateDefaultBoundListenSocket(System.Net.EndPoint! endpoint) -> System.Net.Sockets.Socket!
 Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateBoundListenSocket.get -> System.Func<System.Net.EndPoint!, System.Net.Sockets.Socket!>!
 Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateBoundListenSocket.set -> void
+static Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.DefaultAcceptSocketAsync(System.Net.Sockets.Socket! listenSocket, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Net.Sockets.Socket!>
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.AcceptSocketAsync.get -> System.Func<System.Net.Sockets.Socket!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.Net.Sockets.Socket!>>!
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.AcceptSocketAsync.set -> void

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
                 {
                     Debug.Assert(_listenSocket != null, "Bind must be called first.");
 
-                    var acceptSocket = await _listenSocket.AcceptAsync(cancellationToken);
+                    var acceptSocket = await _options.AcceptSocketAsync(_listenSocket, cancellationToken);
 
                     // Only apply no delay to Tcp based endpoints
                     if (acceptSocket.LocalEndPoint is IPEndPoint)

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -81,6 +81,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         public Func<EndPoint, Socket> CreateBoundListenSocket { get; set; } = CreateDefaultBoundListenSocket;
 
         /// <summary>
+        /// A function used to accept a new <see cref="Socket"/> given a listening <see cref="Socket"/>.
+        /// </summary>
+        /// <remarks>
+        /// The listening <see cref="Socket"/> passed is the one created by a previous call to <see cref="CreateBoundListenSocket"/>.
+        ///
+        /// This property defaults to <see cref="DefaultAcceptSocketAsync"/>.
+        /// </remarks>
+        public Func<Socket, CancellationToken, ValueTask<Socket>> AcceptSocketAsync { get; set; } = DefaultAcceptSocketAsync;
+
+        /// <summary>
+        /// Accepts a new <see cref="Socket"/> from a listen <see cref="Socket"/> previously obtained from <see cref="CreateBoundListenSocket"/>.
+        /// </summary>
+        /// <param name="listenSocket">A listening <see cref="Socket"/>.</param>
+        /// <param name="cancellationToken">Indicates if the accept operation should be aborted.</param>
+        /// <returns>A newly accepted <see cref="Socket"/>.</returns>
+        public static ValueTask<Socket> DefaultAcceptSocketAsync(Socket listenSocket, CancellationToken cancellationToken)
+        => listenSocket.AcceptAsync(cancellationToken);
+
+        /// <summary>
         /// Creates a default instance of <see cref="Socket"/> for the given <see cref="EndPoint"/>
         /// that can be used by a connection listener to listen for inbound requests. <see cref="Socket.Bind"/>
         /// is called by this method.


### PR DESCRIPTION
**Add AcceptSocketAsync to SocketTransportOptions**

Introduces a new option on `SocketTransportOptions` that allows customizing what happens between wanting to accept a new connection, and actually wrapping it up in a `SocketConnection`.

The motivating use case for this is to conditionally shove certain sockets to different processes based on peeking at the first packet or two.

Addresses #34344