### PR TITLE
Set IsRequired on ApiDescriptions for endpoints

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -28,6 +28,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         private readonly IHostEnvironment _environment;
         private readonly IServiceProviderIsService? _serviceProviderIsService;
         private readonly TryParseMethodCache TryParseMethodCache = new();
+        private readonly NullabilityInfoContext NullabilityContext = new();
 
         // Executes before MVC's DefaultApiDescriptionProvider and GrpcHttpApiDescriptionProvider for no particular reason.
         public int Order => -1100;
@@ -132,13 +133,17 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
         private ApiParameterDescription? CreateApiParameterDescription(ParameterInfo parameter, RoutePattern pattern)
         {
-            var (source, name) = GetBindingSourceAndName(parameter, pattern);
+            var (source, name, allowEmpty) = GetBindingSourceAndName(parameter, pattern);
 
             // Services are ignored because they are not request parameters.
             if (source == BindingSource.Services)
             {
                 return null;
             }
+
+            // Determine the "requiredness" based on nullability, default value or if allowEmpty is set
+            var nullability = NullabilityContext.Create(parameter);
+            var isOptional = parameter.HasDefaultValue || nullability.ReadState == NullabilityState.Nullable || allowEmpty;
 
             return new ApiParameterDescription
             {
@@ -147,30 +152,31 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 Source = source,
                 DefaultValue = parameter.DefaultValue,
                 Type = parameter.ParameterType,
+                IsRequired = !isOptional
             };
         }
 
         // TODO: Share more of this logic with RequestDelegateFactory.CreateArgument(...) using RequestDelegateFactoryUtilities
         // which is shared source.
-        private (BindingSource, string) GetBindingSourceAndName(ParameterInfo parameter, RoutePattern pattern)
+        private (BindingSource, string, bool) GetBindingSourceAndName(ParameterInfo parameter, RoutePattern pattern)
         {
             var attributes = parameter.GetCustomAttributes();
 
             if (attributes.OfType<IFromRouteMetadata>().FirstOrDefault() is { } routeAttribute)
             {
-                return (BindingSource.Path, routeAttribute.Name ?? parameter.Name ?? string.Empty);
+                return (BindingSource.Path, routeAttribute.Name ?? parameter.Name ?? string.Empty, false);
             }
             else if (attributes.OfType<IFromQueryMetadata>().FirstOrDefault() is { } queryAttribute)
             {
-                return (BindingSource.Query, queryAttribute.Name ?? parameter.Name ?? string.Empty);
+                return (BindingSource.Query, queryAttribute.Name ?? parameter.Name ?? string.Empty, false);
             }
             else if (attributes.OfType<IFromHeaderMetadata>().FirstOrDefault() is { } headerAttribute)
             {
-                return (BindingSource.Header, headerAttribute.Name ?? parameter.Name ?? string.Empty);
+                return (BindingSource.Header, headerAttribute.Name ?? parameter.Name ?? string.Empty, false);
             }
-            else if (parameter.CustomAttributes.Any(a => typeof(IFromBodyMetadata).IsAssignableFrom(a.AttributeType)))
+            else if (attributes.OfType<IFromBodyMetadata>().FirstOrDefault() is { } fromBodyAttribute)
             {
-                return (BindingSource.Body, parameter.Name ?? string.Empty);
+                return (BindingSource.Body, parameter.Name ?? string.Empty, fromBodyAttribute.AllowEmpty);
             }
             else if (parameter.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)) ||
                      parameter.ParameterType == typeof(HttpContext) ||
@@ -180,23 +186,23 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                      parameter.ParameterType == typeof(CancellationToken) ||
                      _serviceProviderIsService?.IsService(parameter.ParameterType) == true)
             {
-                return (BindingSource.Services, parameter.Name ?? string.Empty);
+                return (BindingSource.Services, parameter.Name ?? string.Empty, false);
             }
             else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseMethod(parameter))
             {
                 // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
                 if (parameter.Name is { } name && pattern.GetParameter(name) is not null)
                 {
-                    return (BindingSource.Path, name);
+                    return (BindingSource.Path, name, false);
                 }
                 else
                 {
-                    return (BindingSource.Query, parameter.Name ?? string.Empty);
+                    return (BindingSource.Query, parameter.Name ?? string.Empty, false);
                 }
             }
             else
             {
-                return (BindingSource.Body, parameter.Name ?? string.Empty);
+                return (BindingSource.Body, parameter.Name ?? string.Empty, false);
             }
         }
 

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -384,6 +384,9 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             Assert.False(fromBodyParam1.IsRequired);
         }
 
+        // This is necessary for TestIsRequiredFromBody to pass until https://github.com/dotnet/roslyn/issues/55254 is resolved.
+        private object RandomMethod() => throw new NotImplementedException();
+
 #nullable disable
 
         [Fact]

--- a/src/Mvc/Mvc.ApiExplorer/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test.csproj
+++ b/src/Mvc/Mvc.ApiExplorer/test/Microsoft.AspNetCore.Mvc.ApiExplorer.Test.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <LangVersion>Preview</LangVersion>
+    <Features>$(Features.Replace('nullablePublicOnly', '')</Features>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Use the same logic we have in RequestDelegateFactory.Create to
determine if a method parameter is required or not. We then set the
IsRequired property on the ApiParameterDesciption.
- Added tests

Fixes https://github.com/dotnet/aspnetcore/issues/35081

~TODO: Figure out why tests don't properly expose NRT metadata. It might be because of this bug https://github.com/dotnet/roslyn/issues/55254~