### PR TITLE
[release/6.0-rc1] HTTP/3: Response drain timeout

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -67,10 +67,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         public PipeReader Input => _context.Transport.Input;
         public IKestrelTrace Log => _context.ServiceContext.Log;
 
-        public long HeaderTimeoutTicks { get; set; }
-        public bool ReceivedHeader => _headerType >= 0;
-
+        public long StreamTimeoutTicks { get; set; }
+        public bool IsReceivingHeader => _headerType == -1;
+        public bool IsDraining => false;
         public bool IsRequestStream => false;
+        public string TraceIdentifier => _context.StreamContext.ConnectionId;
 
         public void Abort(ConnectionAbortedException abortReason, Http3ErrorCode errorCode)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/IHttp3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/IHttp3Stream.cs
@@ -14,19 +14,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         long StreamId { get; }
 
         /// <summary>
-        /// Used to track the timeout between when the stream was started by the client, and getting a header.
-        /// Value is driven by <see cref="KestrelServerLimits.RequestHeadersTimeout"/>.
+        /// Used to track the timeout in two situations:
+        /// 1. Between when the stream was started by the client, and getting a header.
+        ///    Value is driven by <see cref="KestrelServerLimits.RequestHeadersTimeout"/>.
+        /// 2. Between when the request delegate is complete and the transport draining.
+        ///    Value is driven by <see cref="KestrelServerLimits.MinResponseDataRate"/>.
         /// </summary>
-        long HeaderTimeoutTicks { get; set; }
+        long StreamTimeoutTicks { get; set; }
 
         /// <summary>
-        /// The stream has received and parsed the header frame.
+        /// The stream is receiving the header frame.
         /// - Request streams = HEADERS frame.
         /// - Control streams = unidirectional stream header.
         /// </summary>
-        bool ReceivedHeader { get; }
+        bool IsReceivingHeader { get; }
+
+        /// <summary>
+        /// The stream request delegate is complete and the transport is draining.
+        /// </summary>
+        bool IsDraining { get; }
 
         bool IsRequestStream { get; }
+
+        string TraceIdentifier { get; }
 
         void Abort(ConnectionAbortedException abortReason, Http3ErrorCode errorCode);
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ITimeoutControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ITimeoutControl.cs
@@ -26,5 +26,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         void StartTimingWrite();
         void StopTimingWrite();
         void BytesWrittenToBuffer(MinDataRate minRate, long count);
+        long GetResponseDrainDeadline(long ticks, MinDataRate minRate);
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TimeoutControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TimeoutControl.cs
@@ -330,5 +330,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
 
             ResetTimeout(timeSpan.Ticks, TimeoutReason.TimeoutFeature);
         }
+
+        public long GetResponseDrainDeadline(long ticks, MinDataRate minRate)
+        {
+            // On grace period overflow, use max value.
+            var gracePeriod = ticks + minRate.GracePeriod.Ticks;
+            gracePeriod = gracePeriod >= 0 ? gracePeriod : long.MaxValue;
+
+            return Math.Max(_writeTimingTimeoutTimestamp, gracePeriod);
+        }
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 
@@ -31,15 +30,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         {
             lock (_shutdownLock)
             {
-                if (_stream.CanRead)
+                if (_stream != null)
                 {
-                    _shutdownReadReason = abortReason;
-                    _log.StreamAbortRead(this, errorCode, abortReason.Message);
-                    _stream.AbortRead(errorCode);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Unable to abort reading from a stream that doesn't support reading.");
+                    if (_stream.CanRead)
+                    {
+                        _shutdownReadReason = abortReason;
+                        _log.StreamAbortRead(this, errorCode, abortReason.Message);
+                        _stream.AbortRead(errorCode);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Unable to abort reading from a stream that doesn't support reading.");
+                    }
                 }
             }
         }
@@ -48,15 +50,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         {
             lock (_shutdownLock)
             {
-                if (_stream.CanWrite)
+                if (_stream != null)
                 {
-                    _shutdownWriteReason = abortReason;
-                    _log.StreamAbortWrite(this, errorCode, abortReason.Message);
-                    _stream.AbortWrite(errorCode);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Unable to abort writing to a stream that doesn't support writing.");
+                    if (_stream.CanWrite)
+                    {
+                        _shutdownWriteReason = abortReason;
+                        _log.StreamAbortWrite(this, errorCode, abortReason.Message);
+                        _stream.AbortWrite(errorCode);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Unable to abort writing to a stream that doesn't support writing.");
+                    }
                 }
             }
         }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -17,12 +17,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 {
-    internal partial class QuicStreamContext : TransportConnection, IPooledStream
+    internal partial class QuicStreamContext : TransportConnection, IPooledStream, IDisposable
     {
         // Internal for testing.
         internal Task _processingTask = Task.CompletedTask;
 
-        private QuicStream _stream = default!;
+        private QuicStream? _stream;
         private readonly QuicConnectionContext _connection;
         private readonly QuicTransportContext _context;
         private readonly Pipe _inputPipe;
@@ -140,6 +140,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
         private async Task StartAsync()
         {
+            Debug.Assert(_stream != null);
+
             try
             {
                 // Spawn send and receive logic
@@ -169,6 +171,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
         private async Task DoReceive()
         {
+            Debug.Assert(_stream != null);
+
             Exception? error = null;
 
             try
@@ -316,6 +320,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
         private async Task DoSend()
         {
+            Debug.Assert(_stream != null);
+
             Exception? shutdownReason = null;
             Exception? unexpectedError = null;
 
@@ -413,13 +419,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             lock (_shutdownLock)
             {
-                if (_stream.CanRead)
+                if (_stream != null)
                 {
-                    _stream.AbortRead(Error);
-                }
-                if (_stream.CanWrite)
-                {
-                    _stream.AbortWrite(Error);
+                    if (_stream.CanRead)
+                    {
+                        _stream.AbortRead(Error);
+                    }
+                    if (_stream.CanWrite)
+                    {
+                        _stream.AbortWrite(Error);
+                    }
                 }
             }
 
@@ -429,6 +438,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
         private void ShutdownWrite(Exception? shutdownReason)
         {
+            Debug.Assert(_stream != null);
+
             try
             {
                 lock (_shutdownLock)
@@ -449,6 +460,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
         public override async ValueTask DisposeAsync()
         {
+            if (_stream == null)
+            {
+                return;
+            }
+            
             // Be conservative about what can be pooled.
             // Only pool bidirectional streams whose pipes have completed successfully and haven't been aborted.
             CanReuse = _stream.CanRead && _stream.CanWrite
@@ -464,9 +480,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             await _processingTask;
 
-            _stream.Dispose();
-            _stream = null!;
+            lock (_shutdownLock)
+            {
+                if (!CanReuse)
+                {
+                    DisposeCore();
+                }
 
+                _stream.Dispose();
+                _stream = null!;
+            }
+        }
+
+        public void Dispose()
+        {
             if (!_connection.TryReturnStream(this))
             {
                 // Dispose when one of:

--- a/src/Servers/Kestrel/Transport.Quic/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/src/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.csproj
@@ -17,6 +17,7 @@
     <Compile Include="$(KestrelSharedSourceRoot)\PooledStreamStack.cs" Link="Internal\PooledStreamStack.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeReader.cs" Link="Internal\CompletionPipeReader.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeWriter.cs" Link="Internal\CompletionPipeWriter.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\ConnectionCompletion.cs" Link="Internal\ConnectionCompletion.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CorrelationIdGenerator.cs" Link="Internal\CorrelationIdGenerator.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" Link="Internal\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\StringUtilities.cs" Link="Internal\StringUtilities.cs" />

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -578,6 +578,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
                 // Both send and receive loops have exited.
                 await quicStreamContext._processingTask.DefaultTimeout();
                 await quicStreamContext.DisposeAsync();
+                quicStreamContext.Dispose();
             }
         }
 
@@ -614,6 +615,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             var quicStreamContext1 = Assert.IsType<QuicStreamContext>(serverStream1);
             await quicStreamContext1._processingTask.DefaultTimeout();
             await quicStreamContext1.DisposeAsync();
+            quicStreamContext1.Dispose();
 
             var clientStream2 = clientConnection.OpenBidirectionalStream();
             await clientStream2.WriteAsync(TestData, endStream: true).DefaultTimeout();
@@ -634,6 +636,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             var quicStreamContext2 = Assert.IsType<QuicStreamContext>(serverStream2);
             await quicStreamContext2._processingTask.DefaultTimeout();
             await quicStreamContext2.DisposeAsync();
+            quicStreamContext2.Dispose();
 
             Assert.Same(quicStreamContext1, quicStreamContext2);
 

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
@@ -88,6 +88,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             Assert.True(quicStreamContext.CanRead);
 
             await quicStreamContext.DisposeAsync();
+            quicStreamContext.Dispose();
 
             var quicConnectionContext = Assert.IsType<QuicConnectionContext>(serverConnection);
 
@@ -147,6 +148,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 
             Logger.LogInformation("Server disposing stream.");
             await quicStreamContext.DisposeAsync().DefaultTimeout();
+            quicStreamContext.Dispose();
 
             Logger.LogInformation("Client reading until end of stream.");
             var data = await clientStream.ReadUntilEndAsync().DefaultTimeout();

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
@@ -130,6 +130,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             Assert.True(quicStreamContext.CanRead);
 
             await quicStreamContext.DisposeAsync();
+            quicStreamContext.Dispose();
 
             return quicStreamContext;
         }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks.csproj
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(KestrelSharedSourceRoot)test\TestKestrelTrace.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestContextFactory.cs" />
     <Compile Include="..\..\Transport.Sockets\src\Internal\IOQueue.cs" Link="Internal\IOQueue.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\ConnectionCompletion.cs" Link="Internal\ConnectionCompletion.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CorrelationIdGenerator.cs" Link="Internal\CorrelationIdGenerator.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.cs" Link="Internal\TransportConnection.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.Generated.cs" Link="Internal\TransportConnection.Generated.cs" />

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTimeoutControl.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Mocks/MockTimeoutControl.cs
@@ -24,6 +24,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks
         {
         }
 
+        public long GetResponseDrainDeadline(long ticks, MinDataRate minRate)
+        {
+            return 0;
+        }
+
         public void InitializeHttp2(InputFlowControl connectionInputFlowControl)
         {
         }

--- a/src/Servers/Kestrel/shared/ConnectionCompletion.cs
+++ b/src/Servers/Kestrel/shared/ConnectionCompletion.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Connections
+{
+    internal static class ConnectionCompletion
+    {
+        public static Task FireOnCompletedAsync(ILogger logger, Stack<KeyValuePair<Func<object, Task>, object>>? onCompleted)
+        {
+            if (onCompleted == null || onCompleted.Count == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            return CompleteAsyncMayAwait(logger, onCompleted);
+        }
+
+        private static Task CompleteAsyncMayAwait(ILogger logger, Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
+        {
+            while (onCompleted.TryPop(out var entry))
+            {
+                try
+                {
+                    var task = entry.Key.Invoke(entry.Value);
+                    if (!task.IsCompletedSuccessfully)
+                    {
+                        return CompleteAsyncAwaited(task, logger, onCompleted);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "An error occurred running an IConnectionCompleteFeature.OnCompleted callback.");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static async Task CompleteAsyncAwaited(Task currentTask, ILogger logger, Stack<KeyValuePair<Func<object, Task>, object>> onCompleted)
+        {
+            try
+            {
+                await currentTask;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "An error occurred running an IConnectionCompleteFeature.OnCompleted callback.");
+            }
+
+            while (onCompleted.TryPop(out var entry))
+            {
+                try
+                {
+                    await entry.Key.Invoke(entry.Value);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "An error occurred running an IConnectionCompleteFeature.OnCompleted callback.");
+                }
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -1384,6 +1384,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 _realTimeoutControl.Tick(now);
             }
+
+            public long GetResponseDrainDeadline(long ticks, MinDataRate minRate)
+            {
+                return _realTimeoutControl.GetResponseDrainDeadline(ticks, minRate);
+            }
         }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TimeoutTests.cs
@@ -257,6 +257,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _mockTimeoutHandler.VerifyNoOtherCalls();
             _mockConnectionContext.VerifyNoOtherCalls();
+
+            Assert.Contains(TestSink.Writes, w => w.EventId.Name == "ResponseMinimumDataRateNotSatisfied");
         }
 
         [Theory]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/InMemory.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/InMemory.FunctionalTests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeReader.cs" Link="Internal\CompletionPipeReader.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeWriter.cs" Link="Internal\CompletionPipeWriter.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\ConnectionCompletion.cs" Link="Internal\ConnectionCompletion.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CorrelationIdGenerator.cs" Link="Internal\CorrelationIdGenerator.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.cs" Link="Internal\TransportConnection.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\TransportConnection.Generated.cs" Link="Internal\TransportConnection.Generated.cs" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/35322 to release/6.0-rc1

## Customer Impact

Response drain timeout is a security feature. It hardens Kestrel against certain attacks. This feature exists in HTTP/1.1 and HTTP/2. This PR adds it to HTTP/3.

## Testing

Unit tests and functional tests.

## Risk

Low. This feature only impacts HTTP/3. HTTP/3 is a preview feature in .NET 6.