### PR TITLE
Observe changes to IWebHostBuilder settings

### DIFF
--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -17,7 +17,6 @@ namespace Microsoft.AspNetCore.Builder
     {
         private readonly WebHostEnvironment _environment;
         private readonly ConfigurationManager _configuration;
-        private readonly Dictionary<string, string?> _settings = new(StringComparer.OrdinalIgnoreCase);
         private readonly IServiceCollection _services;
 
         private readonly WebHostBuilderContext _context;
@@ -66,14 +65,13 @@ namespace Microsoft.AspNetCore.Builder
         /// <inheritdoc />
         public string? GetSetting(string key)
         {
-            _settings.TryGetValue(key, out var value);
-            return value;
+            return _configuration[key];
         }
 
         /// <inheritdoc />
         public IWebHostBuilder UseSetting(string key, string? value)
         {
-            _settings[key] = value;
+            _configuration[key] = value;
 
             // All properties on IWebHostEnvironment are non-nullable.
             if (value is null)
@@ -99,14 +97,6 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             return this;
-        }
-
-        internal void ApplySettings(IWebHostBuilder webHostBuilder)
-        {
-            foreach (var (key, value) in _settings)
-            {
-                webHostBuilder.UseSetting(key, value);
-            }
         }
     }
 }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -49,6 +49,9 @@ namespace Microsoft.AspNetCore.Builder
 
             // Add default services
             _deferredHostBuilder.ConfigureDefaults(args);
+
+            // Enable changes here because we need to pick up configuration sources added by the generic web host
+            _deferredHostBuilder.ConfigurationEnabled = true;
             _deferredHostBuilder.ConfigureWebHostDefaults(configure: _ => { });
 
             // This is important because GenericWebHostBuilder does the following and we want to preserve the WebHostBuilderContext:
@@ -58,10 +61,6 @@ namespace Microsoft.AspNetCore.Builder
             {
                 _hostBuilder.Properties[key] = value;
             }
-
-            // Configuration changes made by ConfigureDefaults(args) were already picked up by the BootstrapHostBuilder,
-            // so we ignore changes to config until ConfigureDefaults completes.
-            _deferredHostBuilder.ConfigurationEnabled = true;
         }
 
         /// <summary>
@@ -220,7 +219,6 @@ namespace Microsoft.AspNetCore.Builder
             genericWebHostBuilder.Configure(ConfigureApplication);
 
             _deferredHostBuilder.RunDeferredCallbacks(_hostBuilder);
-            _deferredWebHostBuilder.ApplySettings(genericWebHostBuilder);
 
             _environment.ApplyEnvironmentSettings(genericWebHostBuilder);
         }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -197,6 +197,26 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
+        public void WebApplicationBuilderWebHostUseSettingCanBeReadByConfiguration()
+        {
+            var builder = WebApplication.CreateBuilder();
+
+            builder.WebHost.UseSetting("A", "value");
+            builder.WebHost.UseSetting("B", "another");
+
+            Assert.Equal("value", builder.WebHost.GetSetting("A"));
+            Assert.Equal("another", builder.WebHost.GetSetting("B"));
+
+            var app = builder.Build();
+
+            Assert.Equal("value", app.Configuration["A"]);
+            Assert.Equal("another", app.Configuration["B"]);
+
+            Assert.Equal("value", builder.Configuration["A"]);
+            Assert.Equal("another", builder.Configuration["B"]);
+        }
+
+        [Fact]
         public void WebApplicationBuilderHostProperties_IsCaseSensitive()
         {
             var builder = WebApplication.CreateBuilder();
@@ -369,7 +389,7 @@ namespace Microsoft.AspNetCore.Tests
                 Assert.Equal(webRootPath, builder.WebHost.GetSetting("webroot"));
             }
 
-            
+
             var app = builder.Build();
             Assert.Equal(fullWebRootPath, app.Environment.WebRootPath);
         }


### PR DESCRIPTION
- Today we have a complex process to bootstrap configuration, then we use that configuration to bootstrap the default services. This process missed configuration updates in some narrow cases, and one of those was caught by the IIS out of process extension method.
- Today when we configure the `WebApplicationBuilder`, we end up not catching all calls to `UseSetting` on the various `IWebHostBuilder` implementations that are created during bootstrapping. This was observable in 2 ways:
  1. Calls to WebApplicationBuilder.WebHost.UseSetting
  2. Any call to UseSetting during the DeferredHostBuilder. They happen for the same reason, that is, calls to UseSetting tried to mutate the final `GenericWebHostBuilder` via `ApplySettings`, and that configuration source gets thrown away (we clear them all assuming they were already applied). The fix implemented here uses the ConfigurationManager as the source of truth in all cases. We use it as the backing store for the DeferredWebHostBuilder and we add the GenericWebHostBuilder's configuration sources to it. That way it should truly see all of the configuration values.

The reason the IIS case found this issue is because the configuration bootstrapping process misses configuration values added during callbacks to configure services (and possibly other callbacks as well).

PS: I can't really test the IIS case in a unit test because the repro relies on code that runs inside of the call to `WebApplication.CreateBuilder`

Fixes https://github.com/dotnet/aspnetcore/issues/34565
