### PR TITLE
Use globalThis instead of self in FetchHttpClient

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
@@ -36,7 +36,7 @@ export class FetchHttpClient extends HttpClient {
             // Node needs EventListener methods on AbortController which our custom polyfill doesn't provide
             this._abortControllerType = requireFunc("abort-controller");
         } else {
-            this._fetchType = fetch.bind(self);
+            this._fetchType = fetch.bind(globalThis);
             this._abortControllerType = AbortController;
         }
     }


### PR DESCRIPTION
In the TS SignalR client, `FetchHttpClient` binds the global `fetch` instance to a global `self`. However, when running in Node, with a global fetch already defined, it complains that `self` is not defined, so it seems that this piece of code was only considered for use in a browser context.

This instead binds explicitly to `globalThis`, mapping to Node's `global`, and to the browser's `window`/`self`.