### PR TITLE
Require Win10 for ALPN tests

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -794,6 +794,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10)] // HTTP/2 requires Win10
         [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "ALPN not supported")]
         public async Task ServerOptionsSelectionCallback_SetsALPN()
         {
@@ -821,6 +822,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
+        [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10)] // HTTP/2 requires Win10
         [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "ALPN not supported")]
         public async Task TlsHandshakeCallbackOptionsOverload_SetsALPN()
         {


### PR DESCRIPTION
There are new tests that failed on Win8.1 because HTTP/2 isn't supported there. https://github.com/dotnet/aspnetcore/pull/34242