### PR TITLE
Reject CR/LF's in Kestrel header decoding

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ParsingHandler.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             else
             {
-                Connection.OnHeader(name, value);
+                Connection.OnHeader(name, value, checkForNewlineChars : false);
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7455,11 +7455,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
+        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value)
         {
             ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
             var nameStr = string.Empty;
             var flag = 0L;
+            var checkForNewlineChars = true;
 
             // Does the HPack static index match any "known" headers
             switch (index)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7053,7 +7053,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
         
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
+        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {
             ref byte nameStart = ref MemoryMarshal.GetReference(name);
             var nameStr = string.Empty;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7053,7 +7053,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
         
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
         {
             ref byte nameStart = ref MemoryMarshal.GetReference(name);
             var nameStr = string.Empty;
@@ -7430,7 +7430,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
 
                 // We didn't have a previous matching header value, or have already added a header, so get the string for this value.
-                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector);
+                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector, checkForNewlineChars);
                 if ((_bits & flag) == 0)
                 {
                     // We didn't already have a header set, so add a new one.
@@ -7449,13 +7449,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 // Convert value to string first, because passing two spans causes 8 bytes stack zeroing in 
                 // this method with rep stosd, which is slower than necessary.
                 nameStr = name.GetHeaderName();
-                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector);
+                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector, checkForNewlineChars);
                 AppendUnknownHeaders(nameStr, valueStr);
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value)
+        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
         {
             ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
             var nameStr = string.Empty;
@@ -7646,7 +7646,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
 
                 // We didn't have a previous matching header value, or have already added a header, so get the string for this value.
-                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector);
+                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector, checkForNewlineChars);
                 if ((_bits & flag) == 0)
                 {
                     // We didn't already have a header set, so add a new one.

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -537,7 +537,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             IncrementRequestHeadersCount();
 
             string key = name.GetHeaderName();
-            var valueStr = value.GetRequestHeaderString(key, HttpRequestHeaders.EncodingSelector);
+            var valueStr = value.GetRequestHeaderString(key, HttpRequestHeaders.EncodingSelector, checkForNewlineChars : false);
             RequestTrailers.Append(key, valueStr);
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -517,11 +517,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        public virtual void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        public virtual void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
         {
             IncrementRequestHeadersCount();
 
-            HttpRequestHeaders.Append(name, value);
+            HttpRequestHeaders.Append(name, value, checkForNewlineChars);
         }
 
         public virtual void OnHeader(int index, bool indexOnly, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -517,7 +517,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        public virtual void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
+        public virtual void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {
             IncrementRequestHeadersCount();
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 parsed < 0 ||
                 consumed != value.Length)
             {
-                KestrelBadHttpRequestException.Throw(RequestRejectionReason.InvalidContentLength, value.GetRequestHeaderString(HeaderNames.ContentLength, EncodingSelector));
+                KestrelBadHttpRequestException.Throw(RequestRejectionReason.InvalidContentLength, value.GetRequestHeaderString(HeaderNames.ContentLength, EncodingSelector, checkForNewlineChars : false));
             }
 
             _contentLength = parsed;
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 !long.TryParse(decodedChars.Slice(0, numChars), NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed) ||
                 parsed < 0)
             {
-                KestrelBadHttpRequestException.Throw(RequestRejectionReason.InvalidContentLength, value.GetRequestHeaderString(HeaderNames.ContentLength, EncodingSelector));
+                KestrelBadHttpRequestException.Throw(RequestRejectionReason.InvalidContentLength, value.GetRequestHeaderString(HeaderNames.ContentLength, EncodingSelector, checkForNewlineChars : false));
             }
 
             _contentLength = parsed;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1307,7 +1307,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     }
                     else
                     {
-                        _currentHeadersStream.OnHeader(name, value);
+                        _currentHeadersStream.OnHeader(name, value, true);
                     }
                 }
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1307,7 +1307,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
                     }
                     else
                     {
-                        _currentHeadersStream.OnHeader(name, value, true);
+                        _currentHeadersStream.OnHeader(name, value, checkForNewlineChars : true);
                     }
                 }
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -664,7 +664,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // HPack append will return false if the index is not a known request header.
             // For example, someone could send the index of "Server" (a response header) in the request.
             // If that happens then fallback to using Append with the name bytes.
-            if (!HttpRequestHeaders.TryHPackAppend(index, value))
+            if (!HttpRequestHeaders.TryHPackAppend(index, value, true))
             {
                 AppendHeader(name, value);
             }
@@ -673,7 +673,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void AppendHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
-            HttpRequestHeaders.Append(name, value);
+            HttpRequestHeaders.Append(name, value, true);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -664,7 +664,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // HPack append will return false if the index is not a known request header.
             // For example, someone could send the index of "Server" (a response header) in the request.
             // If that happens then fallback to using Append with the name bytes.
-            if (!HttpRequestHeaders.TryHPackAppend(index, value, true))
+            if (!HttpRequestHeaders.TryHPackAppend(index, value))
             {
                 AppendHeader(name, value);
             }
@@ -673,7 +673,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void AppendHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
-            HttpRequestHeaders.Append(name, value, true);
+            HttpRequestHeaders.Append(name, value, checkForNewlineChars : true);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -159,9 +159,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             OnHeader(knownHeader.Name, value);
         }
 
-        public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value) => OnHeader(name, value, true);
+        public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value) => OnHeader(name, value, checkForNewlineChars : true);
 
-        public override void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars = true)
+        public override void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {
             // https://tools.ietf.org/html/rfc7540#section-6.5.2
             // "The value is based on the uncompressed size of header fields, including the length of the name and value in octets plus an overhead of 32 octets for each header field.";

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -159,7 +159,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             OnHeader(knownHeader.Name, value);
         }
 
-        public override void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value) => OnHeader(name, value, true);
+
+        public override void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars = true)
         {
             // https://tools.ietf.org/html/rfc7540#section-6.5.2
             // "The value is based on the uncompressed size of header fields, including the length of the name and value in octets plus an overhead of 32 octets for each header field.";
@@ -180,7 +182,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 {
                     // Throws BadRequest for header count limit breaches.
                     // Throws InvalidOperation for bad encoding.
-                    base.OnHeader(name, value);
+                    base.OnHeader(name, value, checkForNewlineChars);
                 }
             }
             catch (Microsoft.AspNetCore.Http.BadHttpRequestException bre)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -143,13 +143,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 }
             }
 
-            foreach (char c in result)
+            // Non-tab control characters are considered invalid
+            if (((ReadOnlySpan<char>)result).IndexOfAny('\u000A', '\u000D') != -1)
             {
-                // Non-tab control characters are considered invalid
-                if (Char.IsControl(c) && c != '\u0009')
-                {
-                    throw new InvalidOperationException();
-                }
+                throw new InvalidOperationException();
             }
 
             return result;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -143,8 +143,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 }
             }
 
-            // Non-tab control characters are considered invalid
-            if (((ReadOnlySpan<char>)result).IndexOfAny('\u000A', '\u000D') != -1)
+            // New Line characters (CR, LF) are considered invalid at this point.
+            if (((ReadOnlySpan<char>)result).IndexOfAny('\r', '\n') >= 0)
             {
                 throw new InvalidOperationException();
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public static string GetAsciiOrUTF8StringNonNullCharacters(this ReadOnlySpan<byte> span)
             => StringUtilities.GetAsciiOrUTF8StringNonNullCharacters(span, DefaultRequestHeaderEncoding);
 
-        public static string GetRequestHeaderString(this ReadOnlySpan<byte> span, string name, Func<string, Encoding?> encodingSelector)
+        public static string GetRequestHeaderString(this ReadOnlySpan<byte> span, string name, Func<string, Encoding?> encodingSelector, bool checkForNewlineChars = false)
         {
             string result;
             if (ReferenceEquals(KestrelServerOptions.DefaultHeaderEncodingSelector, encodingSelector))
@@ -144,9 +144,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
 
             // New Line characters (CR, LF) are considered invalid at this point.
-            if (((ReadOnlySpan<char>)result).IndexOfAny('\r', '\n') >= 0)
+            if (checkForNewlineChars && ((ReadOnlySpan<char>)result).IndexOfAny('\r', '\n') >= 0)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("Newline characters (CR/LF) are not allowed in request headers.");
             }
 
             return result;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public static string GetAsciiOrUTF8StringNonNullCharacters(this ReadOnlySpan<byte> span)
             => StringUtilities.GetAsciiOrUTF8StringNonNullCharacters(span, DefaultRequestHeaderEncoding);
 
-        public static string GetRequestHeaderString(this ReadOnlySpan<byte> span, string name, Func<string, Encoding?> encodingSelector, bool checkForNewlineChars = false)
+        public static string GetRequestHeaderString(this ReadOnlySpan<byte> span, string name, Func<string, Encoding?> encodingSelector, bool checkForNewlineChars)
         {
             string result;
             if (ReferenceEquals(KestrelServerOptions.DefaultHeaderEncodingSelector, encodingSelector))

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -137,23 +137,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             {
                 return span.GetAsciiOrUTF8StringNonNullCharacters(DefaultRequestHeaderEncoding);
             }
-            else
+            if (ReferenceEquals(encoding, Encoding.Latin1))
             {
-                if (ReferenceEquals(encoding, Encoding.Latin1))
-                {
-                    return span.GetLatin1StringNonNullCharacters();
-                }
-                else
-                {
-                    try
-                    {
-                        return encoding.GetString(span);
-                    }
-                    catch (DecoderFallbackException ex)
-                    {
-                        throw new InvalidOperationException(ex.Message, ex);
-                    }
-                }
+                return span.GetLatin1StringNonNullCharacters();
+            }
+            try
+            {
+                return encoding.GetString(span);
+            }
+            catch (DecoderFallbackException ex)
+            {
+                throw new InvalidOperationException(ex.Message, ex);
             }
         }
 

--- a/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
@@ -311,7 +311,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 #pragma warning disable CS0618 // Type or member is obsolete
             var exception = Assert.Throws<BadHttpRequestException>(
 #pragma warning restore CS0618 // Type or member is obsolete
-                () => headers.Append(Encoding.Latin1.GetBytes(key), Encoding.ASCII.GetBytes("value")));
+                () => headers.Append(Encoding.Latin1.GetBytes(key), Encoding.ASCII.GetBytes("value"), checkForNewlineChars : false));
             Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
         }
 
@@ -461,7 +461,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     var headerName = Encoding.ASCII.GetBytes(header.Name).AsSpan();
                     var prevSpan = Encoding.UTF8.GetBytes(headerValueUtf16Latin1CrossOver).AsSpan();
 
-                    headers.Append(headerName, prevSpan);
+                    headers.Append(headerName, prevSpan, checkForNewlineChars : false);
                     headers.OnHeadersComplete();
                     var prevHeaderValue = ((IHeaderDictionary)headers)[header.Name].ToString();
 
@@ -477,7 +477,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
                         Assert.False(nextSpan.SequenceEqual(Encoding.ASCII.GetBytes(headerValueUtf16Latin1CrossOver)));
 
-                        headers.Append(headerName, nextSpan);
+                        headers.Append(headerName, nextSpan, checkForNewlineChars : false);
                     });
                 }
 
@@ -523,12 +523,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     Assert.False(latinValueSpan.SequenceEqual(Encoding.ASCII.GetBytes(headerValueUtf16Latin1CrossOver)));
 
                     headers.Reset();
-                    headers.Append(headerName, latinValueSpan);
+                    headers.Append(headerName, latinValueSpan, checkForNewlineChars : false);
                     headers.OnHeadersComplete();
                     var parsedHeaderValue1 = ((IHeaderDictionary)headers)[header.Name].ToString();
 
                     headers.Reset();
-                    headers.Append(headerName, latinValueSpan);
+                    headers.Append(headerName, latinValueSpan, checkForNewlineChars : false);
                     headers.OnHeadersComplete();
                     var parsedHeaderValue2 = ((IHeaderDictionary)headers)[header.Name].ToString();
 
@@ -567,7 +567,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     var headerName = Encoding.ASCII.GetBytes(header.Name).AsSpan();
                     var valueSpan = Encoding.ASCII.GetBytes(valueString).AsSpan();
 
-                    headers.Append(headerName, valueSpan);
+                    headers.Append(headerName, valueSpan, checkForNewlineChars : false);
                 });
 
                 valueArray[i] = 'a';
@@ -593,8 +593,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 return Encoding.UTF8;
             });
 
-            Assert.Throws<InvalidOperationException>(() => headers.Append(acceptNameBytes, headerValueBytes));
-            headers.Append(cookieNameBytes, headerValueBytes);
+            Assert.Throws<InvalidOperationException>(() => headers.Append(acceptNameBytes, headerValueBytes, checkForNewlineChars : false));
+            headers.Append(cookieNameBytes, headerValueBytes, checkForNewlineChars : false);
             headers.OnHeadersComplete();
 
             var parsedAcceptHeaderValue = ((IHeaderDictionary)headers).Accept.ToString();
@@ -612,13 +612,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var contentLengthValueBytes = Encoding.UTF32.GetBytes("1337");
 
             var headers = new HttpRequestHeaders(encodingSelector: _ => Encoding.UTF32);
-            headers.Append(contentLengthNameBytes, contentLengthValueBytes);
+            headers.Append(contentLengthNameBytes, contentLengthValueBytes, checkForNewlineChars : false);
             headers.OnHeadersComplete();
 
             Assert.Equal(1337, headers.ContentLength);
 
             Assert.Throws<InvalidOperationException>(() =>
-                new HttpRequestHeaders().Append(contentLengthNameBytes, contentLengthValueBytes));
+                new HttpRequestHeaders().Append(contentLengthNameBytes, contentLengthValueBytes, checkForNewlineChars : false));
         }
 
         [Fact]
@@ -658,7 +658,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var headerName = Encoding.ASCII.GetBytes(header.Name).AsSpan();
             var prevSpan = Encoding.UTF8.GetBytes(HeaderValue).AsSpan();
 
-            headers.Append(headerName, prevSpan);
+            headers.Append(headerName, prevSpan, checkForNewlineChars : false);
             headers.OnHeadersComplete();
             var prevHeaderValue = ((IHeaderDictionary)headers)[header.Name].ToString();
 
@@ -707,8 +707,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var prevSpan1 = Encoding.UTF8.GetBytes(HeaderValue1).AsSpan();
             var prevSpan2 = Encoding.UTF8.GetBytes(HeaderValue2).AsSpan();
 
-            headers.Append(headerName, prevSpan1);
-            headers.Append(headerName, prevSpan2);
+            headers.Append(headerName, prevSpan1, checkForNewlineChars : false);
+            headers.Append(headerName, prevSpan2, checkForNewlineChars : false);
             headers.OnHeadersComplete();
             var prevHeaderValue = ((IHeaderDictionary)headers)[header.Name];
 
@@ -748,7 +748,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var headerName = Encoding.ASCII.GetBytes(prevName).AsSpan();
             var prevSpan = Encoding.UTF8.GetBytes(prevValue).AsSpan();
 
-            headers.Append(headerName, prevSpan);
+            headers.Append(headerName, prevSpan, checkForNewlineChars : false);
             headers.OnHeadersComplete();
             var prevHeaderValue = ((IHeaderDictionary)headers)[prevName].ToString();
 
@@ -758,7 +758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 headerName = Encoding.ASCII.GetBytes(prevName).AsSpan();
                 var nextSpan = Encoding.UTF8.GetBytes(nextValue).AsSpan();
-                headers.Append(headerName, nextSpan);
+                headers.Append(headerName, nextSpan, checkForNewlineChars : false);
             }
 
             headers.OnHeadersComplete();

--- a/src/Servers/Kestrel/Core/test/HttpUtilitiesTest.cs
+++ b/src/Servers/Kestrel/Core/test/HttpUtilitiesTest.cs
@@ -247,15 +247,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             byte[] encodedBytes = { 0x01, 0x0A, 0x0D };
             Assert.Throws<InvalidOperationException>(() =>
-                HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, selector, true));
+                HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, selector, checkForNewlineChars : true));
         }
 
         [Theory]
         [MemberData(nameof(ExceptionThrownForCRLFData))]
-        private void ExceptionNotThrownForCRLF_ByDefault(Func<string, Encoding> selector)
+        private void ExceptionNotThrownForCRLF(Func<string, Encoding> selector)
         {
             byte[] encodedBytes = { 0x01, 0x0A, 0x0D };
-            HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, selector);
+            HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, selector, checkForNewlineChars : false);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/test/HttpUtilitiesTest.cs
+++ b/src/Servers/Kestrel/Core/test/HttpUtilitiesTest.cs
@@ -247,7 +247,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             byte[] encodedBytes = { 0x01, 0x0A, 0x0D };
             Assert.Throws<InvalidOperationException>(() =>
-                HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, selector));
+                HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, selector, true));
+        }
+
+        [Theory]
+        [MemberData(nameof(ExceptionThrownForCRLFData))]
+        private void ExceptionNotThrownForCRLF_ByDefault(Func<string, Encoding> selector)
+        {
+            byte[] encodedBytes = { 0x01, 0x0A, 0x0D };
+            HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, selector);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/test/HttpUtilitiesTest.cs
+++ b/src/Servers/Kestrel/Core/test/HttpUtilitiesTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
@@ -226,6 +227,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public void InvalidHostHeadersRejected(string host)
         {
             Assert.False(HttpUtilities.IsHostHeaderValid(host));
+        }
+
+        public static TheoryData<Func<string, Encoding>> ExceptionThrownForCRLFData
+        {
+            get
+            {
+                return new TheoryData<Func<string, Encoding>> {
+                    KestrelServerOptions.DefaultHeaderEncodingSelector,
+                    str => null,
+                    str => Encoding.Latin1
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ExceptionThrownForCRLFData))]
+        private void ExceptionThrownForCRLF(Func<string, Encoding> selector)
+        {
+            byte[] encodedBytes = { 0x01, 0x0A, 0x0D };
+            Assert.Throws<InvalidOperationException>(() =>
+                HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, selector));
         }
     }
 }

--- a/src/Servers/Kestrel/Core/test/UTF8Decoding.cs
+++ b/src/Servers/Kestrel/Core/test/UTF8Decoding.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [InlineData(new byte[] { 0xef, 0xbf, 0xbd })] // 3 bytes: Replacement character, highest UTF-8 character currently encoded in the UTF-8 code page
         private void FullUTF8RangeSupported(byte[] encodedBytes)
         {
-            var s = HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, KestrelServerOptions.DefaultHeaderEncodingSelector);
+            var s = HttpUtilities.GetRequestHeaderString(encodedBytes.AsSpan(), HeaderNames.Accept, KestrelServerOptions.DefaultHeaderEncodingSelector, checkForNewlineChars : false);
 
             Assert.Equal(1, s.Length);
         }
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                     Array.Copy(bytes, 0, byteRange, position, bytes.Length);
 
                     Assert.Throws<InvalidOperationException>(() =>
-                        HttpUtilities.GetRequestHeaderString(byteRange.AsSpan(), HeaderNames.Accept, KestrelServerOptions.DefaultHeaderEncodingSelector));
+                        HttpUtilities.GetRequestHeaderString(byteRange.AsSpan(), HeaderNames.Accept, KestrelServerOptions.DefaultHeaderEncodingSelector, checkForNewlineChars : false));
                 }
             }
         }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/BytesToStringBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/BytesToStringBenchmark.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         {
             for (uint i = 0; i < Iterations; i++)
             {
-                HttpUtilities.GetRequestHeaderString(_utf8Bytes, _headerName, KestrelServerOptions.DefaultHeaderEncodingSelector);
+                HttpUtilities.GetRequestHeaderString(_utf8Bytes, _headerName, KestrelServerOptions.DefaultHeaderEncodingSelector, checkForNewlineChars : true);
             }
         }
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
             }
 
             public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
-                => RequestHandler.Connection.OnHeader(name, value);
+                => RequestHandler.Connection.OnHeader(name, value, checkForNewlineChars : false);
 
             public void OnHeadersComplete(bool endStream)
                 => RequestHandler.Connection.OnHeadersComplete();

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/NullParser.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/NullParser.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         private readonly byte[] _hostHeaderName = Encoding.ASCII.GetBytes("Host");
         private readonly byte[] _hostHeaderValue = Encoding.ASCII.GetBytes("www.example.com");
         private readonly byte[] _acceptHeaderName = Encoding.ASCII.GetBytes("Accept");
-        private readonly byte[] _acceptHeaderValue = Encoding.ASCII.GetBytes("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n\r\n");
+        private readonly byte[] _acceptHeaderValue = Encoding.ASCII.GetBytes("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7");
         private readonly byte[] _connectionHeaderName = Encoding.ASCII.GetBytes("Connection");
         private readonly byte[] _connectionHeaderValue = Encoding.ASCII.GetBytes("keep-alive");
 

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -311,7 +311,7 @@ namespace CodeGenerator
                 }}
 
                 // We didn't have a previous matching header value, or have already added a header, so get the string for this value.
-                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector);
+                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector, checkForNewlineChars);
                 if ((_bits & flag) == 0)
                 {{
                     // We didn't already have a header set, so add a new one.
@@ -1239,7 +1239,7 @@ $@"        private void Clear(long bitsToClear)
             }} while (tempBits != 0);
         }}" : "")}{(loop.ClassName == "HttpRequestHeaders" ? $@"
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
         {{
             ref byte nameStart = ref MemoryMarshal.GetReference(name);
             var nameStr = string.Empty;
@@ -1259,13 +1259,13 @@ $@"        private void Clear(long bitsToClear)
                 // Convert value to string first, because passing two spans causes 8 bytes stack zeroing in 
                 // this method with rep stosd, which is slower than necessary.
                 nameStr = name.GetHeaderName();
-                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector);
+                var valueStr = value.GetRequestHeaderString(nameStr, EncodingSelector, checkForNewlineChars);
                 AppendUnknownHeaders(nameStr, valueStr);
             }}
         }}
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value)
+        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
         {{
             ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
             var nameStr = string.Empty;

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1239,7 +1239,7 @@ $@"        private void Clear(long bitsToClear)
             }} while (tempBits != 0);
         }}" : "")}{(loop.ClassName == "HttpRequestHeaders" ? $@"
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
+        public unsafe void Append(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {{
             ref byte nameStart = ref MemoryMarshal.GetReference(name);
             var nameStr = string.Empty;

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1265,11 +1265,12 @@ $@"        private void Clear(long bitsToClear)
         }}
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars = false)
+        public unsafe bool TryHPackAppend(int index, ReadOnlySpan<byte> value)
         {{
             ref StringValues values = ref Unsafe.AsRef<StringValues>(null);
             var nameStr = string.Empty;
             var flag = 0L;
+            var checkForNewlineChars = true;
 
             // Does the HPack static index match any ""known"" headers
             {AppendHPackSwitch(GroupHPack(loop.Headers))}

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -410,7 +410,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
             var nameStr = name.GetHeaderName();
-            _decodedHeaders[nameStr] = value.GetRequestHeaderString(nameStr, _serviceContext.ServerOptions.RequestHeaderEncodingSelector);
+            _decodedHeaders[nameStr] = value.GetRequestHeaderString(nameStr, _serviceContext.ServerOptions.RequestHeaderEncodingSelector, checkForNewlineChars : true);
         }
 
         public void OnStaticIndexedHeader(int index)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/33522 by rejecting CR/LF's in headers in Kestrel. Benchmark data before/after:

Before:

|             Method |      Type |      Mean |    Error |   StdDev |         Op/s | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------- |----------:|---------:|---------:|-------------:|------:|--------:|-------:|------:|------:|----------:|
| AsciiBytesToString | KeepAlive |  16.76 ns | 0.278 ns | 0.260 ns | 59,660,899.4 |  1.00 |    0.00 | 0.0006 |     - |     - |      48 B |
|  Utf8BytesToString | KeepAlive |  67.72 ns | 0.403 ns | 0.357 ns | 14,766,770.9 |  4.04 |    0.07 | 0.0013 |     - |     - |     104 B |
|                    |           |           |          |          |              |       |         |        |       |       |           |
| AsciiBytesToString |    Accept |  26.11 ns | 0.491 ns | 0.459 ns | 38,296,680.3 |  1.00 |    0.00 | 0.0025 |     - |     - |     200 B |
|  Utf8BytesToString |    Accept | 153.32 ns | 2.618 ns | 2.449 ns |  6,522,365.0 |  5.87 |    0.14 | 0.0050 |     - |     - |     408 B |
|                    |           |           |          |          |              |       |         |        |       |       |           |
| AsciiBytesToString | UserAgent |  30.06 ns | 0.521 ns | 0.462 ns | 33,262,624.7 |  1.00 |    0.00 | 0.0030 |     - |     - |     240 B |
|  Utf8BytesToString | UserAgent | 166.91 ns | 0.801 ns | 0.749 ns |  5,991,283.3 |  5.55 |    0.10 | 0.0061 |     - |     - |     504 B |
|                    |           |           |          |          |              |       |         |        |       |       |           |
| AsciiBytesToString |    Cookie |  50.06 ns | 0.588 ns | 0.491 ns | 19,975,125.6 |  1.00 |    0.00 | 0.0068 |     - |     - |     544 B |
|  Utf8BytesToString |    Cookie | 372.37 ns | 1.479 ns | 1.384 ns |  2,685,524.5 |  7.44 |    0.09 | 0.0140 |     - |     - |   1,144 B |

After:

|             Method |      Type |      Mean |    Error |   StdDev |         Op/s | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------- |----------:|---------:|---------:|-------------:|------:|--------:|-------:|------:|------:|----------:|
| AsciiBytesToString | KeepAlive |  15.56 ns | 0.300 ns | 0.357 ns | 64,271,699.2 |  1.00 |    0.00 | 0.0006 |     - |     - |      48 B |
|  Utf8BytesToString | KeepAlive |  74.81 ns | 1.029 ns | 0.859 ns | 13,366,906.2 |  4.76 |    0.14 | 0.0013 |     - |     - |     104 B |
|                    |           |           |          |          |              |       |         |        |       |       |           |
| AsciiBytesToString |    Accept |  25.87 ns | 0.460 ns | 0.430 ns | 38,648,372.4 |  1.00 |    0.00 | 0.0025 |     - |     - |     200 B |
|  Utf8BytesToString |    Accept | 151.04 ns | 0.674 ns | 0.563 ns |  6,620,945.7 |  5.84 |    0.10 | 0.0050 |     - |     - |     408 B |
|                    |           |           |          |          |              |       |         |        |       |       |           |
| AsciiBytesToString | UserAgent |  29.25 ns | 0.377 ns | 0.352 ns | 34,187,918.0 |  1.00 |    0.00 | 0.0030 |     - |     - |     240 B |
|  Utf8BytesToString | UserAgent | 172.23 ns | 0.881 ns | 0.735 ns |  5,806,140.1 |  5.88 |    0.08 | 0.0061 |     - |     - |     504 B |
|                    |           |           |          |          |              |       |         |        |       |       |           |
| AsciiBytesToString |    Cookie |  49.61 ns | 0.908 ns | 1.081 ns | 20,155,682.8 |  1.00 |    0.00 | 0.0068 |     - |     - |     544 B |
|  Utf8BytesToString |    Cookie | 363.82 ns | 3.277 ns | 2.905 ns |  2,748,632.6 |  7.33 |    0.15 | 0.0140 |     - |     - |   1,144 B |

The biggest loss was 10.4% in `Utf8BytesToString KeepAlive`, other benchmarks were between a 2% gain and a 3% loss.

Also fixes https://github.com/dotnet/aspnetcore/issues/34402