### PR TITLE
Add logging to flaky Kestrel connection middleware test

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionMiddlewareTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
@@ -67,12 +68,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34947")]
         public async Task CanReadAndWriteWithAsyncConnectionMiddleware(RequestDelegate requestDelegate)
         {
-            var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0));
-            listenOptions.Use(next => new AsyncConnectionMiddleware(next).OnConnectionAsync);
-
             var serviceContext = new TestServiceContext(LoggerFactory);
 
-            await using (var server = new TestServer(requestDelegate, serviceContext, listenOptions))
+            await using (var server = new TestServer(requestDelegate, serviceContext, listenOptions =>
+            {
+                listenOptions.UseConnectionLogging();
+                listenOptions.Use(next => new AsyncConnectionMiddleware(next).OnConnectionAsync);
+                listenOptions.UseConnectionLogging();
+            }))
             {
                 using (var connection = server.CreateConnection())
                 {


### PR DESCRIPTION
This is to help investigate #34947. This test is a little weird in that it mutates the write buffer before passing it through to the inner Stream/PipeWriter, but I don't see how that could cause problems. Or why it would only fail part of the time. This adds logging to the now-quarantined test so we'll have more details if this comes up again.

My current theory is there's some bug somewhere in StreamPipeReader, StreamPipeWriter, PipeReaderStream or PipeWriterStream.