### PR TITLE
Add analyzer for detecting misplaced attributes on delegates

### DIFF
--- a/src/Framework/Analyzer/src/DelegateEndpoints/DelegateEndpointAnalyzer.cs
+++ b/src/Framework/Analyzer/src/DelegateEndpoints/DelegateEndpointAnalyzer.cs
@@ -18,6 +18,7 @@ public partial class DelegateEndpointAnalyzer : DiagnosticAnalyzer
     {
         DiagnosticDescriptors.DoNotUseModelBindingAttributesOnDelegateEndpointParameters,
         DiagnosticDescriptors.DoNotReturnActionResultsFromMapActions,
+        DiagnosticDescriptors.DetectMisplacedLambdaAttribute
     });
 
     public override void Initialize(AnalysisContext context)
@@ -54,6 +55,7 @@ public partial class DelegateEndpointAnalyzer : DiagnosticAnalyzer
                     var lambda = ((IAnonymousFunctionOperation)delegateCreation.Target);
                     DisallowMvcBindArgumentsOnParameters(in operationAnalysisContext, wellKnownTypes, invocation, lambda.Symbol);
                     DisallowReturningActionResultFromMapMethods(in operationAnalysisContext, wellKnownTypes, invocation, lambda);
+                    DetectMisplacedLambdaAttribute(operationAnalysisContext, invocation, lambda);
                 }
                 else if (delegateCreation.Target.Kind == OperationKind.MethodReference)
                 {

--- a/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
+++ b/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
@@ -72,7 +72,7 @@ public partial class DelegateEndpointAnalyzer : DiagnosticAnalyzer
             if (@namespace != null && !@namespace.IsGlobalNamespace)
             {
                 // Check for Microsoft.AspNetCore in the ContainingNamespaces for this type
-                if (@namespace.Name.Equals("AspNetCore", StringComparison.Ordinal) && @namespace.ContainingNamespace.Name.Equals("Microsoft", StringComparison.Ordinal))
+                if (@namespace.Name.Equals("AspNetCore", System.StringComparison.Ordinal) && @namespace.ContainingNamespace.Name.Equals("Microsoft", System.StringComparison.Ordinal))
                 {
                     return true;
                 }

--- a/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
+++ b/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
@@ -72,7 +72,7 @@ public partial class DelegateEndpointAnalyzer : DiagnosticAnalyzer
             if (@namespace != null && !@namespace.IsGlobalNamespace)
             {
                 // Check for Microsoft.AspNetCore in the ContainingNamespaces for this type
-                if (@namespace.Name.Equals("AspNetCore") && @namespace.ContainingNamespace.Name.Equals("Microsoft"))
+                if (@namespace.Name.Equals("AspNetCore", StringComparison.Ordinal) && @namespace.ContainingNamespace.Name.Equals("Microsoft", StringComparison.Ordinal))
                 {
                     return true;
                 }

--- a/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
+++ b/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
@@ -67,18 +67,17 @@ public partial class DelegateEndpointAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        static bool IsInValidNamespace(INamespaceSymbol? containingNamespace)
+        bool IsInValidNamespace(INamespaceSymbol? @namespace)
         {
-            var supportedNamespace = "Microsoft.AspNetCore";
-
-            if (containingNamespace != null)
+            if (@namespace != null && !@namespace.IsGlobalNamespace)
             {
-                if (containingNamespace.ToString().Equals(supportedNamespace, System.StringComparison.OrdinalIgnoreCase))
+                // Check for Microsoft.AspNetCore in the ContainingNamespaces for this type
+                if (@namespace.Name.Equals("AspNetCore") && @namespace.ContainingNamespace.Name.Equals("Microsoft"))
                 {
                     return true;
                 }
 
-                return IsInValidNamespace(containingNamespace.ContainingNamespace);
+                return IsInValidNamespace(@namespace.ContainingNamespace);
             }
 
             return false;

--- a/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
+++ b/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.AspNetCore.Analyzers.DelegateEndpoints;
+
+public partial class DelegateEndpointAnalyzer : DiagnosticAnalyzer
+{
+    private static void DetectMisplacedLambdaAttribute(
+        in OperationAnalysisContext context,
+        IInvocationOperation invocation,
+        IAnonymousFunctionOperation lambda)
+    {
+        // This analyzer will only process invocations that are immediate children of the
+        // AnonymousFunctionOperation provided as the delegate endpoint. We'll support checking
+        // for misplaced attributes in `() => Hello()` and `() => { return Hello(); }` but not in:
+        // () => {
+        //    Hello();
+        //    return "foo";
+        // }
+        InvocationExpressionSyntax? targetInvocation = null;
+
+        // () => Hello() has a single child which is a BlockOperation so we check to see if
+        // expression associated with that operation is an invocation expression
+        if (lambda.Children.First().Syntax is InvocationExpressionSyntax innerInvocation)
+        {
+            targetInvocation = innerInvocation;
+        }
+
+        if (lambda.Children.First().Children.First() is IReturnOperation returnOperation
+            && returnOperation.ReturnedValue is IInvocationOperation returnedInvocation)
+
+        {
+            targetInvocation = (InvocationExpressionSyntax)returnedInvocation.Syntax;
+        }
+
+        if (targetInvocation is null)
+        {
+            return;
+        }
+
+
+        var methodOperation = invocation.SemanticModel.GetSymbolInfo(targetInvocation);
+
+        var attributes = methodOperation.Symbol.GetAttributes();
+        var location = lambda.Syntax.GetLocation();
+
+        foreach (var attribute in attributes)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.DetectMisplacedLambdaAttribute,
+                location,
+                attribute.AttributeClass?.Name,
+                methodOperation.Symbol.Name));
+        }
+    }
+}

--- a/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
+++ b/src/Framework/Analyzer/src/DelegateEndpoints/DetectMisplacedLambdaAttribute.cs
@@ -57,7 +57,7 @@ public partial class DelegateEndpointAnalyzer : DiagnosticAnalyzer
 
         foreach (var attribute in attributes)
         {
-            if (IsInValidNamespace(attribute))
+            if (IsInValidNamespace(attribute.AttributeClass?.ContainingNamespace))
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     DiagnosticDescriptors.DetectMisplacedLambdaAttribute,
@@ -67,19 +67,21 @@ public partial class DelegateEndpointAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        bool IsInValidNamespace(AttributeData attribute)
+        static bool IsInValidNamespace(INamespaceSymbol? containingNamespace)
         {
             var supportedNamespace = "Microsoft.AspNetCore";
-            var symbolDisplayFormat = new SymbolDisplayFormat(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
 
-            if (attribute.AttributeClass is null)
+            if (containingNamespace != null)
             {
-                return false;
+                if (containingNamespace.ToString().Equals(supportedNamespace, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                return IsInValidNamespace(containingNamespace.ContainingNamespace);
             }
 
-            var fullyQualifiedName = attribute.AttributeClass.ContainingNamespace.ToDisplayString(symbolDisplayFormat);
-            return fullyQualifiedName.StartsWith(supportedNamespace, System.StringComparison.OrdinalIgnoreCase);
+            return false;
         }
     }
 }

--- a/src/Framework/Analyzer/src/DelegateEndpoints/DiagnosticDescriptors.cs
+++ b/src/Framework/Analyzer/src/DelegateEndpoints/DiagnosticDescriptors.cs
@@ -25,5 +25,14 @@ namespace Microsoft.AspNetCore.Analyzers.DelegateEndpoints
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             helpLinkUri: "https://aka.ms/aspnet/analyzers");
+
+        internal static readonly DiagnosticDescriptor DetectMisplacedLambdaAttribute = new(
+            "ASP0005",
+            "Do not place attribute on invoked method",
+            "'{0}' should not be placed on '{1}'. Place '{0}' on the endpoint delegate instead.",
+            "Usage",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://aka.ms/aspnet/analyzers");
     }
 }

--- a/src/Framework/Analyzer/src/DelegateEndpoints/DiagnosticDescriptors.cs
+++ b/src/Framework/Analyzer/src/DelegateEndpoints/DiagnosticDescriptors.cs
@@ -28,8 +28,8 @@ namespace Microsoft.AspNetCore.Analyzers.DelegateEndpoints
 
         internal static readonly DiagnosticDescriptor DetectMisplacedLambdaAttribute = new(
             "ASP0005",
-            "Do not place attribute on invoked method",
-            "'{0}' should not be placed on '{1}'. Place '{0}' on the endpoint delegate instead.",
+            "Do not place attribute on route handlers",
+            "'{0}' should be placed on the endpoint delegate to be effective",
             "Usage",
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,

--- a/src/Framework/Analyzer/test/MinimalActions/DetectMisplacedLambdaAttributeTest.cs
+++ b/src/Framework/Analyzer/test/MinimalActions/DetectMisplacedLambdaAttributeTest.cs
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.AspNetCore.Analyzer.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Analyzers.DelegateEndpoints;
+
+public partial class DetectMisplacedLambdaAttributeTest
+{
+    private TestDiagnosticAnalyzerRunner Runner { get; } = new(new DelegateEndpointAnalyzer());
+
+    [Fact]
+    public async Task MinimalAction_WithCorrectlyPlacedAttribute_Works()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+app.MapGet(""/"", [Authorize] () => Hello());
+void Hello() { }
+";
+        // Act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source);
+
+        // Assert
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task MinimalAction_WithMisplacedAttribute_ProducesDiagnostics()
+    {
+        // Arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+app.MapGet(""/"", /*MM*/() => Hello());
+[Authorize]
+void Hello() { }
+");
+        // Act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+
+        // Assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DetectMisplacedLambdaAttribute, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("'AuthorizeAttribute' should not be placed on 'Hello'. Place 'AuthorizeAttribute' on the endpoint delegate instead.", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task MinimalAction_WithMisplacedAttributeAndBlockSyntax_ProducesDiagnostics()
+    {
+        // Arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+app.MapGet(""/"", /*MM*/() => { return Hello(); });
+[Authorize]
+string Hello() { return ""foo""; }
+");
+        // Act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+
+        // Assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DetectMisplacedLambdaAttribute, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("'AuthorizeAttribute' should not be placed on 'Hello'. Place 'AuthorizeAttribute' on the endpoint delegate instead.", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task MinimalAction_WithMultipleMisplacedAttributes_ProducesDiagnostics()
+    {
+        // Arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+var app = WebApplication.Create();
+app.MapGet(""/"", /*MM*/() => Hello());
+[Authorize]
+[Produces(""application/xml"")]
+void Hello() { }
+");
+        // Act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+
+        // Assert
+        Assert.Collection(diagnostics,
+            diagnostic => {
+                Assert.Same(DiagnosticDescriptors.DetectMisplacedLambdaAttribute, diagnostic.Descriptor);
+                AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+                Assert.Equal("'AuthorizeAttribute' should not be placed on 'Hello'. Place 'AuthorizeAttribute' on the endpoint delegate instead.", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+            },
+            diagnostic => {
+                Assert.Same(DiagnosticDescriptors.DetectMisplacedLambdaAttribute, diagnostic.Descriptor);
+                AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+                Assert.Equal("'ProducesAttribute' should not be placed on 'Hello'. Place 'ProducesAttribute' on the endpoint delegate instead.", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+            }
+        );
+    }
+
+    [Fact]
+    public async Task MinimalAction_WithSingleMisplacedAttribute_ProducesDiagnostics()
+    {
+        // Arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+var app = WebApplication.Create();
+app.MapGet(""/"", /*MM*/[Authorize]() => Hello());
+[Produces(""application/xml"")]
+void Hello() { }
+");
+        // Act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+
+        // Assert
+        Assert.Collection(diagnostics,
+            diagnostic => {
+                Assert.Same(DiagnosticDescriptors.DetectMisplacedLambdaAttribute, diagnostic.Descriptor);
+                AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+                Assert.Equal("'ProducesAttribute' should not be placed on 'Hello'. Place 'ProducesAttribute' on the endpoint delegate instead.", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+            }
+        );
+    }
+
+    [Fact]
+    public async Task MinimalAction_DoesNotWarnOnNonReturningMethods()
+    {
+        // Arrange
+        var source = @"
+using System;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+app.MapGet(""/"", /*MM*/() => {
+    Console.WriteLine(""foo"");
+    return ""foo"";
+});";
+        // Act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source);
+
+        // Assert
+        Assert.Empty(diagnostics);
+    }
+}
+


### PR DESCRIPTION
This PR adds an analyzer that detects if attributes are incorrectly placed on a method invoked from an attribute in a lambda.

```csharp
using Microsoft.AspNetCore.Authorization;
using Microsoft.AspNetCore.Builder;
var app = WebApplication.Create();
app.MapGet(""/"", () => Hello());
[Authorize]
void Hello() { }
```

The above will produce a diagnostic warning the user about the misplaced `AuthorizeAttribute` with the following message:

> 'AuthorizeAttribute' should not be placed on 'Hello'. Place 'AuthorizeAttribute' on the endpoint delegate instead.

Fixes https://github.com/dotnet/aspnetcore/issues/35638
