### PR TITLE
Refactor WebViewManager API to have JS component config passed in

### DIFF
--- a/src/Components/WebView/Samples/PhotinoPlatform/src/BlazorWindow.cs
+++ b/src/Components/WebView/Samples/PhotinoPlatform/src/BlazorWindow.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.FileProviders;
 using PhotinoNET;
 
@@ -43,8 +44,9 @@ namespace Microsoft.AspNetCore.Components.WebView.Photino
             var fileProvider = new PhysicalFileProvider(contentRootDir);
 
             var dispatcher = new PhotinoDispatcher(_window);
-            _manager = new PhotinoWebViewManager(_window, services, dispatcher, new Uri(PhotinoWebViewManager.AppBaseUri), fileProvider, hostPageRelativePath);
-            RootComponents = new BlazorWindowRootComponents(_manager);
+            var jsComponents = new JSComponentConfigurationStore();
+            _manager = new PhotinoWebViewManager(_window, services, dispatcher, new Uri(PhotinoWebViewManager.AppBaseUri), fileProvider, jsComponents, hostPageRelativePath);
+            RootComponents = new BlazorWindowRootComponents(_manager, jsComponents);
         }
 
         /// <summary>

--- a/src/Components/WebView/Samples/PhotinoPlatform/src/BlazorWindowRootComponents.cs
+++ b/src/Components/WebView/Samples/PhotinoPlatform/src/BlazorWindowRootComponents.cs
@@ -12,13 +12,12 @@ namespace Microsoft.AspNetCore.Components.WebView.Photino
     {
         private readonly PhotinoWebViewManager _manager;
 
-        internal BlazorWindowRootComponents(PhotinoWebViewManager manager)
+        internal BlazorWindowRootComponents(PhotinoWebViewManager manager, JSComponentConfigurationStore jsComponents)
         {
             _manager = manager;
-            JSComponents = manager.JSComponentConfiguration;
+            JSComponents = jsComponents;
         }
 
-        /// <inheritdoc />
         public JSComponentConfigurationStore JSComponents { get; }
 
         /// <summary>

--- a/src/Components/WebView/Samples/PhotinoPlatform/src/PhotinoWebViewManager.cs
+++ b/src/Components/WebView/Samples/PhotinoPlatform/src/PhotinoWebViewManager.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.FileProviders;
 using PhotinoNET;
 
@@ -26,8 +27,8 @@ namespace Microsoft.AspNetCore.Components.WebView.Photino
         internal static readonly string AppBaseUri
             = $"{BlazorAppScheme}://0.0.0.0/";
 
-        public PhotinoWebViewManager(PhotinoWindow window, IServiceProvider provider, Dispatcher dispatcher, Uri appBaseUri, IFileProvider fileProvider, string hostPageRelativePath)
-            : base(provider, dispatcher, appBaseUri, fileProvider, hostPageRelativePath)
+        public PhotinoWebViewManager(PhotinoWindow window, IServiceProvider provider, Dispatcher dispatcher, Uri appBaseUri, IFileProvider fileProvider, JSComponentConfigurationStore jsComponents, string hostPageRelativePath)
+            : base(provider, dispatcher, appBaseUri, fileProvider, jsComponents, hostPageRelativePath)
         {
             _window = window ?? throw new ArgumentNullException(nameof(window));
             _window.WebMessageReceived += (sender, message) =>

--- a/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
@@ -1,14 +1,13 @@
-﻿#nullable enable
+#nullable enable
 Microsoft.AspNetCore.Components.WebView.WebViewManager
 Microsoft.AspNetCore.Components.WebView.WebViewManager.AddRootComponentAsync(System.Type! componentType, string! selector, Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.WebView.WebViewManager.Dispatcher.get -> Microsoft.AspNetCore.Components.Dispatcher!
 Microsoft.AspNetCore.Components.WebView.WebViewManager.DisposeAsync() -> System.Threading.Tasks.ValueTask
-Microsoft.AspNetCore.Components.WebView.WebViewManager.JSComponentConfiguration.get -> Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore!
 Microsoft.AspNetCore.Components.WebView.WebViewManager.MessageReceived(System.Uri! sourceUri, string! message) -> void
 Microsoft.AspNetCore.Components.WebView.WebViewManager.Navigate(string! url) -> void
 Microsoft.AspNetCore.Components.WebView.WebViewManager.RemoveRootComponentAsync(string! selector) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.WebView.WebViewManager.TryGetResponseContent(string! uri, bool allowFallbackOnHostPage, out int statusCode, out string! statusMessage, out System.IO.Stream! content, out System.Collections.Generic.IDictionary<string!, string!>! headers) -> bool
-Microsoft.AspNetCore.Components.WebView.WebViewManager.WebViewManager(System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, System.Uri! appBaseUri, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, string! hostPageRelativePath) -> void
+Microsoft.AspNetCore.Components.WebView.WebViewManager.WebViewManager(System.IServiceProvider! provider, Microsoft.AspNetCore.Components.Dispatcher! dispatcher, System.Uri! appBaseUri, Microsoft.Extensions.FileProviders.IFileProvider! fileProvider, Microsoft.AspNetCore.Components.Web.JSComponentConfigurationStore! jsComponents, string! hostPageRelativePath) -> void
 Microsoft.Extensions.DependencyInjection.ComponentsWebViewServiceCollectionExtensions
 abstract Microsoft.AspNetCore.Components.WebView.WebViewManager.NavigateCore(System.Uri! absoluteUri) -> void
 abstract Microsoft.AspNetCore.Components.WebView.WebViewManager.SendMessage(string! message) -> void

--- a/src/Components/WebView/WebView/test/Infrastructure/TestWebViewManager.cs
+++ b/src/Components/WebView/WebView/test/Infrastructure/TestWebViewManager.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Components.WebView
         private readonly List<string> _sentIpcMessages = new();
 
         public TestWebViewManager(IServiceProvider provider, IFileProvider fileProvider)
-            : base(provider, Dispatcher.CreateDefault(), AppBaseUri, fileProvider, hostPageRelativePath: "index.html")
+            : base(provider, Dispatcher.CreateDefault(), AppBaseUri, fileProvider, new(), hostPageRelativePath: "index.html")
         {
         }
 


### PR DESCRIPTION
@eilon found that we needed to change this, because in MAUI, the `WebViewManager` doesn't get created until later in the process. We need the application builder to be able to configure JS root components before `WebViewManager` is instantiated, and pass the config in, instead of getting the config out.