### PR TITLE
Skip, quarantine and un-Quarantine

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -1080,7 +1080,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33373")]
         public async Task ContentLength_Received_MultipleDataFramesOverSize_Reset()
         {
             IOException thrownEx = null;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/LoggingConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/LoggingConnectionMiddlewareTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
     public class LoggingConnectionMiddlewareTests : LoggedTest
     {
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34561")]
         public async Task LoggingConnectionMiddlewareCanBeAddedBeforeAndAfterHttps()
         {
             await using (var server = new TestServer(context =>

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.reactivex.rxjava3.core.Single;
@@ -126,7 +126,7 @@ public class LongPollingTransportTest {
         assertTrue(onReceivedRan.get());
     }
 
-    @Ignore("https://github.com/dotnet/aspnetcore/issues/34563")
+    @Disabled("https://github.com/dotnet/aspnetcore/issues/34563")
     @Test
     public void LongPollingTransportOnReceiveGetsCalled() {
         AtomicInteger requestCount = new AtomicInteger();

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 import io.reactivex.rxjava3.core.Single;

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -125,6 +125,7 @@ public class LongPollingTransportTest {
         assertTrue(onReceivedRan.get());
     }
 
+    @Ignore("https://github.com/dotnet/aspnetcore/issues/34563")
     @Test
     public void LongPollingTransportOnReceiveGetsCalled() {
         AtomicInteger requestCount = new AtomicInteger();


### PR DESCRIPTION
- un-quarantine `ContentLength_Received_MultipleDataFramesOverSize_Reset`, #33373 fix seems to have worked
- quarantine `LoggingConnectionMiddlewareCanBeAddedBeforeAndAfterHttps()`, #34561
- skip `LongPollingTransportOnReceiveGetsCalled()` because we can't quarantine Java tests, #34563