### PR TITLE
Fix SignalR TS unit tests not running on CI

### DIFF
--- a/src/SignalR/clients/ts/client-ts.npmproj
+++ b/src/SignalR/clients/ts/client-ts.npmproj
@@ -1,11 +1,14 @@
 <Project>
   <PropertyGroup>
-    <IsTestProject>true</IsTestProject>
+    <TestDependsOnAspNetRuntime>false</TestDependsOnAspNetRuntime>
+    <TestDependsOnAspNetPackages>false</TestDependsOnAspNetPackages>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <!-- Keep this property after importing Directory.Build.props, it works around arcade assuming test projects have "Test" in the name -->
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <IsBuildable>false</IsBuildable>
     <!-- Npm tests don't run on Helix currently, so we need to set this to false to still run the tests on non-Helix -->

--- a/src/SignalR/clients/ts/jest.config.js
+++ b/src/SignalR/clients/ts/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     },
     reporters: [
         "default",
-        ["./common/node_modules/jest-junit/index.js", { "output": "../../../../artifacts/log/" + `${process.platform}` + ".signalr.junit.xml" }]
+        ["./common/node_modules/jest-junit/index.js", { "outputDirectory": "../../../../artifacts/log/", "outputName": `${process.platform}` + ".signalr.junit.xml" }]
     ],
     transform: {
         "^.+\\.tsx?$": "./common/node_modules/ts-jest"

--- a/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
@@ -7,7 +7,7 @@ import { CookieJar } from "@types/tough-cookie";
 import { AbortError, HttpError, TimeoutError } from "./Errors";
 import { HttpClient, HttpRequest, HttpResponse } from "./HttpClient";
 import { ILogger, LogLevel } from "./ILogger";
-import { Platform } from "./Utils";
+import { Platform, getGlobalThis } from "./Utils";
 
 export class FetchHttpClient extends HttpClient {
     private readonly _abortControllerType: { prototype: AbortController, new(): AbortController };
@@ -33,7 +33,7 @@ export class FetchHttpClient extends HttpClient {
             // fetch-cookie will wrap a fetch implementation with a default CookieJar or a provided one
             this._fetchType = requireFunc("fetch-cookie")(this._fetchType, this._jar);
         } else {
-            this._fetchType = fetch.bind(globalThis);
+            this._fetchType = fetch.bind(getGlobalThis());
         }
         if (typeof AbortController === "undefined") {
             // In order to ignore the dynamic require in webpack builds we need to do this magic

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -277,3 +277,21 @@ export function getErrorString(e: any): string {
     }
     return `${e}`;
 }
+
+/** @private */
+export function getGlobalThis() {
+    // globalThis is semi-new and not available in Node until v12
+    if (typeof globalThis !== "undefined") {
+        return globalThis;
+    }
+    if (typeof self !== "undefined") {
+        return self;
+    }
+    if (typeof window !== "undefined") {
+        return window;
+    }
+    if (typeof global !== "undefined") {
+        return global;
+    }
+    throw new Error("could not find global");
+}

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -272,7 +272,8 @@ describe("HttpConnection", () => {
         },
         "Failed to start the transport 'WebSockets': Error: Don't allow Websockets.",
         "Failed to start the transport 'ServerSentEvents': Error: Don't allow ServerSentEvents.",
-        "Failed to start the connection: Error: Unable to connect to the server with any of the available transports. Error: WebSockets failed: Error: Don't allow Websockets. Error: ServerSentEvents failed: Error: Don't allow ServerSentEvents. LongPolling failed: Error: 'LongPolling' is disabled by the client.");
+        "Failed to start the connection: Error: Unable to connect to the server with any of the available transports. Error: WebSockets failed: Error: Don't allow Websockets. " +
+        "Error: ServerSentEvents failed: Error: Don't allow ServerSentEvents. LongPolling failed: Error: 'LongPolling' is disabled by the client.");
     });
 
     it("failed re-negotiate fails start", async () => {

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -230,7 +230,7 @@ describe("HttpConnection", () => {
             const connection = new HttpConnection("http://tempuri.org", options);
             await expect(connection.start(TransferFormat.Text))
                 .rejects
-                .toThrow("Unable to connect to the server with any of the available transports. WebSockets failed: Error: WebSocket failed to connect. " +
+                .toThrow("Unable to connect to the server with any of the available transports. Error: WebSockets failed: Error: WebSocket failed to connect. " +
                 "The connection could not be found on the server, either the endpoint may not be a SignalR endpoint, the connection ID is not present on the server, " +
                 "or there is a proxy blocking WebSockets. If you have multiple servers check that sticky sessions are enabled. ServerSentEvents failed: Error: 'ServerSentEvents' is disabled by the client. LongPolling failed: Error: 'LongPolling' is disabled by the client.");
 
@@ -239,7 +239,7 @@ describe("HttpConnection", () => {
         /* eslint-disable max-len */
         "Failed to start the transport 'WebSockets': Error: WebSocket failed to connect. The connection could not be found on the server, " +
         "either the endpoint may not be a SignalR endpoint, the connection ID is not present on the server, or there is a proxy blocking WebSockets. If you have multiple servers check that sticky sessions are enabled.",
-        "Failed to start the connection: Error: Unable to connect to the server with any of the available transports. WebSockets failed: " +
+        "Failed to start the connection: Error: Unable to connect to the server with any of the available transports. Error: WebSockets failed: " +
         "Error: WebSocket failed to connect. The connection could not be found on the server, either the endpoint may not be a SignalR endpoint, the connection ID is not present on the server, or there is a proxy blocking WebSockets. If you have multiple servers check that sticky sessions are enabled. ServerSentEvents failed: Error: 'ServerSentEvents' is disabled by the client. LongPolling failed: Error: 'LongPolling' is disabled by the client.");
         /* eslint-enable max-len */
     });
@@ -266,13 +266,13 @@ describe("HttpConnection", () => {
             const connection = new HttpConnection("http://tempuri.org", options);
             await expect(connection.start(TransferFormat.Text))
                 .rejects
-                .toThrow("Unable to connect to the server with any of the available transports. WebSockets failed: Error: Don't allow Websockets. ServerSentEvents failed: Error: Don't allow ServerSentEvents. LongPolling failed: Error: 'LongPolling' is disabled by the client.");
+                .toThrow("Unable to connect to the server with any of the available transports. Error: WebSockets failed: Error: Don't allow Websockets. Error: ServerSentEvents failed: Error: Don't allow ServerSentEvents. LongPolling failed: Error: 'LongPolling' is disabled by the client.");
 
             expect(negotiateCount).toEqual(2);
         },
         "Failed to start the transport 'WebSockets': Error: Don't allow Websockets.",
         "Failed to start the transport 'ServerSentEvents': Error: Don't allow ServerSentEvents.",
-        "Failed to start the connection: Error: Unable to connect to the server with any of the available transports. WebSockets failed: Error: Don't allow Websockets. ServerSentEvents failed: Error: Don't allow ServerSentEvents. LongPolling failed: Error: 'LongPolling' is disabled by the client.");
+        "Failed to start the connection: Error: Unable to connect to the server with any of the available transports. Error: WebSockets failed: Error: Don't allow Websockets. Error: ServerSentEvents failed: Error: Don't allow ServerSentEvents. LongPolling failed: Error: 'LongPolling' is disabled by the client.");
     });
 
     it("failed re-negotiate fails start", async () => {
@@ -1331,12 +1331,12 @@ describe("HttpConnection", () => {
 
                 await expect(connection.start(TransferFormat.Text))
                     .rejects
-                    .toEqual(new Error("Unable to connect to the server with any of the available transports. ServerSentEvents failed: Error: EventSource constructor called."));
+                    .toEqual(new Error("Unable to connect to the server with any of the available transports. Error: ServerSentEvents failed: Error: EventSource constructor called."));
 
                 expect(eventSourceConstructorCalled).toEqual(true);
             },
             "Failed to start the transport 'ServerSentEvents': Error: EventSource constructor called.",
-            "Failed to start the connection: Error: Unable to connect to the server with any of the available transports. ServerSentEvents failed: Error: EventSource constructor called.");
+            "Failed to start the connection: Error: Unable to connect to the server with any of the available transports. Error: ServerSentEvents failed: Error: EventSource constructor called.");
         });
 
         it("uses WebSocket constructor from options if provided", async () => {


### PR DESCRIPTION
Broken by https://github.com/dotnet/aspnetcore/pull/32510 which moved the `<IsTestProject>` property above the import. So added a comment to help us remember not to move it.

Also noticed that when we updated jest-junit earlier this year it had a breaking change in how it output test result files, so fixed that so it's picked up by the CI correctly.