### PR TITLE
Add ApiParameterDescription to ApiDescription to represent the request body - 35421

### DIFF
--- a/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Builder
@@ -289,7 +288,7 @@ namespace Microsoft.AspNetCore.Builder
         public void MapPost_BuildsEndpointWithCorrectEndpointMetadata()
         {
             var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
-            _ = builder.MapPost("/", [ConsumesAttribute(typeof(Todo), "application/xml")] (Todo todo) => { });
+            _ = builder.MapPost("/", [TestConsumesAttribute(typeof(Todo), "application/xml")] (Todo todo) => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
             // Trigger Endpoint build by calling getter.
@@ -299,7 +298,7 @@ namespace Microsoft.AspNetCore.Builder
             Assert.NotNull(endpointMetadata);
             Assert.Equal(2, endpointMetadata.Count);
 
-            var lastAddedMetadata = endpointMetadata[endpointMetadata.Count -1];
+            var lastAddedMetadata = endpointMetadata[^1];
   
             Assert.Equal(typeof(Todo), lastAddedMetadata.RequestType);
             Assert.Equal(new[] { "application/xml" }, lastAddedMetadata.ContentTypes);
@@ -484,9 +483,9 @@ namespace Microsoft.AspNetCore.Builder
             public string? Name { get; set; }
         }
 
-        class ConsumesAttribute : Attribute, IAcceptsMetadata
+        class TestConsumesAttribute : Attribute, IAcceptsMetadata
         {
-            public ConsumesAttribute(Type requestType, string contentType, params string[] otherContentTypes)
+            public TestConsumesAttribute(Type requestType, string contentType, params string[] otherContentTypes)
             {
                 if (contentType == null)
                 {

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     hasJsonBody = true;
                 }
 
-                apiDescription.ParameterDescriptions.Add(parameterDescription!);
+                apiDescription.ParameterDescriptions.Add(parameterDescription);
             }
 
             // Get custom attributes for the handler. ConsumesAttribute is one of the examples. 

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             var acceptsRequestType = routeEndpoint.Metadata.GetMetadata<IAcceptsMetadata>()?.RequestType;
             if (acceptsRequestType is not null)
             {
-                var parameterDescriptor = new ApiParameterDescription
+                var parameterDescription = new ApiParameterDescription
                 {
                     Name = acceptsRequestType.Name,
                     ModelMetadata = CreateModelMetadata(acceptsRequestType),
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                     IsRequired = true,
                 };
 
-                apiDescription.ParameterDescriptions.Add(parameterDescriptor);
+                apiDescription.ParameterDescriptions.Add(parameterDescription);
             }
 
             AddSupportedRequestFormats(apiDescription.SupportedRequestFormats, hasJsonBody, routeEndpoint.Metadata);

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         public void AddsMultipleRequestFormatsFromMetadata()
         {
             var apiDescription = GetApiDescription(
-                [Consumes(typeof(InferredJsonClass),"application/custom0", "application/custom1")]
+                [Consumes("application/custom0", "application/custom1")]
             (InferredJsonClass fromBody) =>
                 { });
 
@@ -105,10 +105,6 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             var requestFormat1 = apiDescription.SupportedRequestFormats[1];
             Assert.Equal("application/custom1", requestFormat1.MediaType);
             Assert.Null(requestFormat1.Formatter);
-
-            var apiParameterDescription = apiDescription.ParameterDescriptions[0];
-            Assert.Equal("InferredJsonClass", apiParameterDescription.Type.Name);
-            Assert.True(apiParameterDescription.IsRequired);
         }
 
         [Fact]

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         public void AddsMultipleRequestFormatsFromMetadata()
         {
             var apiDescription = GetApiDescription(
-                [Consumes("application/custom0", "application/custom1")]
+                [Consumes(typeof(InferredJsonClass),"application/custom0", "application/custom1")]
             (InferredJsonClass fromBody) =>
                 { });
 
@@ -105,6 +105,24 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             var requestFormat1 = apiDescription.SupportedRequestFormats[1];
             Assert.Equal("application/custom1", requestFormat1.MediaType);
             Assert.Null(requestFormat1.Formatter);
+
+            var apiParameterDescription = apiDescription.ParameterDescriptions[0];
+            Assert.Equal("InferredJsonClass", apiParameterDescription.Type.Name);
+            Assert.True(apiParameterDescription.IsRequired);
+        }
+
+        [Fact]
+        public void AddsMultipleRequestFormatsFromMetadataWithRequestType()
+        {
+            var apiDescription = GetApiDescription(
+                [Consumes(typeof(InferredJsonClass), "application/custom0", "application/custom1")]
+                () => { });
+
+            Assert.Equal(2, apiDescription.SupportedRequestFormats.Count);
+
+            var apiParameterDescription = apiDescription.ParameterDescriptions[0];
+            Assert.Equal("InferredJsonClass", apiParameterDescription.Type.Name);
+            Assert.True(apiParameterDescription.IsRequired);
         }
 
         [Fact]

--- a/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="additionalContentTypes">Additional response content types the endpoint accepts</param>
         /// <returns>A <see cref="DelegateEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
         public static DelegateEndpointConventionBuilder Accepts(this DelegateEndpointConventionBuilder builder, Type requestType,
-            string contentType, params string[] additionalContentTypes) 
+            string contentType, params string[] additionalContentTypes)
         {
             builder.WithMetadata(new ConsumesAttribute(requestType, contentType, additionalContentTypes));
             return builder;

--- a/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
@@ -130,7 +130,8 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="contentType">The request content type. Defaults to "application/json" if empty.</param>
         /// <param name="additionalContentTypes">Additional response content types the endpoint produces for the supplied status code.</param>
         /// <returns>A <see cref="DelegateEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static DelegateEndpointConventionBuilder Accepts<TRequest>(this DelegateEndpointConventionBuilder builder, string contentType, params string[] additionalContentTypes)
+        public static DelegateEndpointConventionBuilder Accepts<TRequest>(this DelegateEndpointConventionBuilder builder,
+            string contentType, params string[] additionalContentTypes) where TRequest : notnull
         {
             Accepts(builder, typeof(TRequest), contentType, additionalContentTypes);
 
@@ -147,7 +148,7 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="additionalContentTypes">Additional response content types the endpoint accepts</param>
         /// <returns>A <see cref="DelegateEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
         public static DelegateEndpointConventionBuilder Accepts(this DelegateEndpointConventionBuilder builder, Type requestType,
-            string contentType, params string[] additionalContentTypes)
+            string contentType, params string[] additionalContentTypes) 
         {
             builder.WithMetadata(new ConsumesAttribute(requestType, contentType, additionalContentTypes));
             return builder;

--- a/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
@@ -147,8 +147,8 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="contentType">The response content type that the endpoint accepts.</param>
         /// <param name="additionalContentTypes">Additional response content types the endpoint accepts</param>
         /// <returns>A <see cref="DelegateEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static DelegateEndpointConventionBuilder Accepts(this DelegateEndpointConventionBuilder builder, Type requestType,
-            string contentType, params string[] additionalContentTypes)
+        public static DelegateEndpointConventionBuilder Accepts(this DelegateEndpointConventionBuilder builder,
+            Type requestType, string contentType, params string[] additionalContentTypes)
         {
             builder.WithMetadata(new ConsumesAttribute(requestType, contentType, additionalContentTypes));
             return builder;

--- a/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="additionalContentTypes">Additional response content types the endpoint produces for the supplied status code.</param>
         /// <returns>A <see cref="DelegateEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
         public static DelegateEndpointConventionBuilder Accepts<TRequest>(this DelegateEndpointConventionBuilder builder,
-            string contentType, params string[] additionalContentTypes) where TRequest : notnull
+            string contentType, params string[] additionalContentTypes)
         {
             Accepts(builder, typeof(TRequest), contentType, additionalContentTypes);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Add the Api Parameter Description to API Explorer to represent the request body. 

**PR Description**
```ApiExplorer``` should be updated to add a ```ApiParameterDescription``` to the ```ApiDescription``` to represent the incoming request body based on the details in the endpoint's ```IApiRequestMetadataProvider``` metadata if present.

**API Change included.**

This change adds a generic constraint (``` where TRequest : notnull ```) to a newly added API for rc1 .

``` diff


namespace Microsoft.AspNetCore.Http
{
    public static class OpenApiEndpointConventionBuilderExtensions
    {
+        public static DelegateEndpointConventionBuilder Accepts<TRequest>(this DelegateEndpointConventionBuilder 
+        builder,  string contentType, params string[] additionalContentTypes) where TRequest : notnull
  }
}

```

Fixes #35421
