### PR TITLE
Make sure route binding isn't case sensitive

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -208,7 +208,7 @@ namespace Microsoft.AspNetCore.Http
 
             if (parameterCustomAttributes.OfType<IFromRouteMetadata>().FirstOrDefault() is { } routeAttribute)
             {
-                if (factoryContext.RouteParameters is { } routeParams && !routeParams.Contains(parameter.Name))
+                if (factoryContext.RouteParameters is { } routeParams && !routeParams.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase))
                 {
                     throw new InvalidOperationException($"{parameter.Name} is not a route paramter.");
                 }
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Http
             {
                 // We're in the fallback case and we have a parameter and route parameter match so don't fallback
                 // to query string in this case
-                if (factoryContext.RouteParameters is { } routeParams && routeParams.Contains(parameter.Name))
+                if (factoryContext.RouteParameters is { } routeParams && routeParams.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase))
                 {
                     return BindParameterFromProperty(parameter, RouteValuesExpr, parameter.Name, factoryContext);
                 }

--- a/src/Http/Routing/test/UnitTests/Builder/MinimalActionEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/MinimalActionEndpointRouteBuilderExtensionsTest.cs
@@ -29,6 +29,32 @@ namespace Microsoft.AspNetCore.Builder
             return Assert.IsType<RouteEndpointBuilder>(Assert.Single(GetBuilderEndpointDataSource(endpointRouteBuilder).EndpointBuilders));
         }
 
+        public static object[][] MapMethods
+        {
+            get
+            {
+                void MapGet(IEndpointRouteBuilder routes, string template, Delegate action) =>
+                    routes.MapGet(template, action);
+
+                void MapPost(IEndpointRouteBuilder routes, string template, Delegate action) =>
+                    routes.MapPost(template, action);
+
+                void MapPut(IEndpointRouteBuilder routes, string template, Delegate action) =>
+                    routes.MapPut(template, action);
+
+                void MapDelete(IEndpointRouteBuilder routes, string template, Delegate action) =>
+                    routes.MapDelete(template, action);
+
+                return new object[][]
+                {
+                    new object[] { (Action<IEndpointRouteBuilder, string, Delegate>)MapGet, "GET" },
+                    new object[] { (Action<IEndpointRouteBuilder, string, Delegate>)MapPost, "POST" },
+                    new object[] { (Action<IEndpointRouteBuilder, string, Delegate>)MapPut, "PUT" },
+                    new object[] { (Action<IEndpointRouteBuilder, string, Delegate>)MapDelete, "DELETE" },
+                };
+            }
+        }
+
         [Fact]
         public void MapEndpoint_PrecedenceOfMetadata_BuilderMetadataReturned()
         {
@@ -101,6 +127,82 @@ namespace Microsoft.AspNetCore.Builder
             var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
             Assert.Equal("/{id} HTTP: GET", routeEndpointBuilder.DisplayName);
             Assert.Equal("/{id}", routeEndpointBuilder.RoutePattern.RawText);
+
+            // Assert that we don't fallback to the query string
+            var httpContext = new DefaultHttpContext();
+
+            httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = "42"
+            });
+
+            await endpoint.RequestDelegate!(httpContext);
+
+            Assert.Null(httpContext.Items["input"]);
+        }
+
+        [Theory]
+        [MemberData(nameof(MapMethods))]
+        public async Task MapVerbWithExplicitRouteParameterIsCaseInsensitive(Action<IEndpointRouteBuilder, string, Delegate> map, string expectedMethod)
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+
+            map(builder, "/{ID}", ([FromRoute] int? id, HttpContext httpContext) =>
+            {
+                if (id is not null)
+                {
+                    httpContext.Items["input"] = id;
+                }
+            });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            var methodMetadata = endpoint.Metadata.GetMetadata<IHttpMethodMetadata>();
+            Assert.NotNull(methodMetadata);
+            var method = Assert.Single(methodMetadata!.HttpMethods);
+            Assert.Equal(expectedMethod, method);
+
+            var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
+            Assert.Equal($"/{{ID}} HTTP: {expectedMethod}", routeEndpointBuilder.DisplayName);
+            Assert.Equal($"/{{ID}}", routeEndpointBuilder.RoutePattern.RawText);
+
+            var httpContext = new DefaultHttpContext();
+
+            httpContext.Request.RouteValues["id"] = "13";
+
+            await endpoint.RequestDelegate!(httpContext);
+
+            Assert.Equal(13, httpContext.Items["input"]);
+        }
+
+        [Theory]
+        [MemberData(nameof(MapMethods))]
+        public async Task MapVerbWithRouteParameterDoesNotFallbackToQuery(Action<IEndpointRouteBuilder, string, Delegate> map, string expectedMethod)
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+
+            map(builder, "/{ID}", (int? id, HttpContext httpContext) =>
+            {
+                if (id is not null)
+                {
+                    httpContext.Items["input"] = id;
+                }
+            });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            var methodMetadata = endpoint.Metadata.GetMetadata<IHttpMethodMetadata>();
+            Assert.NotNull(methodMetadata);
+            var method = Assert.Single(methodMetadata!.HttpMethods);
+            Assert.Equal(expectedMethod, method);
+
+            var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
+            Assert.Equal($"/{{ID}} HTTP: {expectedMethod}", routeEndpointBuilder.DisplayName);
+            Assert.Equal($"/{{ID}}", routeEndpointBuilder.RoutePattern.RawText);
 
             // Assert that we don't fallback to the query string
             var httpContext = new DefaultHttpContext();


### PR DESCRIPTION
- For error handling cases, we were doing a case sensitive match against route parameters instead of a case insensitive one.
- Added tests

Fixes https://github.com/dotnet/aspnetcore/issues/35087