### PR TITLE
Cancel the token when it's created after an Abort/Disconnect

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                         }
                         else
                         {
-                            _disconnectToken = CancellationToken.None;
+                            _disconnectToken = new CancellationToken(canceled: true);
                         }
                     }
                 }
@@ -180,6 +180,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     Log.AbortError(Logger, ex);
                 }
                 _requestAbortSource.Dispose();
+            }
+            else
+            {
+                _disconnectToken = new CancellationToken(canceled: true);
             }
             ForceCancelRequest();
             Request.Dispose();

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                         }
                         else
                         {
-                            _disconnectToken = new CancellationToken(canceled: true);
+                            _disconnectToken = CancellationToken.None;
                         }
                     }
                 }

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestTests.cs
@@ -468,6 +468,101 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             }
         }
 
+        [ConditionalFact]
+        public async Task RequestAborted_AfterAccessingProperty_Notified()
+        {
+            var registered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var result = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var server = Utilities.CreateHttpServerReturnRoot("/", out var address, async httpContext =>
+            {
+                var ct = httpContext.RequestAborted;
+
+                if (!ct.CanBeCanceled || ct.IsCancellationRequested)
+                {
+                    result.SetException(new Exception("The CT isn't valid."));
+                    return;
+                }
+
+                ct.Register(() => result.SetResult());
+
+                registered.SetResult();
+
+                // Don't exit until it fires or else it could be disposed.
+                await result.Task.DefaultTimeout();
+            });
+
+            // Send a request and then abort.
+
+            var uri = new Uri(address);
+            StringBuilder builder = new StringBuilder();
+            builder.AppendLine("POST / HTTP/1.1");
+            builder.AppendLine("Connection: close");
+            builder.AppendLine("Content-Length: 10");
+            builder.Append("HOST: ");
+            builder.AppendLine(uri.Authority);
+            builder.AppendLine();
+
+            byte[] request = Encoding.ASCII.GetBytes(builder.ToString());
+
+            using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
+            await socket.ConnectAsync(uri.Host, uri.Port);
+            socket.Send(request);
+
+            // Wait for the token to be setup before aborting.
+            await registered.Task.DefaultTimeout();
+
+            socket.Close();
+
+            await result.Task.DefaultTimeout();
+        }
+
+        [ConditionalFact]
+        public async Task RequestAbortedDurringRead_BeforeAccessingProperty_TokenAlreadyCanceled()
+        {
+            var requestAborted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var result = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var server = Utilities.CreateHttpServerReturnRoot("/", out var address, async httpContext =>
+            {
+                await requestAborted.Task.DefaultTimeout();
+                try
+                {
+                    await httpContext.Request.Body.ReadAsync(new byte[10]).DefaultTimeout();
+                    result.SetException(new Exception("This should have aborted"));
+                    return;
+                }
+                catch (IOException)
+                {
+                }
+
+                result.SetResult(httpContext.RequestAborted.IsCancellationRequested);
+            });
+
+            // Send a request and then abort.
+
+            var uri = new Uri(address);
+            StringBuilder builder = new StringBuilder();
+            builder.AppendLine("POST / HTTP/1.1");
+            builder.AppendLine("Connection: close");
+            builder.AppendLine("Content-Length: 10");
+            builder.Append("HOST: ");
+            builder.AppendLine(uri.Authority);
+            builder.AppendLine();
+
+            byte[] request = Encoding.ASCII.GetBytes(builder.ToString());
+
+            using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
+            await socket.ConnectAsync(uri.Host, uri.Port);
+            socket.Send(request);
+            socket.Close();
+
+            requestAborted.SetResult();
+
+            var wasCancelled = await result.Task;
+            Assert.True(wasCancelled);
+        }
+
         private IServer CreateServer(out string root, RequestDelegate app)
         {
             // TODO: We're just doing this to get a dynamic port. This can be removed later when we add support for hot-adding prefixes.


### PR DESCRIPTION
Fixes #17278 Before this change there were two conditions where an aborted request could return a default CT from RequestAborted:
1) The client had disconnected during a request body Read before the CT is accessed. This triggers a full request abort, but doesn't create the CT. Trying to access the CT later gets you a default one.
2) We're unable to register for disconnect notifications. We assume this is because of disconnects, but I haven't found a way to force that failure code path.

rc2 backport candidate.