### PR TITLE
Stop retrying with project fixtures with selenium e2e

### DIFF
--- a/src/Components/test/E2ETest/AssemblyInfo.cs
+++ b/src/Components/test/E2ETest/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using Microsoft.AspNetCore.Testing;
-
-[assembly:Retry]


### PR DESCRIPTION
The retry attribute is retrying tests directly without going through any test initialization so it doesn't work with the fixtures in components e2e that require reinitialization, so removing the attribute from this assembly

cc @SteveSandersonMS @TanayParikh 