### PR TITLE
HTTP/3: Refactor alt-svc upgrade

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/BaseHttpConnectionContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/BaseHttpConnectionContext.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         public BaseHttpConnectionContext(
             string connectionId,
             HttpProtocols protocols,
+            AltSvcHeader? altSvcHeader,
             BaseConnectionContext connectionContext,
             ServiceContext serviceContext,
             IFeatureCollection connectionFeatures,
@@ -24,6 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         {
             ConnectionId = connectionId;
             Protocols = protocols;
+            AltSvcHeader = altSvcHeader;
             ConnectionContext = connectionContext;
             ServiceContext = serviceContext;
             ConnectionFeatures = connectionFeatures;
@@ -34,6 +36,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 
         public string ConnectionId { get; set; }
         public HttpProtocols Protocols { get; }
+        public AltSvcHeader? AltSvcHeader { get; }
         public BaseConnectionContext ConnectionContext { get; }
         public ServiceContext ServiceContext { get; }
         public IFeatureCollection ConnectionFeatures { get; }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1194,20 +1194,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 }
             }
 
-            if (ServerOptions.EnableAltSvc && _httpVersion < Http.HttpVersion.Http3)
+            if (_context.AltSvcHeader != null && !responseHeaders.HasAltSvc)
             {
-                // TODO: Perf. Avoid allocating enumerator and property's LINQ.
-                // https://github.com/dotnet/aspnetcore/issues/34468
-                foreach (var option in ServerOptions.ListenOptions)
-                {
-                    if ((option.Protocols & HttpProtocols.Http3) == HttpProtocols.Http3)
-                    {
-                        // TODO: Perf. Create string once instead of per-request.
-                        // https://github.com/dotnet/aspnetcore/issues/34468
-                        responseHeaders.HeaderAltSvc = $"h3=\":{option.IPEndPoint!.Port}\"; ma=84600";
-                        break;
-                    }
-                }
+                responseHeaders.SetRawAltSvc(_context.AltSvcHeader.Value, _context.AltSvcHeader.RawBytes);
             }
 
             if (ServerOptions.AddServerHeader && !responseHeaders.HasServer)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -650,6 +650,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             var streamContext = new Http2StreamContext(
                 ConnectionId,
                 protocols: default,
+                _context.AltSvcHeader,
                 _context.ServiceContext,
                 _context.ConnectionFeatures,
                 _context.MemoryPool,

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamContext.cs
@@ -7,6 +7,7 @@ using System.Net;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 {
@@ -15,6 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         public Http2StreamContext(
             string connectionId,
             HttpProtocols protocols,
+            AltSvcHeader? altSvcHeader,
             ServiceContext serviceContext,
             IFeatureCollection connectionFeatures,
             MemoryPool<byte> memoryPool,
@@ -26,7 +28,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             Http2PeerSettings serverPeerSettings,
             Http2FrameWriter frameWriter,
             InputFlowControl connectionInputFlowControl,
-            OutputFlowControl connectionOutputFlowControl) : base(connectionId, protocols, connectionContext: null!, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint)
+            OutputFlowControl connectionOutputFlowControl) : base(connectionId, protocols, altSvcHeader, connectionContext: null!, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint)
         {
             StreamId = streamId;
             StreamLifetimeHandler = streamLifetimeHandler;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -379,6 +379,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             var httpConnectionContext = new Http3StreamContext(
                 _multiplexedContext.ConnectionId,
                 HttpProtocols.Http3,
+                _context.AltSvcHeader,
                 _multiplexedContext,
                 _context.ServiceContext,
                 streamContext.Features,
@@ -461,6 +462,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             var httpConnectionContext = new Http3StreamContext(
                 _multiplexedContext.ConnectionId,
                 HttpProtocols.Http3,
+                _context.AltSvcHeader,
                 _multiplexedContext,
                 _context.ServiceContext,
                 streamContext.Features,

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamContext.cs
@@ -6,6 +6,7 @@ using System.IO.Pipelines;
 using System.Net;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {
@@ -14,6 +15,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         public Http3StreamContext(
             string connectionId,
             HttpProtocols protocols,
+            AltSvcHeader? altSvcHeader,
             BaseConnectionContext connectionContext,
             ServiceContext serviceContext,
             IFeatureCollection connectionFeatures,
@@ -23,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             IHttp3StreamLifetimeHandler streamLifetimeHandler,
             ConnectionContext streamContext,
             Http3PeerSettings clientPeerSettings,
-            Http3PeerSettings serverPeerSettings) : base(connectionId, protocols, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint)
+            Http3PeerSettings serverPeerSettings) : base(connectionId, protocols, altSvcHeader, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint)
         {
             StreamLifetimeHandler = streamLifetimeHandler;
             StreamContext = streamContext;

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -202,8 +202,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             var hasTls = _context.ConnectionFeatures.Get<ITlsConnectionFeature>() != null;
             var applicationProtocol = _context.ConnectionFeatures.Get<ITlsApplicationProtocolFeature>()?.ApplicationProtocol
                 ?? new ReadOnlyMemory<byte>();
-            var http1Enabled = (_context.Protocols & HttpProtocols.Http1) == HttpProtocols.Http1;
-            var http2Enabled = (_context.Protocols & HttpProtocols.Http2) == HttpProtocols.Http2;
+            var isMultiplexTransport = _context is HttpMultiplexedConnectionContext;
+            var http1Enabled = _context.Protocols.HasFlag(HttpProtocols.Http1);
+            var http2Enabled = _context.Protocols.HasFlag(HttpProtocols.Http2);
+            var http3Enabled = _context.Protocols.HasFlag(HttpProtocols.Http3);
 
             string? error = null;
 
@@ -212,9 +214,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
                 error = CoreStrings.EndPointRequiresAtLeastOneProtocol;
             }
 
-            if (_context.Protocols == HttpProtocols.Http3)
+            if (isMultiplexTransport)
             {
-                return HttpProtocols.Http3;
+                if (http3Enabled)
+                {
+                    return HttpProtocols.Http3;
+                }
+
+                error = $"Protocols {_context.Protocols} not supported on multiplexed transport.";
             }
 
             if (!http1Enabled && http2Enabled && hasTls && !Http2Id.SequenceEqual(applicationProtocol.Span))

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnectionContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnectionContext.cs
@@ -6,6 +6,7 @@ using System.IO.Pipelines;
 using System.Net;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -14,12 +15,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
         public HttpConnectionContext(
             string connectionId,
             HttpProtocols protocols,
+            AltSvcHeader? altSvcHeader,
             BaseConnectionContext connectionContext,
             ServiceContext serviceContext,
             IFeatureCollection connectionFeatures,
             MemoryPool<byte> memoryPool,
             IPEndPoint? localEndPoint,
-            IPEndPoint? remoteEndPoint) : base(connectionId, protocols, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint)
+            IPEndPoint? remoteEndPoint) : base(connectionId, protocols, altSvcHeader, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint)
         {
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/HttpMultiplexedConnectionContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpMultiplexedConnectionContext.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Net;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -12,12 +13,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     {
         public HttpMultiplexedConnectionContext(
             string connectionId,
+            HttpProtocols protocols,
+            AltSvcHeader? altSvcHeader,
             MultiplexedConnectionContext connectionContext,
             ServiceContext serviceContext,
             IFeatureCollection connectionFeatures,
             MemoryPool<byte> memoryPool,
             IPEndPoint? localEndPoint,
-            IPEndPoint? remoteEndPoint) : base(connectionId, HttpProtocols.Http3, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint)
+            IPEndPoint? remoteEndPoint) : base(connectionId, protocols, altSvcHeader, connectionContext, serviceContext, connectionFeatures, memoryPool, localEndPoint, remoteEndPoint)
         {
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                             throw new InvalidOperationException($"Cannot start HTTP/1.x or HTTP/2 server if no {nameof(IConnectionListenerFactory)} is registered.");
                         }
 
-                        options.UseHttpServer(ServiceContext, application, options.Protocols);
+                        options.UseHttpServer(ServiceContext, application, options.Protocols, options.AddAltSvcHeader);
                         var connectionDelegate = options.Build();
 
                         // Add the connection limit middleware
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                             throw new InvalidOperationException($"Cannot start HTTP/3 server if no {nameof(IMultiplexedConnectionListenerFactory)} is registered.");
                         }
 
-                        options.UseHttp3Server(ServiceContext, application);
+                        options.UseHttp3Server(ServiceContext, application, options.Protocols, options.AddAltSvcHeader);
                         var multiplexedConnectionDelegate = ((IMultiplexedConnectionBuilder)options).Build();
 
                         // Add the connection limit middleware

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                             throw new InvalidOperationException($"Cannot start HTTP/1.x or HTTP/2 server if no {nameof(IConnectionListenerFactory)} is registered.");
                         }
 
-                        options.UseHttpServer(ServiceContext, application, options.Protocols, options.AddAltSvcHeader);
+                        options.UseHttpServer(ServiceContext, application, options.Protocols, !options.DisableAltSvcHeader);
                         var connectionDelegate = options.Build();
 
                         // Add the connection limit middleware
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                             throw new InvalidOperationException($"Cannot start HTTP/3 server if no {nameof(IMultiplexedConnectionListenerFactory)} is registered.");
                         }
 
-                        options.UseHttp3Server(ServiceContext, application, options.Protocols, options.AddAltSvcHeader);
+                        options.UseHttp3Server(ServiceContext, application, options.Protocols, !options.DisableAltSvcHeader);
                         var multiplexedConnectionDelegate = ((IMultiplexedConnectionBuilder)options).Build();
 
                         // Add the connection limit middleware

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -70,6 +70,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// </remarks>
         public bool AllowSynchronousIO { get; set; }
 
+        /// <summary>
         /// Gets or sets a value that controls how the `:scheme` field for HTTP/2 and HTTP/3 requests is validated.
         /// <para>
         /// If <c>false</c> then the `:scheme` field for HTTP/2 and HTTP/3 requests must exactly match the transport (e.g. https for TLS
@@ -79,6 +80,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// scenarios such as proxies converting from alternate protocols. See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3.
         /// Applications that enable this should validate an expected scheme is provided before using it.
         /// </para>
+        /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
@@ -99,6 +101,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// <remarks>
         /// Defaults to false.
         /// </remarks>
+        [Obsolete($"This property is obsolete and will be removed in a future version. It no longer has any impact on runtime behavior. Use {nameof(Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions)}.{nameof(Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.AddAltSvcHeader)} to configure \"Alt-Svc\" behavior.")]
         public bool EnableAltSvc { get; set; }
 
         /// <summary>

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// <remarks>
         /// Defaults to false.
         /// </remarks>
-        [Obsolete($"This property is obsolete and will be removed in a future version. It no longer has any impact on runtime behavior. Use {nameof(Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions)}.{nameof(Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.AddAltSvcHeader)} to configure \"Alt-Svc\" behavior.")]
+        [Obsolete($"This property is obsolete and will be removed in a future version. It no longer has any impact on runtime behavior. Use {nameof(Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions)}.{nameof(Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.DisableAltSvcHeader)} to configure \"Alt-Svc\" behavior.", error: true)]
         public bool EnableAltSvc { get; set; }
 
         /// <summary>

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -89,8 +89,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// The "Alt-Svc" header is used by clients to upgrade HTTP/1.1 and HTTP/2 connections to HTTP/3.
         /// <para>
         /// The "Alt-Svc" header is automatically included with a response if <see cref="Protocols"/> has either
-        /// HTTP/1.1 or HTTP/2 enabled, and HTTP/3 is enabled. If an "Alt-Svc" header already has a value then it
-        /// isn't changed.
+        /// HTTP/1.1 or HTTP/2 enabled, and HTTP/3 is enabled. If the "Alt-Svc" header already has a value then
+        /// it isn't changed.
         /// </para>
         /// </summary>
         /// <remarks>

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -85,6 +85,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public HttpProtocols Protocols { get; set; } = DefaultHttpProtocols;
 
         /// <summary>
+        /// Gets or sets a value that controls whether to the "Alt-Svc" header is included with response headers.
+        /// The "Alt-Svc" header is used by clients to upgrade HTTP/1.1 and HTTP/2 connections to HTTP/3.
+        /// <para>
+        /// The "Alt-Svc" header is only included with a response if <see cref="Protocols"/> has either
+        /// HTTP/1.1 or HTTP/2 enabled, and HTTP/3 is enabled.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Defaults to true.
+        /// </remarks>
+        public bool AddAltSvcHeader { get; set; } = true;
+
+        /// <summary>
         /// Gets the application <see cref="IServiceProvider"/>.
         /// </summary>
         public IServiceProvider ApplicationServices => KestrelServerOptions?.ApplicationServices!; // TODO - Always available?

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -89,8 +89,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         /// The "Alt-Svc" header is used by clients to upgrade HTTP/1.1 and HTTP/2 connections to HTTP/3.
         /// <para>
         /// The "Alt-Svc" header is automatically included with a response if <see cref="Protocols"/> has either
-        /// HTTP/1.1 or HTTP/2 enabled, and HTTP/3 is enabled. If the "Alt-Svc" header already has a value then
-        /// it isn't changed.
+        /// HTTP/1.1 or HTTP/2 enabled, and HTTP/3 is enabled. If an "Alt-Svc" header value has already been set
+        /// by the app then it isn't changed.
         /// </para>
         /// </summary>
         /// <remarks>

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -85,17 +85,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
         public HttpProtocols Protocols { get; set; } = DefaultHttpProtocols;
 
         /// <summary>
-        /// Gets or sets a value that controls whether to the "Alt-Svc" header is included with response headers.
+        /// Gets or sets a value that controls whether the "Alt-Svc" header is included with response headers.
         /// The "Alt-Svc" header is used by clients to upgrade HTTP/1.1 and HTTP/2 connections to HTTP/3.
         /// <para>
-        /// The "Alt-Svc" header is only included with a response if <see cref="Protocols"/> has either
-        /// HTTP/1.1 or HTTP/2 enabled, and HTTP/3 is enabled.
+        /// The "Alt-Svc" header is automatically included with a response if <see cref="Protocols"/> has either
+        /// HTTP/1.1 or HTTP/2 enabled, and HTTP/3 is enabled. If an "Alt-Svc" header already has a value then it
+        /// isn't changed.
         /// </para>
         /// </summary>
         /// <remarks>
-        /// Defaults to true.
+        /// Defaults to false.
         /// </remarks>
-        public bool AddAltSvcHeader { get; set; } = true;
+        public bool DisableAltSvcHeader { get; set; }
 
         /// <summary>
         /// Gets the application <see cref="IServiceProvider"/>.

--- a/src/Servers/Kestrel/Core/src/LocalhostListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/LocalhostListenOptions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             {
                 KestrelServerOptions = KestrelServerOptions,
                 Protocols = Protocols,
-                AddAltSvcHeader = AddAltSvcHeader,
+                DisableAltSvcHeader = DisableAltSvcHeader,
                 IsTls = IsTls,
                 HttpsOptions = HttpsOptions,
                 EndpointConfig = EndpointConfig

--- a/src/Servers/Kestrel/Core/src/LocalhostListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/LocalhostListenOptions.cs
@@ -74,6 +74,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             {
                 KestrelServerOptions = KestrelServerOptions,
                 Protocols = Protocols,
+                AddAltSvcHeader = AddAltSvcHeader,
                 IsTls = IsTls,
                 HttpsOptions = HttpsOptions,
                 EndpointConfig = EndpointConfig

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionBuilderExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionBuilderExtensions.cs
@@ -8,18 +8,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
     internal static class HttpConnectionBuilderExtensions
     {
-        public static IConnectionBuilder UseHttpServer<TContext>(this IConnectionBuilder builder, ServiceContext serviceContext, IHttpApplication<TContext> application, HttpProtocols protocols) where TContext : notnull
+        public static IConnectionBuilder UseHttpServer<TContext>(this IConnectionBuilder builder, ServiceContext serviceContext, IHttpApplication<TContext> application, HttpProtocols protocols, bool addAltSvcHeader) where TContext : notnull
         {
-            var middleware = new HttpConnectionMiddleware<TContext>(serviceContext, application, protocols);
+            var middleware = new HttpConnectionMiddleware<TContext>(serviceContext, application, protocols, addAltSvcHeader);
             return builder.Use(next =>
             {
                 return middleware.OnConnectionAsync;
             });
         }
 
-        public static IMultiplexedConnectionBuilder UseHttp3Server<TContext>(this IMultiplexedConnectionBuilder builder, ServiceContext serviceContext, IHttpApplication<TContext> application) where TContext : notnull
+        public static IMultiplexedConnectionBuilder UseHttp3Server<TContext>(this IMultiplexedConnectionBuilder builder, ServiceContext serviceContext, IHttpApplication<TContext> application, HttpProtocols protocols, bool addAltSvcHeader) where TContext : notnull
         {
-            var middleware = new HttpMultiplexedConnectionMiddleware<TContext>(serviceContext, application);
+            var middleware = new HttpMultiplexedConnectionMiddleware<TContext>(serviceContext, application, protocols, addAltSvcHeader);
             return builder.Use(next =>
             {
                 return middleware.OnConnectionAsync;

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
 {
@@ -13,24 +14,32 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
     {
         private readonly ServiceContext _serviceContext;
         private readonly IHttpApplication<TContext> _application;
+        private readonly HttpProtocols _protocols;
+        private readonly bool _addAltSvcHeader;
 
-        public HttpMultiplexedConnectionMiddleware(ServiceContext serviceContext, IHttpApplication<TContext> application)
+        public HttpMultiplexedConnectionMiddleware(ServiceContext serviceContext, IHttpApplication<TContext> application, HttpProtocols protocols, bool addAltSvcHeader)
         {
             _serviceContext = serviceContext;
             _application = application;
+            _protocols = protocols;
+            _addAltSvcHeader = addAltSvcHeader;
         }
 
         public Task OnConnectionAsync(MultiplexedConnectionContext connectionContext)
         {
             var memoryPoolFeature = connectionContext.Features.Get<IMemoryPoolFeature>();
+            var localEndPoint = connectionContext.LocalEndPoint as IPEndPoint;
+            var altSvcHeader = _addAltSvcHeader && localEndPoint != null ? HttpUtilities.GetEndpointAltSvc(localEndPoint, _protocols) : null;
 
             var httpConnectionContext = new HttpMultiplexedConnectionContext(
                 connectionContext.ConnectionId,
+                _protocols,
+                altSvcHeader,
                 connectionContext,
                 _serviceContext,
                 connectionContext.Features,
                 memoryPoolFeature?.MemoryPool ?? System.Buffers.MemoryPool<byte>.Shared,
-                connectionContext.LocalEndPoint as IPEndPoint,
+                localEndPoint,
                 connectionContext.RemoteEndPoint as IPEndPoint);
 
             var connection = new HttpConnection(httpConnectionContext);

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -213,5 +213,5 @@ static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this M
 static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, System.Security.Cryptography.X509Certificates.X509Certificate2! serverCertificate, System.Action<Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions!>! configureOptions) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!
 static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, string! fileName) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!
 static Microsoft.AspNetCore.Server.Kestrel.Https.CertificateLoader.LoadFromStoreCert(string! subject, string! storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, bool allowInvalid) -> System.Security.Cryptography.X509Certificates.X509Certificate2!
-Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.AddAltSvcHeader.get -> bool
-Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.AddAltSvcHeader.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.DisableAltSvcHeader.get -> bool
+Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.DisableAltSvcHeader.set -> void

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -213,3 +213,5 @@ static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this M
 static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, System.Security.Cryptography.X509Certificates.X509Certificate2! serverCertificate, System.Action<Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions!>! configureOptions) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!
 static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.UseHttps(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions, string! fileName) -> Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!
 static Microsoft.AspNetCore.Server.Kestrel.Https.CertificateLoader.LoadFromStoreCert(string! subject, string! storeName, System.Security.Cryptography.X509Certificates.StoreLocation storeLocation, bool allowInvalid) -> System.Security.Cryptography.X509Certificates.X509Certificate2!
+Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.AddAltSvcHeader.get -> bool
+Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.AddAltSvcHeader.set -> void

--- a/src/Servers/Kestrel/Core/test/PooledStreamStackTests.cs
+++ b/src/Servers/Kestrel/Core/test/PooledStreamStackTests.cs
@@ -99,6 +99,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             (
                 connectionId: "TestConnectionId",
                 protocols: HttpProtocols.Http2,
+                altSvcHeader: null,
                 serviceContext: TestContextFactory.CreateServiceContext(serverOptions: new KestrelServerOptions()),
                 connectionFeatures: new FeatureCollection(),
                 memoryPool: MemoryPool<byte>.Shared,

--- a/src/Servers/Kestrel/Transport.Libuv/test/LibuvTransportTests.cs
+++ b/src/Servers/Kestrel/Transport.Libuv/test/LibuvTransportTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.Tests
                 return context.Response.WriteAsync("Hello World");
             });
 
-            listenOptions.UseHttpServer(serviceContext, testApplication, Core.HttpProtocols.Http1);
+            listenOptions.UseHttpServer(serviceContext, testApplication, Core.HttpProtocols.Http1, addAltSvcHeader: false);
 
             var transportContext = new TestLibuvTransportContext
             {

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
                         {
                             o.ConfigureEndpointDefaults(listenOptions =>
                             {
-                                listenOptions.AddAltSvcHeader = false;
+                                listenOptions.DisableAltSvcHeader = true;
                             });
                             o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
                             {

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -163,7 +163,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
                     webHostBuilder
                         .UseKestrel(o =>
                         {
-                            o.EnableAltSvc = true;
                             o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
                             {
                                 listenOptions.Protocols = Core.HttpProtocols.Http1AndHttp2AndHttp3;
@@ -196,8 +195,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
                 var responseText1 = await response1.Content.ReadAsStringAsync().DefaultTimeout();
                 Assert.Equal("hello, world", responseText1);
 
-                Assert.True(response1.Headers.TryGetValues("alt-svc", out var altSvcValues));
-                Assert.Single(altSvcValues, @$"h3="":{host.GetPort()}""; ma=84600");
+                Assert.True(response1.Headers.TryGetValues("alt-svc", out var altSvcValues1));
+                Assert.Single(altSvcValues1, @$"h3="":{host.GetPort()}""");
 
                 // Act
                 var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
@@ -207,6 +206,73 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
                 // Assert
                 response2.EnsureSuccessStatusCode();
                 Assert.Equal(HttpVersion.Version30, response2.Version);
+                var responseText2 = await response2.Content.ReadAsStringAsync().DefaultTimeout();
+                Assert.Equal("hello, world", responseText2);
+
+                Assert.True(response2.Headers.TryGetValues("alt-svc", out var altSvcValues2));
+                Assert.Single(altSvcValues2, @$"h3="":{host.GetPort()}""");
+            }
+
+            await host.StopAsync().DefaultTimeout();
+        }
+
+        [ConditionalFact]
+        [MsQuicSupported]
+        public async Task Listen_Http3AndSocketsCoexistOnSameEndpoint_AltSvcDisabled_NoUpgrade()
+        {
+            // Arrange
+            var builder = GetHostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseKestrel(o =>
+                        {
+                            o.ConfigureEndpointDefaults(listenOptions =>
+                            {
+                                listenOptions.AddAltSvcHeader = false;
+                            });
+                            o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
+                            {
+                                listenOptions.Protocols = Core.HttpProtocols.Http1AndHttp2AndHttp3;
+                                listenOptions.UseHttps();
+                            });
+                        })
+                        .Configure(app =>
+                        {
+                            app.Run(async context =>
+                            {
+                                await context.Response.WriteAsync("hello, world");
+                            });
+                        });
+                })
+                .ConfigureServices(AddTestLogging);
+
+            using var host = builder.Build();
+            await host.StartAsync().DefaultTimeout();
+
+            using (var client = CreateClient())
+            {
+                // Act
+                var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+                request1.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+                var response1 = await client.SendAsync(request1).DefaultTimeout();
+
+                // Assert
+                response1.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response1.Version);
+                var responseText1 = await response1.Content.ReadAsStringAsync().DefaultTimeout();
+                Assert.Equal("hello, world", responseText1);
+
+                Assert.False(response1.Headers.Contains("alt-svc"));
+
+                // Act
+                var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+                request2.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+                var response2 = await client.SendAsync(request2).DefaultTimeout();
+
+                // Assert
+                response2.EnsureSuccessStatusCode();
+                Assert.Equal(HttpVersion.Version20, response2.Version);
                 var responseText2 = await response2.Content.ReadAsStringAsync().DefaultTimeout();
                 Assert.Equal("hello, world", responseText2);
 

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -36,7 +36,6 @@ namespace Http3SampleApp
                     .ConfigureKestrel((context, options) =>
                     {
                         var basePort = 5557;
-                        options.EnableAltSvc = true;
 
                         options.Listen(IPAddress.Any, basePort, listenOptions =>
                         {

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -167,14 +167,16 @@ namespace CodeGenerator
                 HeaderNames.Connection,
                 HeaderNames.Server,
                 HeaderNames.Date,
-                HeaderNames.TransferEncoding
+                HeaderNames.TransferEncoding,
+                HeaderNames.AltSvc
             };
             var enhancedHeaders = new[]
             {
                 HeaderNames.Connection,
                 HeaderNames.Server,
                 HeaderNames.Date,
-                HeaderNames.TransferEncoding
+                HeaderNames.TransferEncoding,
+                HeaderNames.AltSvc
             };
             // http://www.w3.org/TR/cors/#syntax
             var corsResponseHeaders = new[]

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
@@ -219,6 +220,8 @@ namespace Microsoft.AspNetCore.Testing
 
             var httpConnectionContext = new HttpMultiplexedConnectionContext(
                 connectionId: "TestConnectionId",
+                HttpProtocols.Http3,
+                altSvcHeader: null,
                 connectionContext: MultiplexedConnectionContext,
                 connectionFeatures: MultiplexedConnectionContext.Features,
                 serviceContext: _serviceContext,

--- a/src/Servers/Kestrel/shared/test/StreamBackedTestConnection.cs
+++ b/src/Servers/Kestrel/shared/test/StreamBackedTestConnection.cs
@@ -122,7 +122,8 @@ namespace Microsoft.AspNetCore.Testing
                     ex);
             }
 
-            Assert.Equal(expected, new string(actual, 0, offset));
+            var actualText = new string(actual, 0, offset);
+            Assert.Equal(expected, actualText);
         }
 
         public async Task ReceiveEnd(params string[] lines)

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -61,6 +61,7 @@ namespace Microsoft.AspNetCore.Testing
             var context = new HttpConnectionContext(
                 "TestConnectionId",
                 HttpProtocols.Http1,
+                altSvcHeader: null,
                 connectionContext,
                 serviceContext,
                 connectionFeatures,
@@ -84,6 +85,8 @@ namespace Microsoft.AspNetCore.Testing
         {
             var http3ConnectionContext = new HttpMultiplexedConnectionContext(
                 "TestConnectionId",
+                HttpProtocols.Http3,
+                altSvcHeader: null,
                 connectionContext ?? new TestMultiplexedConnectionContext(),
                 serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
                 connectionFeatures ?? new FeatureCollection(),
@@ -145,6 +148,7 @@ namespace Microsoft.AspNetCore.Testing
             (
                 connectionId: connectionId ?? "TestConnectionId",
                 protocols: HttpProtocols.Http2,
+                altSvcHeader: null,
                 serviceContext: serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
                 connectionFeatures: connectionFeatures ?? new FeatureCollection(),
                 memoryPool: memoryPool ?? MemoryPool<byte>.Shared,
@@ -179,6 +183,7 @@ namespace Microsoft.AspNetCore.Testing
             (
                 connectionId: connectionId ?? "TestConnectionId",
                 protocols: HttpProtocols.Http3,
+                altSvcHeader: null,
                 connectionContext: connectionContext,
                 serviceContext: serviceContext ?? CreateServiceContext(new KestrelServerOptions()),
                 connectionFeatures: connectionFeatures ?? new FeatureCollection(),

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -4058,7 +4058,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 Assert.Equal(2, httpContext.Response.Body.Length);
 
                 httpContext.Response.Body = oldBody;
-
             }, new TestServiceContext(LoggerFactory)))
             {
                 using (var connection = server.CreateConnection())
@@ -4078,19 +4077,22 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             }
         }
 
-        [Theory]
-        [InlineData(HttpProtocols.Http1AndHttp2AndHttp3)]
-        [InlineData(HttpProtocols.Http3)]
-        public async Task EnableAltSvc_Http3EndpointConfigured_AltSvcInResponseHeaders(HttpProtocols protocols)
+        [Fact]
+        public async Task EnableAltSvc_HeaderSetInAppCode_AltSvcNotOverwritten()
         {
             await using (var server = new TestServer(
-                context => Task.CompletedTask,
-                new TestServiceContext(),
+                httpContext =>
+                {
+                    httpContext.Response.Headers.AltSvc = "Custom";
+                    return Task.CompletedTask;
+                },
+                new TestServiceContext(LoggerFactory),
                 options =>
                 {
-                    options.EnableAltSvc = true;
-                    options.CodeBackedListenOptions.Add(new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)));
-                    options.CodeBackedListenOptions.Add(new ListenOptions(new IPEndPoint(IPAddress.Loopback, 1)) { Protocols = protocols });
+                    options.CodeBackedListenOptions.Add(new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
+                    {
+                        Protocols = HttpProtocols.Http1AndHttp2AndHttp3
+                    });
                 },
                 services => { }))
             {
@@ -4101,12 +4103,138 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         "Host:",
                         "",
                         "");
-
                     await connection.Receive(
-                        $"HTTP/1.1 200 OK",
+                        "HTTP/1.1 200 OK",
                         "Content-Length: 0",
                         $"Date: {server.Context.DateHeaderValue}",
-                        @"Alt-Svc: h3="":1""; ma=84600",
+                        @"Alt-Svc: Custom",
+                        "",
+                        "");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task EnableAltSvc_Enabled_Http1And2And3EndpointConfigured_AltSvcInResponseHeaders()
+        {
+            await using (var server = new TestServer(
+                httpContext => Task.CompletedTask,
+                new TestServiceContext(LoggerFactory),
+                options =>
+                {
+                    options.CodeBackedListenOptions.Add(new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
+                    {
+                        Protocols = HttpProtocols.Http1AndHttp2AndHttp3
+                    });
+                },
+                services => { }))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "Host:",
+                        "",
+                        "");
+                    await connection.Receive(
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: 0",
+                        $"Date: {server.Context.DateHeaderValue}",
+                        @"Alt-Svc: h3="":0""; ma=86400",
+                        "",
+                        "");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task EnableAltSvc_Enabled_Http1_NoAltSvcInResponseHeaders()
+        {
+            await using (var server = new TestServer(
+                httpContext => Task.CompletedTask,
+                new TestServiceContext(LoggerFactory),
+                new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0)) { Protocols = HttpProtocols.Http1 }))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "Host:",
+                        "",
+                        "");
+                    await connection.Receive(
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: 0",
+                        $"Date: {server.Context.DateHeaderValue}",
+                        "",
+                        "");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task EnableAltSvc_Enabled_Http3ConfiguredDifferentEndpoint_NoAltSvcInResponseHeaders()
+        {
+            await using (var server = new TestServer(
+                httpContext => Task.CompletedTask,
+                new TestServiceContext(LoggerFactory),
+                options =>
+                {
+                    options.CodeBackedListenOptions.Add(new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
+                    {
+                        Protocols = HttpProtocols.Http1
+                    });
+                    options.CodeBackedListenOptions.Add(new ListenOptions(new IPEndPoint(IPAddress.Loopback, 1))
+                    {
+                        Protocols = HttpProtocols.Http3
+                    });
+                },
+                services => { }))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "Host:",
+                        "",
+                        "");
+                    await connection.Receive(
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: 0",
+                        $"Date: {server.Context.DateHeaderValue}",
+                        "",
+                        "");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task EnableAltSvc_Disabled_Http1And2And3EndpointConfigured_NoAltSvcInResponseHeaders()
+        {
+            await using (var server = new TestServer(
+                httpContext => Task.CompletedTask,
+                new TestServiceContext(LoggerFactory),
+                options =>
+                {
+                    options.CodeBackedListenOptions.Add(new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
+                    {
+                        Protocols = HttpProtocols.Http1AndHttp2AndHttp3,
+                        AddAltSvcHeader = false
+                    });
+                },
+                services => { }))
+            {
+                using (var connection = server.CreateConnection())
+                {
+                    await connection.Send(
+                        "GET / HTTP/1.1",
+                        "Host:",
+                        "",
+                        "");
+                    await connection.Receive(
+                        "HTTP/1.1 200 OK",
+                        "Content-Length: 0",
+                        $"Date: {server.Context.DateHeaderValue}",
                         "",
                         "");
                 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -4078,7 +4078,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task EnableAltSvc_HeaderSetInAppCode_AltSvcNotOverwritten()
+        public async Task AltSvc_HeaderSetInAppCode_AltSvcNotOverwritten()
         {
             await using (var server = new TestServer(
                 httpContext =>
@@ -4115,7 +4115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task EnableAltSvc_Enabled_Http1And2And3EndpointConfigured_AltSvcInResponseHeaders()
+        public async Task AltSvc_Http1And2And3EndpointConfigured_AltSvcInResponseHeaders()
         {
             await using (var server = new TestServer(
                 httpContext => Task.CompletedTask,
@@ -4148,7 +4148,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task EnableAltSvc_Enabled_Http1_NoAltSvcInResponseHeaders()
+        public async Task AltSvc_Http1_NoAltSvcInResponseHeaders()
         {
             await using (var server = new TestServer(
                 httpContext => Task.CompletedTask,
@@ -4173,7 +4173,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task EnableAltSvc_Enabled_Http3ConfiguredDifferentEndpoint_NoAltSvcInResponseHeaders()
+        public async Task AltSvc_Http3ConfiguredDifferentEndpoint_NoAltSvcInResponseHeaders()
         {
             await using (var server = new TestServer(
                 httpContext => Task.CompletedTask,
@@ -4209,7 +4209,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task EnableAltSvc_Disabled_Http1And2And3EndpointConfigured_NoAltSvcInResponseHeaders()
+        public async Task AltSvc_DisableAltSvcHeaderIsTrue_Http1And2And3EndpointConfigured_NoAltSvcInResponseHeaders()
         {
             await using (var server = new TestServer(
                 httpContext => Task.CompletedTask,
@@ -4219,7 +4219,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                     options.CodeBackedListenOptions.Add(new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0))
                     {
                         Protocols = HttpProtocols.Http1AndHttp2AndHttp3,
-                        AddAltSvcHeader = false
+                        DisableAltSvcHeader = true
                     });
                 },
                 services => { }))


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/34472
Fixes https://github.com/dotnet/aspnetcore/issues/34468
Fixes https://github.com/dotnet/aspnetcore/issues/34467

API changes:

* Obsolete `public bool KestrelServerOptions.EnableAltSvc { get; set; }` - Removing because we want to give people control over this behavior per-endpoint. Also the name is ambiguous as AltSvc can mean alt-svc header or ALTSVC HTTP/2 frame.
* Add `public bool ListenOptions.AddAltSvcHeader { get; set; }`