### PR TITLE
Bump Swashbuckle.AspNetCore version used in templates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -255,7 +255,7 @@
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.2.4</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>3.1.1</SystemReactiveLinqVersion>
-    <SwashbuckleAspNetCoreVersion>5.6.3</SwashbuckleAspNetCoreVersion>
+    <SwashbuckleAspNetCoreVersion>6.1.5</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
     <XunitAnalyzersVersion>0.10.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.1</XunitVersion>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/34558.

Update Swashbuckle.AspNetCore to bring in the following fixes:

- https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2173
- https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2125