### PR TITLE
HTTP/3: Clone multiplex middleware with listener

### DIFF
--- a/src/Servers/Kestrel/Core/src/LocalhostListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/LocalhostListenOptions.cs
@@ -80,6 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             };
 
             options._middleware.AddRange(_middleware);
+            options._multiplexedMiddleware.AddRange(_multiplexedMiddleware);
             return options;
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -48,6 +48,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public async Task UnauthorizedHttpStatusResponse()
+        {
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            };
+
+            var requestStream = await InitializeConnectionAndStreamsAsync(context =>
+            {
+                context.Response.StatusCode = 401;
+                return Task.CompletedTask;
+            });
+
+            await requestStream.SendHeadersAsync(headers, endStream: true);
+
+            var responseHeaders = await requestStream.ExpectHeadersAsync();
+            Assert.Equal("401", responseHeaders[HeaderNames.Status]);
+
+            await requestStream.ExpectReceiveEndOfStream();
+        }
+
+        [Fact]
         public async Task EmptyMethod_Reset()
         {
             var headers = new[]

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -203,12 +203,12 @@ namespace Interop.FunctionalTests.Http3
                 // Assert
                 var hasWriteLog = TestSink.Writes.Any(
                     w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware" &&
-                    w.Message.StartsWith("WriteAsync"));
+                    w.Message.StartsWith("WriteAsync", StringComparison.Ordinal));
                 Assert.True(hasWriteLog);
 
                 var hasReadLog = TestSink.Writes.Any(
                     w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware" &&
-                    w.Message.StartsWith("ReadAsync"));
+                    w.Message.StartsWith("ReadAsync", StringComparison.Ordinal));
                 Assert.True(hasReadLog);
 
                 await host.StopAsync();

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -165,7 +165,57 @@ namespace Interop.FunctionalTests.Http3
             }
         }
 
-        private IHostBuilder CreateHttp3HostBuilder(RequestDelegate requestDelegate)
+        [ConditionalFact]
+        [MsQuicSupported]
+        public async Task GET_ConnectionLoggingConfigured_OutputToLogs()
+        {
+            // Arrange
+            var builder = CreateHttp3HostBuilder(
+                context =>
+                {
+                    return Task.CompletedTask;
+                },
+                kestrel =>
+                {
+                    kestrel.ListenLocalhost(5001, listenOptions =>
+                    {
+                        listenOptions.Protocols = HttpProtocols.Http3;
+                        listenOptions.UseHttps();
+                        listenOptions.UseConnectionLogging();
+                    });
+                });
+
+            using (var host = builder.Build())
+            using (var client = new HttpClient())
+            {
+                await host.StartAsync();
+
+                var port = 5001;
+
+                // Act
+                var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{port}/");
+                request1.Version = HttpVersion.Version30;
+                request1.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+                var response1 = await client.SendAsync(request1);
+                response1.EnsureSuccessStatusCode();
+
+                // Assert
+                var hasWriteLog = TestSink.Writes.Any(
+                    w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware" &&
+                    w.Message.StartsWith("WriteAsync"));
+                Assert.True(hasWriteLog);
+
+                var hasReadLog = TestSink.Writes.Any(
+                    w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Core.Internal.LoggingConnectionMiddleware" &&
+                    w.Message.StartsWith("ReadAsync"));
+                Assert.True(hasReadLog);
+
+                await host.StopAsync();
+            }
+        }
+
+        private IHostBuilder CreateHttp3HostBuilder(RequestDelegate requestDelegate, Action<KestrelServerOptions> configureKestrel = null)
         {
             return GetHostBuilder()
                 .ConfigureWebHost(webHostBuilder =>
@@ -173,12 +223,19 @@ namespace Interop.FunctionalTests.Http3
                     webHostBuilder
                         .UseKestrel(o =>
                         {
-                            o.ConfigureEndpointDefaults(listenOptions =>
+                            if (configureKestrel == null)
                             {
-                                listenOptions.Protocols = HttpProtocols.Http3;
-                            });
+                                o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
+                                {
+                                    listenOptions.Protocols = HttpProtocols.Http3;
+                                    listenOptions.UseHttps();
+                                });
+                            }
+                            else
+                            {
+                                configureKestrel(o);
+                            }
                         })
-                        .UseUrls("https://127.0.0.1:0")
                         .Configure(app =>
                         {
                             app.Run(requestDelegate);


### PR DESCRIPTION
Multiplex middleware wasn't being copied when ListenOptions were cloned.