### PR TITLE
Update API name in obsolete message

### DIFF
--- a/src/Components/Web/src/Forms/InputFile/RemoteBrowserFileStreamOptions.cs
+++ b/src/Components/Web/src/Forms/InputFile/RemoteBrowserFileStreamOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Components.Forms
     /// Repesents configurable options for <see cref="BrowserFileStream"/> with Blazor Server.
     /// </summary>
     [UnsupportedOSPlatform("browser")]
-    [Obsolete("JSDataStream defaults are utilized instead of the options here.")]
+    [Obsolete("RemoteJSDataStream defaults are utilized instead of the options here.")]
     public class RemoteBrowserFileStreamOptions
     {
         /// <summary>


### PR DESCRIPTION
Noticed while documenting the change from `RemoteBrowserFileStreamOptions` for Blazor Server at 6.0.

cc: @TanayParikh
