### PR TITLE
Fix flakiness in HeadModificationPrerenderingTest

### DIFF
--- a/src/Components/Web/src/Forms/InputDateType.cs
+++ b/src/Components/Web/src/Forms/InputDateType.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.AspNetCore.Components.Forms
 {

--- a/src/Components/test/E2ETest/ServerExecutionTests/HeadModificationPrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/HeadModificationPrerenderingTest.cs
@@ -52,6 +52,9 @@ namespace Microsoft.AspNetCore.Components.E2ETests.ServerExecutionTests
         private void BeginInteractivity()
         {
             Browser.Exists(By.Id("load-boot-script")).Click();
+
+            var javascript = (IJavaScriptExecutor)Browser;
+            Browser.True(() => (bool)javascript.ExecuteScript("return window['__aspnetcore__testing__blazor__started__'] === true;"));
         }
     }
 }

--- a/src/Components/test/testassets/TestServer/Pages/DeferredComponentContentLayout.cshtml
+++ b/src/Components/test/testassets/TestServer/Pages/DeferredComponentContentLayout.cshtml
@@ -31,7 +31,7 @@
                 logLevel: 1 // LogLevel.Debug
             }).then(function () {
                 window['__aspnetcore__testing__blazor__started__'] = true;
-            })
+            });
         }
     </script>
 </body>

--- a/src/Components/test/testassets/TestServer/Pages/DeferredComponentContentLayout.cshtml
+++ b/src/Components/test/testassets/TestServer/Pages/DeferredComponentContentLayout.cshtml
@@ -29,7 +29,9 @@
         function start() {
             Blazor.start({
                 logLevel: 1 // LogLevel.Debug
-            });
+            }).then(function () {
+                window['__aspnetcore__testing__blazor__started__'] = true;
+            })
         }
     </script>
 </body>


### PR DESCRIPTION
**Fix flakiness in HeadModificationPrerenderingTest**
`HeadModificationPrerenderingTest` did not wait for interactivity to start completely before interacting with the browser. This is now fixed.

I've also updated InputDateType.cs with the new header so this can complete the checks.
