### PR TITLE
Fix AllowRenegotiation naming in ClientCertificateMethod enum

### DIFF
--- a/src/Servers/HttpSys/src/ClientCertificateMethod.cs
+++ b/src/Servers/HttpSys/src/ClientCertificateMethod.cs
@@ -21,6 +21,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// <summary>
         /// The TLS session can be renegotiated to request a client certificate.
         /// </summary>
-        AllowRenegotation
+        AllowRenegotiation
     }
 }

--- a/src/Servers/HttpSys/src/PublicAPI.Shipped.txt
+++ b/src/Servers/HttpSys/src/PublicAPI.Shipped.txt
@@ -15,7 +15,7 @@ Microsoft.AspNetCore.Server.HttpSys.AuthenticationSchemes.Negotiate = 8 -> Micro
 Microsoft.AspNetCore.Server.HttpSys.AuthenticationSchemes.None = 0 -> Microsoft.AspNetCore.Server.HttpSys.AuthenticationSchemes
 Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod
 Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod.AllowCertificate = 1 -> Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod
-Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod.AllowRenegotation = 2 -> Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod
+Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod.AllowRenegotiation = 2 -> Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod
 Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod.NoCertificate = 0 -> Microsoft.AspNetCore.Server.HttpSys.ClientCertificateMethod
 Microsoft.AspNetCore.Server.HttpSys.DelegationRule
 Microsoft.AspNetCore.Server.HttpSys.DelegationRule.Dispose() -> void

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -346,7 +346,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             var tlsFeature = (ITlsConnectionFeature)this;
             var clientCert = tlsFeature.ClientCertificate; // Lazy initialized
             if (clientCert != null
-                || Server.Options.ClientCertificateMethod != ClientCertificateMethod.AllowRenegotation
+                || Server.Options.ClientCertificateMethod != ClientCertificateMethod.AllowRenegotiation
                 // Delayed client cert negotiation is not allowed on HTTP/2.
                 || Request.ProtocolVersion >= HttpVersion.Version20)
             {

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 Assert.NotNull(tls);
                 Assert.Null(tls.ClientCertificate);
                 var cert = await tls.GetClientCertificateAsync(CancellationToken.None);
-                if (clientCertificateMethod == ClientCertificateMethod.AllowRenegotation)
+                if (clientCertificateMethod == ClientCertificateMethod.AllowRenegotiation)
                 {
                     Assert.NotNull(cert);
                     Assert.NotNull(tls.ClientCertificate);

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         [ConditionalTheory]
         [InlineData(ClientCertificateMethod.NoCertificate)]
         [InlineData(ClientCertificateMethod.AllowCertificate)]
-        [InlineData(ClientCertificateMethod.AllowRenegotation)]
+        [InlineData(ClientCertificateMethod.AllowRenegotiation)]
         public async Task Https_ClientCertNotSent_ClientCertNotPresent(ClientCertificateMethod clientCertificateMethod)
         {
             using (Utilities.CreateDynamicHttpsServer("", out var root, out var address, options =>
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         [ConditionalTheory]
         [InlineData(ClientCertificateMethod.NoCertificate)]
         [InlineData(ClientCertificateMethod.AllowCertificate)]
-        [InlineData(ClientCertificateMethod.AllowRenegotation)]
+        [InlineData(ClientCertificateMethod.AllowRenegotiation)]
         public async Task Https_ClientCertRequested_ClientCertPresent(ClientCertificateMethod clientCertificateMethod)
         {
             using (Utilities.CreateDynamicHttpsServer("", out var root, out var address, options =>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Fix AllowRenegotiation naming in ClientCertificateMethod enum


