### PR TITLE
Do not use emphasis for headings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,11 @@
 One of the easiest ways to contribute is to participate in discussions on GitHub issues. You can also contribute by submitting pull requests with code changes.
 
 ## General feedback and discussions?
+
 Start a discussion on the [repository issue tracker](https://github.com/dotnet/aspnetcore/issues).
 
 ## Bugs and feature requests?
+
 ❗ **IMPORTANT: If you want to report a security related issue, please see the `Reporting security issues and bugs` section below.**
 
 Before reporting a new issue, try to find an existing issue if one already exists. If it already exists, upvote (👍) it. Also consider adding a comment with your unique scenarios and requirements related to that issue.  Upvotes and clear details on the issue's impact help us prioritize the most important issues to be worked on sooner rather than later. If you can't find one, that's okay, we'd rather get a duplicate report than none.
@@ -21,10 +23,11 @@ If you can't find an existing issue, log a new issue in the appropriate GitHub r
 Or browse the full list of repositories in the [aspnet](https://github.com/aspnet/) organization.
 
 ## Reporting security issues and bugs
-Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC)  secure@microsoft.com. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://technet.microsoft.com/en-us/security/ff852094.aspx).
 
+Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC)  secure@microsoft.com. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://technet.microsoft.com/security/ff852094.aspx).
 
 ## Other discussions
+
 Our team members also monitor several other discussion forums:
 
 * [ASP.NET Core forum](https://forums.asp.net/1255.aspx/1?ASP+NET+5)
@@ -35,7 +38,7 @@ Our team members also monitor several other discussion forums:
 We are always happy to see PRs from community members both for bug fixes as well as new features.
 To help you be successful we've put together a few simple rules to follow when you prepare to contribute to our codebase:
 
-**Finding an issue to work on**
+### Finding an issue to work on
 
   Over the years we've seen many PRs targeting areas of the framework, which we didn't plan to expand further at the time.
   In all these cases we had to say `no` to those PRs and close them. That, obviously, is not a great outcome for us. And it's especially bad for the contributor, as they've spent a lot of effort preparing the change.
@@ -45,36 +48,39 @@ Within that set, we have additionally marked issues which are good candidates fo
 
 If there is some other area not included here where you want to contribute to, first open an issue to describe the problem you are trying to solve and state that you're willing to contribute a fix for it. We will then discuss in that issue, whether we think it belongs in the platform and the best approach to solve it.
 
-**Before writing code**
+### Before writing code
 
-  This can save you a lot of time. We've seen PRs, where customers would solve an issue in a way, which either wouldn't fit into the framework because of how it's designed or it would change the framework in a way, which is not something we'd like to do. To avoid these situations, we encourage customers to discuss the preferred design with the team first. To do so, file a new `design proposal` issue, link to the issue you'd like to address and provide detailed information about how you'd like to solve a specific problem. We triage issues peridocially and it will not take long for a team member to engage with you on that proposal.
+  This can save you a lot of time. We've seen PRs, where customers would solve an issue in a way, which either wouldn't fit into the framework because of how it's designed or it would change the framework in a way, which is not something we'd like to do. To avoid these situations, we encourage customers to discuss the preferred design with the team first. To do so, file a new `design proposal` issue, link to the issue you'd like to address and provide detailed information about how you'd like to solve a specific problem. We triage issues periodically and it will not take long for a team member to engage with you on that proposal.
   When you get an agreement from our team members that the design proposal you have is solid, then go ahead and prepare the PR.
   To file a design proposal, look for the relevant issue in the `New issue` page or simply click [this link](https://github.com/dotnet/aspnetcore/issues/new?assignees=&labels=design-proposal&template=4_design_proposal.md):
   ![image](https://user-images.githubusercontent.com/34246760/107969904-41b9ae80-6f65-11eb-8b84-d15e7d94753b.png)
 
-**Before submitting the pull request**
+### Before submitting the pull request
 
 Before submitting a pull request, make sure that it checks the following requirements:
 
-- You find an existing issue with the "help-wanted" label or discuss with the team to agree on adding a new issue with that label
-- You post a high-level description of how it will be implemented, and receive a positive acknowledgement from the team before getting too committed to the approach or investing too much effort implementing it
-- You add test coverage following existing patterns within the codebase
-- Your code matches the existing syntax conventions within the codebase
-- Your PR is small, focused, and avoids making unrelated changes
+* You find an existing issue with the "help-wanted" label or discuss with the team to agree on adding a new issue with that label
+* You post a high-level description of how it will be implemented, and receive a positive acknowledgement from the team before getting too committed to the approach or investing too much effort implementing it
+* You add test coverage following existing patterns within the codebase
+* Your code matches the existing syntax conventions within the codebase
+* Your PR is small, focused, and avoids making unrelated changes
 
 If your pull request contains any of the below, it's less likely to be merged.
 
-- Changes that break backward compatibility
-- Changes that are only wanted by one person/company. Changes need to benefit a large enough proportion of ASP.NET developers.
-- Changes that add entirely new feature areas without prior agreement
-- Changes that are mostly about refactoring existing code or code style
-- Very large PRs that would take hours to review (remember, we're trying to help lots of people at once). For larger work areas, please discuss with us to find ways of breaking it down into smaller, incremental pieces that can go into separate PRs.
+* Changes that break backward compatibility
+* Changes that are only wanted by one person/company. Changes need to benefit a large enough proportion of ASP.NET developers.
+* Changes that add entirely new feature areas without prior agreement
+* Changes that are mostly about refactoring existing code or code style
+* Very large PRs that would take hours to review (remember, we're trying to help lots of people at once). For larger work areas, please discuss with us to find ways of breaking it down into smaller, incremental pieces that can go into separate PRs.
 
-**During pull request review**
+### During pull request review
+
 A core contributor will review your pull request and provide feedback. To ensure that there is not a large backlog of inactive PRs, the pull request will be marked as stale after two weeks of no activity. After another four days, it will be closed.
 
 ### Resources to help you get started
+
 Here are some resources to help you get started on how to contribute code or new content.
+
 * Look at the [Contributor documentation](/docs/README.md) to get started on building the source code on your own.
 * ["Help wanted" issues](https://github.com/dotnet/aspnetcore/labels/help%20wanted) - these issues are up for grabs. Comment on an issue if you want to create a fix.
 * ["Good first issue" issues](https://github.com/dotnet/aspnetcore/labels/good%20first%20issue) - we think these are a good for newcomers.
@@ -87,14 +93,14 @@ If you would like to contribute to one of our repositories, first identify the s
 
 You will need to sign a [Contributor License Agreement](https://cla.dotnetfoundation.org/) when submitting your pull request. To complete the Contributor License Agreement (CLA), you will need to follow the instructions provided by the CLA bot when you send the pull request. This needs to only be done once for any .NET Foundation OSS project.
 
-If you don't know what a pull request is read this article: https://help.github.com/articles/using-pull-requests. Make sure the repository can build and all tests pass. Familiarize yourself with the project workflow and our coding conventions. The coding, style, and general engineering guidelines are published on the [Engineering guidelines](https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines) page.
+If you don't know what a pull request is read this article: <https://help.github.com/articles/using-pull-requests>. Make sure the repository can build and all tests pass. Familiarize yourself with the project workflow and our coding conventions. The coding, style, and general engineering guidelines are published on the [Engineering guidelines](https://github.com/dotnet/aspnetcore/wiki/Engineering-guidelines) page.
 
 ### Tests
 
--  Tests need to be provided for every bug/feature that is completed.
--  Tests only need to be present for issues that need to be verified by QA (for example, not tasks)
--  If there is a scenario that is far too hard to test there does not need to be a test for it.
-  - "Too hard" is determined by the team as a whole.
+* Tests need to be provided for every bug/feature that is completed.
+* Tests only need to be present for issues that need to be verified by QA (for example, not tasks)
+* If there is a scenario that is far too hard to test there does not need to be a test for it.
+  * "Too hard" is determined by the team as a whole.
 
 ### Feedback
 

--- a/docs/APIBaselines.md
+++ b/docs/APIBaselines.md
@@ -1,8 +1,9 @@
 # API Baselines
 
 This document contains information regarding API baseline files and how to work with them. For additional details on how these files works, consult:
--	https://github.com/dotnet/roslyn-analyzers/blob/master/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
--	https://github.com/dotnet/roslyn-analyzers/blob/master/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.md
+
+- <https://github.com/dotnet/roslyn-analyzers/blob/master/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md>
+- <https://github.com/dotnet/roslyn-analyzers/blob/master/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.md>
 
 ## Add baseline files for new projects
 
@@ -25,7 +26,7 @@ This file contains new APIs since the last major version. Steps for working with
 
 A new entry needs to be added to the PublicAPI.Unshipped.txt file for a new API. For example:
 
-```
+```text
 #nullable enable
 Microsoft.AspNetCore.Builder.NewApplicationBuilder.New() -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 ```
@@ -34,7 +35,7 @@ Microsoft.AspNetCore.Builder.NewApplicationBuilder.New() -> Microsoft.AspNetCore
 
 A new entry needs to be added to the PublicAPI.Unshipped.txt file for a removed API. For example:
 
-```
+```text
 #nullable enable
 *REMOVED*Microsoft.Builder.OldApplicationBuilder.New() -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 ```
@@ -43,7 +44,7 @@ A new entry needs to be added to the PublicAPI.Unshipped.txt file for a removed 
 
 Two new entry needs to be added to the PublicAPI.Unshipped.txt file for an updated API, one to remove the old API and one for the new API. This also applies to APIs that are now nullable aware. For example:
 
-```
+```text
 #nullable enable
 *REMOVED*Microsoft.AspNetCore.DataProtection.Infrastructure.IApplicationDiscriminator.Discriminator.get -> string!
 Microsoft.AspNetCore.DataProtection.Infrastructure.IApplicationDiscriminator.Discriminator.get -> string?
@@ -66,4 +67,4 @@ Microsoft.AspNetCore.DataProtection.Infrastructure.IApplicationDiscriminator.Dis
 
 ## Updating baselines after major releases
 
-This will be performed by the build team using scripts at https://github.com/dotnet/roslyn/tree/master/scripts/PublicApi (or an Arcade successor). The process moves the content of PublicAPI.Unshipped.txt into PublicAPI.Shipped.txt
+This will be performed by the build team using scripts at <https://github.com/dotnet/roslyn/tree/master/scripts/PublicApi> (or an Arcade successor). The process moves the content of PublicAPI.Unshipped.txt into PublicAPI.Shipped.txt

--- a/docs/APIReviewProcess.md
+++ b/docs/APIReviewProcess.md
@@ -1,4 +1,5 @@
-## Description
+# Description
+
 Starting in 5.0, certain areas within the dotnet/aspnetcore and dotnet/extensions repos will require formal *incremental* API reviews before any PRs that change APIs are merged.
 
 API changes to the following areas are required to go follow this process:
@@ -8,13 +9,13 @@ API changes to the following areas are required to go follow this process:
 * area-healthchecks
 * area-grpc
 * area-mvc
-    * feature-model-binding
-    * feature-razor-pages
-    * feature-JSONPatch
-    * feature-discovery
-    * feature-formatters
-    * feature-api-explorer
-    * feature-tag-helpers
+  * feature-model-binding
+  * feature-razor-pages
+  * feature-JSONPatch
+  * feature-discovery
+  * feature-formatters
+  * feature-api-explorer
+  * feature-tag-helpers
 * area-razor.compiler
 * area-security
 * area-signalr
@@ -22,12 +23,12 @@ API changes to the following areas are required to go follow this process:
 * area-servers
 
 ## Process
+
 The goal of the API Review process is to ensure that the new APIs are following common patterns and the best practices.
 Also, it's aimed to help and guide engineers towards better API design decisions. People should feel empowered to submit their APIs for review as besides all the benefits it's also a learning and knowledge sharing experience.
 
 The process is visualized in the below diagram:
 ![A sequence diagram illustrating the same process described below.](https://user-images.githubusercontent.com/34246760/66542496-95052c80-eae7-11e9-9c7c-549b82a8d492.png)
-
 
 1. API review process kicks in after the owner for the issue identifies that the work required for the issue will need an API change or addition. In such cases, the issue owner will handle (either himself/herself, or with the community member who has expressed interest in handling the work) driving a design proposal. When working with a community member, the issue owner is responsible for guiding them to an acceptable design.
 1. If the proposed design adds new APIs, mark those issues with the `api-suggestion` label
@@ -42,12 +43,12 @@ The process is visualized in the below diagram:
 
 Before marking an issue as `api-ready-for-review`, make sure that the issue has the following:
 
-- A short description that will help reviewers not familiar with this area.
-- The API changes in ref-assembly format. It's fine to link this to the generated ref-assembly-code in the PR. If the changes are to an area that does produce ref-assemblies, please write out what it would look like in ref-assembly format for us to review.
+* A short description that will help reviewers not familiar with this area.
+* The API changes in ref-assembly format. It's fine to link this to the generated ref-assembly-code in the PR. If the changes are to an area that does produce ref-assemblies, please write out what it would look like in ref-assembly format for us to review.
 
 ```txt
-Good: This is the API for the widget factory, users use it in startup code to 
-configure how their widgets work. We have an overload that accepts URI, but 
+Good: This is the API for the widget factory, users use it in startup code to
+configure how their widgets work. We have an overload that accepts URI, but
 not one that accepts string, so we're adding it for convenience.
 
 Bad: Adding a string overload for Widget.ConfigureFactory.
@@ -69,4 +70,4 @@ If you are assigned a community-submitted change to *champion* in our API-review
 
 ## API Review Meeting
 
-The API Review meeting is open to all members of the ASP.NET Core team. The meeting invite is sent out to all the team members to join. Every API review meeting should include the area owners of the API change proposals as mandatory attendees. To list of all pending API review proposals can be found at: https://aka.ms/aspnet/apireviews
+The API Review meeting is open to all members of the ASP.NET Core team. The meeting invite is sent out to all the team members to join. Every API review meeting should include the area owners of the API change proposals as mandatory attendees. To list of all pending API review proposals can be found at: <https://aka.ms/aspnet/apireviews>

--- a/docs/DailyBuilds.md
+++ b/docs/DailyBuilds.md
@@ -1,12 +1,11 @@
-How to get daily builds of ASP.NET Core
-=======================================
+# How to get daily builds of ASP.NET Core
 
 Daily builds include the latest source code changes. They are not supported for production use and are subject to frequent changes, but we strive to make sure daily builds function correctly.
 
 If you want to download the latest daily build and use it in a project, then you need to:
 
-- Obtain the latest [build of the .NET Core SDK](https://github.com/dotnet/core-sdk#installers-and-binaries).
-- Add a NuGet.Config to your project directory with the following content:
+* Obtain the latest [build of the .NET Core SDK](https://github.com/dotnet/core-sdk#installers-and-binaries).
+* Add a NuGet.Config to your project directory with the following content:
 
   ```xml
   <?xml version="1.0" encoding="utf-8"?>
@@ -24,7 +23,7 @@ If you want to download the latest daily build and use it in a project, then you
 Some features, such as new target frameworks, may require prerelease tooling builds for Visual Studio.
 These are available in the [Visual Studio Preview](https://www.visualstudio.com/vs/preview/).
 
-#### To debug daily builds using Visual Studio
+## To debug daily builds using Visual Studio
 
 * *Enable Source Link support* in Visual Studio should be enabled.
 * *Enable source server support* in Visual should be enabled.

--- a/docs/EventSourceAndCounters.md
+++ b/docs/EventSourceAndCounters.md
@@ -6,9 +6,9 @@ This is a quick overview of how to add `EventSource` and `EventCounter` tracing 
 
 ### Prerequisites
 
-You should have a basic understanding of `EventSource` and how to write events. See https://blogs.msdn.microsoft.com/vancem/2012/07/09/introduction-tutorial-logging-etw-events-in-c-system-diagnostics-tracing-eventsource/ for some guidance.
+You should have a basic understanding of `EventSource` and how to write events. See <https://blogs.msdn.microsoft.com/vancem/2012/07/09/introduction-tutorial-logging-etw-events-in-c-system-diagnostics-tracing-eventsource/> for some guidance.
 
-Similarly, you should have a basic understanding of `EventCounter` and how they work. See https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md for guidance.
+Similarly, you should have a basic understanding of `EventCounter` and how they work. See <https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.Tracing/documentation/EventCounterTutorial.md> for guidance.
 
 ## Event Patterns
 
@@ -55,13 +55,13 @@ public void SomethingHappened(ObjectNeededToCalulateThePayload p, AnotherObjectN
   {
     // Write to an event counter if one is associated with this event
     _somethingsHappenedCounter.WriteMetric(1.0f);
-    
+
     // Check that this specific event is actually enabled (by level and optionally keywords).
     if (IsEnabled(EventLevel.Informational, EventKeyords.None))
     {
       // Do any complex calculation needed to determine the payload values.
       var payloadValue = CalculateThePayload(p);
-      
+
       // Fire the actual event method
       SomethingHappened(payloadValue, p2.MorePayload, p2.SomeValue - p2.SomeOtherValue);
     }
@@ -78,7 +78,7 @@ The above example is one that covers basically all the scenarios. However, many 
 
 ```csharp
 [Event(eventId: 42, Level = EventLevel.Informational)]
-public void SomethingHappened(string payloadValue) 
+public void SomethingHappened(string payloadValue)
 {
   if (IsEnabled(EventLevel.Informational, EventKeywords.None))
   {
@@ -89,7 +89,7 @@ public void SomethingHappened(string payloadValue)
 
 ## Keywords
 
-When we have places where we want to enable events but only when explicitly requested by the user, we can use Keywords to control those. Keywords are a simple flags value that are provided when a listener enables an event source, and can be tested when calling `IsEnabled`. See [https://msdn.microsoft.com/en-us/library/dn774985(v=pandp.20).aspx#_Using_keywords](https://msdn.microsoft.com/en-us/library/dn774985(v=pandp.20).aspx#_Using_keywords) for some guidance about keywords
+When we have places where we want to enable events but only when explicitly requested by the user, we can use Keywords to control those. Keywords are a simple flags value that are provided when a listener enables an event source, and can be tested when calling `IsEnabled`. See <https://msdn.microsoft.com/library/dn774985(v=pandp.20).aspx#_Using_keywords> for some guidance about keywords
 
 ## Event Counters
 
@@ -100,7 +100,7 @@ There are a number of different "kinds" of event counters in our system. They ar
 * Counters track the number of times an event occurs. They are written by calling `.WriteMetric(1.0f)` to the counter. The consumer can determine the number of events that occurred over an interval by reading the "Count" aggregation. They should have names combining a plural noun and adjective, like "RequestsStarted"
 * Metrics track a value that changes over time or per "unit" (i.e. per request, per connection, etc.). They are written by calling `.WriteMetric` with the current value of the metric. The consumer can use the aggregates to get data about the metric over time. They should have names combining a singular nouns describing the metric, like "RequestBodySize"
   * Durations are a Metric that tracks a time duration in milliseconds. They have names ending with "Duration", like "RequestDuration"
-  
+
 ## Full Example
 
 Here is an example of a straw-man Event Source for Authentication:
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Authentication.Internal
             if (IsEnabled())
             {
                 _authenticationMiddlewareDuration.WriteMetric((float)duration.TotalMilliseconds);
-                
+
                 if (IsEnabled(EventLevel.Informational, EventKeywords.None))
                 {
                     AuthenticationMiddlewareEnd(context.TraceIdentifier, context.Request.Path.Value, duration.TotalMilliseconds);
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Authentication.Internal
     }
 }
 ```
-  
+
 ## Automated Testing of EventSources
 
 EventSources can be tested using the `EventSourceTestBase` base class in `Microsoft.AspNetCore.Testing`. An example test is below:
@@ -184,10 +184,10 @@ public class SomeTest : EventSourceTestBase
 
         // Act: Do things that causes the events to be fired.
         DoStuff();
-        
+
         // Assert: Get the collected events and assert that they match the expectations
         var events = GetEvents();
-        
+
         // EventAssert is a helper for testing events. It's a little odd in that EventAssert.Event returns a "builder"
         // that creates an Action<EventWrittenEventArgs> that will assert the things you configured when called.
         // This pattern makes for clearer test code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ The table below outlines the different docs in this folder and what they are hel
 | Documentation        | What is it about?   | Who is it for?      |
 |--------------------------------------------------------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | [API review process](APIReviewProcess.md)      | Outlines the process for reviewing API changes in ASP.NET Core          | Anyone looking to understand the process for making API changes to ASP.NET Core      |
-| [Artifacts structure](Artifacts.md)            | Outlines the artifacts produced by the build  | Anyone looking to understand artifiacts produced from an Azure DevOps build          |
+| [Artifacts structure](Artifacts.md)            | Outlines the artifacts produced by the build  | Anyone looking to understand artifacts produced from an Azure DevOps build          |
 | [Troubleshooting build errors](BuildErrors.md) | Common errors that occur when building the repo and how to resolve them | Anyone running into an issue with the build        |
 | [Building from source](BuildFromSource.md)     | Setup instructions for the ASP.NET Core repo  | First-time contributors          |
 | [Working with EventSources and EventCounters](EventSourceAndCounters.md) | Guidance on adding event tracing to a library | Anyone needing to add event tracing for diagnostics purposes      |
@@ -24,4 +24,3 @@ The table below outlines the different docs in this folder and what they are hel
 | [Shared framework](SharedFramework.md)         | Overview of the ASP.NET Core Shared framework | Anyone looking to understand the policies in place for managing the code of the shared framework         |
 | Submodules           | Documentation on working with submodules in Git     |   Anyone working with submodules in the repo     |
 | [Triage process](TriageProcess.md)| Overview of the issue triage process used in the repo     | Anyone looking to understand the triage process on the repo  |
-

--- a/docs/ReferenceResolution.md
+++ b/docs/ReferenceResolution.md
@@ -106,7 +106,7 @@ is changing to `Microsoft.AspNetCore.BetterThanOrange`, you would need to make t
 
 Once `darc` is installed and set-up, it can be used to modify the subscriptions and dependencies in a project.
 
-**Getting the list of subscriptions in a repo**
+### Getting the list of subscriptions in a repo
 
 Subscriptions are objects that define the ecosystem repos we are listening for updates to, the frequency we are looking for updates, and more.
 
@@ -114,14 +114,14 @@ Subscriptions are objects that define the ecosystem repos we are listening for u
 darc get-subscriptions --target-branch main --target-repo aspnetcore$ --regex
 ```
 
-**Disable/enable a subscription**
+### Disable/enable a subscription
 
 ```bash
 darc subscription-status --id {subscriptionIdHere} --enable
 darc subscription-status --id {subscriptionIdHere} --disable
 ```
 
-**Trigger a subscription**
+### Trigger a subscription
 
 Triggering a subscription will search for updates in its dependencies and open a PR in the target repo via the dotnet-maestro bot with these changes.
 
@@ -129,7 +129,7 @@ Triggering a subscription will search for updates in its dependencies and open a
 darc trigger-subscriptions --id {subscriptionIdHere}
 ```
 
-**Manually update dependencies**
+### Manually update dependencies
 
 If the `dotnet-maestro` bot has not correctly updated the dependencies, `darc update-dependencies` may be used to update the dependencies manually. Note, you'll need to run the commands below in a separate branch and submit a PR with the changes. These are the things that the bot should do for you if you use `trigger-subscriptions` or automatically (when the subscription fires e.g. about 15 minutes after a dependency's build completes if `Update Frequency: EveryBuild`).
 
@@ -140,7 +140,7 @@ darc update-dependencies --channel '.NET 5 Dev' --source-repo efcore
 
 Generally, using `trigger-subscriptions` is preferred for creating dependency updates instead of manually updating dependencies in your own PR.
 
-**Toggling batchability of subscription**
+### Toggling batchability of subscription
 
 Subscriptions can be batched. When a dependency update is detected, `darc` will bundle the commits for that update with existing dependency PRs. To toggle whether a subscription is batched or not, you will need to use the `update-subscription` command.
 
@@ -152,7 +152,7 @@ Your shell's default editor will open and allow you to edit the metadata of the 
 
 To disable batching, set `Batchable` to `False` and update the `Merge Policies` section with the following YAML.
 
-```
+```yaml
   - Name: Standard
     Properties: {}
 ```
@@ -160,4 +160,3 @@ To disable batching, set `Batchable` to `False` and update the `Merge Policies` 
 To enable batching, set `Batchable` to `True` and remove any `Merge Policies` set on the subscription.
 
 Note: Merge policies can only be set on unbatched subscriptions. Be sure to set/unset the `Merge Policies` field properly as you toggle batchability.
-

--- a/docs/Servicing.md
+++ b/docs/Servicing.md
@@ -1,6 +1,6 @@
 # Servicing Process
 
-We maintain several on-going releases at once and produce patches for them. An essential part of our support committment to users is that we build high-quality patches that avoid breaking applications. This means we have to be extremely cautious with taking changes in patch releases. This document describes the "bar" (criteria for accepting servicing fixes) and the process for managing these changes.
+We maintain several on-going releases at once and produce patches for them. An essential part of our support committent to users is that we build high-quality patches that avoid breaking applications. This means we have to be extremely cautious with taking changes in patch releases. This document describes the "bar" (criteria for accepting servicing fixes) and the process for managing these changes.
 
 See the [.NET Core release lifecycle](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle) for more details on the currently-supported .NET releases.
 

--- a/docs/SharedFramework.md
+++ b/docs/SharedFramework.md
@@ -1,9 +1,8 @@
-ASP.NET Core Shared Framework
-=============================
+# ASP.NET Core Shared Framework
 
 Guidance on developing the ASP.NET Core shared framework (`Microsoft.AspNetCore.App`).
 
-### What goes into the shared framework?
+## What goes into the shared framework?
 
 The ASP.NET Core shared framework contains assemblies that are fully developed, supported, and serviceable by Microsoft. You can think of this as constituting the ASP.NET Core *platform*. As such, all assemblies which are included in the shared framework are expected to meet specific requirements. Here are the principles we are using to guide our decisions about what is allowed in the shared framework.
 
@@ -15,12 +14,12 @@ The ASP.NET Core shared framework contains assemblies that are fully developed, 
 * Teams which own components in the shared framework must coordinate security fixes, patches, and updates with the .NET Core team.
 * Code must be open-source and buildable using only open-source tools
 * Usage
-   * How much an API is used is an important metric, but not the only factor
-   * API we believe is essential for central experiences in .NET Core should be in the shared framework
-   * Examples of central experiences: MVC, Kestrel, Razor, SignalR
+* How much an API is used is an important metric, but not the only factor
+  * API we believe is essential for central experiences in .NET Core should be in the shared framework
+  * Examples of central experiences: MVC, Kestrel, Razor, SignalR
 * New API can ship as out-of-band packages first, and move into the base framework later when it meets these standards
 
-### How to adjust what is in the shared framework
+## How to adjust what is in the shared framework
 
 The contents of the shared framework are defined in two ways:
 

--- a/docs/Submodules.md
+++ b/docs/Submodules.md
@@ -1,5 +1,4 @@
-Submodules
-==========
+# Submodules
 
 This repository composes ASP.NET Core repos from a collection of many submodules.
 Working with submodules in git requires using commands not used in a normal git workflow.
@@ -22,11 +21,15 @@ Other info may appear in the .gitmodules file, but it is only used when attempti
 
 By default, submodules will not be present. Use `--recursive` to clone all submodules.
 
-    git clone https://github.com/dotnet/aspnetcore.git --recursive
+```bash
+git clone https://github.com/dotnet/aspnetcore.git --recursive
+```
 
 If you have already cloned, run this to initialize all submodules.
 
-    git submodule update --init
+```bash
+git submodule update --init
+```
 
 ## Pulling updates
 
@@ -34,25 +37,35 @@ When you execute `git pull`, submodules do not automatically snap to the version
 used in new commits of the parent repo. Update all submodules to match the parent repo's
 expected version by running this command.
 
-    git submodule update
+```bash
+git submodule update
+```
 
 ## Executing a command on each submodule
 
-    git submodule foreach '<command>'
+```bash
+git submodule foreach '<command>'
+```
 
 For example, to clean and reset each submodule:
 
-    git submodule foreach 'git reset --hard; git clean -xfd'
+```bash
+git submodule foreach 'git reset --hard; git clean -xfd'
+```
 
 ## Updating submodules
 
 Updating all submodules to newer versions can be done like this.
 
-    git submodule update --remote
+```bash
+git submodule update --remote
+```
 
 Updating just one subumodule.
 
-    git submodule update --remote modules/EntityFrameworkCore/
+```bash
+git submodule update --remote modules/EntityFrameworkCore/
+```
 
 This uses the remote url and branch info configuration stored in .gitmodules to pull new commits.
 This does not guarantee the commit is going to be a fast-forward commit.
@@ -61,16 +74,20 @@ This does not guarantee the commit is going to be a fast-forward commit.
 
 You can see which commits have changed in submodules from the last parent repo commit by adding `--submodule` to git-diff.
 
-    git diff --submodule
+```bash
+git diff --submodule
+```
 
 ## Saving an update to a submodule
 
 To move the parent repo to use a new commit, you must create a commit in the parent repo
 that contains the new commit.
 
-    git submodule update --remote modules/KestrelHttpServer/
-    git add modules/KestrelhttpServer/
-    git commit -m "Update Kestrel to latest version"
+```bash
+git submodule update --remote modules/KestrelHttpServer/
+git add modules/KestrelhttpServer/
+git commit -m "Update Kestrel to latest version"
+```
 
 ## PowerShell is slow in dotnet/aspnetcore
 
@@ -78,7 +95,9 @@ Many users have post-git, and extension that shows git status on the prompt line
 on Windows is very slow, it can make PowerShell unbearable to use.
 
 To workaround this, disable checking git-status for each prompt.
-```ps1
+
+```powershell
 $GitPromptSettings.EnableFileStatus = $false
 ```
+
 You can disable this permanently by adding to your `$PROFILE` file. (`notepad $PROFILE`)

--- a/docs/TriageProcess.md
+++ b/docs/TriageProcess.md
@@ -1,3 +1,5 @@
+# Triage Process
+
 Managing a popular GitHub repo with a small team is not an easy task. It requires a good balance between creating new features while handling many investigations and bug fixes associated with existing ones.
 
 During the last couple of years the amount of incoming issues has been constantly growing. While this is a sign of a healthy framework and ecosystem surrounding it, it's becoming harder to react to all those issues.
@@ -6,26 +8,32 @@ To be able to keep up with ever-evolving expectations, we're introducing a set o
 **Note:** Customers that need help with **urgent investigations** should contact [Microsoft Support](https://dotnet.microsoft.com/platform/support).
 
 ## Goals
+
 The goals of these rules are listed below in priority order:
+
 - Make it easy to make triage decisions for each issue filed in this repository
 - Be able to easily prioritize issues for each milestone
 - Set proper expectations with customers regarding how issues are going to be handled
 
-## Triage Process
+## Triage Process Details
+
 The feature teams should be able look through every single issue filed against this repository and be able to make a quick call regarding the nature of the issue.
-We will first categorize the issues and further handle these depending on the category the issue is in. The subsections below reprsent these categories and the rules we apply for them during our triage meeting.
+We will first categorize the issues and further handle these depending on the category the issue is in. The subsections below represent these categories and the rules we apply for them during our triage meeting.
 
 ### Information Gathering
+
 In this phase we instruct the user on how to collect the appropriate diagnostics and see if they are able to address the issue with that additional information.  When we need user input we will mark the issue with `Needs: Author Feedback` label. Issues in this phase may be closed automatically if we do not receive timely responses, they often do not provide enough information for us to investigate further.
 We'll try to respond quickly to such issues (within days). If a user has collected all of the relevant diagnostics and the issue is still not apparent, then we will consider it for further [investigation](#investigations) by the team.
 
 ### Feature requests
+
 As soon as we identify an issue represents an ask for a new feature, we will label the issue with the `enhancement` label.
 Most of the time, we will automatically move these issues into the `Next Sprint Planning` milestone for further review during the [next sprint planning meeting](#milestone-planning).
 If we think the feature request is not aligned with our goals, we may choose to close it immediately.
 In some situations, however, we may choose to collect more feedback before acting on the issue. In these situations we will move the issue in the `Backlog` so that we can review it during the [release planning](#release-planning).
 
 ### Bug reports
+
 If it's immediately clear, that the issue is related to a bug in the framework, we will apply the `bug` label to the issue.
 
 At this point, we will try to make a call regarding it's impact and severity. If the issue is critical, we may choose to include it in our current milestone for immediate handling or potentially patching.
@@ -33,17 +41,20 @@ If the bug is relatively high impact, we will move the issue into the `Next Spri
 If the impact is unclear or the is a very corner case scenario, we may move it to the `Backlog` milestone to further evaluate the impact by reviewing customer upvotes / comments at a later time.
 
 ### Investigations
+
 In many situations it's not immediately clear whether a specific issue reported is a bug or not. To be certain, the team will need to spend time to investigate it before making a call regarding the faith of the issue. In these situations we will apply the `investigate` label to the issue.
 In many situations, these issues turn out to be a result of some kind of misconfiguration in the user code.
 In some rare situations, however, these turn out to be caused by very impactful issues. So we will make a call during the triage whether we need to immediately investigate certain issues or not.
 If not, we will move the investigation to the `Next Sprint Planning` to review during the [next sprint planning meeting](#milestone-planning).
 
 ### Documentation requests
+
 Some issues turn out to indicate user confusion around how to configure different aspects of the framework.
-When we determine such isssues, we will mark these with the `Docs` label and move them into the `Next Sprint Planning` milestone to handle at a later time. The goal here will be to fill in the gaps or clarify our documentation, so that customers can be successful by using the guidance provided in the documentation.
+When we determine such issues, we will mark these with the `Docs` label and move them into the `Next Sprint Planning` milestone to handle at a later time. The goal here will be to fill in the gaps or clarify our documentation, so that customers can be successful by using the guidance provided in the documentation.
 If we identify a documentation issue which too many customers are having trouble with, we may choose to address that in current milestone.
 
 ## Milestone Planning
+
 Our milestones are usually a month long.
 Before each milestone we have one or more planning meetings, where we look through all the accumulated issues in the `Next Sprint Planning` milestone and choose the most important and impactful ones to handle during the next milestone. This will be a mixture of feature requests, bug fixes, documentation issues as well as some investigations.
 
@@ -53,15 +64,17 @@ We may not investigate issues which haven't received many votes/comments and cho
 For some feature requests and bug reports, depending on the user involvement, we may choose to move these to the backlog at this point. What this means, is that they will not be looked at again up until the next major release planning.
 
 ## Release Planning
+
 Once we approach to the end of the release cycle (.NET Core 3, .NET 5) we will look through the accumulated issues in the `Backlog` milestone. This is a long process as the amount of issues accumulated in this milestone is quite large.
 
 We will try to prioritize issues with most community requests / upvotes assuming these are aligned with our goals.
 Issues, which we will think are candidates for the upcoming release, will be moved to the `Next Sprint Planning` milestone.
 
 ## Process Visualization
+
 The following diagram summarizes the processes detailed above:
 ![image](https://user-images.githubusercontent.com/34246760/84076162-23d58c00-a98a-11ea-909d-6d17b91d4f84.png)
 
-
 ## References
+
 We rely on some automation to help us with this process. You can learn more about some of these by reading our [Issue Management Policies](https://github.com/dotnet/aspnetcore/blob/main/docs/IssueManagementPolicies.md) document.

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -1,3 +1,5 @@
+# Area Owners
+
 The below table lists all the `area-`labels used in the `aspnetcore` repository and their owners:
 
 | Area label | Owner | Description|

--- a/docs/tooling-consolidation.md
+++ b/docs/tooling-consolidation.md
@@ -3,18 +3,20 @@
 ## Objectives
 
 We want to consolidate dotnet/aspnetcore-tooling into dotnet/aspnetcore to achieve 3 goals
+
 1. Reduce overall build time end to end for the .NET Core SDK
 2. Reduce the complexity of maintaining multiple repositories.
 3. Maintain, or if possible, improve, developer productivity
 
-We are prioritizing the first objective since it is part of a cross-team efforct to reduce the SDK build time. To ensure we are able to achieve this goal quickly and with minimal risk, we plan to take a multi-phase approach. The first phase will involve moving the language components from aspnetcore-tooling to aspnetcore which is required for the SDK build. The second phase will involve a more gradual migration for the remaining tooling components with an emphasis on maintaining developer productivity.
+We are prioritizing the first objective since it is part of a cross-team effort to reduce the SDK build time. To ensure we are able to achieve this goal quickly and with minimal risk, we plan to take a multi-phase approach. The first phase will involve moving the language components from aspnetcore-tooling to aspnetcore which is required for the SDK build. The second phase will involve a more gradual migration for the remaining tooling components with an emphasis on maintaining developer productivity.
 
 ## Phase one: Migration of language components
 
 In this phase, we are primarily concerned with the overall goals of repo consolidation to reduce the number of repository required to build the SDK while keeping the build in aspnetcore as simple as possible without needing to support build/test for tooling scenarios such as testing on VSCode. As such, we will not require all of aspnetcore-tooling to be merged into aspnetcore. For example, tooling for VSMac and VSCode will remain in aspnetcore-tooling. There is also an added benefit of maintaining the current development and release workflow for aspnetcore-tooling which is more "agile" than aspnetcore (e.g. faster PR builds, release cycles that synchronize with VS releases).
 
 To achieve this we will be migrating the following (and associated tests) from aspnetcore-tooling to aspnetcore:
-```
+
+```text
 Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X
 Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X
 Microsoft.AspNetCore.Mvc.Razor.Extensions
@@ -22,9 +24,11 @@ Microsoft.AspNetCore.Razor.Language
 Microsoft.AspNetCore.Razor.Tools
 Microsoft.CodeAnalysis.Razor
 Microsoft.NET.Sdk.Razor
-````
-The following (and associated tests) will remain in aspnetcore-tooling:
 ```
+
+The following (and associated tests) will remain in aspnetcore-tooling:
+
+```text
 Microsoft.AspNetCore.Razor.LanguageServer.Common
 Microsoft.AspNetCore.Razor.LanguageServer
 Microsoft.AspNetCore.Razor.OmniSharpPlugin.StrongNamed
@@ -42,19 +46,22 @@ Microsoft.VisualStudio.Mac.RazorAddin
 Microsoft.VisualStudio.RazorExtension
 RazorDeveloperTools
 rzls
-````
-THe following will be deleted:
 ```
+
+THe following will be deleted:
+
+```text
 RazorPageGenerator
 ```
 
 Due to the separation of tooling projects, the new dependency flow will be:
 
-```
+```text
 runtime +--> aspnetcore +--> SDK
         \               \
          +-> extensions -+-> aspnetcore-tooling
 ```
+
 ### Known action items
 
 1. Migrate source with `git filter-branch`, preserving commit history
@@ -75,17 +82,17 @@ Due to runtime and tooling divergence of Roslyn packages, we may need to pin mul
 
 ### Assets
 
-The migrated projects are C# only in phase one so we will use existing infrastructure in aspnetcore to handle signing and publishing of these packages. Phase two will involve additional asset types including vsix, zips, npm packages and mpacks. We have asset publishing mechanisms for most of these asset types but may need to add addtional asset publishing mechanisms and/or release management for some assets (mpacks for example). We will evaluate the additional requirements when phase two is discussed.
+The migrated projects are C# only in phase one so we will use existing infrastructure in aspnetcore to handle signing and publishing of these packages. Phase two will involve additional asset types including vsix, zips, npm packages and mpacks. We have asset publishing mechanisms for most of these asset types but may need to add additional asset publishing mechanisms and/or release management for some assets (mpacks for example). We will evaluate the additional requirements when phase two is discussed.
 
 ### Developer efficiency (PR builds)
 
 A concern that has been voiced is that working in aspnetcore would be significantly slower than in aspnetcore-tooling given that the PR validation in aspnetcore takes longer. For comparison, it takes about 30 mins to run builds and tests in aspnetcore-tooling whereas builds and tests in aspnetcore takes about 1.5 - 2 hours. We are making efforts in improving this experience but it will be out of scope of aspnetcore-tooling consolidation.
 
- Note that this will only apply to the migrated language projects in phase one. In phase two, we will explore several approaches to improve this area. We are considering adopting additiona logic (from dotnet/runtime) that will allow us to run only portions of tests based on what source changes were detected. However, we will always build the entire repository regardless of what source changes were made.
+ Note that this will only apply to the migrated language projects in phase one. In phase two, we will explore several approaches to improve this area. We are considering adopting additional logic (from dotnet/runtime) that will allow us to run only portions of tests based on what source changes were detected. However, we will always build the entire repository regardless of what source changes were made.
 
 ### Testing
 
-In phase one, the migrated projects are C# only so there are no test infrasture changes needed in aspnetcore. The existing vscode jest, and node tests will remain in aspnetcore-tooling during phase one and will be migrated in phase two.
+In phase one, the migrated projects are C# only so there are no test infrastructure changes needed in aspnetcore. The existing vscode jest, and node tests will remain in aspnetcore-tooling during phase one and will be migrated in phase two.
 
 ### Reliability
 

--- a/src/Identity/README.md
+++ b/src/Identity/README.md
@@ -6,16 +6,16 @@ ASP.NET Core Identity is the membership system for building ASP.NET Core web app
 
 The following contains a description of each sub-directory in the `Identity` directory.
 
-- `ApiAuthorization.IdentityServer`: Contains IdentityServer based support for API Authorization.
-- `Core`: Contains the main abstractions and types for providing support for Identity in ASP.NET Core applications.
-- `EntityFrameworkCore`: Contains implementations for Identity stores based on EntityFrameworkCore.
-- `Extensions.Core`: Contains the abstractions and types for general Identity concerns.
-- `Extensions.Stores`: Contains abstractions and types for Identity storage providers.
-- `samples`: Contains a collection of sample apps.
-- `Specification.Tests`: Contains a test suite for ASP.NET Core Identity store implemenations.
-- `test`: Contains the unit and functional tests for Microsoft.Extensions.Identity and Microsoft.AspNetCore.Identity components.
-- `testassets`: Contains a webapp used for functional testing.
-- `UI`: Contains compiled Razor UI components for use in ASP.NET Core Identity.
+* `ApiAuthorization.IdentityServer`: Contains IdentityServer based support for API Authorization.
+* `Core`: Contains the main abstractions and types for providing support for Identity in ASP.NET Core applications.
+* `EntityFrameworkCore`: Contains implementations for Identity stores based on EntityFrameworkCore.
+* `Extensions.Core`: Contains the abstractions and types for general Identity concerns.
+* `Extensions.Stores`: Contains abstractions and types for Identity storage providers.
+* `samples`: Contains a collection of sample apps.
+* `Specification.Tests`: Contains a test suite for ASP.NET Core Identity store implementations.
+* `test`: Contains the unit and functional tests for Microsoft.Extensions.Identity and Microsoft.AspNetCore.Identity components.
+* `testassets`: Contains a webapp used for functional testing.
+* `UI`: Contains compiled Razor UI components for use in ASP.NET Core Identity.
 
 ## Development Setup
 
@@ -33,27 +33,27 @@ For more information, see the [ASP.NET Core README](../../README.md).
 
 ## ASP.NET Identity for ASP.NET MVC 5
 
-The previous versions of Identity for MVC5 and lower, previously available on CodePlex, are available at https://github.com/aspnet/AspNetIdentity
+The previous versions of Identity for MVC5 and lower, previously available on CodePlex, are available at <https://github.com/aspnet/AspNetIdentity>
 
 ## Community Maintained Store Providers
 
-**IMPORTANT: Extensions are built by a variety of sources and not maintained as part of the ASP.NET Identity project. When considering a third party provider, be sure to evaluate quality, licensing, compatibility, support, etc. to ensure they meet your requirements.**
+**IMPORTANT:** Extensions are built by a variety of sources and not maintained as part of the ASP.NET Identity project. When considering a third party provider, be sure to evaluate quality, licensing, compatibility, support, etc. to ensure they meet your requirements.
 
 * [ASP.NET Identity Azure Table Storage Provider](https://dlmelendez.github.io/identityazuretable/)
 * [ASP.NET Identity CosmosDB SQL Provider](https://github.com/dlmelendez/identitycosmosdb)
 * ASP.NET Identity MongoDB Providers:
   * [By Tugberk Ugurlu](https://github.com/tugberkugurlu/AspNetCore.Identity.MongoDB)
   * [By Alexandre Spieser](https://github.com/alexandre-spieser/AspNetCore.Identity.MongoDbCore)
- * [ASP.NET Identity LinqToDB Provider](https://github.com/ili/LinqToDB.Identity)
- * ASP.NET Identity DynamoDB Providers:
-    * [By Vasyl Solovei](https://github.com/miltador/AspNetCore.Identity.DynamoDB)
-    * [By Anna Aitchison](https://github.com/Ara225/ara225.DynamoDBUserStore)
- * ASP.NET Identity RavenDB Providers:
-    * [By Judah Gabriel Himango](https://github.com/JudahGabriel/RavenDB.Identity)
-    * [By Iskandar Rafiev](https://github.com/maqduni/AspNetCore.Identity.RavenDB)
- * [ASP.NET Identity Cassandra Provider](https://github.com/lkubis/AspNetCore.Identity.Cassandra)
- * [ASP.NET Identity Firebase Provider](https://github.com/aguacongas/Identity.Firebase)
- * [ASP.NET Identity Redis Provider](https://github.com/aguacongas/Identity.Redis)
- * [ASP.NET Identity DocumentDB](https://github.com/codekoenig/AspNetCore.Identity.DocumentDb)
- * [ASP.NET Identity Amazon Cognito Provider](https://github.com/aws/aws-aspnet-cognito-identity-provider)
- * [ASP.NET Identity Marten Provider](https://github.com/yetanotherchris/Marten.AspNetIdentity)
+* [ASP.NET Identity LinqToDB Provider](https://github.com/ili/LinqToDB.Identity)
+* ASP.NET Identity DynamoDB Providers:
+  * [By Vasyl Solovei](https://github.com/miltador/AspNetCore.Identity.DynamoDB)
+  * [By Anna Aitchison](https://github.com/Ara225/ara225.DynamoDBUserStore)
+* ASP.NET Identity RavenDB Providers:
+  * [By Judah Gabriel Himango](https://github.com/JudahGabriel/RavenDB.Identity)
+  * [By Iskandar Rafiev](https://github.com/maqduni/AspNetCore.Identity.RavenDB)
+* [ASP.NET Identity Cassandra Provider](https://github.com/lkubis/AspNetCore.Identity.Cassandra)
+* [ASP.NET Identity Firebase Provider](https://github.com/aguacongas/Identity.Firebase)
+* [ASP.NET Identity Redis Provider](https://github.com/aguacongas/Identity.Redis)
+* [ASP.NET Identity DocumentDB](https://github.com/codekoenig/AspNetCore.Identity.DocumentDb)
+* [ASP.NET Identity Amazon Cognito Provider](https://github.com/aws/aws-aspnet-cognito-identity-provider)
+* [ASP.NET Identity Marten Provider](https://github.com/yetanotherchris/Marten.AspNetIdentity)

--- a/src/Mvc/README.md
+++ b/src/Mvc/README.md
@@ -1,7 +1,6 @@
-ASP.NET Core MVC
-===
+# ASP.NET Core MVC
 
-**Note: For ASP.NET MVC 5.x, Web API 2.x, and Web Pages 3.x (not ASP.NET Core), see https://github.com/aspnet/AspNetWebStack**
+**Note:** For ASP.NET MVC 5.x, Web API 2.x, and Web Pages 3.x (not ASP.NET Core), see <https://github.com/aspnet/AspNetWebStack>
 
 ASP.NET Core MVC gives you a powerful, patterns-based way to build dynamic websites that enables a clean separation of concerns and gives you full control over markup for enjoyable, agile development. ASP.NET Core MVC includes many features that enable fast, TDD-friendly development for creating sophisticated applications that use the latest web standards.
 
@@ -10,6 +9,7 @@ ASP.NET Core MVC includes support for building web pages and HTTP services in a 
 See the [ASP.NET Core MVC documentation](https://docs.microsoft.com/aspnet/core/).
 
 Related community projects:
+
 * [AspNet.Mvc.TypedRouting](https://github.com/ivaylokenov/AspNet.Mvc.TypedRouting): A collection of extension methods providing strongly typed routing and link generation for ASP.NET Core MVC projects.
 * [ASP.NET API Versioning](https://github.com/Microsoft/aspnet-api-versioning): Adds API versioning semantics to your new and existing REST services built with ASP.NET Core. (Also supports ASP.NET Web API and OData.)
 * [ASP.NET MVC Boilerplate](https://visualstudiogallery.msdn.microsoft.com/6cf50a48-fc1e-4eaf-9e82-0b2a6705ca7d): Rich templates for ASP.NET Core MVC.


### PR DESCRIPTION
- address a markdown accessibility issue

nits:
- accept most markdownlint fixes e.g. about using consistent list characters
- correct a few spelling errors