### PR TITLE
[release/6.0-rc1] HTTP/3: Fix incorrectly pooling aborted streams

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -415,11 +415,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
         public override async ValueTask DisposeAsync()
         {
+            // Be conservative about what can be pooled.
+            // Only pool bidirectional streams whose pipes have completed successfully and haven't been aborted.
             CanReuse = _stream.CanRead && _stream.CanWrite
                 && _transportPipeReader.IsCompletedSuccessfully
                 && _transportPipeWriter.IsCompletedSuccessfully
                 && !_clientAbort
-                && !_serverAborted;
+                && !_serverAborted
+                && _shutdownReadReason == null
+                && _shutdownWriteReason == null;
 
             _originalTransport.Input.Complete();
             _originalTransport.Output.Complete();

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -115,8 +115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 
             // https://github.com/dotnet/runtime/issues/57246 The accept still completes even though the connection was rejected, but it's already failed.
             var serverContext = await connectionListener.AcceptAndAddFeatureAsync().DefaultTimeout();
-            qex = await Assert.ThrowsAsync<QuicException>(() => serverContext.ConnectAsync().DefaultTimeout());
-            Assert.Equal("Failed to open stream to peer. Error Code: INVALID_STATE", qex.Message);
+            await Assert.ThrowsAsync<QuicException>(() => serverContext.ConnectAsync().DefaultTimeout());
         }
     }
 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -516,6 +516,69 @@ namespace Interop.FunctionalTests.Http3
 
         [ConditionalFact]
         [MsQuicSupported]
+        public async Task StreamResponseContent_DelayAndTrailers_ClientSuccess()
+        {
+            // Arrange
+            var builder = CreateHostBuilder(async context =>
+            {
+                var feature = context.Features.Get<IHttpResponseTrailersFeature>();
+
+                for (var i = 1; i < 200; i++)
+                {
+                    feature.Trailers.Append($"trailer-{i}", new string('!', i));
+                }
+
+                Logger.LogInformation($"Server trailer count: {feature.Trailers.Count}");
+
+                await context.Request.BodyReader.ReadAtLeastAsync(TestData.Length);
+
+                for (var i = 0; i < 3; i++)
+                {
+                    await context.Response.BodyWriter.WriteAsync(TestData);
+
+                    await Task.Delay(TimeSpan.FromMilliseconds(10));
+                }
+            });
+
+            using (var host = builder.Build())
+            using (var client = Http3Helpers.CreateClient())
+            {
+                await host.StartAsync();
+
+                // Act
+                var request = new HttpRequestMessage(HttpMethod.Post, $"https://127.0.0.1:{host.GetPort()}/");
+                request.Content = new ByteArrayContent(TestData);
+                request.Version = HttpVersion.Version30;
+                request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+                var response = await client.SendAsync(request, CancellationToken.None);
+                response.EnsureSuccessStatusCode();
+
+                var responseStream = await response.Content.ReadAsStreamAsync();
+
+                await responseStream.ReadUntilEndAsync();
+
+                Logger.LogInformation($"Client trailer count: {response.TrailingHeaders.Count()}");
+
+                for (var i = 1; i < 200; i++)
+                {
+                    try
+                    {
+                        var value = response.TrailingHeaders.GetValues($"trailer-{i}").Single();
+                        Assert.Equal(new string('!', i), value);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"Error checking trailer {i}", ex);
+                    }
+                }
+
+                await host.StopAsync();
+            }
+        }
+
+        [ConditionalFact]
+        [MsQuicSupported]
         public async Task GET_MultipleRequests_ConnectionAndTraceIdsUpdated()
         {
             // Arrange


### PR DESCRIPTION
Cherry-picked from https://github.com/dotnet/aspnetcore/pull/35434

---

### Description

An HTTP/3 stream is pooled and reused by Kestrel if it completed gracefully. The check for graceful complete is wrong. A stream that was aborted could be pooled.

### Customer Impact

An HTTP/3 request that uses an incorrectly pooled stream will have undefined behavior. Various bad things could happen depending upon the stream state when it was pooled. Makes HTTP/3 unstable. IMO this is a must-fix bug.

### Risk

Low. Changes are to QUIC which is only used by HTTP/3 which is shipping as a preview feature in .NET 6.

### Original issue and/or the PR to master.

- https://github.com/dotnet/runtime/issues/57608