### PR TITLE
Quarantine recently failing components tests

### DIFF
--- a/src/Components/test/E2ETest/Tests/AuthTest.cs
+++ b/src/Components/test/E2ETest/Tests/AuthTest.cs
@@ -214,6 +214,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34941")]
         public void Router_RequireRole_NotAuthorized()
         {
             SignInAs("Bert", "IrrelevantRole");

--- a/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
+++ b/src/Components/test/E2ETest/Tests/BootResourceCachingTest.cs
@@ -42,6 +42,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34941")]
         public void CachesResourcesAfterFirstLoad()
         {
             // On the first load, we have to fetch everything

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -240,6 +240,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34941")]
         public void CanAddAndRemoveChildComponentsDynamically()
         {
             // Initially there are zero child components

--- a/src/Components/test/E2ETest/Tests/SvgTest.cs
+++ b/src/Components/test/E2ETest/Tests/SvgTest.cs
@@ -78,6 +78,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34941")]
         public void CanRenderSvgWithLink()
         {
             var appElement = Browser.MountTestComponent<SvgComponent>();


### PR DESCRIPTION
Most of these tests are failing because Selenium:

- Fails to load the test page application
- Is unable to connect to the test server for whatever reason

Instead of quarantining these under individual items, I've decided to put them in a single bucket since we've already mostly decided that we'll need to solve this uniformly across the board instead of on a case-by-case basis.