### PR TITLE
Added support for type based parameter binding (#35496)

### DIFF
--- a/src/Http/Http.Extensions/test/TryParseMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/TryParseMethodCacheTests.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Globalization;
 using System.Linq.Expressions;
-
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Http.Extensions.Tests
@@ -25,9 +25,9 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [InlineData(typeof(ushort))]
         [InlineData(typeof(uint))]
         [InlineData(typeof(ulong))]
-        public void FindTryParseMethod_ReturnsTheExpectedTryParseMethodWithInvariantCulture(Type @type)
+        public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCulture(Type type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseMethod(@type);
+            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -48,9 +48,9 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [InlineData(typeof(DateTimeOffset))]
         [InlineData(typeof(TimeOnly))]
         [InlineData(typeof(TimeSpan))]
-        public void FindTryParseMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureDateType(Type @type)
+        public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureDateType(Type type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseMethod(@type);
+            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -76,10 +76,11 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         }
 
         [Theory]
-        [InlineData(typeof(TryParsableInvariantRecord))]
-        public void FindTryParseMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureCustomType(Type @type)
+        [InlineData(typeof(TryParseStringRecord))]
+        [InlineData(typeof(TryParseStringStruct))]
+        public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureCustomType(Type type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseMethod(@type);
+            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -94,11 +95,40 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
             Assert.True(((call.Arguments[1] as ConstantExpression)!.Value as CultureInfo)!.Equals(CultureInfo.InvariantCulture));
         }
 
+        public static IEnumerable<object[]> TryParseStringParameterInfoData
+        {
+            get
+            {
+                return new[]
+                {
+                    new[]
+                    {
+                        GetFirstParameter((TryParseStringRecord arg) => TryParseStringRecordMethod(arg)),
+                    },
+                    new[]
+                    {
+                        GetFirstParameter((TryParseStringStruct arg) => TryParseStringStructMethod(arg)),
+                    },
+                    new[]
+                    {
+                        GetFirstParameter((TryParseStringStruct? arg) => TryParseStringNullableStructMethod(arg)),
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TryParseStringParameterInfoData))]
+        public void HasTryParseStringMethod_ReturnsTrueWhenMethodExists(ParameterInfo parameterInfo)
+        {
+            Assert.True(new TryParseMethodCache().HasTryParseStringMethod(parameterInfo));
+        }
+
         [Fact]
-        public void FindTryParseMethodForEnums()
+        public void FindTryParseStringMethod_WorksForEnums()
         {
             var type = typeof(Choice);
-            var methodFound = new TryParseMethodCache().FindTryParseMethod(type);
+            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(type);
 
             Assert.NotNull(methodFound);
 
@@ -115,11 +145,11 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         }
 
         [Fact]
-        public void FindTryParseMethodForEnumsWhenNonGenericEnumParseIsUsed()
+        public void FindTryParseStringMethod_WorksForEnumsWhenNonGenericEnumParseIsUsed()
         {
             var type = typeof(Choice);
             var cache = new TryParseMethodCache(preferNonGenericEnumParseOverload: true);
-            var methodFound = cache.FindTryParseMethod(type);
+            var methodFound = cache.FindTryParseStringMethod(type);
 
             Assert.NotNull(methodFound);
 
@@ -243,7 +273,7 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
 
         private record struct TryParseStringStruct(int Value)
         {
-            public static bool TryParse(string? value, IFormatProvider formatProvider, out TryParsableInvariantRecord? result)
+            public static bool TryParse(string? value, IFormatProvider formatProvider, out TryParseStringStruct result)
             {
                 if (!int.TryParse(value, NumberStyles.Integer, formatProvider, out var val))
                 {

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             {
                 return (BindingSource.Services, parameter.Name ?? string.Empty, false);
             }
-            else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseMethod(parameter))
+            else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseStringMethod(parameter))
             {
                 // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
                 if (parameter.Name is { } name && pattern.GetParameter(name) is not null)

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -184,6 +184,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                      parameter.ParameterType == typeof(HttpResponse) ||
                      parameter.ParameterType == typeof(ClaimsPrincipal) ||
                      parameter.ParameterType == typeof(CancellationToken) ||
+                     TryParseMethodCache.HasBindAsyncMethod(parameter) ||
                      _serviceProviderIsService?.IsService(parameter.ParameterType) == true)
             {
                 return (BindingSource.Services, parameter.Name ?? string.Empty, false);

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -291,6 +291,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             Assert.Empty(GetApiDescription((HttpResponse response) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription((ClaimsPrincipal user) => { }).ParameterDescriptions);
             Assert.Empty(GetApiDescription((CancellationToken token) => { }).ParameterDescriptions);
+            Assert.Empty(GetApiDescription((BindAsyncRecord context) => { }).ParameterDescriptions);
         }
 
         [Fact]
@@ -664,6 +665,20 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             public ICollection<EndpointDataSource> DataSources { get; }
 
             public IServiceProvider ServiceProvider => ApplicationBuilder.ApplicationServices;
+        }
+
+        private record TryParseStringRecord(int Value)
+        {
+            public static bool TryParse(string value, out TryParseStringRecord result) =>
+                throw new NotImplementedException();
+        }
+
+        private record BindAsyncRecord(int Value)
+        {
+            public static ValueTask<object> BindAsync(HttpContext context) =>
+                throw new NotImplementedException();
+            public static bool TryParse(string value, out BindAsyncRecord result) =>
+                throw new NotImplementedException();
         }
     }
 }

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -19,7 +19,8 @@ namespace Microsoft.AspNetCore.Http
         private readonly MethodInfo _enumTryParseMethod;
 
         // Since this is shared source, the cache won't be shared between RequestDelegateFactory and the ApiDescriptionProvider sadly :(
-        private readonly ConcurrentDictionary<Type, Func<Expression, Expression>?> _methodCallCache = new();
+        private readonly ConcurrentDictionary<Type, Func<Expression, Expression>?> _stringMethodCallCache = new();
+        private readonly ConcurrentDictionary<Type, Expression?> _bindAsyncMethodCallCache = new();
 
         internal readonly ParameterExpression TempSourceStringExpr = Expression.Variable(typeof(string), "tempSourceString");
 
@@ -41,7 +42,10 @@ namespace Microsoft.AspNetCore.Http
             return FindTryParseMethod(nonNullableParameterType) is not null;
         }
 
-        public Func<Expression, Expression>? FindTryParseMethod(Type type)
+        public bool HasBindAsyncMethod(ParameterInfo parameter) =>
+            FindBindAsyncMethod(parameter.ParameterType) is not null;
+
+        public Func<Expression, Expression>? FindTryParseStringMethod(Type type)
         {
             Func<Expression, Expression>? Finder(Type type)
             {
@@ -117,7 +121,26 @@ namespace Microsoft.AspNetCore.Http
                 return null;
             }
 
-            return _methodCallCache.GetOrAdd(type, Finder);
+            return _stringMethodCallCache.GetOrAdd(type, Finder);
+        }
+
+        public Expression? FindBindAsyncMethod(Type type)
+        {
+            Expression? Finder(Type type)
+            {
+                var methodInfo = type.GetMethod("BindAsync", BindingFlags.Public | BindingFlags.Static, new[] { typeof(HttpContext) });
+
+                // We're looking for a method with the following signature:
+                // static ValueTask<object> BindAsync(HttpContext context)
+                if (methodInfo is not null && methodInfo.ReturnType == typeof(ValueTask<object>))
+                {
+                    return Expression.Call(methodInfo, HttpContextExpr);
+                }
+
+                return null;
+            }
+
+            return _bindAsyncMethodCallCache.GetOrAdd(type, Finder);
         }
 
         private static MethodInfo GetEnumTryParseMethod(bool preferNonGenericEnumParseOverload)

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -23,6 +23,7 @@ namespace Microsoft.AspNetCore.Http
         private readonly ConcurrentDictionary<Type, Expression?> _bindAsyncMethodCallCache = new();
 
         internal readonly ParameterExpression TempSourceStringExpr = Expression.Variable(typeof(string), "tempSourceString");
+        internal readonly ParameterExpression HttpContextExpr = Expression.Parameter(typeof(HttpContext), "httpContext");
 
         // If IsDynamicCodeSupported is false, we can't use the static Enum.TryParse<T> since there's no easy way for
         // this code to generate the specific instantiation for any enums used
@@ -36,10 +37,10 @@ namespace Microsoft.AspNetCore.Http
             _enumTryParseMethod = GetEnumTryParseMethod(preferNonGenericEnumParseOverload);
         }
 
-        public bool HasTryParseMethod(ParameterInfo parameter)
+        public bool HasTryParseStringMethod(ParameterInfo parameter)
         {
             var nonNullableParameterType = Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType;
-            return FindTryParseMethod(nonNullableParameterType) is not null;
+            return FindTryParseStringMethod(nonNullableParameterType) is not null;
         }
 
         public bool HasBindAsyncMethod(ParameterInfo parameter) =>


### PR DESCRIPTION
## Customer Impact

We've had several requests to enable MVC style model binding for minimal APIs, for both framework authors and customers who have written basic model binders for various types. We're enabling typed based modeling binding to unlock these scenarios so we can get feedback for [.NET 7.0 for the overall design](https://github.com/dotnet/aspnetcore/issues/35489)

## Testing

Unit testing, lots of it.

## Risk

Low