### PR TITLE
HTTP/3: Connection shutdown improvements

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -298,7 +298,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     feature = ExtraFeatureGet(key);
                 }
 
-                return feature ?? ConnectionFeatures[key];
+                return feature ?? ConnectionFeatures?[key];
             }
 
             set
@@ -564,7 +564,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 feature = (TFeature?)(ExtraFeatureGet(typeof(TFeature)));
             }
 
-            if (feature == null)
+            if (feature == null && ConnectionFeatures != null)
             {
                 feature = ConnectionFeatures.Get<TFeature>();
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -229,6 +229,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             Exception? error = null;
             ValueTask outboundControlStreamTask = default;
+            bool clientAbort = false;
 
             try
             {
@@ -339,10 +340,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
                 try
                 {
-                    if (TryClose())
+                    // Only send goaway if the connection close was initiated on the server.
+                    if (TryClose() && clientAbort)
                     {
-                        // This throws when connection is shut down.
-                        // TODO how to make it so we can distinguish between Abort from server vs client?
                         await SendGoAway(GetHighestStreamId());
                     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -100,6 +100,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
                 if (Interlocked.CompareExchange(ref _gracefulCloseInitiator, initiator, GracefulCloseInitiator.None) == GracefulCloseInitiator.None)
                 {
+                    if (_gracefulCloseInitiator == GracefulCloseInitiator.Server)
+                    {
+                        if (TryClose())
+                        {
+                            SendGoAway(GetHighestStreamId()).Preserve();
+                        }
+                    }
+
                     // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-5.2-11
                     // An endpoint that completes a graceful shutdown SHOULD use the H3_NO_ERROR error code
                     // when closing the connection.

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -282,6 +282,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                                 // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-4.1.2-3
                                 streamContext.Features.Get<IProtocolErrorCodeFeature>()!.Error = (long)Http3ErrorCode.RequestRejected;
                                 streamContext.Abort(new ConnectionAbortedException("HTTP/3 connection is closing and no longer accepts new requests."));
+                                await streamContext.DisposeAsync();
+
                                 continue;
                             }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -256,8 +256,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                                 _acceptStreamsCts = new CancellationTokenSource();
                             }
 
-                            // There is no stream so run UpdateConnectionState in finally.
-                            // It may update state to stop accepting streams.
+                            // There is no stream so continue to skip to UpdateConnectionState in finally.
+                            // UpdateConnectionState is responsible for updating connection to
+                            // stop accepting streams and break out of accept loop.
                             continue;
                         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         internal ValueTask<FlushResult> SendGoAway(long id)
         {
-            Log.Http3GoAwayHighestStreamId(_context.ConnectionId, id);
+            Log.Http3GoAwayHighestOpenedStreamId(_context.ConnectionId, id);
             return _frameWriter.WriteGoAway(id);
         }
 
@@ -342,6 +342,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     // https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-7.2.4
                     break;
             }
+        }
+
+        internal ValueTask CompleteAsync()
+        {
+            return _frameWriter.CompleteAsync();
         }
 
         private ValueTask ProcessGoAwayFrameAsync()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -108,6 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         internal ValueTask<FlushResult> SendGoAway(long id)
         {
+            Log.Http3GoAwayHighestStreamId(_context.ConnectionId, id);
             return _frameWriter.WriteGoAway(id);
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         internal ValueTask<FlushResult> SendGoAway(long id)
         {
-            Log.Http3GoAwayHighestOpenedStreamId(_context.ConnectionId, id);
+            Log.Http3GoAwayStreamId(_context.ConnectionId, id);
             return _frameWriter.WriteGoAway(id);
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Formatting.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Formatting.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                 Http3FrameType.CancelPush => "CANCEL_PUSH",
                 Http3FrameType.Settings => "SETTINGS",
                 Http3FrameType.PushPromise => "PUSH_PROMISE",
-                Http3FrameType.GoAway => "GO_AWAY",
+                Http3FrameType.GoAway => "GOAWAY",
                 Http3FrameType.MaxPushId => "MAX_PUSH_ID",
                 _ => type.ToString()
             };

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -371,9 +371,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         private void CompleteStream(bool errored)
         {
-            Debug.Assert(_appCompleted != null);
-            _appCompleted.SetResult();
-
             if (!EndStreamReceived)
             {
                 if (!errored)
@@ -395,6 +392,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
                 TryClose();
             }
+
+            // Stream will be pooled after app completed.
+            // Wait to signal app completed after any potential aborts on the stream.
+            Debug.Assert(_appCompleted != null);
+            _appCompleted.SetResult();
         }
 
         private bool TryClose()

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -100,6 +100,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         void Http3OutboundControlStreamError(string connectionId, Exception ex);
 
-        void Http3GoAwayHighestStreamId(string connectionId, long highestStreamId);
+        void Http3GoAwayHighestOpenedStreamId(string connectionId, long highestOpenedStreamId);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -99,5 +99,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         void QPackEncodingError(string connectionId, long streamId, Exception ex);
 
         void Http3OutboundControlStreamError(string connectionId, Exception ex);
+
+        void Http3GoAwayHighestStreamId(string connectionId, long highestStreamId);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -100,6 +100,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         void Http3OutboundControlStreamError(string connectionId, Exception ex);
 
-        void Http3GoAwayHighestOpenedStreamId(string connectionId, long highestOpenedStreamId);
+        void Http3GoAwayStreamId(string connectionId, long goAwayStreamId);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IKestrelTrace.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
         void Http3ConnectionClosing(string connectionId);
 
-        void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId);
+        void Http3ConnectionClosed(string connectionId, long? highestOpenedStreamId);
 
         void Http3StreamAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason);
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -387,12 +387,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             QPackEncodingError(_http3Logger, connectionId, streamId, ex);
         }
 
-        [LoggerMessage(53, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Highest stream ID {highestStreamId} in GOAWAY.", EventName = "Http3GoAwayHighestStreamId")]
-        private static partial void Http3GoAwayHighestStreamId(ILogger logger, string connectionId, long highestStreamId);
+        [LoggerMessage(53, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Highest opened stream ID {HighestOpenedStreamId} in GOAWAY.", EventName = "Http3GoAwayHighestOpenedStreamId")]
+        private static partial void Http3GoAwayHighestOpenedStreamId(ILogger logger, string connectionId, long highestOpenedStreamId);
 
-        public void Http3GoAwayHighestStreamId(string connectionId, long highestStreamId)
+        public void Http3GoAwayHighestOpenedStreamId(string connectionId, long highestOpenedStreamId)
         {
-            Http3GoAwayHighestStreamId(_http3Logger, connectionId, highestStreamId);
+            Http3GoAwayHighestOpenedStreamId(_http3Logger, connectionId, highestOpenedStreamId);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using System.Net.Http;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
@@ -362,6 +363,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             }
         }
 
+        [LoggerMessage(50, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Unexpected error when initializing outbound control stream.", EventName = "Http3OutboundControlStreamError")]
+        private static partial void Http3OutboundControlStreamError(ILogger logger, string connectionId, Exception ex);
+
+        public void Http3OutboundControlStreamError(string connectionId, Exception ex)
+        {
+            Http3OutboundControlStreamError(_http3Logger, connectionId, ex);
+        }
+
         [LoggerMessage(51, LogLevel.Debug, @"Connection id ""{ConnectionId}"": QPACK decoding error while decoding headers for stream ID {StreamId}.", EventName = "QPackDecodingError")]
         private static partial void QPackDecodingError(ILogger logger, string connectionId, long streamId, Exception ex);
 
@@ -378,12 +387,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             QPackEncodingError(_http3Logger, connectionId, streamId, ex);
         }
 
-        [LoggerMessage(50, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Unexpected error when initializing outbound control stream.", EventName = "Http3OutboundControlStreamError")]
-        private static partial void Http3OutboundControlStreamError(ILogger logger, string connectionId, Exception ex);
+        [LoggerMessage(53, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Highest stream ID {highestStreamId} in GOAWAY.", EventName = "Http3GoAwayHighestStreamId")]
+        private static partial void Http3GoAwayHighestStreamId(ILogger logger, string connectionId, long highestStreamId);
 
-        public void Http3OutboundControlStreamError(string connectionId, Exception ex)
+        public void Http3GoAwayHighestStreamId(string connectionId, long highestStreamId)
         {
-            Http3OutboundControlStreamError(_http3Logger, connectionId, ex);
+            Http3GoAwayHighestStreamId(_http3Logger, connectionId, highestStreamId);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -387,12 +387,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             QPackEncodingError(_http3Logger, connectionId, streamId, ex);
         }
 
-        [LoggerMessage(53, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Highest opened stream ID {HighestOpenedStreamId} in GOAWAY.", EventName = "Http3GoAwayHighestOpenedStreamId")]
-        private static partial void Http3GoAwayHighestOpenedStreamId(ILogger logger, string connectionId, long highestOpenedStreamId);
+        [LoggerMessage(53, LogLevel.Debug, @"Connection id ""{ConnectionId}"": GOAWAY stream ID {GoAwayStreamId}.", EventName = "Http3GoAwayHighestOpenedStreamId")]
+        private static partial void Http3GoAwayStreamId(ILogger logger, string connectionId, long goAwayStreamId);
 
-        public void Http3GoAwayHighestOpenedStreamId(string connectionId, long highestOpenedStreamId)
+        public void Http3GoAwayStreamId(string connectionId, long goAwayStreamId)
         {
-            Http3GoAwayHighestOpenedStreamId(_http3Logger, connectionId, highestOpenedStreamId);
+            Http3GoAwayStreamId(_http3Logger, connectionId, goAwayStreamId);
         }
 
         public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -323,9 +323,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         }
 
         [LoggerMessage(44, LogLevel.Debug, @"Connection id ""{ConnectionId}"" is closed. The last processed stream ID was {HighestOpenedStreamId}.", EventName = "Http3ConnectionClosed")]
-        private static partial void Http3ConnectionClosed(ILogger logger, string connectionId, long highestOpenedStreamId);
+        private static partial void Http3ConnectionClosed(ILogger logger, string connectionId, long? highestOpenedStreamId);
 
-        public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId)
+        public void Http3ConnectionClosed(string connectionId, long? highestOpenedStreamId)
         {
             Http3ConnectionClosed(_http3Logger, connectionId, highestOpenedStreamId);
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                 var sslServerAuthenticationOptions = new SslServerAuthenticationOptions
                 {
                     ServerCertificate = listenOptions.HttpsOptions.ServerCertificate,
-                    ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol("h3") }
+                    ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol("h3"), new SslApplicationProtocol("h3-29") }
                 };
 
                 features.Set(sslServerAuthenticationOptions);

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
@@ -13,15 +13,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         void AcceptedStream(QuicStreamContext streamContext);
         void ConnectedStream(QuicStreamContext streamContext);
         void ConnectionError(BaseConnectionContext connection, Exception ex);
-        void ConnectionAborted(BaseConnectionContext connection, Exception ex);
-        void ConnectionAbort(BaseConnectionContext connection, string reason);
+        void ConnectionAborted(BaseConnectionContext connection, long errorCode, Exception ex);
+        void ConnectionAbort(BaseConnectionContext connection, long errorCode, string reason);
         void StreamError(QuicStreamContext streamContext, Exception ex);
         void StreamPause(QuicStreamContext streamContext);
         void StreamResume(QuicStreamContext streamContext);
         void StreamShutdownWrite(QuicStreamContext streamContext, string reason);
-        void StreamAborted(QuicStreamContext streamContext, Exception ex);
-        void StreamAbort(QuicStreamContext streamContext, string reason);
-        void StreamAbortRead(QuicStreamContext streamContext, string reason);
-        void StreamAbortWrite(QuicStreamContext streamContext, string reason);
+        void StreamAborted(QuicStreamContext streamContext, long errorCode, Exception ex);
+        void StreamAbort(QuicStreamContext streamContext, long errorCode, string reason);
+        void StreamAbortRead(QuicStreamContext streamContext, long errorCode, string reason);
+        void StreamAbortWrite(QuicStreamContext streamContext, long errorCode, string reason);
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -119,6 +119,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 },
                 this,
                 preferLocal: false);
+
+                // Throw error so consumer sees the connection is aborted by peer.
+                throw new ConnectionResetException(ex.Message, ex);
             }
             catch (QuicOperationAbortedException)
             {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Net.Quic;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -23,12 +24,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         private long _heartbeatTicks;
         private readonly object _poolLock = new object();
 
+        private readonly object _shutdownLock = new object();
         private readonly QuicConnection _connection;
         private readonly QuicTransportContext _context;
         private readonly IQuicTrace _log;
         private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
 
         private Task? _closeTask;
+        private ExceptionDispatchInfo? _abortReason;
 
         internal const int InitialStreamPoolSize = 5;
         internal const int MaxStreamPoolSize = 100;
@@ -53,7 +56,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         {
             try
             {
-                _closeTask ??= _connection.CloseAsync(errorCode: 0).AsTask();
+                lock (_shutdownLock)
+                {
+                    _closeTask ??= _connection.CloseAsync(errorCode: 0).AsTask();
+                }
+
                 await _closeTask;
             }
             catch (Exception ex)
@@ -68,9 +75,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
         public override void Abort(ConnectionAbortedException abortReason)
         {
-            // dedup calls to abort here.
-            _log.ConnectionAbort(this, abortReason.Message);
-            _closeTask = _connection.CloseAsync(errorCode: Error).AsTask();
+            lock (_shutdownLock)
+            {
+                // Check if connection has already been already aborted.
+                if (_abortReason != null)
+                {
+                    return;
+                }
+
+                _abortReason = ExceptionDispatchInfo.Capture(abortReason);
+                _log.ConnectionAbort(this, abortReason.Message);
+                _closeTask = _connection.CloseAsync(errorCode: Error).AsTask();
+            }
         }
 
         public override async ValueTask<ConnectionContext?> AcceptAsync(CancellationToken cancellationToken = default)
@@ -125,11 +141,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
             catch (QuicOperationAbortedException)
             {
-                // Shutdown initiated by us
+                // Shutdown initiated by us.
 
-                // Allow for graceful closure.
+                lock (_shutdownLock)
+                {
+                    // Connection has been aborted. Throw reason exception.
+                    _abortReason?.Throw();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown initiated by us.
+
+                lock (_shutdownLock)
+                {
+                    // Connection has been aborted. Throw reason exception.
+                    _abortReason?.Throw();
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning(0, ex, $"Unexpected exception in {nameof(QuicConnectionContext)}.{nameof(AcceptAsync)}.");
+                throw;
             }
 
+            // Return null for graceful closure.
             return null;
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -162,11 +162,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
             catch (Exception ex)
             {
-                _log.LogWarning(0, ex, $"Unexpected exception in {nameof(QuicConnectionContext)}.{nameof(AcceptAsync)}.");
+                Debug.Fail($"Unexpected exception in {nameof(QuicConnectionContext)}.{nameof(AcceptAsync)}: {ex}");
                 throw;
             }
 
-            // Return null for graceful closure.
+            // Return null for graceful closure or cancellation.
             return null;
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 }
 
                 _abortReason = ExceptionDispatchInfo.Capture(abortReason);
-                _log.ConnectionAbort(this, abortReason.Message);
+                _log.ConnectionAbort(this, Error, abortReason.Message);
                 _closeTask = _connection.CloseAsync(errorCode: Error).AsTask();
             }
         }
@@ -127,7 +127,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicConnectionAbortedException ex)
             {
                 // Shutdown initiated by peer, abortive.
-                _log.ConnectionAborted(this, ex);
+                Error = ex.ErrorCode;
+                _log.ConnectionAborted(this, ex.ErrorCode, ex);
 
                 ThreadPool.UnsafeQueueUserWorkItem(state =>
                 {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
@@ -68,7 +68,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             _currentIProtocolErrorCodeFeature = this;
             _currentIStreamIdFeature = this;
             _currentIStreamAbortFeature = this;
-            _currentITlsConnectionFeature = _connection._currentITlsConnectionFeature;
         }
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 if (_stream.CanRead)
                 {
                     _shutdownReadReason = abortReason;
-                    _log.StreamAbortRead(this, abortReason.Message);
+                    _log.StreamAbortRead(this, errorCode, abortReason.Message);
                     _stream.AbortRead(errorCode);
                 }
                 else
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 if (_stream.CanWrite)
                 {
                     _shutdownWriteReason = abortReason;
-                    _log.StreamAbortWrite(this, abortReason.Message);
+                    _log.StreamAbortWrite(this, errorCode, abortReason.Message);
                     _stream.AbortWrite(errorCode);
                 }
                 else

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             _context = context;
             _log = context.Log;
             MemoryPool = connection.MemoryPool;
+            MultiplexedConnectionFeatures = connection.Features;
 
             RemoteEndPoint = connection.RemoteEndPoint;
             LocalEndPoint = connection.LocalEndPoint;
@@ -223,8 +224,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicOperationAbortedException ex)
             {
                 // AbortRead has been called for the stream.
-                // Possibily might also get here from connection closing.
-                // System.Net.Quic exception handling not finalized.
+                error = ex;
+            }
+            catch (QuicConnectionAbortedException ex)
+            {
+                // Connection has aborted.
                 error = ex;
             }
             catch (Exception ex)

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -224,7 +224,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicOperationAbortedException ex)
             {
                 // AbortRead has been called for the stream.
-                error = ex;
+                error = new ConnectionAbortedException(ex.Message, ex);
             }
             catch (QuicConnectionAbortedException ex)
             {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -214,7 +214,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             {
                 // Abort from peer.
                 Error = ex.ErrorCode;
-                _log.StreamAborted(this, ex);
+                _log.StreamAborted(this, ex.ErrorCode, ex);
 
                 // This could be ignored if _shutdownReason is already set.
                 error = new ConnectionResetException(ex.Message, ex);
@@ -320,7 +320,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             {
                 // Abort from peer.
                 Error = ex.ErrorCode;
-                _log.StreamAborted(this, ex);
+                _log.StreamAborted(this, ex.ErrorCode, ex);
 
                 // This could be ignored if _shutdownReason is already set.
                 shutdownReason = new ConnectionResetException(ex.Message, ex);
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             _serverAborted = true;
 
-            _log.StreamAbort(this, abortReason.Message);
+            _log.StreamAbort(this, Error, abortReason.Message);
 
             lock (_shutdownLock)
             {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -327,6 +327,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
                 _clientAbort = true;
             }
+            catch (QuicConnectionAbortedException ex)
+            {
+                // Abort from peer.
+                Error = ex.ErrorCode;
+                _log.StreamAborted(this, ex.ErrorCode, ex);
+
+                // This could be ignored if _shutdownReason is already set.
+                shutdownReason = new ConnectionResetException(ex.Message, ex);
+
+                _clientAbort = true;
+            }
             catch (QuicOperationAbortedException ex)
             {
                 // AbortWrite has been called for the stream.

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -66,25 +66,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(5, LogLevel.Debug, @"Connection id ""{ConnectionId}"" aborted by peer.", EventName = "ConnectionAborted", SkipEnabledCheck = true)]
-        private static partial void ConnectionAborted(ILogger logger, string connectionId, Exception ex);
+        [LoggerMessage(5, LogLevel.Debug, @"Connection id ""{ConnectionId}"" aborted by peer with error code {ErrorCode}.", EventName = "ConnectionAborted", SkipEnabledCheck = true)]
+        private static partial void ConnectionAborted(ILogger logger, string connectionId, long errorCode, Exception ex);
 
-        public void ConnectionAborted(BaseConnectionContext connection, Exception ex)
+        public void ConnectionAborted(BaseConnectionContext connection, long errorCode, Exception ex)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                ConnectionAborted(_logger, connection.ConnectionId, ex);
+                ConnectionAborted(_logger, connection.ConnectionId, errorCode, ex);
             }
         }
 
-        [LoggerMessage(6, LogLevel.Debug, @"Connection id ""{ConnectionId}"" aborted by application because: ""{Reason}"".", EventName = "ConnectionAbort", SkipEnabledCheck = true)]
-        private static partial void ConnectionAbort(ILogger logger, string connectionId, string reason);
+        [LoggerMessage(6, LogLevel.Debug, @"Connection id ""{ConnectionId}"" aborted by application with error code {ErrorCode} because: ""{Reason}"".", EventName = "ConnectionAbort", SkipEnabledCheck = true)]
+        private static partial void ConnectionAbort(ILogger logger, string connectionId, long errorCode, string reason);
 
-        public void ConnectionAbort(BaseConnectionContext connection, string reason)
+        public void ConnectionAbort(BaseConnectionContext connection, long errorCode, string reason)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                ConnectionAbort(_logger, connection.ConnectionId, reason);
+                ConnectionAbort(_logger, connection.ConnectionId, errorCode, reason);
             }
         }
 
@@ -132,47 +132,47 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(11, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by peer.", EventName = "StreamAborted", SkipEnabledCheck = true)]
-        private static partial void StreamAborted(ILogger logger, string connectionId, Exception ex);
+        [LoggerMessage(11, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
+        private static partial void StreamAborted(ILogger logger, string connectionId, long errorCode, Exception ex);
 
-        public void StreamAborted(QuicStreamContext streamContext, Exception ex)
+        public void StreamAborted(QuicStreamContext streamContext, long errorCode, Exception ex)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                StreamAborted(_logger, streamContext.ConnectionId, ex);
+                StreamAborted(_logger, streamContext.ConnectionId, errorCode, ex);
             }
         }
 
-        [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by application because: ""{Reason}"".", EventName = "StreamAbort", SkipEnabledCheck = true)]
-        private static partial void StreamAbort(ILogger logger, string connectionId, string reason);
+        [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by application with error code {ErrorCode} because: ""{Reason}"".", EventName = "StreamAbort", SkipEnabledCheck = true)]
+        private static partial void StreamAbort(ILogger logger, string connectionId, long errorCode, string reason);
 
-        public void StreamAbort(QuicStreamContext streamContext, string reason)
+        public void StreamAbort(QuicStreamContext streamContext, long errorCode, string reason)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                StreamAbort(_logger, streamContext.ConnectionId, reason);
+                StreamAbort(_logger, streamContext.ConnectionId, errorCode, reason);
             }
         }
 
-        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application because: ""{Reason}"".", SkipEnabledCheck = true)]
-        private static partial void StreamAbortRead(ILogger logger, string connectionId, string reason);
+        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
+        private static partial void StreamAbortRead(ILogger logger, string connectionId, long errorCode, string reason);
 
-        public void StreamAbortRead(QuicStreamContext streamContext, string reason)
+        public void StreamAbortRead(QuicStreamContext streamContext, long errorCode, string reason)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                StreamAbortRead(_logger, streamContext.ConnectionId, reason);
+                StreamAbortRead(_logger, streamContext.ConnectionId, errorCode, reason);
             }
         }
 
-        [LoggerMessage(14, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application because: ""{Reason}"".", SkipEnabledCheck = true)]
-        private static partial void StreamAbortWrite(ILogger logger, string connectionId, string reason);
+        [LoggerMessage(14, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
+        private static partial void StreamAbortWrite(ILogger logger, string connectionId, long errorCode, string reason);
         
-        public void StreamAbortWrite(QuicStreamContext streamContext, string reason)
+        public void StreamAbortWrite(QuicStreamContext streamContext, long errorCode, string reason)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                StreamAbortWrite(_logger, streamContext.ConnectionId, reason);
+                StreamAbortWrite(_logger, streamContext.ConnectionId, errorCode, reason);
             }
         }
         

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -39,17 +39,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 
             var options = QuicTestHelpers.CreateClientConnectionOptions(connectionListener.EndPoint);
 
-            using var quicConnection = new QuicConnection(QuicImplementationProviders.MsQuic, options);
-            await quicConnection.ConnectAsync().DefaultTimeout();
+            using var clientConnection = new QuicConnection(QuicImplementationProviders.MsQuic, options);
+            await clientConnection.ConnectAsync().DefaultTimeout();
 
             // Assert
-            await using var connection = await acceptTask.DefaultTimeout();
-            Assert.False(connection.ConnectionClosed.IsCancellationRequested);
+            await using var serverConnection = await acceptTask.DefaultTimeout();
+            Assert.False(serverConnection.ConnectionClosed.IsCancellationRequested);
 
-            await connection.DisposeAsync().AsTask().DefaultTimeout();
+            await serverConnection.DisposeAsync().AsTask().DefaultTimeout();
 
             // ConnectionClosed isn't triggered because the server initiated close.
-            Assert.False(connection.ConnectionClosed.IsCancellationRequested);
+            Assert.False(serverConnection.ConnectionClosed.IsCancellationRequested);
         }
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
@@ -103,6 +103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 
             Logger.LogInformation("Client reading until end of stream.");
             var data = await clientStream.ReadUntilEndAsync().DefaultTimeout();
+            Assert.Equal(testData.Length, data.Length);
             Assert.Equal(testData, data);
 
             var quicConnectionContext = Assert.IsType<QuicConnectionContext>(serverConnection);

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
@@ -70,5 +70,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public void QPackDecodingError(string connectionId, long streamId, Exception ex) { }
         public void QPackEncodingError(string connectionId, long streamId, Exception ex) { }
         public void Http3OutboundControlStreamError(string connectionId, Exception ex) { }
+        public void Http3GoAwayHighestStreamId(string connectionId, long highestStreamId) { }
     }
 }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
@@ -70,6 +70,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public void QPackDecodingError(string connectionId, long streamId, Exception ex) { }
         public void QPackEncodingError(string connectionId, long streamId, Exception ex) { }
         public void Http3OutboundControlStreamError(string connectionId, Exception ex) { }
-        public void Http3GoAwayHighestStreamId(string connectionId, long highestStreamId) { }
+        public void Http3GoAwayHighestOpenedStreamId(string connectionId, long highestStreamId) { }
     }
 }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public void InvalidResponseHeaderRemoved() { }
         public void Http3ConnectionError(string connectionId, Http3ConnectionErrorException ex) { }
         public void Http3ConnectionClosing(string connectionId) { }
-        public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId) { }
+        public void Http3ConnectionClosed(string connectionId, long? highestOpenedStreamId) { }
         public void Http3StreamAbort(string traceIdentifier, Http3ErrorCode error, ConnectionAbortedException abortReason) { }
         public void Http3FrameReceived(string connectionId, long streamId, Http3RawFrame frame) { }
         public void Http3FrameSending(string connectionId, long streamId, Http3RawFrame frame) { }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTrace.cs
@@ -70,6 +70,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         public void QPackDecodingError(string connectionId, long streamId, Exception ex) { }
         public void QPackEncodingError(string connectionId, long streamId, Exception ex) { }
         public void Http3OutboundControlStreamError(string connectionId, Exception ex) { }
-        public void Http3GoAwayHighestOpenedStreamId(string connectionId, long highestStreamId) { }
+        public void Http3GoAwayStreamId(string connectionId, long goAwayStreamId) { }
     }
 }

--- a/src/Servers/Kestrel/shared/TransportConnection.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.cs
@@ -19,6 +19,9 @@ namespace Microsoft.AspNetCore.Connections
         private IDictionary<object, object?>? _items;
         private string? _connectionId;
 
+        // Will only have a value if the transport is created from a multiplexed transport.
+        public IFeatureCollection? MultiplexedConnectionFeatures { get; protected set; }
+
         public TransportConnection()
         {
             FastReset();

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -300,10 +300,10 @@ namespace Microsoft.AspNetCore.Testing
             _trace2.Http3OutboundControlStreamError(connectionId, ex);
         }
 
-        public void Http3GoAwayHighestStreamId(string connectionId, long highestStreamId)
+        public void Http3GoAwayHighestOpenedStreamId(string connectionId, long highestStreamId)
         {
-            _trace1.Http3GoAwayHighestStreamId(connectionId, highestStreamId);
-            _trace2.Http3GoAwayHighestStreamId(connectionId, highestStreamId);
+            _trace1.Http3GoAwayHighestOpenedStreamId(connectionId, highestStreamId);
+            _trace2.Http3GoAwayHighestOpenedStreamId(connectionId, highestStreamId);
         }
     }
 }

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -299,5 +299,11 @@ namespace Microsoft.AspNetCore.Testing
             _trace1.Http3OutboundControlStreamError(connectionId, ex);
             _trace2.Http3OutboundControlStreamError(connectionId, ex);
         }
+
+        public void Http3GoAwayHighestStreamId(string connectionId, long highestStreamId)
+        {
+            _trace1.Http3GoAwayHighestStreamId(connectionId, highestStreamId);
+            _trace2.Http3GoAwayHighestStreamId(connectionId, highestStreamId);
+        }
     }
 }

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Testing
             _trace2.Http3ConnectionClosing(connectionId);
         }
 
-        public void Http3ConnectionClosed(string connectionId, long highestOpenedStreamId)
+        public void Http3ConnectionClosed(string connectionId, long? highestOpenedStreamId)
         {
             _trace1.Http3ConnectionClosed(connectionId, highestOpenedStreamId);
             _trace2.Http3ConnectionClosed(connectionId, highestOpenedStreamId);

--- a/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
+++ b/src/Servers/Kestrel/shared/test/CompositeKestrelTrace.cs
@@ -300,10 +300,10 @@ namespace Microsoft.AspNetCore.Testing
             _trace2.Http3OutboundControlStreamError(connectionId, ex);
         }
 
-        public void Http3GoAwayHighestOpenedStreamId(string connectionId, long highestStreamId)
+        public void Http3GoAwayStreamId(string connectionId, long goAwayStreamId)
         {
-            _trace1.Http3GoAwayHighestOpenedStreamId(connectionId, highestStreamId);
-            _trace2.Http3GoAwayHighestOpenedStreamId(connectionId, highestStreamId);
+            _trace1.Http3GoAwayStreamId(connectionId, goAwayStreamId);
+            _trace2.Http3GoAwayStreamId(connectionId, goAwayStreamId);
         }
     }
 }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Testing
             return _inboundControlStream;
         }
 
-        internal void CloseConnectionGracefully()
+        internal void CloseServerGracefully()
         {
             MultiplexedConnectionContext.ConnectionClosingCts.Cancel();
         }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -383,7 +383,7 @@ namespace Microsoft.AspNetCore.Testing
         internal async ValueTask<Http3ControlStream> CreateControlStream(int? id)
         {
             var testStreamContext = new TestStreamContext(canRead: true, canWrite: false, this);
-            testStreamContext.Initialize(GetStreamId(0x02));
+            testStreamContext.Initialize(streamId: 2);
 
             var stream = new Http3ControlStream(this, testStreamContext);
             _runningStreams[stream.StreamId] = stream;
@@ -969,7 +969,7 @@ namespace Microsoft.AspNetCore.Testing
         public override ValueTask<ConnectionContext> ConnectAsync(IFeatureCollection features = null, CancellationToken cancellationToken = default)
         {
             var testStreamContext = new TestStreamContext(canRead: true, canWrite: false, _testBase);
-            testStreamContext.Initialize(_testBase.GetStreamId(0x03));
+            testStreamContext.Initialize(streamId: 3);
 
             var stream = _testBase.OnCreateServerControlStream?.Invoke(testStreamContext) ?? new Http3ControlStream(_testBase, testStreamContext);
             ToClientAcceptQueue.Writer.WriteAsync(stream);

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -1107,9 +1107,14 @@ namespace Microsoft.AspNetCore.Testing
             Disposed = true;
             _disposedTcs.TrySetResult();
 
-            if (!_isAborted &&
+            var canReuse = !_isAborted &&
                 _transportPipeReader.IsCompletedSuccessfully &&
-                _transportPipeWriter.IsCompletedSuccessfully)
+                _transportPipeWriter.IsCompletedSuccessfully;
+
+            _pair.Transport.Input.Complete();
+            _pair.Transport.Output.Complete();
+
+            if (canReuse)
             {
                 _testBase._streamContextPool.Enqueue(this);
             }

--- a/src/Servers/Kestrel/shared/test/StreamExtensions.cs
+++ b/src/Servers/Kestrel/shared/test/StreamExtensions.cs
@@ -71,9 +71,9 @@ namespace System.IO
             var data = new List<byte>();
             var offset = 0;
 
-            while (offset < buffer.Length)
+            while (true)
             {
-                var read = await stream.ReadAsync(buffer, 0, buffer.Length - offset, cancellationToken);
+                var read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
                 offset += read;
 
                 if (read == 0)
@@ -83,10 +83,6 @@ namespace System.IO
 
                 data.AddRange(buffer.AsMemory(0, read).ToArray());
             }
-
-            Assert.Equal(0, await stream.ReadAsync(new byte[1], 0, 1, cancellationToken));
-
-            return data.ToArray();
         }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -20,6 +20,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 {
     public class Http3ConnectionTests : Http3TestBase
     {
+        private static readonly KeyValuePair<string, string>[] Headers = new[]
+        {
+            new KeyValuePair<string, string>(HeaderNames.Method, "Custom"),
+            new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+        };
+
         [Fact]
         public async Task CreateRequestStream_RequestCompleted_Disposed()
         {
@@ -64,20 +72,50 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             Assert.True(requestStream.Disposed);
         }
 
-        [Fact]
-        public async Task GracefulServerShutdownClosesConnection()
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 4)]
+        [InlineData(111, 444)]
+        [InlineData(512, 2048)]
+        public async Task GOAWAY_GracefulServerShutdown_SendsGoAway(int connectionRequests, int expectedStreamId)
         {
             await Http3Api.InitializeConnectionAsync(_echoApplication);
 
             var inboundControlStream = await Http3Api.GetInboundControlStream();
             await inboundControlStream.ExpectSettingsAsync();
 
+            for (var i = 0; i < connectionRequests; i++)
+            {
+                var request = await Http3Api.CreateRequestStream();
+                await request.SendHeadersAsync(Headers);
+                await request.EndStreamAsync();
+                await request.ExpectReceiveEndOfStream();
+            }
+
             // Trigger server shutdown.
-            Http3Api.CloseConnectionGracefully();
+            Http3Api.CloseServerGracefully();
+
+            Assert.Null(await Http3Api.MultiplexedConnectionContext.AcceptAsync().DefaultTimeout());
+
+            await Http3Api.WaitForConnectionStopAsync(expectedStreamId, false, expectedErrorCode: Http3ErrorCode.NoError);
+        }
+
+        [Fact]
+        public async Task Request_AfterGracefulServerShutdown_Aborted()
+        {
+            await Http3Api.InitializeConnectionAsync(_echoApplication);
+
+            var inboundControlStream = await Http3Api.GetInboundControlStream();
+            await inboundControlStream.ExpectSettingsAsync();
+
+            Http3Api.CloseServerGracefully();
 
             Assert.Null(await Http3Api.MultiplexedConnectionContext.AcceptAsync().DefaultTimeout());
 
             await Http3Api.WaitForConnectionStopAsync(0, false, expectedErrorCode: Http3ErrorCode.NoError);
+
+            var request = await Http3Api.CreateRequestStream();
+            await request.SendHeadersAsync(Headers);
         }
 
         [Theory]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -118,8 +118,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             // Request made while shutting down is rejected.
             var rejectedRequest = await Http3Api.CreateRequestStream();
-            await rejectedRequest.SendHeadersAsync(Headers);
-            await rejectedRequest.EndStreamAsync();
             await rejectedRequest.WaitForStreamErrorAsync(Http3ErrorCode.RequestRejected);
 
             // End active request.

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2127,7 +2127,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await Http3Api.WaitForConnectionErrorAsync<Http3ConnectionErrorException>(
                 ignoreNonGoAwayFrames: true,
-                expectedLastStreamId: 8,
+                expectedLastStreamId: 4,
                 expectedErrorCode: Http3ErrorCode.UnexpectedFrame,
                 expectedErrorMessage: CoreStrings.FormatHttp3ErrorUnsupportedFrameOnRequestStream(Http3Formatting.ToFormattedType(f)));
         }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
@@ -225,7 +225,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             await Http3Api.WaitForConnectionErrorAsync<ConnectionAbortedException>(
                 ignoreNonGoAwayFrames: false,
-                expectedLastStreamId: 8,
+                expectedLastStreamId: 4,
                 Http3ErrorCode.InternalError,
                 null);
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -1149,12 +1149,12 @@ namespace Interop.FunctionalTests.Http3
                 .ConfigureServices(AddTestLogging)
                 .ConfigureHostOptions(o =>
                 {
-                    //if (Debugger.IsAttached)
-                    //{
-                    //    // Avoid timeout while debugging.
-                    //    o.ShutdownTimeout = TimeSpan.FromHours(1);
-                    //}
-                    //else
+                    if (Debugger.IsAttached)
+                    {
+                        // Avoid timeout while debugging.
+                        o.ShutdownTimeout = TimeSpan.FromHours(1);
+                    }
+                    else
                     {
                         o.ShutdownTimeout = TimeSpan.FromSeconds(1);
                     }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -819,7 +819,7 @@ namespace Interop.FunctionalTests.Http3
                 await WaitForLogAsync(logs =>
                 {
                     return logs.Any(w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Http3" &&
-                                         w.Message.Contains("Highest opened stream ID 4611686018427387903 in GOAWAY."));
+                                         w.Message.Contains("GOAWAY stream ID 4611686018427387903."));
                 }, "Check for initial GOAWAY frame sent on server initiated shutdown.");
 
                 // TODO https://github.com/dotnet/runtime/issues/56944
@@ -838,7 +838,7 @@ namespace Interop.FunctionalTests.Http3
                 await WaitForLogAsync(logs =>
                 {
                     return logs.Any(w => w.LoggerName == "Microsoft.AspNetCore.Server.Kestrel.Http3" &&
-                                         w.Message.Contains("Highest opened stream ID 0 in GOAWAY."));
+                                         w.Message.Contains("GOAWAY stream ID 4."));
                 }, "Check for exact GOAWAY frame sent on server initiated shutdown.");
 
                 await WaitForLogAsync(logs =>

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -742,7 +742,7 @@ namespace Interop.FunctionalTests.Http3
             }
         }
 
-        [ConditionalFact(Skip = "https://github.com/dotnet/runtime/issues/56766")]
+        [ConditionalFact]
         [MsQuicSupported]
         public async Task GET_ClientDisconnected_ConnectionAbortRaised()
         {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -745,7 +745,7 @@ namespace Interop.FunctionalTests.Http3
                     request1.Version = HttpVersion.Version30;
                     request1.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
 
-                    var response1 = await client.SendAsync(request1);
+                    var response1 = await client.SendAsync(request1, CancellationToken.None);
                     response1.EnsureSuccessStatusCode();
 
                     await connectionStartedTcs.Task.DefaultTimeout();
@@ -789,7 +789,7 @@ namespace Interop.FunctionalTests.Http3
                 request1.Version = HttpVersion.Version30;
                 request1.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
 
-                var responseTask = client.SendAsync(request1);
+                var responseTask = client.SendAsync(request1, CancellationToken.None);
 
                 // Connection started.
                 var connection = await connectionStartedTcs.Task.DefaultTimeout();
@@ -861,7 +861,7 @@ namespace Interop.FunctionalTests.Http3
                 request1.Version = HttpVersion.Version30;
                 request1.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
 
-                var responseTask = client.SendAsync(request1);
+                var responseTask = client.SendAsync(request1, CancellationToken.None);
 
                 // Connection started.
                 var connection = await connectionStartedTcs.Task.DefaultTimeout();

--- a/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/FeatureCollectionGenerator.cs
@@ -130,7 +130,7 @@ namespace {namespaceName}
                     feature = ExtraFeatureGet(key);
                 }}
 
-                return feature{(string.IsNullOrEmpty(fallbackFeatures) ? "" : $" ?? {fallbackFeatures}[key]")};
+                return feature{(string.IsNullOrEmpty(fallbackFeatures) ? "" : $" ?? {fallbackFeatures}?[key]")};
             }}
 
             set
@@ -164,7 +164,7 @@ namespace {namespaceName}
                 feature = (TFeature?)(ExtraFeatureGet(typeof(TFeature)));
             }}{(string.IsNullOrEmpty(fallbackFeatures) ? "" : $@"
 
-            if (feature == null)
+            if (feature == null && {fallbackFeatures} != null)
             {{
                 feature = {fallbackFeatures}.Get<TFeature>();
             }}")}

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
@@ -24,8 +24,7 @@ namespace CodeGenerator
                 "IProtocolErrorCodeFeature",
                 "IStreamDirectionFeature",
                 "IStreamIdFeature",
-                "IStreamAbortFeature",
-                "ITlsConnectionFeature"
+                "IStreamAbortFeature"
             };
 
             var implementedFeatures = new[]
@@ -47,7 +46,7 @@ using Microsoft.AspNetCore.Http.Features;";
                 allFeatures: allFeatures,
                 implementedFeatures: implementedFeatures,
                 extraUsings: usings,
-                fallbackFeatures: null);
+                fallbackFeatures: "MultiplexedConnectionFeatures");
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35026

This PR kind of just grew and now fixes a lot of things:

* Fallback to multiplex features
* Fix stream ID in GOAWAY. It doesn't signal rejection of stream IDs greater than this value, it signals rejection of stream IDs greater **or equal** to this value. Basically, we need to add 4 to the value sent.
* Many graceful shutdown fixes
  * Send GOAWAY at correct times
  * Abort incoming requests with H3_REQUEST_REJECTED error code
  * Correctly listen to `IConnectionLifetimeNotificationFeature`
* Fix race between pooling a stream and aborting its remaining reads
* Log error codes for stream and connection aborts
* Log GOAWAY stream ID
* Lock connection shutdown and throw passed in abortReason from AcceptAsync.