### PR TITLE
Enable RazorSourceGenerator all the time

### DIFF
--- a/eng/Workarounds.props
+++ b/eng/Workarounds.props
@@ -37,8 +37,4 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 
-  <!-- Turn off RazorSourceGenerator in VS until we're ready to make VS 17.0 a pre-req for this repo -->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <UseRazorSourceGenerator>false</UseRazorSourceGenerator>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Now that 17.0 p3 is public, we could require it and make the source generator default. The rc1 SDK we use already requires new compiler features
