### PR TITLE
Update RazorPage template to be able to be SxS with previous version

### DIFF
--- a/src/ProjectTemplates/Web.ItemTemplates/Microsoft.DotNet.Web.ItemTemplates.csproj
+++ b/src/ProjectTemplates/Web.ItemTemplates/Microsoft.DotNet.Web.ItemTemplates.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <PackageId>Microsoft.DotNet.Web.ItemTemplates.$(AspNetCoreMajorMinorVersion)</PackageId>
     <Description>Web File Templates for Microsoft Template Engine.</Description>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
@@ -12,8 +12,8 @@
     "language": "",
     "type": "item"
   },
-  "groupIdentity": "Microsoft.Web.Grpc.Protobuf",
-  "precedence": "100",
+  "groupIdentity": "Microsoft.Web.Grpc.Protobuf.6.0",
+  "precedence": "600",
   "identity": "Microsoft.Web.Grpc.Protobuf",
   "shortname": "proto",
   "sourceName": "protobuf",

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorComponent/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorComponent/.template.config/template.json
@@ -13,8 +13,8 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.AspNetCore.Components.RazorComponent",
-  "precedence": "100",
-  "identity": "Microsoft.AspNetCore.Components.RazorComponent",
+  "precedence": "600",
+  "identity": "Microsoft.AspNetCore.Components.RazorComponent.6.0",
   "shortname": "razorcomponent",
   "sourceName": "Component1",
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
@@ -10,8 +10,8 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.RazorPage",
-  "precedence": "100",
-  "identity": "Microsoft.AspNetCore.Mvc.RazorPage",
+  "precedence": "600",
+  "identity": "Microsoft.AspNetCore.Mvc.RazorPage.6.0",
   "shortName": "page",
   "sourceName": "Index",
   "primaryOutputs": [
@@ -45,6 +45,19 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the template.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0"
+        }
+      ],
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
@@ -46,19 +46,6 @@
       "datatype": "bool",
       "defaultValue": "false"
     },
-    "Framework": {
-      "type": "parameter",
-      "description": "The target framework for the template.",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0"
-        }
-      ],
-      "replaces": "net6.0",
-      "defaultValue": "net6.0"
-    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/Index.cshtml.cs
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/Index.cshtml.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/Index.cshtml.cs
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/Index.cshtml.cs
@@ -5,15 +5,16 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace MyApp.Namespace;
-
-#if NameIsPage
-public class IndexModel : Microsoft.AspNetCore.Mvc.RazorPages.PageModel
-#else
-public class IndexModel : PageModel
-#endif
+namespace MyApp.Namespace
 {
-    public void OnGet()
+    #if NameIsPage
+    public class IndexModel : Microsoft.AspNetCore.Mvc.RazorPages.PageModel
+    #else
+    public class IndexModel : PageModel
+    #endif
     {
+        public void OnGet()
+        {
+        }
     }
 }

--- a/src/ProjectTemplates/Web.ItemTemplates/content/ViewImports/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/ViewImports/.template.config/template.json
@@ -10,8 +10,8 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.ViewImports",
-  "precedence": "100",
-  "identity": "Microsoft.AspNetCore.Mvc.ViewImports",
+  "precedence": "600",
+  "identity": "Microsoft.AspNetCore.Mvc.ViewImports.6.0",
   "shortName": "viewimports",
   "sourceName": "ignoreme",
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.ItemTemplates/content/ViewStart/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/ViewStart/.template.config/template.json
@@ -10,8 +10,8 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.ViewStart",
-  "precedence": "100",
-  "identity": "Microsoft.AspNetCore.Mvc.ViewStart",
+  "precedence": "600",
+  "identity": "Microsoft.AspNetCore.Mvc.ViewStart.6.0",
   "shortName": "viewstart",
   "sourceName": "ignoreme",
   "primaryOutputs": [


### PR DESCRIPTION
- Update Web.ItemTemplates to use a versioned package identity
- Bump up the precedence
- Make unique identities
- Add Framework symbol for RazorPage template

This fixes the issue with template creation in Visual Studio where the NET 6 template hides the NET 5 version of the template resulting in errors due to the file-scoped namespace usage in the net 6 version of the template.