### PR TITLE
Revert "Enable client cert renegotiation tests on linux"

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -531,7 +531,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [ConditionalTheory]
         [InlineData(HttpProtocols.Http1)]
         [InlineData(HttpProtocols.Http1AndHttp2)] // Make sure turning on Http/2 doesn't regress HTTP/1
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
         public async Task CanRenegotiateForClientCertificate(HttpProtocols httpProtocols)
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -540,7 +540,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 listenOptions.UseHttps(options =>
                 {
                     options.ServerCertificate = _x509Certificate2;
-                    options.SslProtocols = SslProtocols.Tls12; // Linux doesn't support renegotiate on TLS1.3 yet. https://github.com/dotnet/runtime/issues/55757
                     options.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
                     options.AllowAnyClientCertificate();
                 });
@@ -613,7 +612,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
         public async Task CanRenegotiateForTlsCallbackOptions()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -626,7 +625,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         return ValueTask.FromResult(new SslServerAuthenticationOptions()
                         {
                             ServerCertificate = _x509Certificate2,
-                            EnabledSslProtocols = SslProtocols.Tls12, // Linux doesn't support renegotiate on TLS1.3 yet. https://github.com/dotnet/runtime/issues/55757
                             ClientCertificateRequired = false,
                             RemoteCertificateValidationCallback = (_, _, _, _) => true,
                         });
@@ -660,7 +658,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
         public async Task CanRenegotiateForClientCertificateOnHttp1CanReturnNoCert()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -669,7 +667,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 listenOptions.UseHttps(options =>
                 {
                     options.ServerCertificate = _x509Certificate2;
-                    options.SslProtocols = SslProtocols.Tls12; // Linux doesn't support renegotiate on TLS1.3 yet. https://github.com/dotnet/runtime/issues/55757
                     options.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
                     options.AllowAnyClientCertificate();
                 });
@@ -710,7 +707,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [ConditionalFact]
         // TLS 1.2 and lower have to renegotiate the whole connection to get a client cert, and if that hits an error
         // then the connection is aborted.
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
         public async Task RenegotiateForClientCertificateOnPostWithoutBufferingThrows_TLS12()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -755,7 +752,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         // TLS 1.3 uses a new client cert negotiation extension that doesn't cause the connection to abort
         // for this error.
         [MinimumOSVersion(OperatingSystems.Windows, "10.0.20145")] // Needs a preview version with TLS 1.3 enabled.
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "https://github.com/dotnet/runtime/issues/55757")]
+        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
         public async Task RenegotiateForClientCertificateOnPostWithoutBufferingThrows_TLS13()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -891,7 +888,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
         public async Task CanRenegotiateForClientCertificateOnPostIfDrained()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -900,7 +897,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 listenOptions.UseHttps(options =>
                 {
                     options.ServerCertificate = _x509Certificate2;
-                    options.SslProtocols = SslProtocols.Tls12; // Linux doesn't support renegotiate on TLS1.3 yet. https://github.com/dotnet/runtime/issues/55757
                     options.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
                     options.AllowAnyClientCertificate();
                 });


### PR DESCRIPTION
Reverts dotnet/aspnetcore#34853

This caused failures on Redhat 7, reverting while we investigate.

https://dev.azure.com/dnceng/public/_build/results?buildId=1272938&view=ms.vss-test-web.build-test-results-tab&runId=37646264&resultId=108909&paneView=debug

```
System.IO.IOException : The read operation failed, see inner exception.
---- System.Security.Authentication.AuthenticationException : Authentication failed, see inner exception.
-------- Interop+OpenSsl+SslException : SSL Handshake failed with OpenSSL error - SSL_ERROR_SSL.
------------ Interop+Crypto+OpenSslCryptographicException : error:1408E0F4:SSL routines:ssl3_get_message:unexpected message
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](TIOAdapter adapter, Memory`1 buffer) in System.Net.Security.dll:token 0x6000339+0x402
   at System.IO.StreamReader.ReadBufferAsync(CancellationToken cancellationToken) in System.Private.CoreLib.dll:token 0x6005eab+0xe8
   at System.IO.StreamReader.ReadLineAsyncInternal() in System.Private.CoreLib.dll:token 0x6005ea3+0xa0
   at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.HttpsConnectionMiddlewareTests.AssertConnectionResult(SslStream stream, Boolean success, String body) in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs:line 1315
   at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.HttpsConnectionMiddlewareTests.CanRenegotiateForClientCertificateOnPostIfDrained() in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs:line 936
   at Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.HttpsConnectionMiddlewareTests.CanRenegotiateForClientCertificateOnPostIfDrained() in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs:line 936
--- End of stack trace from previous location ---
----- Inner Stack Trace -----
   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](TIOAdapter adapter, Boolean receiveFirst, Byte[] reAuthenticationData, Boolean isApm) in System.Net.Security.dll:token 0x600032c+0x517
   at System.Net.Security.SslStream.ReplyOnReAuthenticationAsync[TIOAdapter](TIOAdapter adapter, Byte[] buffer) in System.Net.Security.dll:token 0x600032a+0x7c
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](TIOAdapter adapter, Memory`1 buffer) in System.Net.Security.dll:token 0x6000339+0x2ec
----- Inner Stack Trace -----
   at Interop.OpenSsl.DoSslHandshake(SafeSslHandle context, ReadOnlySpan`1 input, Byte[]& sendBuf, Int32& sendCount) in System.Net.Security.dll:token 0x600008c+0xd2
   at System.Net.Security.SslStreamPal.HandshakeInternal(SafeFreeCredentials credential, SafeDeleteSslContext& context, ReadOnlySpan`1 inputBuffer, Byte[]& outputBuffer, SslAuthenticationOptions sslAuthenticationOptions) in System.Net.Security.dll:token 0x6000459+0x20
----- Inner Stack Trace -----
```

@wfurt 