### PR TITLE
Big-endian fixes: binary data in RenderBatch

### DIFF
--- a/src/Components/Ignitor/test/RenderBatchReaderTest.cs
+++ b/src/Components/Ignitor/test/RenderBatchReaderTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -232,7 +233,7 @@ namespace Ignitor
 
             // The string table position is given by the final int, and continues
             // until we get to the final set of top-level indices
-            var stringTableStartPosition = BitConverter.ToInt32(bytes, bytes.Length - 4);
+            var stringTableStartPosition = ReadInt(bytes, bytes.Length - 4);
             var stringTableEndPositionExcl = bytes.Length - 20;
 
             var result = new List<string>();
@@ -241,7 +242,7 @@ namespace Ignitor
                 entryPosition += 4)
             {
                 // The string table entries are all length-prefixed UTF8 blobs
-                var tableEntryPos = BitConverter.ToInt32(bytes, entryPosition);
+                var tableEntryPos = ReadInt(bytes, entryPosition);
                 var length = (int)ReadUnsignedLEB128(bytes, tableEntryPos, out var numLEB128Bytes);
                 var value = Encoding.UTF8.GetString(bytes, tableEntryPos + numLEB128Bytes, length);
                 result.Add(value);
@@ -299,7 +300,7 @@ namespace Ignitor
         }
 
         static int ReadInt(Span<byte> bytes, int startOffset)
-            => BitConverter.ToInt32(bytes.Slice(startOffset, 4).ToArray(), 0);
+            => BinaryPrimitives.ReadInt32LittleEndian(bytes.Slice(startOffset, 4));
 
         public static uint ReadUnsignedLEB128(byte[] bytes, int startOffset, out int numBytesRead)
         {

--- a/src/Components/Server/test/Circuits/RenderBatchWriterTest.cs
+++ b/src/Components/Server/test/Circuits/RenderBatchWriterTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -283,7 +284,7 @@ namespace Microsoft.AspNetCore.Components.Server
 
             // The string table position is given by the final int, and continues
             // until we get to the final set of top-level indices
-            var stringTableStartPosition = BitConverter.ToInt32(bytes, bytes.Length - 4);
+            var stringTableStartPosition = ReadInt(bytes, bytes.Length - 4);
             var stringTableEndPositionExcl = bytes.Length - 20;
 
             var result = new List<string>();
@@ -292,7 +293,7 @@ namespace Microsoft.AspNetCore.Components.Server
                 entryPosition += 4)
             {
                 // The string table entries are all length-prefixed UTF8 blobs
-                var tableEntryPos = BitConverter.ToInt32(bytes, entryPosition);
+                var tableEntryPos = ReadInt(bytes, entryPosition);
                 var length = (int)ReadUnsignedLEB128(bytes, tableEntryPos, out var numLEB128Bytes);
                 var value = Encoding.UTF8.GetString(bytes, tableEntryPos + numLEB128Bytes, length);
                 result.Add(value);
@@ -350,7 +351,7 @@ namespace Microsoft.AspNetCore.Components.Server
         }
 
         static int ReadInt(Span<byte> bytes, int startOffset)
-            => BitConverter.ToInt32(bytes.Slice(startOffset, 4).ToArray(), 0);
+            => BinaryPrimitives.ReadInt32LittleEndian(bytes.Slice(startOffset, 4));
 
         public static uint ReadUnsignedLEB128(byte[] bytes, int startOffset, out int numBytesRead)
         {


### PR DESCRIPTION
* Use little-endian accessors for RenderBatch binary data throughout

* Fixes part 3 of https://github.com/dotnet/aspnetcore/issues/35709


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Big-endian fixes: binary data in RenderBatch

**PR Description**
* Use little-endian accessors for RenderBatch binary data throughout
* Fixes part 3 of https://github.com/dotnet/aspnetcore/issues/35709
