### PR TITLE
Add ParameterInfo argument to BindAsync

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -818,11 +818,9 @@ namespace Microsoft.AspNetCore.Http
             var isOptional = IsOptionalParameter(parameter);
 
             // Get the BindAsync method for the type.
-            var bindAsyncWithoutParameterInfo = TryParseMethodCache.FindBindAsyncMethod(parameter.ParameterType);
+            var bindAsyncExpression = TryParseMethodCache.FindBindAsyncMethod(parameter);
             // We know BindAsync exists because there's no way to opt-in without defining the method on the type.
-            Debug.Assert(bindAsyncWithoutParameterInfo is not null);
-
-            var bindAsyncExpression = bindAsyncWithoutParameterInfo(parameter);
+            Debug.Assert(bindAsyncExpression is not null);
 
             // Compile the delegate to the BindAsync method for this parameter index
             var bindAsyncDelegate = Expression.Lambda<Func<HttpContext, ValueTask<object?>>>(bindAsyncExpression, HttpContextExpr).Compile();

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -548,7 +548,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
         private record struct MyBindAsyncStruct(Uri Uri)
         {
-            public static ValueTask<MyBindAsyncStruct?> BindAsync(HttpContext context, ParameterInfo parameter)
+            public static ValueTask<MyBindAsyncStruct> BindAsync(HttpContext context, ParameterInfo parameter)
             {
                 Assert.Equal(typeof(MyBindAsyncStruct), parameter.ParameterType);
                 Assert.Equal("myBindAsyncStruct", parameter.Name);

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Net;
@@ -25,7 +24,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Routing.Internal
 {

--- a/src/Http/Http.Extensions/test/TryParseMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/TryParseMethodCacheTests.cs
@@ -3,11 +3,9 @@
 
 #nullable enable
 
-using System;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Http.Extensions.Tests
 {
@@ -172,15 +170,15 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         {
             var type = typeof(BindAsyncRecord);
             var cache = new TryParseMethodCache();
-            var methodFoundFunc = cache.FindBindAsyncMethod(type);
+            var parameter = new MockParameterInfo(type, "bindAsyncRecord");
+            var methodFound = cache.FindBindAsyncMethod(parameter);
 
-            Assert.NotNull(methodFoundFunc);
+            Assert.NotNull(methodFound);
 
             var parsedValue = Expression.Variable(type, "parsedValue");
-            var methodFound = methodFoundFunc!(new MockParameterInfo(type, "bindAsyncRecord"));
 
             var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object>>>(
-                Expression.Block(new[] { parsedValue }, methodFound),
+                Expression.Block(new[] { parsedValue }, methodFound!),
                 cache.HttpContextExpr).Compile();
 
             var httpContext = new DefaultHttpContext

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -737,7 +737,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
         private record BindAsyncRecord(int Value)
         {
-            public static ValueTask<object> BindAsync(HttpContext context) =>
+            public static ValueTask<BindAsyncRecord> BindAsync(HttpContext context, ParameterInfo parameter) =>
                 throw new NotImplementedException();
             public static bool TryParse(string value, out BindAsyncRecord result) =>
                 throw new NotImplementedException();

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -142,6 +142,8 @@ namespace Microsoft.AspNetCore.Http
                 {
                     return (parameter) =>
                     {
+                        // parameter is being intentionally shadowed. We never want to use the outer ParameterInfo inside
+                        // this Func because the ParameterInfo varies after it's been cached for a given parameter type.
                         var typedCall = Expression.Call(methodInfo, HttpContextExpr, Expression.Constant(parameter));
                         return Expression.Call(ConvertValueTaskMethod.MakeGenericMethod(type), typedCall);
                     };

--- a/src/Shared/TryParseMethodCache.cs
+++ b/src/Shared/TryParseMethodCache.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Http
         }
 
         public bool HasBindAsyncMethod(ParameterInfo parameter) =>
-            FindBindAsyncMethod(parameter.ParameterType) is not null;
+            FindBindAsyncMethod(parameter) is not null;
 
         public Func<ParameterExpression, Expression>? FindTryParseStringMethod(Type type)
         {
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Http
             return _stringMethodCallCache.GetOrAdd(type, Finder);
         }
 
-        public Func<ParameterInfo, Expression>? FindBindAsyncMethod(Type type)
+        public Expression? FindBindAsyncMethod(ParameterInfo parameter)
         {
             Func<ParameterInfo, Expression>? Finder(Type type)
             {
@@ -150,7 +150,7 @@ namespace Microsoft.AspNetCore.Http
                 return null;
             }
 
-            return _bindAsyncMethodCallCache.GetOrAdd(type, Finder);
+            return _bindAsyncMethodCallCache.GetOrAdd(parameter.ParameterType, Finder)?.Invoke(parameter);
         }
 
         private static MethodInfo GetEnumTryParseMethod(bool preferNonGenericEnumParseOverload)


### PR DESCRIPTION
Before:

```C#
var builder = WebApplication.CreateBuilder(args);
var app = builder.Build();

app.MapGet("/webhook", (CloudEvent cloudEvent) =>
{
    redis.Publish(cloudEvent);
});

app.Run();

public class CloudEvent
{
    public static async ValueTask<object?> BindAsync(HttpContext context)
    {
        return await CloudEventParser.ReadEventAsync(context);
    }
}
```

After:

```C#
public class CloudEvent
{
    public static async ValueTask<CloudEvent?> BindAsync(HttpContext context, ParameterInfo parameter)
    {
        return await CloudEventParser.ReadEventAsync(context, parameter.Name);
    }
}
```

This adds a `ParameterInfo` as a second parameter and changes the return type from `ValueTask<object?>` to `ValueTask<T>` (and/or `ValueTask<T?>` for reference types).

Static methods with close-but-different signatures (e.g. `ValueTask<CloudEvent?> BindAsync(HttpContext context)` or `ValueTask<object?> BindAsync(HttpContext context, ParameterInfo parameter)` will not be matched.

Note: If CloudEvent is a struct, the return type must be `ValueTask<CloudEventStruct>` not `ValueTask<ClouldEventStruct?>`. I do not think this is a major issue since if CloudEven was a struct we already wouldn't call `BindAsync` given a `CloudEventStruct?` parameter. When we add support for nullable struct BindAsync parameter, we should also look for a nullable-returning BindAsync method.

```C#
public struct CloudEventStruct
{
	// This will NOT be matched because it returns a nullable struct!!!
    public static async ValueTask<CloudEventStruct?> BindAsync(HttpContext context, ParameterInfo parameter)
    {
        return await CloudEventParser.ReadEventAsync(context, parameter.Name);
    }
}
```

Fixes #35748
