### PR TITLE
Avoid using new C# language features in Razor code generation

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Razor.Language;
@@ -25,6 +25,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.IntegrationTests
         protected override CSharpCompilation BaseCompilation => DefaultBaseCompilation;
 
         protected override RazorConfiguration Configuration { get; }
+
+        protected override CSharpParseOptions CSharpParseOptions => base.CSharpParseOptions.WithLanguageVersion(LanguageVersion.CSharp8);
 
         [Fact]
         public void InvalidNamespaceAtEOF_DesignTime()

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
@@ -27,6 +27,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.IntegrationTests
         protected override CSharpCompilation BaseCompilation => DefaultBaseCompilation;
 
         protected override RazorConfiguration Configuration { get; }
+
+        protected override CSharpParseOptions CSharpParseOptions => base.CSharpParseOptions.WithLanguageVersion(LanguageVersion.CSharp8);
 
         #region Runtime
 

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_Runtime.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic_Runtime.codegen.cs
@@ -23,7 +23,7 @@ namespace AspNetCore
             WriteLiteral("<div");
             EndContext();
             BeginWriteAttribute("class", " class=\"", 4, "\"", 28, 1);
-#line (1,13)-(1,29) 28 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml"
+#line 1 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml"
 WriteAttributeValue("", 12, this.ToString(), 12, 16, false);
 
 #line default
@@ -33,7 +33,7 @@ WriteAttributeValue("", 12, this.ToString(), 12, 16, false);
             WriteLiteral(">\r\n    Hello world\r\n    ");
             EndContext();
             BeginContext(54, 29, false);
-#line (3,6)-(3,35) 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml"
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml"
 Write(string.Format("{0}", "Hello"));
 
 #line default
@@ -60,8 +60,8 @@ Write(string.Format("{0}", "Hello"));
 #line default
 #line hidden
                 BeginContext(153, 3, false);
-#line (8,31)-(8,34) 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml"
-Write(cls);
+#line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/Basic.cshtml"
+                        Write(cls);
 
 #line default
 #line hidden

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_Runtime.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate_Runtime.codegen.cs
@@ -35,8 +35,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
             WriteLiteral("\r\n<h1>New Customer ");
             EndContext();
             BeginContext(213, 10, false);
-#line (13,19)-(13,29) 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml"
-Write(Model.Name);
+#line 13 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/RazorPagesWithRouteTemplate.cshtml"
+            Write(Model.Name);
 
 #line default
 #line hidden

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperTargetExtension.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperTargetExtension.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -176,7 +176,10 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions
                 TagHelperProcessInvokeAsyncArgsMethodName,
                 new Dictionary<string, string>() { { TagHelperContextTypeName, TagHelperContextVariableName } }))
             {
-                writer.WriteStartAssignment($"{methodReturnType} args").WriteLine("new();");
+                writer.WriteStartAssignment($"{methodReturnType} args")
+                    .WriteStartNewObject(methodReturnType)
+                    .WriteEndMethodInvocation();
+
                 for (var i = 0; i < tagHelper.BoundAttributes.Count; i++)
                 {
                     var attributeName = tagHelper.BoundAttributes[i].Name;

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelperOptionalParam_Runtime.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelperOptionalParam_Runtime.codegen.cs
@@ -306,7 +306,7 @@ __OptionalWithMultipleTypesViewComponentTagHelper.birthDate = DateTime.Now;
             }
             private Dictionary<string, object> ProcessInvokeAsyncArgs(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context)
             {
-                Dictionary<string, object> args = new();
+                Dictionary<string, object> args = new Dictionary<string, object>();
                 if (__context.AllAttributes.ContainsName("show-secret"))
                 {
                     args[nameof(showSecret)] = showSecret;
@@ -335,7 +335,7 @@ __OptionalWithMultipleTypesViewComponentTagHelper.birthDate = DateTime.Now;
             }
             private Dictionary<string, object> ProcessInvokeAsyncArgs(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context)
             {
-                Dictionary<string, object> args = new();
+                Dictionary<string, object> args = new Dictionary<string, object>();
                 if (__context.AllAttributes.ContainsName("secret"))
                 {
                     args[nameof(secret)] = secret;
@@ -371,7 +371,7 @@ __OptionalWithMultipleTypesViewComponentTagHelper.birthDate = DateTime.Now;
             }
             private Dictionary<string, object> ProcessInvokeAsyncArgs(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context)
             {
-                Dictionary<string, object> args = new();
+                Dictionary<string, object> args = new Dictionary<string, object>();
                 if (__context.AllAttributes.ContainsName("age"))
                 {
                     args[nameof(age)] = age;

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/ViewComponentTagHelper_DesignTime.codegen.cs
@@ -94,7 +94,7 @@ global::System.Object __typeHelper = "*, AppCode";
             }
             private Dictionary<string, object> ProcessInvokeAsyncArgs(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context)
             {
-                Dictionary<string, object> args = new();
+                Dictionary<string, object> args = new Dictionary<string, object>();
                 if (__context.AllAttributes.ContainsName("first-name"))
                 {
                     args[nameof(firstName)] = firstName;

--- a/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/ViewComponentTagHelperTargetExtensionTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/ViewComponentTagHelperTargetExtensionTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Razor.Language;
@@ -58,7 +58,7 @@ public class __Generated__TagCloudViewComponentTagHelper : Microsoft.AspNetCore.
     }
     private Dictionary<string, object> ProcessInvokeAsyncArgs(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context)
     {
-        Dictionary<string, object> args = new();
+        Dictionary<string, object> args = new Dictionary<string, object>();
         if (__context.AllAttributes.ContainsName(""Foo""))
         {
             args[nameof(Foo)] = Foo;
@@ -122,7 +122,7 @@ public class __Generated__TagCloudViewComponentTagHelper : Microsoft.AspNetCore.
     }
     private Dictionary<string, object> ProcessInvokeAsyncArgs(Microsoft.AspNetCore.Razor.TagHelpers.TagHelperContext __context)
     {
-        Dictionary<string, object> args = new();
+        Dictionary<string, object> args = new Dictionary<string, object>();
         if (__context.AllAttributes.ContainsName(""Foo""))
         {
             args[nameof(Tags)] = Tags;


### PR DESCRIPTION
The generated code for tag helpers is used all the way back in 3.1 which defaults to C# 8. Our code generation
currently produces a target-typed new expression that is available in C# 10.

Updating some of the older tests to pin the language to a fixed version so we can catch these kinds of regressions as part of tests.

Fixes https://github.com/dotnet/aspnetcore/issues/35554
