### PR TITLE
Allow DefaultPageLoader.LoadAsync to work with CompiledPageActionDesriptor

### DIFF
--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/DefaultPageLoader.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/DefaultPageLoader.cs
@@ -45,6 +45,14 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 throw new ArgumentNullException(nameof(actionDescriptor));
             }
 
+            if (actionDescriptor is CompiledPageActionDescriptor compiledPageActionDescriptor)
+            {
+                // It's possible for some code paths of PageLoaderMatcherPolicy to invoke LoadAsync with an instance
+                // of CompiledPageActionDescriptor. In that case, we'll return the instance as-is.
+                compiledPageActionDescriptor.CompiledPageActionDescriptorTask ??= Task.FromResult(compiledPageActionDescriptor);
+                return compiledPageActionDescriptor.CompiledPageActionDescriptorTask;
+            }
+
             var task = actionDescriptor.CompiledPageActionDescriptorTask;
 
             if (task != null)

--- a/src/Mvc/Mvc.RazorPages/test/Infrastructure/DefaultPageLoaderTest.cs
+++ b/src/Mvc/Mvc.RazorPages/test/Infrastructure/DefaultPageLoaderTest.cs
@@ -294,7 +294,6 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
                 },
             };
 
-
             var transformer = new Mock<RoutePatternTransformer>();
             transformer
                 .Setup(t => t.SubstituteRequiredValues(It.IsAny<RoutePattern>(), It.IsAny<object>()))
@@ -333,6 +332,29 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages.Infrastructure
 
             // Assert
             Assert.NotSame(result1, result2);
+        }
+
+        [Fact]
+        public async Task LoadAsync_CompiledPageActionDescriptor_ReturnsSelf()
+        {
+            // Arrange
+            var mvcOptions = Options.Create(new MvcOptions());
+            var endpointFactory = new ActionEndpointFactory(Mock.Of<RoutePatternTransformer>(), Enumerable.Empty<IRequestDelegateFactory>());
+            var loader = new DefaultPageLoader(
+                new[] { Mock.Of<IPageApplicationModelProvider>() },
+                Mock.Of<IViewCompilerProvider>(),
+                endpointFactory,
+                RazorPagesOptions,
+                mvcOptions);
+            var pageDescriptor = new CompiledPageActionDescriptor();
+
+            // Act
+            var result1 = await loader.LoadAsync(pageDescriptor, new EndpointMetadataCollection());
+            var result2 = await loader.LoadAsync(pageDescriptor, new EndpointMetadataCollection());
+
+            // Assert
+            Assert.Same(pageDescriptor, result1);
+            Assert.Same(pageDescriptor, result2);
         }
 
         private static IViewCompilerProvider GetCompilerProvider()

--- a/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RazorBuildTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -48,6 +48,19 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("Hello from runtime-compiled rzc page!", responseBody.Trim());
+        }
+
+        [Fact]
+        public async Task RuntimeCompilation_WithFallbackPage_Works()
+        {
+            // Regression test for https://github.com/dotnet/aspnetcore/issues/35060
+            // Act
+            var response = await Client.GetAsync("Fallback");
+
+            // Assert
+            await response.AssertStatusCodeAsync(HttpStatusCode.OK);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Assert.Equal("Hello from fallback page!", responseBody.Trim());
         }
 
         [Fact]

--- a/src/Mvc/test/WebSites/RazorBuildWebSite/Pages/Fallback.cshtml
+++ b/src/Mvc/test/WebSites/RazorBuildWebSite/Pages/Fallback.cshtml
@@ -1,0 +1,3 @@
+﻿@page
+
+Hello from fallback page!

--- a/src/Mvc/test/WebSites/RazorBuildWebSite/Startup.cs
+++ b/src/Mvc/test/WebSites/RazorBuildWebSite/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
@@ -27,6 +27,7 @@ namespace RazorBuildWebSite
             {
                 endpoints.MapDefaultControllerRoute();
                 endpoints.MapRazorPages();
+                endpoints.MapFallbackToPage("/Fallback");
             });
         }
 


### PR DESCRIPTION
With a fallback page, DefaultPageLoader might observe a mix of PageActionDescriptor
and CompiledPageActionDescriptor instances. Currently encountering the latter results in an exception.

Fixes https://github.com/dotnet/aspnetcore/issues/35060
