### PR TITLE
Enable ServerCertificateSelector for HTTP/3 

### DIFF
--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -42,13 +42,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https
         /// <summary>
         /// <para>
         /// A callback that will be invoked to dynamically select a server certificate. This is higher priority than ServerCertificate.
-        /// If SNI is not available then the name parameter will be null.
+        /// If SNI is not available then the name parameter will be null. The <see cref="ConnectionContext"/> will be null for HTTP/3 connections.
         /// </para>
         /// <para>
         /// If the server certificate has an Extended Key Usage extension, the usages must include Server Authentication (OID 1.3.6.1.5.5.7.3.1).
         /// </para>
         /// </summary>
-        public Func<ConnectionContext, string?, X509Certificate2?>? ServerCertificateSelector { get; set; }
+        public Func<ConnectionContext?, string?, X509Certificate2?>? ServerCertificateSelector { get; set; }
 
         /// <summary>
         /// Specifies the client certificate requirements for a HTTPS connection. Defaults to <see cref="ClientCertificateMode.NoCertificate"/>.

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 {
@@ -72,8 +73,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                     sslServerAuthenticationOptions.ServerCertificate = null;
                     sslServerAuthenticationOptions.ServerCertificateSelectionCallback = (sender, host) =>
                     {
-                        // There is no ConnectionContext available durring the handshake.
-                        return listenOptions.HttpsOptions.ServerCertificateSelector(null!, host)!;
+                        // There is no ConnectionContext available durring the QUIC handshake.
+                        var cert = listenOptions.HttpsOptions.ServerCertificateSelector(null, host);
+                        if (cert != null)
+                        {
+                            HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(cert);
+                        }
+                        return cert!;
                     };
                 }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
@@ -66,6 +66,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
                     ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol("h3"), new SslApplicationProtocol("h3-29") }
                 };
 
+                if (listenOptions.HttpsOptions.ServerCertificateSelector != null)
+                {
+                    // We can't set both
+                    sslServerAuthenticationOptions.ServerCertificate = null;
+                    sslServerAuthenticationOptions.ServerCertificateSelectionCallback = (sender, host) =>
+                    {
+                        // There is no ConnectionContext available durring the handshake.
+                        return listenOptions.HttpsOptions.ServerCertificateSelector(null!, host)!;
+                    };
+                }
+
                 features.Set(sslServerAuthenticationOptions);
             }
 

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -183,7 +183,7 @@ Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.OnAuthen
 Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.OnAuthenticate.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ServerCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2?
 Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ServerCertificate.set -> void
-Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ServerCertificateSelector.get -> System.Func<Microsoft.AspNetCore.Connections.ConnectionContext!, string?, System.Security.Cryptography.X509Certificates.X509Certificate2?>?
+Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ServerCertificateSelector.get -> System.Func<Microsoft.AspNetCore.Connections.ConnectionContext?, string?, System.Security.Cryptography.X509Certificates.X509Certificate2?>?
 Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ServerCertificateSelector.set -> void
 Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.AnyIPEndpoint(int port) -> Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader!
 Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.AnyIPEndpoint(int port, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader!

--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportFactory.cs
@@ -54,9 +54,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic
             {
                 throw new InvalidOperationException("Couldn't find HTTPS configuration for QUIC transport.");
             }
-            if (sslServerAuthenticationOptions.ServerCertificate == null)
+            if (sslServerAuthenticationOptions.ServerCertificate == null
+                && sslServerAuthenticationOptions.ServerCertificateContext == null
+                && sslServerAuthenticationOptions.ServerCertificateSelectionCallback == null)
             {
-                var message = $"{nameof(SslServerAuthenticationOptions)}.{nameof(SslServerAuthenticationOptions.ServerCertificate)} must be configured with a value.";
+                var message = $"{nameof(SslServerAuthenticationOptions)} must provide a server certificate using {nameof(SslServerAuthenticationOptions.ServerCertificate)},"
+                    + $" {nameof(SslServerAuthenticationOptions.ServerCertificateContext)}, or {nameof(SslServerAuthenticationOptions.ServerCertificateSelectionCallback)}.";
                 throw new InvalidOperationException(message);
             }
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3Helpers.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3Helpers.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Interop.FunctionalTests.Http3
+{
+    public static class Http3Helpers
+    {
+        public static HttpMessageInvoker CreateClient(TimeSpan? idleTimeout = null)
+        {
+            var handler = new SocketsHttpHandler();
+            handler.SslOptions = new System.Net.Security.SslClientAuthenticationOptions
+            {
+                RemoteCertificateValidationCallback = (_, __, ___, ____) => true,
+                TargetHost = "targethost"
+            };
+            if (idleTimeout != null)
+            {
+                handler.PooledConnectionIdleTimeout = idleTimeout.Value;
+            }
+
+            return new HttpMessageInvoker(handler);
+        }
+
+        public static IHostBuilder CreateHostBuilder(Action<IServiceCollection> configureServices, RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)
+        {
+            return new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseKestrel(o =>
+                        {
+                            if (configureKestrel == null)
+                            {
+                                o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
+                                {
+                                    listenOptions.Protocols = protocol ?? HttpProtocols.Http3;
+                                    listenOptions.UseHttps();
+                                });
+                            }
+                            else
+                            {
+                                configureKestrel(o);
+                            }
+                        })
+                        .Configure(app =>
+                        {
+                            app.Run(requestDelegate);
+                        });
+                })
+                .ConfigureServices(configureServices)
+                .ConfigureHostOptions(o =>
+                {
+                    if (Debugger.IsAttached)
+                    {
+                        // Avoid timeout while debugging.
+                        o.ShutdownTimeout = TimeSpan.FromHours(1);
+                    }
+                    else
+                    {
+                        o.ShutdownTimeout = TimeSpan.FromSeconds(1);
+                    }
+                });
+        }
+    }
+}

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Interop.FunctionalTests.Http3
+{
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
+    public class Http3TlsTests : LoggedTest
+    {
+        [ConditionalFact]
+        [MsQuicSupported]
+        public async Task ServerCertificateSelector_Invoked()
+        {
+            var builder = CreateHostBuilder(async context =>
+            {
+                await context.Response.WriteAsync("Hello World");
+            }, configureKestrel: kestrelOptions =>
+            {
+                kestrelOptions.ListenAnyIP(0, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http3;
+                    listenOptions.UseHttps(httpsOptions =>
+                    {
+                        httpsOptions.ServerCertificateSelector = (context, host) =>
+                        {
+                            Assert.Null(context); // The context isn't available durring the quic handshake.
+                            Assert.Equal("localhost", host);
+                            return TestResources.GetTestCertificate();
+                        };
+                    });
+                });
+            });
+
+            using var host = builder.Build();
+            using var client = CreateClient();
+
+            await host.StartAsync().DefaultTimeout();
+
+            // Using localhost instead of 127.0.0.1 because IPs don't set SNI and the Host header isn't currently used as an override.
+            var request = new HttpRequestMessage(HttpMethod.Get, $"https://localhost:{host.GetPort()}/");
+            request.Version = HttpVersion.Version30;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+            // https://github.com/dotnet/runtime/issues/57169 Host isn't used for SNI
+            request.Headers.Host = "testhost";
+
+            var response = await client.SendAsync(request, CancellationToken.None);
+            response.EnsureSuccessStatusCode();
+            var result = await response.Content.ReadAsStringAsync();
+            Assert.Equal(HttpVersion.Version30, response.Version);
+            Assert.Equal("Hello World", result);
+
+            await host.StopAsync().DefaultTimeout();
+        }
+
+        private static HttpMessageInvoker CreateClient(TimeSpan? idleTimeout = null)
+        {
+            var handler = new SocketsHttpHandler();
+            handler.SslOptions = new System.Net.Security.SslClientAuthenticationOptions
+            {
+                RemoteCertificateValidationCallback = (_, __, ___, ____) => true,
+                TargetHost = "targethost"
+            };
+            if (idleTimeout != null)
+            {
+                handler.PooledConnectionIdleTimeout = idleTimeout.Value;
+            }
+
+            return new HttpMessageInvoker(handler);
+        }
+
+        private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)
+        {
+            return new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseKestrel(o =>
+                        {
+                            if (configureKestrel == null)
+                            {
+                                o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
+                                {
+                                    listenOptions.Protocols = protocol ?? HttpProtocols.Http3;
+                                    listenOptions.UseHttps();
+                                });
+                            }
+                            else
+                            {
+                                configureKestrel(o);
+                            }
+                        })
+                        .Configure(app =>
+                        {
+                            app.Run(requestDelegate);
+                        });
+                })
+                .ConfigureServices(AddTestLogging)
+                .ConfigureHostOptions(o =>
+                {
+                    if (Debugger.IsAttached)
+                    {
+                        // Avoid timeout while debugging.
+                        o.ShutdownTimeout = TimeSpan.FromHours(1);
+                    }
+                    else
+                    {
+                        o.ShutdownTimeout = TimeSpan.FromSeconds(1);
+                    }
+                });
+        }
+    }
+}


### PR DESCRIPTION
Contributes to #34858

ServerCertificateSelector is the only SNI callback we can support with the current quic APIs. All of the others return a full SslServerAuthenticationOptions per connection which isn't supported.

Note because the SNI callback happens before the connection is accepted, there is no ConnectionContext to pass to the callback (nor a MultiplexedConnectionContext). Invoking it with null seemed preferable to not supporting SNI at all.