### PR TITLE
Big-endian fixes: Guid handling in KeyRingBasedDataProtector.cs

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
@@ -149,10 +149,28 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             Debug.Assert((long)ptr % 4 == 0);
 
             Guid retVal;
-            ((int*)&retVal)[0] = ((int*)ptr)[0];
-            ((int*)&retVal)[1] = ((int*)ptr)[1];
-            ((int*)&retVal)[2] = ((int*)ptr)[2];
-            ((int*)&retVal)[3] = ((int*)ptr)[3];
+            if (BitConverter.IsLittleEndian)
+            {
+                ((int*)&retVal)[0] = ((int*)ptr)[0];
+                ((int*)&retVal)[1] = ((int*)ptr)[1];
+                ((int*)&retVal)[2] = ((int*)ptr)[2];
+                ((int*)&retVal)[3] = ((int*)ptr)[3];
+            }
+            else
+            {
+                // The first 8 bytes of the Guid hold one 32-bit integer
+                // and two 16-bit integers that must be byte-swapped.
+                ((byte*)&retVal)[0] = ((byte*)ptr)[3];
+                ((byte*)&retVal)[1] = ((byte*)ptr)[2];
+                ((byte*)&retVal)[2] = ((byte*)ptr)[1];
+                ((byte*)&retVal)[3] = ((byte*)ptr)[0];
+                ((byte*)&retVal)[4] = ((byte*)ptr)[5];
+                ((byte*)&retVal)[5] = ((byte*)ptr)[4];
+                ((byte*)&retVal)[6] = ((byte*)ptr)[7];
+                ((byte*)&retVal)[7] = ((byte*)ptr)[6];
+                ((int*)&retVal)[2] = ((int*)ptr)[2];
+                ((int*)&retVal)[3] = ((int*)ptr)[3];
+            }
             return retVal;
         }
 
@@ -306,10 +324,28 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         {
             Debug.Assert((long)ptr % 4 == 0);
 
-            ((int*)ptr)[0] = ((int*)&value)[0];
-            ((int*)ptr)[1] = ((int*)&value)[1];
-            ((int*)ptr)[2] = ((int*)&value)[2];
-            ((int*)ptr)[3] = ((int*)&value)[3];
+            if (BitConverter.IsLittleEndian)
+            {
+                ((int*)ptr)[0] = ((int*)&value)[0];
+                ((int*)ptr)[1] = ((int*)&value)[1];
+                ((int*)ptr)[2] = ((int*)&value)[2];
+                ((int*)ptr)[3] = ((int*)&value)[3];
+            }
+            else
+            {
+                // The first 8 bytes of the Guid hold one 32-bit integer
+                // and two 16-bit integers that must be byte-swapped.
+                ((byte*)ptr)[0] = ((byte*)&value)[3];
+                ((byte*)ptr)[1] = ((byte*)&value)[2];
+                ((byte*)ptr)[2] = ((byte*)&value)[1];
+                ((byte*)ptr)[3] = ((byte*)&value)[0];
+                ((byte*)ptr)[4] = ((byte*)&value)[5];
+                ((byte*)ptr)[5] = ((byte*)&value)[4];
+                ((byte*)ptr)[6] = ((byte*)&value)[7];
+                ((byte*)ptr)[7] = ((byte*)&value)[6];
+                ((int*)ptr)[2] = ((int*)&value)[2];
+                ((int*)ptr)[3] = ((int*)&value)[3];
+            }
         }
 
         private static void WriteBigEndianInteger(byte* ptr, uint value)


### PR DESCRIPTION
* Add big-endian version of optimized Guid accessors

* Fixes part 4 of https://github.com/dotnet/aspnetcore/issues/35709


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Big-endian fixes: Guid handling in KeyRingBasedDataProtector.cs

**PR Description**
* Add big-endian version of optimized Guid accessors
* Fixes part 4 of https://github.com/dotnet/aspnetcore/issues/35709
