### PR TITLE
Added the ability to configure the buffer sizes on the client

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionFactoryTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionFactoryTests.cs
@@ -98,6 +98,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 { $"{nameof(HttpConnectionOptions.DefaultTransferFormat)}", TransferFormat.Text },
                 { $"{nameof(HttpConnectionOptions.WebSocketConfiguration)}", webSocketConfig },
                 { $"{nameof(HttpConnectionOptions.WebSocketFactory)}", webSocketFactory },
+                { $"{nameof(HttpConnectionOptions.ApplicationMaxBufferSize)}", 1L * 1024 * 1024 },
+                { $"{nameof(HttpConnectionOptions.TransportMaxBufferSize)}", 1L * 1024 * 1024 },
             };
 
             var options = new HttpConnectionOptions();

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.ConnectionLifecycle.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.ConnectionLifecycle.cs
@@ -337,7 +337,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.InternalServerError));
                     });
 
-                    var sse = new ServerSentEventsTransport(new HttpClient(httpHandler), LoggerFactory);
+                    var sse = new ServerSentEventsTransport(new HttpClient(httpHandler), loggerFactory: LoggerFactory);
 
                     await WithConnectionAsync(
                         CreateConnection(httpHandler, loggerFactory: LoggerFactory, transport: sse),
@@ -363,7 +363,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         return ResponseUtils.CreateResponse(HttpStatusCode.Accepted);
                     });
 
-                    var sse = new ServerSentEventsTransport(new HttpClient(httpHandler), LoggerFactory);
+                    var sse = new ServerSentEventsTransport(new HttpClient(httpHandler), loggerFactory: LoggerFactory);
 
                     await WithConnectionAsync(
                         CreateConnection(httpHandler, loggerFactory: LoggerFactory, transport: sse),
@@ -434,7 +434,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                     await WithConnectionAsync(
                         CreateConnection(httpHandler,
-                        transport: new TestTransport(onTransportStart: () => {
+                        transport: new TestTransport(onTransportStart: () =>
+                        {
                             // Cancel the token when the transport is starting  which will fail the startTask.
                             cts.Cancel();
                             return Task.CompletedTask;
@@ -462,7 +463,8 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 
                     await WithConnectionAsync(
                         CreateConnection(httpHandler,
-                        transport: new TestTransport(onTransportStart: () => {
+                        transport: new TestTransport(onTransportStart: () =>
+                        {
                             transportStartCalled = true;
                             return Task.CompletedTask;
                         })),
@@ -493,7 +495,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                         throw new OperationCanceledException("Cancel SSE Start.");
                     });
 
-                    var sse = new ServerSentEventsTransport(new HttpClient(httpHandler), LoggerFactory);
+                    var sse = new ServerSentEventsTransport(new HttpClient(httpHandler), loggerFactory: LoggerFactory);
 
                     await WithConnectionAsync(
                         CreateConnection(httpHandler, loggerFactory: LoggerFactory, transport: sse, transportType: HttpTransportType.ServerSentEvents),

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.AspNetCore.SignalR.Tests;
@@ -21,6 +22,25 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
 {
     public partial class HttpConnectionTests : VerifiableLoggedTest
     {
+        [Fact]
+        public void HttpConnectionOptionsDefaults()
+        {
+            var httpOptions = new HttpConnectionOptions();
+            Assert.Equal(1024 * 1024, httpOptions.TransportMaxBufferSize);
+            Assert.Equal(1024 * 1024, httpOptions.ApplicationMaxBufferSize);
+            Assert.Equal(TimeSpan.FromSeconds(5), httpOptions.CloseTimeout);
+            Assert.Equal(TransferFormat.Binary, httpOptions.DefaultTransferFormat);
+            Assert.Equal(HttpTransports.All, httpOptions.Transports);
+        }
+
+        [Fact]
+        public void HttpConnectionOptionsNegativeBufferSizeThrows()
+        {
+            var httpOptions = new HttpConnectionOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() => httpOptions.TransportMaxBufferSize = -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => httpOptions.ApplicationMaxBufferSize = -1);
+        }
+
         [Fact]
         public void CannotCreateConnectionWithNullUrl()
         {

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/LongPollingTransportTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/LongPollingTransportTests.cs
@@ -254,7 +254,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             {
                 using (var httpClient = new HttpClient(mockHttpHandler.Object))
                 {
-                    var longPollingTransport = new LongPollingTransport(httpClient, LoggerFactory);
+                    var longPollingTransport = new LongPollingTransport(httpClient, loggerFactory: LoggerFactory);
 
                     await longPollingTransport.StartAsync(TestUri, TransferFormat.Binary).DefaultTimeout();
 

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/ServerSentEventsTransportTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/ServerSentEventsTransportTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
                 using (var httpClient = new HttpClient(mockHttpHandler.Object))
                 using (StartVerifiableLog())
                 {
-                    var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                    var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
                     await sseTransport.StartAsync(
                         new Uri("http://fakeuri.org"), TransferFormat.Text).DefaultTimeout();
 
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (StartVerifiableLog())
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
 
                 Task transportActiveTask;
                 try
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (StartVerifiableLog())
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
 
                 await sseTransport.StartAsync(
                     new Uri("http://fakeuri.org"), TransferFormat.Text).DefaultTimeout();
@@ -208,7 +208,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (StartVerifiableLog(expectedErrorsFilter: ExpectedErrors))
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
 
                 await sseTransport.StartAsync(
                     new Uri("http://fakeuri.org"), TransferFormat.Text).DefaultTimeout();
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (StartVerifiableLog())
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
 
                 await sseTransport.StartAsync(
                     new Uri("http://fakeuri.org"), TransferFormat.Text).DefaultTimeout();
@@ -285,7 +285,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (StartVerifiableLog())
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
 
                 await sseTransport.StartAsync(
                     new Uri("http://fakeuri.org"), TransferFormat.Text).DefaultTimeout();
@@ -339,7 +339,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (StartVerifiableLog())
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
 
                 await sseTransport.StartAsync(
                     new Uri("http://fakeuri.org"), TransferFormat.Text).DefaultTimeout();
@@ -374,7 +374,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (StartVerifiableLog())
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
 
                 var ex = await Assert.ThrowsAsync<ArgumentException>(() => sseTransport.StartAsync(new Uri("http://fakeuri.org"), TransferFormat.Binary).DefaultTimeout());
 
@@ -401,7 +401,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             using (var httpClient = new HttpClient(mockHttpHandler.Object))
             using (StartVerifiableLog())
             {
-                var sseTransport = new ServerSentEventsTransport(httpClient, LoggerFactory);
+                var sseTransport = new ServerSentEventsTransport(httpClient, loggerFactory: LoggerFactory);
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
                     sseTransport.StartAsync(new Uri("http://fakeuri.org"), transferFormat));
 

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionFactory.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionFactory.cs
@@ -92,6 +92,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 AccessTokenProvider = options.AccessTokenProvider,
                 CloseTimeout = options.CloseTimeout,
                 DefaultTransferFormat = options.DefaultTransferFormat,
+                ApplicationMaxBufferSize = options.ApplicationMaxBufferSize,
+                TransportMaxBufferSize = options.TransportMaxBufferSize
             };
 
             if (!OperatingSystem.IsBrowser())

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionOptions.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionOptions.cs
@@ -77,8 +77,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         }
 
         /// <summary>
-        /// Gets or sets the maximum buffer size for data written from the transport before it is
-        /// throttled.
+        /// Gets or sets the maximum buffer size for data read by the application before backpressure is applied.
         /// </summary>
         /// <remarks>
         /// The default value is 1MB.
@@ -86,8 +85,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         public long TransportMaxBufferSize { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum buffer size for data written from the application before it is
-        /// throttled.
+        /// Gets or sets the maximum buffer size for data written by the application before backpressure is applied.
         /// </summary>
         /// <remarks>
         /// The default value is 1MB.

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionOptions.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnectionOptions.cs
@@ -29,6 +29,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         private Action<ClientWebSocketOptions>? _webSocketConfiguration;
         private PipeOptions? _transportPipeOptions;
         private PipeOptions? _appPipeOptions;
+        private long _transportMaxBufferSize;
+        private long _applicationMaxBufferSize;
 
         // Selected because of the number of client connections is usually much lower than
         // server connections and therefore willing to use more memory. We'll default
@@ -82,7 +84,22 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         /// <remarks>
         /// The default value is 1MB.
         /// </remarks>
-        public long TransportMaxBufferSize { get; set; }
+        /// <value>
+        /// The default value is 1MB.
+        /// </value>
+        public long TransportMaxBufferSize
+        {
+            get => _transportMaxBufferSize;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _transportMaxBufferSize = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the maximum buffer size for data written by the application before backpressure is applied.
@@ -90,7 +107,22 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
         /// <remarks>
         /// The default value is 1MB.
         /// </remarks>
-        public long ApplicationMaxBufferSize { get; set; }
+        /// <value>
+        /// The default value is 1MB.
+        /// </value>
+        public long ApplicationMaxBufferSize
+        {
+            get => _applicationMaxBufferSize;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _applicationMaxBufferSize = value;
+            }
+        }
 
         // We initialize these lazily based on the state of the options specified here.
         // Though these are mutable it's extremely rare that they would be mutated past the

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/DefaultTransportFactory.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/DefaultTransportFactory.cs
@@ -49,13 +49,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             if ((availableServerTransports & HttpTransportType.ServerSentEvents & _requestedTransportType) == HttpTransportType.ServerSentEvents)
             {
                 // We don't need to give the transport the accessTokenProvider because the HttpClient has a message handler that does the work for us.
-                return new ServerSentEventsTransport(_httpClient!, _loggerFactory);
+                return new ServerSentEventsTransport(_httpClient!, _httpConnectionOptions, _loggerFactory);
             }
 
             if ((availableServerTransports & HttpTransportType.LongPolling & _requestedTransportType) == HttpTransportType.LongPolling)
             {
                 // We don't need to give the transport the accessTokenProvider because the HttpClient has a message handler that does the work for us.
-                return new LongPollingTransport(_httpClient!, _loggerFactory);
+                return new LongPollingTransport(_httpClient!, _httpConnectionOptions, _loggerFactory);
             }
 
             throw new InvalidOperationException("No requested transports available on the server.");

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LongPollingTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LongPollingTransport.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
     {
         private readonly HttpClient _httpClient;
         private readonly ILogger _logger;
+        private readonly HttpConnectionOptions _httpConnectionOptions;
         private IDuplexPipe? _application;
         private IDuplexPipe? _transport;
         // Volatile so that the poll loop sees the updated value set from a different thread
@@ -31,14 +32,11 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
         public PipeWriter Output => _transport!.Output;
 
-        public LongPollingTransport(HttpClient httpClient)
-            : this(httpClient, null)
-        { }
-
-        public LongPollingTransport(HttpClient httpClient, ILoggerFactory? loggerFactory)
+        public LongPollingTransport(HttpClient httpClient, HttpConnectionOptions? httpConnectionOptions = null, ILoggerFactory? loggerFactory = null)
         {
             _httpClient = httpClient;
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<LongPollingTransport>();
+            _httpConnectionOptions = httpConnectionOptions ?? new();
         }
 
         public async Task StartAsync(Uri url, TransferFormat transferFormat, CancellationToken cancellationToken = default)
@@ -59,8 +57,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             }
 
             // Create the pipe pair (Application's writer is connected to Transport's reader, and vice versa)
-            var options = ClientPipeOptions.DefaultOptions;
-            var pair = DuplexPipe.CreateConnectionPair(options, options);
+            var pair = DuplexPipe.CreateConnectionPair(_httpConnectionOptions.TransportPipeOptions, _httpConnectionOptions.AppPipeOptions);
 
             _transport = pair.Transport;
             _application = pair.Application;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
     {
         private readonly HttpClient _httpClient;
         private readonly ILogger _logger;
-
+        private readonly HttpConnectionOptions _httpConnectionOptions;
         // Volatile so that the SSE loop sees the updated value set from a different thread
         private volatile Exception? _error;
         private readonly CancellationTokenSource _transportCts = new CancellationTokenSource();
@@ -33,11 +33,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
         public PipeWriter Output => _transport!.Output;
 
-        public ServerSentEventsTransport(HttpClient httpClient)
-            : this(httpClient, null)
-        { }
-
-        public ServerSentEventsTransport(HttpClient httpClient, ILoggerFactory? loggerFactory)
+        public ServerSentEventsTransport(HttpClient httpClient, HttpConnectionOptions? httpConnectionOptions = null, ILoggerFactory? loggerFactory = null)
         {
             if (httpClient == null)
             {
@@ -46,6 +42,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
 
             _httpClient = httpClient;
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<ServerSentEventsTransport>();
+            _httpConnectionOptions = httpConnectionOptions ?? new();
         }
 
         public async Task StartAsync(Uri url, TransferFormat transferFormat, CancellationToken cancellationToken = default)
@@ -77,8 +74,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             }
 
             // Create the pipe pair (Application's writer is connected to Transport's reader, and vice versa)
-            var options = ClientPipeOptions.DefaultOptions;
-            var pair = DuplexPipe.CreateConnectionPair(options, options);
+            var pair = DuplexPipe.CreateConnectionPair(_httpConnectionOptions.TransportPipeOptions, _httpConnectionOptions.AppPipeOptions);
 
             _transport = pair.Transport;
             _application = pair.Application;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -181,8 +181,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal
             Log.StartedTransport(_logger);
 
             // Create the pipe pair (Application's writer is connected to Transport's reader, and vice versa)
-            var options = ClientPipeOptions.DefaultOptions;
-            var pair = DuplexPipe.CreateConnectionPair(options, options);
+            var pair = DuplexPipe.CreateConnectionPair(_httpConnectionOptions.TransportPipeOptions, _httpConnectionOptions.AppPipeOptions);
 
             _transport = pair.Transport;
             _application = pair.Application;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/PublicAPI.Unshipped.txt
@@ -35,6 +35,10 @@
 *REMOVED*~Microsoft.AspNetCore.Http.Connections.Client.NoTransportSupportedException.NoTransportSupportedException(string message) -> void
 *REMOVED*~Microsoft.AspNetCore.Http.Connections.Client.TransportFailedException.TransportFailedException(string transportType, string message, System.Exception innerException = null) -> void
 *REMOVED*~Microsoft.AspNetCore.Http.Connections.Client.TransportFailedException.TransportType.get -> string
+Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions.ApplicationMaxBufferSize.get -> long
+Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions.ApplicationMaxBufferSize.set -> void
+Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions.TransportMaxBufferSize.get -> long
+Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions.TransportMaxBufferSize.set -> void
 Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions.WebSocketFactory.get -> System.Func<Microsoft.AspNetCore.Http.Connections.Client.WebSocketConnectionContext!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.Net.WebSockets.WebSocket!>>?
 Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions.WebSocketFactory.set -> void
 Microsoft.AspNetCore.Http.Connections.Client.WebSocketConnectionContext

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -22,6 +22,8 @@ namespace Microsoft.AspNetCore.Http.Connections
         private PipeOptions? _transportPipeOptions;
         private PipeOptions? _appPipeOptions;
         private TimeSpan _transportSendTimeout;
+        private long _transportMaxBufferSize;
+        private long _applicationMaxBufferSize;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpConnectionDispatcherOptions"/> class.
@@ -63,7 +65,19 @@ namespace Microsoft.AspNetCore.Http.Connections
         /// <remarks>
         /// The default value is 65KB.
         /// </remarks>
-        public long TransportMaxBufferSize { get; set; }
+        public long TransportMaxBufferSize
+        {
+            get => _transportMaxBufferSize;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _transportMaxBufferSize = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the maximum buffer size for data written by the application before backpressure is applied.
@@ -71,7 +85,19 @@ namespace Microsoft.AspNetCore.Http.Connections
         /// <remarks>
         /// The default value is 65KB.
         /// </remarks>
-        public long ApplicationMaxBufferSize { get; set; }
+        public long ApplicationMaxBufferSize
+        {
+            get => _applicationMaxBufferSize;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _applicationMaxBufferSize = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the minimum protocol verison supported by the server.

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Http.Connections
     {
         // Selected because this is the default value of PipeWriter.PauseWriterThreshold.
         // There maybe the opportunity for performance gains by tuning this default.
-        private const int DefaultPipeBufferSize = 32768;
+        private const int DefaultBufferSize = 65536;
 
         private PipeOptions? _transportPipeOptions;
         private PipeOptions? _appPipeOptions;
@@ -32,8 +32,8 @@ namespace Microsoft.AspNetCore.Http.Connections
             Transports = HttpTransports.All;
             WebSockets = new WebSocketOptions();
             LongPolling = new LongPollingOptions();
-            TransportMaxBufferSize = DefaultPipeBufferSize;
-            ApplicationMaxBufferSize = DefaultPipeBufferSize;
+            TransportMaxBufferSize = DefaultBufferSize;
+            ApplicationMaxBufferSize = DefaultBufferSize;
             TransportSendTimeout = TimeSpan.FromSeconds(10);
         }
 
@@ -58,13 +58,21 @@ namespace Microsoft.AspNetCore.Http.Connections
         public LongPollingOptions LongPolling { get; }
 
         /// <summary>
-        /// Gets or sets the maximum buffer size of the transport writer.
+        /// Gets or sets the maximum buffer size for data written from the transport before it is
+        /// throttled.
         /// </summary>
+        /// <remarks>
+        /// The default value is 65KB.
+        /// </remarks>
         public long TransportMaxBufferSize { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum buffer size of the application writer.
+        /// Gets or sets the maximum buffer size for data written from the application before it is
+        /// throttled.
         /// </summary>
+        /// <remarks>
+        /// The default value is 65KB.
+        /// </remarks>
         public long ApplicationMaxBufferSize { get; set; }
 
         /// <summary>

--- a/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/HttpConnectionDispatcherOptions.cs
@@ -58,8 +58,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         public LongPollingOptions LongPolling { get; }
 
         /// <summary>
-        /// Gets or sets the maximum buffer size for data written from the transport before it is
-        /// throttled.
+        /// Gets or sets the maximum buffer size for data read by the application before backpressure is applied.
         /// </summary>
         /// <remarks>
         /// The default value is 65KB.
@@ -67,8 +66,7 @@ namespace Microsoft.AspNetCore.Http.Connections
         public long TransportMaxBufferSize { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum buffer size for data written from the application before it is
-        /// throttled.
+        /// Gets or sets the maximum buffer size for data written by the application before backpressure is applied.
         /// </summary>
         /// <remarks>
         /// The default value is 65KB.

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
@@ -17,6 +17,25 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
     public class HttpConnectionManagerTests : VerifiableLoggedTest
     {
         [Fact]
+        public void HttpConnectionDispatcherOptionsDefaults()
+        {
+            var options = new HttpConnectionDispatcherOptions();
+            Assert.Equal(TimeSpan.FromSeconds(10), options.TransportSendTimeout);
+            Assert.Equal(65536, options.TransportMaxBufferSize);
+            Assert.Equal(65536, options.ApplicationMaxBufferSize);
+            Assert.Equal(HttpTransports.All, options.Transports);
+            Assert.False(options.CloseOnAuthenticationExpiration);
+        }
+
+        [Fact]
+        public void HttpConnectionDispatcherOptionsNegativeBufferSizeThrows()
+        {
+            var httpOptions = new HttpConnectionDispatcherOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() => httpOptions.TransportMaxBufferSize = -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => httpOptions.ApplicationMaxBufferSize = -1);
+        }
+
+        [Fact]
         public void NewConnectionsHaveConnectionId()
         {
             using (StartVerifiableLog())


### PR DESCRIPTION
- When data comes in from the transport or sent to the transport, we use the default pipe buffer size on the client (which is 65K). This change makes it possible to configure both the transport buffer and the application buffer so that it can be configured based on users scenarios.
- Raise the default limit from 65K to 1MB on the client side and raise it from 32K (old pipe limit) to 65K on the server side.

Fixes #17797 

PS: I haven't figured out how to test this as yet.