### PR TITLE
Check for Node if fetch is defined.  

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
@@ -36,7 +36,13 @@ export class FetchHttpClient extends HttpClient {
             // Node needs EventListener methods on AbortController which our custom polyfill doesn't provide
             this._abortControllerType = requireFunc("abort-controller");
         } else {
-            this._fetchType = fetch.bind(self);
+            if(Platform.isNode) {
+                this._fetchType = fetch.bind(global);
+            }
+            else{
+                this._fetchType = fetch.bind(self);
+            }
+
             this._abortControllerType = AbortController;
         }
     }


### PR DESCRIPTION




**PR Title**
Check for Node if fetch is defined and use the proper global if so.

**PR Description**
The current version appears to assume if fetch is globally defined that we are a browser however some polyfills for fetch define fetch globally in Node which means the bind target should then be global rather than self.

