### PR TITLE
Update PR template to include "Fixes #bugnumber"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,4 @@ Summary of the changes (Less than 80 chars)
 Detail 1
 Detail 2
 
-Addresses #bugnumber (in this specific format)
+Fixes #bugnumber (in this specific format)


### PR DESCRIPTION
- "Addresses" is not one of github's keywords
- This will close #bugnumber when the PR is merged