### PR TITLE
Skip consistently failing `Components.E2ETests.ServerTransportsTest`s

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -42,7 +42,6 @@ stages:
         cancelTimeoutInMinutes: 30
         buildArgs: -all -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
                    /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
-                   /p:RunQuarantinedTests=true
         beforeBuild:
         - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
           displayName: Setup IISExpress test certificates and schema

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerTransportsTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerTransportsTest.cs
@@ -8,6 +8,7 @@ using BasicTestApp.Reconnection;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit;
@@ -25,7 +26,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35481")]
+        [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35481")]
         public void DefaultTransportsWorksWithWebSockets()
         {
             Navigate("/defaultTransport/Transports");
@@ -43,7 +45,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "Blazor server-side application started.");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35481")]
+        [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35481")]
         public void ErrorIfClientAttemptsLongPollingWithServerOnWebSockets()
         {
             Navigate("/defaultTransport/Transports");
@@ -64,7 +67,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal("block", () => errorUiElem.GetCssValue("display"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35481")]
+        [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35481")]
         public void ErrorIfWebSocketsConnectionIsRejected()
         {
             Navigate("/defaultTransport/Transports");
@@ -88,7 +92,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal("block", () => errorUiElem.GetCssValue("display"));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35481")]
+        [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35481")]
         public void ErrorIfClientAttemptsWebSocketsWithServerOnLongPolling()
         {
             Navigate("/longPolling/Transports");

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerTransportsTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerTransportsTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         {
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35481")]
         public void DefaultTransportsWorksWithWebSockets()
         {
             Navigate("/defaultTransport/Transports");
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
                 "Blazor server-side application started.");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35481")]
         public void ErrorIfClientAttemptsLongPollingWithServerOnWebSockets()
         {
             Navigate("/defaultTransport/Transports");
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal("block", () => errorUiElem.GetCssValue("display"));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35481")]
         public void ErrorIfWebSocketsConnectionIsRejected()
         {
             Navigate("/defaultTransport/Transports");
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             Browser.Equal("block", () => errorUiElem.GetCssValue("display"));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35481")]
         public void ErrorIfClientAttemptsWebSocketsWithServerOnLongPolling()
         {
             Navigate("/longPolling/Transports");


### PR DESCRIPTION
I filed #35481 to unskip these.
