### PR TITLE
Use Fedora queue that supports msquic

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -16,6 +16,11 @@
     <HelixAvailableTargetQueue Include="Windows.10.Amd64.Server20H2.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="OSX.1014.Amd64.Open" Platform="OSX" />
   </ItemGroup>
+  
+  <!-- Quarantined test queues -->
+  <ItemGroup Condition="'$(IsRequiredCheck)' == 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(RunQuarantinedTests)' == 'true'">
+    <HelixAvailableTargetQueue Include="(Fedora.34.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210728124700-4f64125" Platform="Linux" />
+  </ItemGroup>
 
   <!-- queues for helix-matrix.yml pipeline -->
   <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -23,7 +23,7 @@
     <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
     <HelixAvailableTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="(Fedora.33.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-helix-20210120000908-a9df267" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="(Fedora.34.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210728124700-4f64125" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Alpine.312.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Mariner)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620" Platform="Linux" />    
   </ItemGroup>

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class QuicConnectionContextTests : TestApplicationErrorLoggerLoggedTest
     {
         private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
     {
         [ConditionalFact]

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
@@ -20,6 +20,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class QuicStreamContextTests : TestApplicationErrorLoggerLoggedTest
     {
         private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTransportFactoryTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTransportFactoryTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class QuicTransportFactoryTests : TestApplicationErrorLoggerLoggedTest
     {
         [ConditionalFact]

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class WebHostTests : LoggedTest
     {
         [ConditionalFact]

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 
 namespace Interop.FunctionalTests.Http3
 {
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class Http3RequestTests : LoggedTest
     {
         private class StreamingHttpContext : HttpContent


### PR DESCRIPTION
Seeing if this is sufficient to satisfy the `MsQuicSupported` attribute and get quic tests running on at least 1 Linux helix queue.

Partially addresses https://github.com/dotnet/aspnetcore/issues/34741, but we still need to get tests running on Windows/OSX