### PR TITLE
Fix client cert negotiation error message

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -733,7 +733,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 Assert.Null(context.Connection.ClientCertificate);
 
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Connection.GetClientCertificateAsync());
-                Assert.Equal("Received data during renegotiation.", ex.Message);
+                Assert.Equal("Client stream needs to be drained before renegotiation.", ex.Message);
                 Assert.Null(tlsFeature.ClientCertificate);
                 Assert.Null(context.Connection.ClientCertificate);
             }, new TestServiceContext(LoggerFactory), ConfigureListenOptions);
@@ -778,7 +778,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 Assert.Null(context.Connection.ClientCertificate);
 
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Connection.GetClientCertificateAsync());
-                Assert.Equal("Received data during renegotiation.", ex.Message);
+                Assert.Equal("Client stream needs to be drained before renegotiation.", ex.Message);
                 Assert.Null(tlsFeature.ClientCertificate);
                 Assert.Null(context.Connection.ClientCertificate);
             }, new TestServiceContext(LoggerFactory), ConfigureListenOptions);


### PR DESCRIPTION
These tests fail locally because the runtime changed the error message text. They're not running on the CI yet due to the TLS 1.3 requirement. There's a separate issue with them related to the read/write locks tracked as https://github.com/dotnet/runtime/issues/56345.