### PR TITLE
HTTP/3: Fix missing await in test

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -255,7 +255,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             await quicConnection.CloseAsync((long)Http3ErrorCode.NoError).DefaultTimeout();
 
             // Assert
-            var ex = Assert.ThrowsAsync<ConnectionResetException>(() => acceptTask).DefaultTimeout();
+            var ex = await Assert.ThrowsAsync<ConnectionResetException>(() => acceptTask).DefaultTimeout();
+            var innerEx = Assert.IsType<QuicConnectionAbortedException>(ex.InnerException);
+            Assert.Equal((long)Http3ErrorCode.NoError, innerEx.ErrorCode);
+
             Assert.Equal((long)Http3ErrorCode.NoError, serverConnection.Features.Get<IProtocolErrorCodeFeature>().Error);
         }
 


### PR DESCRIPTION
It may have taken 30 minutes to figure out why this test was randomly failing.