### PR TITLE
Source build patches necessary for tarball build

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -754,7 +754,7 @@ stages:
       platform:
         name: 'Managed'
         container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-f39df28-20191023143754'
-        buildScript: './eng/build.sh $(_PublishArgs)'
+        buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
         skipPublishValidation: true
 
   # Publish to the BAR

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -47,7 +47,7 @@
           BeforeTargets="Execute">
 
     <Exec
-      Command="./eng/build.sh --only-build-repo-tasks"
+      Command="./eng/build.sh --only-build-repo-tasks -bl"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -13,7 +13,7 @@
   <!-- Update the generated files when we restore projects. Skip in desktop msbuild due to VS 16.8 requirements. -->
   <Target Name="GenerateDirectoryBuildFiles"
       AfterTargets="Restore"
-      Condition=" '$(DotNetBuildFromSource)' != 'true' AND '$(MSBuildRuntimeType)' == 'core' ">
+      Condition=" '$(MSBuildRuntimeType)' == 'core' ">
     <!-- Separate invocations and use different properties to ensure second can load the restored package info. -->
     <MSBuild Projects="$(RepoRoot)eng\tools\GenerateFiles\GenerateFiles.csproj"
         RemoveProperties="BaseIntermediateOutputPath"

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <!-- Use fixed version instead of $(DefaultNetCoreTargetFramework) to avoid needing workarounds set up here. -->
     <TargetFramework>net5.0</TargetFramework>
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">


### PR DESCRIPTION
These are various changes needed while building aspnetcore within the source-build tarball.  See https://github.com/dotnet/installer/pull/11113 for context.

1. Tweak CI to not build the RepoTasks in the "outer" build.  This gets invoked within the "inner" source-build.  This more accurately reflects how the source-build tarball build works.  This will surface/catch more issues at the repo level.
2. Capture the binaryLog while building RepoTasks for source-build.
3. Update the RepoTasks' Microsoft.Extensions.DependencyModel reference to use the version specified in the versions.props file.  This allows the RepoTasks to pickup the version that is source-built during source builds.  This eliminates a pre-built.
4. Refactor the GenerateFiles to run for source build.  The generated props and target files are necessary for source build.
