### PR TITLE
Add support for TryParse(HttpContext, ...) to RequestDelegateFactory

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -34,17 +35,19 @@ namespace Microsoft.AspNetCore.Http
         private static readonly MethodInfo ResultWriteResponseAsyncMethod = typeof(RequestDelegateFactory).GetMethod(nameof(ExecuteResultWriteResponse), BindingFlags.NonPublic | BindingFlags.Static)!;
         private static readonly MethodInfo StringResultWriteResponseAsyncMethod = typeof(RequestDelegateFactory).GetMethod(nameof(ExecuteWriteStringResponseAsync), BindingFlags.NonPublic | BindingFlags.Static)!;
         private static readonly MethodInfo JsonResultWriteResponseAsyncMethod = GetMethodInfo<Func<HttpResponse, object, Task>>((response, value) => HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, default));
-        private static readonly MethodInfo LogParameterBindingFailureMethod = GetMethodInfo<Action<HttpContext, string, string, string>>((httpContext, parameterType, parameterName, sourceValue) =>
-            Log.ParameterBindingFailed(httpContext, parameterType, parameterName, sourceValue));
 
+        private static readonly MethodInfo LogParameterBindingFailedMethod = GetMethodInfo<Action<HttpContext, string, string, string>>((httpContext, parameterType, parameterName, sourceValue) =>
+            Log.ParameterBindingFailed(httpContext, parameterType, parameterName, sourceValue));
         private static readonly MethodInfo LogRequiredParameterNotProvidedMethod = GetMethodInfo<Action<HttpContext, string, string>>((httpContext, parameterType, parameterName) =>
             Log.RequiredParameterNotProvided(httpContext, parameterType, parameterName));
+        private static readonly MethodInfo LogParameterBindingFromHttpContextFailedMethod = GetMethodInfo<Action<HttpContext, string, string>>((httpContext, parameterType, parameterName) =>
+            Log.ParameterBindingFromHttpContextFailed(httpContext, parameterType, parameterName));
 
         private static readonly ParameterExpression TargetExpr = Expression.Parameter(typeof(object), "target");
-        private static readonly ParameterExpression HttpContextExpr = Expression.Parameter(typeof(HttpContext), "httpContext");
         private static readonly ParameterExpression BodyValueExpr = Expression.Parameter(typeof(object), "bodyValue");
         private static readonly ParameterExpression WasParamCheckFailureExpr = Expression.Variable(typeof(bool), "wasParamCheckFailure");
 
+        private static ParameterExpression HttpContextExpr => TryParseMethodCache.HttpContextExpr;
         private static readonly MemberExpression RequestServicesExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.RequestServices))!);
         private static readonly MemberExpression HttpRequestExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.Request))!);
         private static readonly MemberExpression HttpResponseExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.Response))!);
@@ -56,8 +59,9 @@ namespace Microsoft.AspNetCore.Http
         private static readonly MemberExpression StatusCodeExpr = Expression.Property(HttpResponseExpr, typeof(HttpResponse).GetProperty(nameof(HttpResponse.StatusCode))!);
         private static readonly MemberExpression CompletedTaskExpr = Expression.Property(null, (PropertyInfo)GetMemberInfo<Func<Task>>(() => Task.CompletedTask));
 
-        private static readonly BinaryExpression TempSourceStringNotNullExpr = Expression.NotEqual(TryParseMethodCache.TempSourceStringExpr, Expression.Constant(null));
-        private static readonly BinaryExpression TempSourceStringNullExpr = Expression.Equal(TryParseMethodCache.TempSourceStringExpr, Expression.Constant(null));
+        private static ParameterExpression TempSourceStringExpr => TryParseMethodCache.TempSourceStringExpr;
+        private static readonly BinaryExpression TempSourceStringNotNullExpr = Expression.NotEqual(TempSourceStringExpr, Expression.Constant(null));
+        private static readonly BinaryExpression TempSourceStringNullExpr = Expression.Equal(TempSourceStringExpr, Expression.Constant(null));
 
         /// <summary>
         /// Creates a <see cref="RequestDelegate"/> implementation for <paramref name="action"/>.
@@ -169,7 +173,7 @@ namespace Microsoft.AspNetCore.Http
 
             if (factoryContext.UsingTempSourceString)
             {
-                responseWritingMethodCall = Expression.Block(new[] { TryParseMethodCache.TempSourceStringExpr }, responseWritingMethodCall);
+                responseWritingMethodCall = Expression.Block(new[] { TempSourceStringExpr }, responseWritingMethodCall);
             }
 
             return HandleRequestBodyAndCompileRequestDelegate(responseWritingMethodCall, factoryContext);
@@ -246,7 +250,11 @@ namespace Microsoft.AspNetCore.Http
             {
                 return RequestAbortedExpr;
             }
-            else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseMethod(parameter))
+            else if (TryParseMethodCache.HasTryParseHttpContextMethod(parameter))
+            {
+                return BindParameterFromTryParseHttpContext(parameter, factoryContext);
+            }
+            else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseStringMethod(parameter))
             {
                 // 1. We bind from route values only, if route parameters are non-null and the parameter name is in that set.
                 // 2. We bind from query only, if route parameters are non-null and the parameter name is NOT in that set.
@@ -602,7 +610,7 @@ namespace Microsoft.AspNetCore.Http
             var isNotNullable = underlyingNullableType is null;
 
             var nonNullableParameterType = underlyingNullableType ?? parameter.ParameterType;
-            var tryParseMethodCall = TryParseMethodCache.FindTryParseMethod(nonNullableParameterType);
+            var tryParseMethodCall = TryParseMethodCache.FindTryParseStringMethod(nonNullableParameterType);
 
             if (tryParseMethodCall is null)
             {
@@ -646,7 +654,7 @@ namespace Microsoft.AspNetCore.Http
             //     param2_local = 42;
             // }
 
-            // If the parameter is nullable, create a "parsedValue" local to TryParse into since we cannot the parameter directly.
+            // If the parameter is nullable, create a "parsedValue" local to TryParse into since we cannot use the parameter directly.
             var parsedValue = isNotNullable ? argument : Expression.Variable(nonNullableParameterType, "parsedValue");
 
             var parameterTypeNameConstant = Expression.Constant(parameter.ParameterType.Name);
@@ -654,8 +662,8 @@ namespace Microsoft.AspNetCore.Http
 
             var failBlock = Expression.Block(
                 Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
-                Expression.Call(LogParameterBindingFailureMethod,
-                    HttpContextExpr, parameterTypeNameConstant, parameterNameConstant, TryParseMethodCache.TempSourceStringExpr));
+                Expression.Call(LogParameterBindingFailedMethod,
+                    HttpContextExpr, parameterTypeNameConstant, parameterNameConstant, TempSourceStringExpr));
 
             var tryParseCall = tryParseMethodCall(parsedValue);
 
@@ -694,14 +702,14 @@ namespace Microsoft.AspNetCore.Http
             var fullParamCheckBlock = !isOptional
                 ? Expression.Block(
                     // tempSourceString = httpContext.RequestValue["id"];
-                    Expression.Assign(TryParseMethodCache.TempSourceStringExpr, valueExpression),
+                    Expression.Assign(TempSourceStringExpr, valueExpression),
                     // if (tempSourceString == null) { ... } only produced when parameter is required
                     checkRequiredParaseableParameterBlock,
                     // if (tempSourceString != null) { ... }
                     ifNotNullTryParse)
                 : Expression.Block(
                     // tempSourceString = httpContext.RequestValue["id"];
-                    Expression.Assign(TryParseMethodCache.TempSourceStringExpr, valueExpression),
+                    Expression.Assign(TempSourceStringExpr, valueExpression),
                     // if (tempSourceString != null) { ... }
                     ifNotNullTryParse);
 
@@ -719,6 +727,42 @@ namespace Microsoft.AspNetCore.Http
             var routeValue = GetValueFromProperty(RouteValuesExpr, key);
             var queryValue = GetValueFromProperty(QueryExpr, key);
             return BindParameterFromValue(parameter, Expression.Coalesce(routeValue, queryValue), factoryContext);
+        }
+
+        private static Expression BindParameterFromTryParseHttpContext(ParameterInfo parameter, FactoryContext factoryContext)
+        {
+            // bool wasParamCheckFailure = false;
+            //
+            // // Assume "Foo param1" is the first parameter and "public static bool TryParse(HttpContext context, out Foo foo)" exists.
+            // Foo param1_local;
+            //
+            // if (!Foo.TryParse(httpContext, out param1_local))
+            // {
+            //     wasParamCheckFailure = true;
+            //     Log.ParameterBindingFromHttpContextFailed(httpContext, "Foo", "foo")
+            // }
+
+            var argument = Expression.Variable(parameter.ParameterType, $"{parameter.Name}_local");
+            var tryParseMethodCall = TryParseMethodCache.FindTryParseHttpContextMethod(parameter.ParameterType);
+
+            // There's no way to opt-in to using a TryParse method on HttpContext other than defining the method, so it's guaranteed to exist here.
+            Debug.Assert(tryParseMethodCall is not null);
+
+            var parameterTypeNameConstant = Expression.Constant(parameter.ParameterType.Name);
+            var parameterNameConstant = Expression.Constant(parameter.Name);
+
+            var failBlock = Expression.Block(
+                Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
+                Expression.Call(LogParameterBindingFromHttpContextFailedMethod,
+                    HttpContextExpr, parameterTypeNameConstant, parameterNameConstant));
+
+            var tryParseCall = tryParseMethodCall(argument);
+            var fullParamCheckBlock = Expression.IfThen(Expression.Not(tryParseCall), failBlock);
+
+            factoryContext.ExtraLocals.Add(argument);
+            factoryContext.ParamCheckExpressions.Add(fullParamCheckBlock);
+
+            return argument;
         }
 
         private static Expression BindParameterFromBody(ParameterInfo parameter, bool allowEmpty, FactoryContext factoryContext)
@@ -982,18 +1026,26 @@ namespace Microsoft.AspNetCore.Http
             public static void ParameterBindingFailed(HttpContext httpContext, string parameterTypeName, string parameterName, string sourceValue)
                 => ParameterBindingFailed(GetLogger(httpContext), parameterTypeName, parameterName, sourceValue);
 
-            public static void RequiredParameterNotProvided(HttpContext httpContext, string parameterTypeName, string parameterName)
-                => RequiredParameterNotProvided(GetLogger(httpContext), parameterTypeName, parameterName);
-
             [LoggerMessage(3, LogLevel.Debug,
                 @"Failed to bind parameter ""{ParameterType} {ParameterName}"" from ""{SourceValue}"".",
                 EventName = "ParamaterBindingFailed")]
             private static partial void ParameterBindingFailed(ILogger logger, string parameterType, string parameterName, string sourceValue);
 
+            public static void RequiredParameterNotProvided(HttpContext httpContext, string parameterTypeName, string parameterName)
+                => RequiredParameterNotProvided(GetLogger(httpContext), parameterTypeName, parameterName);
+
             [LoggerMessage(4, LogLevel.Debug,
                 @"Required parameter ""{ParameterType} {ParameterName}"" was not provided.",
                 EventName = "RequiredParameterNotProvided")]
             private static partial void RequiredParameterNotProvided(ILogger logger, string parameterType, string parameterName);
+
+            public static void ParameterBindingFromHttpContextFailed(HttpContext httpContext, string parameterTypeName, string parameterName)
+                => ParameterBindingFromHttpContextFailed(GetLogger(httpContext), parameterTypeName, parameterName);
+
+            [LoggerMessage(5, LogLevel.Debug,
+                @"Failed to bind parameter ""{ParameterType} {ParameterName}"" from HttpContext.",
+                EventName = "ParameterBindingFromHttpContextFailed")]
+            private static partial void ParameterBindingFromHttpContextFailed(ILogger logger, string parameterType, string parameterName);
 
             private static ILogger GetLogger(HttpContext httpContext)
             {

--- a/src/Http/Http.Extensions/test/TryParseMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/TryParseMethodCacheTests.cs
@@ -25,9 +25,9 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [InlineData(typeof(ushort))]
         [InlineData(typeof(uint))]
         [InlineData(typeof(ulong))]
-        public void FindTryParseMethod_ReturnsTheExpectedTryParseMethodWithInvariantCulture(Type @type)
+        public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCulture(Type @type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseMethod(@type);
+            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -48,9 +48,9 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [InlineData(typeof(DateTimeOffset))]
         [InlineData(typeof(TimeOnly))]
         [InlineData(typeof(TimeSpan))]
-        public void FindTryParseMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureDateType(Type @type)
+        public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureDateType(Type @type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseMethod(@type);
+            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -77,9 +77,9 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
 
         [Theory]
         [InlineData(typeof(TryParsableInvariantRecord))]
-        public void FindTryParseMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureCustomType(Type @type)
+        public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureCustomType(Type @type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseMethod(@type);
+            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -95,10 +95,10 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         }
 
         [Fact]
-        public void FindTryParseMethodForEnums()
+        public void FindTryParseStringMethod_WorksForEnums()
         {
             var type = typeof(Choice);
-            var methodFound = new TryParseMethodCache().FindTryParseMethod(type);
+            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(type);
 
             Assert.NotNull(methodFound);
 
@@ -115,11 +115,11 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         }
 
         [Fact]
-        public void FindTryParseMethodForEnumsWhenNonGenericEnumParseIsUsed()
+        public void FindTryParseStringMethod_WorksForEnumsWhenNonGenericEnumParseIsUsed()
         {
             var type = typeof(Choice);
             var cache = new TryParseMethodCache(preferNonGenericEnumParseOverload: true);
-            var methodFound = cache.FindTryParseMethod(type);
+            var methodFound = cache.FindTryParseStringMethod(type);
 
             Assert.NotNull(methodFound);
 

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -184,11 +184,12 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                      parameter.ParameterType == typeof(HttpResponse) ||
                      parameter.ParameterType == typeof(ClaimsPrincipal) ||
                      parameter.ParameterType == typeof(CancellationToken) ||
+                     TryParseMethodCache.HasTryParseHttpContextMethod(parameter) ||
                      _serviceProviderIsService?.IsService(parameter.ParameterType) == true)
             {
                 return (BindingSource.Services, parameter.Name ?? string.Empty, false);
             }
-            else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseMethod(parameter))
+            else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseStringMethod(parameter))
             {
                 // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
                 if (parameter.Name is { } name && pattern.GetParameter(name) is not null)

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -1,13 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Security.Claims;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -17,7 +12,6 @@ using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 {
@@ -256,6 +250,20 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         }
 
         [Fact]
+        public void AddsFromRouteParameterAsPathWithCustomTypep()
+        {
+            static void AssertPathParameter(ApiDescription apiDescription)
+            {
+                var param = Assert.Single(apiDescription.ParameterDescriptions);
+                Assert.Equal(typeof(TryParseStringRecord), param.Type);
+                Assert.Equal(typeof(TryParseStringRecord), param.ModelMetadata.ModelType);
+                Assert.Equal(BindingSource.Path, param.Source);
+            }
+
+            AssertPathParameter(GetApiDescription((TryParseStringRecord foo) => { }, "/{foo}"));
+        }
+
+        [Fact]
         public void AddsFromQueryParameterAsQuery()
         {
             static void AssertQueryParameter(ApiDescription apiDescription)
@@ -291,6 +299,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             Assert.Empty(GetApiDescription((HttpResponse response) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription((ClaimsPrincipal user) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription((CancellationToken token) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription((TryParseHttpContextRecord context) => { }).ParameterDescriptions);
         }
 
         [Fact]
@@ -664,6 +673,20 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             public ICollection<EndpointDataSource> DataSources { get; }
 
             public IServiceProvider ServiceProvider => ApplicationBuilder.ApplicationServices;
+        }
+
+        private record TryParseStringRecord(int Value)
+        {
+            public static bool TryParse(string value, out TryParseStringRecord result) =>
+                throw new NotImplementedException();
+        }
+
+        private record TryParseHttpContextRecord(int Value)
+        {
+            public static bool TryParse(HttpContext context, out TryParseHttpContextRecord result) =>
+                throw new NotImplementedException();
+            public static bool TryParse(string value, out TryParseHttpContextRecord result) =>
+                throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
- This also checks for the new TryParse overload in EndpointMetadataApiDescriptionProvider.cs
- `TryParse(HttpContext, ...)` is preferred over `TryParse(string, ...)` if both are present.
- This has no support for optionality since there's no way to determine if the parameter is simply missing or invalid
  - As a consequence `TryParse(HttpContext, ...)` will never be used if the parameter is a nullable struct, but it could fall back to `TryParse(string, ...)` in this case
