### PR TITLE
Reliability improvement for input date E2E tests

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -63,8 +63,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 
             // Assert
-            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages);
-            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages);
+            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages.ToArray());
+            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages.ToArray());
         }
 
         [Fact]
@@ -76,8 +76,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             // Assert
             Assert.True(GracefulDisconnectCompletionSource.Task.IsCompletedSuccessfully);
-            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages);
-            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages);
+            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages.ToArray());
+            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages.ToArray());
         }
 
         [Fact]
@@ -90,8 +90,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
 
             // Assert
             Assert.Equal(GracefulDisconnectCompletionSource.Task, task);
-            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages);
-            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages);
+            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages.ToArray());
+            Assert.Contains((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages.ToArray());
         }
 
         [Fact]
@@ -103,8 +103,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 
             // Assert
-            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages);
-            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages);
+            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages.ToArray());
+            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages.ToArray());
         }
 
         [Fact]
@@ -116,8 +116,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 
             // Assert
-            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages);
-            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages);
+            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages.ToArray());
+            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages.ToArray());
         }
 
         [Fact]
@@ -129,8 +129,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
             await Task.WhenAny(Task.Delay(10000), GracefulDisconnectCompletionSource.Task);
 
             // Assert
-            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages);
-            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages);
+            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully"), Messages.ToArray());
+            Assert.DoesNotContain((Extensions.Logging.LogLevel.Debug, "CircuitDisconnectedPermanently"), Messages.ToArray());
         }
 
         private void Log(WriteContext wc)

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -485,7 +485,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("focus-input-onafterrender", () => Browser.SwitchTo().ActiveElement().GetAttribute("id"));
 
             // As well as actually focusing and triggering the onfocusin event, we should not be seeing any errors
-            var log = Browser.Manage().Logs.GetLog(LogType.Browser);
+            var log = Browser.Manage().Logs.GetLog(LogType.Browser).ToArray();
             Assert.DoesNotContain(log, entry => entry.Level == LogLevel.Severe);
         }
 

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -271,7 +271,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal(new[] { "The DepartureTime field must be a time." }, messagesAccessor);
         }
 
-        [Fact(Skip = "Failing")]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35498")]
         public void InputDateInteractsWithEditContext_MonthInput()
         {
             var appElement = MountTypicalValidationComponent();

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("modified valid", () => renewalDateInput.GetAttribute("class"));
 
             // Can become invalid
-            ApplyInvalidInputDateValue(".renewal-date input", "11111-11-11");
+            renewalDateInput.SendKeys("11-11-11111\t");
             Browser.Equal("modified invalid", () => renewalDateInput.GetAttribute("class"));
             Browser.Equal(new[] { "The RenewalDate field must be a date." }, messagesAccessor);
 
@@ -236,12 +236,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Validates on edit
             Browser.Equal("valid", () => expiryDateInput.GetAttribute("class"));
-            expiryDateInput.SendKeys("01/01/2000\t");
+            expiryDateInput.SendKeys("01-01-2000\t");
             Browser.Equal("modified valid", () => expiryDateInput.GetAttribute("class"));
 
             // Can become invalid
-            ApplyInvalidInputDateValue(".expiry-date input", "11111-11-11");
-            Browser.Equal("modified invalid", () => expiryDateInput.GetAttribute("class"));
+            expiryDateInput.SendKeys("11-11-11111\t");
+            Browser.Equal("modified invalid", () => expiryDateInput.GetAttribute("class")); // FAIL here, still valid
             Browser.Equal(new[] { "The OptionalExpiryDate field must be a date." }, messagesAccessor);
 
             // Empty is valid, because it's nullable
@@ -264,21 +264,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("modified valid", () => departureTimeInput.GetAttribute("class"));
 
             // Can become invalid
-            ApplyInvalidInputDateValue(".departure-time input", "01:234:56");
+            // Stricly speaking the following is equivalent to the empty state, because that's how incomplete input is represented
+            // We don't know of any way to produce a different (non-empty-equivalent) state using UI gestures, so there's nothing else to test
+            departureTimeInput.SendKeys($"20{Keys.Backspace}\t");
             Browser.Equal("modified invalid", () => departureTimeInput.GetAttribute("class"));
             Browser.Equal(new[] { "The DepartureTime field must be a time." }, messagesAccessor);
-
-            // Empty is invalid, because it's not nullable
-            departureTimeInput.SendKeys($"{Keys.Backspace}\t{Keys.Backspace}\t{Keys.Backspace}\t");
-            Browser.Equal("modified invalid", () => departureTimeInput.GetAttribute("class"));
-            Browser.Equal(new[] { "The DepartureTime field must be a time." }, messagesAccessor);
-
-            departureTimeInput.SendKeys("07201\t");
-            Browser.Equal("modified valid", () => departureTimeInput.GetAttribute("class"));
-            Browser.Empty(messagesAccessor);
         }
 
-        [Fact]
+        [Fact(Skip = "Failing")]
         public void InputDateInteractsWithEditContext_MonthInput()
         {
             var appElement = MountTypicalValidationComponent();
@@ -287,12 +280,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Validates on edit
             Browser.Equal("valid", () => visitMonthInput.GetAttribute("class"));
-            visitMonthInput.SendKeys("03\t2005\t");
+            visitMonthInput.SendKeys($"03{Keys.ArrowRight}2005\t");
             Browser.Equal("modified valid", () => visitMonthInput.GetAttribute("class"));
 
             // Can become invalid
-            ApplyInvalidInputDateValue(".visit-month input", "05/1992");
-            Browser.Equal("modified invalid", () => visitMonthInput.GetAttribute("class"));
+            visitMonthInput.SendKeys($"11{Keys.ArrowRight}11111\t");
+            Browser.Equal("modified invalid", () => visitMonthInput.GetAttribute("class")); // FAIL HERE Expected: modified invalid; Actual: modified valid
             Browser.Equal(new[] { "The VisitMonth field must be a year and month." }, messagesAccessor);
 
             // Empty is invalid, because it's not nullable
@@ -300,12 +293,13 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("modified invalid", () => visitMonthInput.GetAttribute("class"));
             Browser.Equal(new[] { "The VisitMonth field must be a year and month." }, messagesAccessor);
 
-            visitMonthInput.SendKeys("05\t2007\t");
+            visitMonthInput.Clear();
+            visitMonthInput.SendKeys($"05{Keys.ArrowRight}2007\t");
             Browser.Equal("modified valid", () => visitMonthInput.GetAttribute("class"));
             Browser.Empty(messagesAccessor);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/35498")]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34884")]
         public void InputDateInteractsWithEditContext_DateTimeLocalInput()
         {
@@ -319,7 +313,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("modified valid", () => appointmentInput.GetAttribute("class"));
 
             // Can become invalid
-            ApplyInvalidInputDateValue(".appointment-date-time input", "1234/567/89 33:44 FM");
+            appointmentInput.SendKeys($"11{Keys.ArrowRight}11{Keys.ArrowRight}11111{Keys.ArrowRight}\t");
             Browser.Equal("modified invalid", () => appointmentInput.GetAttribute("class"));
             Browser.Equal(new[] { "The AppointmentDateAndTime field must be a date and time." }, messagesAccessor);
 
@@ -860,21 +854,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 .Select(x => x.Text)
                 .OrderBy(x => x)
                 .ToArray();
-        }
-
-        private void ApplyInvalidInputDateValue(string cssSelector, string invalidValue)
-        {
-            // It's very difficult to enter an invalid value into an <input type=date>, because
-            // most combinations of keystrokes get normalized to something valid. Additionally,
-            // using Selenium's SendKeys interacts unpredictably with this normalization logic,
-            // most likely based on timings. As a workaround, use JS to apply the values. This
-            // should only be used when strictly necessary, as it doesn't represent actual user
-            // interaction as authentically as SendKeys in other cases.
-            var javascript = (IJavaScriptExecutor)Browser;
-            javascript.ExecuteScript(
-                $"document.querySelector('{cssSelector}').value = {JsonSerializer.Serialize(invalidValue, TestJsonSerializerOptionsProvider.Options)}");
-            javascript.ExecuteScript(
-                $"document.querySelector('{cssSelector}').dispatchEvent(new KeyboardEvent('change'))");
         }
 
         private void EnsureAttributeRendering(IWebElement element, string attributeName, bool shouldBeRendered = true)

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Can become invalid
             expiryDateInput.SendKeys("11-11-11111\t");
-            Browser.Equal("modified invalid", () => expiryDateInput.GetAttribute("class")); // FAIL here, still valid
+            Browser.Equal("modified invalid", () => expiryDateInput.GetAttribute("class"));
             Browser.Equal(new[] { "The OptionalExpiryDate field must be a date." }, messagesAccessor);
 
             // Empty is valid, because it's nullable
@@ -285,7 +285,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
 
             // Can become invalid
             visitMonthInput.SendKeys($"11{Keys.ArrowRight}11111\t");
-            Browser.Equal("modified invalid", () => visitMonthInput.GetAttribute("class")); // FAIL HERE Expected: modified invalid; Actual: modified valid
+            Browser.Equal("modified invalid", () => visitMonthInput.GetAttribute("class"));
             Browser.Equal(new[] { "The VisitMonth field must be a year and month." }, messagesAccessor);
 
             // Empty is invalid, because it's not nullable

--- a/src/Components/test/testassets/BasicTestApp/ElementFocusComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ElementFocusComponent.razor
@@ -30,15 +30,18 @@
     {
         Task.Run(async () =>
         {
-            await Task.Yield();
-            performFocusDuringOnAfterRender = true;
-            _ = InvokeAsync(StateHasChanged);
+            await Task.Delay(500);
+            _ = InvokeAsync(() =>
+            {
+                performFocusDuringOnAfterRender = true;
+                StateHasChanged();
+            });
         });
     }
 
     private async Task FocusDuringOnAfterRenderViaAwait()
     {
-        await Task.Yield();
+        await Task.Delay(500);
         performFocusDuringOnAfterRender = true;
     }
 


### PR DESCRIPTION
I've run the Components E2E tests on a VM in a loop about 30 times, and the only ones that ever failed are:

 * InputDateInteractsWithEditContext_MonthInput
 * InputDateInteractsWithEditContext_NullableDateTimeOffset
 * InputDateInteractsWithEditContext_DateTimeLocalInput

They each only failed only 1 or 2 times over the 30 runs, but the fact that they are all roughly the same test suggests it's something problematic about those tests, and not just pure randomness. It's hard to know *why* they occasionally fail, but the screenshots captured in failing runs imply that their `ApplyInvalidInputDateValue` logic either doesn't run or has no effect when it does.

Strictly speaking, `ApplyInvalidInputDateValue` is a bit artificial because it's simulating doing something that an end user could not do. It's creating an invalid state (via JavaScript) that you couldn't actually create using mouse and keyboard gestures. So I'm going to make the case that it's not really a valid thing for us to do anyway.

In this PR,

 * I've removed `ApplyInvalidInputDateValue` from all the tests, and replaced it with real user gestures
 * In two cases, doing so caused the tests to fail consistently (which is a lot better than failing inconsistently!). I think this reflects an actual product defect so I've filed https://github.com/dotnet/aspnetcore/issues/35498 and am marking those tests as skipped here.

Now, with these improvements, I've run the full test suite in my VM another 10 times and it's had a 100% pass rate across that set. I'll keep the loop running.

---

## Update

After running 78 more times, there were 4 failing runs:

 * 1 failed on `ReloadingThePage_GracefullyDisconnects_TheCurrentCircuit`
   * Fails with "collection was modified" enumeration error. Looking at the code, it's pretty obvious how a timing issue can make this fail. I've added a fix to this PR, and am fairly confident this is sorted.
 * 3 of which failed on `CanFocusDuringOnAfterRenderAsyncWithFocusInEvent`
    * It's not so clear how this can fail. My best guess is that there's some rare interference between renders and/or concurrent writes to the `performFocusDuringOnAfterRender` flag, since this test (very unusually) causes a render to be triggered from a background thread, and reads/writes that flag simultaneously on different threads.
    * I've added what is hopefully a fix in this PR, but will only know by running it a lot to see.

