### PR TITLE
Throw if Quic is not supported.

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         {
             if (!QuicImplementationProviders.Default.IsSupported)
             {
-                throw new NotSupportedException("Quic is not supported or enabled on this platform.");
+                throw new NotSupportedException("QUIC is not supported or enabled on this platform. See https://aka.ms/aspnet/kestrel/http3reqs for details.");
             }
 
             if (options.Alpn == null)

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -26,6 +26,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
         public QuicConnectionListener(QuicTransportOptions options, IQuicTrace log, EndPoint endpoint, SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
+            if (!QuicImplementationProviders.Default.IsSupported)
+            {
+                throw new NotSupportedException("Quic is not supported or enabled on this platform.");
+            }
+
             if (options.Alpn == null)
             {
                 throw new InvalidOperationException("QuicTransportOptions.Alpn must be configured with a value.");
@@ -44,7 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             quicListenerOptions.MaxBidirectionalStreams = options.MaxBidirectionalStreamCount;
             quicListenerOptions.MaxUnidirectionalStreams = options.MaxUnidirectionalStreamCount;
 
-            _listener = new QuicListener(QuicImplementationProviders.MsQuic, quicListenerOptions);
+            _listener = new QuicListener(quicListenerOptions);
 
             // Listener endpoint will resolve an ephemeral port, e.g. 127.0.0.1:0, into the actual port.
             EndPoint = _listener.ListenEndPoint;

--- a/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Hosting
         {
             if (!QuicImplementationProviders.Default.IsSupported)
             {
-                throw new NotSupportedException("Quic is not supported or enabled on this platform.");
+                throw new NotSupportedException("QUIC is not supported or enabled on this platform. See https://aka.ms/aspnet/kestrel/http3reqs for details.");
             }
             return hostBuilder.ConfigureServices(services =>
             {

--- a/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Quic;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Quic;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,10 @@ namespace Microsoft.AspNetCore.Hosting
     {
         public static IWebHostBuilder UseQuic(this IWebHostBuilder hostBuilder)
         {
+            if (!QuicImplementationProviders.Default.IsSupported)
+            {
+                throw new NotSupportedException("Quic is not supported or enabled on this platform.");
+            }
             return hostBuilder.ConfigureServices(services =>
             {
                 services.AddSingleton<IMultiplexedConnectionListenerFactory, QuicTransportFactory>();

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -14,6 +14,9 @@ namespace Http3SampleApp
     {
         public static void Main(string[] args)
         {
+            // Required to enable Quic.
+            AppContext.SetSwitch("System.Net.SocketsHttpHandler.Http3Support", true);
+
             var cert = CertificateLoader.LoadFromStoreCert("localhost", StoreName.My.ToString(), StoreLocation.CurrentUser, false);
 
             var hostBuilder = new HostBuilder()

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -14,9 +14,6 @@ namespace Http3SampleApp
     {
         public static void Main(string[] args)
         {
-            // Required to enable Quic.
-            AppContext.SetSwitch("System.Net.SocketsHttpHandler.Http3Support", true);
-
             var cert = CertificateLoader.LoadFromStoreCert("localhost", StoreName.My.ToString(), StoreLocation.CurrentUser, false);
 
             var hostBuilder = new HostBuilder()


### PR DESCRIPTION
System.Net.Quic now requires `AppContext.SetSwitch("System.Net.SocketsHttpHandler.Http3Support", true);` to load msquic. Without that it null refs on load.

I'm adding some temporary IsSupported checks to at least make the issue more obvious. The switch is still under discussion, and we may want to move these checks around later (e.g. only log and no-op if you enabled http3 but quic wasn't supported).

```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Net.Quic.Implementations.MsQuic.Internal.SafeMsQuicConfigurationHandle.Create(QuicOptions options, QUIC_CREDENTIAL_FLAGS flags, X509Certificate certificate, SslStreamCertificateContext certificateContext, List`1 alpnProtocols) in System.Net.Quic.dll:token 0x60001e1+0x13e
   at System.Net.Quic.Implementations.MsQuic.Internal.SafeMsQuicConfigurationHandle.Create(QuicListenerOptions options) in System.Net.Quic.dll:token 0x60001e0+0x17
   at System.Net.Quic.Implementations.MsQuic.MsQuicListener.State..ctor(QuicListenerOptions options) in System.Net.Quic.dll:token 0x6000124+0x0
   at System.Net.Quic.Implementations.MsQuic.MsQuicListener..ctor(QuicListenerOptions options) in System.Net.Quic.dll:token 0x6000119+0x6
   at System.Net.Quic.Implementations.MsQuic.MsQuicImplementationProvider.CreateListener(QuicListenerOptions options) in System.Net.Quic.dll:token 0x6000116+0x0
   at System.Net.Quic.QuicListener..ctor(QuicImplementationProvider implementationProvider, QuicListenerOptions options) in System.Net.Quic.dll:token 0x6000081+0x6
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal.QuicConnectionListener..ctor(QuicTransportOptions options, IQuicTrace log, EndPoint endpoint, SslServerAuthenticationOptions sslServerAuthenticationOptions) in D:\github\AspNetCore\src\Servers\Kestrel\Transport.Quic\src\Internal\QuicConnectionListener.cs:line 47
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportFactory.BindAsync(EndPoint endpoint, IFeatureCollection features, CancellationToken cancellationToken) in D:\github\AspNetCore\src\Servers\Kestrel\Transport.Quic\src\QuicTransportFactory.cs:line 63
```