### PR TITLE
Observe more mutations to configuration and services

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -206,8 +206,7 @@ namespace Microsoft.AspNetCore.Builder
         {
             genericWebHostBuilder.Configure(ConfigureApplication);
 
-            // This needs to go here to avoid adding the IHostedService that boots the server twice
-
+            // This needs to go here to avoid adding the IHostedService that boots the server twice (the GenericWebHostService).
             // Copy the services that were added via WebApplicationBuilder.Services into the final IServiceCollection
             genericWebHostBuilder.ConfigureServices((context, services) =>
             {
@@ -234,7 +233,6 @@ namespace Microsoft.AspNetCore.Builder
                 // to the new one. This allows code that has references to the service collection to still function.
                 _services.InnerCollection = services;
             });
-
 
             // Run the other callbacks on the final host builder
             _deferredHostBuilder.RunDeferredCallbacks(_hostBuilder);

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -23,10 +23,12 @@ namespace Microsoft.AspNetCore.Builder
         private readonly ConfigureHostBuilder _deferredHostBuilder;
         private readonly ConfigureWebHostBuilder _deferredWebHostBuilder;
         private readonly WebHostEnvironment _environment;
+        private readonly WebApplicationServiceCollection _services = new();
         private WebApplication? _builtApplication;
 
         internal WebApplicationBuilder(Assembly? callingAssembly, string[]? args = null)
         {
+            Services = _services;
             // HACK: MVC and Identity do this horrible thing to get the hosting environment as an instance
             // from the service collection before it is built. That needs to be fixed...
             Environment = _environment = new WebHostEnvironment(callingAssembly);
@@ -45,9 +47,6 @@ namespace Microsoft.AspNetCore.Builder
             Logging = new LoggingBuilder(Services);
             WebHost = _deferredWebHostBuilder = new ConfigureWebHostBuilder(Configuration, _environment, Services);
             Host = _deferredHostBuilder = new ConfigureHostBuilder(Configuration, _environment, Services);
-
-            // Register Configuration as IConfiguration so updates can be observed even after the WebApplication is built.
-            Services.AddSingleton<IConfiguration>(Configuration);
 
             // Add default services
             _deferredHostBuilder.ConfigureDefaults(args);
@@ -73,7 +72,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// A collection of services for the application to compose. This is useful for adding user provided or framework provided services.
         /// </summary>
-        public IServiceCollection Services { get; } = new ServiceCollection();
+        public IServiceCollection Services { get; } = default!;
 
         /// <summary>
         /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
@@ -103,11 +102,66 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>A configured <see cref="WebApplication"/>.</returns>
         public WebApplication Build()
         {
+            // Copy the configuration sources into the final IConfigurationBuilder
+            _hostBuilder.ConfigureHostConfiguration(builder =>
+            {
+                foreach (var source in ((IConfigurationBuilder)Configuration).Sources)
+                {
+                    builder.Sources.Add(source);
+                }
+
+                foreach (var (key, value) in ((IConfigurationBuilder)Configuration).Properties)
+                {
+                    builder.Properties[key] = value;
+                }
+            });
+
             // We call ConfigureWebHostDefaults AGAIN because config might be added like "ForwardedHeaders_Enabled"
             // which can add even more services. If not for that, we probably call _hostBuilder.ConfigureWebHost(ConfigureWebHost)
             // instead in order to avoid duplicate service registration.
             _hostBuilder.ConfigureWebHostDefaults(ConfigureWebHost);
-            return _builtApplication = new WebApplication(_hostBuilder.Build());
+
+            // Copy the services that were added via WebApplicationBuilder.Services into the final IServiceCollection
+            _hostBuilder.ConfigureServices((context, services) =>
+            {
+                // We've only added services configured by the GenericWebHostBuilder and WebHost.ConfigureWebDefaults
+                // at this point. HostBuilder news up a new ServiceCollection in HostBuilder.Build() we haven't seen
+                // until now, so we cannot clear these services even though some are redundant because
+                // we called ConfigureWebHostDefaults on both the _deferredHostBuilder and _hostBuilder.
+
+                // Ideally, we'd only call _hostBuilder.ConfigureWebHost(ConfigureWebHost) instead of
+                // _hostBuilder.ConfigureWebHostDefaults(ConfigureWebHost) to avoid some duplicate service descriptors,
+                // but we want to add services in the WebApplicationBuilder constructor so code can inspect
+                // WebApplicationBuilder.Services. At the same time, we want to be able which services are loaded
+                // to react to config changes (e.g. ForwardedHeadersStartupFilter).
+                foreach (var s in _services)
+                {
+                    services.Add(s);
+                }
+
+                // Add any services to the user visible service collection so that they are observable
+                // just in case users capture the Services property. Orchard does this to get a "blueprint"
+                // of the service collection
+
+                // Clear the original collection.
+                _services.Clear();
+
+                // Drop the reference to the existing collection and set the inner collection
+                // to the new one. This allows code that has references to the service collection to still function.
+                _services.InnerCollection = services;
+            });
+
+            // Run the other callbacks on the final host builder
+            _deferredHostBuilder.RunDeferredCallbacks(_hostBuilder);
+
+            _builtApplication = new WebApplication(_hostBuilder.Build());
+
+            // Make builder.Configuration match the final configuration. To do that
+            // we clear the sources and add the built configuration as a source
+            ((IConfigurationBuilder)Configuration).Sources.Clear();
+            Configuration.AddConfiguration(_builtApplication.Configuration);
+
+            return _builtApplication;
         }
 
         private void ConfigureApplication(WebHostBuilderContext context, IApplicationBuilder app)
@@ -183,51 +237,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private void ConfigureWebHost(IWebHostBuilder genericWebHostBuilder)
         {
-            _hostBuilder.ConfigureHostConfiguration(builder =>
-            {
-                // All the sources in builder.Sources should be in Configuration.Sources
-                // already thanks to the BootstrapHostBuilder.
-                builder.Sources.Clear();
-
-                foreach (var (key, value) in ((IConfigurationBuilder)Configuration).Properties)
-                {
-                    builder.Properties[key] = value;
-                }
-
-                builder.AddConfiguration(Configuration, shouldDisposeConfiguration: true);
-            });
-
-            genericWebHostBuilder.ConfigureServices((context, services) =>
-            {
-                // We've only added services configured by the GenericWebHostBuilder and WebHost.ConfigureWebDefaults
-                // at this point. HostBuilder news up a new ServiceCollection in HostBuilder.Build() we haven't seen
-                // until now, so we cannot clear these services even though some are redundant because
-                // we called ConfigureWebHostDefaults on both the _deferredHostBuilder and _hostBuilder.
-
-                // Ideally, we'd only call _hostBuilder.ConfigureWebHost(ConfigureWebHost) instead of
-                // _hostBuilder.ConfigureWebHostDefaults(ConfigureWebHost) to avoid some duplicate service descriptors,
-                // but we want to add services in the WebApplicationBuilder constructor so code can inspect
-                // WebApplicationBuilder.Services. At the same time, we want to be able which services are loaded
-                // to react to config changes (e.g. ForwardedHeadersStartupFilter).
-                foreach (var s in Services)
-                {
-                    services.Add(s);
-                }
-
-                // Add any services to the user visible service collection so that they are observable
-                // just in case users capture the Services property. Orchard does this to get a "blueprint"
-                // of the service collection. The order needs to be preserved here so we clear the original
-                // collection and add all of the services in order.
-                Services.Clear();
-                foreach (var s in services)
-                {
-                    Services.Add(s);
-                }
-            });
-
             genericWebHostBuilder.Configure(ConfigureApplication);
-
-            _deferredHostBuilder.RunDeferredCallbacks(_hostBuilder);
 
             _environment.ApplyEnvironmentSettings(genericWebHostBuilder);
         }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// A collection of services for the application to compose. This is useful for adding user provided or framework provided services.
         /// </summary>
-        public IServiceCollection Services { get; } = default!;
+        public IServiceCollection Services { get; }
 
         /// <summary>
         /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
@@ -142,9 +142,6 @@ namespace Microsoft.AspNetCore.Builder
                 // Add any services to the user visible service collection so that they are observable
                 // just in case users capture the Services property. Orchard does this to get a "blueprint"
                 // of the service collection
-
-                // Clear the original collection.
-                _services.Clear();
 
                 // Drop the reference to the existing collection and set the inner collection
                 // to the new one. This allows code that has references to the service collection to still function.

--- a/src/DefaultBuilder/src/WebApplicationServiceCollection.cs
+++ b/src/DefaultBuilder/src/WebApplicationServiceCollection.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore
+{
+    internal sealed class WebApplicationServiceCollection : IServiceCollection
+    {
+        private IServiceCollection _services = new ServiceCollection();
+
+        public ServiceDescriptor this[int index] { get => _services[index]; set => _services[index] = value; }
+
+        public int Count => _services.Count;
+
+        public bool IsReadOnly => _services.IsReadOnly;
+
+        public IServiceCollection InnerCollection { get => _services; set => _services = value; }
+
+        public void Add(ServiceDescriptor item)
+        {
+            _services.Add(item);
+        }
+
+        public void Clear()
+        {
+            _services.Clear();
+        }
+
+        public bool Contains(ServiceDescriptor item)
+        {
+            return _services.Contains(item);
+        }
+
+        public void CopyTo(ServiceDescriptor[] array, int arrayIndex)
+        {
+            _services.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<ServiceDescriptor> GetEnumerator()
+        {
+            return _services.GetEnumerator();
+        }
+
+        public int IndexOf(ServiceDescriptor item)
+        {
+            return _services.IndexOf(item);
+        }
+
+        public void Insert(int index, ServiceDescriptor item)
+        {
+            _services.Insert(index, item);
+        }
+
+        public bool Remove(ServiceDescriptor item)
+        {
+            return _services.Remove(item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _services.RemoveAt(index);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
- When using WebApplicationFactory with the WebApplicationFactory, mutations are made very late that aren't observable via the WebApplicationBuilder.Configuration nor  WebApplicationBuilder.Services. The configuration tries to be the source of truth but more sources are added it can't see, the same with the service collection (though that is more rare). To fix this, the strategy is to use the initial service collection and configuration as data that will feed into the final IConfigurationBuilder and IServiceCollection, and then "update" these properties to point back to the final configuration and service collection. Results in the properties on the builder being consistent (from a data POV) with the built application.
- Added tests that mimic what the WebApplicationFactory does but using the diagnostic source to capture the right events for the right host and mutate the IHostBuilder.

Fixes https://github.com/dotnet/aspnetcore/issues/33876