### PR TITLE
Add [RequiresPreviewFeaturesAttribute] to Http3

### DIFF
--- a/src/Servers/Kestrel/Core/src/HttpProtocols.cs
+++ b/src/Servers/Kestrel/Core/src/HttpProtocols.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         Http1AndHttp2 = Http1 | Http2,
         [RequiresPreviewFeatures]
         Http3 = 0x4,
-        [RequiresPreviewFeaturesAttribute]
+        [RequiresPreviewFeatures]
         Http1AndHttp2AndHttp3 = Http1 | Http2 | Http3
     }
 }

--- a/src/Servers/Kestrel/Core/src/HttpProtocols.cs
+++ b/src/Servers/Kestrel/Core/src/HttpProtocols.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.Versioning;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core
 {

--- a/src/Servers/Kestrel/Core/src/HttpProtocols.cs
+++ b/src/Servers/Kestrel/Core/src/HttpProtocols.cs
@@ -15,7 +15,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         Http1 = 0x1,
         Http2 = 0x2,
         Http1AndHttp2 = Http1 | Http2,
+        [RequiresPreviewFeaturesAttribute]
         Http3 = 0x4,
+        [RequiresPreviewFeaturesAttribute]
         Http1AndHttp2AndHttp3 = Http1 | Http2 | Http3
     }
 }

--- a/src/Servers/Kestrel/Core/src/HttpProtocols.cs
+++ b/src/Servers/Kestrel/Core/src/HttpProtocols.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         Http1 = 0x1,
         Http2 = 0x2,
         Http1AndHttp2 = Http1 | Http2,
-        [RequiresPreviewFeaturesAttribute]
+        [RequiresPreviewFeatures]
         Http3 = 0x4,
         [RequiresPreviewFeaturesAttribute]
         Http1AndHttp2AndHttp3 = Http1 | Http2 | Http3

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <!-- Turn off warnings about using preview features -->
+    <NoWarn>CA2252;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
-    <!-- Turn off warnings about using preview features -->
-    <NoWarn>CA2252;$(NoWarn)</NoWarn>
+    <!-- Turn on preview features so we can use Http3 -->
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/34738. Confirmed in ILSpy that the attribute is present on the 2 enum values.