### PR TITLE
Move IResultsExtension to M.A.Http namespace

### DIFF
--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Http.Metadata;
-using Microsoft.AspNetCore.Http.Result;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/Http/Http.Results/src/IResultExtensions.cs
+++ b/src/Http/Http.Results/src/IResultExtensions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.AspNetCore.Http.Result
+namespace Microsoft.AspNetCore.Http
 {
     /// <summary>
     /// Provides an interface for registering external methods that provide

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -31,5 +31,5 @@ static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentTy
 static Microsoft.AspNetCore.Http.Results.Unauthorized() -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.UnprocessableEntity(object? error = null) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.ValidationProblem(System.Collections.Generic.IDictionary<string!, string![]!>! errors, string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.Extensions.get -> Microsoft.AspNetCore.Http.Result.IResultExtensions!
-Microsoft.AspNetCore.Http.Result.IResultExtensions
+static Microsoft.AspNetCore.Http.Results.Extensions.get -> Microsoft.AspNetCore.Http.IResultExtensions!
+Microsoft.AspNetCore.Http.IResultExtensions

--- a/src/Http/Http.Results/src/ResultExtensions.cs
+++ b/src/Http/Http.Results/src/ResultExtensions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.AspNetCore.Http.Result
+namespace Microsoft.AspNetCore.Http
 {
     /// <summary>
     /// Implements an interface for registering external methods that provide


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/dotnet/aspnetcore/pull/35571.

It captures API feedback about the namespace location of new types that were introduced in .NET 6 RC1.

Looking to take this change into RC1, the same release the API was introduced in, to avoid having to make a breaking change in RC2.

## Customer Impact

Making this change in RC1 will reduce the likelihood of users having to deal with breaking changes as they migrate from RC1 to RC2.


## Regression?
- [ ] Yes
- [X] No

## Risk
- [ ] High
- [ ] Medium
- [X] Low

No change in functionality, just a change to namespace.

## Verification
- [ ] Manual (required)
- [X] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A

