### PR TITLE
Fix ambiguous Map method with minimal APIs

### DIFF
--- a/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs
@@ -20,6 +20,19 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pathMatch">The request path to match.</param>
         /// <param name="configuration">The branch to take for positive path matches.</param>
         /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        public static IApplicationBuilder Map(this IApplicationBuilder app, string pathMatch, Action<IApplicationBuilder> configuration)
+        {
+            return Map(app, pathMatch, preserveMatchedPathSegment: false, configuration);
+        }
+
+        /// <summary>
+        /// Branches the request pipeline based on matches of the given request path. If the request path starts with
+        /// the given path, the branch is executed.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
+        /// <param name="pathMatch">The request path to match.</param>
+        /// <param name="configuration">The branch to take for positive path matches.</param>
+        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
         public static IApplicationBuilder Map(this IApplicationBuilder app, PathString pathMatch, Action<IApplicationBuilder> configuration)
         {
             return Map(app, pathMatch, preserveMatchedPathSegment: false, configuration);

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -27,6 +27,7 @@ Microsoft.AspNetCore.Http.RequestDelegateResult.EndpointMetadata.get -> System.C
 Microsoft.AspNetCore.Http.RequestDelegateResult.RequestDelegate.get -> Microsoft.AspNetCore.Http.RequestDelegate!
 Microsoft.AspNetCore.Http.RequestDelegateResult.RequestDelegateResult(Microsoft.AspNetCore.Http.RequestDelegate! requestDelegate, System.Collections.Generic.IReadOnlyList<object!>! metadata) -> void
 Microsoft.AspNetCore.Routing.RouteValueDictionary.TryAdd(string! key, object? value) -> bool
+static Microsoft.AspNetCore.Builder.MapExtensions.Map(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, string! pathMatch, System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder!>! configuration) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 abstract Microsoft.AspNetCore.Http.HttpResponse.ContentType.get -> string?
 static readonly Microsoft.AspNetCore.Http.HttpProtocol.Http09 -> string!
 static Microsoft.AspNetCore.Http.HttpProtocol.IsHttp09(string! protocol) -> bool

--- a/src/Http/Http.Abstractions/test/MapPathMiddlewareTests.cs
+++ b/src/Http/Http.Abstractions/test/MapPathMiddlewareTests.cs
@@ -1,11 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Http;
-using Xunit;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Builder.Extensions
 {
@@ -214,12 +212,62 @@ namespace Microsoft.AspNetCore.Builder.Extensions
             Assert.Equal("/route2/subroute2/subsub2", context.Request.Path.Value);
         }
 
+        [Fact]
+        public void ApplicationBuilderMapOverloadPreferredOverEndpointBuilderGivenStringPathAndImplicitLambdaParameterType()
+        {
+            var mockWebApplication = new MockWebApplication();
+
+            mockWebApplication.Map("/foo", app => { });
+
+            Assert.True(mockWebApplication.UseCalled);
+        }
+
+        [Fact]
+        public void ApplicationBuilderMapOverloadPreferredOverEndpointBuilderGivenStringPathAndExplicitLambdaParameterType()
+        {
+            var mockWebApplication = new MockWebApplication();
+
+            mockWebApplication.Map("/foo", (IApplicationBuilder app) => { });
+
+            Assert.True(mockWebApplication.UseCalled);
+        }
+
         private HttpContext CreateRequest(string basePath, string requestPath)
         {
             HttpContext context = new DefaultHttpContext();
             context.Request.PathBase = new PathString(basePath);
             context.Request.Path = new PathString(requestPath);
             return context;
+        }
+
+        private class MockWebApplication : IApplicationBuilder, IEndpointRouteBuilder
+        {
+            public bool UseCalled { get; set; }
+
+            public IServiceProvider ApplicationServices { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public IFeatureCollection ServerFeatures => throw new NotImplementedException();
+
+            public IDictionary<string, object?> Properties => throw new NotImplementedException();
+
+            public IServiceProvider ServiceProvider => throw new NotImplementedException();
+
+            public ICollection<EndpointDataSource> DataSources => throw new NotImplementedException();
+
+            public IApplicationBuilder CreateApplicationBuilder() => throw new NotImplementedException();
+
+            public IApplicationBuilder New() => this;
+
+            public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware)
+            {
+                UseCalled = true;
+                return this;
+            }
+
+            public RequestDelegate Build()
+            {
+                return context => Task.CompletedTask;
+            }
         }
     }
 }

--- a/src/Http/Http.Abstractions/test/Microsoft.AspNetCore.Http.Abstractions.Tests.csproj
+++ b/src/Http/Http.Abstractions/test/Microsoft.AspNetCore.Http.Abstractions.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http" />
+    <Reference Include="Microsoft.AspNetCore.Routing" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This adds a an `Map(this IApplicationBuilder app, string pathMatch, Action<IApplicationBuilder> configuration)` overload. This will get chosen where `Map(this IApplicationBuilder app, PathString pathMatch, Action<IApplicationBuilder> configuration)` would be chosen previously with an implicit conversion.

The purpose for this is to make something like `app.Map("/foo", (IApplicationBuilder app) => { });` unambiguous when `app` is `WebApplication` which implements both `IApplicationBuilder` and `IEndpointRouteBuilder` meaning both `Map(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler)` and the old `PathString` overload are valid.

Normally the more specific `Action<IApplicationBuilder>` overload would be preferred over the `Delegate` overload and it is after this change, but the implicit conversion from `PathString` to `string` was stopping this this from happening with the old overload. See https://github.com/dotnet/roslyn/issues/55691

Starts addressing #35323 (needs backport to rc1 because public API change)