### PR TITLE
HTTP/3: Add IStreamAbortFeature

### DIFF
--- a/src/Servers/Connections.Abstractions/src/BaseConnectionContext.cs
+++ b/src/Servers/Connections.Abstractions/src/BaseConnectionContext.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Connections
         /// <summary>
         /// Aborts the underlying connection.
         /// </summary>
-        /// <param name="abortReason">An optional <see cref="ConnectionAbortedException"/> describing the reason the connection is being terminated.</param>
+        /// <param name="abortReason">A <see cref="ConnectionAbortedException"/> describing the reason the connection is being terminated.</param>
         public abstract void Abort(ConnectionAbortedException abortReason);
 
         /// <summary>

--- a/src/Servers/Connections.Abstractions/src/ConnectionContext.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Connections
         /// <summary>
         /// Aborts the underlying connection.
         /// </summary>
-        /// <param name="abortReason">An optional <see cref="ConnectionAbortedException"/> describing the reason the connection is being terminated.</param>
+        /// <param name="abortReason">A <see cref="ConnectionAbortedException"/> describing the reason the connection is being terminated.</param>
         public override void Abort(ConnectionAbortedException abortReason)
         {
             // We expect this to be overridden, but this helps maintain back compat

--- a/src/Servers/Connections.Abstractions/src/Features/IStreamAbortFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IStreamAbortFeature.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.AspNetCore.Connections.Features
 {

--- a/src/Servers/Connections.Abstractions/src/Features/IStreamAbortFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IStreamAbortFeature.cs
@@ -12,14 +12,14 @@ namespace Microsoft.AspNetCore.Connections.Features
         /// Abort the read side of the connection stream.
         /// </summary>
         /// <param name="errorCode">The error code to send with the abort.</param>
-        /// <param name="abortReason">An optional <see cref="ConnectionAbortedException"/> describing the reason to abort the read side of the connection stream.</param>
+        /// <param name="abortReason">A <see cref="ConnectionAbortedException"/> describing the reason to abort the read side of the connection stream.</param>
         void AbortRead(long errorCode, ConnectionAbortedException abortReason);
 
         /// <summary>
         /// Abort the write side of the connection stream.
         /// </summary>
         /// <param name="errorCode">The error code to send with the abort.</param>
-        /// <param name="abortReason">An optional <see cref="ConnectionAbortedException"/> describing the reason to abort the write side of the connection stream.</param>
+        /// <param name="abortReason">A <see cref="ConnectionAbortedException"/> describing the reason to abort the write side of the connection stream.</param>
         void AbortWrite(long errorCode, ConnectionAbortedException abortReason);
     }
 }

--- a/src/Servers/Connections.Abstractions/src/Features/IStreamAbortFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IStreamAbortFeature.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Connections.Features
 {
     /// <summary>
-    /// Supports aborting one side of a connection stream.
+    /// Supports aborting individual sides of a connection stream.
     /// </summary>
     public interface IStreamAbortFeature
     {

--- a/src/Servers/Connections.Abstractions/src/Features/IStreamAbortFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IStreamAbortFeature.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Connections.Features
+{
+    /// <summary>
+    /// Supports aborting one side of a connection stream.
+    /// </summary>
+    public interface IStreamAbortFeature
+    {
+        /// <summary>
+        /// Abort the read side of the connection stream.
+        /// </summary>
+        /// <param name="errorCode">The error code to send with the abort.</param>
+        /// <param name="abortReason">An optional <see cref="ConnectionAbortedException"/> describing the reason to abort the read side of the connection stream.</param>
+        void AbortRead(long errorCode, ConnectionAbortedException abortReason);
+
+        /// <summary>
+        /// Abort the write side of the connection stream.
+        /// </summary>
+        /// <param name="errorCode">The error code to send with the abort.</param>
+        /// <param name="abortReason">An optional <see cref="ConnectionAbortedException"/> describing the reason to abort the write side of the connection stream.</param>
+        void AbortWrite(long errorCode, ConnectionAbortedException abortReason);
+    }
+}

--- a/src/Servers/Connections.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI.Unshipped.txt
@@ -4,6 +4,9 @@ Microsoft.AspNetCore.Connections.Features.IConnectionSocketFeature
 Microsoft.AspNetCore.Connections.Features.IConnectionSocketFeature.Socket.get -> System.Net.Sockets.Socket!
 Microsoft.AspNetCore.Connections.Features.IPersistentStateFeature
 Microsoft.AspNetCore.Connections.Features.IPersistentStateFeature.State.get -> System.Collections.Generic.IDictionary<object!, object?>!
+Microsoft.AspNetCore.Connections.Features.IStreamAbortFeature
+Microsoft.AspNetCore.Connections.Features.IStreamAbortFeature.AbortRead(long errorCode, Microsoft.AspNetCore.Connections.ConnectionAbortedException! abortReason) -> void
+Microsoft.AspNetCore.Connections.Features.IStreamAbortFeature.AbortWrite(long errorCode, Microsoft.AspNetCore.Connections.ConnectionAbortedException! abortReason) -> void
 Microsoft.AspNetCore.Connections.IConnectionListener.AcceptAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Connections.ConnectionContext?>
 Microsoft.AspNetCore.Connections.IMultiplexedConnectionBuilder
 Microsoft.AspNetCore.Connections.IMultiplexedConnectionBuilder.ApplicationServices.get -> System.IServiceProvider!

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -43,6 +43,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private Http3StreamContext _context = default!;
         private IProtocolErrorCodeFeature _errorCodeFeature = default!;
         private IStreamIdFeature _streamIdFeature = default!;
+        private IStreamAbortFeature _streamAbortFeature = default!;
         private int _isClosed;
         private readonly Http3RawFrame _incomingFrame = new Http3RawFrame();
         protected RequestHeaderParsingState _requestHeaderParsingState;
@@ -58,7 +59,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public bool EndStreamReceived => (_completionState & StreamCompletionFlags.EndStreamReceived) == StreamCompletionFlags.EndStreamReceived;
         private bool IsAborted => (_completionState & StreamCompletionFlags.Aborted) == StreamCompletionFlags.Aborted;
-        internal bool RstStreamReceived => (_completionState & StreamCompletionFlags.RstStreamReceived) == StreamCompletionFlags.RstStreamReceived;
 
         public Pipe RequestBodyPipe { get; private set; } = default!;
 
@@ -87,6 +87,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             _errorCodeFeature = _context.ConnectionFeatures.Get<IProtocolErrorCodeFeature>()!;
             _streamIdFeature = _context.ConnectionFeatures.Get<IStreamIdFeature>()!;
+            _streamAbortFeature = _context.ConnectionFeatures.Get<IStreamAbortFeature>()!;
 
             _appCompleted = null;
             _isClosed = 0;
@@ -371,7 +372,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     Log.RequestBodyNotEntirelyRead(ConnectionIdFeature, TraceIdentifier);
                 }
 
-                var (oldState, newState) = ApplyCompletionFlag(StreamCompletionFlags.Aborted);
+                var (oldState, newState) = ApplyCompletionFlag(StreamCompletionFlags.AbortedRead);
                 if (oldState != newState)
                 {
                     // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1-15
@@ -379,10 +380,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     // the request stream, send a complete response, and cleanly close the sending part of the stream.
                     // The error code H3_NO_ERROR SHOULD be used when requesting that the client stop sending on the
                     // request stream.
-
-                    // TODO(JamesNK): Abort the read half of the stream with H3_NO_ERROR
-                    // https://github.com/dotnet/aspnetcore/issues/33575
-
+                    _streamAbortFeature.AbortRead((long)Http3ErrorCode.NoError, new ConnectionAbortedException("The application completed without reading the entire request body."));
                     RequestBodyPipe.Writer.Complete();
                 }
 
@@ -940,8 +938,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private enum StreamCompletionFlags
         {
             None = 0,
-            RstStreamReceived = 1,
-            EndStreamReceived = 2,
+            EndStreamReceived = 1,
+            AbortedRead = 2,
             Aborted = 4,
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
@@ -21,5 +21,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         void StreamShutdownWrite(QuicStreamContext streamContext, string reason);
         void StreamAborted(QuicStreamContext streamContext, Exception ex);
         void StreamAbort(QuicStreamContext streamContext, string reason);
+        void StreamAbortRead(QuicStreamContext streamContext, string reason);
+        void StreamAbortWrite(QuicStreamContext streamContext, string reason);
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Connections.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 {
-    internal sealed partial class QuicStreamContext : IPersistentStateFeature, IStreamDirectionFeature, IProtocolErrorCodeFeature, IStreamIdFeature
+    internal sealed partial class QuicStreamContext : IPersistentStateFeature, IStreamDirectionFeature, IProtocolErrorCodeFeature, IStreamIdFeature, IStreamAbortFeature
     {
         private IDictionary<object, object?>? _persistentState;
 
@@ -27,12 +27,47 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
+        public void AbortRead(long errorCode, ConnectionAbortedException abortReason)
+        {
+            lock (_shutdownLock)
+            {
+                if (_stream.CanRead)
+                {
+                    _shutdownReadReason = abortReason;
+                    _log.StreamAbortRead(this, abortReason.Message);
+                    _stream.AbortRead(errorCode);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unable to abort reading from a stream that doesn't support reading.");
+                }
+            }
+        }
+
+        public void AbortWrite(long errorCode, ConnectionAbortedException abortReason)
+        {
+            lock (_shutdownLock)
+            {
+                if (_stream.CanWrite)
+                {
+                    _shutdownWriteReason = abortReason;
+                    _log.StreamAbortWrite(this, abortReason.Message);
+                    _stream.AbortWrite(errorCode);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unable to abort writing to a stream that doesn't support writing.");
+                }
+            }
+        }
+
         private void InitializeFeatures()
         {
             _currentIPersistentStateFeature = this;
             _currentIStreamDirectionFeature = this;
             _currentIProtocolErrorCodeFeature = this;
             _currentIStreamIdFeature = this;
+            _currentIStreamAbortFeature = this;
             _currentITlsConnectionFeature = _connection._currentITlsConnectionFeature;
         }
     }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -35,6 +35,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         private CancellationTokenSource _streamClosedTokenSource = default!;
         private string? _connectionId;
         private const int MinAllocBufferSize = 4096;
+        private volatile Exception? _shutdownReadReason;
+        private volatile Exception? _shutdownWriteReason;
         private volatile Exception? _shutdownReason;
         private bool _streamClosed;
         private bool _serverAborted;
@@ -175,7 +177,42 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             try
             {
-                await ProcessReceives();
+                var input = Input;
+                while (true)
+                {
+                    var buffer = Input.GetMemory(MinAllocBufferSize);
+                    var bytesReceived = await _stream.ReadAsync(buffer);
+
+                    if (bytesReceived == 0)
+                    {
+                        // Read completed.
+                        break;
+                    }
+
+                    input.Advance(bytesReceived);
+
+                    var flushTask = input.FlushAsync();
+
+                    var paused = !flushTask.IsCompleted;
+
+                    if (paused)
+                    {
+                        _log.StreamPause(this);
+                    }
+
+                    var result = await flushTask;
+
+                    if (paused)
+                    {
+                        _log.StreamResume(this);
+                    }
+
+                    if (result.IsCompleted || result.IsCanceled)
+                    {
+                        // Pipe consumer is shut down, do we stop writing
+                        break;
+                    }
+                }
             }
             catch (QuicStreamAbortedException ex)
             {
@@ -204,51 +241,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             finally
             {
                 // If Shutdown() has already bee called, assume that was the reason ProcessReceives() exited.
-                Input.Complete(_shutdownReason ?? error);
+                Input.Complete(_shutdownReadReason ?? _shutdownReason ?? error);
 
                 FireStreamClosed();
 
                 await _waitForConnectionClosedTcs.Task;
-            }
-        }
-
-        private async Task ProcessReceives()
-        {
-            var input = Input;
-            while (true)
-            {
-                var buffer = Input.GetMemory(MinAllocBufferSize);
-                var bytesReceived = await _stream.ReadAsync(buffer);
-
-                if (bytesReceived == 0)
-                {
-                    // Read completed.
-                    break;
-                }
-
-                input.Advance(bytesReceived);
-
-                var flushTask = input.FlushAsync();
-
-                var paused = !flushTask.IsCompleted;
-
-                if (paused)
-                {
-                    _log.StreamPause(this);
-                }
-
-                var result = await flushTask;
-
-                if (paused)
-                {
-                    _log.StreamResume(this);
-                }
-
-                if (result.IsCompleted || result.IsCanceled)
-                {
-                    // Pipe consumer is shut down, do we stop writing
-                    break;
-                }
             }
         }
 
@@ -291,7 +288,34 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             try
             {
-                await ProcessSends();
+                // Resolve `output` PipeReader via the IDuplexPipe interface prior to loop start for performance.
+                var output = Output;
+                while (true)
+                {
+                    var result = await output.ReadAsync();
+
+                    if (result.IsCanceled)
+                    {
+                        break;
+                    }
+
+                    var buffer = result.Buffer;
+
+                    var end = buffer.End;
+                    var isCompleted = result.IsCompleted;
+                    if (!buffer.IsEmpty)
+                    {
+                        await _stream.WriteAsync(buffer, endStream: isCompleted);
+                    }
+
+                    output.AdvanceTo(end);
+
+                    if (isCompleted)
+                    {
+                        // Once the stream pipe is closed, shutdown the stream.
+                        break;
+                    }
+                }
             }
             catch (QuicStreamAbortedException ex)
             {
@@ -329,38 +353,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        private async Task ProcessSends()
-        {
-            // Resolve `output` PipeReader via the IDuplexPipe interface prior to loop start for performance.
-            var output = Output;
-            while (true)
-            {
-                var result = await output.ReadAsync();
-
-                if (result.IsCanceled)
-                {
-                    break;
-                }
-
-                var buffer = result.Buffer;
-
-                var end = buffer.End;
-                var isCompleted = result.IsCompleted;
-                if (!buffer.IsEmpty)
-                {
-                    await _stream.WriteAsync(buffer, endStream: isCompleted);
-                }
-
-                output.AdvanceTo(end);
-
-                if (isCompleted)
-                {
-                    // Once the stream pipe is closed, shutdown the stream.
-                    break;
-                }
-            }
-        }
-
         public override void Abort(ConnectionAbortedException abortReason)
         {
             // This abort is called twice, make sure that doesn't happen.
@@ -388,6 +380,40 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             // Cancel ProcessSends loop after calling shutdown to ensure the correct _shutdownReason gets set.
             Output.CancelPendingRead();
+        }
+
+        public void AbortRead(long errorCode, ConnectionAbortedException abortReason)
+        {
+            lock (_shutdownLock)
+            {
+                if (_stream.CanRead)
+                {
+                    _shutdownReadReason = abortReason;
+                    _log.StreamAbortRead(this, abortReason.Message);
+                    _stream.AbortRead(errorCode);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unable to abort reading from a stream that doesn't support reading.");
+                }
+            }
+        }
+
+        public void AbortWrite(long errorCode, ConnectionAbortedException abortReason)
+        {
+            lock (_shutdownLock)
+            {
+                if (_stream.CanWrite)
+                {
+                    _shutdownWriteReason = abortReason;
+                    _log.StreamAbortWrite(this, abortReason.Message);
+                    _stream.AbortWrite(errorCode);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Unable to abort writing to a stream that doesn't support writing.");
+                }
+            }
         }
 
         private async ValueTask ShutdownWrite(Exception? shutdownReason)

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -382,40 +382,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             Output.CancelPendingRead();
         }
 
-        public void AbortRead(long errorCode, ConnectionAbortedException abortReason)
-        {
-            lock (_shutdownLock)
-            {
-                if (_stream.CanRead)
-                {
-                    _shutdownReadReason = abortReason;
-                    _log.StreamAbortRead(this, abortReason.Message);
-                    _stream.AbortRead(errorCode);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Unable to abort reading from a stream that doesn't support reading.");
-                }
-            }
-        }
-
-        public void AbortWrite(long errorCode, ConnectionAbortedException abortReason)
-        {
-            lock (_shutdownLock)
-            {
-                if (_stream.CanWrite)
-                {
-                    _shutdownWriteReason = abortReason;
-                    _log.StreamAbortWrite(this, abortReason.Message);
-                    _stream.AbortWrite(errorCode);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Unable to abort writing to a stream that doesn't support writing.");
-                }
-            }
-        }
-
         private async ValueTask ShutdownWrite(Exception? shutdownReason)
         {
             try

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -154,6 +154,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
+        [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application because: ""{Reason}"".", SkipEnabledCheck = true)]
+        private static partial void StreamAbortRead(ILogger logger, string connectionId, string reason);
+
+        public void StreamAbortRead(QuicStreamContext streamContext, string reason)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _streamAbortRead(_logger, streamContext.ConnectionId, reason, null);
+            }
+        }
+
+        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application because: ""{Reason}"".", SkipEnabledCheck = true)]
+        private static partial void StreamAbortWrite(ILogger logger, string connectionId, string reason);
+        
+        public void StreamAbortWrite(QuicStreamContext streamContext, string reason)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _streamAbortWrite(_logger, streamContext.ConnectionId, reason, null);
+            }
+        }
+        
         private static StreamType GetStreamType(QuicStreamContext streamContext) =>
             streamContext.CanRead && streamContext.CanWrite
                 ? StreamType.Bidirectional

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _streamAbortRead(_logger, streamContext.ConnectionId, reason, null);
+                StreamAbortRead(_logger, streamContext.ConnectionId, reason);
             }
         }
 
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _streamAbortWrite(_logger, streamContext.ConnectionId, reason, null);
+                StreamAbortWrite(_logger, streamContext.ConnectionId, reason);
             }
         }
         

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -154,7 +154,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application because: ""{Reason}"".", SkipEnabledCheck = true)]
+        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application because: ""{Reason}"".", SkipEnabledCheck = true)]
         private static partial void StreamAbortRead(ILogger logger, string connectionId, string reason);
 
         public void StreamAbortRead(QuicStreamContext streamContext, string reason)
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application because: ""{Reason}"".", SkipEnabledCheck = true)]
+        [LoggerMessage(14, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application because: ""{Reason}"".", SkipEnabledCheck = true)]
         private static partial void StreamAbortWrite(ILogger logger, string connectionId, string reason);
         
         public void StreamAbortWrite(QuicStreamContext streamContext, string reason)

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
@@ -306,12 +306,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             await serverStream.Transport.Output.CompleteAsync().DefaultTimeout();
 
             // Client successfully reads data to end
-            var buffer = new byte[1024];
-            var readCount = await clientStream.ReadUntilEndAsync(buffer).DefaultTimeout();
-            Assert.Equal(TestData.Length, readCount);
+            var data = await clientStream.ReadUntilEndAsync().DefaultTimeout();
+            Assert.Equal(TestData, data);
 
             // Client errors when writing
-            var clientEx = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => clientStream.WriteAsync(buffer).AsTask()).DefaultTimeout();
+            var clientEx = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => clientStream.WriteAsync(data).AsTask()).DefaultTimeout();
             Assert.Equal((long)Http3ErrorCode.InternalError, clientEx.ErrorCode);
 
             // Server errors when reading

--- a/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNetCore.Connections
         internal protected IProtocolErrorCodeFeature? _currentIProtocolErrorCodeFeature;
         internal protected IStreamDirectionFeature? _currentIStreamDirectionFeature;
         internal protected IStreamIdFeature? _currentIStreamIdFeature;
+        internal protected IStreamAbortFeature? _currentIStreamAbortFeature;
         internal protected ITlsConnectionFeature? _currentITlsConnectionFeature;
 
         private int _featureRevision;
@@ -52,6 +53,7 @@ namespace Microsoft.AspNetCore.Connections
             _currentIProtocolErrorCodeFeature = null;
             _currentIStreamDirectionFeature = null;
             _currentIStreamIdFeature = null;
+            _currentIStreamAbortFeature = null;
             _currentITlsConnectionFeature = null;
         }
 
@@ -164,6 +166,10 @@ namespace Microsoft.AspNetCore.Connections
                 {
                     feature = _currentIStreamIdFeature;
                 }
+                else if (key == typeof(IStreamAbortFeature))
+                {
+                    feature = _currentIStreamAbortFeature;
+                }
                 else if (key == typeof(ITlsConnectionFeature))
                 {
                     feature = _currentITlsConnectionFeature;
@@ -219,6 +225,10 @@ namespace Microsoft.AspNetCore.Connections
                 else if (key == typeof(IStreamIdFeature))
                 {
                     _currentIStreamIdFeature = (IStreamIdFeature?)value;
+                }
+                else if (key == typeof(IStreamAbortFeature))
+                {
+                    _currentIStreamAbortFeature = (IStreamAbortFeature?)value;
                 }
                 else if (key == typeof(ITlsConnectionFeature))
                 {
@@ -277,6 +287,10 @@ namespace Microsoft.AspNetCore.Connections
             else if (typeof(TFeature) == typeof(IStreamIdFeature))
             {
                 feature = Unsafe.As<IStreamIdFeature?, TFeature?>(ref _currentIStreamIdFeature);
+            }
+            else if (typeof(TFeature) == typeof(IStreamAbortFeature))
+            {
+                feature = Unsafe.As<IStreamAbortFeature?, TFeature?>(ref _currentIStreamAbortFeature);
             }
             else if (typeof(TFeature) == typeof(ITlsConnectionFeature))
             {
@@ -337,6 +351,10 @@ namespace Microsoft.AspNetCore.Connections
             {
                 _currentIStreamIdFeature = Unsafe.As<TFeature?, IStreamIdFeature?>(ref feature);
             }
+            else if (typeof(TFeature) == typeof(IStreamAbortFeature))
+            {
+                _currentIStreamAbortFeature = Unsafe.As<TFeature?, IStreamAbortFeature?>(ref feature);
+            }
             else if (typeof(TFeature) == typeof(ITlsConnectionFeature))
             {
                 _currentITlsConnectionFeature = Unsafe.As<TFeature?, ITlsConnectionFeature?>(ref feature);
@@ -388,6 +406,10 @@ namespace Microsoft.AspNetCore.Connections
             if (_currentIStreamIdFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IStreamIdFeature), _currentIStreamIdFeature);
+            }
+            if (_currentIStreamAbortFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IStreamAbortFeature), _currentIStreamAbortFeature);
             }
             if (_currentITlsConnectionFeature != null)
             {

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Testing
 
                 if (_http3TestBase._runningStreams.TryRemove(stream.StreamId, out var testStream))
                 {
-                    testStream._onStreamCompletedTcs.TrySetResult();
+                    testStream.OnStreamCompletedTcs.TrySetResult();
                 }
             }
 
@@ -312,7 +312,7 @@ namespace Microsoft.AspNetCore.Testing
 
                 if (_http3TestBase._runningStreams.TryGetValue(stream.StreamId, out var testStream))
                 {
-                    testStream._onStreamCreatedTcs.TrySetResult();
+                    testStream.OnStreamCreatedTcs.TrySetResult();
                 }
             }
 
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.Testing
 
                 if (_http3TestBase._runningStreams.TryGetValue(stream.StreamId, out var testStream))
                 {
-                    testStream._onHeaderReceivedTcs.TrySetResult();
+                    testStream.OnHeaderReceivedTcs.TrySetResult();
                 }
             }
         }
@@ -404,38 +404,39 @@ namespace Microsoft.AspNetCore.Testing
         }
     }
 
-    internal class Http3StreamBase : IProtocolErrorCodeFeature
+    internal class Http3StreamBase
     {
-        internal TaskCompletionSource _onStreamCreatedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        internal TaskCompletionSource _onStreamCompletedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        internal TaskCompletionSource _onHeaderReceivedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource OnStreamCreatedTcs { get; } = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource OnStreamCompletedTcs { get; } = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource OnHeaderReceivedTcs { get; } = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        internal ConnectionContext StreamContext { get; }
-        internal IProtocolErrorCodeFeature _protocolErrorCodeFeature;
-        internal DuplexPipe.DuplexPipePair _pair;
-        internal Http3InMemory _testBase;
-        internal Http3Connection _connection;
+        internal TestStreamContext StreamContext { get; }
+        internal DuplexPipe.DuplexPipePair Pair { get; }
+        internal Http3InMemory TestBase { get; private protected set; }
+        internal Http3Connection Connection { get; private protected set; }
         public long BytesReceived { get; private set; }
         public long Error
         {
-            get => _protocolErrorCodeFeature.Error;
-            set => _protocolErrorCodeFeature.Error = value;
+            get => StreamContext.Error;
+            set => StreamContext.Error = value;
         }
 
-        public Task OnStreamCreatedTask => _onStreamCreatedTcs.Task;
-        public Task OnStreamCompletedTask => _onStreamCompletedTcs.Task;
-        public Task OnHeaderReceivedTask => _onHeaderReceivedTcs.Task;
+        public Task OnStreamCreatedTask => OnStreamCreatedTcs.Task;
+        public Task OnStreamCompletedTask => OnStreamCompletedTcs.Task;
+        public Task OnHeaderReceivedTask => OnHeaderReceivedTcs.Task;
+
+        public ConnectionAbortedException AbortReadException => StreamContext.AbortReadException;
+        public ConnectionAbortedException AbortWriteException => StreamContext.AbortWriteException;
 
         public Http3StreamBase(TestStreamContext testStreamContext)
         {
             StreamContext = testStreamContext;
-            _protocolErrorCodeFeature = testStreamContext;
-            _pair = testStreamContext._pair;
+            Pair = testStreamContext._pair;
         }
 
         protected Task SendAsync(ReadOnlySpan<byte> span)
         {
-            var writableBuffer = _pair.Application.Output;
+            var writableBuffer = Pair.Application.Output;
             writableBuffer.Write(span);
             return FlushAsync(writableBuffer);
         }
@@ -462,12 +463,12 @@ namespace Microsoft.AspNetCore.Testing
 #if IS_FUNCTIONAL_TESTS
         protected Task<ReadResult> ReadApplicationInputAsync()
         {
-            return _pair.Application.Input.ReadAsync().AsTask().DefaultTimeout();
+            return Pair.Application.Input.ReadAsync().AsTask().DefaultTimeout();
         }
 #else
         protected ValueTask<ReadResult> ReadApplicationInputAsync()
         {
-            return _pair.Application.Input.ReadAsync();
+            return Pair.Application.Input.ReadAsync();
         }
 #endif
 
@@ -523,14 +524,14 @@ namespace Microsoft.AspNetCore.Testing
                 finally
                 {
                     BytesReceived += copyBuffer.Slice(copyBuffer.Start, consumed).Length;
-                    _pair.Application.Input.AdvanceTo(consumed, examined);
+                    Pair.Application.Input.AdvanceTo(consumed, examined);
                 }
             }
         }
 
         internal async Task SendFrameAsync(Http3FrameType frameType, Memory<byte> data, bool endStream = false)
         {
-            var outputWriter = _pair.Application.Output;
+            var outputWriter = Pair.Application.Output;
             Http3FrameWriter.WriteHeader(frameType, data.Length, outputWriter);
 
             if (!endStream)
@@ -547,7 +548,7 @@ namespace Microsoft.AspNetCore.Testing
 
         internal Task EndStreamAsync(ReadOnlySpan<byte> span = default)
         {
-            var writableBuffer = _pair.Application.Output;
+            var writableBuffer = Pair.Application.Output;
             if (span.Length > 0)
             {
                 writableBuffer.Write(span);
@@ -595,8 +596,8 @@ namespace Microsoft.AspNetCore.Testing
         public Http3RequestStream(Http3InMemory testBase, Http3Connection connection, TestStreamContext testStreamContext, Http3RequestHeaderHandler headerHandler)
             : base(testStreamContext)
         {
-            _testBase = testBase;
-            _connection = connection;
+            TestBase = testBase;
+            Connection = connection;
             _streamId = testStreamContext.StreamId;
             _testStreamContext = testStreamContext;
             this._headerHandler = headerHandler;
@@ -635,7 +636,7 @@ namespace Microsoft.AspNetCore.Testing
         internal async Task SendHeadersPartialAsync()
         {
             // Send HEADERS frame header without content.
-            var outputWriter = _pair.Application.Output;
+            var outputWriter = Pair.Application.Output;
             Http3FrameWriter.WriteHeader(Http3FrameType.Data, frameLength: 10, outputWriter);
             await SendAsync(Span<byte>.Empty);
         }
@@ -727,7 +728,7 @@ namespace Microsoft.AspNetCore.Testing
         public Http3ControlStream(Http3InMemory testBase, TestStreamContext testStreamContext)
             : base(testStreamContext)
         {
-            _testBase = testBase;
+            TestBase = testBase;
             _streamId = testStreamContext.StreamId;
         }
 
@@ -764,7 +765,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public async Task WriteStreamIdAsync(int id)
         {
-            var writableBuffer = _pair.Application.Output;
+            var writableBuffer = Pair.Application.Output;
 
             void WriteSpan(PipeWriter pw)
             {
@@ -845,7 +846,7 @@ namespace Microsoft.AspNetCore.Testing
                 }
                 finally
                 {
-                    _pair.Application.Input.AdvanceTo(consumed, examined);
+                    Pair.Application.Input.AdvanceTo(consumed, examined);
                 }
             }
         }
@@ -938,7 +939,7 @@ namespace Microsoft.AspNetCore.Testing
         }
     }
 
-    internal class TestStreamContext : ConnectionContext, IStreamDirectionFeature, IStreamIdFeature, IProtocolErrorCodeFeature, IPersistentStateFeature
+    internal class TestStreamContext : ConnectionContext, IStreamDirectionFeature, IStreamIdFeature, IProtocolErrorCodeFeature, IPersistentStateFeature, IStreamAbortFeature
     {
         private readonly Http3InMemory _testBase;
 
@@ -999,16 +1000,22 @@ namespace Microsoft.AspNetCore.Testing
 
             Features.Set<IStreamDirectionFeature>(this);
             Features.Set<IStreamIdFeature>(this);
+            Features.Set<IStreamAbortFeature>(this);
             Features.Set<IProtocolErrorCodeFeature>(this);
             Features.Set<IPersistentStateFeature>(this);
 
             StreamId = streamId;
             _testBase.Logger.LogInformation($"Initializing stream {streamId}");
             ConnectionId = "TEST:" + streamId.ToString();
+            AbortReadException = null;
+            AbortWriteException = null;
 
             _disposedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             Disposed = false;
         }
+
+        public ConnectionAbortedException AbortReadException { get; private set; }
+        public ConnectionAbortedException AbortWriteException { get; private set; }
 
         public bool Disposed { get; private set; }
 
@@ -1075,6 +1082,16 @@ namespace Microsoft.AspNetCore.Testing
                 // Lazily allocate persistent state
                 return _persistentState ?? (_persistentState = new ConnectionItems());
             }
+        }
+
+        void IStreamAbortFeature.AbortRead(long errorCode, ConnectionAbortedException abortReason)
+        {
+            AbortReadException = abortReason;
+        }
+
+        void IStreamAbortFeature.AbortWrite(long errorCode, ConnectionAbortedException abortReason)
+        {
+            AbortWriteException = abortReason;
         }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2488,8 +2488,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await requestStream.OnStreamCompletedTask.DefaultTimeout();
 
-            // TODO(JamesNK): Check for abort of request side of stream after https://github.com/dotnet/aspnetcore/issues/31970
             Assert.Contains(LogMessages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Equal("The application completed without reading the entire request body.", requestStream.AbortReadException.Message);
 
             Assert.Equal(3, receivedHeaders.Count);
             Assert.Contains("date", receivedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
@@ -2817,8 +2817,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await requestStream.OnStreamCompletedTask.DefaultTimeout();
 
-            // TODO(JamesNK): Check for abort of request side of stream after https://github.com/dotnet/aspnetcore/issues/31970
             Assert.Contains(LogMessages, m => m.Message.Contains("the application completed without reading the entire request body."));
+            Assert.Equal("The application completed without reading the entire request body.", requestStream.AbortReadException.Message);
         }
 
         [Fact]

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
@@ -24,6 +24,7 @@ namespace CodeGenerator
                 "IProtocolErrorCodeFeature",
                 "IStreamDirectionFeature",
                 "IStreamIdFeature",
+                "IStreamAbortFeature",
                 "ITlsConnectionFeature"
             };
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/31970
Fixes https://github.com/dotnet/aspnetcore/issues/33575

HTTP/3 streams support aborting individual sides of a connection stream. Feature is so HTTP layer can abort reading/writing in transport layer.

Args:
* `errorCode` is sent to the peer. long is used because it is variable length.
* Exception is used to complete transport pipes.

Example usage:

The client is uploading data to the server in an HTTP/3 request. The server completes `RequestDelegate` (i.e. user app code) without reading all of the data. HTTP/3 layer in the server will gracefully finish writing the response and abort reading the request. The abort tells the client it can stop uploading.

```cs
namespace Microsoft.AspNetCore.Connections.Features
{
    /// <summary>
    /// Supports aborting individual sides of a connection stream.
    /// </summary>
    public interface IStreamAbortFeature
    {
        /// <summary>
        /// Abort the read side of the connection stream.
        /// </summary>
        /// <param name="errorCode">The error code to send with the abort.</param>
        /// <param name="abortReason">An optional <see cref="ConnectionAbortedException"/> describing the reason to abort the read side of the connection stream.</param>
        void AbortRead(long errorCode, ConnectionAbortedException abortReason);

        /// <summary>
        /// Abort the write side of the connection stream.
        /// </summary>
        /// <param name="errorCode">The error code to send with the abort.</param>
        /// <param name="abortReason">An optional <see cref="ConnectionAbortedException"/> describing the reason to abort the write side of the connection stream.</param>
        void AbortWrite(long errorCode, ConnectionAbortedException abortReason);
    }
}
```