### PR TITLE
Remove some low hanging allocations

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/CreateNewOnMetadataUpdateAttributePass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/CreateNewOnMetadataUpdateAttributePass.cs
@@ -16,9 +16,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
     {
         protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
         {
-            if (FileKinds.IsComponent(codeDocument.GetFileKind()))
+            if (documentNode.DocumentKind != RazorPageDocumentClassifierPass.RazorPageDocumentKind &&
+                documentNode.DocumentKind != MvcViewDocumentClassifierPass.MvcViewDocumentKind)
             {
-                // Hot reload does not apply to components.
+                // Not a MVC file. Skip.
                 return;
             }
 

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ModelExpressionPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ModelExpressionPass.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -15,6 +15,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
         protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
         {
+            if (documentNode.DocumentKind != RazorPageDocumentClassifierPass.RazorPageDocumentKind &&
+                documentNode.DocumentKind != MvcViewDocumentClassifierPass.MvcViewDocumentKind)
+            {
+                // Not a MVC file. Skip.
+                return;
+            }
+
             var visitor = new Visitor();
             visitor.Visit(documentNode);
         }

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperPass.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperPass.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -15,6 +15,13 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
 
         protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
         {
+            if (documentNode.DocumentKind != RazorPageDocumentClassifierPass.RazorPageDocumentKind &&
+                documentNode.DocumentKind != MvcViewDocumentClassifierPass.MvcViewDocumentKind)
+            {
+                // Not a MVC file. Skip.
+                return;
+            }
+
             var @namespace = documentNode.FindPrimaryNamespace();
             var @class = documentNode.FindPrimaryClass();
             if (@namespace == null || @class == null)

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/ModelExpressionPassTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/ModelExpressionPassTest.cs
@@ -170,7 +170,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 }
             }
 
-            return codeDocument.GetDocumentIntermediateNode();
+            var irNode = codeDocument.GetDocumentIntermediateNode();
+            irNode.DocumentKind = MvcViewDocumentClassifierPass.MvcViewDocumentKind;
+
+            return irNode;
         }
 
         private TagHelperIntermediateNode FindTagHelperNode(IntermediateNode node)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -36,10 +36,10 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public AllowedChildTagDescriptor Build()
         {
-            var validationDiagnostics = Validate();
-            var diagnostics = new HashSet<RazorDiagnostic>(validationDiagnostics);
+            var diagnostics = Validate();
             if (_diagnostics != null)
             {
+                diagnostics ??= new();
                 diagnostics.UnionWith(_diagnostics);
             }
 
@@ -47,31 +47,35 @@ namespace Microsoft.AspNetCore.Razor.Language
             var descriptor = new DefaultAllowedChildTagDescriptor(
                 Name,
                 displayName,
-                diagnostics.ToArray());
+                diagnostics?.ToArray() ?? Array.Empty<RazorDiagnostic>());
 
             return descriptor;
         }
 
-        private IEnumerable<RazorDiagnostic> Validate()
+        private HashSet<RazorDiagnostic> Validate()
         {
+            HashSet<RazorDiagnostic> diagnostics = null;
             if (string.IsNullOrWhiteSpace(Name))
             {
                 var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidRestrictedChildNullOrWhitespace(_parent.GetDisplayName());
 
-                yield return diagnostic;
+                diagnostics ??= new();
+                diagnostics.Add(diagnostic);
             }
             else if (Name != TagHelperMatchingConventions.ElementCatchAllName)
             {
                 foreach (var character in Name)
                 {
-                    if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
+                    if (char.IsWhiteSpace(character) || HtmlConventions.IsInvalidNonWhitespaceHtmlCharacters(character))
                     {
                         var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidRestrictedChild(_parent.GetDisplayName(), Name, character);
-
-                        yield return diagnostic;
+                        diagnostics ??= new();
+                        diagnostics.Add(diagnostic);
                     }
                 }
             }
+
+            return diagnostics;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.cs
@@ -45,10 +45,10 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public RequiredAttributeDescriptor Build()
         {
-            var validationDiagnostics = Validate();
-            var diagnostics = new HashSet<RazorDiagnostic>(validationDiagnostics);
+            var diagnostics = Validate();
             if (_diagnostics != null)
             {
+                diagnostics ??= new();
                 diagnostics.UnionWith(_diagnostics);
             }
 
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 Value,
                 ValueComparisonMode,
                 displayName,
-                diagnostics.ToArray(),
+                diagnostics?.ToArray() ?? Array.Empty<RazorDiagnostic>(),
                 new Dictionary<string, string>(Metadata));
 
             return rule;
@@ -71,39 +71,47 @@ namespace Microsoft.AspNetCore.Razor.Language
             return NameComparisonMode == RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch ? string.Concat(Name, "...") : Name;
         }
 
-        private IEnumerable<RazorDiagnostic> Validate()
+        private HashSet<RazorDiagnostic> Validate()
         {
+            HashSet<RazorDiagnostic> diagnostics = null;
+
             if (string.IsNullOrWhiteSpace(Name))
             {
                 var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidTargetedAttributeNameNullOrWhitespace();
 
-                yield return diagnostic;
+                diagnostics ??= new();
+                diagnostics.Add(diagnostic);
             }
             else
             {
-                var name = Name;
+                var name = new StringSegment(Name);
                 var isDirectiveAttribute = this.IsDirectiveAttribute();
                 if (isDirectiveAttribute && name.StartsWith("@", StringComparison.Ordinal))
                 {
-                    name = name.Substring(1);
+                    name = name.Subsegment(1);
                 }
                 else if (isDirectiveAttribute)
                 {
                     var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidRequiredDirectiveAttributeName(GetDisplayName(), Name);
 
-                    yield return diagnostic;
+                    diagnostics ??= new();
+                    diagnostics.Add(diagnostic);
                 }
 
-                foreach (var character in name)
+                for (var i = 0; i < name.Length; i++)
                 {
-                    if (char.IsWhiteSpace(character) || HtmlConventions.InvalidNonWhitespaceHtmlCharacters.Contains(character))
+                    var character = name[i];
+                    if (char.IsWhiteSpace(character) || HtmlConventions.IsInvalidNonWhitespaceHtmlCharacters(character))
                     {
                         var diagnostic = RazorDiagnosticFactory.CreateTagHelper_InvalidTargetedAttributeName(Name, character);
 
-                        yield return diagnostic;
+                        diagnostics ??= new();
+                        diagnostics.Add(diagnostic);
                     }
                 }
             }
+
+            return diagnostics;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/HtmlConventions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/HtmlConventions.cs
@@ -1,8 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.Razor.Language
@@ -10,6 +9,8 @@ namespace Microsoft.AspNetCore.Razor.Language
     public static class HtmlConventions
     {
         private const string HtmlCaseRegexReplacement = "-$1$2";
+        private static readonly char[] InvalidNonWhitespaceHtmlCharacters =
+            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' };
 
         // This matches the following AFTER the start of the input string (MATCH).
         // Any letter/number followed by an uppercase letter then lowercase letter: 1(Aa), a(Aa), A(Aa)
@@ -21,8 +22,19 @@ namespace Microsoft.AspNetCore.Razor.Language
                 RegexOptions.None,
                 TimeSpan.FromMilliseconds(500));
 
-        internal static IReadOnlyCollection<char> InvalidNonWhitespaceHtmlCharacters { get; } = new List<char>(
-            new[] { '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*' });
+
+        internal static bool IsInvalidNonWhitespaceHtmlCharacters(char testChar)
+        {
+            foreach (var c in InvalidNonWhitespaceHtmlCharacters)
+            {
+                if (c == testChar)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// Converts from pascal/camel case to lower kebab-case.


### PR DESCRIPTION
* [x] In the ordinary case, diagnostics aren't produced by builders. The current pattern results in allocating a HashSet
and an empty array for this case. Removing some of these allocations
* [x] ViewComponentTagHelperPass does not need to operate on .razor files, but does some unnecessary work. We can avoid it

