### PR TITLE
Log KestrelServerOptions when tracing is enabled

### DIFF
--- a/src/Servers/Kestrel/Core/src/Http2Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http2Limits.cs
@@ -195,5 +195,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 _keepAlivePingTimeout = value != Timeout.InfiniteTimeSpan ? value : TimeSpan.MaxValue;
             }
         }
+
+        internal void Serialize(Dictionary<string, string?> config)
+        {
+            config[nameof(MaxStreamsPerConnection)] = MaxStreamsPerConnection.ToString();
+            config[nameof(HeaderTableSize)] = HeaderTableSize.ToString();
+            config[nameof(MaxFrameSize)] = MaxFrameSize.ToString();
+            config[nameof(MaxRequestHeaderFieldSize)] = MaxRequestHeaderFieldSize.ToString();
+            config[nameof(InitialConnectionWindowSize)] = InitialConnectionWindowSize.ToString();
+            config[nameof(InitialStreamWindowSize)] = InitialStreamWindowSize.ToString();
+            config[nameof(KeepAlivePingDelay)] = KeepAlivePingDelay.ToString();
+            config[nameof(KeepAlivePingTimeout)] = KeepAlivePingTimeout.ToString();
+        }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Http2Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http2Limits.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
@@ -196,16 +197,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
         }
 
-        internal void Serialize(Dictionary<string, string?> config)
+        internal void Serialize(Utf8JsonWriter writer)
         {
-            config[nameof(MaxStreamsPerConnection)] = MaxStreamsPerConnection.ToString();
-            config[nameof(HeaderTableSize)] = HeaderTableSize.ToString();
-            config[nameof(MaxFrameSize)] = MaxFrameSize.ToString();
-            config[nameof(MaxRequestHeaderFieldSize)] = MaxRequestHeaderFieldSize.ToString();
-            config[nameof(InitialConnectionWindowSize)] = InitialConnectionWindowSize.ToString();
-            config[nameof(InitialStreamWindowSize)] = InitialStreamWindowSize.ToString();
-            config[nameof(KeepAlivePingDelay)] = KeepAlivePingDelay.ToString();
-            config[nameof(KeepAlivePingTimeout)] = KeepAlivePingTimeout.ToString();
+            writer.WritePropertyName(nameof(MaxStreamsPerConnection));
+            writer.WriteNumberValue(MaxStreamsPerConnection);
+
+            writer.WritePropertyName(nameof(HeaderTableSize));
+            writer.WriteNumberValue(HeaderTableSize);
+            
+            writer.WritePropertyName(nameof(MaxFrameSize));
+            writer.WriteNumberValue(MaxFrameSize);
+
+            writer.WritePropertyName(nameof(MaxRequestHeaderFieldSize));
+            writer.WriteNumberValue(MaxRequestHeaderFieldSize);
+
+            writer.WritePropertyName(nameof(InitialConnectionWindowSize));
+            writer.WriteNumberValue(InitialConnectionWindowSize);
+
+            writer.WritePropertyName(nameof(InitialStreamWindowSize));
+            writer.WriteNumberValue(InitialStreamWindowSize);
+
+            writer.WriteString(nameof(KeepAlivePingDelay), KeepAlivePingDelay.ToString());
+            writer.WriteString(nameof(KeepAlivePingTimeout), KeepAlivePingTimeout.ToString());
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -55,5 +55,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 _maxRequestHeaderFieldSize = value;
             }
         }
+
+        internal void Serialize(Dictionary<string, string?> config)
+        {
+            config[nameof(HeaderTableSize)] = HeaderTableSize.ToString();
+            config[nameof(MaxRequestHeaderFieldSize)] = MaxRequestHeaderFieldSize.ToString();
+        }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core
 {
@@ -56,10 +57,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
         }
 
-        internal void Serialize(Dictionary<string, string?> config)
+        internal void Serialize(Utf8JsonWriter writer)
         {
-            config[nameof(HeaderTableSize)] = HeaderTableSize.ToString();
-            config[nameof(MaxRequestHeaderFieldSize)] = MaxRequestHeaderFieldSize.ToString();
+            writer.WritePropertyName(nameof(HeaderTableSize));
+            writer.WriteNumberValue(HeaderTableSize);
+
+            writer.WritePropertyName(nameof(MaxRequestHeaderFieldSize));
+            writer.WriteNumberValue(MaxRequestHeaderFieldSize);
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -230,18 +230,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         [NonEvent]
         public void Configuration(KestrelServerOptions options)
         {
-            var config = new Dictionary<string, string?>();
-
-            options.Serialize(config);
-
             var bufferWriter = new ArrayBufferWriter<byte>();
             var writer = new Utf8JsonWriter(bufferWriter);
 
             writer.WriteStartObject();
-            foreach (var (key, value) in config)
-            {
-                writer.WriteString(key, value);
-            }
+            options.Serialize(writer);
             writer.WriteEndObject();
             writer.Flush();
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -244,7 +244,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [NonEvent]
-        public void RegisterOptions(KestrelServerOptions options)
+        public void AddServerOptions(KestrelServerOptions options)
         {
             lock (_options)
             {
@@ -255,6 +255,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             if (IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 Configuration(options);
+            }
+        }
+
+        [NonEvent]
+        public void RemoveServerOptions(KestrelServerOptions options)
+        {
+            lock (_options)
+            {
+                _options.Remove(options);
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
 
             // Register the options with the event source so it can be logged (if necessary)
-            KestrelEventSource.Log.RegisterOptions(Options);
+            KestrelEventSource.Log.AddServerOptions(Options);
         }
 
         // Graceful shutdown if possible
@@ -245,6 +245,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
 
             _stoppedTcs.TrySetResult();
+
+            // Remove the options from the event source so we don't have a leak if
+            // the server is stopped and started again in the same process.
+            KestrelEventSource.Log.RemoveServerOptions(Options);
         }
 
         // Ungraceful shutdown

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -140,6 +140,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
         public async Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken) where TContext : notnull
         {
+            // Register the options with the event source so it can be logged (if necessary)
+            KestrelEventSource.Log.RegisterOptions(Options);
+
             try
             {
                 if (!BitConverter.IsLittleEndian)

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -140,9 +140,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
         public async Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken) where TContext : notnull
         {
-            // Register the options with the event source so it can be logged (if necessary)
-            KestrelEventSource.Log.RegisterOptions(Options);
-
             try
             {
                 if (!BitConverter.IsLittleEndian)
@@ -210,6 +207,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                 Dispose();
                 throw;
             }
+
+            // Register the options with the event source so it can be logged (if necessary)
+            KestrelEventSource.Log.RegisterOptions(Options);
         }
 
         // Graceful shutdown if possible

--- a/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
@@ -257,6 +257,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
         }
 
+        internal void Serialize(Dictionary<string, string?> config)
+        {
+            config[nameof(KeepAliveTimeout)] = KeepAliveTimeout.ToString();
+            config[nameof(MaxConcurrentConnections)] = MaxConcurrentConnections?.ToString();
+            config[nameof(MaxConcurrentUpgradedConnections)] = MaxConcurrentUpgradedConnections?.ToString();
+            config[nameof(MaxRequestBodySize)] = MaxRequestBodySize?.ToString();
+            config[nameof(MaxRequestBufferSize)] = MaxRequestBufferSize?.ToString();
+            config[nameof(MaxRequestHeaderCount)] = MaxRequestHeaderCount.ToString();
+            config[nameof(MaxRequestHeadersTotalSize)] = MaxRequestHeadersTotalSize.ToString();
+            config[nameof(MaxRequestLineSize)] = MaxRequestLineSize.ToString();
+            config[nameof(MaxResponseBufferSize)] = MaxResponseBufferSize.ToString();
+            config[nameof(MinRequestBodyDataRate)] = MinRequestBodyDataRate?.ToString();
+            config[nameof(MinResponseDataRate)] = MinResponseDataRate?.ToString();
+            config[nameof(RequestHeadersTimeout)] = RequestHeadersTimeout.ToString();
+
+            // HTTP2
+            Http2.Serialize(config);
+
+            // HTTP3
+            Http3.Serialize(config);
+        }
+
         /// <summary>
         /// Limits only applicable to HTTP/2 connections.
         /// </summary>

--- a/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
@@ -257,26 +258,84 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             }
         }
 
-        internal void Serialize(Dictionary<string, string?> config)
+        internal void Serialize(Utf8JsonWriter writer)
         {
-            config[nameof(KeepAliveTimeout)] = KeepAliveTimeout.ToString();
-            config[nameof(MaxConcurrentConnections)] = MaxConcurrentConnections?.ToString();
-            config[nameof(MaxConcurrentUpgradedConnections)] = MaxConcurrentUpgradedConnections?.ToString();
-            config[nameof(MaxRequestBodySize)] = MaxRequestBodySize?.ToString();
-            config[nameof(MaxRequestBufferSize)] = MaxRequestBufferSize?.ToString();
-            config[nameof(MaxRequestHeaderCount)] = MaxRequestHeaderCount.ToString();
-            config[nameof(MaxRequestHeadersTotalSize)] = MaxRequestHeadersTotalSize.ToString();
-            config[nameof(MaxRequestLineSize)] = MaxRequestLineSize.ToString();
-            config[nameof(MaxResponseBufferSize)] = MaxResponseBufferSize.ToString();
-            config[nameof(MinRequestBodyDataRate)] = MinRequestBodyDataRate?.ToString();
-            config[nameof(MinResponseDataRate)] = MinResponseDataRate?.ToString();
-            config[nameof(RequestHeadersTimeout)] = RequestHeadersTimeout.ToString();
+            writer.WriteString(nameof(KeepAliveTimeout), KeepAliveTimeout.ToString());
+
+            writer.WritePropertyName(nameof(MaxConcurrentConnections));
+            if (MaxConcurrentConnections is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteNumberValue(MaxConcurrentConnections.Value);
+            }
+
+            writer.WritePropertyName(nameof(MaxConcurrentUpgradedConnections));
+            if (MaxConcurrentUpgradedConnections is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteNumberValue(MaxConcurrentUpgradedConnections.Value);
+            }
+
+            writer.WritePropertyName(nameof(MaxRequestBodySize));
+            if (MaxRequestBodySize is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteNumberValue(MaxRequestBodySize.Value);
+            }
+
+            writer.WritePropertyName(nameof(MaxRequestBufferSize));
+            if (MaxRequestBufferSize is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteNumberValue(MaxRequestBufferSize.Value);
+            }
+
+            writer.WritePropertyName(nameof(MaxRequestHeaderCount));
+            writer.WriteNumberValue(MaxRequestHeaderCount);
+
+            writer.WritePropertyName(nameof(MaxRequestHeadersTotalSize));
+            writer.WriteNumberValue(MaxRequestHeadersTotalSize);
+
+            writer.WritePropertyName(nameof(MaxRequestLineSize));
+            writer.WriteNumberValue(MaxRequestLineSize);
+
+            writer.WritePropertyName(nameof(MaxResponseBufferSize));
+            if (MaxResponseBufferSize is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteNumberValue(MaxResponseBufferSize.Value);
+            }
+
+            writer.WriteString(nameof(MinRequestBodyDataRate), MinRequestBodyDataRate?.ToString());
+            writer.WriteString(nameof(MinResponseDataRate), MinResponseDataRate?.ToString());
+            writer.WriteString(nameof(RequestHeadersTimeout), RequestHeadersTimeout.ToString());
 
             // HTTP2
-            Http2.Serialize(config);
+            writer.WritePropertyName(nameof(Http2));
+            writer.WriteStartObject();
+            Http2.Serialize(writer);
+            writer.WriteEndObject();
 
             // HTTP3
-            Http3.Serialize(config);
+            writer.WritePropertyName(nameof(Http3));
+            writer.WriteStartObject();
+            Http3.Serialize(writer);
+            writer.WriteEndObject();
         }
 
         /// <summary>

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
 using Microsoft.Extensions.Configuration;
@@ -197,6 +198,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             EnsureDefaultCert();
 
             httpsOptions.ServerCertificate = DefaultCertificate;
+        }
+
+        internal void Serialize(Dictionary<string, string?> config)
+        {
+            config[nameof(AllowSynchronousIO)] = AllowSynchronousIO.ToString();
+            config[nameof(AddServerHeader)] = AddServerHeader.ToString();
+            config[nameof(AllowAlternateSchemes)] = AllowAlternateSchemes.ToString();
+            config[nameof(AllowResponseHeaderCompression)] = AllowResponseHeaderCompression.ToString();
+            config[nameof(EnableAltSvc)] = EnableAltSvc.ToString();
+            config[nameof(RequestHeaderEncodingSelector)] = RequestHeaderEncodingSelector is null ? "null" : "configured";
+            config[nameof(ResponseHeaderEncodingSelector)] = ResponseHeaderEncodingSelector is null ? "null" : "configured";
+
+            // Limits
+            Limits.Serialize(config);
         }
 
         private void EnsureDefaultCert()

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             // ListenOptions
             writer.WritePropertyName(nameof(ListenOptions));
             writer.WriteStartArray();
-            foreach (var listenOptions in ListenOptions)
+            foreach (var listenOptions in OptionsInUse)
             {
                 writer.WriteStartObject();
                 writer.WriteString("Address", listenOptions.GetDisplayName());

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
@@ -200,18 +201,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             httpsOptions.ServerCertificate = DefaultCertificate;
         }
 
-        internal void Serialize(Dictionary<string, string?> config)
+        internal void Serialize(Utf8JsonWriter writer)
         {
-            config[nameof(AllowSynchronousIO)] = AllowSynchronousIO.ToString();
-            config[nameof(AddServerHeader)] = AddServerHeader.ToString();
-            config[nameof(AllowAlternateSchemes)] = AllowAlternateSchemes.ToString();
-            config[nameof(AllowResponseHeaderCompression)] = AllowResponseHeaderCompression.ToString();
-            config[nameof(EnableAltSvc)] = EnableAltSvc.ToString();
-            config[nameof(RequestHeaderEncodingSelector)] = RequestHeaderEncodingSelector is null ? "null" : "configured";
-            config[nameof(ResponseHeaderEncodingSelector)] = ResponseHeaderEncodingSelector is null ? "null" : "configured";
+            writer.WritePropertyName(nameof(AllowSynchronousIO));
+            writer.WriteBooleanValue(AllowSynchronousIO);
+
+            writer.WritePropertyName(nameof(AddServerHeader));
+            writer.WriteBooleanValue(AddServerHeader);
+
+            writer.WritePropertyName(nameof(AllowAlternateSchemes));
+            writer.WriteBooleanValue(AllowAlternateSchemes);
+
+            writer.WritePropertyName(nameof(AllowResponseHeaderCompression));
+            writer.WriteBooleanValue(AllowResponseHeaderCompression);
+
+            writer.WritePropertyName(nameof(EnableAltSvc));
+            writer.WriteBooleanValue(EnableAltSvc);
+
+            writer.WriteString(nameof(RequestHeaderEncodingSelector), RequestHeaderEncodingSelector == DefaultHeaderEncodingSelector ? "default" : "configured");
+            writer.WriteString(nameof(ResponseHeaderEncodingSelector), ResponseHeaderEncodingSelector == DefaultHeaderEncodingSelector ? "default" : "configured");
 
             // Limits
-            Limits.Serialize(config);
+            writer.WritePropertyName(nameof(Limits));
+            writer.WriteStartObject();
+            Limits.Serialize(writer);
+            writer.WriteEndObject();
         }
 
         private void EnsureDefaultCert()

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -218,6 +218,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             writer.WritePropertyName(nameof(EnableAltSvc));
             writer.WriteBooleanValue(EnableAltSvc);
 
+            writer.WritePropertyName(nameof(IsDevCertLoaded));
+            writer.WriteBooleanValue(IsDevCertLoaded);
+
             writer.WriteString(nameof(RequestHeaderEncodingSelector), RequestHeaderEncodingSelector == DefaultHeaderEncodingSelector ? "default" : "configured");
             writer.WriteString(nameof(ResponseHeaderEncodingSelector), ResponseHeaderEncodingSelector == DefaultHeaderEncodingSelector ? "default" : "configured");
 
@@ -226,6 +229,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             writer.WriteStartObject();
             Limits.Serialize(writer);
             writer.WriteEndObject();
+            
+            // ListenOptions
+            writer.WritePropertyName(nameof(ListenOptions));
+            writer.WriteStartArray();
+            foreach (var listenOptions in ListenOptions)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("Address", listenOptions.GetDisplayName());
+                writer.WritePropertyName(nameof(listenOptions.IsTls));
+                writer.WriteBooleanValue(listenOptions.IsTls);
+                writer.WriteString(nameof(listenOptions.Protocols), listenOptions.Protocols.ToString());
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
         }
 
         private void EnsureDefaultCert()

--- a/src/Servers/Kestrel/Core/src/MinDataRate.cs
+++ b/src/Servers/Kestrel/Core/src/MinDataRate.cs
@@ -43,5 +43,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// starting at the time data is first read or written.
         /// </summary>
         public TimeSpan GracePeriod { get; }
+
+        public override string ToString()
+        {
+            return $"{BytesPerSecond} BPS, Grace Period: {GracePeriod}";
+        }
     }
 }

--- a/src/Servers/Kestrel/Core/src/MinDataRate.cs
+++ b/src/Servers/Kestrel/Core/src/MinDataRate.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
         public override string ToString()
         {
-            return $"{BytesPerSecond} BPS, Grace Period: {GracePeriod}";
+            return $"Bytes per second: {BytesPerSecond}, Grace Period: {GracePeriod}";
         }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/EventSourceTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/EventSourceTests.cs
@@ -423,7 +423,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.Equal(eventIndex, events.Count);
         }
 
-        private string GetProperty(EventSnapshot data, string propName) => data.Payload[propName];
+        private string GetProperty(EventSnapshot data, string propName) => data.Payload.TryGetValue(propName, out var value) ? value : null;
 
         private class TestEventListener : EventListener
         {


### PR DESCRIPTION
- Dump configured values in a JSON blob and emit an event

```JSON
{
  "AllowSynchronousIO": false,
  "AddServerHeader": true,
  "AllowAlternateSchemes": false,
  "AllowResponseHeaderCompression": true,
  "EnableAltSvc": false,
  "IsDevCertLoaded": true,
  "RequestHeaderEncodingSelector": "default",
  "ResponseHeaderEncodingSelector": "default",
  "Limits": {
    "KeepAliveTimeout": "00:02:10",
    "MaxConcurrentConnections": null,
    "MaxConcurrentUpgradedConnections": null,
    "MaxRequestBodySize": 30000000,
    "MaxRequestBufferSize": 1048576,
    "MaxRequestHeaderCount": 100,
    "MaxRequestHeadersTotalSize": 32768,
    "MaxRequestLineSize": 8192,
    "MaxResponseBufferSize": 65536,
    "MinRequestBodyDataRate": "Bytes per second: 240, Grace Period: 00:00:05",
    "MinResponseDataRate": "Bytes per second: 240, Grace Period: 00:00:05",
    "RequestHeadersTimeout": "00:00:30",
    "Http2": {
      "MaxStreamsPerConnection": 100,
      "HeaderTableSize": 4096,
      "MaxFrameSize": 16384,
      "MaxRequestHeaderFieldSize": 16384,
      "InitialConnectionWindowSize": 131072,
      "InitialStreamWindowSize": 98304,
      "KeepAlivePingDelay": "10675199.02:48:05.4775807",
      "KeepAlivePingTimeout": "00:00:20"
    },
    "Http3": {
      "HeaderTableSize": 0,
      "MaxRequestHeaderFieldSize": 16384
    }
  },
  "ListenOptions": [
    {
      "Address": "https://127.0.0.1:7030",
      "IsTls": true,
      "Protocols": "Http1AndHttp2"
    },
    {
      "Address": "https://[::1]:7030",
      "IsTls": true,
      "Protocols": "Http1AndHttp2"
    },
    {
      "Address": "http://127.0.0.1:5030",
      "IsTls": false,
      "Protocols": "Http1AndHttp2"
    },
    {
      "Address": "http://[::1]:5030",
      "IsTls": false,
      "Protocols": "Http1AndHttp2"
    }
  ]
}
```

The payload size is event source and LOH safe so >= 2K and 4K (with more listen options).

Contributes to #34578  