### PR TITLE
Fix nullability in `User` property

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/ShowProfile.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/ShowProfile.razor
@@ -28,7 +28,7 @@ else
 }
 
 @code {
-    User user;
+    User? user;
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
Template tests are failing in CI because this property should be set as nullable when it isn't.

```
[xUnit.net 00:01:11.25]         | [28.154s] Templates.Test.BlazorServerTemplateTest Information: /private/tmp/helix/working/AA290943/p/dotnet-cli/sdk/6.0.100-rc.1.21376.4/MSBuild.dll -maxcpucount -property:Configuration=Release -restore -target:Publish -verbosity:m /bl ./AspNet.i11muovbsaj.csproj
[xUnit.net 00:01:11.25]         | [28.682s] Templates.Test.BlazorServerTemplateTest Information:   Determining projects to restore...
[xUnit.net 00:01:11.25]         | [29.289s] Templates.Test.BlazorServerTemplateTest Information:   Restored /private/tmp/helix/working/AA290943/w/B3AA0A2B/e/Templates/BaseFolder/AspNet.i11muovbsaj/AspNet.i11muovbsaj.csproj (in 357 ms).
[xUnit.net 00:01:11.25]         | [29.415s] Templates.Test.BlazorServerTemplateTest Information:   You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
[xUnit.net 00:01:11.25]         | [30.392s] Templates.Test.BlazorServerTemplateTest Information: /private/tmp/helix/working/AA290943/w/B3AA0A2B/e/Templates/BaseFolder/AspNet.i11muovbsaj/Pages/ShowProfile.razor(31,10): error CS8618: Non-nullable field 'user' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/private/tmp/helix/working/AA290943/w/B3AA0A2B/e/Templates/BaseFolder/AspNet.i11muovbsaj/AspNet.i11muovbsaj.csproj]
[xUnit.net 00:01:11.25]         | [30.426s] Templates.Test.BlazorServerTemplateTest Information: Process exited.
[xUnit.net 00:01:11.25]         | [30.427s] Templates.Test.BlazorServerTemplateTest Error: Test threw an exception.
[xUnit.net 00:01:11.25]         | Xunit.Sdk.TrueException: Project new blazorserver  --auth SingleOrg --calls-graph failed to publish. Exit code 1.
[xUnit.net 00:01:11.25]         | /private/tmp/helix/working/AA290943/p/dotnet-cli/dotnet publish  -c Release /bl \nStdErr: \nStdOut: Microsoft (R) Build Engine version 17.0.0-preview-21371-01+9e576281e for .NET
[xUnit.net 00:01:11.25]         | Copyright (C) Microsoft Corporation. All rights reserved.
[xUnit.net 00:01:11.25]         | /private/tmp/helix/working/AA290943/p/dotnet-cli/sdk/6.0.100-rc.1.21376.4/MSBuild.dll -maxcpucount -property:Configuration=Release -restore -target:Publish -verbosity:m /bl ./AspNet.i11muovbsaj.csproj
[xUnit.net 00:01:11.25]         |   Determining projects to restore...
[xUnit.net 00:01:11.25]         |   Restored /private/tmp/helix/working/AA290943/w/B3AA0A2B/e/Templates/BaseFolder/AspNet.i11muovbsaj/AspNet.i11muovbsaj.csproj (in 357 ms).
[xUnit.net 00:01:11.25]         |   You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
[xUnit.net 00:01:11.25]         | /private/tmp/helix/working/AA290943/w/B3AA0A2B/e/Templates/BaseFolder/AspNet.i11muovbsaj/Pages/ShowProfile.razor(31,10): error CS8618: Non-nullable field 'user' must contain a non-null value when exiting constructor. Consider declaring the field as nullable. [/private/tmp/helix/working/AA290943/w/B3AA0A2B/e/Templates/BaseFolder/AspNet.i11muovbsaj/AspNet.i11muovbsaj.csproj]
[xUnit.net 00:01:11.25]         | Expected: True
[xUnit.net 00:01:11.25]         | Actual:   False
[xUnit.net 00:01:11.25]         |    at Xunit.Assert.True(Nullable`1 condition, String userMessage) in C:\Dev\xunit\xunit\src\xunit.assert\Asserts\BooleanAsserts.cs:line 95
[xUnit.net 00:01:11.25]         |    at Templates.Test.BlazorTemplateTest.CreateBuildPublishAsync(String projectName, String auth, String[] args, String targetFramework, Boolean serverProject, Boolean onlyCreate) in /_/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplateTest.cs:line 114
```