### PR TITLE
Mark public Quic API as preview

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal;
 
@@ -11,6 +12,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic
     /// <summary>
     /// Options for Quic based connections.
     /// </summary>
+    [RequiresPreviewFeatures]
     public class QuicTransportOptions
     {
         /// <summary>

--- a/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Quic;
+using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Quic;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +15,7 @@ namespace Microsoft.AspNetCore.Hosting
     /// </summary>
     public static class WebHostBuilderQuicExtensions
     {
+        [RequiresPreviewFeatures]
         public static IWebHostBuilder UseQuic(this IWebHostBuilder hostBuilder)
         {
             if (QuicImplementationProviders.Default.IsSupported)
@@ -27,6 +29,7 @@ namespace Microsoft.AspNetCore.Hosting
             return hostBuilder;
         }
 
+        [RequiresPreviewFeatures]
         public static IWebHostBuilder UseQuic(this IWebHostBuilder hostBuilder, Action<QuicTransportOptions> configureOptions)
         {
             return hostBuilder.UseQuic().ConfigureServices(services =>


### PR DESCRIPTION
Replaces https://github.com/dotnet/aspnetcore/pull/35202

@pgovind @jeffhandley @jkotas do we need to mark the individual properties in `QuicTransportOptions` too, or does marking the whole class do the trick?