### PR TITLE
Do not generate hot reload attributes on Blazor components

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.codegen.cs
@@ -8,8 +8,6 @@ namespace __GeneratedComponent
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
-    [global::Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemMetadataAttribute("Identifier", "/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml")]
-    [global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdateAttribute]
     public partial class AspNetCore_d3c3d6059615673cb46fc4974164d61eabadb890 : Microsoft.AspNetCore.Components.ComponentBase, IDisposable
     {
         #pragma warning disable 219

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.ir.txt
@@ -5,8 +5,6 @@ Document -
         UsingDirective - (51:2,1 [17] ) - System.Linq
         UsingDirective - (71:3,1 [28] ) - System.Threading.Tasks
         UsingDirective - (102:4,1 [37] ) - Microsoft.AspNetCore.Components
-        RazorCompiledItemMetadataAttribute - 
-        CreateNewOnMetadataUpdateAttribute - 
         ClassDeclaration -  - public partial - AspNetCore_d3c3d6059615673cb46fc4974164d61eabadb890 - Microsoft.AspNetCore.Components.ComponentBase - IDisposable
             DesignTimeDirective - 
                 DirectiveToken - (12:0,12 [11] BasicComponent.cshtml) - IDisposable

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.mappings.txt
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_DesignTime.mappings.txt
@@ -1,23 +1,23 @@
 Source Location: (12:0,12 [11] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |IDisposable|
-Generated Location: (913:19,0 [11] )
+Generated Location: (649:17,0 [11] )
 |IDisposable|
 
 Source Location: (38:1,13 [15] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |this.ToString()|
-Generated Location: (1512:37,13 [15] )
+Generated Location: (1248:35,13 [15] )
 |this.ToString()|
 
 Source Location: (79:3,5 [29] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |string.Format("{0}", "Hello")|
-Generated Location: (1709:45,6 [29] )
+Generated Location: (1445:43,6 [29] )
 |string.Format("{0}", "Hello")|
 
 Source Location: (132:6,12 [37] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml)
 |
     void IDisposable.Dispose(){ }
 |
-Generated Location: (1961:54,12 [37] )
+Generated Location: (1697:52,12 [37] )
 |
     void IDisposable.Dispose(){ }
 |

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_Runtime.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_Runtime.codegen.cs
@@ -9,8 +9,6 @@ namespace __GeneratedComponent
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
-    [global::Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemMetadataAttribute("Identifier", "/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent.cshtml")]
-    [global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdateAttribute]
     public partial class AspNetCore_d3c3d6059615673cb46fc4974164d61eabadb890 : Microsoft.AspNetCore.Components.ComponentBase, IDisposable
     {
         #pragma warning disable 1998

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_Runtime.ir.txt
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/BasicComponent_Runtime.ir.txt
@@ -5,8 +5,6 @@ Document -
         UsingDirective - (51:2,1 [19] ) - System.Linq
         UsingDirective - (71:3,1 [30] ) - System.Threading.Tasks
         UsingDirective - (102:4,1 [37] ) - Microsoft.AspNetCore.Components
-        RazorCompiledItemMetadataAttribute - 
-        CreateNewOnMetadataUpdateAttribute - 
         ClassDeclaration -  - public partial - AspNetCore_d3c3d6059615673cb46fc4974164d61eabadb890 - Microsoft.AspNetCore.Components.ComponentBase - IDisposable
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 MarkupElement - (25:1,0 [91] BasicComponent.cshtml) - div


### PR DESCRIPTION
Fixes build break found in https://github.com/dotnet/sdk/pull/19539

