### PR TITLE
Fixed page title in Blazor Server project templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/_Layout.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/_Layout.cshtml
@@ -7,12 +7,11 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BlazorServerWeb-CSharp</title>
     <base href="~/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="css/site.css" rel="stylesheet" />
     <link href="BlazorServerWeb-CSharp.styles.css" rel="stylesheet" />
-	<component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+    <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
 <body>
     @RenderBody()

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.Auth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.Auth.razor
@@ -1,5 +1,7 @@
 ﻿@inherits LayoutComponentBase
 
+<PageTitle>BlazorServerWeb-CSharp</PageTitle>
+
 <div class="page">
     <div class="sidebar">
         <NavMenu />

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.NoAuth.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/MainLayout.NoAuth.razor
@@ -1,5 +1,7 @@
 ﻿@inherits LayoutComponentBase
 
+<PageTitle>BlazorServerWeb-CSharp</PageTitle>
+
 <div class="page">
     <div class="sidebar">
         <NavMenu />


### PR DESCRIPTION
**Fixed page title in Blazor Server project templates**
The project templates had a static `<title>` element in `_Layout.cshtml`, and this was overriding the page title specified by individual pages (via `<PageTitle>`).

**PR Description**
* Removed the static `<title>` element in `_Layout.cshtml`
* Added a default `<PageTitle>` to MainLayout.Auth.razor and MainLayout.NoAuth.razor

Fixes #35343 