### PR TITLE
Unquarantine `CanUploadSingleLargeFile`

### DIFF
--- a/src/Components/test/E2ETest/Tests/InputFileTest.cs
+++ b/src/Components/test/E2ETest/Tests/InputFileTest.cs
@@ -66,7 +66,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/26331")]
         public void CanUploadSingleLargeFile()
         {
             // Create a large text file


### PR DESCRIPTION
Everything seems to be working as expected and we're seeing a consistent pass rate over the past 30 days:

![image](https://user-images.githubusercontent.com/14852843/126516380-be068b45-ee81-4c68-bde2-ec8f9871f926.png)

![image](https://user-images.githubusercontent.com/14852843/126516785-162f75d3-a7f4-4ef3-a448-bbb5d5a74975.png)

Fixes: https://github.com/dotnet/aspnetcore/issues/26331