### PR TITLE
Revert "Skip component governance"

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -261,8 +261,7 @@ jobs:
         condition: always()
 
     # Run component detection after all successful Build:* jobs unless overridden e.g. for Alpine build.
-    # Disabled for now because detector limits some error handling to the auto-injected task. Will re-enable once fixed.
-    - ${{ if and(startsWith(parameters.jobDisplayName, 'Build:'), eq(parameters.agentOs, 'NotARealOperatingSystem'), ne(variables['skipComponentGovernanceDetection'], 'true'), ne(parameters.skipComponentGovernanceDetection, 'true'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if and(startsWith(parameters.jobDisplayName, 'Build:'), ne(variables['skipComponentGovernanceDetection'], 'true'), ne(parameters.skipComponentGovernanceDetection, 'true'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
         condition: and(succeeded(), ne(variables['CG_RAN'], 'true'))
         displayName: 'Component Detection'


### PR DESCRIPTION
Reverts dotnet/aspnetcore#30125. Should be able to un-skip this by now

Fixes https://github.com/dotnet/aspnetcore/issues/30126