### PR TITLE
Linux: Fix nested group resolution for RBAC claims

### DIFF
--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -110,16 +110,15 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate
                 }
 
                 var group = searchResponse.Entries[0]; //Get the object that was found on ldap
-                string name = group.DistinguishedName;
-                retrievedClaims.Add(name);
+                retrievedClaims.Add(groupCN);
 
                 var memberof = group.Attributes["memberof"]; // You can access ldap Attributes with Attributes property
                 if (memberof != null)
                 {
                     foreach (var member in memberof)
                     {
-                        var groupDN = $"{Encoding.UTF8.GetString((byte[])member)}";
-                        var nestedGroupCN = groupDN.Split(',')[0].Substring("CN=".Length);
+                        var nestedGroupDN = $"{Encoding.UTF8.GetString((byte[])member)}";
+                        var nestedGroupCN = nestedGroupDN.Split(',')[0].Substring("CN=".Length);
                         GetNestedGroups(connection, principal, distinguishedName, nestedGroupCN, logger, retrievedClaims);
                     }
                 }


### PR DESCRIPTION
This PR fixes three issues with current RBAC claims resolution code. Every issue is fixed in a separate commit, to simplify review.

----
We have been trying to set up claims resolution for our services running in docker, and it was crashing when we set [`IgnoreNestedGroups = true`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.negotiate.ldapsettings.ignorenestedgroups?view=aspnetcore-5.0). So I did some research, and found three issues which I managed to fix.

https://github.com/dotnet/aspnetcore/commit/c6c45166bfffabceb6d49fb6ff4df1bbc01152b0: **Fix nested claims retrieval -- use CN instead of DN**
I think this one is simple. Naturally, we should use group canonical name (CN) as a claim value. But for some reason the code used group distinguished name (DN) instead. So instead of `SomeGroup`, the claim value would be `CN=SomeGroup,DC=domain,DC=COM`, which is obviously not what we want.

https://github.com/dotnet/aspnetcore/commit/bba75b7f89869a20770c30f796edaba16f07a990: **Keep track of already processed group to account for possible circular references**
This one fixes a particular corner case which is possible in real-world AD deployments, namely circular group references.
That is, e.g. `GroupA -> GroupB -> GroupC -> GroupA`. This is a problematic scenario for [any software working with AD](https://serverfault.com/questions/351524/what-are-the-consequences-of-an-ad-group-that-has-as-its-member-a-group-that-is).
The fix is basically to keep track of groups that we already processed.
Fixes https://github.com/dotnet/aspnetcore/issues/37225

https://github.com/dotnet/aspnetcore/commit/7f72499bb428bc1828d13e14367dc3c69c05b4d7: **Escape LDAP filter arguments**
This one fixes another real-world scenario. It's possible for a group CN to include characters such as `(` or `)`, for example `Some (very) important group`. Parentheses in partucular are a part of filter syntax. When we construct the LDAP filter expression and don't escape these symbols, openldap fails with `LdapException: The search filter is invalid`. So the solution is to simply escape them according to the [relevant RFC](https://tools.ietf.org/search/rfc4515#section-3).
This one might be somewhat related to https://github.com/dotnet/runtime/issues/38609.
The caveat here is that on Windows unescaped filter is working, while on Linux it doesn't. There's likely a difference in the way underlying native libraries (Wldap32 vs openldap) operate.

TODO: 
- [ ] Tests? Not sure where to implement them.