### PR TITLE
HTTP/3: Headers only response is completed with headers

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -305,11 +305,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     return;
                 }
 
-                if (appCompleted && !_startedWritingDataFrames && (_stream.ResponseTrailers == null || _stream.ResponseTrailers.Count == 0))
-                {
-                    // TODO figure out something to do here.
-                }
-
                 _frameWriter.WriteResponseHeaders(statusCode, responseHeaders);
             }
         }
@@ -362,9 +357,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                         }
 
                         // Headers have already been written and there is no other content to write
-                        // TODO complete something here.
-                        flushResult = await _frameWriter.FlushAsync(outputAborter: null, cancellationToken: default);
+
+                        // Need to complete framewriter immediately as CompleteAsync could be called
+                        // in the app delegate and we don't want to wait for the app delegate to
+                        // finish before sending response.
                         await _frameWriter.CompleteAsync();
+                        flushResult = default;
                     }
                     else
                     {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2844,5 +2844,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await requestStream.ExpectReceiveEndOfStream();
         }
+
+        [Fact]
+        public async Task HEADERS_NoResponseBody_RequestEndsOnHeaders()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+
+            var requestStream = await InitializeConnectionAndStreamsAsync(c =>
+            {
+                return Task.CompletedTask;
+            });
+
+            await requestStream.SendHeadersAsync(headers);
+
+            var responseHeaders = await requestStream.ExpectHeadersAsync(expectEnd: true);
+            Assert.Equal("200", responseHeaders[HeaderNames.Status]);
+        }
     }
 }


### PR DESCRIPTION
Test with an in-memory functional test.

btw I'm not sure if System.Net.Quic.QuicStream is capable of reporting that it has read data and completed in one operation. Created this issue for networking team: https://github.com/dotnet/runtime/issues/55707