### PR TITLE
Avoid TypeLoadExceptions in VS 2022

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,12 @@
     <AnalysisMode>Default</AnalysisMode>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '17.0' ">
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+    <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <RunAnalyzers>false</RunAnalyzers>
+  </PropertyGroup>
+
   <!-- Defines project type conventions. -->
   <PropertyGroup>
     <RepoRelativeProjectDir>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</RepoRelativeProjectDir>


### PR DESCRIPTION
This avoids errors like the following when building or testing in VS 2022:

```
5>Done building project "Microsoft.AspNetCore.Testing.csproj" -- FAILED.
5>CSC : error AD0001: Analyzer 'Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports.CSharpRemoveUnnecessaryImportsDiagnosticAnalyzer' threw an exception of type 'System.TypeLoadException' with message 'Could not load type 'Microsoft.CodeAnalysis.CSharp.Syntax.BaseNamespaceDeclarationSyntax' from assembly 'Microsoft.CodeAnalysis.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.'.
...
```

![image](https://user-images.githubusercontent.com/54385/126852340-15c8a61b-8f79-48ad-90f2-2b5a98704256.png)

I haven't filed an issue related to this since as far as I can tell, Microsoft.CodeAnalysis.CSharp.dll ships with VS. I don't see a realistic way to keep the latest SDKs we use in our repo always working with VS previews. Presumably this will resolve itself with VS updates.
