### PR TITLE
Use PoolingAsyncValueTaskMethodBuilder on various ReadAsync methods.

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -29,6 +30,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _unexaminedInputLength = contentLength;
         }
 
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
         public override async ValueTask<ReadResult> ReadAsyncInternal(CancellationToken cancellationToken = default)
         {
             VerifyIsNotReading();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1UpgradeMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1UpgradeMessageBody.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -92,6 +93,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             return new ValueTask<ReadResult>(readResult);
         }
 
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
         private async ValueTask<ReadResult> ReadAsyncInternalAwaited(ValueTask<ReadResult> readTask, CancellationToken cancellationToken = default)
         {
             var readResult = await readTask;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2MessageBody.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -89,6 +90,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             return hasResult;
         }
 
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
         public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
         {
             await TryStartAsync();

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3MessageBody.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -68,6 +69,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             return hasResult;
         }
 
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
         public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
         {
             await TryStartAsync();

--- a/src/Shared/ServerInfrastructure/DuplexPipeStream.cs
+++ b/src/Shared/ServerInfrastructure/DuplexPipeStream.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Buffers;
 using Microsoft.AspNetCore.Internal;
+using System.Runtime.CompilerServices;
 
 #nullable enable
 
@@ -112,6 +113,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             return _output.FlushAsync(cancellationToken).GetAsTask();
         }
 
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
         private async ValueTask<int> ReadAsyncInternal(Memory<byte> destination, CancellationToken cancellationToken)
         {
             while (true)


### PR DESCRIPTION
Use `[AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]` on Kestrel ReadAsync methods to remove per read allocations in the mainline body reading logic.

Will collect allocation metrics before/after.

Fixes https://github.com/dotnet/aspnetcore/issues/34645