### PR TITLE
Add ability to modify UseRouting/UseEndpoint behavior for WebApplicationBuilder 

### DIFF
--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -28,6 +28,9 @@ namespace Microsoft.AspNetCore.Builder
             _host = host;
             ApplicationBuilder = new ApplicationBuilder(host.Services);
             Logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(Environment.ApplicationName);
+
+            //Properties.Add("__EndpointRouteBuilder", this);
+            //Properties.Add("__GlobalEndpointRouteBuilder", this);
         }
 
         /// <summary>

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -31,7 +31,6 @@ namespace Microsoft.AspNetCore.Builder
             ApplicationBuilder = new ApplicationBuilder(host.Services);
             Logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(Environment.ApplicationName);
 
-            //Properties.Add("__EndpointRouteBuilder", this);
             Properties.Add(GlobalEndpointRouteBuilderKey, this);
         }
 

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Builder
             ApplicationBuilder = new ApplicationBuilder(host.Services);
             Logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(Environment.ApplicationName);
 
-            Properties.Add(GlobalEndpointRouteBuilderKey, this);
+            Properties[GlobalEndpointRouteBuilderKey] = this;
         }
 
         /// <summary>
@@ -174,7 +174,12 @@ namespace Microsoft.AspNetCore.Builder
         RequestDelegate IApplicationBuilder.Build() => BuildRequestDelegate();
 
         // REVIEW: Should this be wrapping another type?
-        IApplicationBuilder IApplicationBuilder.New() => ApplicationBuilder.New();
+        IApplicationBuilder IApplicationBuilder.New()
+        {
+            var newBuilder = ApplicationBuilder.New();
+            newBuilder.Properties.Remove(GlobalEndpointRouteBuilderKey);
+            return newBuilder;
+        }
 
         IApplicationBuilder IApplicationBuilder.Use(Func<RequestDelegate, RequestDelegate> middleware)
         {

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AspNetCore.Builder
         private readonly IHost _host;
         private readonly List<EndpointDataSource> _dataSources = new();
 
+        internal static string GlobalEndpointRouteBuilderKey = "__GlobalEndpointRouteBuilder";
+
         internal WebApplication(IHost host)
         {
             _host = host;
@@ -30,7 +32,7 @@ namespace Microsoft.AspNetCore.Builder
             Logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(Environment.ApplicationName);
 
             //Properties.Add("__EndpointRouteBuilder", this);
-            //Properties.Add("__GlobalEndpointRouteBuilder", this);
+            Properties.Add(GlobalEndpointRouteBuilderKey, this);
         }
 
         /// <summary>

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -177,6 +177,7 @@ namespace Microsoft.AspNetCore.Builder
         IApplicationBuilder IApplicationBuilder.New()
         {
             var newBuilder = ApplicationBuilder.New();
+            // Remove the route builder so branched pipelines have their own routing world
             newBuilder.Properties.Remove(GlobalEndpointRouteBuilderKey);
             return newBuilder;
         }
@@ -187,7 +188,7 @@ namespace Microsoft.AspNetCore.Builder
             return this;
         }
 
-        IApplicationBuilder IEndpointRouteBuilder.CreateApplicationBuilder() => ApplicationBuilder.New();
+        IApplicationBuilder IEndpointRouteBuilder.CreateApplicationBuilder() => ((IApplicationBuilder)this).New();
 
         private void Listen(string? url)
         {

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -20,6 +19,7 @@ namespace Microsoft.AspNetCore.Builder
         private readonly HostBuilder _hostBuilder = new();
         private readonly BootstrapHostBuilder _bootstrapHostBuilder;
         private readonly WebApplicationServiceCollection _services = new();
+        private const string GlobalEndpointBuilderCopyRoutesKey = "__GlobalEndpointBuilderShouldCopyRoutes";
 
         private WebApplication? _builtApplication;
 
@@ -209,9 +209,9 @@ namespace Microsoft.AspNetCore.Builder
 
             // We don't know if user code called UseEndpoints(), so we will call it just in case, and we will make sure we are the only ones setting
             // the EndpointDataSource in RouteOptions with this property
-            app.Properties.Add("__GlobalEndpointBuilderShouldCopyRoutes", null);
+            app.Properties[GlobalEndpointBuilderCopyRoutesKey] = null;
             app.UseEndpoints(_ => { });
-            app.Properties.Remove("__GlobalEndpointBuilderShouldCopyRoutes");
+            app.Properties.Remove(GlobalEndpointBuilderCopyRoutesKey);
 
             // Copy the properties to the destination app builder
             foreach (var item in _builtApplication.Properties)

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -197,17 +197,17 @@ namespace Microsoft.AspNetCore.Builder
             // The endpoints were already added on the outside
             if (_builtApplication.DataSources.Count > 0)
             {
-                // The user did not register the routing middleware so wrap the entire
-                // destination pipeline in UseRouting() and UseEndpoints(), essentially:
-                // destination.UseRouting()
-                // destination.Run(source)
-                // destination.UseEndpoints()
-
                 // Copy endpoints to the IEndpointRouteBuilder created by an explicit call to UseRouting() if possible.
                 var targetRouteBuilder = GetEndpointRouteBuilder(_builtApplication);
 
                 if (targetRouteBuilder is null)
                 {
+                    // The user did not register the routing middleware so wrap the entire
+                    // destination pipeline in UseRouting() and UseEndpoints(), essentially:
+                    // destination.UseRouting()
+                    // destination.Run(source)
+                    // destination.UseEndpoints()
+
                     // The app defined endpoints without calling UseRouting() explicitly, so call UseRouting() implicitly.
                     app.UseRouting();
 
@@ -226,7 +226,7 @@ namespace Microsoft.AspNetCore.Builder
                 // so it must be called after we copy the endpoints.
                 if (!implicitRouting)
                 {
-                    // UseRouting() was called explicitely, but we may still need to call UseEndpoints() implicitely at
+                    // UseRouting() was called explicitly, but we may still need to call UseEndpoints() implicitly at
                     // the end of the pipeline.
                     _builtApplication.UseEndpoints(_ => { });
                 }

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Builder
             // lets remove the property and reset it at the end so we don't mess with the routes in the filter
             if (app.Properties.TryGetValue(EndpointRouteBuilderKey, out var priorRouteBuilder))
             {
-                app.Properties.Remove("__EndpointRouteBuilder");
+                app.Properties.Remove(EndpointRouteBuilderKey);
             }
 
             if (context.HostingEnvironment.IsDevelopment())
@@ -242,8 +242,6 @@ namespace Microsoft.AspNetCore.Builder
 
             // Remove the route builder to clean up the properties, we're done adding routes to the pipeline
             app.Properties.Remove(WebApplication.GlobalEndpointRouteBuilderKey);
-            app.Properties.Remove(EndpointRouteBuilderKey);
-            _builtApplication.Properties.Remove(EndpointRouteBuilderKey);
 
             // reset route builder if it existed, this is needed for StartupFilters
             if (priorRouteBuilder is not null)

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -19,7 +19,6 @@ namespace Microsoft.AspNetCore.Builder
         private readonly HostBuilder _hostBuilder = new();
         private readonly BootstrapHostBuilder _bootstrapHostBuilder;
         private readonly WebApplicationServiceCollection _services = new();
-        private const string GlobalEndpointBuilderCopyRoutesKey = "__GlobalEndpointBuilderShouldCopyRoutes";
 
         private WebApplication? _builtApplication;
 
@@ -221,11 +220,8 @@ namespace Microsoft.AspNetCore.Builder
 
             if (_builtApplication.DataSources.Count > 0)
             {
-                // We don't know if user code called UseEndpoints(), so we will call it just in case, and we will make sure we are the only ones setting
-                // the EndpointDataSource in RouteOptions with this property
-                app.Properties[GlobalEndpointBuilderCopyRoutesKey] = null;
+                // We don't know if user code called UseEndpoints(), so we will call it just in case, UseEndpoints() will ignore duplicate DataSources
                 app.UseEndpoints(_ => { });
-                app.Properties.Remove(GlobalEndpointBuilderCopyRoutesKey);
             }
 
             // Copy the properties to the destination app builder

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Builder
         private readonly HostBuilder _hostBuilder = new();
         private readonly BootstrapHostBuilder _bootstrapHostBuilder;
         private readonly WebApplicationServiceCollection _services = new();
-        private static string EndpointRouteBuilderKey = "__EndpointRouteBuilder";
+        private const string EndpointRouteBuilderKey = "__EndpointRouteBuilder";
 
         private WebApplication? _builtApplication;
 

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -203,11 +203,12 @@ namespace Microsoft.AspNetCore.Builder
             // destination.Run(source)
             // destination.UseEndpoints()
 
+            // Set the route builder so that UseRouting will use the WebApplication as the IEndpointRouteBuilder for route matching
+            app.Properties.Add(WebApplication.GlobalEndpointRouteBuilderKey, _builtApplication);
+
             // Only call UseRouting() if there are endpoints configured and UseRouting() wasn't called on the global route builder already
             if (_builtApplication.DataSources.Count > 0 && !_builtApplication.Properties.TryGetValue("__UseRoutingWithGlobalSet", out _))
             {
-                // Set the route builder so that UseRouting will use the WebApplication as the IEndpointRouteBuilder for route matching
-                app.Properties.Add(WebApplication.GlobalEndpointRouteBuilderKey, _builtApplication);
                 app.UseRouting();
             }
 
@@ -220,7 +221,6 @@ namespace Microsoft.AspNetCore.Builder
 
             if (_builtApplication.DataSources.Count > 0)
             {
-                app.Properties.TryAdd(WebApplication.GlobalEndpointRouteBuilderKey, _builtApplication);
                 // We don't know if user code called UseEndpoints(), so we will call it just in case, and we will make sure we are the only ones setting
                 // the EndpointDataSource in RouteOptions with this property
                 app.Properties[GlobalEndpointBuilderCopyRoutesKey] = null;
@@ -235,13 +235,10 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             // Remove the route builder to clean up the properties, we're done adding routes to the pipeline
-            // REVIEW: There aren't any tests that fail if these two lines are removed (except the one that verfies the properties are removed)
-            //         Not sure if it's a missing scenario or not needed
             app.Properties.Remove(WebApplication.GlobalEndpointRouteBuilderKey);
-            _builtApplication.Properties.Remove(WebApplication.GlobalEndpointRouteBuilderKey);
 
             // reset route builder if it existed, this is needed for StartupFilters
-            if (priorRouteBuilder is { })
+            if (priorRouteBuilder is not null)
             {
                 app.Properties["__EndpointRouteBuilder"] = priorRouteBuilder;
             }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -943,9 +943,9 @@ namespace Microsoft.AspNetCore.Tests
 
             var ds = app.Services.GetRequiredService<EndpointDataSource>();
             Assert.Equal(3, ds.Endpoints.Count);
-            Assert.Equal("Two", ds.Endpoints[0].DisplayName);
-            Assert.Equal("Three", ds.Endpoints[1].DisplayName);
-            Assert.Equal("One", ds.Endpoints[2].DisplayName);
+            Assert.Equal("One", ds.Endpoints[0].DisplayName);
+            Assert.Equal("Two", ds.Endpoints[1].DisplayName);
+            Assert.Equal("Three", ds.Endpoints[2].DisplayName);
         }
 
         [Fact]

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1058,21 +1058,6 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task AppPropertiesDoNotContainARouteBuilder()
-        {
-            var builder = WebApplication.CreateBuilder();
-            await using var app = builder.Build();
-
-            app.UseRouting();
-
-            app.UseEndpoints(endpoints => { });
-
-            app.Start();
-
-            Assert.False(app.Properties.TryGetValue("__EndpointRouteBuilder", out _));
-        }
-
-        [Fact]
         public async Task WebApplication_CallsUseRoutingAndUseEndpoints()
         {
             var builder = WebApplication.CreateBuilder();

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1085,7 +1085,6 @@ namespace Microsoft.AspNetCore.Tests
             app.Start();
 
             Assert.False(app.Properties.TryGetValue("__EndpointRouteBuilder", out _));
-            Assert.False(app.Properties.TryGetValue("__GlobalEndpointRouteBuilder", out _));
         }
 
         [Fact]
@@ -1160,11 +1159,11 @@ namespace Microsoft.AspNetCore.Tests
 
             var ds = app.Services.GetRequiredService<EndpointDataSource>();
             Assert.Equal(5, ds.Endpoints.Count);
-            Assert.Equal("Four", ds.Endpoints[0].DisplayName);
-            Assert.Equal("Five", ds.Endpoints[1].DisplayName);
-            Assert.Equal("One", ds.Endpoints[2].DisplayName);
-            Assert.Equal("Two", ds.Endpoints[3].DisplayName);
-            Assert.Equal("Three", ds.Endpoints[4].DisplayName);
+            Assert.Equal("One", ds.Endpoints[0].DisplayName);
+            Assert.Equal("Two", ds.Endpoints[1].DisplayName);
+            Assert.Equal("Three", ds.Endpoints[2].DisplayName);
+            Assert.Equal("Four", ds.Endpoints[3].DisplayName);
+            Assert.Equal("Five", ds.Endpoints[4].DisplayName);
 
             var client = app.GetTestClient();
 

--- a/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             builder.Properties.Remove(EndpointRouteBuilder);
-            //builder.Properties.Remove("__GlobalEndpointRouteBuilder");
+            builder.Properties.Remove("__GlobalEndpointRouteBuilder");
 
             return builder.UseMiddleware<EndpointMiddleware>();
         }

--- a/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Builder
             {
                 endpointRouteBuilder = (IEndpointRouteBuilder)obj!;
                 // Let interested parties know if UseRouting() was called while a global route builder was set
-                builder.Properties["__UseRoutingWithGlobalSet"] = true;
+                builder.Properties[EndpointRouteBuilder] = endpointRouteBuilder;
             }
             else
             {
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private static void VerifyEndpointRoutingMiddlewareIsRegistered(IApplicationBuilder app, out IEndpointRouteBuilder endpointRouteBuilder)
         {
-            if (!app.Properties.TryGetValue(EndpointRouteBuilder, out var obj) && !app.Properties.TryGetValue(GlobalEndpointRouteBuilderKey, out obj))
+            if (!app.Properties.TryGetValue(EndpointRouteBuilder, out var obj))
             {
                 var message =
                     $"{nameof(EndpointRoutingMiddleware)} matches endpoints setup by {nameof(EndpointMiddleware)} and so must be added to the request " +

--- a/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Builder
     {
         private const string EndpointRouteBuilder = "__EndpointRouteBuilder";
         private const string GlobalEndpointRouteBuilderKey = "__GlobalEndpointRouteBuilder";
-        private const string GlobalEndpointBuilderCopyRoutesKey = "__GlobalEndpointBuilderShouldCopyRoutes";
 
         /// <summary>
         /// Adds a <see cref="EndpointRoutingMiddleware"/> middleware to the specified <see cref="IApplicationBuilder"/>.
@@ -108,13 +107,10 @@ namespace Microsoft.AspNetCore.Builder
             //
             // Each middleware gets its own collection of data sources, and all of those data sources also
             // get added to a global collection.
-            // In the global endpoint route case we only want to copy data sources once, so we wait for a specific key before copying data sources
-            // like in the case of minimal hosting
-            if (builder.Properties.TryGetValue(GlobalEndpointBuilderCopyRoutesKey, out _) ||
-                !builder.Properties.TryGetValue(GlobalEndpointRouteBuilderKey, out _))
+            var routeOptions = builder.ApplicationServices.GetRequiredService<IOptions<RouteOptions>>();
+            foreach (var dataSource in endpointRouteBuilder.DataSources)
             {
-                var routeOptions = builder.ApplicationServices.GetRequiredService<IOptions<RouteOptions>>();
-                foreach (var dataSource in endpointRouteBuilder.DataSources)
+                if (!routeOptions.Value.EndpointDataSources.Contains(dataSource))
                 {
                     routeOptions.Value.EndpointDataSources.Add(dataSource);
                 }

--- a/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
@@ -50,6 +50,8 @@ namespace Microsoft.AspNetCore.Builder
             if (builder.Properties.TryGetValue(GlobalEndpointRouteBuilderKey, out var obj))
             {
                 endpointRouteBuilder = (IEndpointRouteBuilder)obj!;
+                // Let interested parties know if UseRouting() was called while a global route builder was set
+                builder.Properties["__UseRoutingWithGlobalSet"] = true;
             }
             else
             {
@@ -116,12 +118,6 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     routeOptions.Value.EndpointDataSources.Add(dataSource);
                 }
-            }
-
-            // REVIEW: this 'if' could be removed, see comment in WebApplicationBuilder
-            if (!builder.Properties.TryGetValue(GlobalEndpointRouteBuilderKey, out _))
-            {
-                builder.Properties.Remove(EndpointRouteBuilder);
             }
 
             return builder.UseMiddleware<EndpointMiddleware>();

--- a/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
@@ -382,23 +382,6 @@ namespace Microsoft.AspNetCore.Builder
             Assert.True(app.Properties.TryGetValue("__GlobalEndpointRouteBuilder", out _));
         }
 
-        [Fact]
-        public void UseEndpoints_RemovesEndpointRouteBuilderProperty()
-        {
-            // Arrange
-            var services = CreateServices();
-
-            var app = new ApplicationBuilder(services);
-
-            app.UseRouting();
-
-            Assert.True(app.Properties.TryGetValue("__EndpointRouteBuilder", out _));
-
-            app.UseEndpoints(endpoints => { });
-
-            Assert.False(app.Properties.TryGetValue("__EndpointRouteBuilder", out _));
-        }
-
         private IServiceProvider CreateServices()
         {
             return CreateServices(matcherFactory: null);

--- a/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         [Fact]
-        public void UseEndpoints_WithGlobalEndpointRouteBuilder_CopiesRoutesWhenPropertySet()
+        public void UseEndpoints_WithGlobalEndpointRouteBuilderHasRoutes()
         {
             // Arrange
             var services = CreateServices();
@@ -317,12 +317,6 @@ namespace Microsoft.AspNetCore.Builder
             {
                 endpoints.Map("/1", d => Task.CompletedTask).WithDisplayName("Test endpoint 1");
             });
-            var routeOptions = app.ApplicationServices.GetRequiredService<IOptions<RouteOptions>>();
-            Assert.Empty(routeOptions.Value.EndpointDataSources);
-
-            app.Properties.Add("__GlobalEndpointBuilderShouldCopyRoutes", null);
-
-            app.UseEndpoints(endpoints => { });
 
             var requestDelegate = app.Build();
 
@@ -330,40 +324,8 @@ namespace Microsoft.AspNetCore.Builder
             Assert.Collection(endpointDataSource.Endpoints,
                 e => Assert.Equal("Test endpoint 1", e.DisplayName));
 
-            routeOptions = app.ApplicationServices.GetRequiredService<IOptions<RouteOptions>>();
+            var routeOptions = app.ApplicationServices.GetRequiredService<IOptions<RouteOptions>>();
             Assert.Equal(mockRouteBuilder.Object.DataSources, routeOptions.Value.EndpointDataSources);
-        }
-
-        [Fact]
-        public void UseEndpoint_WithGlobalEndpointRouteBuilderNoCopyProperty_HasEndpointsNoRoutes()
-        {
-            // Arrange
-            var services = CreateServices();
-
-            var app = new ApplicationBuilder(services);
-
-            var mockRouteBuilder = new Mock<IEndpointRouteBuilder>();
-            mockRouteBuilder.Setup(m => m.DataSources).Returns(new List<EndpointDataSource>());
-
-            var routeBuilder = mockRouteBuilder.Object;
-            app.Properties.Add("__GlobalEndpointRouteBuilder", routeBuilder);
-            app.UseRouting();
-
-            Assert.False(app.Properties.TryGetValue("__EndpointRouteBuilder", out _));
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.Map("/1", d => Task.CompletedTask).WithDisplayName("Test endpoint 1");
-            });
-
-            var requestDelegate = app.Build();
-
-            var endpointDataSource = Assert.Single(mockRouteBuilder.Object.DataSources);
-            Assert.Collection(endpointDataSource.Endpoints,
-                e => Assert.Equal("Test endpoint 1", e.DisplayName));
-
-            var routeOptions = app.ApplicationServices.GetRequiredService<IOptions<RouteOptions>>();
-            Assert.Empty(routeOptions.Value.EndpointDataSources);
         }
 
         [Fact]

--- a/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
@@ -311,8 +311,6 @@ namespace Microsoft.AspNetCore.Builder
             app.Properties.Add("__GlobalEndpointRouteBuilder", routeBuilder);
             app.UseRouting();
 
-            Assert.False(app.Properties.TryGetValue("__EndpointRouteBuilder", out _));
-
             app.UseEndpoints(endpoints =>
             {
                 endpoints.Map("/1", d => Task.CompletedTask).WithDisplayName("Test endpoint 1");
@@ -329,7 +327,7 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         [Fact]
-        public void UseRouting_DoesNotSetEndpointRouteBuilder_IfGlobalOneExists()
+        public void UseRouting_SetsEndpointRouteBuilder_IfGlobalOneExists()
         {
             // Arrange
             var services = CreateServices();
@@ -340,8 +338,9 @@ namespace Microsoft.AspNetCore.Builder
             app.Properties.Add("__GlobalEndpointRouteBuilder", routeBuilder);
             app.UseRouting();
 
-            Assert.False(app.Properties.TryGetValue("__EndpointRouteBuilder", out _));
-            Assert.True(app.Properties.TryGetValue("__GlobalEndpointRouteBuilder", out _));
+            Assert.True(app.Properties.TryGetValue("__EndpointRouteBuilder", out var local));
+            Assert.True(app.Properties.TryGetValue("__GlobalEndpointRouteBuilder", out var global));
+            Assert.Same(local, global);
         }
 
         private IServiceProvider CreateServices()


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35147
Fixes https://github.com/dotnet/aspnetcore/issues/35281
Pre-req for https://github.com/dotnet/aspnetcore/issues/34146

UseRouting will not replace the EndpointRouteBuilder if a "global" one exists, this allows us to set a global one that will effectively ignore users calling UseRouting a second time (or multiple times themselves) so we can have all routes on the same route builder.

UseEndpoints also honors the global builder so it wont throw in some of it's checks that were specific to the default route builder.

Lastly, we use the new global route builder concept in WebApplicationBuilder so we can safely wrap users code in UseRouting/UseEndpoints and put all routes onto a single route builder.