### PR TITLE
[release/3.1] Backport #22406

### DIFF
--- a/eng/targets/CSharp.Common.props
+++ b/eng/targets/CSharp.Common.props
@@ -25,6 +25,7 @@
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
     <Reference Include="Microsoft.AspNetCore.Testing" />
     <Reference Include="Moq" />
+    <Compile Include="$(SharedSourceRoot)test\SuccessfulTests.cs" LinkBase="SharedTests" />
   </ItemGroup>
 
   <ItemDefinitionGroup Condition=" '$(IsTestProject)' == 'true' ">

--- a/src/Shared/test/SuccessfulTests.cs
+++ b/src/Shared/test/SuccessfulTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace AlwaysTestTests
+{
+    /// <summary>
+    /// Tests for every test assembly to ensure quarantined and unquarantined runs report at least one test execution.
+    /// </summary>
+    public class SuccessfulTests
+    {
+        /// <summary>
+        /// Test that executes in quarantined runs and always succeeds.
+        /// </summary>
+        [Fact]
+        [QuarantinedTest]
+        public void GuaranteedQuarantinedTest()
+        {
+        }
+
+        /// <summary>
+        /// Test that executes in unquarantined runs and always succeeds.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="TraitAttribute"/> applied to ensure test runs even if assembly is quarantined overall.
+        /// <c>dotnet test --filter</c>, <c>dotnet vstest --testcasefilter</c>, and
+        /// <c>vstest.console.exe --testcasefilter</c> handle the "no Quarantined=true trait OR Quarantined=false" case
+        /// e.g. <c>"Quarantined!=true|Quarantined=false</c>. But, <c>xunit.console.exe</c> doesn't have a syntax to
+        /// make it work (yet?).
+        /// </remarks>
+        [Fact]
+        [Trait("Quarantined", "false")]
+        public void GuaranteedUnquarantinedTest()
+        {
+        }
+    }
+}

--- a/src/Shared/test/SuccessfulTests.cs
+++ b/src/Shared/test/SuccessfulTests.cs
@@ -15,7 +15,7 @@ namespace AlwaysTestTests
         /// Test that executes in quarantined runs and always succeeds.
         /// </summary>
         [Fact]
-        [QuarantinedTest]
+        [Flaky("No issue", FlakyOn.All)]
         public void GuaranteedQuarantinedTest()
         {
         }
@@ -31,7 +31,7 @@ namespace AlwaysTestTests
         /// make it work (yet?).
         /// </remarks>
         [Fact]
-        [Trait("Quarantined", "false")]
+        [Trait("Flaky:AzP:All", "false")]
         public void GuaranteedUnquarantinedTest()
         {
         }


### PR DESCRIPTION
- add `SuccessfulTests` to ensure something runs in every non-Helix run (#22406)
- see also #22241
- `cherry-pick` of 256045729a86
- cleans up hundreds of warnings
  - but see comments about xUnit runner command line in the new class
- does not include "Remove extra `[SkipOnHelix]` attribute" portion
  - no extra attribute and Helix infra isn't used in this branch

!fixup! `[Quarantined]` -> `[Flaky]`
- transformation never applied in release/3.1