### PR TITLE
Adapted test case to set Authority to an http address

### DIFF
--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectConfigurationTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectConfigurationTests.cs
@@ -521,7 +521,7 @@ namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect
                 {
                     o.SignInScheme = "TestScheme";
                     o.ClientId = "Test Id";
-                    o.MetadataAddress = "http://example.com";
+                    o.Authority = "http://example.com";
                     o.CallbackPath = "/";
                 },
                 ex => Assert.Equal("The MetadataAddress or Authority must use HTTPS unless disabled for development by setting RequireHttpsMetadata=false.", ex.Message)


### PR DESCRIPTION
**Adapted test case to set Authority to an http address**

`ThrowsWhenAuthorityIsNotHttps` in `OpenIdConnectConfigurationTests` now sets the `Autority` property instead of `MetadataAddress`. 

**PR Description**

As outlined in issue #35219, the implementation of the test case is not in sync with the naming of the test. This PR attempts to address this. As far as I can tell, there is nothing more to this than this simple change with which the test evaluates a slighly different code path appending a default path to the Authority when (only) it is set.

Fixes #35219
