### PR TITLE
Differentiate namespaces in IIS functionals

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
@@ -13,7 +13,20 @@ using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class AspNetCorePortTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
@@ -17,11 +17,11 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/BasicAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/BasicAuthTests.cs
@@ -12,7 +12,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class BasicAuthTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/BasicAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/BasicAuthTests.cs
@@ -16,11 +16,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
@@ -14,11 +14,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
@@ -10,7 +10,20 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(IISCompressionSiteCollection.Name)]
     public class CompressionTests : FixtureLoggedTest

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
@@ -49,6 +49,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         }
 
         [ConditionalFact]
+        [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "Shutdown hangs https://github.com/dotnet/aspnetcore/issues/25107")]
         [RequiresIIS(IISCapability.FailedRequestTracingModule)]
         public async Task CheckCommonFrebEvents()
         {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
@@ -19,11 +19,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
@@ -15,7 +15,20 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class FrebTests : IISFunctionalTestBase
@@ -36,7 +49,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         }
 
         [ConditionalFact]
-        [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "Shutdown hangs https://github.com/dotnet/aspnetcore/issues/25107")]
         [RequiresIIS(IISCapability.FailedRequestTracingModule)]
         public async Task CheckCommonFrebEvents()
         {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/GlobalVersionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/GlobalVersionTests.cs
@@ -13,7 +13,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class GlobalVersionTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/GlobalVersionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/GlobalVersionTests.cs
@@ -17,11 +17,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
@@ -22,11 +22,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
@@ -18,7 +18,20 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     /// <summary>
     /// These are HTTP/2 tests that work on both IIS and Express. See Http2TrailerResetTests for IIS specific tests

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -18,11 +18,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/HttpsTests.cs
@@ -14,7 +14,20 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     [SkipIfNotAdmin]

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
@@ -14,11 +14,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress.InProcess
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests.InProcess
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler.InProcess
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests.InProcess
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim.InProcess
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests.InProcess
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
@@ -10,7 +10,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress.InProcess
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler.InProcess
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim.InProcess
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class MaxRequestBodySizeTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Latin1Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Latin1Tests.cs
@@ -11,7 +11,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class Latin1Tests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Latin1Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Latin1Tests.cs
@@ -15,11 +15,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
@@ -12,7 +12,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class LoggingTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
@@ -16,11 +16,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -14,11 +14,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -10,7 +10,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class MaxRequestBodySizeTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
@@ -16,11 +16,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
@@ -12,7 +12,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class MultiApplicationTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
@@ -18,11 +18,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
@@ -14,7 +14,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(IISTestSiteCollection.Name)]
     public class RequestResponseTests

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
@@ -20,11 +20,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
@@ -16,7 +16,20 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     // Contains all tests related to shutdown, including app_offline, abort, and app recycle
     [Collection(PublishedSitesCollection.Name)]

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
@@ -21,7 +21,20 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Win32;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     // Contains all tests related to Startup, requiring starting ANCM/IIS every time.
     [Collection(PublishedSitesCollection.Name)]

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
@@ -436,7 +436,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalFact]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31893")]
-        [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "Shutdown hangs https://github.com/dotnet/aspnetcore/issues/25107")]
         public async Task RemoveInProcessReference_FailedToFindRequestHandler()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
@@ -436,6 +436,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalFact]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31893")]
+        [MaximumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2, SkipReason = "Shutdown hangs https://github.com/dotnet/aspnetcore/issues/25107")]
         public async Task RemoveInProcessReference_FailedToFindRequestHandler()
         {
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
@@ -25,11 +25,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
@@ -14,11 +14,11 @@ using Xunit;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 
 #if IISEXPRESS_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 #elif NEWHANDLER_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 #elif NEWSHIM_FUNCTIONALS
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 #endif
 
 #else

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
@@ -10,7 +10,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.FunctionalTests.IISExpress
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewHandler
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.NewShim
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class WindowsAuthTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestGroupName>IIS.FunctionalTests</TestGroupName>
+    <DefineConstants>IIS_FUNCTIONALS</DefineConstants>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
     <SkipTests Condition=" '$(SkipIISTests)' == 'true' ">true</SkipTests>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestGroupName>IISNewHandler.FunctionalTests</TestGroupName>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
+    <DefineConstants>NEWHANDLER_FUNCTIONALS</DefineConstants>
     <SkipTests Condition=" '$(SkipIISNewHandlerTests)' == 'true' ">true</SkipTests>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/NewHandlerTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/NewHandlerTests.cs
@@ -4,11 +4,12 @@
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 using Xunit.Sdk;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
     public class NewHandlerTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestGroupName>IISNewShim.FunctionalTests</TestGroupName>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
+    <DefineConstants>NEWSHIM_FUNCTIONALS</DefineConstants>
     <SkipTests Condition=" '$(SkipIISNewShimTests)' == 'true' ">true</SkipTests>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/NewShimTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/NewShimTests.cs
@@ -3,12 +3,13 @@
 
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 using Xunit.Sdk;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
     public class NewShimTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
@@ -7,13 +7,25 @@ using System.ServiceProcess;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
-using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class ApplicationInitializationTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
@@ -9,7 +9,20 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
+#elif NEWHANDLER_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.NewHandler.FunctionalTests
+#elif NEWSHIM_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.NewShim.FunctionalTests
+#endif
+
+#else
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+#endif
 {
     [Collection(PublishedSitesCollection.Name)]
     public class StdOutRedirectionTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
+    <DefineConstants>IISEXPRESS_FUNCTIONALS</DefineConstants>
     <TestGroupName>IISExpress.FunctionalTests</TestGroupName>
     <SkipTests Condition=" '$(SkipIISExpressTests)' == 'true' ">true</SkipTests>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
 {
     [Collection(PublishedSitesCollection.Name)]
     public class AppOfflineIISExpressTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AppOfflineIISExpressTests.cs
@@ -2,13 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
     public class AppOfflineIISExpressTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AuthenticationTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AuthenticationTests.cs
@@ -5,11 +5,12 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
     public class AuthenticationTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AuthenticationTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/AuthenticationTests.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
 {
     [Collection(PublishedSitesCollection.Name)]
     public class AuthenticationTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/IISExpressShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/IISExpressShutdownTests.cs
@@ -6,13 +6,14 @@ using System.IO;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
     public class IISExpressShutdownTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/IISExpressShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/IISExpressShutdownTests.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
 {
     [Collection(PublishedSitesCollection.Name)]
     public class IISExpressShutdownTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/WebSocketTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/WebSocketTests.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
 {
     [Collection(IISTestSiteCollection.Name)]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "No WebSocket supported on Win7")]

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/WebSocketTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/WebSocketTests.cs
@@ -10,9 +10,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 {
     [Collection(IISTestSiteCollection.Name)]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win8, SkipReason = "No WebSocket supported on Win7")]

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/MultipleAppTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/MultipleAppTests.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
 {
     [Collection(PublishedSitesCollection.Name)]
     public class MultipleAppTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/MultipleAppTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/MultipleAppTests.cs
@@ -6,12 +6,13 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
     public class MultipleAppTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Testing;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
 {
     [Collection(PublishedSitesCollection.Name)]
     public class NtlmAuthenticationTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/OutOfProcess/NtlmAuthentationTest.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
@@ -11,7 +12,7 @@ using Microsoft.AspNetCore.Testing;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
     public class NtlmAuthenticationTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/UpgradeFeatureDetectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/UpgradeFeatureDetectionTests.cs
@@ -4,13 +4,14 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests
 {
     [Collection(PublishedSitesCollection.Name)]
     public class UpgradeFeatureDetectionTests : IISFunctionalTestBase

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/UpgradeFeatureDetectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/UpgradeFeatureDetectionTests.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
-namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.IISExpress
 {
     [Collection(PublishedSitesCollection.Name)]
     public class UpgradeFeatureDetectionTests : IISFunctionalTestBase


### PR DESCRIPTION
Adds IISExpress/NewHandler/NewShim so the namespaces of the common tests display which variant failed