### PR TITLE
Always download blazor-hotreload.js from app root

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
 
             // Attempt to read previously applied hot reload deltas. dotnet-watch and VS will serve the script that can provide results from local-storage and
             // the injected middleware if present.
-            var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "./_framework/blazor-hotreload.js"));
+            var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "/_framework/blazor-hotreload.js"));
             await jsObjectReference.InvokeUnmarshalled<Task<int>>("receiveHotReload");
         }
 


### PR DESCRIPTION
The middleware that we inject always listens to the root of the app while the module is imported from relative path. Changing this to be root relative. We do something similar with the aspnet-browser-refresh.js script and haven't had issues with it so far.

Fixes https://github.com/dotnet/aspnetcore/issues/35555
