### PR TITLE
Update MonoPlatform.toUint8Array Implementation

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -68,7 +68,9 @@ export const monoPlatform: Platform = {
   toUint8Array: function toUint8Array(array: System_Array<any>): Uint8Array {
     const dataPtr = getArrayDataPointer(array);
     const length = getValueI32(dataPtr);
-    return new Uint8Array(Module.HEAPU8.buffer, dataPtr + 4, length);
+    const uint8Array = new Uint8Array(length);
+    uint8Array.set(Module.HEAPU8.subarray(dataPtr + 4, dataPtr + 4 + length));
+    return uint8Array;
   },
 
   getArrayLength: function getArrayLength(array: System_Array<any>): number {


### PR DESCRIPTION
Through https://github.com/dotnet/aspnetcore/pull/34526, it was discovered there's an issue with the `roundTripByteArrayAsyncFromJS` WASM E2E test. I validated the failure locally, and it repro'd for other .NET -> JS byte[] WASM interop as well. It appeared to be an issue with the reference of the byte array being sent from .NET to JS being invalidated after a while. Further investigation indicated the `MonoPlatform.toUint8Array` method is the culprit. The technique used to access the heap seems to cause issues with long lived references, and a cursory look didn't find other places where this pattern is used. This PR uses an alternate pattern in line with [how it's done in `mono/wasm/runtime`](https://github.com/dotnet/runtime/blob/04e6dcc6ae1425f90dc9a2a34629e7f53a3275dc/src/mono/wasm/runtime/binding_support.js#L701-L707).

Additional runs:
- https://dev.azure.com/dnceng/public/_build/results?buildId=1251965&view=results
- https://dev.azure.com/dnceng/public/_build/results?buildId=1251969&view=results