### PR TITLE
Bump spa-templates SHA to pick up local build fix

### DIFF
--- a/eng/targets/Packaging.targets
+++ b/eng/targets/Packaging.targets
@@ -25,11 +25,11 @@
   </Target>
 
   <PropertyGroup>
-    <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);_AppendRepostoryUrlToPackageDescription</GenerateNuspecDependsOn>
+    <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);_AppendRepositoryUrlToPackageDescription</GenerateNuspecDependsOn>
   </PropertyGroup>
 
-  <Target Name="_AppendRepostoryUrlToPackageDescription"
-    DependsOnTargets="InitializeSourceControlInformation">
+  <Target Name="_AppendRepositoryUrlToPackageDescription"
+      DependsOnTargets="InitializeSourceControlInformation">
     <PropertyGroup Condition="'$(RepositoryUrl)' != '' AND '$(SourceRevisionId)' != ''">
       <PackageDescription>$(PackageDescription)
 

--- a/src/ProjectTemplates/Directory.Build.targets
+++ b/src/ProjectTemplates/Directory.Build.targets
@@ -4,8 +4,7 @@
   <PropertyGroup>
     <Description>$(Description)
 
-To install the templates in this package, run 'dotnet new --install $(PackageId)::$(PackageVersion)'.
-    </Description>
+To install the templates in this package, run 'dotnet new --install $(PackageId)::$(PackageVersion)'.</Description>
   </PropertyGroup>
 
   <Import Project="GenerateContent.targets" />

--- a/src/ProjectTemplates/build.cmd
+++ b/src/ProjectTemplates/build.cmd
@@ -1,4 +1,11 @@
 @ECHO OFF
 SET RepoRoot=%~dp0..\..
-%RepoRoot%\eng\build.cmd -projects %~dp0*\*.*proj "/p:EnforceE2ETestPrerequisites=true" %*
-%RepoRoot%\eng\build.cmd -projects %~dp0\..\submodules\spa-templates\src\*.*proj "/p:EnforceE2ETestPrerequisites=true" -noBuildRepoTasks -noBuildNative %*
+CALL "%RepoRoot%\eng\build.cmd" -projects "%~dp0*\*.*proj" "/p:EnforceE2ETestPrerequisites=true" %*
+IF %ERRORLEVEL% NEQ 0 (
+   EXIT /b %ErrorLevel%
+)
+
+CALL "%RepoRoot%\eng\build.cmd" -projects "%RepoRoot%\src\submodules\spa-templates\src\*.*proj" "/p:EnforceE2ETestPrerequisites=true" -noBuildRepoTasks -noBuildNative %*
+IF %ERRORLEVEL% NEQ 0 (
+   EXIT /b %ErrorLevel%
+)

--- a/src/submodules/Directory.Build.props
+++ b/src/submodules/Directory.Build.props
@@ -1,9 +1,5 @@
-<Project>
-  <!--
-    For everything but Microsoft.DotNet.Web.Spa.ProjectTemplates, intentionally break the inheritance chain so
-    submodules do not inherit build settings from this repo. For Microsoft.DotNet.Web.Spa.ProjectTemplates, break the
-    build if referenced file does not exist.
-  -->
-  <Import Project="..\ProjectTemplates\Directory.Build.props"
-      Condition=" '$(MSBuildProjectName)' == 'Microsoft.DotNet.Web.Spa.ProjectTemplates' " />
-</Project>
+<!--
+  For everything but Microsoft.DotNet.Web.Spa.ProjectTemplates (which bypasses this file), intentionally break
+  the inheritance chain so submodules do not inherit build settings from this repo.
+-->
+<Project />

--- a/src/submodules/Directory.Build.targets
+++ b/src/submodules/Directory.Build.targets
@@ -1,9 +1,5 @@
-<Project>
-  <!--
-    For everything but Microsoft.DotNet.Web.Spa.ProjectTemplates, intentionally break the inheritance chain so
-    submodules do not inherit build settings from this repo. For Microsoft.DotNet.Web.Spa.ProjectTemplates, break the
-    build if referenced file does not exist.
-  -->
-<Import Project="..\ProjectTemplates\Directory.Build.targets"
-      Condition=" '$(MSBuildProjectName)' == 'Microsoft.DotNet.Web.Spa.ProjectTemplates' " />
-</Project>
+<!--
+  For everything but Microsoft.DotNet.Web.Spa.ProjectTemplates (which bypasses this file), intentionally break
+  the inheritance chain so submodules do not inherit build settings from this repo.
+-->
+<Project />


### PR DESCRIPTION
- see dotnet/spa-templates#7
  - ~~testing for now; will update submodule SHA when that goes in~~
- restore simpler src/submodules/Directory.Build.* files

separately, dotnet/spa-templates#7 helped me fix this repo:
- correct syntax in src/ProjectTemplates/build.cmd
- fix whitespace src/ProjectTemplates/Directory.Build.targets target added to `$(Description)`
- fix typo in the `_AppendRepositoryUrlToPackageDescription` target name