### PR TITLE
Identity: Tweak input floating forms

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml
@@ -19,8 +19,8 @@
         <form asp-page-handler="Confirmation" asp-route-returnUrl="@Model.ReturnUrl" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Input.Email" class="form-label"></label>
                 <input asp-for="Input.Email" class="form-control" autocomplete="email" />
+                <label asp-for="Input.Email" class="form-label"></label>
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Register</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ForgotPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ForgotPassword.cshtml
@@ -12,8 +12,8 @@
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Input.Email" class="form-label"></label>
                 <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
+                <label asp-for="Input.Email" class="form-label"></label>
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Reset Password</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Login.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Login.cshtml
@@ -14,13 +14,13 @@
                 <hr />
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <div class="form-floating">
-                    <label asp-for="Input.Email" class="form-label"></label>
                     <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
+                    <label asp-for="Input.Email" class="form-label"></label>
                     <span asp-validation-for="Input.Email" class="text-danger"></span>
                 </div>
                 <div class="form-floating">
-                    <label asp-for="Input.Password" class="form-label"></label>
                     <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" />
+                    <label asp-for="Input.Password" class="form-label"></label>
                     <span asp-validation-for="Input.Password" class="text-danger"></span>
                 </div>
                 <div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWith2fa.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWith2fa.cshtml
@@ -13,8 +13,8 @@
             <input asp-for="RememberMe" type="hidden" />
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Input.TwoFactorCode" class="form-label"></label>
                 <input asp-for="Input.TwoFactorCode" class="form-control" autocomplete="off" />
+                <label asp-for="Input.TwoFactorCode" class="form-label"></label>
                 <span asp-validation-for="Input.TwoFactorCode" class="text-danger"></span>
             </div>
             <div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWithRecoveryCode.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWithRecoveryCode.cshtml
@@ -15,8 +15,8 @@
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Input.RecoveryCode" class="form-label"></label>
                 <input asp-for="Input.RecoveryCode" class="form-control" autocomplete="off" />
+                <label asp-for="Input.RecoveryCode" class="form-label"></label>
                 <span asp-validation-for="Input.RecoveryCode" class="text-danger"></span>
             </div>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/ChangePassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/ChangePassword.cshtml
@@ -12,18 +12,18 @@
         <form id="change-password-form" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Input.OldPassword" class="form-label"></label>
                 <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" aria-required="true" />
+                <label asp-for="Input.OldPassword" class="form-label"></label>
                 <span asp-validation-for="Input.OldPassword" class="text-danger"></span>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.NewPassword" class="form-label"></label>
                 <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" aria-required="true" />
+                <label asp-for="Input.NewPassword" class="form-label"></label>
                 <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
+                <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Update password</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/DeletePersonalData.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/DeletePersonalData.cshtml
@@ -19,8 +19,8 @@
         @if (Model.RequirePassword)
         {
             <div class="form-floating">
-                <label asp-for="Input.Password" class="form-label"></label>
                 <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" />
+                <label asp-for="Input.Password" class="form-label"></label>
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>
         }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Email.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Email.cshtml
@@ -12,7 +12,6 @@
         <form id="email-form" method="post">
             <div asp-validation-summary="All" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Email" class="form-label"></label>
                 @if (Model.IsEmailConfirmed)
                 {
                     <div class="input-group">
@@ -21,16 +20,18 @@
                             <span class="input-group-text text-success font-weight-bold">✓</span>
                         </div>
                     </div>
+                    <label asp-for="Email" class="form-label"></label>
                 }
                 else
                 {
                     <input asp-for="Email" class="form-control" disabled />
+                    <label asp-for="Email" class="form-label"></label>
                     <button id="email-verification" type="submit" asp-page-handler="SendVerificationEmail" class="btn btn-link">Send verification email</button>
                 }
             </div>
             <div class="form-floating">
-                <label asp-for="Input.NewEmail" class="form-label"></label>
                 <input asp-for="Input.NewEmail" class="form-control" autocomplete="email" aria-required="true" />
+                <label asp-for="Input.NewEmail" class="form-label"></label>
                 <span asp-validation-for="Input.NewEmail" class="text-danger"></span>
             </div>
             <button id="change-email-button" type="submit" asp-page-handler="ChangeEmail" class="w-100 btn btn-lg btn-primary">Change email</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/EnableAuthenticator.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/EnableAuthenticator.cshtml
@@ -35,8 +35,8 @@
                 <div class="col-md-6">
                     <form id="send-code" method="post">
                         <div class="form-floating">
-                            <label asp-for="Input.Code" class="control-label form-label">Verification Code</label>
                             <input asp-for="Input.Code" class="form-control" autocomplete="off" />
+                            <label asp-for="Input.Code" class="control-label form-label">Verification Code</label>
                             <span asp-validation-for="Input.Code" class="text-danger"></span>
                         </div>
                         <button type="submit" class="w-100 btn btn-lg btn-primary">Verify</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Index.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Index.cshtml
@@ -12,12 +12,12 @@
         <form id="profile-form" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Username" class="form-label"></label>
                 <input asp-for="Username" class="form-control" disabled />
+                <label asp-for="Username" class="form-label"></label>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.PhoneNumber" class="form-label"></label>
                 <input asp-for="Input.PhoneNumber" class="form-control" />
+                <label asp-for="Input.PhoneNumber" class="form-label"></label>
                 <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
             </div>
             <button id="update-profile-button" type="submit" class="w-100 btn btn-lg btn-primary">Save</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/SetPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/SetPassword.cshtml
@@ -16,13 +16,13 @@
         <form id="set-password-form" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Input.NewPassword" class="form-label"></label>
                 <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" />
+                <label asp-for="Input.NewPassword" class="form-label"></label>
                 <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
+                <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Set password</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Register.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Register.cshtml
@@ -13,18 +13,18 @@
             <hr />
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Input.Email"></label>
                 <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
+                <label asp-for="Input.Email"></label>
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.Password"></label>
                 <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" />
+                <label asp-for="Input.Password"></label>
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.ConfirmPassword"></label>
                 <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
+                <label asp-for="Input.ConfirmPassword"></label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
             <button id="registerSubmit" type="submit" class="w-100 btn btn-lg btn-primary">Register</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResendEmailConfirmation.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResendEmailConfirmation.cshtml
@@ -12,8 +12,8 @@
         <form method="post">
             <div asp-validation-summary="All" class="text-danger"></div>
             <div class="form-floating">
-                <label asp-for="Input.Email" class="form-label"></label>
                 <input asp-for="Input.Email" class="form-control" aria-required="true" />
+                <label asp-for="Input.Email" class="form-label"></label>
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Resend</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResetPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResetPassword.cshtml
@@ -13,18 +13,18 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input asp-for="Input.Code" type="hidden" />
             <div class="form-floating">
-                <label asp-for="Input.Email" class="form-label"></label>
                 <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
+                <label asp-for="Input.Email" class="form-label"></label>
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.Password" class="form-label"></label>
                 <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" />
+                <label asp-for="Input.Password" class="form-label"></label>
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
+                <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
             <button type="submit" class="w-100 btn btn-lg btn-primary">Reset</button>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/35295

Turns out inputs have to be before the labels for floating, see: https://getbootstrap.com/docs/5.0/forms/floating-labels/

Before:
![image](https://user-images.githubusercontent.com/6537861/129240422-0ebf50b9-6a2e-4d3e-b51a-c37b684089b7.png)

After:
![image](https://user-images.githubusercontent.com/6537861/129240516-b373dab7-ddc8-4208-9504-cc13657a0408.png)
