### PR TITLE
E2E test fixes

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -42,6 +42,7 @@ stages:
         cancelTimeoutInMinutes: 30
         buildArgs: -all -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
                    /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
+                   /p:RunQuarantinedTests=true
         beforeBuild:
         - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
           displayName: Setup IISExpress test certificates and schema

--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/WebDriverExtensions.cs
@@ -15,15 +15,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest
         {
             var absoluteUrl = new Uri(baseUri, relativeUrl);
 
-            if (noReload)
-            {
-                var existingUrl = browser.Url;
-                if (string.Equals(existingUrl, absoluteUrl.AbsoluteUri, StringComparison.Ordinal))
-                {
-                    return;
-                }
-            }
-
             browser.Navigate().GoToUrl("about:blank");
             browser.Navigate().GoToUrl(absoluteUrl);
         }

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -26,6 +26,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             ITestOutputHelper output)
             : base(browserFixture, serverFixture, output)
         {
+            // The browser won't sent the disconnection message if it's headless
+            browserFixture.EnsureNotHeadless = true;
         }
 
         public TaskCompletionSource<object> GracefulDisconnectCompletionSource { get; private set; }
@@ -65,7 +67,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/23015")]
+        [Fact]
         public async Task ClosingTheBrowserWindow_GracefullyDisconnects_TheCurrentCircuit()
         {
             // Arrange & Act
@@ -73,6 +75,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 
             // Assert
+            Assert.True(GracefulDisconnectCompletionSource.Task.IsCompletedSuccessfully);
             Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages);
             Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages);
         }

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             ITestOutputHelper output)
             : base(browserFixture, serverFixture, output)
         {
-            // The browser won't sent the disconnection message if it's headless
+            // The browser won't send the disconnection message if it's headless
             browserFixture.EnsureNotHeadless = true;
         }
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubInvalidEventTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ComponentHubInvalidEventTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Equal(2, Batches.Count);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task DispatchingAnInvalidEventArgument_DoesNotProduceWarnings()
         {
             // Arrange
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Contains(Logs, l => (l.LogLevel, l.Exception?.Message) == (LogLevel.Debug, "There was an error parsing the event arguments. EventId: '3'."));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task DispatchingAnInvalidEvent_DoesNotTriggerWarnings()
         {
             // Arrange
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "There is no event handler associated with this event. EventId: '1990'. (Parameter 'eventHandlerId')"));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task DispatchingAnInvalidRenderAcknowledgement_DoesNotTriggerWarnings()
         {
             // Arrange

--- a/src/Components/test/E2ETest/ServerExecutionTests/HeadModificationPrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/HeadModificationPrerenderingTest.cs
@@ -9,7 +9,7 @@ using TestServer;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.AspNetCore.Components.E2ETests.ServerExecutionTests
+namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 {
     public class HeadModificationPrerenderingTest : ServerTestBase<BasicTestAppServerSiteFixture<DeferredComponentContentStartup>>
     {

--- a/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/InteropReliabilityTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Equal(2, Batches.Count);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeNonJSInvokableMethods()
         {
             // Arrange
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeNonExistingMethods()
         {
             // Arrange
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeJSInvokableMethodsWithWrongNumberOfArguments()
         {
             // Arrange
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeJSInvokableMethodsEmptyAssemblyName()
         {
             // Arrange
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeJSInvokableMethodsEmptyMethodName()
         {
             // Arrange
@@ -142,7 +142,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeJSInvokableMethodsWithWrongReferenceId()
         {
             // Arrange
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeJSInvokableMethodsWrongReferenceIdType()
         {
             // Arrange
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task ContinuesWorkingAfterInvalidAsyncReturnCallback()
         {
             // Arrange
@@ -242,7 +242,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task JSInteropCompletionSuccess()
         {
             // Arrange
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Assert.Equal(LogLevel.Debug, entry.LogLevel);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task JSInteropThrowsInUserCode()
         {
             // Arrange
@@ -304,7 +304,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task MalformedJSInteropCallbackDisposesCircuit()
         {
             // Arrange
@@ -339,7 +339,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             });
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeJSInvokableMethodsWithInvalidArgumentsPayload()
         {
             // Arrange
@@ -360,7 +360,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task CannotInvokeJSInvokableMethodsWithMalformedArgumentPayload()
         {
             // Arrange
@@ -381,7 +381,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await ValidateClientKeepsWorking(Client, Batches);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task DispatchingEventsWithInvalidPayloadsShutsDownCircuitGracefully()
         {
             // Arrange
@@ -405,7 +405,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             });
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task DispatchingEventsWithInvalidEventDescriptor()
         {
             // Arrange
@@ -429,7 +429,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             });
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task DispatchingEventsWithInvalidEventArgs()
         {
             // Arrange
@@ -461,7 +461,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             });
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task DispatchingEventsWithInvalidEventHandlerId()
         {
             // Arrange
@@ -495,7 +495,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             });
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task EventHandlerThrowsSyncExceptionTerminatesTheCircuit()
         {
             // Arrange

--- a/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/PrerenderingTest.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal($"Hello, {interactiveUsername ?? "anonymous"}!", () => Browser.Exists(By.TagName("h1")).Text);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35449")]
         public async Task NoHotReloadListenersAreOrdinarilyRegistered()
         {
             Navigate("/prerendered/prerendered-transition");

--- a/src/Components/test/E2ETest/ServerExecutionTests/RemoteRendererBufferLimitTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/RemoteRendererBufferLimitTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/19666")]
         public async Task DispatchedEventsWillKeepBeingProcessed_ButUpdatedWillBeDelayedUntilARenderIsAcknowledged()
         {
             // Arrange

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestDefaultExceptionsBehavior.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerInteropTestDefaultExceptionsBehavior.cs
@@ -63,8 +63,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             }
 
             string GetExpectedMessage(string method) =>
-                $"\"There was an exception invoking '{method}' on assembly 'BasicTestApp'. For more details turn on " +
-                $"detailed exceptions in '{typeof(CircuitOptions).Name}.{nameof(CircuitOptions.DetailedErrors)}'\"";
+                "\"There was an exception invoking '" + method + "' on assembly 'BasicTestApp'. For more details turn on " +
+                "detailed exceptions in '" + typeof(CircuitOptions).Name + "." + nameof(CircuitOptions.DetailedErrors) + "'\"";
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -2022,9 +2022,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // interaction as authentically as SendKeys in other cases.
             var javascript = (IJavaScriptExecutor)Browser;
             javascript.ExecuteScript(
-                $"var elem = document.querySelector('{cssSelector}');"
-                + $"elem.value = '{value}';"
-                + "elem.dispatchEvent(new KeyboardEvent('change'));");
+                $"document.querySelector('{cssSelector}').value = '{value}'");
+            javascript.ExecuteScript(
+                $"document.querySelector('{cssSelector}').dispatchEvent(new KeyboardEvent('change'));");
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             string getFocusedElementId() => Browser.SwitchTo().ActiveElement().GetAttribute("id");
 
             // A local helper that gets window.PageYOffset
-            long getPageYOffset() => (long)((IJavaScriptExecutor)Browser).ExecuteScript("return window.pageYOffset");
+            long getPageYOffset() => (long)((IJavaScriptExecutor)Browser).ExecuteScript("return Math.round(window.pageYOffset)");
         }
 
         [Theory]

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -320,7 +320,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 elem => Assert.Equal(typeof(AssemblyHashAlgorithm).FullName, elem.Text));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/34679")]
+        [Fact]
         public void CanUseComponentAndStaticContentFromExternalNuGetPackage()
         {
             var appElement = Browser.MountTestComponent<ExternalContentPackage>();
@@ -725,7 +725,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             });
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/34857")]
+        [Fact]
         public void CanHandleClearedChild()
         {
             var appElement = Browser.MountTestComponent<ContentEditable>();

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -201,9 +201,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         {
             var jsExecutor = (IJavaScriptExecutor)Browser;
             jsExecutor.ExecuteScript(
-                $"document.getElementById('{elementId}').dispatchEvent(" +
-                $"    new Event('{eventName}', {{ bubbles: true }})" +
-                $")");
+                $"window.testelem = document.getElementById('{elementId}')");
+            jsExecutor.ExecuteScript(
+                $"window.testelem.dispatchEvent(new Event('{eventName}', {{ bubbles: true }}))");
         }
     }
 }

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -739,16 +739,15 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("modified invalid-socks", () => socksInput.GetAttribute("class"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/34857")]
+        [Fact]
         public void NavigateOnSubmitWorks()
         {
             var app = Browser.MountTestComponent<NavigateOnSubmit>();
             var input = app.FindElement(By.Id("text-input"));
 
-            input.SendKeys("Enter");
+            input.SendKeys(Keys.Enter);
 
-            var log = Browser.Manage().Logs.GetLog(LogType.Browser);
-            Assert.DoesNotContain(log, entry => entry.Level == LogLevel.Severe);
+            Browser.Equal("Choose...", () => Browser.WaitUntilTestSelectorReady().SelectedOption.Text);
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -809,9 +809,9 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             // interaction as authentically as SendKeys in other cases.
             var javascript = (IJavaScriptExecutor)Browser;
             javascript.ExecuteScript(
-                $"var elem = document.querySelector('{cssSelector}');"
-                + $"elem.value = {JsonSerializer.Serialize(invalidValue, TestJsonSerializerOptionsProvider.Options)};"
-                + "elem.dispatchEvent(new KeyboardEvent('change'));");
+                $"document.querySelector('{cssSelector}').value = {JsonSerializer.Serialize(invalidValue, TestJsonSerializerOptionsProvider.Options)}");
+            javascript.ExecuteScript(
+                $"document.querySelector('{cssSelector}').dispatchEvent(new KeyboardEvent('change'))");
         }
 
         private void EnsureAttributeRendering(IWebElement element, string attributeName, bool shouldBeRendered = true)

--- a/src/Components/test/E2ETest/Tests/HeadModificationTest.cs
+++ b/src/Components/test/E2ETest/Tests/HeadModificationTest.cs
@@ -10,7 +10,7 @@ using OpenQA.Selenium;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.AspNetCore.Components.E2ETests.Tests
+namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 {
     public class HeadModificationTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
     {

--- a/src/Components/test/E2ETest/Tests/WebAssemblyAuthenticationTests.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyAuthenticationTests.cs
@@ -207,8 +207,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             },
             payload.Scopes.OrderBy(id => id));
 
-            var currentTime = DateTimeOffset.Parse(Browser.Exists(By.Id("current-time")).Text, CultureInfo.InvariantCulture);
-            var tokenExpiration = DateTimeOffset.Parse(Browser.Exists(By.Id("access-token-expires")).Text, CultureInfo.InvariantCulture);
+            // The browser formats the text using the current language, so the following parsing relies on
+            // the server being set to an equivalent culture. This should be true in our test scenarios.
+            var currentTime = DateTimeOffset.Parse(Browser.Exists(By.Id("current-time")).Text, CultureInfo.CurrentCulture);
+            var tokenExpiration = DateTimeOffset.Parse(Browser.Exists(By.Id("access-token-expires")).Text, CultureInfo.CurrentCulture);
             Assert.True(currentTime.AddMinutes(50) < tokenExpiration);
             Assert.True(currentTime.AddMinutes(60) >= tokenExpiration);
         }

--- a/src/Components/test/E2ETest/xunit.runner.json
+++ b/src/Components/test/E2ETest/xunit.runner.json
@@ -1,7 +1,6 @@
 {
-  // This is set to -1 to allow the usage of an
-  // unlimited ammount of threads.
-  "maxParallelThreads": -1,
   "diagnosticMessages": true,
-  "longRunningTestSeconds": 30
+  "longRunningTestSeconds": 30,
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
 }

--- a/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
+++ b/src/Components/test/testassets/BasicTestApp/BasicTestApp.csproj
@@ -14,8 +14,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestTrimmedApps)' == 'true'">
-    <StaticWebAssetBasePath>/subdir</StaticWebAssetBasePath>
-
     <!-- Avoid spending time brotli compression publish output.-->
     <_BlazorBrotliCompressionLevel>NoCompression</_BlazorBrotliCompressionLevel>
   </PropertyGroup>

--- a/src/Components/test/testassets/BasicTestApp/BindCasesComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/BindCasesComponent.razor
@@ -168,12 +168,6 @@
     <input id="textbox-datetime-format-mirror" @bind="textboxDateTimeFormatValue" readonly />
 </p>
 <p>
-    DateTime (format):
-    <input id="textbox-datetime-format-invalid" @bind="textboxDateTimeFormatValue" type="text" @bind:format="MM-dd" />
-    <span id="textbox-datetime-format-invalid-value">@textboxDateTimeFormatValue</span>
-    <input id="textbox-datetime-format-invalid-mirror" @bind="textboxDateTimeFormatValue" readonly />
-</p>
-<p>
     DateTime (format / invalid value):
     <input id="textbox-datetime-format-invalid" @bind-value="textboxDateTimeFormatInvalidValue" type="text" @bind-value:format="MM-dd" />
     <span id="textbox-datetime-format-invalid-value">@textboxDateTimeFormatInvalidValue</span>

--- a/src/Components/test/testassets/TestServer/Controllers/CultureController.cs
+++ b/src/Components/test/testassets/TestServer/Controllers/CultureController.cs
@@ -22,8 +22,8 @@ namespace Components.TestServer.Controllers
             }
 
             var htmlEncoder = HtmlEncoder.Default;
-            var html = $"<h1>Culture has been changed to {htmlEncoder.Encode(culture)}</h1>" +
-                $"<a class='return-from-culture-setter' href='{htmlEncoder.Encode(redirectUri)}'>Return to previous page</a>";
+            var html = "<h1>Culture has been changed to " + htmlEncoder.Encode(culture) + "</h1>" +
+                "<a class='return-from-culture-setter' href='" + htmlEncoder.Encode(redirectUri) + "'>Return to previous page</a>";
             return Content(html, "text/html");
         }
     }

--- a/src/Components/test/testassets/TestServer/Pages/Transports.cshtml
+++ b/src/Components/test/testassets/TestServer/Pages/Transports.cshtml
@@ -1,6 +1,13 @@
 ﻿@page
 @addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
 
+<!DOCTYPE html>
+<html>
+<head>
+    <base href="~/" />
+</head>
+<body>
+
 <root><component type="typeof(BasicTestApp.Index)" render-mode="Server" /></root>
 
 <div id="blazor-error-ui">
@@ -58,3 +65,5 @@
         });
     }
 </script>
+</body>
+</html>

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -35,6 +35,8 @@ namespace Microsoft.AspNetCore.E2ETesting
 
         public string UserProfileDir { get; private set; }
 
+        public bool EnsureNotHeadless { get; set; }
+
         public static void EnforceSupportedConfigurations()
         {
             // Do not change the current platform support without explicit approval.
@@ -143,7 +145,8 @@ namespace Microsoft.AspNetCore.E2ETesting
             // Force language to english for tests
             opts.AddUserProfilePreference("intl.accept_languages", "en");
 
-            if (!Debugger.IsAttached &&
+            if (!EnsureNotHeadless &&
+                !Debugger.IsAttached &&
                 !string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_VISIBLE"), "true", StringComparison.OrdinalIgnoreCase))
             {
                 opts.AddArgument("--headless");


### PR DESCRIPTION
As of this PR:

 * The Ignitor tests are all skipped.
     * Previously, they were already quarantined, but still ran and failed locally. As previously discussed on the team, we should remove both the Ignitor tests and Ignitor itself, but that can be done in a later PR.
 * Every other E2E test now passes, at least if you re-run enough times
     * Previously, there were a number of quarantined tests that would never pass due to bugs in either the test implementation or (in several cases) the recent string interpolation bug in .NET Core itself. These are all now fixed/workarounded, so I've seen them all go green at least once.

This doesn't address the reliability/consistency concerns, which we still need to take on as a later piece of work. Running the tests locally I don't see many (or any?) random failures of the form "expected x, got y" but I do see random failures like "the test server did not start". This *might* be assuaged by running without parallelism but it's a whole separate investigation.