### PR TITLE
Deflake new SignalR test

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Reconnect.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.Reconnect.cs
@@ -347,6 +347,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     var firstException = new Exception();
                     (await testConnectionFactory.GetNextOrCurrentTestConnection()).CompleteFromTransport(firstException);
 
+                    Assert.Same(firstException, await reconnectingErrorTcs.Task.DefaultTimeout());
+
                     var reconnectException = new Exception();
                     failReconnectTcs.SetException(reconnectException);
 
@@ -365,6 +367,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                     Assert.NotNull(waitingLog);
                     Assert.Contains($"Reconnect attempt number 1 will start in ", waitingLog.Write.Message);
                     Assert.Equal(LogLevel.Trace, waitingLog.Write.LogLevel);
+
+                    Assert.Equal(0, reconnectedCount);
                 }
             }
 


### PR DESCRIPTION
Reconnecting event is dispatched so we don't block on user callbacks. Just needed to make sure the event ran before asserting everything.