### PR TITLE
Remove async state machines from middlewares when they do nothing

### DIFF
--- a/src/Http/Http.Abstractions/src/Extensions/MapMiddleware.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapMiddleware.cs
@@ -55,7 +55,11 @@ namespace Microsoft.AspNetCore.Builder.Extensions
 
             if (context.Request.Path.StartsWithSegments(_options.PathMatch, out var matchedPath, out var remainingPath))
             {
-                return InvokeCore(context, matchedPath, remainingPath);
+                if (!_options.PreserveMatchedPathSegment)
+                {
+                    return InvokeCore(context, matchedPath, remainingPath);
+                }
+                return _options.Branch!(context);
             }
             return _next(context);
         }
@@ -65,12 +69,9 @@ namespace Microsoft.AspNetCore.Builder.Extensions
             var path = context.Request.Path;
             var pathBase = context.Request.PathBase;
 
-            if (!_options.PreserveMatchedPathSegment)
-            {
-                // Update the path
-                context.Request.PathBase = pathBase.Add(matchedPath);
-                context.Request.Path = remainingPath;
-            }
+            // Update the path
+            context.Request.PathBase = pathBase.Add(matchedPath);
+            context.Request.Path = remainingPath;
 
             try
             {
@@ -78,11 +79,8 @@ namespace Microsoft.AspNetCore.Builder.Extensions
             }
             finally
             {
-                if (!_options.PreserveMatchedPathSegment)
-                {
-                    context.Request.PathBase = pathBase;
-                    context.Request.Path = path;
-                }
+                context.Request.PathBase = pathBase;
+                context.Request.Path = path;
             }
         }
     }

--- a/src/Http/Http.Abstractions/src/Extensions/MapMiddleware.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapMiddleware.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Builder.Extensions
         /// </summary>
         /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
         /// <returns>A task that represents the execution of this middleware.</returns>
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (context == null)
             {
@@ -55,32 +55,34 @@ namespace Microsoft.AspNetCore.Builder.Extensions
 
             if (context.Request.Path.StartsWithSegments(_options.PathMatch, out var matchedPath, out var remainingPath))
             {
-                var path = context.Request.Path;
-                var pathBase = context.Request.PathBase;
+                return InvokeCore(context, matchedPath, remainingPath);
+            }
+            return _next(context);
+        }
 
+        private async Task InvokeCore(HttpContext context, string matchedPath, string remainingPath)
+        {
+            var path = context.Request.Path;
+            var pathBase = context.Request.PathBase;
+
+            if (!_options.PreserveMatchedPathSegment)
+            {
+                // Update the path
+                context.Request.PathBase = pathBase.Add(matchedPath);
+                context.Request.Path = remainingPath;
+            }
+
+            try
+            {
+                await _options.Branch!(context);
+            }
+            finally
+            {
                 if (!_options.PreserveMatchedPathSegment)
                 {
-                    // Update the path
-                    context.Request.PathBase = pathBase.Add(matchedPath);
-                    context.Request.Path = remainingPath;
+                    context.Request.PathBase = pathBase;
+                    context.Request.Path = path;
                 }
-
-                try
-                {
-                    await _options.Branch!(context);
-                }
-                finally
-                {
-                    if (!_options.PreserveMatchedPathSegment)
-                    {
-                        context.Request.PathBase = pathBase;
-                        context.Request.Path = path;
-                    }
-                }
-            }
-            else
-            {
-                await _next(context);
             }
         }
     }

--- a/src/Http/Http.Abstractions/src/Extensions/MapWhenMiddleware.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapWhenMiddleware.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Builder.Extensions
         /// </summary>
         /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
         /// <returns>A task that represents the execution of this middleware.</returns>
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (context == null)
             {
@@ -60,12 +60,9 @@ namespace Microsoft.AspNetCore.Builder.Extensions
 
             if (_options.Predicate!(context))
             {
-                await _options.Branch!(context);
+                return _options.Branch!(context);
             }
-            else
-            {
-                await _next(context);
-            }
+            return _next(context);
         }
     }
 }

--- a/src/Http/Http.Abstractions/src/Extensions/UsePathBaseMiddleware.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UsePathBaseMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -41,36 +41,35 @@ namespace Microsoft.AspNetCore.Builder.Extensions
         /// </summary>
         /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
         /// <returns>A task that represents the execution of this middleware.</returns>
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            PathString matchedPath;
-            PathString remainingPath;
-
-            if (context.Request.Path.StartsWithSegments(_pathBase, out matchedPath, out remainingPath))
+            if (context.Request.Path.StartsWithSegments(_pathBase, out var matchedPath, out var remainingPath))
             {
-                var originalPath = context.Request.Path;
-                var originalPathBase = context.Request.PathBase;
-                context.Request.Path = remainingPath;
-                context.Request.PathBase = originalPathBase.Add(matchedPath);
-
-                try
-                {
-                    await _next(context);
-                }
-                finally
-                {
-                    context.Request.Path = originalPath;
-                    context.Request.PathBase = originalPathBase;
-                }
+                return InvokeCore(context, matchedPath, remainingPath);
             }
-            else
+            return _next(context);
+        }
+
+        private async Task InvokeCore(HttpContext context, string matchedPath, string remainingPath)
+        {
+            var originalPath = context.Request.Path;
+            var originalPathBase = context.Request.PathBase;
+            context.Request.Path = remainingPath;
+            context.Request.PathBase = originalPathBase.Add(matchedPath);
+
+            try
             {
                 await _next(context);
+            }
+            finally
+            {
+                context.Request.Path = originalPath;
+                context.Request.PathBase = originalPathBase;
             }
         }
     }

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionMiddleware.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionMiddleware.cs
@@ -44,14 +44,17 @@ namespace Microsoft.AspNetCore.ResponseCompression
         /// </summary>
         /// <param name="context">The <see cref="HttpContext"/>.</param>
         /// <returns>A task that represents the execution of this middleware.</returns>
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (!_provider.CheckRequestAcceptsCompression(context))
             {
-                await _next(context);
-                return;
+                return _next(context);
             }
+            return InvokeCore(context);
+        }
 
+        private async Task InvokeCore(HttpContext context)
+        {
             var originalBodyFeature = context.Features.Get<IHttpResponseBodyFeature>();
             var originalCompressionFeature = context.Features.Get<IHttpsCompressionFeature>();
 

--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyMiddleware.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyMiddleware.cs
@@ -45,29 +45,31 @@ namespace Microsoft.AspNetCore.SpaProxy
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (context.Request.Path.Equals(new Uri(_options.Value.ServerUrl).LocalPath))
             {
-                context.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store, must-revalidate, max-age=0";
-                if (!await _spaProxyLaunchManager.IsSpaProxyRunning(context.RequestAborted))
-                {
-                    _spaProxyLaunchManager.StartInBackground(_hostLifetime.ApplicationStopping);
-                    _logger.LogInformation("SPA proxy is not ready. Returning temporary landing page.");
-                    context.Response.ContentType = "text/html";
+                return InvokeCore(context);
+            }
+            return _next(context);
+        }
 
-                    await using var writer = new StreamWriter(context.Response.Body, Encoding.UTF8);
-                    await writer.WriteAsync(GenerateSpaLaunchPage(_options.Value));
-                }
-                else
-                {
-                    _logger.LogInformation($"SPA proxy is ready. Redirecting to {_options.Value.ServerUrl}.");
-                    context.Response.Redirect(_options.Value.ServerUrl);
-                }
+        private async Task InvokeCore(HttpContext context)
+        {
+            context.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store, must-revalidate, max-age=0";
+            if (!await _spaProxyLaunchManager.IsSpaProxyRunning(context.RequestAborted))
+            {
+                _spaProxyLaunchManager.StartInBackground(_hostLifetime.ApplicationStopping);
+                _logger.LogInformation("SPA proxy is not ready. Returning temporary landing page.");
+                context.Response.ContentType = "text/html";
+
+                await using var writer = new StreamWriter(context.Response.Body, Encoding.UTF8);
+                await writer.WriteAsync(GenerateSpaLaunchPage(_options.Value));
             }
             else
             {
-                await _next(context);
+                _logger.LogInformation($"SPA proxy is ready. Redirecting to {_options.Value.ServerUrl}.");
+                context.Response.Redirect(_options.Value.ServerUrl);
             }
 
             string GenerateSpaLaunchPage(SpaDevelopmentServerOptions options)

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/ConditionalProxyMiddleware.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Proxying/ConditionalProxyMiddleware.cs
@@ -43,16 +43,22 @@ namespace Microsoft.AspNetCore.SpaServices.Extensions.Proxy
             _applicationStoppingToken = applicationLifetime.ApplicationStopping;
         }
 
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
         {
             if (context.Request.Path.StartsWithSegments(_pathPrefix) || _pathPrefixIsRoot)
             {
-                var didProxyRequest = await SpaProxy.PerformProxyRequest(
-                    context, _httpClient, _baseUriTask, _applicationStoppingToken, proxy404s: false);
-                if (didProxyRequest)
-                {
-                    return;
-                }
+                return InvokeCore(context);
+            }
+            return _next.Invoke(context);
+        }
+
+        private async Task InvokeCore(HttpContext context)
+        {
+            var didProxyRequest = await SpaProxy.PerformProxyRequest(
+                context, _httpClient, _baseUriTask, _applicationStoppingToken, proxy404s: false);
+            if (didProxyRequest)
+            {
+                return;
             }
 
             // Not a request we can proxy


### PR DESCRIPTION
**PR Title**
Remove async state machines from middlewares when they do nothing

**PR Description**
Searched for `await _next(` and found a couple more in src\Http and src\Middleware
- MapMiddleware
- MapWhenMiddleware
- UsePathBaseMiddleware
- MigrationsEndPointMiddleware
- HttpMethodOverrideMiddleware
- ResponseCompressionMiddleware
- SpaProxyMiddleware
- ConditionalProxyMiddleware
- IISMiddleware

Fixes https://github.com/dotnet/aspnetcore/issues/34574
