### PR TITLE
Make typed hub clients public

### DIFF
--- a/src/SignalR/server/Core/src/Hub`T.cs
+++ b/src/SignalR/server/Core/src/Hub`T.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.SignalR.Internal;
-
 namespace Microsoft.AspNetCore.SignalR
 {
     /// <summary>
@@ -22,7 +20,7 @@ namespace Microsoft.AspNetCore.SignalR
             {
                 if (_clients == null)
                 {
-                    _clients = new TypedHubClients<T>(base.Clients);
+                    _clients = new TypedHubCallerClients<T>(base.Clients);
                 }
                 return _clients;
             }

--- a/src/SignalR/server/Core/src/TypedHubCallerClients.cs
+++ b/src/SignalR/server/Core/src/TypedHubCallerClients.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.SignalR.Internal;
 
 namespace Microsoft.AspNetCore.SignalR
 {
-    internal class TypedHubCallerClients<T> : TypedHubClients<T>, IHubCallerClients<T>
+    public class TypedHubCallerClients<T> : TypedHubClients<T>, IHubCallerClients<T>
     {
         private readonly IHubCallerClients _hubClients;
 

--- a/src/SignalR/server/Core/src/TypedHubCallerClients.cs
+++ b/src/SignalR/server/Core/src/TypedHubCallerClients.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.SignalR.Internal;
+
+namespace Microsoft.AspNetCore.SignalR
+{
+    internal class TypedHubCallerClients<T> : TypedHubClients<T>, IHubCallerClients<T>
+    {
+        private readonly IHubCallerClients _hubClients;
+
+        public TypedHubClients(IHubCallerClients dynamicContext)
+            : base(dynamicContext)
+        {
+            _hubClients = dynamicContext;
+        }
+
+        public T Caller => TypedClientBuilder<T>.Build(_hubClients.Caller);
+
+        public T Others => TypedClientBuilder<T>.Build(_hubClients.Others);
+
+        public T OthersInGroup(string groupName)
+        {
+            return TypedClientBuilder<T>.Build(_hubClients.OthersInGroup(groupName));
+        }
+    }
+}

--- a/src/SignalR/server/Core/src/TypedHubCallerClients.cs
+++ b/src/SignalR/server/Core/src/TypedHubCallerClients.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.SignalR
     {
         private readonly IHubCallerClients _hubClients;
 
-        public TypedHubClients(IHubCallerClients dynamicContext)
+        public TypedHubCallerClients(IHubCallerClients dynamicContext)
             : base(dynamicContext)
         {
             _hubClients = dynamicContext;

--- a/src/SignalR/server/Core/src/TypedHubClients.cs
+++ b/src/SignalR/server/Core/src/TypedHubClients.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.SignalR.Internal;
-using System.Collections.Generics;
+using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.SignalR
 {

--- a/src/SignalR/server/Core/src/TypedHubClients.cs
+++ b/src/SignalR/server/Core/src/TypedHubClients.cs
@@ -1,24 +1,21 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+using Microsoft.AspNetCore.SignalR.Internal;
+using System.Collections.Generics;
 
-namespace Microsoft.AspNetCore.SignalR.Internal
+namespace Microsoft.AspNetCore.SignalR
 {
-    internal class TypedHubClients<T> : IHubCallerClients<T>
+    internal class TypedHubClients<T> : IHubClients<T>
     {
-        private readonly IHubCallerClients _hubClients;
+        private readonly IHubClients _hubClients;
 
-        public TypedHubClients(IHubCallerClients dynamicContext)
+        public TypedHubClients(IHubClients dynamicContext)
         {
             _hubClients = dynamicContext;
         }
 
         public T All => TypedClientBuilder<T>.Build(_hubClients.All);
-
-        public T Caller => TypedClientBuilder<T>.Build(_hubClients.Caller);
-
-        public T Others => TypedClientBuilder<T>.Build(_hubClients.Others);
 
         public T AllExcept(IReadOnlyList<string> excludedConnectionIds) => TypedClientBuilder<T>.Build(_hubClients.AllExcept(excludedConnectionIds));
 
@@ -45,11 +42,6 @@ namespace Microsoft.AspNetCore.SignalR.Internal
         public T Groups(IReadOnlyList<string> groupNames)
         {
             return TypedClientBuilder<T>.Build(_hubClients.Groups(groupNames));
-        }
-
-        public T OthersInGroup(string groupName)
-        {
-            return TypedClientBuilder<T>.Build(_hubClients.OthersInGroup(groupName));
         }
 
         public T User(string userId)

--- a/src/SignalR/server/Core/src/TypedHubClients.cs
+++ b/src/SignalR/server/Core/src/TypedHubClients.cs
@@ -6,7 +6,7 @@ using System.Collections.Generics;
 
 namespace Microsoft.AspNetCore.SignalR
 {
-    internal class TypedHubClients<T> : IHubClients<T>
+    public class TypedHubClients<T> : IHubClients<T>
     {
         private readonly IHubClients _hubClients;
 


### PR DESCRIPTION
**PR Title**
Expose Typed Hub Clients Classes

**PR Description**
Made `TypeHubCallerClients` and `TypedHubClients` public in order to support typed client proxy for serverless hubs within azure signalR extensions repository. Serverless hubs contain no caller context so `TypedHubClients` should only implement `IHubClients<T>` and provides a base type for caller clients.

See: [Support Strongly Typed Hub Clients #131](https://github.com/Azure/azure-functions-signalrservice-extension/issues/131)