### PR TITLE
HTTP/3: Only add alt-svc header if environment supports QUIC

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                         // Http/3 requires TLS. Note we only let it fall back to HTTP/1, not HTTP/2
                         else if (hasHttp3)
                         {
-                            throw new InvalidOperationException("HTTP/3 requires https.");
+                            throw new InvalidOperationException("HTTP/3 requires HTTPS.");
                         }
                     }
 
@@ -187,6 +187,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                     {
                         throw new InvalidOperationException("This platform doesn't support QUIC or HTTP/3.");
                     }
+
+                    // Disable adding alt-svc header if endpoint has configured not to or there is no
+                    // multiplexed transport factory, which happens if QUIC isn't supported.
+                    var addAltSvcHeader = !options.DisableAltSvcHeader && _multiplexedTransportFactory != null;
 
                     // Add the HTTP middleware as the terminal connection middleware
                     if (hasHttp1 || hasHttp2
@@ -198,7 +202,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                             throw new InvalidOperationException($"Cannot start HTTP/1.x or HTTP/2 server if no {nameof(IConnectionListenerFactory)} is registered.");
                         }
 
-                        options.UseHttpServer(ServiceContext, application, options.Protocols, !options.DisableAltSvcHeader);
+                        options.UseHttpServer(ServiceContext, application, options.Protocols, addAltSvcHeader);
                         var connectionDelegate = options.Build();
 
                         // Add the connection limit middleware
@@ -209,7 +213,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
                     if (hasHttp3 && _multiplexedTransportFactory is not null)
                     {
-                        options.UseHttp3Server(ServiceContext, application, options.Protocols, !options.DisableAltSvcHeader);
+                        options.UseHttp3Server(ServiceContext, application, options.Protocols, addAltSvcHeader);
                         var multiplexedConnectionDelegate = ((IMultiplexedConnectionBuilder)options).Build();
 
                         // Add the connection limit middleware

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -553,7 +553,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             });
 
             Assert.False(bindCalled);
-            Assert.Equal("HTTP/3 requires https.", ex.InnerException.InnerException.Message);
+            Assert.Equal("HTTP/3 requires HTTPS.", ex.InnerException.InnerException.Message);
         }
 
         [Fact]
@@ -589,7 +589,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             });
 
             Assert.False(bindCalled);
-            Assert.Equal("HTTP/3 requires https.", ex.InnerException.InnerException.Message);
+            Assert.Equal("HTTP/3 requires HTTPS.", ex.InnerException.InnerException.Message);
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/TestServer.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/TestTransport/TestServer.cs
@@ -84,14 +84,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTrans
                 {
                     configureServices(services);
 
-                    // Ensure there is at least one multiplexed connection lister factory if none was added to services.
-                    if (!services.Any(d => d.ServiceType == typeof(IMultiplexedConnectionListenerFactory)))
-                    {
-                        // Mock multiplexed connection listner is added so Kestrel doesn't error
-                        // when a HTTP/3 endpoint is configured.
-                        services.AddSingleton<IMultiplexedConnectionListenerFactory>(new MockMultiplexedConnectionListenerFactory());
-                    }
-
                     services.AddSingleton<IStartup>(this);
                     services.AddSingleton(context.LoggerFactory);
 


### PR DESCRIPTION
alt-svc was being added even if server didn't support QUIC.

Check for HttpProtocols.Http3 **and** server support.