### PR TITLE
Restore debugging support in WebAssembly hosted template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Program.cs
@@ -74,26 +74,24 @@ builder.Services.AddRazorPages();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-#if (IndividualLocalAuth)
 if (app.Environment.IsDevelopment())
 {
+#if (IndividualLocalAuth)
     app.UseMigrationsEndPoint();
+#endif
     app.UseWebAssemblyDebugging();
 }
 else
-#else
-if (!app.Environment.IsDevelopment())
-#endif
 {
     app.UseExceptionHandler("/Error");
 #if (RequiresHttps)
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
+#endif
 }
 
+#if (RequiresHttps)
 app.UseHttpsRedirection();
-#else
-}
 
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/814

A recent change resulted in the `UseWebAssemblyDebugging` call only being included for projects with individual auth. This is incorrect, since it should in included regardless of auth settings.

Additionally, the way the `#if`/`#else`/`#endif` pragmas were used was very hard to read, probably leading to the above mistake - they were trying to minimize the number of such pragmas at the cost of deliberately mismatching C# scope boundaries. To make these files readable, we should ensure that `#if` blocks are correctly nested inside C# scopes (and vice-versa) as if they were regular `if` statements.