### PR TITLE
Use Environment.TickCount64 instead of UtcNow in SignalR

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             ConnectionId = connectionId;
             ConnectionToken = connectionToken;
-            LastSeenTick = Environment.TickCount64;
+            LastSeenTicks = Environment.TickCount64;
             _options = options;
 
             // The default behavior is that both formats are supported.
@@ -121,15 +121,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         public Task? ApplicationTask { get; set; }
 
-        public long LastSeenTick { get; set; }
+        public long LastSeenTicks { get; set; }
 
-        public long? LastSeenTickIfInactive
+        public long? LastSeenTicksIfInactive
         {
             get
             {
                 lock (_stateLock)
                 {
-                    return Status == HttpConnectionStatus.Inactive ? LastSeenTick : null;
+                    return Status == HttpConnectionStatus.Inactive ? LastSeenTicks : null;
                 }
             }
         }
@@ -543,7 +543,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 if (Status == HttpConnectionStatus.Active)
                 {
                     Status = HttpConnectionStatus.Inactive;
-                    LastSeenTick = Environment.TickCount64;
+                    LastSeenTicks = Environment.TickCount64;
                 }
             }
         }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             ConnectionId = connectionId;
             ConnectionToken = connectionToken;
-            LastSeenUtc = DateTime.UtcNow;
+            LastSeenTick = Environment.TickCount64;
             _options = options;
 
             // The default behavior is that both formats are supported.
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             _connectionCloseRequested = new CancellationTokenSource();
             ConnectionClosedRequested = _connectionCloseRequested.Token;
-            AuthenticationExpiration = DateTimeOffset.MaxValue;
+            AuthenticationExpirationTick = long.MaxValue;
         }
 
         public CancellationTokenSource? Cancellation { get; set; }
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         // Used for LongPolling because we need to create a scope that spans the lifetime of multiple requests on the cloned HttpContext
         internal AsyncServiceScope? ServiceScope { get; set; }
 
-        internal DateTimeOffset AuthenticationExpiration { get; set; }
+        internal long AuthenticationExpirationTick { get; set; }
 
         internal bool IsAuthenticationExpirationEnabled => _options.CloseOnAuthenticationExpiration;
 
@@ -121,15 +121,15 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         public Task? ApplicationTask { get; set; }
 
-        public DateTime LastSeenUtc { get; set; }
+        public long LastSeenTick { get; set; }
 
-        public DateTime? LastSeenUtcIfInactive
+        public long? LastSeenTickIfInactive
         {
             get
             {
                 lock (_stateLock)
                 {
-                    return Status == HttpConnectionStatus.Inactive ? (DateTime?)LastSeenUtc : null;
+                    return Status == HttpConnectionStatus.Inactive ? LastSeenTick : null;
                 }
             }
         }
@@ -543,7 +543,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 if (Status == HttpConnectionStatus.Active)
                 {
                     Status = HttpConnectionStatus.Inactive;
-                    LastSeenUtc = DateTime.UtcNow;
+                    LastSeenTick = Environment.TickCount64;
                 }
             }
         }
@@ -575,7 +575,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                     _sendCts = new CancellationTokenSource();
                     SendingToken = _sendCts.Token;
                 }
-                _startedSendTime = DateTime.UtcNow.Ticks;
+                _startedSendTime = Environment.TickCount64;
                 _activeSend = true;
             }
         }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             _connectionCloseRequested = new CancellationTokenSource();
             ConnectionClosedRequested = _connectionCloseRequested.Token;
-            AuthenticationExpirationTick = long.MaxValue;
+            AuthenticationExpiration = DateTimeOffset.MaxValue;
         }
 
         public CancellationTokenSource? Cancellation { get; set; }
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         // Used for LongPolling because we need to create a scope that spans the lifetime of multiple requests on the cloned HttpContext
         internal AsyncServiceScope? ServiceScope { get; set; }
 
-        internal long AuthenticationExpirationTick { get; set; }
+        internal DateTimeOffset AuthenticationExpiration { get; set; }
 
         internal bool IsAuthenticationExpirationEnabled => _options.CloseOnAuthenticationExpiration;
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -583,10 +583,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             if (authenticateResultFeature is not null)
             {
-                // get the future Environment.TickCount64 value of when auth expires
-                var expiresTime = (authenticateResultFeature.AuthenticateResult?.Properties?.ExpiresUtc ?? DateTimeOffset.MaxValue);
-                var expiresTick = (long)(expiresTime - DateTimeOffset.UtcNow).TotalMilliseconds + Environment.TickCount64;
-                connection.AuthenticationExpirationTick = expiresTick;
+                connection.AuthenticationExpiration =
+                    authenticateResultFeature.AuthenticateResult?.Properties?.ExpiresUtc ?? DateTimeOffset.MaxValue;
             }
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -583,8 +583,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
             if (authenticateResultFeature is not null)
             {
-                connection.AuthenticationExpiration =
-                    authenticateResultFeature.AuthenticateResult?.Properties?.ExpiresUtc ?? DateTimeOffset.MaxValue;
+                // get the future Environment.TickCount64 value of when auth expires
+                var expiresTime = (authenticateResultFeature.AuthenticateResult?.Properties?.ExpiresUtc ?? DateTimeOffset.MaxValue);
+                var expiresTick = (long)(expiresTime - DateTimeOffset.UtcNow).TotalMilliseconds + Environment.TickCount64;
+                connection.AuthenticationExpirationTick = expiresTick;
             }
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -133,6 +133,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
         public void Scan()
         {
+            var now = DateTimeOffset.UtcNow;
+
             // Scan the registered connections looking for ones that have timed out
             foreach (var c in _connections)
             {
@@ -163,7 +165,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                     // Tick the heartbeat, if the connection is still active
                     connection.TickHeartbeat();
 
-                    if (connection.IsAuthenticationExpirationEnabled && connection.AuthenticationExpirationTick < ticks &&
+                    if (connection.IsAuthenticationExpirationEnabled && connection.AuthenticationExpiration < now &&
                         !connection.ConnectionClosedRequested.IsCancellationRequested)
                     {
                         Log.AuthenticationExpired(_logger, connection.ConnectionId);

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -134,6 +134,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
         public void Scan()
         {
             var now = DateTimeOffset.UtcNow;
+            var ticks = Environment.TickCount64;
 
             // Scan the registered connections looking for ones that have timed out
             foreach (var c in _connections)
@@ -142,7 +143,6 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 // Capture the connection state
                 var lastSeenTick = connection.LastSeenTicksIfInactive;
 
-                var ticks = Environment.TickCount64;
                 // Once the decision has been made to dispose we don't check the status again
                 // But don't clean up connections while the debugger is attached.
                 if (!Debugger.IsAttached && lastSeenTick.HasValue && (ticks - lastSeenTick.Value) > _disconnectTimeoutTicks)

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
             {
                 var connection = c.Value.Connection;
                 // Capture the connection state
-                var lastSeenTick = connection.LastSeenTickIfInactive;
+                var lastSeenTick = connection.LastSeenTicksIfInactive;
 
                 var ticks = Environment.TickCount64;
                 // Once the decision has been made to dispose we don't check the status again

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -551,7 +551,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                     await task.DefaultTimeout();
 
                     // We've been gone longer than the expiration time
-                    connection.LastSeenTick = Environment.TickCount64 - (long)disconnectTimeout.TotalMilliseconds - 1;
+                    connection.LastSeenTicks = Environment.TickCount64 - (long)disconnectTimeout.TotalMilliseconds - 1;
 
                     // The application is still running here because the poll is only killed
                     // by the heartbeat so we pretend to do a scan and this should force the application task to complete

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -2697,7 +2697,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 pollTask = dispatcher.ExecuteAsync(context, options, app);
 
                 // Set auth to an expired time
-                connection.AuthenticationExpirationTick = Environment.TickCount64 - 1;
+                connection.AuthenticationExpiration = DateTimeOffset.Now.AddSeconds(-1);
 
                 manager.Scan();
 
@@ -2801,8 +2801,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
             Assert.True(manager.TryGetConnection(negotiateResponse.ConnectionToken, out var context));
 
-            Assert.True(context.AuthenticationExpirationTick > Environment.TickCount64);
-            Assert.True(context.AuthenticationExpirationTick < long.MaxValue);
+            Assert.True(context.AuthenticationExpiration > DateTimeOffset.UtcNow);
+            Assert.True(context.AuthenticationExpiration < DateTimeOffset.MaxValue);
 
             await connection.DisposeAsync();
         }
@@ -2863,8 +2863,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
             Assert.True(manager.TryGetConnection(negotiateResponse.ConnectionToken, out var context));
 
-            Assert.True(context.AuthenticationExpirationTick > Environment.TickCount64);
-            Assert.True(context.AuthenticationExpirationTick < long.MaxValue);
+            Assert.True(context.AuthenticationExpiration > DateTimeOffset.UtcNow);
+            Assert.True(context.AuthenticationExpiration < DateTimeOffset.MaxValue);
 
             await connection.DisposeAsync();
         }
@@ -2963,8 +2963,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
             Assert.True(manager.TryGetConnection(negotiateResponse.ConnectionToken, out var context));
 
-            Assert.True(context.AuthenticationExpirationTick > Environment.TickCount64);
-            Assert.True(context.AuthenticationExpirationTick < long.MaxValue);
+            Assert.True(context.AuthenticationExpiration > DateTimeOffset.UtcNow);
+            Assert.True(context.AuthenticationExpiration < DateTimeOffset.MaxValue);
 
             await connection.DisposeAsync();
         }
@@ -3002,7 +3002,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
 
             Assert.True(manager.TryGetConnection(negotiateResponse.ConnectionToken, out var context));
 
-            Assert.Equal(long.MaxValue, context.AuthenticationExpirationTick);
+            Assert.Equal(DateTimeOffset.MaxValue, context.AuthenticationExpiration);
 
             await connection.DisposeAsync();
         }

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 Assert.Null(connection.ApplicationTask);
                 Assert.Null(connection.TransportTask);
                 Assert.Null(connection.Cancellation);
-                Assert.NotEqual(default, connection.LastSeenTick);
+                Assert.NotEqual(default, connection.LastSeenTicks);
                 Assert.NotNull(connection.Transport);
                 Assert.NotNull(connection.Application);
             }

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 Assert.Null(connection.ApplicationTask);
                 Assert.Null(connection.TransportTask);
                 Assert.Null(connection.Cancellation);
-                Assert.NotEqual(default, connection.LastSeenUtc);
+                Assert.NotEqual(default, connection.LastSeenTick);
                 Assert.NotNull(connection.Transport);
                 Assert.NotNull(connection.Application);
             }

--- a/src/SignalR/common/Shared/ISystemClock.cs
+++ b/src/SignalR/common/Shared/ISystemClock.cs
@@ -1,26 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.AspNetCore.Internal
 {
     internal interface ISystemClock
     {
         /// <summary>
-        /// Retrieves the current UTC system time.
+        /// Retrieves ticks for the current system up time.
         /// </summary>
-        DateTimeOffset UtcNow { get; }
-
-        /// <summary>
-        /// Retrieves ticks for the current UTC system time.
-        /// </summary>
-        long UtcNowTicks { get; }
-
-        /// <summary>
-        /// Retrieves the current UTC system time.
-        /// This is only safe to use from code called by the Heartbeat.
-        /// </summary>
-        DateTimeOffset UtcNowUnsynchronized { get; }
+        long CurrentTick { get; }
     }
 }

--- a/src/SignalR/common/Shared/ISystemClock.cs
+++ b/src/SignalR/common/Shared/ISystemClock.cs
@@ -8,6 +8,6 @@ namespace Microsoft.AspNetCore.Internal
         /// <summary>
         /// Retrieves ticks for the current system up time.
         /// </summary>
-        long CurrentTick { get; }
+        long CurrentTicks { get; }
     }
 }

--- a/src/SignalR/common/Shared/SystemClock.cs
+++ b/src/SignalR/common/Shared/SystemClock.cs
@@ -9,6 +9,6 @@ namespace Microsoft.AspNetCore.Internal
     internal class SystemClock : ISystemClock
     {
         /// <inheritdoc />
-        public long CurrentTick => Environment.TickCount64;
+        public long CurrentTicks => Environment.TickCount64;
     }
 }

--- a/src/SignalR/common/Shared/SystemClock.cs
+++ b/src/SignalR/common/Shared/SystemClock.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.AspNetCore.Internal
 {
     /// <summary>
@@ -10,19 +8,7 @@ namespace Microsoft.AspNetCore.Internal
     /// </summary>
     internal class SystemClock : ISystemClock
     {
-        /// <summary>
-        /// Retrieves the current UTC system time.
-        /// </summary>
-        public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
-
-        /// <summary>
-        /// Retrieves ticks for the current UTC system time.
-        /// </summary>
-        public long UtcNowTicks => DateTimeOffset.UtcNow.Ticks;
-
-        /// <summary>
-        /// Retrieves the current UTC system time.
-        /// </summary>
-        public DateTimeOffset UtcNowUnsynchronized => DateTimeOffset.UtcNow;
+        /// <inheritdoc />
+        public long CurrentTick => Environment.TickCount64;
     }
 }

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.SignalR
         private readonly CancellationTokenRegistration? _closedRequestedRegistration;
 
         private StreamTracker? _streamTracker;
-        private long _lastSendTimeStamp;
+        private long _lastSendTick;
         private ReadOnlyMemory<byte> _cachedPingMessage;
         private bool _clientTimeoutActive;
         private volatile bool _connectionAborted;
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.SignalR
         private readonly long? _maxMessageSize;
         private bool _receivedMessageTimeoutEnabled;
         private long _receivedMessageElapsedTicks;
-        private long _receivedMessageTimestamp;
+        private long _receivedMessageTick;
         private ClaimsPrincipal? _user;
 
         /// <summary>
@@ -62,8 +62,8 @@ namespace Microsoft.AspNetCore.SignalR
         /// <param name="contextOptions">The options to configure the HubConnectionContext.</param>
         public HubConnectionContext(ConnectionContext connectionContext, HubConnectionContextOptions contextOptions, ILoggerFactory loggerFactory)
         {
-            _keepAliveInterval = contextOptions.KeepAliveInterval.Ticks;
-            _clientTimeoutInterval = contextOptions.ClientTimeoutInterval.Ticks;
+            _keepAliveInterval = (long)contextOptions.KeepAliveInterval.TotalMilliseconds;
+            _clientTimeoutInterval = (long)contextOptions.ClientTimeoutInterval.TotalMilliseconds;
             _streamBufferCapacity = contextOptions.StreamBufferCapacity;
             _maxMessageSize = contextOptions.MaximumReceiveMessageSize;
 
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.SignalR
             HubCallerContext = new DefaultHubCallerContext(this);
 
             _systemClock = contextOptions.SystemClock ?? new SystemClock();
-            _lastSendTimeStamp = _systemClock.UtcNowTicks;
+            _lastSendTick = _systemClock.CurrentTick;
 
             // We'll be avoiding using the semaphore when the limit is set to 1, so no need to allocate it
             var maxInvokeLimit = contextOptions.MaximumParallelInvocations;
@@ -623,7 +623,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         private void KeepAliveTick()
         {
-            var currentTime = _systemClock.UtcNowTicks;
+            var currentTime = _systemClock.CurrentTick;
 
             // Implements the keep-alive tick behavior
             // Each tick, we check if the time since the last send is larger than the keep alive duration (in ticks).
@@ -631,7 +631,7 @@ namespace Microsoft.AspNetCore.SignalR
             // true "ping rate" of the server could be (_hubOptions.KeepAliveInterval + HubEndPoint.KeepAliveTimerInterval),
             // because if the interval elapses right after the last tick of this timer, it won't be detected until the next tick.
 
-            if (currentTime - Volatile.Read(ref _lastSendTimeStamp) > _keepAliveInterval)
+            if (currentTime - Volatile.Read(ref _lastSendTick) > _keepAliveInterval)
             {
                 // Haven't sent a message for the entire keep-alive duration, so send a ping.
                 // If the transport channel is full, this will fail, but that's OK because
@@ -641,7 +641,7 @@ namespace Microsoft.AspNetCore.SignalR
 
                 // We only update the timestamp here, because updating on each sent message is bad for performance
                 // There can be a lot of sent messages per 15 seconds
-                Volatile.Write(ref _lastSendTimeStamp, currentTime);
+                Volatile.Write(ref _lastSendTick, currentTime);
             }
         }
 
@@ -666,7 +666,7 @@ namespace Microsoft.AspNetCore.SignalR
             {
                 if (_receivedMessageTimeoutEnabled)
                 {
-                    _receivedMessageElapsedTicks = _systemClock.UtcNowTicks - _receivedMessageTimestamp;
+                    _receivedMessageElapsedTicks = _systemClock.CurrentTick - _receivedMessageTick;
 
                     if (_receivedMessageElapsedTicks >= _clientTimeoutInterval)
                     {
@@ -716,7 +716,7 @@ namespace Microsoft.AspNetCore.SignalR
             lock (_receiveMessageTimeoutLock)
             {
                 _receivedMessageTimeoutEnabled = true;
-                _receivedMessageTimestamp = _systemClock.UtcNowTicks;
+                _receivedMessageTick = _systemClock.CurrentTick;
             }
         }
 
@@ -727,7 +727,7 @@ namespace Microsoft.AspNetCore.SignalR
                 // we received a message so stop the timer and reset it
                 // it will resume after the message has been processed
                 _receivedMessageElapsedTicks = 0;
-                _receivedMessageTimestamp = 0;
+                _receivedMessageTick = 0;
                 _receivedMessageTimeoutEnabled = false;
             }
         }

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.SignalR
             HubCallerContext = new DefaultHubCallerContext(this);
 
             _systemClock = contextOptions.SystemClock ?? new SystemClock();
-            _lastSendTick = _systemClock.CurrentTick;
+            _lastSendTick = _systemClock.CurrentTicks;
 
             // We'll be avoiding using the semaphore when the limit is set to 1, so no need to allocate it
             var maxInvokeLimit = contextOptions.MaximumParallelInvocations;
@@ -623,7 +623,7 @@ namespace Microsoft.AspNetCore.SignalR
 
         private void KeepAliveTick()
         {
-            var currentTime = _systemClock.CurrentTick;
+            var currentTime = _systemClock.CurrentTicks;
 
             // Implements the keep-alive tick behavior
             // Each tick, we check if the time since the last send is larger than the keep alive duration (in ticks).
@@ -666,7 +666,7 @@ namespace Microsoft.AspNetCore.SignalR
             {
                 if (_receivedMessageTimeoutEnabled)
                 {
-                    _receivedMessageElapsedTicks = _systemClock.CurrentTick - _receivedMessageTick;
+                    _receivedMessageElapsedTicks = _systemClock.CurrentTicks - _receivedMessageTick;
 
                     if (_receivedMessageElapsedTicks >= _clientTimeoutInterval)
                     {
@@ -716,7 +716,7 @@ namespace Microsoft.AspNetCore.SignalR
             lock (_receiveMessageTimeoutLock)
             {
                 _receivedMessageTimeoutEnabled = true;
-                _receivedMessageTick = _systemClock.CurrentTick;
+                _receivedMessageTick = _systemClock.CurrentTicks;
             }
         }
 

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             // Use a random DateTimeOffset to ensure tests that incorrectly use the current DateTimeOffset fail always instead of only rarely.
             // Pick a date between the min DateTimeOffset and a day before the max DateTimeOffset so there's room to advance the clock.
-            _nowTicks = NextLong(0, long.MaxValue - TimeSpan.FromDays(1).TotalMilliseconds);
+            _nowTicks = NextLong(0, long.MaxValue - (long)TimeSpan.FromDays(1).TotalMilliseconds);
         }
 
         public long CurrentTicks

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
@@ -1,41 +1,29 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
 using Microsoft.AspNetCore.Internal;
 
 namespace Microsoft.AspNetCore.SignalR.Tests
 {
     public class MockSystemClock : ISystemClock
     {
-        private long _utcNowTicks;
+        private long _nowTicks;
 
         public MockSystemClock()
         {
             // Use a random DateTimeOffset to ensure tests that incorrectly use the current DateTimeOffset fail always instead of only rarely.
             // Pick a date between the min DateTimeOffset and a day before the max DateTimeOffset so there's room to advance the clock.
-            _utcNowTicks = NextLong(DateTimeOffset.MinValue.Ticks, DateTimeOffset.MaxValue.Ticks - TimeSpan.FromDays(1).Ticks);
+            _nowTicks = NextLong(DateTimeOffset.MinValue.Ticks, DateTimeOffset.MaxValue.Ticks - TimeSpan.FromDays(1).Ticks);
         }
 
-        public DateTimeOffset UtcNow
+        public long CurrentTick
         {
-            get
-            {
-                UtcNowCalled++;
-                return new DateTimeOffset(Interlocked.Read(ref _utcNowTicks), TimeSpan.Zero);
-            }
+            get => _nowTicks;
             set
             {
-                Interlocked.Exchange(ref _utcNowTicks, value.Ticks);
+                Interlocked.Exchange(ref _nowTicks, value);
             }
         }
-
-        public long UtcNowTicks => UtcNow.Ticks;
-
-        public DateTimeOffset UtcNowUnsynchronized => UtcNow;
-
-        public int UtcNowCalled { get; private set; }
 
         private long NextLong(long minValue, long maxValue)
         {

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             _nowTicks = NextLong(DateTimeOffset.MinValue.Ticks, DateTimeOffset.MaxValue.Ticks - TimeSpan.FromDays(1).Ticks);
         }
 
-        public long CurrentTick
+        public long CurrentTicks
         {
             get => _nowTicks;
             set

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/MockSystemClock.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             // Use a random DateTimeOffset to ensure tests that incorrectly use the current DateTimeOffset fail always instead of only rarely.
             // Pick a date between the min DateTimeOffset and a day before the max DateTimeOffset so there's room to advance the clock.
-            _nowTicks = NextLong(DateTimeOffset.MinValue.Ticks, DateTimeOffset.MaxValue.Ticks - TimeSpan.FromDays(1).Ticks);
+            _nowTicks = NextLong(0, long.MaxValue - TimeSpan.FromDays(1).TotalMilliseconds);
         }
 
         public long CurrentTicks

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -2746,7 +2746,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     var heartbeatCount = 5;
                     for (var i = 0; i < heartbeatCount; i++)
                     {
-                        clock.CurrentTick = clock.CurrentTick + intervalInMS + 1;
+                        clock.CurrentTicks = clock.CurrentTicks + intervalInMS + 1;
                         client.TickHeartbeat();
                     }
 
@@ -2808,7 +2808,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     // We go over the 100 ms timeout interval multiple times
                     for (var i = 0; i < 3; i++)
                     {
-                        clock.CurrentTick = clock.CurrentTick + timeoutInMS + 1;
+                        clock.CurrentTicks = clock.CurrentTicks + timeoutInMS + 1;
                         client.TickHeartbeat();
                     }
 
@@ -2841,7 +2841,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     await client.Connected.DefaultTimeout();
                     await client.SendHubMessageAsync(PingMessage.Instance);
 
-                    clock.CurrentTick = clock.CurrentTick + timeoutInMS + 1;
+                    clock.CurrentTicks = clock.CurrentTicks + timeoutInMS + 1;
                     client.TickHeartbeat();
 
                     await connectionHandlerTask.DefaultTimeout();
@@ -2870,7 +2870,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                     for (int i = 0; i < 10; i++)
                     {
-                        clock.CurrentTick = clock.CurrentTick + timeoutInMS - 1;
+                        clock.CurrentTicks = clock.CurrentTicks + timeoutInMS - 1;
                         client.TickHeartbeat();
                         await client.SendHubMessageAsync(PingMessage.Instance);
                     }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -2729,11 +2729,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             using (StartVerifiableLog())
             {
-                var interval = 100;
+                var intervalInMS = 100;
                 var clock = new MockSystemClock();
                 var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
                     services.Configure<HubOptions>(options =>
-                        options.KeepAliveInterval = TimeSpan.FromMilliseconds(interval)), LoggerFactory);
+                        options.KeepAliveInterval = TimeSpan.FromMilliseconds(intervalInMS)), LoggerFactory);
                 var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
                 connectionHandler.SystemClock = clock;
 
@@ -2746,7 +2746,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     var heartbeatCount = 5;
                     for (var i = 0; i < heartbeatCount; i++)
                     {
-                        clock.UtcNow = clock.UtcNow.AddMilliseconds(interval + 1);
+                        clock.CurrentTick = clock.CurrentTick + intervalInMS + 1;
                         client.TickHeartbeat();
                     }
 
@@ -2791,11 +2791,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             using (StartVerifiableLog())
             {
-                var timeout = 100;
+                var timeoutInMS = 100;
                 var clock = new MockSystemClock();
                 var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
                     services.Configure<HubOptions>(options =>
-                        options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(timeout)), LoggerFactory);
+                        options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(timeoutInMS)), LoggerFactory);
                 var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
                 connectionHandler.SystemClock = clock;
 
@@ -2808,7 +2808,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     // We go over the 100 ms timeout interval multiple times
                     for (var i = 0; i < 3; i++)
                     {
-                        clock.UtcNow = clock.UtcNow.AddMilliseconds(timeout + 1);
+                        clock.CurrentTick = clock.CurrentTick + timeoutInMS + 1;
                         client.TickHeartbeat();
                     }
 
@@ -2827,11 +2827,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             using (StartVerifiableLog())
             {
-                var timeout = 100;
+                var timeoutInMS = 100;
                 var clock = new MockSystemClock();
                 var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
                     services.Configure<HubOptions>(options =>
-                        options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(timeout)), LoggerFactory);
+                        options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(timeoutInMS)), LoggerFactory);
                 var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
                 connectionHandler.SystemClock = clock;
 
@@ -2841,7 +2841,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                     await client.Connected.DefaultTimeout();
                     await client.SendHubMessageAsync(PingMessage.Instance);
 
-                    clock.UtcNow = clock.UtcNow.AddMilliseconds(timeout + 1);
+                    clock.CurrentTick = clock.CurrentTick + timeoutInMS + 1;
                     client.TickHeartbeat();
 
                     await connectionHandlerTask.DefaultTimeout();
@@ -2854,11 +2854,11 @@ namespace Microsoft.AspNetCore.SignalR.Tests
         {
             using (StartVerifiableLog())
             {
-                var timeout = 300;
+                var timeoutInMS = 300;
                 var clock = new MockSystemClock();
                 var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
                     services.Configure<HubOptions>(options =>
-                        options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(timeout)), LoggerFactory);
+                        options.ClientTimeoutInterval = TimeSpan.FromMilliseconds(timeoutInMS)), LoggerFactory);
                 var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
                 connectionHandler.SystemClock = clock;
 
@@ -2870,7 +2870,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
 
                     for (int i = 0; i < 10; i++)
                     {
-                        clock.UtcNow = clock.UtcNow.AddMilliseconds(timeout - 1);
+                        clock.CurrentTick = clock.CurrentTick + timeoutInMS - 1;
                         client.TickHeartbeat();
                         await client.SendHubMessageAsync(PingMessage.Instance);
                     }

--- a/src/SignalR/server/StackExchangeRedis/src/Internal/AckHandler.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/Internal/AckHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Internal
     {
         private readonly ConcurrentDictionary<int, AckInfo> _acks = new ConcurrentDictionary<int, AckInfo>();
         private readonly Timer _timer;
-        private readonly TimeSpan _ackThreshold = TimeSpan.FromSeconds(30);
+        private readonly long _ackThreshold = (long)TimeSpan.FromSeconds(30).TotalMilliseconds;
         private readonly TimeSpan _ackInterval = TimeSpan.FromSeconds(5);
         private readonly object _lock = new object();
         private bool _disposed;
@@ -51,11 +51,11 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Internal
                 return;
             }
 
-            var utcNow = DateTime.UtcNow;
+            var currentTick = Environment.TickCount64;
 
             foreach (var pair in _acks)
             {
-                var elapsed = utcNow - pair.Value.Created;
+                var elapsed = currentTick - pair.Value.CreatedTick;
                 if (elapsed > _ackThreshold)
                 {
                     if (_acks.TryRemove(pair.Key, out var ack))
@@ -87,11 +87,11 @@ namespace Microsoft.AspNetCore.SignalR.StackExchangeRedis.Internal
         private class AckInfo
         {
             public TaskCompletionSource Tcs { get; private set; }
-            public DateTime Created { get; private set; }
+            public long CreatedTick { get; private set; }
 
             public AckInfo()
             {
-                Created = DateTime.UtcNow;
+                CreatedTick = Environment.TickCount64;
                 Tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             }
         }


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/13628

Kestrel is proving to be more difficult than I thought it would, so not including it here.