### PR TITLE
Add Backlog to QuicTransportOptions

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -58,6 +58,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             quicListenerOptions.IdleTimeout = options.IdleTimeout;
             quicListenerOptions.MaxBidirectionalStreams = options.MaxBidirectionalStreamCount;
             quicListenerOptions.MaxUnidirectionalStreams = options.MaxUnidirectionalStreamCount;
+            quicListenerOptions.ListenBacklog = options.Backlog;
 
             _listener = new QuicListener(quicListenerOptions);
 

--- a/src/Servers/Kestrel/Transport.Quic/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Quic/src/PublicAPI.Unshipped.txt
@@ -26,6 +26,8 @@
 *REMOVED*~static Microsoft.AspNetCore.Hosting.WebHostBuilderMsQuicExtensions.UseQuic(this Microsoft.AspNetCore.Hosting.IWebHostBuilder hostBuilder) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder
 Microsoft.AspNetCore.Hosting.WebHostBuilderQuicExtensions
 Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions
+Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.Backlog.get -> int
+Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.Backlog.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.IdleTimeout.get -> System.TimeSpan
 Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.IdleTimeout.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxBidirectionalStreamCount.get -> ushort

--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
@@ -38,6 +38,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic
         /// </summary>
         public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
 
+        /// <summary>
+        /// The maximum length of the pending connection queue.
+        /// </summary>
+        public int Backlog { get; set; } = 512;
+
         internal ISystemClock SystemClock = new SystemClock();
     }
 }


### PR DESCRIPTION
Matches what `Transport.Sockets` does, and allows users to configure https://github.com/dotnet/runtime/blob/b2714bc0a738035f10887d87d8b28cb5ac66c3ef/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListenerOptions.cs#L23-L26

Part of https://github.com/dotnet/aspnetcore/issues/32034