### PR TITLE
Throw IOE if services accessed after application is built

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Builder
         private readonly WebHostEnvironment _environment;
         private readonly WebApplicationServiceCollection _services = new();
         private WebApplication? _builtApplication;
+        private IServiceCollection _serviceCollection = new ServiceCollection();
 
         internal WebApplicationBuilder(Assembly? callingAssembly, string[]? args = null)
         {
@@ -72,7 +73,19 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// A collection of services for the application to compose. This is useful for adding user provided or framework provided services.
         /// </summary>
-        public IServiceCollection Services { get; }
+        public IServiceCollection Services
+        {
+            get
+            {
+                if (_builtApplication != null)
+                {
+                    throw new InvalidOperationException("Services cannot be modified after application is built.");
+                }
+                return _serviceCollection;
+            }
+
+            init => _serviceCollection = value;
+        }
 
         /// <summary>
         /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -533,6 +533,15 @@ namespace Microsoft.AspNetCore.Tests
             Assert.Equal(418, (int)terminalResult.StatusCode);
         }
 
+        [Fact]
+        public async Task WebApplicationBuilder_ThrowsExceptionIfServicesAlreadyBuilt()
+        {
+            var builder = WebApplication.CreateBuilder();
+            await using var app = builder.Build();
+
+            Assert.Throws<InvalidOperationException>(() => builder.Services.AddSingleton<IServer>(new MockAddressesServer()));
+        }
+
         private class Service : IService { }
         private interface IService { }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/33812.

The referenced issue mentions:

> and the various methods on IServiceCollection

But it seems more expedient to just throw the exception on `builder.Services`. I didn't spot any extension methods on `WebApplicationBuilder` that access services.

