### PR TITLE
Set the application name in the WebApplicationFactory

### DIFF
--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.Hosting;
@@ -160,6 +161,16 @@ namespace Microsoft.AspNetCore.Mvc.Testing
             {
                 var deferredHostBuilder = new DeferredHostBuilder();
                 deferredHostBuilder.UseEnvironment(Environments.Development);
+                // There's no helper for UseApplicationName, but we need to 
+                // set the application name to the target entry point 
+                // assembly name.
+                deferredHostBuilder.ConfigureHostConfiguration(config =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        { HostDefaults.ApplicationKey, typeof(TEntryPoint).Assembly.GetName()?.Name ?? string.Empty }
+                    });
+                });
                 // This helper call does the hard work to determine if we can fallback to diagnostic source events to get the host instance
                 var factory = HostFactoryResolver.ResolveHostFactory(
                     typeof(TEntryPoint).Assembly,

--- a/src/Mvc/test/Mvc.FunctionalTests/SimpleWithWebApplicationBuilderTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/SimpleWithWebApplicationBuilderTests.cs
@@ -114,6 +114,21 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [Fact]
+        public async Task MvcControllerActionWorks()
+        {
+            // Arrange
+            using var client = _fixture.CreateDefaultClient();
+
+            // Act
+            var response = await client.GetAsync("/greet");
+
+            // Assert
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
+            var content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("Hello human", content);
+        }
+
+        [Fact]
         public async Task DefaultEnvironment_Is_Development()
         {
             // Arrange

--- a/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/Program.cs
+++ b/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/Program.cs
@@ -1,9 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Mvc;
+
 using static Microsoft.AspNetCore.Http.Results;
 
-var app = WebApplication.Create(args);
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
 
 app.MapGet("/", () => "Hello World");
 
@@ -32,3 +40,9 @@ app.MapGet("/greeting", (IConfiguration config) => config["Greeting"]);
 app.Run();
 
 record Person(string Name, int Age);
+
+public class MyController : ControllerBase
+{
+    [HttpGet("/greet")]
+    public string Greet() => $"Hello human";
+}

--- a/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/SimpleWebSiteWithWebApplicationBuilder.csproj
+++ b/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/SimpleWebSiteWithWebApplicationBuilder.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Mvc" />
     <Reference Include="Microsoft.AspNetCore.Http.Results" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- When using the deferred host builder, we set the application name via args so since the default name is the entry assembly. When hosted in tests, this will be the testhost instead of the application assembly name. This changes the default when using the WebApplicationFactory.
- Added a test

Follow up from https://github.com/dotnet/aspnetcore/pull/35063

cc @martincostello 