### PR TITLE
[Spa] Try additional hooks to kill the application

### DIFF
--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -1,15 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.SpaProxy
 {
@@ -25,10 +21,12 @@ namespace Microsoft.AspNetCore.SpaProxy
 
         public SpaProxyLaunchManager(
             ILogger<SpaProxyLaunchManager> logger,
+            IHostApplicationLifetime appLifetime,
             IOptions<SpaDevelopmentServerOptions> options)
         {
             _options = options.Value;
             _logger = logger;
+            appLifetime.ApplicationStopping.Register(() => Dispose(true));
         }
 
         public void StartInBackground(CancellationToken cancellationToken)
@@ -199,7 +197,7 @@ namespace Microsoft.AspNetCore.SpaProxy
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            // We don't need to do anything here since Dispose will take care of cleaning up the process if necessary.
+            Dispose(true);
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Try a couple of additional hooks for killing the SPA proxy.

We got a report that the services remain alive after the debugger has stopped the process. The changes included here are the only two meaningful differences with the previous implemenation ([here](https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/Spa/SpaServices.Extensions/src/Npm/NodeScriptRunner.cs#L77))