### PR TITLE
Add the OS version to the IIS setup script

### DIFF
--- a/src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1
+++ b/src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1
@@ -1,3 +1,6 @@
+# Print the OS version for diagnostic purposes
+$PSVersionTable.BuildVersion
+
 $ErrorActionPreference = 'Stop'
 
 if (-not $PSScriptRoot) {


### PR DESCRIPTION
Logging the OS version to debug some setup issues.

This is the powershell version of `ver`
https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/ver

Displays
```
Major  Minor  Build  Revision
-----  -----  -----  --------
10     0      22000  65
```

Oddly this doesn't exactly match the ver output.
`Microsoft Windows [Version 10.0.22000.100]`
