### PR TITLE
Quarantine two tests

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -601,6 +601,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareDataName))]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35686")]
         public async Task ConnectionClosedTokenFiresOnServerAbort(string listenOptionsName)
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -49,6 +49,7 @@ public class LongPollingTransportTest {
     }
 
     @Test
+    @Disabled("https://github.com/dotnet/aspnetcore/issues/35684")
     public void StatusCode204StopsLongPollingTriggersOnClosed() {
         AtomicBoolean firstPoll = new AtomicBoolean(true);
         CompletableSubject block = CompletableSubject.create();


### PR DESCRIPTION
- see #35684 and #35686
- note Java test is actually skipped, can't be quarantined