### PR TITLE
Unquarantine Reset_PriorOSVersions_NotSupported

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Http2Tests.cs
@@ -624,7 +624,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys.FunctionalTests
             Assert.Equal("Hello World", response);
         }
 
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34003")]
         [ConditionalFact]
         [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10, SkipReason = "Http2 requires Win10")]
         [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "This is last version without Reset support")]


### PR DESCRIPTION
Fixes #34003, the issue was caused by an problem on the CI agents that has since been fixed and the test now passes 100%.