### PR TITLE
Avoid _settingsIndex overflow

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
@@ -20,7 +20,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
         private readonly ISocketsTrace _trace;
         private readonly int _settingsCount;
         private readonly QueueSettings[] _settings;
-        private int _settingsIndex;
+
+        // long to prevent overflow
+        private long _settingsIndex;
 
         /// <summary>
         /// Creates the <see cref="SocketConnectionContextFactory"/>.


### PR DESCRIPTION
This should be a long similar to `CorrelationIdGenerator._lastId` now that we don't mod the value stored in `_settingsIndex` after incrementing.