### PR TITLE
Fix AsyncEnumerableTest to actually test GetAllProjectsAsTask endpoint

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/AsyncEnumerableTestBase.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/AsyncEnumerableTestBase.cs
@@ -24,15 +24,15 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         public HttpClient Client { get; }
 
         [Fact]
-        public Task AsyncEnumerableReturnedWorks() => AsyncEnumerableWorks();
+        public Task AsyncEnumerableReturnedWorks() => AsyncEnumerableWorks("getallprojects");
 
         [Fact]
-        public Task AsyncEnumerableWrappedInTask() => AsyncEnumerableWorks();
+        public Task AsyncEnumerableWrappedInTask() => AsyncEnumerableWorks("getallprojectsastask");
 
-        private async Task AsyncEnumerableWorks()
+        private async Task AsyncEnumerableWorks(string action)
         {
             // Act
-            var response = await Client.GetAsync("asyncenumerable/getallprojects");
+            var response = await Client.GetAsync($"asyncenumerable/{action}");
 
             // Assert
             await response.AssertStatusCodeAsync(HttpStatusCode.OK);


### PR DESCRIPTION
**PR Title**
Call the correct endpoint for `AsyncEnumerableWrappedInTask` which before was the same as `AsyncEnumerableReturnedWorks`.

**PR Description**
`AsyncEnumerableWrappedInTask` didn't call `GetAllProjectsAsTask` which jugding from the method names it seems like it should.

https://github.com/dotnet/aspnetcore/blob/6350af9620165d6a1d65c7f3ce789a7909e95b1b/src/Mvc/test/WebSites/FormatterWebSite/Controllers/AsyncEnumerableController.cs#L19-L24



