### PR TITLE
RC1 Port: Add FailureReasons (#35425)

### DIFF
--- a/src/Security/Authorization/Core/src/AuthorizationFailure.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationFailure.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Authorization
         private AuthorizationFailure() { }
 
         /// <summary>
-        /// Failure was due to <see cref="AuthorizationHandlerContext.Fail"/> being called.
+        /// Failure was due to <see cref="AuthorizationHandlerContext.Fail()"/> being called.
         /// </summary>
         public bool FailCalled { get; private set; }
 
@@ -25,13 +25,29 @@ namespace Microsoft.AspNetCore.Authorization
         public IEnumerable<IAuthorizationRequirement> FailedRequirements { get; private set; } = Array.Empty<IAuthorizationRequirement>();
 
         /// <summary>
-        /// Return a failure due to <see cref="AuthorizationHandlerContext.Fail"/> being called.
+        /// Allows <see cref="IAuthorizationHandler"/> to flow more detailed reasons for why authorization failed.
+        /// </summary>
+        public IEnumerable<AuthorizationFailureReason> Reasons { get; private set; } = Array.Empty<AuthorizationFailureReason>();
+
+        /// <summary>
+        /// Return a failure due to <see cref="AuthorizationHandlerContext.Fail()"/> being called.
         /// </summary>
         /// <returns>The failure.</returns>
         public static AuthorizationFailure ExplicitFail()
             => new AuthorizationFailure
             {
+                FailCalled = true
+            };
+
+        /// <summary>
+        /// Return a failure due to <see cref="AuthorizationHandlerContext.Fail(AuthorizationFailureReason)"/> being called.
+        /// </summary>
+        /// <returns>The failure.</returns>
+        public static AuthorizationFailure Failed(IEnumerable<AuthorizationFailureReason> reasons)
+            => new AuthorizationFailure
+            {
                 FailCalled = true,
+                Reasons = reasons
             };
 
         /// <summary>

--- a/src/Security/Authorization/Core/src/AuthorizationFailure.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationFailure.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Authorization
         /// <summary>
         /// Allows <see cref="IAuthorizationHandler"/> to flow more detailed reasons for why authorization failed.
         /// </summary>
-        public IEnumerable<AuthorizationFailureReason> Reasons { get; private set; } = Array.Empty<AuthorizationFailureReason>();
+        public IEnumerable<AuthorizationFailureReason> FailureReasons { get; private set; } = Array.Empty<AuthorizationFailureReason>();
 
         /// <summary>
         /// Return a failure due to <see cref="AuthorizationHandlerContext.Fail()"/> being called.
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Authorization
             => new AuthorizationFailure
             {
                 FailCalled = true,
-                Reasons = reasons
+                FailureReasons = reasons
             };
 
         /// <summary>

--- a/src/Security/Authorization/Core/src/AuthorizationFailureReason.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationFailureReason.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Authorization
+{
+    /// <summary>
+    /// Encapsulates a reason why authorization failed.
+    /// </summary>
+    public class AuthorizationFailureReason
+    {
+        /// <summary>
+        /// Creates a new failure reason.
+        /// </summary>
+        /// <param name="handler">The handler responsible for this failure reason.</param>
+        /// <param name="message">The message describing the failure.</param>
+        public AuthorizationFailureReason(IAuthorizationHandler handler, string message)
+        {
+            Handler = handler;
+            Message = message;
+        }
+
+        /// <summary>
+        /// A message describing the failure reason.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// The <see cref="IAuthorizationHandler"/> responsible for this failure reason.
+        /// </summary>
+        public IAuthorizationHandler Handler { get; set; }
+    }
+}

--- a/src/Security/Authorization/Core/src/AuthorizationFailureReason.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationFailureReason.cs
@@ -22,11 +22,11 @@ namespace Microsoft.AspNetCore.Authorization
         /// <summary>
         /// A message describing the failure reason.
         /// </summary>
-        public string Message { get; set; }
+        public string Message { get; }
 
         /// <summary>
         /// The <see cref="IAuthorizationHandler"/> responsible for this failure reason.
         /// </summary>
-        public IAuthorizationHandler Handler { get; set; }
+        public IAuthorizationHandler Handler { get; }
     }
 }

--- a/src/Security/Authorization/Core/src/AuthorizationHandlerContext.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationHandlerContext.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Authorization
     public class AuthorizationHandlerContext
     {
         private readonly HashSet<IAuthorizationRequirement> _pendingRequirements;
+        private readonly List<AuthorizationFailureReason> _failedReasons;
         private bool _failCalled;
         private bool _succeedCalled;
 
@@ -37,6 +38,7 @@ namespace Microsoft.AspNetCore.Authorization
             User = user;
             Resource = resource;
             _pendingRequirements = new HashSet<IAuthorizationRequirement>(requirements);
+            _failedReasons = new List<AuthorizationFailureReason>();
         }
 
         /// <summary>
@@ -58,6 +60,11 @@ namespace Microsoft.AspNetCore.Authorization
         /// Gets the requirements that have not yet been marked as succeeded.
         /// </summary>
         public virtual IEnumerable<IAuthorizationRequirement> PendingRequirements { get { return _pendingRequirements; } }
+
+        /// <summary>
+        /// Gets the reasons why authorization has failed.
+        /// </summary>
+        public virtual IEnumerable<AuthorizationFailureReason> FailureReasons { get { return _failedReasons; } }
 
         /// <summary>
         /// Flag indicating whether the current authorization processing has failed.
@@ -82,6 +89,20 @@ namespace Microsoft.AspNetCore.Authorization
         public virtual void Fail()
         {
             _failCalled = true;
+        }
+
+        /// <summary>
+        /// Called to indicate <see cref="AuthorizationHandlerContext.HasSucceeded"/> will
+        /// never return true, even if all requirements are met.
+        /// </summary>
+        /// <param name="reason">Optional <see cref="AuthorizationFailureReason"/> for why authorization failed.</param>
+        public virtual void Fail(AuthorizationFailureReason reason)
+        {
+            Fail();
+            if (reason != null)
+            {
+                _failedReasons.Add(reason);
+            }
         }
 
         /// <summary>

--- a/src/Security/Authorization/Core/src/AuthorizationHandlerContext.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationHandlerContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Authorization
     public class AuthorizationHandlerContext
     {
         private readonly HashSet<IAuthorizationRequirement> _pendingRequirements;
-        private List<AuthorizationFailureReason> _failedReasons;
+        private List<AuthorizationFailureReason>? _failedReasons;
         private bool _failCalled;
         private bool _succeedCalled;
 

--- a/src/Security/Authorization/Core/src/AuthorizationHandlerContext.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationHandlerContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Authorization
     public class AuthorizationHandlerContext
     {
         private readonly HashSet<IAuthorizationRequirement> _pendingRequirements;
-        private readonly List<AuthorizationFailureReason> _failedReasons;
+        private List<AuthorizationFailureReason> _failedReasons;
         private bool _failCalled;
         private bool _succeedCalled;
 
@@ -38,7 +38,6 @@ namespace Microsoft.AspNetCore.Authorization
             User = user;
             Resource = resource;
             _pendingRequirements = new HashSet<IAuthorizationRequirement>(requirements);
-            _failedReasons = new List<AuthorizationFailureReason>();
         }
 
         /// <summary>
@@ -64,7 +63,7 @@ namespace Microsoft.AspNetCore.Authorization
         /// <summary>
         /// Gets the reasons why authorization has failed.
         /// </summary>
-        public virtual IEnumerable<AuthorizationFailureReason> FailureReasons { get { return _failedReasons; } }
+        public virtual IEnumerable<AuthorizationFailureReason> FailureReasons { get { return _failedReasons ?? Array.Empty<AuthorizationFailureReason>(); } }
 
         /// <summary>
         /// Flag indicating whether the current authorization processing has failed.
@@ -101,6 +100,11 @@ namespace Microsoft.AspNetCore.Authorization
             Fail();
             if (reason != null)
             {
+                if (_failedReasons == null)
+                {
+                    _failedReasons = new List<AuthorizationFailureReason>();
+                }
+                
                 _failedReasons.Add(reason);
             }
         }

--- a/src/Security/Authorization/Core/src/AuthorizationHandlerContext.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationHandlerContext.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Authorization
         /// <summary>
         /// Gets the reasons why authorization has failed.
         /// </summary>
-        public virtual IEnumerable<AuthorizationFailureReason> FailureReasons { get { return _failedReasons ?? Array.Empty<AuthorizationFailureReason>(); } }
+        public virtual IEnumerable<AuthorizationFailureReason> FailureReasons { get { return _failedReasons != null ? _failedReasons : Array.Empty<AuthorizationFailureReason>(); } }
 
         /// <summary>
         /// Flag indicating whether the current authorization processing has failed.

--- a/src/Security/Authorization/Core/src/DefaultAuthorizationEvaluator.cs
+++ b/src/Security/Authorization/Core/src/DefaultAuthorizationEvaluator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Authorization
             => context.HasSucceeded
                 ? AuthorizationResult.Success()
                 : AuthorizationResult.Failed(context.HasFailed
-                    ? AuthorizationFailure.ExplicitFail()
+                    ? AuthorizationFailure.Failed(context.FailureReasons)
                     : AuthorizationFailure.Failed(context.PendingRequirements));
     }
 }

--- a/src/Security/Authorization/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Security/Authorization/Core/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,13 @@
 #nullable enable
 *REMOVED*static Microsoft.AspNetCore.Authorization.AuthorizationServiceExtensions.AuthorizeAsync(this Microsoft.AspNetCore.Authorization.IAuthorizationService! service, System.Security.Claims.ClaimsPrincipal! user, object! resource, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement! requirement) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authorization.AuthorizationResult!>!
+Microsoft.AspNetCore.Authorization.AuthorizationFailure.Reasons.get -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Authorization.AuthorizationFailureReason!>!
+Microsoft.AspNetCore.Authorization.AuthorizationFailureReason
+Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.AuthorizationFailureReason(Microsoft.AspNetCore.Authorization.IAuthorizationHandler! handler, string! message) -> void
+Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.Handler.get -> Microsoft.AspNetCore.Authorization.IAuthorizationHandler!
+Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.Handler.set -> void
+Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.Message.get -> string!
+Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.Message.set -> void
+static Microsoft.AspNetCore.Authorization.AuthorizationFailure.Failed(System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Authorization.AuthorizationFailureReason!>! reasons) -> Microsoft.AspNetCore.Authorization.AuthorizationFailure!
 static Microsoft.AspNetCore.Authorization.AuthorizationServiceExtensions.AuthorizeAsync(this Microsoft.AspNetCore.Authorization.IAuthorizationService! service, System.Security.Claims.ClaimsPrincipal! user, object? resource, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement! requirement) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authorization.AuthorizationResult!>!
+virtual Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Fail(Microsoft.AspNetCore.Authorization.AuthorizationFailureReason! reason) -> void
+virtual Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.FailureReasons.get -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Authorization.AuthorizationFailureReason!>!

--- a/src/Security/Authorization/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Security/Authorization/Core/src/PublicAPI.Unshipped.txt
@@ -1,12 +1,10 @@
 #nullable enable
 *REMOVED*static Microsoft.AspNetCore.Authorization.AuthorizationServiceExtensions.AuthorizeAsync(this Microsoft.AspNetCore.Authorization.IAuthorizationService! service, System.Security.Claims.ClaimsPrincipal! user, object! resource, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement! requirement) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authorization.AuthorizationResult!>!
-Microsoft.AspNetCore.Authorization.AuthorizationFailure.Reasons.get -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Authorization.AuthorizationFailureReason!>!
+Microsoft.AspNetCore.Authorization.AuthorizationFailure.FailureReasons.get -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Authorization.AuthorizationFailureReason!>!
 Microsoft.AspNetCore.Authorization.AuthorizationFailureReason
 Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.AuthorizationFailureReason(Microsoft.AspNetCore.Authorization.IAuthorizationHandler! handler, string! message) -> void
 Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.Handler.get -> Microsoft.AspNetCore.Authorization.IAuthorizationHandler!
-Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.Handler.set -> void
 Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.Message.get -> string!
-Microsoft.AspNetCore.Authorization.AuthorizationFailureReason.Message.set -> void
 static Microsoft.AspNetCore.Authorization.AuthorizationFailure.Failed(System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Authorization.AuthorizationFailureReason!>! reasons) -> Microsoft.AspNetCore.Authorization.AuthorizationFailure!
 static Microsoft.AspNetCore.Authorization.AuthorizationServiceExtensions.AuthorizeAsync(this Microsoft.AspNetCore.Authorization.IAuthorizationService! service, System.Security.Claims.ClaimsPrincipal! user, object? resource, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement! requirement) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authorization.AuthorizationResult!>!
 virtual Microsoft.AspNetCore.Authorization.AuthorizationHandlerContext.Fail(Microsoft.AspNetCore.Authorization.AuthorizationFailureReason! reason) -> void

--- a/src/Security/Authorization/test/DefaultAuthorizationServiceTests.cs
+++ b/src/Security/Authorization/test/DefaultAuthorizationServiceTests.cs
@@ -213,11 +213,11 @@ namespace Microsoft.AspNetCore.Authorization.Test
             // Assert
             Assert.False(allowed.Succeeded);
             Assert.NotNull(allowed.Failure);
-            Assert.Equal(2, allowed.Failure.Reasons.Count());
-            var first = allowed.Failure.Reasons.First();
+            Assert.Equal(2, allowed.Failure.FailureReasons.Count());
+            var first = allowed.Failure.FailureReasons.First();
             Assert.Equal("1", first.Message);
             Assert.Equal(handler1, first.Handler);
-            var second = allowed.Failure.Reasons.Last();
+            var second = allowed.Failure.FailureReasons.Last();
             Assert.Equal("3", second.Message);
             Assert.Equal(handler3, second.Handler);
         }

--- a/src/Security/Authorization/test/DenyAnonymousAuthorizationRequirementTests.cs
+++ b/src/Security/Authorization/test/DenyAnonymousAuthorizationRequirementTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Xunit;
 

--- a/src/Security/Authorization/test/NameAuthorizationRequirementTests.cs
+++ b/src/Security/Authorization/test/NameAuthorizationRequirementTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Xunit;
 

--- a/src/Security/Authorization/test/OperationAuthorizationRequirementTests.cs
+++ b/src/Security/Authorization/test/OperationAuthorizationRequirementTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Xunit;
 

--- a/src/Security/Authorization/test/RolesAuthorizationRequirementTests.cs
+++ b/src/Security/Authorization/test/RolesAuthorizationRequirementTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Xunit;
 

--- a/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/Handlers/SampleWithFailureReasonRequirementHandler.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/Handlers/SampleWithFailureReasonRequirementHandler.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using CustomAuthorizationFailureResponse.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
+
+namespace CustomAuthorizationFailureResponse.Authorization.Handlers
+{
+    public class SampleWithFailureReasonRequirementHandler : AuthorizationHandler<SampleFailReasonRequirement>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, SampleFailReasonRequirement requirement)
+        {
+            context.Fail(new AuthorizationFailureReason(this, "This is a way to provide more failure reasons."));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/Requirements/SampleFailReasonRequirement.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/Requirements/SampleFailReasonRequirement.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Authorization;
+
+namespace CustomAuthorizationFailureResponse.Authorization.Requirements
+{
+    public class SampleFailReasonRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/SampleAuthorizationMiddlewareResultHandler.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/SampleAuthorizationMiddlewareResultHandler.cs
@@ -31,6 +31,14 @@ namespace CustomAuthorizationFailureResponse.Authorization
             // if the authorization was forbidden, let's use custom logic to handle that.
             if (policyAuthorizationResult.Forbidden && policyAuthorizationResult.AuthorizationFailure != null)
             {
+                if (policyAuthorizationResult.AuthorizationFailure.Reasons.Any())
+                {
+                    await httpContext.Response.WriteAsync(policyAuthorizationResult.AuthorizationFailure.Reasons.First().Message);
+
+                    // return right away as the default implementation would overwrite the status code
+                    return;
+                }
+
                 // as an example, let's return 404 if specific requirement has failed
                 if (policyAuthorizationResult.AuthorizationFailure.FailedRequirements.Any(requirement => requirement is SampleRequirement))
                 {

--- a/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/SampleAuthorizationMiddlewareResultHandler.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/SampleAuthorizationMiddlewareResultHandler.cs
@@ -31,9 +31,9 @@ namespace CustomAuthorizationFailureResponse.Authorization
             // if the authorization was forbidden, let's use custom logic to handle that.
             if (policyAuthorizationResult.Forbidden && policyAuthorizationResult.AuthorizationFailure != null)
             {
-                if (policyAuthorizationResult.AuthorizationFailure.Reasons.Any())
+                if (policyAuthorizationResult.AuthorizationFailure.FailureReasons.Any())
                 {
-                    await httpContext.Response.WriteAsync(policyAuthorizationResult.AuthorizationFailure.Reasons.First().Message);
+                    await httpContext.Response.WriteAsync(policyAuthorizationResult.AuthorizationFailure.FailureReasons.First().Message);
 
                     // return right away as the default implementation would overwrite the status code
                     return;

--- a/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/SamplePolicyNames.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Authorization/SamplePolicyNames.cs
@@ -7,5 +7,6 @@ namespace CustomAuthorizationFailureResponse.Authorization
     {
         public const string CustomPolicy = "Custom";
         public const string CustomPolicyWithCustomForbiddenMessage = "CustomPolicyWithCustomForbiddenMessage";
+        public const string FailureReasonPolicy = "FailureReason";
     }
 }

--- a/src/Security/samples/CustomAuthorizationFailureResponse/Controllers/SampleController.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Controllers/SampleController.cs
@@ -24,5 +24,12 @@ namespace CustomAuthorizationFailureResponse.Controllers
         {
             return "Hello world from GetWithCustomPolicy";
         }
+
+        [HttpGet("failureReason")]
+        [Authorize(Policy = SamplePolicyNames.FailureReasonPolicy)]
+        public string FailureReason()
+        {
+            return "Hello world from FailureReason";
+        }
     }
 }

--- a/src/Security/samples/CustomAuthorizationFailureResponse/Startup.cs
+++ b/src/Security/samples/CustomAuthorizationFailureResponse/Startup.cs
@@ -37,6 +37,9 @@ namespace CustomAuthorizationFailureResponse
             {
                 options.AddPolicy(SamplePolicyNames.CustomPolicy, policy => 
                     policy.AddRequirements(new SampleRequirement()));
+
+                options.AddPolicy(SamplePolicyNames.FailureReasonPolicy, policy => 
+                    policy.AddRequirements(new SampleFailReasonRequirement()));
                 
                 options.AddPolicy(SamplePolicyNames.CustomPolicyWithCustomForbiddenMessage, policy => 
                     policy.AddRequirements(new SampleWithCustomMessageRequirement()));
@@ -44,6 +47,7 @@ namespace CustomAuthorizationFailureResponse
 
             services.AddTransient<IAuthorizationHandler, SampleRequirementHandler>();
             services.AddTransient<IAuthorizationHandler, SampleWithCustomMessageRequirementHandler>();
+            services.AddTransient<IAuthorizationHandler, SampleWithFailureReasonRequirementHandler>();
             services.AddTransient<IAuthorizationMiddlewareResultHandler, SampleAuthorizationMiddlewareResultHandler>();
         }
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/35425

## Customer Impact

There currently is no way to flow more detailed authorization failures from the IAuthorizationHandler to consumers that are responsible for displaying authorization errors.  This change allows handlers to flow custom messages and state

## Testing

Automated tests and a new sample demonstrating the usage

## Risk

Low