### PR TITLE
Run analyzers in VS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,13 +15,6 @@
     <AnalysisMode>Default</AnalysisMode>
   </PropertyGroup>
 
-  <!-- See https://github.com/dotnet/roslyn/issues/54867 for more info. -->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '17.0'))">
-    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
-    <RunAnalyzers>false</RunAnalyzers>
-  </PropertyGroup>
-
   <!-- Defines project type conventions. -->
   <PropertyGroup>
     <RepoRelativeProjectDir>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</RepoRelativeProjectDir>


### PR DESCRIPTION
This undoes #34664. I'm no longer seeing the TypeLoadExceptions I did before when I disabled the analyzers. Leaving this on in VS makes seeing analyzer warnings and applying fixes for things like public API and unnecessary using much easier.

It'd be nice if reviewers could make this change locally and confirm this is also the case for them.

There's another similar check in CSharp.Common.targets, but I still see an error if I try to remove that.

https://github.com/dotnet/aspnetcore/blob/176d2ae7cf93a1fc6f1b8a59fac8a61922bdaa86/eng/targets/CSharp.Common.targets#L39-L40

![image](https://user-images.githubusercontent.com/54385/128242241-044568f2-d02a-49ec-873d-4dad1296c3c4.png)

<details>
<summary>Stack trace</summary>

```
StreamJsonRpc.RemoteInvocationException: Could not load type 'Microsoft.CodeAnalysis.CSharp.Syntax.BaseNamespaceDeclarationSyntax' from assembly 'Microsoft.CodeAnalysis.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
   at StreamJsonRpc.JsonRpc.<InvokeCoreAsync>d__139`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Remote.BrokeredServiceConnection`1.<TryInvokeAsync>d__17`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)
RPC server exception:
System.TypeLoadException: Could not load type 'Microsoft.CodeAnalysis.CSharp.Syntax.BaseNamespaceDeclarationSyntax' from assembly 'Microsoft.CodeAnalysis.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
      at System.Signature.GetSignature(Void* pCorSig, Int32 cCorSig, RuntimeFieldHandleInternal fieldHandle, IRuntimeMethodInfo methodHandle, RuntimeType declaringType)
      at System.Reflection.RuntimeMethodInfo.FetchNonReturnParameters()
      at System.Reflection.RuntimeMethodInfo.GetParameters()
      at System.Diagnostics.StackTrace.ToString(TraceFormat traceFormat)
      at System.Exception.GetStackTrace(Boolean needFileInfo)
      at System.Exception.ToString(Boolean needFileLineInfo, Boolean needMessage)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExceptionDescriptionBuilder.CreateDiagnosticDescription(Exception exception)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.CreateDiagnosticDescription(Nullable`1 info, Exception e)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.CreateAnalyzerExceptionDiagnostic(DiagnosticAnalyzer analyzer, Exception e, Nullable`1 info)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteSyntaxNodeAction[TLanguageKindEnum](SyntaxNodeAnalyzerAction`1 syntaxNodeAction, SyntaxNode node, ISymbol containingSymbol, SemanticModel semanticModel, Action`1 addDiagnostic, Func`2 isSupportedDiagnostic, SyntaxNodeAnalyzerStateData analyzerState)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteSyntaxNodeActions[TLanguageKindEnum](SyntaxNode node, ImmutableSegmentedDictionary`2 nodeActionsByKind, ISymbol containingSymbol, SemanticModel model, Func`2 getKind, Action`1 addDiagnostic, Func`2 isSupportedDiagnostic, SyntaxNodeAnalyzerStateData analyzerState)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteSyntaxNodeActions[TLanguageKindEnum](IEnumerable`1 nodesToAnalyze, ImmutableSegmentedDictionary`2 nodeActionsByKind, DiagnosticAnalyzer analyzer, ISymbol containingSymbol, SemanticModel model, Func`2 getKind, Action`1 addDiagnostic, Func`2 isSupportedDiagnostic, SyntaxNodeAnalyzerStateData analyzerState)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteSyntaxNodeActionsCore[TLanguageKindEnum](IEnumerable`1 nodesToAnalyze, ImmutableSegmentedDictionary`2 nodeActionsByKind, DiagnosticAnalyzer analyzer, ISymbol containingSymbol, SemanticModel model, Func`2 getKind, TextSpan filterSpan, SyntaxNodeAnalyzerStateData analyzerState, Boolean isGeneratedCode)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.TryExecuteSyntaxNodeActions[TLanguageKindEnum](IEnumerable`1 nodesToAnalyze, ImmutableSegmentedDictionary`2 nodeActionsByKind, DiagnosticAnalyzer analyzer, SemanticModel model, Func`2 getKind, TextSpan filterSpan, Int32 declarationIndex, ISymbol declaredSymbol, AnalysisScope analysisScope, AnalysisState analysisState, Boolean isGeneratedCode)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver`1.<>c__DisplayClass12_0.<TryExecuteDeclaringReferenceActions>g__executeNodeActionsByKind|2(AnalysisScope analysisScope, ImmutableArray`1 nodesToAnalyze, GroupedAnalyzerActions groupedActions)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver`1.<>c__DisplayClass12_0.<TryExecuteDeclaringReferenceActions>g__executeNodeActions|1()
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver`1.TryExecuteDeclaringReferenceActions(SyntaxReference decl, Int32 declarationIndex, SymbolDeclaredCompilationEvent symbolEvent, AnalysisScope analysisScope, AnalysisState analysisState, GroupedAnalyzerActions coreActions, GroupedAnalyzerActions additionalPerSymbolActions, Boolean shouldExecuteSyntaxNodeActions, Boolean shouldExecuteOperationActions, Boolean shouldExecuteCodeBlockActions, Boolean shouldExecuteOperationBlockActions, Boolean isInGeneratedCode, CancellationToken cancellationToken)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver`1.TryExecuteDeclaringReferenceActions(SymbolDeclaredCompilationEvent symbolEvent, AnalysisScope analysisScope, AnalysisState analysisState, Boolean isGeneratedCodeSymbol, IGroupedAnalyzerActions additionalPerSymbolActions, CancellationToken cancellationToken)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver.<TryProcessSymbolDeclaredAsync>d__132.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver.<TryProcessEventCoreAsync>d__131.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver.<ProcessEventAsync>d__129.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver.<ProcessCompilationEventsCoreAsync>d__128.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver.<>c__DisplayClass127_0.<<ProcessCompilationEventsAsync>b__2>d.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver.<ProcessCompilationEventsAsync>d__127.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver.<ExecutePrimaryAnalysisTaskAsync>d__96.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver.<AttachQueueAndProcessAllEventsAsync>d__94.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.<ComputeAnalyzerDiagnosticsCoreAsync>d__72.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.<>c__DisplayClass67_1.<<ComputeAnalyzerDiagnosticsAsync>b__1>d.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.<ComputeAnalyzerDiagnosticsAsync>d__67.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.<ComputeAnalyzerSemanticDiagnosticsAsync>d__66.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.<GetAnalysisResultCoreAsync>d__64.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.Extensions.<GetAnalysisResultAsync>d__12.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Diagnostics.Extensions.<GetAnalysisResultAsync>d__11.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Remote.Diagnostics.DiagnosticComputer.<AnalyzeAsync>d__9.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Remote.Diagnostics.DiagnosticComputer.<GetDiagnosticsAsync>d__8.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Remote.RemoteDiagnosticAnalyzerService.<>c__DisplayClass3_0.<<CalculateDiagnosticsAsync>b__0>d.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
      at Microsoft.CodeAnalysis.Remote.BrokeredServiceBase.<RunServiceImplAsync>d__12`1.MoveNext()
   --- End of stack trace from previous location where exception was thrown ---
      at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
      at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)
```
</details>