### PR TITLE
Support overriding host settings using args

### DIFF
--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -15,33 +15,20 @@ namespace Microsoft.AspNetCore.Builder
     public sealed class ConfigureHostBuilder : IHostBuilder
     {
         private readonly ConfigurationManager _configuration;
-        private readonly IWebHostEnvironment _environment;
         private readonly IServiceCollection _services;
         private readonly HostBuilderContext _context;
 
         private readonly List<Action<IHostBuilder>> _operations = new();
 
-        internal ConfigureHostBuilder(
-            ConfigurationManager configuration,
-            IWebHostEnvironment environment,
-            IServiceCollection services,
-            IDictionary<object, object> properties)
+        internal ConfigureHostBuilder(HostBuilderContext context, ConfigurationManager configuration, IServiceCollection services)
         {
             _configuration = configuration;
-            _environment = environment;
             _services = services;
-
-            Properties = properties;
-
-            _context = new HostBuilderContext(Properties)
-            {
-                Configuration = _configuration,
-                HostingEnvironment = _environment
-            };
+            _context = context;
         }
 
         /// <inheritdoc />
-        public IDictionary<object, object> Properties { get; }
+        public IDictionary<object, object> Properties => _context.Properties;
 
         IHost IHostBuilder.Build()
         {

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -18,20 +18,14 @@ namespace Microsoft.AspNetCore.Builder
         private readonly IWebHostEnvironment _environment;
         private readonly ConfigurationManager _configuration;
         private readonly IServiceCollection _services;
-
         private readonly WebHostBuilderContext _context;
 
-        internal ConfigureWebHostBuilder(ConfigurationManager configuration, IWebHostEnvironment environment, IServiceCollection services)
+        internal ConfigureWebHostBuilder(WebHostBuilderContext webHostBuilderContext, ConfigurationManager configuration, IServiceCollection services)
         {
             _configuration = configuration;
-            _environment = environment;
+            _environment = webHostBuilderContext.HostingEnvironment;
             _services = services;
-
-            _context = new WebHostBuilderContext
-            {
-                Configuration = _configuration,
-                HostingEnvironment = _environment
-            };
+            _context = webHostBuilderContext;
         }
 
         IWebHost IWebHostBuilder.Build()

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private WebApplication? _builtApplication;
 
-        internal WebApplicationBuilder(Assembly? callingAssembly, string[]? args = null)
+        internal WebApplicationBuilder(Assembly? callingAssembly, string[]? args = null, Action<IHostBuilder>? configureDefaults = null)
         {
             Services = _services;
 
@@ -37,6 +37,9 @@ namespace Microsoft.AspNetCore.Builder
             // Don't specify the args here since we want to apply them later so that args
             // can override the defaults specified by ConfigureWebHostDefaults
             _bootstrapHostBuilder.ConfigureDefaults(args: null);
+
+            // This is for testing purposes
+            configureDefaults?.Invoke(_bootstrapHostBuilder);
 
             // We specify the command line here last since we skipped the one in the call to ConfigureDefaults.
             // The args can contain both host and application settings so we want to make sure

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -71,8 +71,10 @@ namespace Microsoft.AspNetCore.Builder
                 });
             }
 
+            Configuration = new();
+
             // This is the application configuration
-            (var hostContext, Configuration) = _bootstrapHostBuilder.RunDefaultCallbacks(_hostBuilder);
+            var hostContext = _bootstrapHostBuilder.RunDefaultCallbacks(Configuration, _hostBuilder);
 
             // Grab the WebHostBuilderContext from the property bag to use in the ConfigureWebHostBuilder
             var webHostContext = (WebHostBuilderContext)_hostBuilder.Properties[typeof(WebHostBuilderContext)];

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -32,8 +32,23 @@ namespace Microsoft.AspNetCore.Builder
             // Run methods to configure both generic and web host defaults early to populate config from appsettings.json
             // environment variables (both DOTNET_ and ASPNETCORE_ prefixed) and other possible default sources to prepopulate
             // the correct defaults.
-            _bootstrapHostBuilder = new BootstrapHostBuilder(Configuration, Services, _hostBuilder.Properties);
-            _bootstrapHostBuilder.ConfigureDefaults(args);
+            _bootstrapHostBuilder = new BootstrapHostBuilder(Services, _hostBuilder.Properties);
+
+            // Don't specify the args here since we want to apply them later so that args
+            // can override the defaults specified by ConfigureWebHostDefaults
+            _bootstrapHostBuilder.ConfigureDefaults(args: null);
+
+            // We specify the command line here last since we skipped the one in the call to ConfigureDefaults.
+            // The args can contain both host and application settings so we want to make sure
+            // we order those configuration providers appropriately without duplicating them
+            if (args is { Length: > 0 })
+            {
+                _bootstrapHostBuilder.ConfigureAppConfiguration(config =>
+                {
+                    config.AddCommandLine(args);
+                });
+            }
+
             _bootstrapHostBuilder.ConfigureWebHostDefaults(webHostBuilder =>
             {
                 // Runs inline.
@@ -44,14 +59,26 @@ namespace Microsoft.AspNetCore.Builder
                 webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, (callingAssembly ?? Assembly.GetEntryAssembly())?.GetName()?.Name ?? string.Empty);
             });
 
-            _bootstrapHostBuilder.RunDefaultCallbacks(_hostBuilder);
+            // Apply the args to host configuration last since ConfigureWebHostDefaults overrides a host specific setting (the application name).
+            if (args is { Length: > 0 })
+            {
+                _bootstrapHostBuilder.ConfigureHostConfiguration(config =>
+                {
+                    config.AddCommandLine(args);
+                });
+            }
 
-            // Get the IWebHostEnvironment from the WebHostBuilderContext.
-            // This also matches the instance in the IServiceCollection.
-            Environment = ((WebHostBuilderContext)_hostBuilder.Properties[typeof(WebHostBuilderContext)]).HostingEnvironment;
+            // This is the application configuration
+            (var hostContext, Configuration) = _bootstrapHostBuilder.RunDefaultCallbacks(_hostBuilder);
+
+            // Grab the WebHostBuilderContext from the property bag to use in the ConfigureWebHostBuilder
+            var webHostContext = (WebHostBuilderContext)_hostBuilder.Properties[typeof(WebHostBuilderContext)];
+
+            // Grab the IWebHostEnvironment from the webHostContext. This also matches the instance in the IServiceCollection.
+            Environment = webHostContext.HostingEnvironment;
             Logging = new LoggingBuilder(Services);
-            Host = new ConfigureHostBuilder(Configuration, Environment, Services, _hostBuilder.Properties);
-            WebHost = new ConfigureWebHostBuilder(Configuration, Environment, Services);
+            Host = new ConfigureHostBuilder(hostContext, Configuration, Services);
+            WebHost = new ConfigureWebHostBuilder(webHostContext, Configuration, Services);
         }
 
         /// <summary>
@@ -67,7 +94,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// A collection of configuration providers for the application to compose. This is useful for adding new configuration sources and providers.
         /// </summary>
-        public ConfigurationManager Configuration { get; } = new();
+        public ConfigurationManager Configuration { get; }
 
         /// <summary>
         /// A collection of logging providers for the application to compose. This is useful for adding new logging providers.

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -234,12 +234,21 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
-        public void WebApplicationBuilderHostEnvironmentAndWebHostEnvironmentAreTheSame()
+        public void WebApplicationBuilderApplicationNameCanBeOverridden()
         {
-            var projectName = typeof(WebApplicationTests).Assembly.GetName().Name;
             var assemblyName = Assembly.GetEntryAssembly().GetName().Name;
 
-            var builder = WebApplication.CreateBuilder(new[] { $"--applicationName={assemblyName}" });
+            var builder = new WebApplicationBuilder(
+                typeof(WebApplicationTests).Assembly,
+                new[] { $"--applicationName={assemblyName}" }, bootstrapBuilder =>
+            {
+                // Verify the defaults observed by the boostrap host builder we use internally to populate
+                // the defaults
+                bootstrapBuilder.ConfigureAppConfiguration((context, config) =>
+                {
+                    Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+                });
+            });
 
             Assert.Equal(assemblyName, builder.Environment.ApplicationName);
             builder.Host.ConfigureAppConfiguration((context, config) =>

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.Hosting;
@@ -230,6 +231,66 @@ namespace Microsoft.AspNetCore.Tests
                     { WebHostDefaults.HostingStartupExcludeAssembliesKey, "hostingexclude" }
                 });
             }));
+        }
+
+        [Fact]
+        public void WebApplicationBuilderHostEnvironmentAndWebHostEnvironmentAreTheSame()
+        {
+            var projectName = typeof(WebApplicationTests).Assembly.GetName().Name;
+            var assemblyName = Assembly.GetEntryAssembly().GetName().Name;
+
+            var builder = WebApplication.CreateBuilder(new[] { $"--applicationName={assemblyName}" });
+
+            Assert.Equal(assemblyName, builder.Environment.ApplicationName);
+            builder.Host.ConfigureAppConfiguration((context, config) =>
+            {
+                Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+            });
+
+            builder.WebHost.ConfigureAppConfiguration((context, config) =>
+            {
+                Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+            });
+
+            var app = builder.Build();
+            var hostEnv = app.Services.GetRequiredService<IHostEnvironment>();
+            var webHostEnv = app.Services.GetRequiredService<IWebHostEnvironment>();
+
+            Assert.Equal(assemblyName, hostEnv.ApplicationName);
+            Assert.Equal(assemblyName, webHostEnv.ApplicationName);
+        }
+
+        [Fact]
+        public void WebApplicationBuilderCanFlowCommandLineConfigurationToApplication()
+        {
+            var builder = WebApplication.CreateBuilder(new[] { "--x=1", "--name=Larry", "--age=20", "--environment=Testing" });
+
+            Assert.Equal("1", builder.Configuration["x"]);
+            Assert.Equal("Larry", builder.Configuration["name"]);
+            Assert.Equal("20", builder.Configuration["age"]);
+            Assert.Equal("Testing", builder.Configuration["environment"]);
+            Assert.Equal("Testing", builder.Environment.EnvironmentName);
+
+            builder.WebHost.ConfigureAppConfiguration((context, config) =>
+            {
+                Assert.Equal("Testing", context.HostingEnvironment.EnvironmentName);
+            });
+
+            builder.Host.ConfigureAppConfiguration((context, config) =>
+            {
+                Assert.Equal("Testing", context.HostingEnvironment.EnvironmentName);
+            });
+
+            var app = builder.Build();
+            var hostEnv = app.Services.GetRequiredService<IHostEnvironment>();
+            var webHostEnv = app.Services.GetRequiredService<IWebHostEnvironment>();
+
+            Assert.Equal("Testing", hostEnv.EnvironmentName);
+            Assert.Equal("Testing", webHostEnv.EnvironmentName);
+            Assert.Equal("1", app.Configuration["x"]);
+            Assert.Equal("Larry", app.Configuration["name"]);
+            Assert.Equal("20", app.Configuration["age"]);
+            Assert.Equal("Testing", app.Configuration["environment"]);
         }
 
         [Fact]


### PR DESCRIPTION
- Today this doesn't for application name because ConfigureWebHostDefaults always calls it.
- Don't let ConfigureAppConfiguration affect the host environment. Today we use a single ConfigurationManager on ConfigureHostConfiguration and ConfigureAppConfiguration, this is problematic because it allows the HostBuilderContext observed during ConfigureAppConfiguration change on the fly. This allowed the IWebHostEnvironment and IHostEnvironment to differ in host configuration.
- Added tests to make sure the environment variables can override the host settings and that IHostEnvironment and IWebHostEnvironment share the same values.

