### PR TITLE
Unquarantine passing tests

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -232,7 +232,6 @@ namespace Test
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/32193")]
         public void ComponentWithConstrainedTypeParameters()
         {
             // Arrange

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiscoveryIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiscoveryIntegrationTest.cs
@@ -84,7 +84,6 @@ namespace Test.AnotherNamespace
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/32592")]
         public void ComponentDiscovery_CanFindComponent_WithTypeParameter()
         {
             // Arrange


### PR DESCRIPTION
Tests were fixed in https://github.com/dotnet/aspnetcore/pull/33456 and have been passing since then.