### PR TITLE
Slightly better support for NativeAOT and trimming

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -44,15 +44,15 @@ namespace Microsoft.AspNetCore.Http
         private static readonly ParameterExpression BodyValueExpr = Expression.Parameter(typeof(object), "bodyValue");
         private static readonly ParameterExpression WasParamCheckFailureExpr = Expression.Variable(typeof(bool), "wasParamCheckFailure");
 
-        private static readonly MemberExpression RequestServicesExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.RequestServices));
-        private static readonly MemberExpression HttpRequestExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.Request));
-        private static readonly MemberExpression HttpResponseExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.Response));
-        private static readonly MemberExpression RequestAbortedExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.RequestAborted));
-        private static readonly MemberExpression UserExpr = Expression.Property(HttpContextExpr, nameof(HttpContext.User));
-        private static readonly MemberExpression RouteValuesExpr = Expression.Property(HttpRequestExpr, nameof(HttpRequest.RouteValues));
-        private static readonly MemberExpression QueryExpr = Expression.Property(HttpRequestExpr, nameof(HttpRequest.Query));
-        private static readonly MemberExpression HeadersExpr = Expression.Property(HttpRequestExpr, nameof(HttpRequest.Headers));
-        private static readonly MemberExpression StatusCodeExpr = Expression.Property(HttpResponseExpr, nameof(HttpResponse.StatusCode));
+        private static readonly MemberExpression RequestServicesExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.RequestServices))!);
+        private static readonly MemberExpression HttpRequestExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.Request))!);
+        private static readonly MemberExpression HttpResponseExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.Response))!);
+        private static readonly MemberExpression RequestAbortedExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.RequestAborted))!);
+        private static readonly MemberExpression UserExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.User))!);
+        private static readonly MemberExpression RouteValuesExpr = Expression.Property(HttpRequestExpr, typeof(HttpRequest).GetProperty(nameof(HttpRequest.RouteValues))!);
+        private static readonly MemberExpression QueryExpr = Expression.Property(HttpRequestExpr, typeof(HttpRequest).GetProperty(nameof(HttpRequest.Query))!);
+        private static readonly MemberExpression HeadersExpr = Expression.Property(HttpRequestExpr, typeof(HttpRequest).GetProperty(nameof(HttpRequest.Headers))!);
+        private static readonly MemberExpression StatusCodeExpr = Expression.Property(HttpResponseExpr, typeof(HttpResponse).GetProperty(nameof(HttpResponse.StatusCode))!);
         private static readonly MemberExpression CompletedTaskExpr = Expression.Property(null, (PropertyInfo)GetMemberInfo<Func<Task>>(() => Task.CompletedTask));
 
         private static readonly BinaryExpression TempSourceStringNotNullExpr = Expression.NotEqual(TryParseMethodCache.TempSourceStringExpr, Expression.Constant(null));

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -1,15 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Numerics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 #nullable enable
 
@@ -24,7 +23,9 @@ namespace Microsoft.AspNetCore.Http
 
         internal readonly ParameterExpression TempSourceStringExpr = Expression.Variable(typeof(string), "tempSourceString");
 
-        public TryParseMethodCache() : this(preferNonGenericEnumParseOverload: false)
+        // If IsDynamicCodeSupported is false, we can't use the static Enum.TryParse<T> since there's no easy way for
+        // this code to generate the specific instantiation for any enums used
+        public TryParseMethodCache() : this(preferNonGenericEnumParseOverload: !RuntimeFeature.IsDynamicCodeSupported)
         {
         }
 
@@ -121,71 +122,79 @@ namespace Microsoft.AspNetCore.Http
 
         private static MethodInfo GetEnumTryParseMethod(bool preferNonGenericEnumParseOverload)
         {
-            var staticEnumMethods = typeof(Enum).GetMethods(BindingFlags.Public | BindingFlags.Static);
+            MethodInfo? methodInfo = null;
 
-            // With NativeAOT, if there's no static usage of Enum.TryParse<T>, it will be removed
-            // we fallback to the non-generic version if that is the case
-            MethodInfo? genericCandidate = null;
-            MethodInfo? nonGenericCandidate = null;
-
-            foreach (var method in staticEnumMethods)
+            if (preferNonGenericEnumParseOverload)
             {
-                if (method.Name != nameof(Enum.TryParse) || method.ReturnType != typeof(bool))
+                methodInfo = typeof(Enum).GetMethod(
+                                nameof(Enum.TryParse),
+                                BindingFlags.Public | BindingFlags.Static,
+                                new[] { typeof(Type), typeof(string), typeof(object).MakeByRefType() });
+            }
+            else
+            {
+                foreach (var method in typeof(Enum).GetMethods(BindingFlags.Public | BindingFlags.Static))
                 {
-                    continue;
-                }
+                    if (!method.IsGenericMethod || method.Name != nameof(Enum.TryParse) || method.ReturnType != typeof(bool))
+                    {
+                        continue;
+                    }
 
-                var tryParseParameters = method.GetParameters();
+                    var tryParseParameters = method.GetParameters();
 
-                // Enum.TryParse<T>(string, out object)
-                if (method.IsGenericMethod &&
-                    tryParseParameters.Length == 2 &&
-                    tryParseParameters[0].ParameterType == typeof(string) &&
-                    tryParseParameters[1].IsOut)
-                {
-                    genericCandidate = method;
-                }
-
-                // Enum.TryParse(type, string, out object)
-                if (!method.IsGenericMethod &&
-                    tryParseParameters.Length == 3 &&
-                    tryParseParameters[0].ParameterType == typeof(Type) &&
-                    tryParseParameters[1].ParameterType == typeof(string) &&
-                    tryParseParameters[2].IsOut)
-                {
-                    nonGenericCandidate = method;
+                    // Enum.TryParse<T>(string, out object)
+                    if (tryParseParameters.Length == 2 &&
+                        tryParseParameters[0].ParameterType == typeof(string) &&
+                        tryParseParameters[1].IsOut)
+                    {
+                        methodInfo = method;
+                    }
                 }
             }
 
-            if (genericCandidate is null && nonGenericCandidate is null)
+            if (methodInfo is null)
             {
                 Debug.Fail("No suitable System.Enum.TryParse method found.");
                 throw new MissingMethodException("No suitable System.Enum.TryParse method found.");
             }
 
-            if (preferNonGenericEnumParseOverload)
-            {
-                return nonGenericCandidate!;
-            }
-
-            return genericCandidate ?? nonGenericCandidate!;
+            return methodInfo!;
         }
 
         private static bool TryGetDateTimeTryParseMethod(Type type, [NotNullWhen(true)] out MethodInfo? methodInfo)
         {
-            methodInfo = null;
-            if (type != typeof(DateTime) && type != typeof(DateOnly) &&
-                 type != typeof(DateTimeOffset) && type != typeof(TimeOnly))
+            if (type == typeof(DateTime))
             {
-                return false;
+                methodInfo = typeof(DateTime).GetMethod(
+                     nameof(DateTime.TryParse),
+                     BindingFlags.Public | BindingFlags.Static,
+                     new[] { typeof(string), typeof(IFormatProvider), typeof(DateTimeStyles), typeof(DateTime).MakeByRefType() });
             }
-
-            var staticTryParseDateMethod = type.GetMethod(
-                "TryParse",
-                BindingFlags.Public | BindingFlags.Static,
-                new[] { typeof(string), typeof(IFormatProvider), typeof(DateTimeStyles), type.MakeByRefType() });
-
-            methodInfo = staticTryParseDateMethod;
+            else if (type == typeof(DateTimeOffset))
+            {
+                methodInfo = typeof(DateTimeOffset).GetMethod(
+                     nameof(DateTimeOffset.TryParse),
+                     BindingFlags.Public | BindingFlags.Static,
+                     new[] { typeof(string), typeof(IFormatProvider), typeof(DateTimeStyles), typeof(DateTimeOffset).MakeByRefType() });
+            }
+            else if (type == typeof(DateOnly))
+            {
+                methodInfo = typeof(DateOnly).GetMethod(
+                     nameof(DateOnly.TryParse),
+                     BindingFlags.Public | BindingFlags.Static,
+                     new[] { typeof(string), typeof(IFormatProvider), typeof(DateTimeStyles), typeof(DateOnly).MakeByRefType() });
+            }
+            else if (type == typeof(TimeOnly))
+            {
+                methodInfo = typeof(TimeOnly).GetMethod(
+                     nameof(TimeOnly.TryParse),
+                     BindingFlags.Public | BindingFlags.Static,
+                     new[] { typeof(string), typeof(IFormatProvider), typeof(DateTimeStyles), typeof(TimeOnly).MakeByRefType() });
+            }
+            else
+            {
+                methodInfo = null;
+            }
 
             return methodInfo != null;
         }
@@ -193,74 +202,120 @@ namespace Microsoft.AspNetCore.Http
         private static bool TryGetNumberStylesTryGetMethod(Type type, [NotNullWhen(true)] out MethodInfo? method, [NotNullWhen(true)] out NumberStyles? numberStyles)
         {
             method = null;
-            numberStyles = null;
+            numberStyles = NumberStyles.Integer;
 
-            if (!UseTryParseWithNumberStyleOption(type))
+            if (type == typeof(long))
             {
-                return false;
+                method = typeof(long).GetMethod(
+                          nameof(long.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(long).MakeByRefType() });
+            }
+            if (type == typeof(ulong))
+            {
+                method = typeof(ulong).GetMethod(
+                          nameof(ulong.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(ulong).MakeByRefType() });
+            }
+            else if (type == typeof(int))
+            {
+                method = typeof(int).GetMethod(
+                          nameof(int.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(int).MakeByRefType() });
+            }
+            else if (type == typeof(uint))
+            {
+                method = typeof(uint).GetMethod(
+                          nameof(uint.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(uint).MakeByRefType() });
+            }
+            else if (type == typeof(short))
+            {
+                method = typeof(short).GetMethod(
+                          nameof(short.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(short).MakeByRefType() });
+            }
+            else if (type == typeof(ushort))
+            {
+                method = typeof(ushort).GetMethod(
+                          nameof(ushort.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(ushort).MakeByRefType() });
+            }
+            else if (type == typeof(byte))
+            {
+                method = typeof(byte).GetMethod(
+                          nameof(byte.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(byte).MakeByRefType() });
+            }
+            else if (type == typeof(sbyte))
+            {
+                method = typeof(sbyte).GetMethod(
+                          nameof(sbyte.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(sbyte).MakeByRefType() });
+            }
+            else if (type == typeof(double))
+            {
+                method = typeof(double).GetMethod(
+                          nameof(double.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(double).MakeByRefType() });
+
+                numberStyles = NumberStyles.AllowThousands | NumberStyles.Float;
+            }
+            else if (type == typeof(float))
+            {
+                method = typeof(float).GetMethod(
+                          nameof(float.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(float).MakeByRefType() });
+
+                numberStyles = NumberStyles.AllowThousands | NumberStyles.Float;
+            }
+            else if (type == typeof(Half))
+            {
+                method = typeof(Half).GetMethod(
+                          nameof(Half.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(Half).MakeByRefType() });
+
+                numberStyles = NumberStyles.AllowThousands | NumberStyles.Float;
+            }
+            else if (type == typeof(decimal))
+            {
+                method = typeof(decimal).GetMethod(
+                          nameof(decimal.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(decimal).MakeByRefType() });
+
+                numberStyles = NumberStyles.Number;
+            }
+            else if (type == typeof(IntPtr))
+            {
+                method = typeof(IntPtr).GetMethod(
+                          nameof(IntPtr.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(IntPtr).MakeByRefType() });
+            }
+            else if (type == typeof(BigInteger))
+            {
+                method = typeof(BigInteger).GetMethod(
+                          nameof(BigInteger.TryParse),
+                          BindingFlags.Public | BindingFlags.Static,
+                          new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(BigInteger).MakeByRefType() });
+            }
+            else
+            {
+                method = null;
             }
 
-            var staticMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                   .Where(m => m.Name == "TryParse" && m.ReturnType == typeof(bool))
-                   .OrderByDescending(m => m.GetParameters().Length);
-
-            var numberStylesToUse = NumberStyles.Integer;
-            var methodToUse = default(MethodInfo);
-
-            foreach (var methodInfo in staticMethods)
-            {
-                var tryParseParameters = methodInfo.GetParameters();
-
-                if (tryParseParameters.Length == 4 &&
-                    tryParseParameters[0].ParameterType == typeof(string) &&
-                    tryParseParameters[1].ParameterType == typeof(NumberStyles) &&
-                    tryParseParameters[2].ParameterType == typeof(IFormatProvider) &&
-                    tryParseParameters[3].IsOut &&
-                    tryParseParameters[3].ParameterType == type.MakeByRefType())
-                {
-                    if (type == typeof(int) || type == typeof(short) || type == typeof(IntPtr) ||
-                        type == typeof(long) || type == typeof(byte) || type == typeof(sbyte) ||
-                        type == typeof(ushort) || type == typeof(uint) || type == typeof(ulong) ||
-                        type == typeof(BigInteger))
-                    {
-                        numberStylesToUse = NumberStyles.Integer;
-                    }
-
-                    if (type == typeof(double) || type == typeof(float) || type == typeof(Half))
-                    {
-                        numberStylesToUse = NumberStyles.AllowThousands | NumberStyles.Float;
-                    }
-
-                    if (type == typeof(decimal))
-                    {
-                        numberStylesToUse = NumberStyles.Number;
-                    }
-
-                    methodToUse = methodInfo!;
-                    break;
-                }
-            }
-
-            numberStyles = numberStylesToUse!;
-            method = methodToUse!;
-
-            return true;
+            return method != null;
         }
-
-        internal static bool UseTryParseWithNumberStyleOption(Type type)
-            => type == typeof(int) ||
-                type == typeof(double) ||
-                type == typeof(decimal) ||
-                type == typeof(float) ||
-                type == typeof(Half) ||
-                type == typeof(short) ||
-                type == typeof(long) ||
-                type == typeof(IntPtr) ||
-                type == typeof(byte) ||
-                type == typeof(sbyte) ||
-                type == typeof(ushort) ||
-                type == typeof(uint) ||
-                type == typeof(ulong) ||
-                type == typeof(BigInteger);
     }
 }

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -133,23 +133,10 @@ namespace Microsoft.AspNetCore.Http
             }
             else
             {
-                foreach (var method in typeof(Enum).GetMethods(BindingFlags.Public | BindingFlags.Static))
-                {
-                    if (!method.IsGenericMethod || method.Name != nameof(Enum.TryParse) || method.ReturnType != typeof(bool))
-                    {
-                        continue;
-                    }
-
-                    var tryParseParameters = method.GetParameters();
-
-                    // Enum.TryParse<T>(string, out object)
-                    if (tryParseParameters.Length == 2 &&
-                        tryParseParameters[0].ParameterType == typeof(string) &&
-                        tryParseParameters[1].IsOut)
-                    {
-                        methodInfo = method;
-                    }
-                }
+                methodInfo = typeof(Enum).GetMethod(
+                               nameof(Enum.TryParse),
+                               genericParameterCount: 1,
+                               new[] { typeof(string), Type.MakeGenericMethodParameter(0).MakeByRefType() });
             }
 
             if (methodInfo is null)
@@ -163,6 +150,8 @@ namespace Microsoft.AspNetCore.Http
 
         private static bool TryGetDateTimeTryParseMethod(Type type, [NotNullWhen(true)] out MethodInfo? methodInfo)
         {
+            methodInfo = null;
+
             if (type == typeof(DateTime))
             {
                 methodInfo = typeof(DateTime).GetMethod(
@@ -191,10 +180,6 @@ namespace Microsoft.AspNetCore.Http
                      BindingFlags.Public | BindingFlags.Static,
                      new[] { typeof(string), typeof(IFormatProvider), typeof(DateTimeStyles), typeof(TimeOnly).MakeByRefType() });
             }
-            else
-            {
-                methodInfo = null;
-            }
 
             return methodInfo != null;
         }
@@ -211,7 +196,7 @@ namespace Microsoft.AspNetCore.Http
                           BindingFlags.Public | BindingFlags.Static,
                           new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(long).MakeByRefType() });
             }
-            if (type == typeof(ulong))
+            else if (type == typeof(ulong))
             {
                 method = typeof(ulong).GetMethod(
                           nameof(ulong.TryParse),
@@ -309,10 +294,6 @@ namespace Microsoft.AspNetCore.Http
                           nameof(BigInteger.TryParse),
                           BindingFlags.Public | BindingFlags.Static,
                           new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(BigInteger).MakeByRefType() });
-            }
-            else
-            {
-                method = null;
             }
 
             return method != null;


### PR DESCRIPTION
- Use explicit reflection to make sure primitive TryParse method are preserved for trimming
- Also use explicit reflection to preserve HttpContext properties when using expression tree compilation.
- This doesn't work for custom types (those need to be preserved by the application).

Follow up to [this conversation](https://github.com/dotnet/aspnetcore/pull/35167#discussion_r685261199)

cc @jkotas @MichalStrehovsky @eerhardt 