### PR TITLE
Throw from extension methods not supported by WebApplicationBuilder

### DIFF
--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Builder
     /// A non-buildable <see cref="IHostBuilder"/> for <see cref="WebApplicationBuilder"/>.
     /// Use <see cref="WebApplicationBuilder.Build"/> to build the <see cref="WebApplicationBuilder"/>.
     /// </summary>
-    public sealed class ConfigureHostBuilder : IHostBuilder
+    public sealed class ConfigureHostBuilder : IHostBuilder, ISupportsConfigureWebHost
     {
         private readonly ConfigurationManager _configuration;
         private readonly IServiceCollection _services;
@@ -123,6 +123,11 @@ namespace Microsoft.AspNetCore.Builder
             {
                 operation(hostBuilder);
             }
+        }
+
+        IHostBuilder ISupportsConfigureWebHost.ConfigureWebHost(Action<IWebHostBuilder> configure, Action<WebHostBuilderOptions> configureOptions)
+        {
+            throw new NotSupportedException($"ConfigureWebHost() is not supported by WebApplicationBuilder.Host. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
         }
     }
 }

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Builder
     /// A non-buildable <see cref="IWebHostBuilder"/> for <see cref="WebApplicationBuilder"/>.
     /// Use <see cref="WebApplicationBuilder.Build"/> to build the <see cref="WebApplicationBuilder"/>.
     /// </summary>
-    public sealed class ConfigureWebHostBuilder : IWebHostBuilder
+    public sealed class ConfigureWebHostBuilder : IWebHostBuilder, ISupportsStartup
     {
         private readonly IWebHostEnvironment _environment;
         private readonly ConfigurationManager _configuration;
@@ -146,6 +147,21 @@ namespace Microsoft.AspNetCore.Builder
             _configuration[key] = value;
 
             return this;
+        }
+
+        IWebHostBuilder ISupportsStartup.Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure)
+        {
+            throw new NotSupportedException($"Configure() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
+        }
+
+        IWebHostBuilder ISupportsStartup.UseStartup(Type startupType)
+        {
+            throw new NotSupportedException($"UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
+        }
+
+        IWebHostBuilder ISupportsStartup.UseStartup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TStartup>(Func<WebHostBuilderContext, TStartup> startupFactory)
+        {
+            throw new NotSupportedException($"UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
         }
     }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -754,6 +754,16 @@ namespace Microsoft.AspNetCore.Tests
             Assert.Throws<InvalidOperationException>(() => builder.Services[0] = ServiceDescriptor.Singleton(new Service()));
         }
 
+        [Fact]
+        public void WebApplicationBuilder_UseStartupAndConfigureAreNotSupportedByWebHost()
+        {
+            var builder = WebApplication.CreateBuilder();
+
+            Assert.Throws<NotSupportedException>(() => builder.WebHost.Configure(app => { }));
+            Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup<MyStartup>());
+            Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup(typeof(MyStartup)));
+        }
+
         private class Service : IService { }
         private interface IService { }
 
@@ -761,6 +771,19 @@ namespace Microsoft.AspNetCore.Tests
         {
             public Service2(Service service)
             {
+            }
+        }
+
+        private class MyStartup : IStartup
+        {
+            public void Configure(IApplicationBuilder app)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IServiceProvider ConfigureServices(IServiceCollection services)
+            {
+                throw new NotImplementedException();
             }
         }
 

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -755,13 +755,17 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
-        public void WebApplicationBuilder_UseStartupAndConfigureAreNotSupportedByWebHost()
+        public void WebApplicationBuilder_ThrowsFromExtensionMethodsNotSupportedByHostAndWebHost()
         {
             var builder = WebApplication.CreateBuilder();
 
             Assert.Throws<NotSupportedException>(() => builder.WebHost.Configure(app => { }));
             Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup<MyStartup>());
             Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup(typeof(MyStartup)));
+
+            Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHost(webHostBuilder => { }));
+            Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHost(webHostBuilder => { }, options => { }));
+            Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHostDefaults(webHostBuilder => { }));
         }
 
         private class Service : IService { }

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Builder;
+using Microsoft.AspNetCore.Hosting.Infrastructure;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;

--- a/src/Hosting/Hosting/src/GenericHost/HostingStartupWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/HostingStartupWebHostBuilder.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Infrastructure;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Hosting/Hosting/src/GenericHost/ISupportsConfigureWebHost.cs
+++ b/src/Hosting/Hosting/src/GenericHost/ISupportsConfigureWebHost.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    /// <summary>
+    /// An interface implemented by IWebHostBuilders that handle <see cref="GenericHostWebHostBuilderExtensions.ConfigureWebHost(IHostBuilder, Action{IWebHostBuilder})"/>
+    /// directly.
+    /// </summary>
+    public interface ISupportsConfigureWebHost
+    {
+        /// <summary>
+        /// Adds and configures an ASP.NET Core web application.
+        /// </summary>
+        /// <param name="configure">The delegate that configures the <see cref="IWebHostBuilder"/>.</param>
+        /// <param name="configureOptions">The delegate that configures the <see cref="WebHostBuilderOptions"/>.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
+        IHostBuilder ConfigureWebHost(Action<IWebHostBuilder> configure, Action<WebHostBuilderOptions> configureOptions);
+    }
+}

--- a/src/Hosting/Hosting/src/GenericHost/ISupportsStartup.cs
+++ b/src/Hosting/Hosting/src/GenericHost/ISupportsStartup.cs
@@ -8,10 +8,33 @@ using Microsoft.AspNetCore.Hosting.Internal;
 
 namespace Microsoft.AspNetCore.Hosting
 {
-    internal interface ISupportsStartup
+    /// <summary>
+    /// An interface implemented by IWebHostBuilders that handle <see cref="WebHostBuilderExtensions.Configure(IWebHostBuilder, Action{IApplicationBuilder})"/>
+    /// <see cref="WebHostBuilderExtensions.UseStartup(IWebHostBuilder, Type)"/> and <see cref="WebHostBuilderExtensions.UseStartup{TStartup}(IWebHostBuilder, Func{WebHostBuilderContext, TStartup})"/>
+    /// directly.
+    /// </summary>
+    public interface ISupportsStartup
     {
+        /// <summary>
+        /// Specify the startup method to be used to configure the web application.
+        /// </summary>
+        /// <param name="configure">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure);
+
+        /// <summary>
+        /// Specify the startup type to be used by the web host.
+        /// </summary>
+        /// <param name="startupType">The <see cref="Type"/> to be used.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         IWebHostBuilder UseStartup([DynamicallyAccessedMembers(StartupLinkerOptions.Accessibility)] Type startupType);
+
+        /// <summary>
+        /// Specify a factory that creates the startup instance to be used by the web host.
+        /// </summary>
+        /// <param name="startupFactory">A delegate that specifies a factory for the startup class.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        /// <remarks>When using the IL linker, all public methods of <typeparamref name="TStartup"/> are preserved. This should match the Startup type directly (and not a base type).</remarks>
         IWebHostBuilder UseStartup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]TStartup>(Func<WebHostBuilderContext, TStartup> startupFactory);
     }
 }

--- a/src/Hosting/Hosting/src/GenericHost/ISupportsStartup.cs
+++ b/src/Hosting/Hosting/src/GenericHost/ISupportsStartup.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Hosting.Internal;
 namespace Microsoft.AspNetCore.Hosting
 {
     /// <summary>
-    /// An interface implemented by IWebHostBuilders that handle <see cref="WebHostBuilderExtensions.Configure(IWebHostBuilder, Action{IApplicationBuilder})"/>
+    /// An interface implemented by IWebHostBuilders that handle <see cref="WebHostBuilderExtensions.Configure(IWebHostBuilder, Action{IApplicationBuilder})"/>,
     /// <see cref="WebHostBuilderExtensions.UseStartup(IWebHostBuilder, Type)"/> and <see cref="WebHostBuilderExtensions.UseStartup{TStartup}(IWebHostBuilder, Func{WebHostBuilderContext, TStartup})"/>
     /// directly.
     /// </summary>

--- a/src/Hosting/Hosting/src/GenericHostWebHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/GenericHostWebHostBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting

--- a/src/Hosting/Hosting/src/GenericHostWebHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/GenericHostWebHostBuilderExtensions.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// Adds and configures an ASP.NET Core web application.
         /// </summary>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to add the <see cref="IWebHostBuilder"/> to.</param>
+        /// <param name="configure">The delegate that configures the <see cref="IWebHostBuilder"/>.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder ConfigureWebHost(this IHostBuilder builder, Action<IWebHostBuilder> configure)
         {
             if (configure is null)
@@ -28,6 +31,10 @@ namespace Microsoft.Extensions.Hosting
         /// <summary>
         /// Adds and configures an ASP.NET Core web application.
         /// </summary>
+        /// <param name="builder">The <see cref="IHostBuilder"/> to add the <see cref="IWebHostBuilder"/> to.</param>
+        /// <param name="configure">The delegate that configures the <see cref="IWebHostBuilder"/>.</param>
+        /// <param name="configureWebHostBuilder">The delegate that configures the <see cref="WebHostBuilderOptions"/>.</param>
+        /// <returns>The <see cref="IHostBuilder"/>.</returns>
         public static IHostBuilder ConfigureWebHost(this IHostBuilder builder, Action<IWebHostBuilder> configure, Action<WebHostBuilderOptions> configureWebHostBuilder)
         {
             if (configure is null)
@@ -38,6 +45,12 @@ namespace Microsoft.Extensions.Hosting
             if (configureWebHostBuilder is null)
             {
                 throw new ArgumentNullException(nameof(configureWebHostBuilder));
+            }
+
+            // Light up custom implementations namely ConfigureHostBuilder which throws.
+            if (builder is ISupportsConfigureWebHost supportsConfigureWebHost)
+            {
+                return supportsConfigureWebHost.ConfigureWebHost(configure, configureWebHostBuilder);
             }
 
             var webHostBuilderOptions = new WebHostBuilderOptions();

--- a/src/Hosting/Hosting/src/Infrastructure/ISupportsConfigureWebHost.cs
+++ b/src/Hosting/Hosting/src/Infrastructure/ISupportsConfigureWebHost.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.Hosting;
 
-namespace Microsoft.AspNetCore.Hosting
+namespace Microsoft.AspNetCore.Hosting.Infrastructure
 {
     /// <summary>
     /// An interface implemented by IWebHostBuilders that handle <see cref="GenericHostWebHostBuilderExtensions.ConfigureWebHost(IHostBuilder, Action{IWebHostBuilder})"/>

--- a/src/Hosting/Hosting/src/Infrastructure/ISupportsStartup.cs
+++ b/src/Hosting/Hosting/src/Infrastructure/ISupportsStartup.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Internal;
 
-namespace Microsoft.AspNetCore.Hosting
+namespace Microsoft.AspNetCore.Hosting.Infrastructure
 {
     /// <summary>
     /// An interface implemented by IWebHostBuilders that handle <see cref="WebHostBuilderExtensions.Configure(IWebHostBuilder, Action{IApplicationBuilder})"/>,

--- a/src/Hosting/Hosting/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/Hosting/src/PublicAPI.Unshipped.txt
@@ -8,6 +8,8 @@
 *REMOVED*~virtual Microsoft.AspNetCore.Hosting.StartupBase.ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> void
 *REMOVED*~virtual Microsoft.AspNetCore.Hosting.StartupBase.CreateServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> System.IServiceProvider
 Microsoft.AspNetCore.Hosting.Builder.IApplicationBuilderFactory.CreateBuilder(Microsoft.AspNetCore.Http.Features.IFeatureCollection! serverFeatures) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+Microsoft.AspNetCore.Hosting.ISupportsConfigureWebHost
+Microsoft.AspNetCore.Hosting.ISupportsConfigureWebHost.ConfigureWebHost(System.Action<Microsoft.AspNetCore.Hosting.IWebHostBuilder!>! configure, System.Action<Microsoft.Extensions.Hosting.WebHostBuilderOptions!>! configureOptions) -> Microsoft.Extensions.Hosting.IHostBuilder!
 Microsoft.AspNetCore.Hosting.ISupportsStartup
 Microsoft.AspNetCore.Hosting.ISupportsStartup.Configure(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, Microsoft.AspNetCore.Builder.IApplicationBuilder!>! configure) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 Microsoft.AspNetCore.Hosting.ISupportsStartup.UseStartup(System.Type! startupType) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!

--- a/src/Hosting/Hosting/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/Hosting/src/PublicAPI.Unshipped.txt
@@ -8,12 +8,12 @@
 *REMOVED*~virtual Microsoft.AspNetCore.Hosting.StartupBase.ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> void
 *REMOVED*~virtual Microsoft.AspNetCore.Hosting.StartupBase.CreateServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> System.IServiceProvider
 Microsoft.AspNetCore.Hosting.Builder.IApplicationBuilderFactory.CreateBuilder(Microsoft.AspNetCore.Http.Features.IFeatureCollection! serverFeatures) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
-Microsoft.AspNetCore.Hosting.ISupportsConfigureWebHost
-Microsoft.AspNetCore.Hosting.ISupportsConfigureWebHost.ConfigureWebHost(System.Action<Microsoft.AspNetCore.Hosting.IWebHostBuilder!>! configure, System.Action<Microsoft.Extensions.Hosting.WebHostBuilderOptions!>! configureOptions) -> Microsoft.Extensions.Hosting.IHostBuilder!
-Microsoft.AspNetCore.Hosting.ISupportsStartup
-Microsoft.AspNetCore.Hosting.ISupportsStartup.Configure(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, Microsoft.AspNetCore.Builder.IApplicationBuilder!>! configure) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
-Microsoft.AspNetCore.Hosting.ISupportsStartup.UseStartup(System.Type! startupType) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
-Microsoft.AspNetCore.Hosting.ISupportsStartup.UseStartup<TStartup>(System.Func<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, TStartup>! startupFactory) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
+Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsConfigureWebHost
+Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsConfigureWebHost.ConfigureWebHost(System.Action<Microsoft.AspNetCore.Hosting.IWebHostBuilder!>! configure, System.Action<Microsoft.Extensions.Hosting.WebHostBuilderOptions!>! configureOptions) -> Microsoft.Extensions.Hosting.IHostBuilder!
+Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup
+Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup.Configure(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, Microsoft.AspNetCore.Builder.IApplicationBuilder!>! configure) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
+Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup.UseStartup(System.Type! startupType) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
+Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup.UseStartup<TStartup>(System.Func<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, TStartup>! startupFactory) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 Microsoft.AspNetCore.Hosting.StartupBase<TBuilder>.StartupBase(Microsoft.Extensions.DependencyInjection.IServiceProviderFactory<TBuilder>! factory) -> void
 abstract Microsoft.AspNetCore.Hosting.StartupBase.Configure(Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> void
 override Microsoft.AspNetCore.Hosting.StartupBase<TBuilder>.CreateServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> System.IServiceProvider!

--- a/src/Hosting/Hosting/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/Hosting/src/PublicAPI.Unshipped.txt
@@ -8,6 +8,10 @@
 *REMOVED*~virtual Microsoft.AspNetCore.Hosting.StartupBase.ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> void
 *REMOVED*~virtual Microsoft.AspNetCore.Hosting.StartupBase.CreateServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> System.IServiceProvider
 Microsoft.AspNetCore.Hosting.Builder.IApplicationBuilderFactory.CreateBuilder(Microsoft.AspNetCore.Http.Features.IFeatureCollection! serverFeatures) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+Microsoft.AspNetCore.Hosting.ISupportsStartup
+Microsoft.AspNetCore.Hosting.ISupportsStartup.Configure(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, Microsoft.AspNetCore.Builder.IApplicationBuilder!>! configure) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
+Microsoft.AspNetCore.Hosting.ISupportsStartup.UseStartup(System.Type! startupType) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
+Microsoft.AspNetCore.Hosting.ISupportsStartup.UseStartup<TStartup>(System.Func<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, TStartup>! startupFactory) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 Microsoft.AspNetCore.Hosting.StartupBase<TBuilder>.StartupBase(Microsoft.Extensions.DependencyInjection.IServiceProviderFactory<TBuilder>! factory) -> void
 abstract Microsoft.AspNetCore.Hosting.StartupBase.Configure(Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> void
 override Microsoft.AspNetCore.Hosting.StartupBase<TBuilder>.CreateServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> System.IServiceProvider!

--- a/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Infrastructure;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Hosting.StaticWebAssets;
 using Microsoft.Extensions.Configuration;

--- a/src/Hosting/Hosting/test/Fakes/GenericWebHostBuilderWrapper.cs
+++ b/src/Hosting/Hosting/test/Fakes/GenericWebHostBuilderWrapper.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;


### PR DESCRIPTION
WebApplicationBuilder.WebHost.UseStartup/Configure no-op today. This makes it clear that they don't work.

This now also causes WebApplicationBuilder.Host.ConfigureWebHost/ConfigureWebHostDefaults to throw for similar reasons. 

Fixes #34824
