### PR TITLE
Removed option for Razor runtime compilation from C# templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -6,7 +6,6 @@
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-0ce56475-d1db-490f-8af1-a881ea4fcd2d</UserSecretsId>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
-    <CopyRefAssembliesToPublishDirectory Condition="'$(RazorRuntimeCompilation)'=='true'">false</CopyRefAssembliesToPublishDirectory>
   </PropertyGroup>
   <!--#if (IndividualLocalAuth && !UseLocalDB) -->
 
@@ -14,13 +13,12 @@
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" ExcludeFromSingleFile="true" />
   </ItemGroup>
   <!--#endif -->
-  <!--#if (IndividualB2CAuth || IndividualLocalAuth || OrganizationalAuth || RazorRuntimeCompilation) -->
+  <!--#if (IndividualB2CAuth || IndividualLocalAuth || OrganizationalAuth) -->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCoreVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="${MicrosoftAspNetCoreIdentityUIVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="${MicrosoftAspNetCoreMvcRazorRuntimeCompilationVersion}" Condition="'$(RazorRuntimeCompilation)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqliteVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />

--- a/src/ProjectTemplates/Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -6,7 +6,6 @@
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
-    <CopyRefAssembliesToPublishDirectory Condition="'$(RazorRuntimeCompilation)'=='true'">false</CopyRefAssembliesToPublishDirectory>
   </PropertyGroup>
   <!--#if (IndividualLocalAuth && !UseLocalDB) -->
 
@@ -14,13 +13,12 @@
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" ExcludeFromSingleFile="true" />
   </ItemGroup>
   <!--#endif -->
-  <!--#if (IndividualB2CAuth || IndividualLocalAuth || OrganizationalAuth || RazorRuntimeCompilation) -->
+  <!--#if (IndividualB2CAuth || IndividualLocalAuth || OrganizationalAuth ) -->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCoreVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCoreVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="${MicrosoftAspNetCoreIdentityUIVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="${MicrosoftAspNetCoreMvcRazorRuntimeCompilationVersion}" Condition="'$(RazorRuntimeCompilation)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqliteVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' " />

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
@@ -74,10 +74,6 @@
       "longName": "no-https",
       "shortName": ""
     },
-    "RazorRuntimeCompilation": {
-      "longName": "razor-runtime-compilation",
-      "shortName": "rrc"
-    },
     "CalledApiUrl": {
         "longName": "called-api-url",
         "shortName": ""

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/ide.host.json
@@ -45,13 +45,7 @@
     }
   ],
   "symbolInfo": [
-    {
-      "id": "RazorRuntimeCompilation",
-      "name": {
-        "text": "Enable _Razor runtime compilation"
-      },
-      "isVisible": "true"
-    }
+    
   ],
   "disableHttpsSymbol": "NoHttps"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -355,12 +355,6 @@
       "defaultValue": "false",
       "description": "Whether to use LocalDB instead of SQLite. This option only applies if --auth Individual or --auth IndividualB2C is specified."
     },
-    "RazorRuntimeCompilation": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Determines if the project is configured to use Razor runtime compilation in Debug builds."
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
@@ -27,24 +27,14 @@
       "applicationUrl": "http://localhost:5000",
       //#endif
       "environmentVariables": {
-        //#if(RazorRuntimeCompilation)
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
-        //#else
         "ASPNETCORE_ENVIRONMENT": "Development"
-        //#endif
       }
     },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
       "environmentVariables": {
-        //#if(RazorRuntimeCompilation)
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
-        //#else
         "ASPNETCORE_ENVIRONMENT": "Development"
-        //#endif
       }
     }
   }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/cs-CZ/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/cs-CZ/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Webová aplikace ASP.NET Core (Model-View-Controller)",
-    "description": "Šablona projektu pro vytvoření aplikace ASP.NET Core s ukázkovými zobrazeními a kontrolery ASP.NET Core MVC. Tato šablona se dá použít i pro služby RESTful HTTP.",
-    "parameter.RazorRuntimeCompilation.name": "Povolit kompilaci _Razor za běhu"
+    "description": "Šablona projektu pro vytvoření aplikace ASP.NET Core s ukázkovými zobrazeními a kontrolery ASP.NET Core MVC. Tato šablona se dá použít i pro služby RESTful HTTP."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/de-DE/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/de-DE/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "ASP.NET Core-Web-App (Model View Controller)",
-    "description": "Eine Projektvorlage zum Erstellen einer ASP.NET Core-Anwendung mit Beispielen für ASP.NET Core-MVC-Ansichten und -Controller. Diese Vorlage kann auch für RESTful HTTP-Dienste verwendet werden.",
-    "parameter.RazorRuntimeCompilation.name": "_Razor-Runtime-Kompilierung aktivieren"
+    "description": "Eine Projektvorlage zum Erstellen einer ASP.NET Core-Anwendung mit Beispielen für ASP.NET Core-MVC-Ansichten und -Controller. Diese Vorlage kann auch für RESTful HTTP-Dienste verwendet werden."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -73,7 +73,7 @@
     "NoHttps": {
       "longName": "no-https",
       "shortName": ""
-    },,
+    },
     "CalledApiUrl": {
         "longName": "called-api-url",
         "shortName": ""

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -73,11 +73,7 @@
     "NoHttps": {
       "longName": "no-https",
       "shortName": ""
-    },
-    "RazorRuntimeCompilation": {
-      "longName": "razor-runtime-compilation",
-      "shortName": "rrc"
-    },
+    },,
     "CalledApiUrl": {
         "longName": "called-api-url",
         "shortName": ""

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/es-ES/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/es-ES/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Aplicación web de ASP.NET Core (Modelo-Vista-Controlador)",
-    "description": "Una plantilla de proyecto para crear una aplicación ASP.NET Core con controladores y vistas de ASP.NET Core MVC de ejemplo. Esta plantilla también puede usarse para servicios RESTful HTTP.",
-    "parameter.RazorRuntimeCompilation.name": "Habilitar compilación en tiempo de ejecución de _Razor"
+    "description": "Una plantilla de proyecto para crear una aplicación ASP.NET Core con controladores y vistas de ASP.NET Core MVC de ejemplo. Esta plantilla también puede usarse para servicios RESTful HTTP."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/fr-FR/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/fr-FR/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Application web ASP.NET Core (modèle-vue-contrôleur)",
-    "description": "Modèle de projet permettant de créer une application ASP.NET Core avec des exemples de vues et de contrôleurs ASP.NET Core MVC. Vous pouvez également utiliser ce modèle pour les services HTTP RESTful.",
-    "parameter.RazorRuntimeCompilation.name": "Activer la compilation de runtime _Razor"
+    "description": "Modèle de projet permettant de créer une application ASP.NET Core avec des exemples de vues et de contrôleurs ASP.NET Core MVC. Vous pouvez également utiliser ce modèle pour les services HTTP RESTful."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/ide.host.json
@@ -45,13 +45,7 @@
     }
   ],
   "symbolInfo": [
-    {
-      "id": "RazorRuntimeCompilation",
-      "name": {
-        "text": "Enable _Razor runtime compilation"
-      },
-      "isVisible": "true"
-    }
+    
   ],
   "disableHttpsSymbol": "NoHttps"
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/it-IT/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/it-IT/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "App Web ASP.NET Core (Model-View-Controller)",
-    "description": "Modello di progetto per la creazione di un'applicazione ASP.NET Core con viste e controller ASP.NET Core MVC di esempio. È possibile usare questo modello anche per i servizi HTTP RESTful.",
-    "parameter.RazorRuntimeCompilation.name": "Abilita compilazione del runtime _Razor"
+    "description": "Modello di progetto per la creazione di un'applicazione ASP.NET Core con viste e controller ASP.NET Core MVC di esempio. È possibile usare questo modello anche per i servizi HTTP RESTful."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/ja-JP/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/ja-JP/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "ASP.NET Core Web アプリ (Model-View-Controller)",
-    "description": "ASP.NET Core MVC のサンプル ビューとコントローラーで ASP.NET Core アプリケーションを作成するためのプロジェクト テンプレートです。このテンプレートは RESTful HTTP サービスでも使用できます。",
-    "parameter.RazorRuntimeCompilation.name": "Razor ランタイム コンパイルを有効にする(_R)"
+    "description": "ASP.NET Core MVC のサンプル ビューとコントローラーで ASP.NET Core アプリケーションを作成するためのプロジェクト テンプレートです。このテンプレートは RESTful HTTP サービスでも使用できます。"
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/ko-KR/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/ko-KR/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "ASP.NET Core 웹앱(Model-View-Controller)",
-    "description": "예제 ASP.NET Core MVC 뷰 및 컨트롤러를 사용하여 ASP.NET Core 애플리케이션을 만드는 데 사용되는 프로젝트 템플릿입니다. 이 템플릿은 RESTful HTTP 서비스에도 사용할 수 있습니다.",
-    "parameter.RazorRuntimeCompilation.name": "Razor 런타임 컴파일 사용(_R)"
+    "description": "예제 ASP.NET Core MVC 뷰 및 컨트롤러를 사용하여 ASP.NET Core 애플리케이션을 만드는 데 사용되는 프로젝트 템플릿입니다. 이 템플릿은 RESTful HTTP 서비스에도 사용할 수 있습니다."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/pl-PL/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/pl-PL/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Aplikacja internetowa ASP.NET Core (Model-View-Controller)",
-    "description": "Szablon projektu służący do tworzenia aplikacji platformy ASP.NET Core z przykładowymi widokami i kontrolerami platformy ASP.NET Core MVC. Tego szablonu można także użyć dla usług HTTP RESTful.",
-    "parameter.RazorRuntimeCompilation.name": "Włącz kompilację _Razor w środowisku uruchomieniowym"
+    "description": "Szablon projektu służący do tworzenia aplikacji platformy ASP.NET Core z przykładowymi widokami i kontrolerami platformy ASP.NET Core MVC. Tego szablonu można także użyć dla usług HTTP RESTful."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/pt-BR/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/pt-BR/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Aplicativo Web do ASP.NET Core (Model-View-Controller)",
-    "description": "Um modelo de projeto para criar um aplicativo ASP.NET Core com Controladores e Exibições do ASP.NET Core MVC de exemplo. Esse modelo também pode ser usado para serviços HTTP RESTful.",
-    "parameter.RazorRuntimeCompilation.name": "Habilitar a compilação de runtime do _Razor"
+    "description": "Um modelo de projeto para criar um aplicativo ASP.NET Core com Controladores e Exibições do ASP.NET Core MVC de exemplo. Esse modelo também pode ser usado para serviços HTTP RESTful."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/ru-RU/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/ru-RU/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "Веб-приложение ASP.NET Core (модель-представление-контроллер)",
-    "description": "Шаблон проекта для создания приложения ASP.NET Core с образцом представлений MVC и контроллеров ASP.NET Core. Этот шаблон можно также использовать для служб HTTP RESTful.",
-    "parameter.RazorRuntimeCompilation.name": "Включить компиляцию в среде выполнения _Razor"
+    "description": "Шаблон проекта для создания приложения ASP.NET Core с образцом представлений MVC и контроллеров ASP.NET Core. Этот шаблон можно также использовать для служб HTTP RESTful."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -345,12 +345,6 @@
       "defaultValue": "false",
       "description": "Whether to use LocalDB instead of SQLite. This option only applies if --auth Individual or --auth IndividualB2C is specified."
     },
-    "RazorRuntimeCompilation": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Determines if the project is configured to use Razor runtime compilation in Debug builds."
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/tr-TR/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/tr-TR/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "ASP.NET Core Web Uygulaması (Model-Görünüm-Denetleyici)",
-    "description": "Örnek ASP.NET Core MVC Görünümleri ve Denetleyicileri içeren bir ASP.NET Core uygulaması oluşturmaya yönelik proje şablonu. Bu şablon aynı zamanda RESTful HTTP hizmetleri için de kullanılabilir.",
-    "parameter.RazorRuntimeCompilation.name": "_Razor çalışma zamanı derlemesini etkinleştir"
+    "description": "Örnek ASP.NET Core MVC Görünümleri ve Denetleyicileri içeren bir ASP.NET Core uygulaması oluşturmaya yönelik proje şablonu. Bu şablon aynı zamanda RESTful HTTP hizmetleri için de kullanılabilir."
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/zh-CN/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/zh-CN/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "ASP.NET Core Web 应用(模型-视图-控制器)",
-    "description": "用于创建包含示例 ASP.NET Core MVC 视图和控制器的 ASP.NET Core 应用程序的项目模板。此模板还可以用于 RESTful HTTP 服务。",
-    "parameter.RazorRuntimeCompilation.name": "启用 Razor 运行时编译(_R)"
+    "description": "用于创建包含示例 ASP.NET Core MVC 视图和控制器的 ASP.NET Core 应用程序的项目模板。此模板还可以用于 RESTful HTTP 服务。"
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/zh-TW/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/zh-TW/strings.json
@@ -2,7 +2,6 @@
   "version": "1.0.0.0",
   "strings": {
     "name": "ASP.NET Core Web 應用程式 (Model-View-Controller)",
-    "description": "用於建立 ASP.NET Core 應用程式的專案範本，附有 ASP.NET Core MVC 的檢視及控制器範例。此範本也可用於 RESTful HTTP 服務。",
-    "parameter.RazorRuntimeCompilation.name": "啟用 Razor 執行階段編譯(_R)"
+    "description": "用於建立 ASP.NET Core 應用程式的專案範本，附有 ASP.NET Core MVC 的檢視及控制器範例。此範本也可用於 RESTful HTTP 服務。"
   }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
@@ -27,24 +27,14 @@
       "applicationUrl": "http://localhost:5000",
       //#endif
       "environmentVariables": {
-        //#if(RazorRuntimeCompilation)
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
-        //#else
         "ASPNETCORE_ENVIRONMENT": "Development"
-        //#endif
       }
     },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
       "environmentVariables": {
-        //#if(RazorRuntimeCompilation)
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
-        //#else
         "ASPNETCORE_ENVIRONMENT": "Development"
-        //#endif
       }
     }
   }

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -305,15 +305,6 @@ namespace Templates.Test
             await aspNetProcess.AssertPagesOk(pages);
         }
 
-        [ConditionalFact]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-        public async Task MvcTemplate_RazorRuntimeCompilation_BuildsAndPublishes()
-        {
-            var project = await MvcTemplateBuildsAndPublishes(auth: null, args: new[] { "--razor-runtime-compilation" });
-
-            Assert.False(Directory.Exists(Path.Combine(project.TemplatePublishDir, "refs")), "The refs directory should not be published.");
-        }
-
         [ConditionalTheory]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("IndividualB2C", null)]

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -222,19 +222,6 @@ namespace Templates.Test
             }
         }
 
-        [ConditionalFact]
-        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-        public async Task RazorPagesTemplate_RazorRuntimeCompilation_BuildsAndPublishes()
-        {
-            var project = await BuildAndPublishRazorPagesTemplate(auth: null, new[] { "--razor-runtime-compilation" });
-
-            Assert.False(Directory.Exists(Path.Combine(project.TemplatePublishDir, "refs")), "The refs directory should not be published.");
-
-            // Verify ref assemblies isn't published
-            var refsDirectory = Path.Combine(project.TemplatePublishDir, "refs");
-            Assert.False(Directory.Exists(refsDirectory), $"{refsDirectory} should not be in the publish output.");
-        }
-
         [ConditionalTheory]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("IndividualB2C", null)]


### PR DESCRIPTION
Note the F# templates still use Razor runtime compilation but it was never behind a template option.

Fixes #35125