### PR TITLE
Remove broken link to dotnet-watch as it moved to SDK repo 7 months ago

### DIFF
--- a/src/Tools/README.md
+++ b/src/Tools/README.md
@@ -4,7 +4,6 @@
 
 The folder contains command-line tools for ASP.NET Core. The following tools are bundled* in the .NET Core CLI. Follow the links below for more details on each tool.
 
-- [dotnet-watch](dotnet-watch/README.md)
 - [dotnet-user-secrets](dotnet-user-secrets/README.md)
 - [dotnet-sql-cache](dotnet-sql-cache/README.md)
 - [dotnet-dev-certs](dotnet-dev-certs/README.md)
@@ -31,15 +30,14 @@ This folder also contains the infrastructure for our partners' service reference
 The command line tools can be invoked as a subcommand of `dotnet`.
 
 ```sh
-dotnet watch
-dotnet user-secrets
-dotnet sql-cache
 dotnet dev-certs
 dotnet openapi
+dotnet sql-cache
+dotnet user-secrets
 ```
 
 Add `--help` to see more details. For example,
 
 ```sh
-dotnet watch --help
+dotnet dev-certs --help
 ```


### PR DESCRIPTION
Removed invalid link to `dotnet-watch`.
Sorted example `dotnet` subcommands alphabetically.
Updated `--help` example to use a subcommand other than `dotnet-watch`.

Fixes: #35332