### PR TITLE
Fix behavioral regression in Mvc.Testing

### DIFF
--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -225,14 +225,16 @@ namespace Microsoft.AspNetCore.Mvc.Testing
             }
         }
 
-        private static string GetContentRootFromFile(string file)
+        private static string? GetContentRootFromFile(string file)
         {
             var data = JsonSerializer.Deserialize<IDictionary<string, string>>(File.ReadAllBytes(file))!;
             var key = typeof(TEntryPoint).Assembly.GetName().FullName;
 
+            // If the `ContentRoot` is not provided in the app manifest, then return null
+            // and fallback to setting the content root relative to the entrypoint's assembly.
             if (!data.TryGetValue(key, out var contentRoot))
             {
-                throw new KeyNotFoundException($"Could not find content root for project '{key}' in test manifest file '{file}'");
+                return null;
             }
 
             return (contentRoot == "~") ? AppContext.BaseDirectory : contentRoot;


### PR DESCRIPTION
As part of the changes made in https://github.com/dotnet/aspnetcore/commit/f7e1712db88db4c01fcc49e5995d9528dbf608df, we introduced a behavior change that caused the `WebApplicationFactory` to throw an exception if it did not find a `ContentRoot` in the manifest file.

This is breaking from the previous implementation that fell back to a path relative to the app assembly if a `ContentRoot` attribute wasn't defined in the assembly.

Update the method signature of `GetContentRootFromFile` to match the signature of `GetContentRootFromAssembly` and return a `string?` without throwing an exception.

Fixes https://github.com/dotnet/aspnetcore/issues/34354
