### PR TITLE
Fix typo in method summary

### DIFF
--- a/src/Components/Components/src/NavigationManager.cs
+++ b/src/Components/Components/src/NavigationManager.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Components
         /// <param name="uri">The destination URI. This can be absolute, or relative to the base URI
         /// (as returned by <see cref="BaseUri"/>).</param>
         /// <param name="forceLoad">If true, bypasses client-side routing and forces the browser to load the new page from the server, whether or not the URI would normally be handled by the client-side router.</param>
-        /// <param name="replace">If true, replaces the currently entry in the history stack. If false, appends the new entry to the history stack.</param>
+        /// <param name="replace">If true, replaces the current entry in the history stack. If false, appends the new entry to the history stack.</param>
         public void NavigateTo(string uri, bool forceLoad = false, bool replace = false)
         {
             AssertInitialized();


### PR DESCRIPTION
Fix a typo in the summary for the `NavigationManager.NavigateTo` method.