### PR TITLE
Guard against null BrowserManager

### DIFF
--- a/src/Shared/BrowserTesting/src/BrowserTestBase.cs
+++ b/src/Shared/BrowserTesting/src/BrowserTestBase.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.BrowserTesting
             return builder.Build();
         }
 
-        public virtual Task DisposeAsync() => BrowserManager.DisposeAsync();
+        public virtual Task DisposeAsync() => BrowserManager?.DisposeAsync();
 
         private ITestOutputHelper _output;
         public ITestOutputHelper Output


### PR DESCRIPTION
Fixes for dispose null refs in https://dev.azure.com/dnceng/public/_test/analytics?definitionId=331&contextType=build for BlazorTemplateTests

