### PR TITLE
Workaround dotnet/core-eng#14186

### DIFF
--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -269,7 +269,7 @@ namespace RunTests
             if (File.Exists("TestResults/TestResults.xml"))
             {
                 Console.WriteLine("Copying TestResults/TestResults.xml to ./testResults.xml");
-                File.Copy("TestResults/TestResults.xml", "testResults.xml");
+                File.Copy("TestResults/TestResults.xml", "testResults.xml", overwrite: true);
             }
             else
             {


### PR DESCRIPTION
- Helix work item root may contain files in some odd cases
- e.g. Helix agent reboots don't result in cleanup
- e.g. [Pipelines - Run 20210820.2 (azure.com)](https://dev.azure.com/dnceng/public/_build/results?buildId=1309341&view=results) had TestResults.xml at start
  - same in [Pipelines - Run 20210821.2 (azure.com)](https://dev.azure.com/dnceng/public/_build/results?buildId=1310402&view=results)