### PR TITLE
Fix NativeAOT with minimal actions

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -27,6 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         private readonly EndpointDataSource _endpointDataSource;
         private readonly IHostEnvironment _environment;
         private readonly IServiceProviderIsService? _serviceProviderIsService;
+        private readonly TryParseMethodCache TryParseMethodCache = new();
 
         // Executes before MVC's DefaultApiDescriptionProvider and GrpcHttpApiDescriptionProvider for no particular reason.
         public int Order => -1100;

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -15,7 +15,7 @@ using System.Reflection;
 
 namespace Microsoft.AspNetCore.Http
 {
-    internal class TryParseMethodCache
+    internal sealed class TryParseMethodCache
     {
         private readonly MethodInfo _enumTryParseMethod;
 
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Http
         {
         }
 
+        // This is for testing
         public TryParseMethodCache(bool preferNonGenericEnumParseOverload)
         {
             _enumTryParseMethod = GetEnumTryParseMethod(preferNonGenericEnumParseOverload);
@@ -159,7 +160,7 @@ namespace Microsoft.AspNetCore.Http
             if (genericCandidate is null && nonGenericCandidate is null)
             {
                 Debug.Fail("No suitable System.Enum.TryParse method found.");
-                throw new Exception("No suitable System.Enum.TryParse method found.");
+                throw new MissingMethodException("No suitable System.Enum.TryParse method found.");
             }
 
             if (preferNonGenericEnumParseOverload)

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -158,8 +158,8 @@ namespace Microsoft.AspNetCore.Http
 
             if (genericCandidate is null && nonGenericCandidate is null)
             {
-                Debug.Fail("No suitable System.Enum.TryParse method not found.");
-                throw new Exception("No suitable System.Enum.TryParse method not found.");
+                Debug.Fail("No suitable System.Enum.TryParse method found.");
+                throw new Exception("No suitable System.Enum.TryParse method found.");
             }
 
             if (preferNonGenericEnumParseOverload)

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -15,35 +15,63 @@ using System.Reflection;
 
 namespace Microsoft.AspNetCore.Http
 {
-    internal static class TryParseMethodCache
+    internal class TryParseMethodCache
     {
-        private static readonly MethodInfo EnumTryParseMethod = GetEnumTryParseMethod();
+        private readonly MethodInfo _enumTryParseMethod;
 
         // Since this is shared source, the cache won't be shared between RequestDelegateFactory and the ApiDescriptionProvider sadly :(
-        private static readonly ConcurrentDictionary<Type, Func<Expression, MethodCallExpression>?> MethodCallCache = new();
-        internal static readonly ParameterExpression TempSourceStringExpr = Expression.Variable(typeof(string), "tempSourceString");
+        private readonly ConcurrentDictionary<Type, Func<Expression, Expression>?> _methodCallCache = new();
 
-        public static bool HasTryParseMethod(ParameterInfo parameter)
+        internal readonly ParameterExpression TempSourceStringExpr = Expression.Variable(typeof(string), "tempSourceString");
+
+        public TryParseMethodCache() : this(preferNonGenericEnumParseOverload: false)
+        {
+        }
+
+        public TryParseMethodCache(bool preferNonGenericEnumParseOverload)
+        {
+            _enumTryParseMethod = GetEnumTryParseMethod(preferNonGenericEnumParseOverload);
+        }
+
+        public bool HasTryParseMethod(ParameterInfo parameter)
         {
             var nonNullableParameterType = Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType;
             return FindTryParseMethod(nonNullableParameterType) is not null;
         }
 
-        public static Func<Expression, MethodCallExpression>? FindTryParseMethod(Type type)
+        public Func<Expression, Expression>? FindTryParseMethod(Type type)
         {
-            static Func<Expression, MethodCallExpression>? Finder(Type type)
+            Func<Expression, Expression>? Finder(Type type)
             {
                 MethodInfo? methodInfo;
 
                 if (type.IsEnum)
                 {
-                    methodInfo = EnumTryParseMethod.MakeGenericMethod(type);
-                    if (methodInfo != null)
+                    if (_enumTryParseMethod.IsGenericMethod)
                     {
+                        methodInfo = _enumTryParseMethod.MakeGenericMethod(type);
+
                         return (expression) => Expression.Call(methodInfo!, TempSourceStringExpr, expression);
                     }
 
-                    return null;
+                    return (expression) =>
+                    {
+                        var enumAsObject = Expression.Variable(typeof(object), "enumAsObject");
+                        var success = Expression.Variable(typeof(bool), "success");
+
+                        // object enumAsObject;
+                        // bool canParse;
+                        // success = Enum.TryParse(type, tempSourceString, out enumAsObject);
+                        // parsedValue = success ? (Type)enumAsObject : default;
+                        // return success;
+
+                        return Expression.Block(new[] { success, enumAsObject },
+                            Expression.Assign(success, Expression.Call(_enumTryParseMethod, Expression.Constant(type), TempSourceStringExpr, enumAsObject)),
+                            Expression.Assign(expression,
+                                Expression.Condition(success, Expression.Convert(enumAsObject, type), Expression.Default(type))),
+                            success);
+                    };
+
                 }
 
                 if (TryGetDateTimeTryParseMethod(type, out methodInfo))
@@ -87,32 +115,59 @@ namespace Microsoft.AspNetCore.Http
                 return null;
             }
 
-            return MethodCallCache.GetOrAdd(type, Finder);
+            return _methodCallCache.GetOrAdd(type, Finder);
         }
 
-        private static MethodInfo GetEnumTryParseMethod()
+        private static MethodInfo GetEnumTryParseMethod(bool preferNonGenericEnumParseOverload)
         {
             var staticEnumMethods = typeof(Enum).GetMethods(BindingFlags.Public | BindingFlags.Static);
 
+            // With NativeAOT, if there's no static usage of Enum.TryParse<T>, it will be removed
+            // we fallback to the non-generic version if that is the case
+            MethodInfo? genericCandidate = null;
+            MethodInfo? nonGenericCandidate = null;
+
             foreach (var method in staticEnumMethods)
             {
-                if (!method.IsGenericMethod || method.Name != nameof(Enum.TryParse) || method.ReturnType != typeof(bool))
+                if (method.Name != nameof(Enum.TryParse) || method.ReturnType != typeof(bool))
                 {
                     continue;
                 }
 
                 var tryParseParameters = method.GetParameters();
 
-                if (tryParseParameters.Length == 2 &&
+                // Enum.TryParse<T>(string, out object)
+                if (method.IsGenericMethod &&
+                    tryParseParameters.Length == 2 &&
                     tryParseParameters[0].ParameterType == typeof(string) &&
                     tryParseParameters[1].IsOut)
                 {
-                    return method;
+                    genericCandidate = method;
+                }
+
+                // Enum.TryParse(type, string, out object)
+                if (!method.IsGenericMethod &&
+                    tryParseParameters.Length == 3 &&
+                    tryParseParameters[0].ParameterType == typeof(Type) &&
+                    tryParseParameters[1].ParameterType == typeof(string) &&
+                    tryParseParameters[2].IsOut)
+                {
+                    nonGenericCandidate = method;
                 }
             }
 
-            Debug.Fail("static bool System.Enum.TryParse<TEnum>(string? value, out TEnum result) not found.");
-            throw new Exception("static bool System.Enum.TryParse<TEnum>(string? value, out TEnum result) not found.");
+            if (genericCandidate is null && nonGenericCandidate is null)
+            {
+                Debug.Fail("No suitable System.Enum.TryParse method not found.");
+                throw new Exception("No suitable System.Enum.TryParse method not found.");
+            }
+
+            if (preferNonGenericEnumParseOverload)
+            {
+                return nonGenericCandidate!;
+            }
+
+            return genericCandidate ?? nonGenericCandidate!;
         }
 
         private static bool TryGetDateTimeTryParseMethod(Type type, [NotNullWhen(true)] out MethodInfo? methodInfo)

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Http
                         var success = Expression.Variable(typeof(bool), "success");
 
                         // object enumAsObject;
-                        // bool canParse;
+                        // bool success;
                         // success = Enum.TryParse(type, tempSourceString, out enumAsObject);
                         // parsedValue = success ? (Type)enumAsObject : default;
                         // return success;


### PR DESCRIPTION
- Generic methods for value types need to be visible at compile time so that the AOT compiler can generate code for the right instantiations (closed generic types). Since Enum.TryParse\<T\> is used purely via reflection is gets removed from the final AOT binary. This causes our logic that looks for Enum.TryParse\<T\> to fail. Instead, we call back to the non-generic overload which doesn't get trimmed and can at runtime lookup the metadata for the enum type in order to allow parsing.
- Made TryParseMethodCache creatable so it could be tested more easily.
- Added tests

Fixes #34875 

PS: To get a better sense of what the exception looks like for not having the code for a specific generic instantiation:

```
Unhandled Exception: EETypeRva:0x01CA62A8(System.Reflection.MissingRuntimeArtifactException): MakeGenericMethod() cannot create this generic method instantiation because no code was generated for it: 'System.Enum.TryParse<Choice>(System.String,System.Boolean,out Choice&)'.
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x1dc
   at System.Reflection.Runtime.MethodInfos.RuntimeConstructedGenericMethodInfo.get_UncachedMethodInvoker() + 0x3b
   at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.get_MethodInvoker() + 0x1c0
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x3e9
   at Microsoft.AspNetCore.Http.TryParseMethodCache.<FindTryParseMethod>g__Finder|4_0(Type) + 0xfd
   at WebApplication520!<BaseAddress>+0x104bc58
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey, Func`2) + 0x124
   at Microsoft.AspNetCore.Http.TryParseMethodCache.FindTryParseMethod(Type) + 0x56
   at Microsoft.AspNetCore.Http.TryParseMethodCache.HasTryParseMethod(ParameterInfo) + 0x87
   at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateArgument(ParameterInfo, RequestDelegateFactory.FactoryContext) + 0xa31
   at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateArguments(ParameterInfo[], RequestDelegateFactory.FactoryContext) + 0xd6
   at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateTargetableRequestDelegate(MethodInfo, RequestDelegateFactoryOptions, Expression) + 0x1bc
   at Microsoft.AspNetCore.Http.RequestDelegateFactory.Create(Delegate, RequestDelegateFactoryOptions) + 0x188
   at Microsoft.AspNetCore.Builder.MinimalActionEndpointRouteBuilderExtensions.Map(IEndpointRouteBuilder, RoutePattern, Delegate) + 0x253
   at Microsoft.AspNetCore.Builder.MinimalActionEndpointRouteBuilderExtensions.MapMethods(IEndpointRouteBuilder, String, IEnumerable`1, Delegate) + 0xa1
   at Microsoft.AspNetCore.Builder.MinimalActionEndpointRouteBuilderExtensions.MapGet(IEndpointRouteBuilder, String, Delegate) + 0x42
   at Program.<Main>$(String[]) + 0x703
   at WebApplication520!<BaseAddress>+0x10ad997
   at WebApplication520!<BaseAddress>+0x10ada20
```

Also, to see how this all of this expression compilation works with native AOT, the expression tree interpreter is used:

```C#
var builder = WebApplication.CreateBuilder(args);

var app = builder.Build();

app.MapGet("/", () => Environment.StackTrace);

app.Run();
```

```
   at System.Environment.get_StackTrace() + 0x32
   at Program.<>c.<<Main>$>b__0_0() + 0x19
   at WebApplication520!<BaseAddress>+0x13d245e
   at System.InvokeUtils.CallDynamicInvokeMethod(Object, IntPtr, IntPtr, IntPtr, Object, Object[], BinderBundle, Boolean, Boolean) + 0x1ac
   at Internal.Runtime.Augments.RuntimeAugments.CallDynamicInvokeMethod(Object, IntPtr, IntPtr, IntPtr, Object, Object[], BinderBundle, Boolean, Boolean) + 0x68
   at Internal.Reflection.Execution.MethodInvokers.InstanceMethodInvoker.Invoke(Object, Object[], BinderBundle, Boolean) + 0x108
   at Internal.Reflection.Core.Execution.MethodInvoker.Invoke(Object, Object[], Binder, BindingFlags, CultureInfo) + 0x83
   at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.Invoke(Object, BindingFlags, Binder, Object[], CultureInfo) + 0x86
   at System.Reflection.MethodBase.Invoke(Object, Object[]) + 0x4d
   at System.Linq.Expressions.Interpreter.MethodInfoCallInstruction.Run(InterpretedFrame) + 0x170
   at System.Linq.Expressions.Interpreter.Interpreter.Run(InterpretedFrame) + 0x69
   at System.Linq.Expressions.Interpreter.LightLambda.Run(Object[]) + 0xac
   at WebApplication520!<BaseAddress>+0x1084590
   at Microsoft.AspNetCore.Http.RequestDelegateFactory.<>c__DisplayClass33_0.<Create>b__0(HttpContext) + 0x62
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.Invoke(HttpContext) + 0x1f4
   at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.SetRoutingAndContinue(HttpContext) + 0xf3
   at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.Invoke(HttpContext) + 0x16a
   at Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware.Invoke(HttpContext) + 0x8d
   at Microsoft.AspNetCore.Hosting.HostingApplication.ProcessRequestAsync(HostingApplication.Context) + 0x53
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.<ProcessRequests>d__223`1.MoveNext() + 0x497
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object) + 0x6a
   at WebApplication520!<BaseAddress>+0x10a353a
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread, ExecutionContext, ContextCallback, Object) + 0x73
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread) + 0x124
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecuteFromThreadPool(Thread) + 0x1f
   at System.Threading.ThreadPoolWorkQueue.DispatchWorkItem(Object, Thread) + 0x52
   at System.Threading.ThreadPoolWorkQueue.Dispatch() + 0x177
   at System.Threading.ThreadPool.DispatchCallback(IntPtr, IntPtr, IntPtr) + 0x6e
```