### PR TITLE
Avoid unnecessary body write scheduling in IIS

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -195,13 +195,15 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
                 (RequestBody, ResponseBody) = _streams.Start();
 
-                var pipe = new Pipe(
-                    new PipeOptions(
-                        _memoryPool,
-                        readerScheduler: PipeScheduler.Inline,
-                        pauseWriterThreshold: PauseWriterThreshold,
-                        resumeWriterThreshold: ResumeWriterTheshold,
-                        minimumSegmentSize: MinAllocBufferSize));
+                var pipe = new Pipe(new PipeOptions(
+                    _memoryPool,
+                    // The readerScheduler schedules internal non-blocking logic, so there's no reason to dispatch.
+                    // The writerScheduler is PipeScheduler.ThreadPool by default which is correct because it
+                    // schedules app code when backpressure is relieved which may block.
+                    readerScheduler: PipeScheduler.Inline,
+                    pauseWriterThreshold: PauseWriterThreshold,
+                    resumeWriterThreshold: ResumeWriterTheshold,
+                    minimumSegmentSize: MinAllocBufferSize));
                 _bodyOutput = new OutputProducer(pipe);
             }
 

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                 var pipe = new Pipe(
                     new PipeOptions(
                         _memoryPool,
-                        readerScheduler: PipeScheduler.ThreadPool,
+                        readerScheduler: PipeScheduler.Inline,
                         pauseWriterThreshold: PauseWriterThreshold,
                         resumeWriterThreshold: ResumeWriterTheshold,
                         minimumSegmentSize: MinAllocBufferSize));


### PR DESCRIPTION
Only internal logic reads from this Pipe, so there's no reason to dispatch this to another thread to avoid potential blocking. Running the [reader loop](https://github.com/dotnet/aspnetcore/blob/b3e8e4a4271c011617063b290f6f1c2044021b01/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs#L153-L213) inline should reduce thread pool load.

This should both improve perf and make in-proc behave better in thread pool starved scenarios. That said, behavior is always going to be bad in thread pool starved scenarios because there's still a bunch of other stuff that gets scheduled. 😄