### PR TITLE
Bind to "port 0" again in project template tests

### DIFF
--- a/src/ProjectTemplates/Shared/AspNetProcess.cs
+++ b/src/ProjectTemplates/Shared/AspNetProcess.cs
@@ -79,7 +79,11 @@ namespace Templates.Test.Helpers
             else
             {
                 process = DotNetMuxer.MuxerPathOrDefault();
-                arguments = "run --no-build";
+
+                // When executing "dotnet run", the launch urls specified in the app's launchSettings.json have higher precedence
+                // than ambient environment variables. We specify the urls using command line arguments instead to allow us
+                // to continue binding to "port 0" and avoid test flakiness due to port conflicts.
+                arguments = $"run --no-build --urls \"{environmentVariables["ASPNETCORE_URLS"]}\"";
             }
 
             logger?.LogInformation($"AspNetProcess - process: {process} arguments: {arguments}");

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -160,31 +160,6 @@ namespace Templates.Test.Helpers
                 ["ASPNETCORE_Logging__Console__FormatterOptions__IncludeScopes"] = "true",
             };
 
-            var launchSettingsJson = Path.Combine(TemplateOutputDir, "Properties", "launchSettings.json");
-            if (File.Exists(launchSettingsJson))
-            {
-                // When executing "dotnet run", the launch urls specified in the app's launchSettings.json have higher precedence
-                // than ambient environment variables. When present, we have to edit this file to allow the application to pick random ports.
-                var original = File.ReadAllText(launchSettingsJson);
-                var updated = original.Replace(
-                    "\"applicationUrl\": \"https://localhost:5001;http://localhost:5000\"",
-                    $"\"applicationUrl\": \"{_urls}\"");
-
-                if (updated == original)
-                {
-                    Output.WriteLine("applicationUrl is not specified in launchSettings.json");
-                }
-                else
-                {
-                    Output.WriteLine("Updating applicationUrl in launchSettings.json");
-                    File.WriteAllText(launchSettingsJson, updated);
-                }
-            }
-            else
-            {
-                Output.WriteLine("No launchSettings.json found to update.");
-            }
-
             var projectDll = Path.Combine(TemplateBuildDir, $"{ProjectName}.dll");
             return new AspNetProcess(DevCert, Output, TemplateOutputDir, projectDll, environment, published: false, hasListeningUri: hasListeningUri, logger: logger);
         }


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/pull/34410 which randomizes the ports passed to Kestrel via launchSettings.json broke the logic in our template tests to bind to "port 0" in the `dotnet run` case causing port conflicts and test flakiness. The publish case continued to work.

Fixes #35041

And yes @BrennanConroy, this time I really do mean fixes since tests weren't quarantined 😆 