### PR TITLE
Added support for type based parameter binding

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -274,7 +274,6 @@ namespace Microsoft.AspNetCore.Http
                 // when RDF.Create is manually invoked.
                 if (factoryContext.RouteParameters is { } routeParams)
                 {
-
                     if (routeParams.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase))
                     {
                         // We're in the fallback case and we have a parameter and route parameter match so don't fallback

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -41,12 +41,11 @@ namespace Microsoft.AspNetCore.Http
             Log.ParameterBindingFailed(httpContext, parameterType, parameterName, sourceValue));
         private static readonly MethodInfo LogRequiredParameterNotProvidedMethod = GetMethodInfo<Action<HttpContext, string, string>>((httpContext, parameterType, parameterName) =>
             Log.RequiredParameterNotProvided(httpContext, parameterType, parameterName));
-        private static readonly MethodInfo LogParameterBindingFromHttpContextFailedMethod = GetMethodInfo<Action<HttpContext, string, string>>((httpContext, parameterType, parameterName) =>
-            Log.ParameterBindingFromHttpContextFailed(httpContext, parameterType, parameterName));
 
         private static readonly ParameterExpression TargetExpr = Expression.Parameter(typeof(object), "target");
         private static readonly ParameterExpression BodyValueExpr = Expression.Parameter(typeof(object), "bodyValue");
         private static readonly ParameterExpression WasParamCheckFailureExpr = Expression.Variable(typeof(bool), "wasParamCheckFailure");
+        private static readonly ParameterExpression BoundValuesArrayExpr = Expression.Parameter(typeof(object[]), "boundValues");
 
         private static ParameterExpression HttpContextExpr => TryParseMethodCache.HttpContextExpr;
         private static readonly MemberExpression RequestServicesExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.RequestServices))!);
@@ -188,23 +187,23 @@ namespace Microsoft.AspNetCore.Http
             }
 
             var args = new Expression[parameters.Length];
+            factoryContext.ParameterCount = parameters.Length;
 
             for (var i = 0; i < parameters.Length; i++)
             {
-                args[i] = CreateArgument(parameters[i], factoryContext);
+                args[i] = CreateArgument(i, parameters[i], factoryContext);
             }
 
             if (factoryContext.HasMultipleBodyParameters)
             {
                 var errorMessage = BuildErrorMessageForMultipleBodyParameters(factoryContext);
                 throw new InvalidOperationException(errorMessage);
-
             }
 
             return args;
         }
 
-        private static Expression CreateArgument(ParameterInfo parameter, FactoryContext factoryContext)
+        private static Expression CreateArgument(int index, ParameterInfo parameter, FactoryContext factoryContext)
         {
             if (parameter.Name is null)
             {
@@ -263,9 +262,9 @@ namespace Microsoft.AspNetCore.Http
             {
                 return RequestAbortedExpr;
             }
-            else if (TryParseMethodCache.HasTryParseHttpContextMethod(parameter))
+            else if (TryParseMethodCache.HasBindAsyncMethod(parameter))
             {
-                return BindParameterFromTryParseHttpContext(parameter, factoryContext);
+                return BindParameterFromBindAsync(index, parameter, factoryContext);
             }
             else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseStringMethod(parameter))
             {
@@ -275,7 +274,7 @@ namespace Microsoft.AspNetCore.Http
                 // when RDF.Create is manually invoked.
                 if (factoryContext.RouteParameters is { } routeParams)
                 {
-                   
+
                     if (routeParams.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase))
                     {
                         // We're in the fallback case and we have a parameter and route parameter match so don't fallback
@@ -360,7 +359,6 @@ namespace Microsoft.AspNetCore.Http
 
             var localVariables = new ParameterExpression[factoryContext.ExtraLocals.Count + 1];
             var checkParamAndCallMethod = new Expression[factoryContext.ParamCheckExpressions.Count + 1];
-
 
             for (var i = 0; i < factoryContext.ExtraLocals.Count; i++)
             {
@@ -508,13 +506,32 @@ namespace Microsoft.AspNetCore.Http
         {
             if (factoryContext.JsonRequestBodyType is null)
             {
+                if (factoryContext.ParameterBinders.Count > 0)
+                {
+                    // We need to generate the code for reading from the custom binders calling into the delegate
+                    var continuation = Expression.Lambda<Func<object?, HttpContext, object?[], Task>>(
+                        responseWritingMethodCall, TargetExpr, HttpContextExpr, BoundValuesArrayExpr).Compile();
+
+                    // Looping over arrays is faster
+                    var binders = factoryContext.ParameterBinders.ToArray();
+                    var count = factoryContext.ParameterCount;
+
+                    return async (target, httpContext) =>
+                    {
+                        var boundValues = new object?[count];
+
+                        foreach (var (index, binder) in binders)
+                        {
+                            boundValues[index] = await binder(httpContext);
+                        }
+
+                        await continuation(target, httpContext, boundValues);
+                    };
+                }
+
                 return Expression.Lambda<Func<object?, HttpContext, Task>>(
                     responseWritingMethodCall, TargetExpr, HttpContextExpr).Compile();
             }
-
-            // We need to generate the code for reading from the body before calling into the delegate
-            var invoker = Expression.Lambda<Func<object?, HttpContext, object?, Task>>(
-                responseWritingMethodCall, TargetExpr, HttpContextExpr, BodyValueExpr).Compile();
 
             var bodyType = factoryContext.JsonRequestBodyType;
             object? defaultBodyValue = null;
@@ -524,31 +541,82 @@ namespace Microsoft.AspNetCore.Http
                 defaultBodyValue = Activator.CreateInstance(bodyType);
             }
 
-            return async (target, httpContext) =>
+            if (factoryContext.ParameterBinders.Count > 0)
             {
-                object? bodyValue = defaultBodyValue;
-                var feature = httpContext.Features.Get<IHttpRequestBodyDetectionFeature>();
-                if (feature?.CanHaveBody == true)
-                {
-                    try
-                    {
-                        bodyValue = await httpContext.Request.ReadFromJsonAsync(bodyType);
-                    }
-                    catch (IOException ex)
-                    {
-                        Log.RequestBodyIOException(httpContext, ex);
-                        return;
-                    }
-                    catch (InvalidDataException ex)
-                    {
+                // We need to generate the code for reading from the body before calling into the delegate
+                var continuation = Expression.Lambda<Func<object?, HttpContext, object?, object?[], Task>>(
+                responseWritingMethodCall, TargetExpr, HttpContextExpr, BodyValueExpr, BoundValuesArrayExpr).Compile();
 
-                        Log.RequestBodyInvalidDataException(httpContext, ex);
-                        httpContext.Response.StatusCode = 400;
-                        return;
+                // Looping over arrays is faster
+                var binders = factoryContext.ParameterBinders.ToArray();
+                var count = factoryContext.ParameterCount;
+
+                return async (target, httpContext) =>
+                {
+                    // Run these first so that they can potentially read and rewind the body
+                    var boundValues = new object?[count];
+
+                    foreach (var (index, binder) in binders)
+                    {
+                        boundValues[index] = await binder(httpContext);
                     }
-                }
-                await invoker(target, httpContext, bodyValue);
-            };
+
+                    var bodyValue = defaultBodyValue;
+                    var feature = httpContext.Features.Get<IHttpRequestBodyDetectionFeature>();
+                    if (feature?.CanHaveBody == true)
+                    {
+                        try
+                        {
+                            bodyValue = await httpContext.Request.ReadFromJsonAsync(bodyType);
+                        }
+                        catch (IOException ex)
+                        {
+                            Log.RequestBodyIOException(httpContext, ex);
+                            return;
+                        }
+                        catch (InvalidDataException ex)
+                        {
+                            Log.RequestBodyInvalidDataException(httpContext, ex);
+                            httpContext.Response.StatusCode = 400;
+                            return;
+                        }
+                    }
+
+                    await continuation(target, httpContext, bodyValue, boundValues);
+                };
+            }
+            else
+            {
+                // We need to generate the code for reading from the body before calling into the delegate
+                var continuation = Expression.Lambda<Func<object?, HttpContext, object?, Task>>(
+                responseWritingMethodCall, TargetExpr, HttpContextExpr, BodyValueExpr).Compile();
+
+                return async (target, httpContext) =>
+                {
+                    var bodyValue = defaultBodyValue;
+                    var feature = httpContext.Features.Get<IHttpRequestBodyDetectionFeature>();
+                    if (feature?.CanHaveBody == true)
+                    {
+                        try
+                        {
+                            bodyValue = await httpContext.Request.ReadFromJsonAsync(bodyType);
+                        }
+                        catch (IOException ex)
+                        {
+                            Log.RequestBodyIOException(httpContext, ex);
+                            return;
+                        }
+                        catch (InvalidDataException ex)
+                        {
+
+                            Log.RequestBodyInvalidDataException(httpContext, ex);
+                            httpContext.Response.StatusCode = 400;
+                            return;
+                        }
+                    }
+                    await continuation(target, httpContext, bodyValue);
+                };
+            }
         }
 
         private static Expression GetValueFromProperty(Expression sourceExpression, string key)
@@ -747,40 +815,40 @@ namespace Microsoft.AspNetCore.Http
             return BindParameterFromValue(parameter, Expression.Coalesce(routeValue, queryValue), factoryContext);
         }
 
-        private static Expression BindParameterFromTryParseHttpContext(ParameterInfo parameter, FactoryContext factoryContext)
+        private static Expression BindParameterFromBindAsync(int index, ParameterInfo parameter, FactoryContext factoryContext)
         {
-            // bool wasParamCheckFailure = false;
-            //
-            // // Assume "Foo param1" is the first parameter and "public static bool TryParse(HttpContext context, out Foo foo)" exists.
-            // Foo param1_local;
-            //
-            // if (!Foo.TryParse(httpContext, out param1_local))
-            // {
-            //     wasParamCheckFailure = true;
-            //     Log.ParameterBindingFromHttpContextFailed(httpContext, "Foo", "foo")
-            // }
+            // We reference the boundValues array by parameter index here
+            var nullability = NullabilityContext.Create(parameter);
+            var isOptional = parameter.HasDefaultValue || nullability.ReadState == NullabilityState.Nullable;
 
-            var argument = Expression.Variable(parameter.ParameterType, $"{parameter.Name}_local");
-            var tryParseMethodCall = TryParseMethodCache.FindTryParseHttpContextMethod(parameter.ParameterType);
+            // Get the BindAsync method
+            var body = TryParseMethodCache.FindBindAsyncMethod(parameter.ParameterType)!;
 
-            // There's no way to opt-in to using a TryParse method on HttpContext other than defining the method, so it's guaranteed to exist here.
-            Debug.Assert(tryParseMethodCall is not null);
+            // Compile the delegate to the BindAsync method for this parameter index
+            var bindAsyncDelegate = Expression.Lambda<Func<HttpContext, ValueTask<object?>>>(body, HttpContextExpr).Compile();
+            factoryContext.ParameterBinders.Add((index, bindAsyncDelegate));
 
-            var parameterTypeNameConstant = Expression.Constant(parameter.ParameterType.Name);
-            var parameterNameConstant = Expression.Constant(parameter.Name);
+            // boundValues[index]
+            var boundValueExpr = Expression.ArrayIndex(BoundValuesArrayExpr, Expression.Constant(index));
 
-            var failBlock = Expression.Block(
-                Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
-                Expression.Call(LogParameterBindingFromHttpContextFailedMethod,
-                    HttpContextExpr, parameterTypeNameConstant, parameterNameConstant));
+            if (!isOptional)
+            {
+                var checkRequiredBodyBlock = Expression.Block(
+                        Expression.IfThen(
+                        Expression.Equal(boundValueExpr, Expression.Constant(null)),
+                            Expression.Block(
+                                Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
+                                Expression.Call(LogRequiredParameterNotProvidedMethod,
+                                        HttpContextExpr, Expression.Constant(parameter.ParameterType.Name), Expression.Constant(parameter.Name))
+                            )
+                        )
+                    );
 
-            var tryParseCall = tryParseMethodCall(argument);
-            var fullParamCheckBlock = Expression.IfThen(Expression.Not(tryParseCall), failBlock);
+                factoryContext.ParamCheckExpressions.Add(checkRequiredBodyBlock);
+            }
 
-            factoryContext.ExtraLocals.Add(argument);
-            factoryContext.ParamCheckExpressions.Add(fullParamCheckBlock);
-
-            return argument;
+            // (ParamterType)boundValues[i]
+            return Expression.Convert(boundValueExpr, parameter.ParameterType);
         }
 
         private static Expression BindParameterFromBody(ParameterInfo parameter, bool allowEmpty, FactoryContext factoryContext)
@@ -793,7 +861,6 @@ namespace Microsoft.AspNetCore.Http
                 {
                     factoryContext.TrackedParameters.Remove(parameterName);
                     factoryContext.TrackedParameters.Add(parameterName, "UNKNOWN");
-
                 }
             }
 
@@ -925,7 +992,6 @@ namespace Microsoft.AspNetCore.Http
 
         private static Task ExecuteTaskOfString(Task<string?> task, HttpContext httpContext)
         {
-
             SetPlaintextContentType(httpContext);
             EnsureRequestTaskNotNull(task);
 
@@ -1032,6 +1098,8 @@ namespace Microsoft.AspNetCore.Http
             public bool UsingTempSourceString { get; set; }
             public List<ParameterExpression> ExtraLocals { get; } = new();
             public List<Expression> ParamCheckExpressions { get; } = new();
+            public List<(int, Func<HttpContext, ValueTask<object?>>)> ParameterBinders { get; } = new();
+            public int ParameterCount { get; set; }
 
             public Dictionary<string, string> TrackedParameters { get; } = new();
             public bool HasMultipleBodyParameters { get; set; }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -499,45 +499,49 @@ namespace Microsoft.AspNetCore.Routing.Internal
             }
         }
 
-        private record MyTryParseHttpContextRecord(Uri Uri)
+        private class MyBindAsyncTypeThatThrows
         {
-            public static bool TryParse(HttpContext context, out MyTryParseHttpContextRecord? result)
+            public static ValueTask<object?> BindAsync(HttpContext context)
+            {
+                throw new InvalidOperationException("BindAsync failed");
+            }
+        }
+
+        private record MyBindAsyncRecord(Uri Uri)
+        {
+            public static ValueTask<object?> BindAsync(HttpContext context)
             {
                 if (!Uri.TryCreate(context.Request.Headers.Referer, UriKind.Absolute, out var uri))
                 {
-                    result = null;
-                    return false;
+                    return ValueTask.FromResult<object?>(null);
                 }
 
-                result = new MyTryParseHttpContextRecord(uri);
-                return true;
+                return ValueTask.FromResult<object?>(new MyBindAsyncRecord(uri));
             }
 
             // TryParse(HttpContext, ...) should be preferred over TryParse(string, ...) if there's
             // no [FromRoute] or [FromQuery] attributes.
-            public static bool TryParse(string? value, out MyTryParseHttpContextRecord? result)
+            public static bool TryParse(string? value, out MyBindAsyncRecord? result)
             {
                 throw new NotImplementedException();
             }
         }
 
-        private record struct MyTryParseHttpContextStruct(Uri Uri)
+        private record struct MyBindAsyncStruct(Uri Uri)
         {
-            public static bool TryParse(HttpContext context, out MyTryParseHttpContextStruct result)
+            public static ValueTask<object?> BindAsync(HttpContext context)
             {
                 if (!Uri.TryCreate(context.Request.Headers.Referer, UriKind.Absolute, out var uri))
                 {
-                    result = default;
-                    return false;
+                    return ValueTask.FromResult<object?>(null);
                 }
 
-                result = new MyTryParseHttpContextStruct(uri);
-                return true;
+                return ValueTask.FromResult<object?>(new MyBindAsyncStruct(uri));
             }
 
             // TryParse(HttpContext, ...) should be preferred over TryParse(string, ...) if there's
             // no [FromRoute] or [FromQuery] attributes.
-            public static bool TryParse(string? value, out MyTryParseHttpContextStruct result) =>
+            public static bool TryParse(string? value, out MyBindAsyncStruct result) =>
                 throw new NotImplementedException();
         }
 
@@ -604,44 +608,44 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Fact]
-        public async Task RequestDelegatePrefersTryParseHttpContextOverTryParseString()
+        public async Task RequestDelegatePrefersBindAsyncOverTryParseString()
         {
             var httpContext = new DefaultHttpContext();
 
             httpContext.Request.Headers.Referer = "https://example.org";
 
-            var requestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, MyTryParseHttpContextRecord tryParsable) =>
+            var requestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, MyBindAsyncRecord tryParsable) =>
             {
                 httpContext.Items["tryParsable"] = tryParsable;
             });
 
             await requestDelegate(httpContext);
 
-            Assert.Equal(new MyTryParseHttpContextRecord(new Uri("https://example.org")), httpContext.Items["tryParsable"]);
+            Assert.Equal(new MyBindAsyncRecord(new Uri("https://example.org")), httpContext.Items["tryParsable"]);
         }
 
         [Fact]
-        public async Task RequestDelegatePrefersTryParseHttpContextOverTryParseStringForNonNullableStruct()
+        public async Task RequestDelegatePrefersBindAsyncOverTryParseStringForNonNullableStruct()
         {
             var httpContext = new DefaultHttpContext();
 
             httpContext.Request.Headers.Referer = "https://example.org";
 
-            var requestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, MyTryParseHttpContextStruct tryParsable) =>
+            var requestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, MyBindAsyncStruct tryParsable) =>
             {
                 httpContext.Items["tryParsable"] = tryParsable;
             });
 
             await requestDelegate(httpContext);
 
-            Assert.Equal(new MyTryParseHttpContextStruct(new Uri("https://example.org")), httpContext.Items["tryParsable"]);
+            Assert.Equal(new MyBindAsyncStruct(new Uri("https://example.org")), httpContext.Items["tryParsable"]);
         }
 
         [Fact]
-        public async Task RequestDelegateUsesTryParseStringoOverTryParseHttpContextGivenExplicitAttribute()
+        public async Task RequestDelegateUsesTryParseStringoOverBindAsyncGivenExplicitAttribute()
         {
-            var fromRouteRequestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, [FromRoute] MyTryParseHttpContextRecord tryParsable) => { });
-            var fromQueryRequestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, [FromQuery] MyTryParseHttpContextRecord tryParsable) => { });
+            var fromRouteRequestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, [FromRoute] MyBindAsyncRecord tryParsable) => { });
+            var fromQueryRequestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, [FromQuery] MyBindAsyncRecord tryParsable) => { });
 
             var httpContext = new DefaultHttpContext
             {
@@ -663,9 +667,9 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Fact]
-        public async Task RequestDelegateUsesTryParseStringoOverTryParseHttpContextGivenNullableStruct()
+        public async Task RequestDelegateUsesTryParseStringOverBindAsyncGivenNullableStruct()
         {
-            var fromRouteRequestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, MyTryParseHttpContextStruct? tryParsable) => { });
+            var fromRouteRequestDelegate = RequestDelegateFactory.Create((HttpContext httpContext, MyBindAsyncStruct? tryParsable) => { });
 
             var httpContext = new DefaultHttpContext
             {
@@ -756,7 +760,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Fact]
-        public async Task RequestDelegateLogsTryParseHttpContextFailuresAndSets400Response()
+        public async Task RequestDelegateLogsBindAsyncFailuresAndSets400Response()
         {
             // Not supplying any headers will cause the HttpContext TryParse overload to fail.
             var httpContext = new DefaultHttpContext()
@@ -766,7 +770,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             var invoked = false;
 
-            var requestDelegate = RequestDelegateFactory.Create((MyTryParseHttpContextRecord arg1, MyTryParseHttpContextRecord arg2) =>
+            var requestDelegate = RequestDelegateFactory.Create((MyBindAsyncRecord arg1, MyBindAsyncRecord arg2) =>
             {
                 invoked = true;
             });
@@ -781,13 +785,136 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             Assert.Equal(2, logs.Length);
 
-            Assert.Equal(new EventId(5, "ParamaterBindingFromHttpContextFailed"), logs[0].EventId);
+            Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), logs[0].EventId);
             Assert.Equal(LogLevel.Debug, logs[0].LogLevel);
-            Assert.Equal(@"Failed to bind parameter ""MyTryParseHttpContextRecord arg1"" from HttpContext.", logs[0].Message);
+            Assert.Equal(@"Required parameter ""MyBindAsyncRecord arg1"" was not provided.", logs[0].Message);
 
-            Assert.Equal(new EventId(5, "ParamaterBindingFromHttpContextFailed"), logs[1].EventId);
+            Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), logs[1].EventId);
             Assert.Equal(LogLevel.Debug, logs[1].LogLevel);
-            Assert.Equal(@"Failed to bind parameter ""MyTryParseHttpContextRecord arg2"" from HttpContext.", logs[1].Message);
+            Assert.Equal(@"Required parameter ""MyBindAsyncRecord arg2"" was not provided.", logs[1].Message);
+        }
+
+        [Fact]
+        public async Task BindAsyncExceptionsThrowException()
+        {
+            // Not supplying any headers will cause the HttpContext TryParse overload to fail.
+            var httpContext = new DefaultHttpContext()
+            {
+                RequestServices = new ServiceCollection().AddSingleton(LoggerFactory).BuildServiceProvider(),
+            };
+
+            var requestDelegate = RequestDelegateFactory.Create((MyBindAsyncTypeThatThrows arg1) => { });
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => requestDelegate(httpContext));
+            Assert.Equal("BindAsync failed", ex.Message);
+        }
+
+        [Fact]
+        public async Task BindAsyncWithBodyArgument()
+        {
+            Todo originalTodo = new()
+            {
+                Name = "Write more tests!"
+            };
+
+            var httpContext = new DefaultHttpContext();
+
+            var requestBodyBytes = JsonSerializer.SerializeToUtf8Bytes(originalTodo);
+            var stream = new MemoryStream(requestBodyBytes); ;
+            httpContext.Request.Body = stream;
+
+            httpContext.Request.Headers["Content-Type"] = "application/json";
+            httpContext.Request.Headers["Content-Length"] = stream.Length.ToString();
+            httpContext.Features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(true));
+
+            var jsonOptions = new JsonOptions();
+            jsonOptions.SerializerOptions.Converters.Add(new TodoJsonConverter());
+
+            var mock = new Mock<IServiceProvider>();
+            mock.Setup(m => m.GetService(It.IsAny<Type>())).Returns<Type>(t =>
+            {
+                if (t == typeof(IOptions<JsonOptions>))
+                {
+                    return Options.Create(jsonOptions);
+                }
+                return null;
+            });
+
+            httpContext.RequestServices = mock.Object;
+            httpContext.Request.Headers.Referer = "https://example.org";
+
+            var invoked = false;
+
+            var requestDelegate = RequestDelegateFactory.Create((HttpContext context, MyBindAsyncRecord arg1, Todo todo) =>
+            {
+                invoked = true;
+                context.Items[nameof(arg1)] = arg1;
+                context.Items[nameof(todo)] = todo;
+            });
+
+            await requestDelegate(httpContext);
+
+            Assert.True(invoked);
+            var arg = httpContext.Items["arg1"] as MyBindAsyncRecord;
+            Assert.NotNull(arg);
+            Assert.Equal("https://example.org/", arg!.Uri.ToString());
+            var todo = httpContext.Items["todo"] as Todo;
+            Assert.NotNull(todo);
+            Assert.Equal("Write more tests!", todo!.Name);
+        }
+
+        [Fact]
+        public async Task BindAsyncRunsBeforeBodyBinding()
+        {
+            Todo originalTodo = new()
+            {
+                Name = "Write more tests!"
+            };
+
+            var httpContext = new DefaultHttpContext();
+
+            var requestBodyBytes = JsonSerializer.SerializeToUtf8Bytes(originalTodo);
+            var stream = new MemoryStream(requestBodyBytes); ;
+            httpContext.Request.Body = stream;
+
+            httpContext.Request.Headers["Content-Type"] = "application/json";
+            httpContext.Request.Headers["Content-Length"] = stream.Length.ToString();
+            httpContext.Features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(true));
+
+            var jsonOptions = new JsonOptions();
+            jsonOptions.SerializerOptions.Converters.Add(new TodoJsonConverter());
+
+            var mock = new Mock<IServiceProvider>();
+            mock.Setup(m => m.GetService(It.IsAny<Type>())).Returns<Type>(t =>
+            {
+                if (t == typeof(IOptions<JsonOptions>))
+                {
+                    return Options.Create(jsonOptions);
+                }
+                return null;
+            });
+
+            httpContext.RequestServices = mock.Object;
+            httpContext.Request.Headers.Referer = "https://example.org";
+
+            var invoked = false;
+
+            var requestDelegate = RequestDelegateFactory.Create((HttpContext context, CustomTodo customTodo, Todo todo) =>
+            {
+                invoked = true;
+                context.Items[nameof(customTodo)] = customTodo;
+                context.Items[nameof(todo)] = todo;
+            });
+
+            await requestDelegate(httpContext);
+
+            Assert.True(invoked);
+            var todo0 = httpContext.Items["customTodo"] as Todo;
+            Assert.NotNull(todo0);
+            Assert.Equal("Write more tests!", todo0!.Name);
+            var todo1 = httpContext.Items["todo"] as Todo;
+            Assert.NotNull(todo1);
+            Assert.Equal("Write more tests!", todo1!.Name);
         }
 
         [Fact]
@@ -1825,11 +1952,9 @@ namespace Microsoft.AspNetCore.Routing.Internal
             }
         }
 
-        public async Task RequestDelegateDoesNotSupportTryParseHttpContextOptionality()
+        [Fact]
+        public async Task RequestDelegateDoesSupportBindAsyncOptionality()
         {
-            // Not supplying any headers will cause the HttpContext TryParse overload to fail.
-            // However, RequestDelegateFactory cannot differentiate between a missing parameter and an invalid one, so
-            // the nullability of the argument doesn't change behavior.
             var httpContext = new DefaultHttpContext()
             {
                 RequestServices = new ServiceCollection().AddSingleton(LoggerFactory).BuildServiceProvider(),
@@ -1837,23 +1962,14 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             var invoked = false;
 
-            var requestDelegate = RequestDelegateFactory.Create((MyTryParseHttpContextRecord? arg1) =>
+            var requestDelegate = RequestDelegateFactory.Create((MyBindAsyncRecord? arg1) =>
             {
                 invoked = true;
             });
 
             await requestDelegate(httpContext);
 
-            Assert.False(invoked);
-            Assert.False(httpContext.RequestAborted.IsCancellationRequested);
-            Assert.Equal(400, httpContext.Response.StatusCode);
-
-            var logs = TestSink.Writes.ToArray();
-            var log = Assert.Single(logs);
-
-            Assert.Equal(new EventId(5, "ParamaterBindingFromHttpContextFailed"), log.EventId);
-            Assert.Equal(LogLevel.Debug, log.LogLevel);
-            Assert.Equal(@"Failed to bind parameter ""MyTryParseHttpContextRecord arg1"" from HttpContext.", log.Message);
+            Assert.True(invoked);
         }
 
         public static IEnumerable<object?[]> ServiceParamOptionalityData
@@ -2028,6 +2144,16 @@ namespace Microsoft.AspNetCore.Routing.Internal
             public int Id { get; set; }
             public string? Name { get; set; } = "Todo";
             public bool IsComplete { get; set; }
+        }
+
+        private class CustomTodo : Todo
+        {
+            public static async ValueTask<object?> BindAsync(HttpContext context)
+            {
+                var body = await context.Request.ReadFromJsonAsync<CustomTodo>();
+                context.Request.Body.Position = 0;
+                return body;
+            }
         }
 
         private record struct TodoStruct(int Id, string? Name, bool IsComplete) : ITodo;

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                      parameter.ParameterType == typeof(HttpResponse) ||
                      parameter.ParameterType == typeof(ClaimsPrincipal) ||
                      parameter.ParameterType == typeof(CancellationToken) ||
-                     TryParseMethodCache.HasTryParseHttpContextMethod(parameter) ||
+                     TryParseMethodCache.HasBindAsyncMethod(parameter) ||
                      _serviceProviderIsService?.IsService(parameter.ParameterType) == true)
             {
                 return (BindingSource.Services, parameter.Name ?? string.Empty, false);

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -299,7 +299,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             Assert.Empty(GetApiDescription((HttpResponse response) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription((ClaimsPrincipal user) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription((CancellationToken token) => { }).ParameterDescriptions);
-            Assert.Empty(GetApiDescription((TryParseHttpContextRecord context) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription((BindAsyncRecord context) => { }).ParameterDescriptions);
         }
 
         [Fact]
@@ -681,11 +681,11 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 throw new NotImplementedException();
         }
 
-        private record TryParseHttpContextRecord(int Value)
+        private record BindAsyncRecord(int Value)
         {
-            public static bool TryParse(HttpContext context, out TryParseHttpContextRecord result) =>
+            public static ValueTask<object> BindAsync(HttpContext context) =>
                 throw new NotImplementedException();
-            public static bool TryParse(string value, out TryParseHttpContextRecord result) =>
+            public static bool TryParse(string value, out BindAsyncRecord result) =>
                 throw new NotImplementedException();
         }
     }


### PR DESCRIPTION
- Added a convention that allows custom async binding logic to run for parameters that have a static BindAsync method that takes an HttpContext and return a ValueTask of object. This allows customers to write custom binders based solely on type (it's an extension of the existing TryParse pattern).
- There's allocation overhead per request once there's a parameter binder for a delegate. This is because we need to box all of the arguments since we're not using generated code to compute data from the list of binders.
- This also supports optionality like everything else since we're always boxing using object.
- Changed TryParse tests to BindAsync tests and added more tests.


Usage:

```C#
var builder = WebApplication.CreateBuilder(args);
var app = builder.Build();

app.MapGet("/webhook", (CloudEvent cloudEvent) =>
{
    redis.Publish(cloudEvent);
});

app.Run();

public class CloudEvent
{
    public static async ValueTask<object?> BindAsync(HttpContext context)
    {
        return await CloudEventParser.ReadEventAsync(context)
    }
}
```
