### PR TITLE
Re-Enable client cert renegotiation tests on linux

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -531,7 +531,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [ConditionalTheory]
         [InlineData(HttpProtocols.Http1)]
         [InlineData(HttpProtocols.Http1AndHttp2)] // Make sure turning on Http/2 doesn't regress HTTP/1
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
         public async Task CanRenegotiateForClientCertificate(HttpProtocols httpProtocols)
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -540,6 +541,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 listenOptions.UseHttps(options =>
                 {
                     options.ServerCertificate = _x509Certificate2;
+                    options.SslProtocols = SslProtocols.Tls12; // Linux doesn't support renegotiate on TLS1.3 yet. https://github.com/dotnet/runtime/issues/55757
                     options.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
                     options.AllowAnyClientCertificate();
                 });
@@ -612,7 +614,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
         public async Task CanRenegotiateForTlsCallbackOptions()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -625,6 +628,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                         return ValueTask.FromResult(new SslServerAuthenticationOptions()
                         {
                             ServerCertificate = _x509Certificate2,
+                            EnabledSslProtocols = SslProtocols.Tls12, // Linux doesn't support renegotiate on TLS1.3 yet. https://github.com/dotnet/runtime/issues/55757
                             ClientCertificateRequired = false,
                             RemoteCertificateValidationCallback = (_, _, _, _) => true,
                         });
@@ -658,7 +662,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
         public async Task CanRenegotiateForClientCertificateOnHttp1CanReturnNoCert()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -667,6 +672,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 listenOptions.UseHttps(options =>
                 {
                     options.ServerCertificate = _x509Certificate2;
+                    options.SslProtocols = SslProtocols.Tls12; // Linux doesn't support renegotiate on TLS1.3 yet. https://github.com/dotnet/runtime/issues/55757
                     options.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
                     options.AllowAnyClientCertificate();
                 });
@@ -707,7 +713,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [ConditionalFact]
         // TLS 1.2 and lower have to renegotiate the whole connection to get a client cert, and if that hits an error
         // then the connection is aborted.
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
         public async Task RenegotiateForClientCertificateOnPostWithoutBufferingThrows_TLS12()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -752,7 +759,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         // TLS 1.3 uses a new client cert negotiation extension that doesn't cause the connection to abort
         // for this error.
         [MinimumOSVersion(OperatingSystems.Windows, "10.0.20145")] // Needs a preview version with TLS 1.3 enabled.
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
+        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "https://github.com/dotnet/runtime/issues/55757")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
         public async Task RenegotiateForClientCertificateOnPostWithoutBufferingThrows_TLS13()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -888,7 +896,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "Not supported yet.")]
+        [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
         public async Task CanRenegotiateForClientCertificateOnPostIfDrained()
         {
             void ConfigureListenOptions(ListenOptions listenOptions)
@@ -897,6 +906,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
                 listenOptions.UseHttps(options =>
                 {
                     options.ServerCertificate = _x509Certificate2;
+                    options.SslProtocols = SslProtocols.Tls12; // Linux doesn't support renegotiate on TLS1.3 yet. https://github.com/dotnet/runtime/issues/55757
                     options.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
                     options.AllowAnyClientCertificate();
                 });

--- a/src/Testing/src/xunit/HelixConstants.cs
+++ b/src/Testing/src/xunit/HelixConstants.cs
@@ -7,5 +7,6 @@ namespace Microsoft.AspNetCore.Testing
     {
         public const string Windows10Arm64 = "Windows.10.Arm64v8.Open;";
         public const string DebianArm64 = "Debian.9.Arm64.Open;";
+        public const string RedhatAmd64 = "Redhat.7.Amd64.Open;";
     }
 }


### PR DESCRIPTION
(re)Fixes #33566. This time we're skipping Redhat7 since it has an outdated version of OpenSsl that breaks the client.