### PR TITLE
Bump Roslyn version to match O# requirements

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -188,8 +188,8 @@
     <MicrosoftBuildUtilitiesCoreVersion>16.9.0</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildUtilitiesCoreVersion>16.9.0</MicrosoftBuildUtilitiesCoreVersion>
-    <MicrosoftCodeAnalysisCommonVersion>4.0.0-2.21354.7</MicrosoftCodeAnalysisCommonVersion>
-    <MicrosoftCodeAnalysisCSharpVersion>4.0.0-2.21354.7</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCommonVersion>4.0.0-2.21322.50</MicrosoftCodeAnalysisCommonVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.0.0-2.21322.50</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.8.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.0</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCssParserVersion>1.0.0-20200708.1</MicrosoftCssParserVersion>


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore-tooling/pull/3934 required updating the O# Roslyn dependency to a new version which required a version of Roslyn higher than what we have Razor pinned to at the moment. Updating here to unblock aspnetcore => aspnetcore-tooling flow.