### PR TITLE
Remove John's assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,12 +5,16 @@
 /global.json                                                                      @dotnet/aspnet-build
 /.azure/                                                                          @dotnet/aspnet-build
 /.config/                                                                         @dotnet/aspnet-build
+/.devcontainer/                                                                   @captainsafia
+/.github/                                                                         @dotnet/aspnet-build
+/.github/*_TEMPLATE/                                                              @dotnet/aspnet-build @mkArtakMSFT
+/.github/workflows/                                                               @dotnet/aspnet-build @tratcher
 /eng/                                                                             @dotnet/aspnet-build
 /eng/common/                                                                      @dotnet-maestro-bot
 /eng/Versions.props                                                               @dotnet-maestro-bot @dougbu
 /eng/Version.Details.xml                                                          @dotnet-maestro-bot @dougbu
-/src/Caching/                                                                     @juntaoluo
-/src/Caching/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @juntaoluo
+/src/Caching/                                                                     @captainsafia @halter73
+/src/Caching/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @captainsafia @halter73
 /src/Components/                                                                  @dotnet/aspnet-blazor-eng
 /src/Components/**/PublicAPI.*Shipped.txt                                         @dotnet/aspnet-api-review @dotnet/aspnet-blazor-eng
 /src/DefaultBuilder/                                                              @tratcher
@@ -18,13 +22,13 @@
 /src/Hosting/                                                                     @tratcher
 /src/Hosting/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @tratcher
 /src/Http/                                                                        @tratcher @BrennanConroy
-/src/Http/**/PublicAPI.*Shipped.txt                                               @dotnet/aspnet-api-review @tratcher
+/src/Http/**/PublicAPI.*Shipped.txt                                               @dotnet/aspnet-api-review @tratcher @BrennanConroy
 /src/Http/Routing/                                                                @javiercn
 /src/Http/Routing/**/PublicAPI.*Shipped.txt                                       @dotnet/aspnet-api-review @javiercn
-/src/HttpClientFactory/                                                           @juntaoluo
-/src/HttpClientFactory/**/PublicAPI.*Shipped.txt                                  @dotnet/aspnet-api-review @juntaoluo
+/src/HttpClientFactory/                                                           @captainsafia @halter73
+/src/HttpClientFactory/**/PublicAPI.*Shipped.txt                                  @dotnet/aspnet-api-review @captainsafia @halter73
 /src/Middleware/                                                                  @tratcher @BrennanConroy
-/src/Middleware/**/PublicAPI.*Shipped.txt                                         @dotnet/aspnet-api-review @tratcher
+/src/Middleware/**/PublicAPI.*Shipped.txt                                         @dotnet/aspnet-api-review @tratcher @BrennanConroy
 /src/Mvc/                                                                         @pranavkm @javiercn
 /src/Mvc/**/PublicAPI.*Shipped.txt                                                @dotnet/aspnet-api-review @pranavkm @javiercn
 /src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/        @dotnet/aspnet-blazor-eng
@@ -32,7 +36,7 @@
 /src/Security/                                                                    @tratcher
 /src/Security/**/PublicAPI.*Shipped.txt                                           @dotnet/aspnet-api-review @tratcher
 /src/Servers/                                                                     @tratcher @halter73 @BrennanConroy
-/src/Servers/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @tratcher @halter73
+/src/Servers/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @tratcher @halter73 @BrennanConroy
 /src/Shared/runtime/                                                              @dotnet/http
 /src/Shared/test/Shared.Tests/runtime/                                            @dotnet/http
 /src/SignalR/                                                                     @BrennanConroy @halter73

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,3 +41,4 @@
 /src/Shared/test/Shared.Tests/runtime/                                            @dotnet/http
 /src/SignalR/                                                                     @BrennanConroy @halter73
 /src/SignalR/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @BrennanConroy @halter73
+/src/submodules                                                                   @dotnet/aspnet-build @dougbu @wtgodbe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /.github/                                                                         @dotnet/aspnet-build
 /.github/*_TEMPLATE/                                                              @dotnet/aspnet-build @mkArtakMSFT
 /.github/workflows/                                                               @dotnet/aspnet-build @tratcher
+/docs/                                                                            @captainsafia @mkArtakMSFT
 /eng/                                                                             @dotnet/aspnet-build
 /eng/common/                                                                      @dotnet-maestro-bot
 /eng/Versions.props                                                               @dotnet-maestro-bot @dougbu

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,65 +8,79 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "all"
-    assignees:
-      - "dougbu"
-      - "juntaoluo"
-      - "wtgodbe"
     commit-message:
       prefix: "[main] "
       include: scope
     labels:
       - area-infrastructure
+    reviewers:
+      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "wtgodbe"
 
   # Keep submodules up to date in 'release/*' branches. (Unfortunately Dependabot security PRs can't target these.)
+  # Monthly interval opens PRs on the first of each month.
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      # Monthly interval opens PRs on the first of s Month.
       interval: "monthly"
     allow:
       - dependency-type: "all"
-    assignees:
-      - "dougbu"
-      - "juntaoluo"
-      - "wtgodbe"
     commit-message:
       prefix: "[release/2.1] "
       include: scope
     labels:
       - area-infrastructure
+    reviewers:
+      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "wtgodbe"
     target-branch: "release/2.1"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      # Monthly interval opens PRs on the first of s Month.
       interval: "monthly"
     allow:
       - dependency-type: "all"
-    assignees:
-      - "dougbu"
-      - "juntaoluo"
-      - "wtgodbe"
     commit-message:
       prefix: "[release/3.1] "
       include: scope
     labels:
       - area-infrastructure
+    reviewers:
+      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "wtgodbe"
     target-branch: "release/3.1"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      # Monthly interval opens PRs on the first of s Month.
       interval: "monthly"
     allow:
       - dependency-type: "all"
-    assignees:
-      - "dougbu"
-      - "juntaoluo"
-      - "wtgodbe"
     commit-message:
       prefix: "[release/5.0] "
       include: scope
     labels:
       - area-infrastructure
+    reviewers:
+      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "wtgodbe"
     target-branch: "release/5.0"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "[release/6.0] "
+      include: scope
+    labels:
+      - area-infrastructure
+    reviewers:
+      - "dotnet/aspnet-build"
+      - "dougbu"
+      - "wtgodbe"
+    target-branch: "release/6.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,6 @@ updates:
       include: scope
     labels:
       - area-infrastructure
-    reviewers:
-      - "dotnet/aspnet-build"
-      - "dougbu"
-      - "wtgodbe"
 
   # Keep submodules up to date in 'release/*' branches. (Unfortunately Dependabot security PRs can't target these.)
   # Monthly interval opens PRs on the first of each month.


### PR DESCRIPTION
- replace him in CODEOWNERS
  - also add a few more owners e.g. to consistently include higher-level owners in contained folders
- switch to `reviewers` in dependabot.yml and add dotnet/aspnet-build
  - Dependabot's `assignments` setting doesn't support teams
  - also add configuration for 'release/6.0' submodules