### PR TITLE
Fix IJSStreamReference API Param

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSStreamReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSStreamReference.cs
@@ -36,11 +36,11 @@ namespace Microsoft.JSInterop.Implementation
         }
 
         /// <inheritdoc />
-        async ValueTask<Stream> IJSStreamReference.OpenReadStreamAsync(long maxLength, CancellationToken cancellationToken)
+        async ValueTask<Stream> IJSStreamReference.OpenReadStreamAsync(long maxAllowedSize, CancellationToken cancellationToken)
         {
-            if (Length > maxLength)
+            if (Length > maxAllowedSize)
             {
-                throw new ArgumentOutOfRangeException(nameof(maxLength), $"The incoming data stream of length {Length} exceeds the maximum length {maxLength}.");
+                throw new ArgumentOutOfRangeException(nameof(maxAllowedSize), $"The incoming data stream of length {Length} exceeds the maximum allowed length {maxAllowedSize}.");
             }
 
             return await _jsRuntime.ReadJSDataAsStreamAsync(this, Length, cancellationToken);


### PR DESCRIPTION
`maxLength` -> `maxAllowedSize` to match:

https://github.com/dotnet/aspnetcore/blob/fe9b9ce6ea5d03592c79ffc545f55fd9f30a178c/src/JSInterop/Microsoft.JSInterop/src/IJSStreamReference.cs#L21-L27

Found during: https://github.com/dotnet/core/pull/6512/files#diff-e5752f6c6c907446aaba4544ccbb6984957fb342ab71fad9b982ea404e0d9e73R7

Thanks @pranavkm for pointing it out!

