### PR TITLE
Remove unnecessary try-catch in Worker template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Worker.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Worker.cs
@@ -14,14 +14,7 @@ public class Worker : BackgroundService
         while (!stoppingToken.IsCancellationRequested)
         {
             _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-            try
-            {
-                await Task.Delay(1000, stoppingToken);
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
+            await Task.Delay(1000, stoppingToken);
         }
     }
 }


### PR DESCRIPTION
**PR Title**
Remove unnecessary try-catch in Worker template

**PR Description**
This was working around a bug in 6.0 (https://github.com/dotnet/runtime/issues/56032) which will be fixed in 6.0. So we no longer need this in the default template.
