### PR TITLE
Use preview langversion and ignore duplicate using warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="eng\Common.props" />
 
   <PropertyGroup>
@@ -111,6 +111,7 @@
   <PropertyGroup>
     <!-- Ensure API docs are available. -->
     <NoWarn>$(NoWarn.Replace('1591', ''))</NoWarn>
+    <NoWarn>$(NoWarn);0105</NoWarn>
 
     <!-- For local builds, don't make missing XML docs a fatal build error, but still surface so we have visibility into undocumented APIs. -->
     <WarningsNotAsErrors Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -111,7 +111,7 @@
   <PropertyGroup>
     <!-- Ensure API docs are available. -->
     <NoWarn>$(NoWarn.Replace('1591', ''))</NoWarn>
-    <NoWarn>$(NoWarn);0105</NoWarn>
+    <NoWarn Condition=" '$(BuildingInsideVisualStudio)' == 'true' ">$(NoWarn);0105</NoWarn>
 
     <!-- For local builds, don't make missing XML docs a fatal build error, but still surface so we have visibility into undocumented APIs. -->
     <WarningsNotAsErrors Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>

--- a/eng/targets/CSharp.Common.props
+++ b/eng/targets/CSharp.Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>preview</LangVersion>
 
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>


### PR DESCRIPTION
Fixes #34292 this enables us to build in VS 2019 again. Otherwise 2022 is required.

Replaces #34324