### PR TITLE
Don't cache CanReuse value

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -108,6 +108,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
 
         // We only want to reuse a stream that was not aborted and has completely finished writing.
         // This ensures Http2OutputProducer.ProcessDataWrites is in the correct state to be reused.
+
+        // CanReuse must be evaluated on the main frame-processing looping after the stream is removed
+        // from the connection's active streams collection. This is required because a RST_STREAM
+        // frame could arrive after the END_STREAM flag is received. Only once the stream is removed
+        // from the connection's active stream collection can no longer be reset, and is safe to
+        // evaluate for pooling.
+
         public bool CanReuse => !_connectionAborted && HasResponseCompleted;
 
         protected override void OnReset()


### PR DESCRIPTION
Fixes #34768

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Worst case is that Http2 streams are pooled less often.

## Verification
- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A

