### PR TITLE
Remove GetCallingAssembly usage

### DIFF
--- a/src/DefaultBuilder/DefaultBuilder.slnf
+++ b/src/DefaultBuilder/DefaultBuilder.slnf
@@ -6,11 +6,11 @@
       "src\\DefaultBuilder\\src\\Microsoft.AspNetCore.csproj",
       "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.FunctionalTests\\Microsoft.AspNetCore.FunctionalTests.csproj",
       "src\\DefaultBuilder\\test\\Microsoft.AspNetCore.Tests\\Microsoft.AspNetCore.Tests.csproj",
+      "src\\Extensions\\Features\\src\\Microsoft.Extensions.Features.csproj",
       "src\\Hosting\\Abstractions\\src\\Microsoft.AspNetCore.Hosting.Abstractions.csproj",
       "src\\Hosting\\Hosting\\src\\Microsoft.AspNetCore.Hosting.csproj",
       "src\\Hosting\\Server.Abstractions\\src\\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj",
       "src\\Hosting\\Server.IntegrationTesting\\src\\Microsoft.AspNetCore.Server.IntegrationTesting.csproj",
-      "src\\Extensions\\Features\\src\\Microsoft.Extensions.Features.csproj",
       "src\\Http\\Authentication.Abstractions\\src\\Microsoft.AspNetCore.Authentication.Abstractions.csproj",
       "src\\Http\\Authentication.Core\\src\\Microsoft.AspNetCore.Authentication.Core.csproj",
       "src\\Http\\Headers\\src\\Microsoft.Net.Http.Headers.csproj",
@@ -34,6 +34,7 @@
       "src\\Servers\\IIS\\IIS\\src\\Microsoft.AspNetCore.Server.IIS.csproj",
       "src\\Servers\\Kestrel\\Core\\src\\Microsoft.AspNetCore.Server.Kestrel.Core.csproj",
       "src\\Servers\\Kestrel\\Kestrel\\src\\Microsoft.AspNetCore.Server.Kestrel.csproj",
+      "src\\Servers\\Kestrel\\Transport.Quic\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.csproj",
       "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj"
     ]
   }

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -86,14 +86,14 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="args">Command line arguments</param>
         /// <returns>The <see cref="WebApplication"/>.</returns>
         public static WebApplication Create(string[]? args = null) =>
-            new WebApplicationBuilder(Assembly.GetCallingAssembly(), new() { Args = args }).Build();
+            new WebApplicationBuilder(new() { Args = args }).Build();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebApplicationBuilder"/> class with preconfigured defaults.
         /// </summary>
         /// <returns>The <see cref="WebApplicationBuilder"/>.</returns>
         public static WebApplicationBuilder CreateBuilder() =>
-            new WebApplicationBuilder(Assembly.GetCallingAssembly(), new());
+            new(new());
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebApplicationBuilder"/> class with preconfigured defaults.
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="args">Command line arguments</param>
         /// <returns>The <see cref="WebApplicationBuilder"/>.</returns>
         public static WebApplicationBuilder CreateBuilder(string[] args) =>
-            new WebApplicationBuilder(Assembly.GetCallingAssembly(), new() { Args = args });
+            new(new() { Args = args });
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebApplicationBuilder"/> class with preconfigured defaults.
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="options">The <see cref="WebApplicationOptions"/> to configure the <see cref="WebApplicationBuilder"/>.</param>
         /// <returns>The <see cref="WebApplicationBuilder"/>.</returns>
         public static WebApplicationBuilder CreateBuilder(WebApplicationOptions options) =>
-            new WebApplicationBuilder(Assembly.GetCallingAssembly(), options);
+            new(options);
 
         /// <summary>
         /// Start the application.

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private WebApplication? _builtApplication;
 
-        internal WebApplicationBuilder(Assembly? callingAssembly, WebApplicationOptions options, Action<IHostBuilder>? configureDefaults = null)
+        internal WebApplicationBuilder(WebApplicationOptions options, Action<IHostBuilder>? configureDefaults = null)
         {
             Services = _services;
 
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Builder
 
                 // We need to override the application name since the call to Configure will set it to
                 // be the calling assembly's name.
-                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, (callingAssembly ?? Assembly.GetEntryAssembly())?.GetName()?.Name ?? string.Empty);
+                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, (Assembly.GetEntryAssembly())?.GetName()?.Name ?? string.Empty);
             });
 
             // Apply the args to host configuration last since ConfigureWebHostDefaults overrides a host specific setting (the application name).

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -386,7 +386,7 @@ namespace Microsoft.AspNetCore.Tests
         [Fact]
         public void WebApplicationBuilderApplicationNameCanBeOverridden()
         {
-            var assemblyName = Assembly.GetEntryAssembly().GetName().Name;
+            var assemblyName = typeof(WebApplicationTests).Assembly.GetName().Name;
 
             var options = new WebApplicationOptions
             {

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -262,7 +262,6 @@ namespace Microsoft.AspNetCore.Tests
             };
 
             var builder = new WebApplicationBuilder(
-                typeof(WebApplicationTests).Assembly,
                 options,
                 bootstrapBuilder =>
                 {
@@ -299,7 +298,6 @@ namespace Microsoft.AspNetCore.Tests
             };
 
             var builder = new WebApplicationBuilder(
-                typeof(WebApplicationTests).Assembly,
                 options,
                 bootstrapBuilder =>
                 {
@@ -333,7 +331,6 @@ namespace Microsoft.AspNetCore.Tests
             };
 
             var builder = new WebApplicationBuilder(
-                typeof(WebApplicationTests).Assembly,
                 options,
                 bootstrapBuilder =>
                 {
@@ -351,6 +348,42 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
+        public void WebApplicationBuilderApplicationNameDefaultsToEntryAssembly()
+        {
+            var assemblyName = Assembly.GetEntryAssembly().GetName().Name;
+
+            var builder = new WebApplicationBuilder(
+                new(),
+                bootstrapBuilder =>
+                {
+                    // Verify the defaults observed by the boostrap host builder we use internally to populate
+                    // the defaults
+                    bootstrapBuilder.ConfigureAppConfiguration((context, config) =>
+                    {
+                        Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+                    });
+                });
+
+            Assert.Equal(assemblyName, builder.Environment.ApplicationName);
+            builder.Host.ConfigureAppConfiguration((context, config) =>
+            {
+                Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+            });
+
+            builder.WebHost.ConfigureAppConfiguration((context, config) =>
+            {
+                Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+            });
+
+            var app = builder.Build();
+            var hostEnv = app.Services.GetRequiredService<IHostEnvironment>();
+            var webHostEnv = app.Services.GetRequiredService<IWebHostEnvironment>();
+
+            Assert.Equal(assemblyName, hostEnv.ApplicationName);
+            Assert.Equal(assemblyName, webHostEnv.ApplicationName);
+        }
+
+        [Fact]
         public void WebApplicationBuilderApplicationNameCanBeOverridden()
         {
             var assemblyName = Assembly.GetEntryAssembly().GetName().Name;
@@ -361,7 +394,6 @@ namespace Microsoft.AspNetCore.Tests
             };
 
             var builder = new WebApplicationBuilder(
-                typeof(WebApplicationTests).Assembly,
                 options,
                 bootstrapBuilder =>
                 {


### PR DESCRIPTION
- Today the WebApplicationBuilder tries to guess what the application name should be based on the immediate caller of the API using Assembly.GetCallingAssembly. This is because several components use the application name as a way to find the application assembly in order to do other things;
- User secrets uses it to find the location of the  directory that holds configuration secrets.
- MVC uses it as the assembly to start the search for controllers, pages, etc.
- Identifty uses it to find application parts.
This API is a bit fragile for internal refactoring (if the immediate caller is anything except for user code, then we will treat our own assembly as the calling assembly) and more importantly, it breaks in NativeAOT scenarios. Instead of the calling assembly, we now default to the entry assembly.
- This will "break" in scenarios where the WebApplication is started in a library and the entry point is the host application (controllers will be scanned in potentially the wrong place by default or it will find the wrong controllers).
- Now that we have the option that allows specifying the name of the application name via WebApplicationOptions, In the future, we're investigating ways that the compiler can inject the calling assembly via an attribute similar to [CallerMemberName] that would capture the calling assembly in a more reliable and AOT friendly way.
- Added a test that asserts that the default application name is the entry assembly.
- Updated the slnf file

Fixes #34838 