### PR TITLE
HTTP/3: QUIC connection listener fixes

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -203,6 +204,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                     // multiplexed transport factory, which happens if QUIC isn't supported.
                     var addAltSvcHeader = !options.DisableAltSvcHeader && _multiplexedTransportFactory != null;
 
+                    var originalEndPoint = options.EndPoint;
+
                     // Add the HTTP middleware as the terminal connection middleware
                     if (hasHttp1 || hasHttp2
                         || options.Protocols == HttpProtocols.None) // TODO a test fails because it doesn't throw an exception in the right place
@@ -219,7 +222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                         // Add the connection limit middleware
                         connectionDelegate = EnforceConnectionLimit(connectionDelegate, Options.Limits.MaxConcurrentConnections, Trace);
 
-                        options.EndPoint = await _transportManager.BindAsync(options.EndPoint, connectionDelegate, options.EndpointConfig, onBindCancellationToken).ConfigureAwait(false);
+                        options.EndPoint = await _transportManager.BindAsync(ResolveEndPoint(originalEndPoint, options.EndPoint), connectionDelegate, options.EndpointConfig, onBindCancellationToken).ConfigureAwait(false);
                     }
 
                     if (hasHttp3 && _multiplexedTransportFactory is not null)
@@ -230,7 +233,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
                         // Add the connection limit middleware
                         multiplexedConnectionDelegate = EnforceConnectionLimit(multiplexedConnectionDelegate, Options.Limits.MaxConcurrentConnections, Trace);
 
-                        options.EndPoint = await _transportManager.BindAsync(options.EndPoint, multiplexedConnectionDelegate, options, onBindCancellationToken).ConfigureAwait(false);
+                        options.EndPoint = await _transportManager.BindAsync(ResolveEndPoint(originalEndPoint, options.EndPoint), multiplexedConnectionDelegate, options, onBindCancellationToken).ConfigureAwait(false);
                     }
                 }
 
@@ -247,6 +250,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
             // Register the options with the event source so it can be logged (if necessary)
             KestrelEventSource.Log.AddServerOptions(Options);
+
+            static EndPoint ResolveEndPoint(EndPoint originalEndPoint, EndPoint currentEndPoint)
+            {
+                // From the original endpoint we want the address. This address could be a constant.
+                // For example, IPAddress.IPv4Any or IPAddress.IPv6Any. QUIC connection listener
+                // has logic that special cases these constants.
+                //
+                // However, from the current endpoint we want to get the port. If there is a port of 0
+                // then the first listener will resolve it to an actual port number. We want additional
+                // listeners to use that port number instead of each using 0 and resolving to different
+                // port numbers.
+                if (originalEndPoint is IPEndPoint originalIP && originalIP.Port == 0 &&
+                    currentEndPoint is IPEndPoint currentIP && currentIP.Port != 0)
+                {
+                    return new IPEndPoint(originalIP.Address, currentIP.Port);
+                }
+
+                return originalEndPoint;
+            }
         }
 
         // Graceful shutdown if possible

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -277,8 +277,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var multiplexedTransportEndPoint = Assert.Single(mockMultiplexedTransportFactory.BoundEndPoints);
 
             // Both transports should get the IPv6Any
-            Assert.Same(IPAddress.IPv6Any, ((IPEndPoint)transportEndPoint.OriginalEndPoint).Address);
-            Assert.Same(IPAddress.IPv6Any, ((IPEndPoint)multiplexedTransportEndPoint.OriginalEndPoint).Address);
+            Assert.Equal(IPAddress.IPv6Any, ((IPEndPoint)transportEndPoint.OriginalEndPoint).Address);
+            Assert.Equal(IPAddress.IPv6Any, ((IPEndPoint)multiplexedTransportEndPoint.OriginalEndPoint).Address);
 
             Assert.Equal(5000, ((IPEndPoint)transportEndPoint.OriginalEndPoint).Port);
             Assert.Equal(5000, ((IPEndPoint)multiplexedTransportEndPoint.OriginalEndPoint).Port);
@@ -311,8 +311,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             var transportEndPoint = Assert.Single(mockTransportFactory.BoundEndPoints);
             var multiplexedTransportEndPoint = Assert.Single(mockMultiplexedTransportFactory.BoundEndPoints);
 
-            Assert.Same(IPAddress.IPv6Any, ((IPEndPoint)transportEndPoint.OriginalEndPoint).Address);
-            Assert.Same(IPAddress.IPv6Any, ((IPEndPoint)multiplexedTransportEndPoint.OriginalEndPoint).Address);
+            Assert.Equal(IPAddress.IPv6Any, ((IPEndPoint)transportEndPoint.OriginalEndPoint).Address);
+            Assert.Equal(IPAddress.IPv6Any, ((IPEndPoint)multiplexedTransportEndPoint.OriginalEndPoint).Address);
 
             // Should have been assigned a random value.
             Assert.NotEqual(0, ((IPEndPoint)transportEndPoint.BoundEndPoint).Port);

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                .BuildServiceProvider();
             options.ListenAnyIP(5000, options =>
             {
-                options.UseHttps();
+                options.UseHttps(TestResources.GetTestCertificate());
                 options.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
             });
 
@@ -293,7 +293,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                .BuildServiceProvider();
             options.ListenAnyIP(0, options =>
             {
-                options.UseHttps();
+                options.UseHttps(TestResources.GetTestCertificate());
                 options.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
             });
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -35,7 +35,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             _context = new QuicTransportContext(_log, options);
             var quicListenerOptions = new QuicListenerOptions();
 
-            var listenEndPoint = (IPEndPoint)endpoint;
+            var listenEndPoint = endpoint as IPEndPoint;
+
+            if (listenEndPoint == null)
+            {
+                throw new InvalidOperationException($"QUIC doesn't support listening on the configured endpoint type. Expected {nameof(IPEndPoint)} but got {endpoint.GetType().Name}.");
+            }
 
             // Workaround for issue in System.Net.Quic
             // https://github.com/dotnet/runtime/issues/57241

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -35,8 +35,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             _context = new QuicTransportContext(_log, options);
             var quicListenerOptions = new QuicListenerOptions();
 
+            var listenEndPoint = (IPEndPoint)endpoint;
+
+            // Workaround for issue in System.Net.Quic
+            // https://github.com/dotnet/runtime/issues/57241
+            if (listenEndPoint.Address.Equals(IPAddress.Any) && listenEndPoint.Address != IPAddress.Any)
+            {
+                listenEndPoint = new IPEndPoint(IPAddress.Any, listenEndPoint.Port);
+            }
+            if (listenEndPoint.Address.Equals(IPAddress.IPv6Any) && listenEndPoint.Address != IPAddress.IPv6Any)
+            {
+                listenEndPoint = new IPEndPoint(IPAddress.IPv6Any, listenEndPoint.Port);
+            }
+
             quicListenerOptions.ServerAuthenticationOptions = sslServerAuthenticationOptions;
-            quicListenerOptions.ListenEndPoint = endpoint as IPEndPoint;
+            quicListenerOptions.ListenEndPoint = listenEndPoint;
             quicListenerOptions.IdleTimeout = options.IdleTimeout;
             quicListenerOptions.MaxBidirectionalStreams = options.MaxBidirectionalStreamCount;
             quicListenerOptions.MaxUnidirectionalStreams = options.MaxUnidirectionalStreamCount;

--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportFactory.cs
@@ -48,6 +48,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic
         /// <returns>A </returns>
         public ValueTask<IMultiplexedConnectionListener> BindAsync(EndPoint endpoint, IFeatureCollection? features = null, CancellationToken cancellationToken = default)
         {
+            if (endpoint == null)
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
             var sslServerAuthenticationOptions = features?.Get<SslServerAuthenticationOptions>();
 
             if (sslServerAuthenticationOptions == null)

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTransportFactoryTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTransportFactoryTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => quicTransportFactory.BindAsync(new IPEndPoint(0, 0), features: features, cancellationToken: CancellationToken.None).AsTask()).DefaultTimeout();
 
             // Assert
-            Assert.Equal("SslServerAuthenticationOptions.ServerCertificate must be configured with a value.", ex.Message);
+            Assert.Equal("SslServerAuthenticationOptions must provide a server certificate using ServerCertificate, ServerCertificateContext, or ServerCertificateSelectionCallback.", ex.Message);
         }
     }
 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -277,7 +277,7 @@ namespace Interop.FunctionalTests.Http3
             using (var host = builder.Build())
             using (var client = Http3Helpers.CreateClient())
             {
-                await host.StartAsync();
+                await host.StartAsync().DefaultTimeout();
 
                 var requestContent = new StreamingHttpContext();
 
@@ -289,22 +289,22 @@ namespace Interop.FunctionalTests.Http3
                 // Act
                 var responseTask = client.SendAsync(request, CancellationToken.None);
 
-                var requestStream = await requestContent.GetStreamAsync();
+                var requestStream = await requestContent.GetStreamAsync().DefaultTimeout();
 
                 // Send headers
-                await requestStream.FlushAsync();
+                await requestStream.FlushAsync().DefaultTimeout();
                 // Write content
-                await requestStream.WriteAsync(TestData);
+                await requestStream.WriteAsync(TestData).DefaultTimeout();
 
-                var response = await responseTask;
+                var response = await responseTask.DefaultTimeout();
 
                 // Assert
                 response.EnsureSuccessStatusCode();
                 Assert.Equal(HttpVersion.Version30, response.Version);
-                var responseText = await response.Content.ReadAsStringAsync();
+                var responseText = await response.Content.ReadAsStringAsync().DefaultTimeout();
                 Assert.Equal("Hello world", responseText);
 
-                await host.StopAsync();
+                await host.StopAsync().DefaultTimeout();
             }
         }
 


### PR DESCRIPTION
ListenAnyIP passes an `EndPoint` with an address of `IPAddress.IPv6Any` to the transports. If there are multiple transports, i.e. TCP and multiplexed QUIC, then the address value was being replaced with an address that looks like IPv6Any, but isn't the `IPAddress.IPv6Any` constant. `QuicConnectionListener` has logic that checks for this constant.

Now the original address of a listener is always passed unchanged to each transport. The overall endpoint can be updated by the first transport when an ephemeral port (port 0) is bound. We want to share that.