### PR TITLE
Update web templates to use port range for Kestrel

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/dotnetcli.host.json
@@ -51,10 +51,16 @@
       "longName": "no-restore",
       "shortName": ""
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
@@ -301,30 +301,74 @@
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -332,12 +376,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/dotnetcli.host.json
@@ -61,10 +61,16 @@
       "longName": "authority",
       "shortName": ""
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -363,30 +363,74 @@
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -394,12 +438,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
@@ -8,10 +8,16 @@
       "longName": "no-restore",
       "shortName": ""
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -40,30 +40,74 @@
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -71,12 +115,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/dotnetcli.host.json
@@ -8,10 +8,16 @@
       "longName": "no-restore",
       "shortName": ""
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
@@ -36,30 +36,74 @@
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -67,12 +111,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/dotnetcli.host.json
@@ -5,6 +5,12 @@
       "longName": "no-restore",
       "shortName": ""
     },
+    "kestrelHttpPort": {
+      "isHidden": true
+    },
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
     "ExcludeLaunchSettings": {
       "longName": "exclude-launch-settings",
       "shortName": ""

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
@@ -58,6 +58,50 @@
       "datatype": "bool",
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
+    },
+    "kestrelHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "kestrelHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
+    },
+    "kestrelHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
+      },
+      "replaces": "5000"
+    },
+    "kestrelHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
     }
   },
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
@@ -47,10 +47,16 @@
     "Framework": {
       "longName": "framework"
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/ide.host.json
@@ -36,11 +36,19 @@
   ],
   "ports": [
     {
-      "name": "HttpPort",
+      "name": "kestrelHttpPort",
       "useHttps": false
     },
     {
-      "name": "HttpsPort",
+      "name": "kestrelHttpsPort",
+      "useHttps": true
+    },
+    {
+      "name": "iisHttpPort",
+      "useHttps": false
+    },
+    {
+      "name": "iisHttpsPort",
       "useHttps": true
     }
   ],

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/ide.host.json
@@ -36,19 +36,11 @@
   ],
   "ports": [
     {
-      "name": "kestrelHttpPort",
+      "name": "HttpPort",
       "useHttps": false
     },
     {
-      "name": "kestrelHttpsPort",
-      "useHttps": true
-    },
-    {
-      "name": "iisHttpPort",
-      "useHttps": false
-    },
-    {
-      "name": "iisHttpsPort",
+      "name": "HttpsPort",
       "useHttps": true
     }
   ],

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -223,30 +223,74 @@
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -254,12 +298,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -51,10 +51,16 @@
       "longName": "no-restore",
       "shortName": ""
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -213,30 +213,74 @@
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -244,12 +288,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -1,10 +1,16 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -41,30 +41,74 @@
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -72,12 +116,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -43,10 +43,16 @@
       "longName": "no-restore",
       "shortName": ""
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -130,30 +130,74 @@
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json in the generated template."
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -161,12 +205,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/dotnetcli.host.json
@@ -1,10 +1,16 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "HttpPort": {
+    "kestrelHttpPort": {
       "isHidden": true
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
+      "isHidden": true
+    },
+    "iisHttpPort": {
+      "isHidden": true
+    },
+    "iisHttpsPort": {
       "isHidden": true
     },
     "ExcludeLaunchSettings": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -36,30 +36,74 @@
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json from the generated template."
     },
-    "HttpPort": {
+    "kestrelHttpPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "HttpPortGenerated": {
+    "kestrelHttpPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 5000,
+        "high": 5300
+      }
     },
-    "HttpPortReplacer": {
+    "kestrelHttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpPort",
-        "fallbackVariableName": "HttpPortGenerated"
+        "sourceVariableName": "kestrelHttpPort",
+        "fallbackVariableName": "kestrelHttpPortGenerated"
       },
-      "replaces": "8080"
+      "replaces": "5000"
     },
-    "HttpsPort": {
+    "kestrelHttpsPort": {
       "type": "parameter",
       "datatype": "integer",
       "description": "Port number to use for the HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
     },
-    "HttpsPortGenerated": {
+    "kestrelHttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 7000,
+        "high": 7300
+      }
+    },
+    "kestrelHttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "kestrelHttpsPort",
+        "fallbackVariableName": "kestrelHttpsPortGenerated"
+      },
+      "replaces": "5001"
+    },
+    "iisHttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTP endpoint in launchSettings.json."
+    },
+    "iisHttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "iisHttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iisHttpPort",
+        "fallbackVariableName": "iisHttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "iisHttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the IIS Express HTTPS endpoint in launchSettings.json. This option is only applicable when the parameter no-https is not used (no-https will be ignored if either IndividualAuth or OrganizationalAuth is used)."
+    },
+    "iisHttpsPortGenerated": {
       "type": "generated",
       "generator": "port",
       "parameters": {
@@ -67,12 +111,12 @@
         "high": 44399
       }
     },
-    "HttpsPortReplacer": {
+    "iisHttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "HttpsPort",
-        "fallbackVariableName": "HttpsPortGenerated"
+        "sourceVariableName": "iisHttpsPort",
+        "fallbackVariableName": "iisHttpsPortGenerated"
       },
       "replaces": "44300"
     },


### PR DESCRIPTION
Updates all the project templates to use a port range for the Kestrel profile in `launchSettings.json` so that new projects don't all get created with the same port. This is the existing behavior for the IIS Express profile but in .NET 6 the default profile is changing to the Kestrel profile.

Selected 5000-5300 for HTTP and 7000-7300 for HTTPS. Note 6000 is reserved (see https://github.com/dotnet/templating/blob/94b1e0839ab49026b3ff654f2b5e5e1a1b4b2c53/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratePortNumberConfig.cs#L19).

Addresses #34363
