### PR TITLE
Change route and query fallback semantics

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -247,9 +247,9 @@ namespace Microsoft.AspNetCore.Http
             }
             else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseMethod(parameter))
             {
-                // 1. We only bind from routes if the name is specified
-                // 2. We only bind from query if there's no matching route parameter
-                // 3. We fallback to route or query if route paramters is null (it means we don't know). This case only happens
+                // 1. We only bind from route values only, if route paramters are non-null and the parameter name is in that set.
+                // 2. We only bind from query only, if route paramters are non-null and the parameter name is NOT in that set.
+                // 3. Otherwise, we fallback to route or query if route paramters is null (it means we don't know what route parameters are defined). This case only happens
                 // when RDF.Create is manually invoked.
                 if (factoryContext.RouteParameters is { } routeParams)
                 {

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -247,9 +247,9 @@ namespace Microsoft.AspNetCore.Http
             }
             else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseMethod(parameter))
             {
-                // 1. We only bind from route values only, if route paramters are non-null and the parameter name is in that set.
-                // 2. We only bind from query only, if route paramters are non-null and the parameter name is NOT in that set.
-                // 3. Otherwise, we fallback to route or query if route paramters is null (it means we don't know what route parameters are defined). This case only happens
+                // 1. We bind from route values only, if route parameters are non-null and the parameter name is in that set.
+                // 2. We bind from query only, if route parameters are non-null and the parameter name is NOT in that set.
+                // 3. Otherwise, we fallback to route or query if route parameters is null (it means we don't know what route parameters are defined). This case only happens
                 // when RDF.Create is manually invoked.
                 if (factoryContext.RouteParameters is { } routeParams)
                 {

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -262,7 +262,10 @@ namespace Microsoft.AspNetCore.Routing.Internal
             },
             new() { RouteParameterNames = new string[] { } });
 
-            httpContext.Request.Query = new QueryCollection();
+            httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = "41"
+            });
             httpContext.Request.RouteValues = new()
             {
                 ["id"] = "42"
@@ -270,7 +273,35 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             await requestDelegate(httpContext);
 
-            Assert.Null(httpContext.Items["input"]);
+            Assert.Equal(41, httpContext.Items["input"]);
+        }
+
+        [Fact]
+        public async Task NullRouteParametersPrefersRouteOverQueryString()
+        {
+            var httpContext = new DefaultHttpContext();
+
+            var requestDelegate = RequestDelegateFactory.Create((int? id, HttpContext httpContext) =>
+            {
+                if (id is not null)
+                {
+                    httpContext.Items["input"] = id;
+                }
+            },
+            new() { RouteParameterNames = null });
+
+            httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["id"] = "41"
+            });
+            httpContext.Request.RouteValues = new()
+            {
+                ["id"] = "42"
+            };
+
+            await requestDelegate(httpContext);
+
+            Assert.Equal(42, httpContext.Items["input"]);
         }
 
         [Fact]

--- a/src/Http/Routing/test/UnitTests/Builder/MinimalActionEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/MinimalActionEndpointRouteBuilderExtensionsTest.cs
@@ -166,7 +166,7 @@ namespace Microsoft.AspNetCore.Builder
             Assert.Equal("/ HTTP: GET", routeEndpointBuilder.DisplayName);
             Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
 
-            // Assert that we don't fallback to the query string
+            // Assert that we don't fallback to the route values
             var httpContext = new DefaultHttpContext();
 
             httpContext.Request.Query = new QueryCollection();

--- a/src/Http/Routing/test/UnitTests/Builder/MinimalActionEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/MinimalActionEndpointRouteBuilderExtensionsTest.cs
@@ -169,13 +169,16 @@ namespace Microsoft.AspNetCore.Builder
             // Assert that we don't fallback to the route values
             var httpContext = new DefaultHttpContext();
 
-            httpContext.Request.Query = new QueryCollection();
+            httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>()
+            {
+                ["id"] = "41"
+            });
             httpContext.Request.RouteValues = new();
             httpContext.Request.RouteValues["id"] = "42";
 
             await endpoint.RequestDelegate!(httpContext);
 
-            Assert.Null(httpContext.Items["input"]);
+            Assert.Equal(41, httpContext.Items["input"]);
         }
 
         [Theory]


### PR DESCRIPTION
- If the list of route paramters is empty then simple parameters are from query only.
- If the list of route parameters is null then fallback from route to query.
- Added tests.

