### PR TITLE
Copy fix for ViewComponentTypeVisitor to other copies

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTypeVisitor.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTypeVisitor.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
@@ -71,11 +70,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
                 return false;
             }
 
-            var attribute = type.GetAttributes().Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, queryAttribute)).FirstOrDefault();
-
-            if (attribute != null)
+            foreach (var attribute in type.GetAttributes())
             {
-                return true;
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, queryAttribute))
+                {
+                    return true;
+                }
             }
 
             return AttributeIsDefined(type.BaseType, queryAttribute);

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTypeVisitor.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTypeVisitor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -76,11 +76,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 return false;
             }
 
-            var attribute = type.GetAttributes().Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, queryAttribute)).FirstOrDefault();
-
-            if (attribute != null)
+            foreach (var attribute in type.GetAttributes())
             {
-                return true;
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, queryAttribute))
+                {
+                    return true;
+                }
             }
 
             return AttributeIsDefined(type.BaseType, queryAttribute);


### PR DESCRIPTION
A fix for this was applied to the v2 version, but there's two additional copies.
Copying the fix from https://github.com/dotnet/aspnetcore/pull/30894 to more places

Fixes https://github.com/dotnet/aspnetcore/issues/34336

