### PR TITLE
WASM: popup readme for identity server

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -526,7 +526,7 @@
     {
       "id": "open-file",
       "condition": "(IndividualLocalAuth && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "description": "Opens Program.cs in the editor",
+      "description": "Opens Readme.txt in the editor",
       "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "args": {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -25,6 +25,10 @@
   "preferNameDirectory": true,
   "primaryOutputs": [
     {
+      "condition": "(Hosted && IndividualLocalAuth && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Server/Readme.txt"
+    },
+    {
       "condition": "(Hosted && (HostIdentifier == \"dotnetcli\" || HostIdentifier == \"dotnetcli-preview\"))",
       "path": "ComponentsWebAssembly-CSharp.sln"
     },
@@ -39,6 +43,10 @@
     {
       "condition": "(Hosted && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "Client/ComponentsWebAssembly-CSharp.Client.csproj"
+    },
+    {
+      "condition": "(Hosted && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Shared/ComponentsWebAssembly-CSharp.Shared.csproj"
     },
     {
       "condition": "(Hosted && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
@@ -517,6 +525,17 @@
         "files": ["ComponentsWebAssembly-CSharp.Client.csproj"]
       },
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    },
+    {
+      "id": "open-file",
+      "condition": "(IndividualLocalAuth && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Program.cs in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "0"
+      },
       "continueOnError": true
     }
   ]

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -47,10 +47,6 @@
     {
       "condition": "(Hosted && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "Shared/ComponentsWebAssembly-CSharp.Shared.csproj"
-    },
-    {
-      "condition": "(Hosted && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "Shared/ComponentsWebAssembly-CSharp.Shared.csproj"
     }
   ],
   "shortName": "blazorwasm",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Readme.txt
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Readme.txt
@@ -1,4 +1,4 @@
 This code includes a dependency on Duende IdentityServer.
 This is an open source product with a reciprocal license agreement. If you plan to use IdentityServer in production this may require a license fee.
 To see how to use AAD for your identity please see https://aka.ms/aspnetidentityserver
-To see if you require a commercial license for Duene IdentityServer please see https://aka.ms/identityserverlicense
+To see if you require a commercial license for Duende IdentityServer please see https://aka.ms/identityserverlicense

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Readme.txt
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Readme.txt
@@ -1,0 +1,1 @@
+See https://aka.ms/aspnetidentityserver.

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Readme.txt
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Readme.txt
@@ -1,1 +1,4 @@
-See https://aka.ms/aspnetidentityserver.
+This code includes a dependency on Duende IdentityServer.
+This is an open source product with a reciprocal license agreement. If you plan to use IdentityServer in production this may require a license fee.
+To see how to use AAD for your identity please see https://aka.ms/aspnetidentityserver
+To see if you require a commercial license for Duene IdentityServer please see https://aka.ms/identityserverlicense


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/32881

Show a readme text when identity server is used to highlight its license (hosted only + individual auth for blazor wasm)