### PR TITLE
HTTP/3: Update ALPN to h3

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
     internal static class QuicTestHelpers
     {
-        public const string Alpn = "h3-29";
+        public const string Alpn = "h3";
         private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");
 
         public static QuicTransportFactory CreateTransportFactory(ILoggerFactory loggerFactory = null, ISystemClock systemClock = null)

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -30,7 +30,7 @@ namespace Http3SampleApp
                     webHost.UseKestrel()
                     .UseQuic(options =>
                     {
-                        options.Alpn = "h3-29"; // Shouldn't need to populate this as well.
+                        options.Alpn = "h3"; // Shouldn't need to populate this as well.
                         options.IdleTimeout = TimeSpan.FromHours(1);
                     })
                     .ConfigureKestrel((context, options) =>

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -729,7 +729,7 @@ namespace Interop.FunctionalTests.Http3
                         .UseQuic(options =>
                         {
                             options.MaxReadBufferSize = maxReadBufferSize;
-                            options.Alpn = "h3-29";
+                            options.Alpn = "h3";
                             options.IdleTimeout = TimeSpan.FromSeconds(20);
                         });
                 });


### PR DESCRIPTION
HttpClient has updated ALPN to h3. React so tests pass.

Temporary change until https://github.com/dotnet/aspnetcore/pull/34877 is merged.