### PR TITLE
[release/6.0-rc1] Add API parameter description to API description to represent the request body - 35421

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -119,6 +118,22 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 {
                     hasJsonBody = true;
                 }
+
+                apiDescription.ParameterDescriptions.Add(parameterDescription);
+            }
+
+            // Get custom attributes for the handler. ConsumesAttribute is one of the examples. 
+            var acceptsRequestType = routeEndpoint.Metadata.GetMetadata<IAcceptsMetadata>()?.RequestType;
+            if (acceptsRequestType is not null)
+            {
+                var parameterDescription = new ApiParameterDescription
+                {
+                    Name = acceptsRequestType.Name,
+                    ModelMetadata = CreateModelMetadata(acceptsRequestType),
+                    Source = BindingSource.Body,
+                    Type = acceptsRequestType,
+                    IsRequired = true,
+                };
 
                 apiDescription.ParameterDescriptions.Add(parameterDescription);
             }

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -114,6 +114,20 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         }
 
         [Fact]
+        public void AddsMultipleRequestFormatsFromMetadataWithRequestType()
+        {
+            var apiDescription = GetApiDescription(
+                [Consumes(typeof(InferredJsonClass), "application/custom0", "application/custom1")]
+                () => { });
+
+            Assert.Equal(2, apiDescription.SupportedRequestFormats.Count);
+
+            var apiParameterDescription = apiDescription.ParameterDescriptions[0];
+            Assert.Equal("InferredJsonClass", apiParameterDescription.Type.Name);
+            Assert.True(apiParameterDescription.IsRequired);
+        }
+
+        [Fact]
         public void AddsJsonResponseFormatWhenFromBodyInferred()
         {
             static void AssertJsonResponse(ApiDescription apiDescription, Type expectedType)

--- a/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/OpenApiEndpointConventionBuilderExtensions.cs
@@ -130,7 +130,8 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="contentType">The request content type. Defaults to "application/json" if empty.</param>
         /// <param name="additionalContentTypes">Additional response content types the endpoint produces for the supplied status code.</param>
         /// <returns>A <see cref="DelegateEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static DelegateEndpointConventionBuilder Accepts<TRequest>(this DelegateEndpointConventionBuilder builder, string contentType, params string[] additionalContentTypes)
+        public static DelegateEndpointConventionBuilder Accepts<TRequest>(this DelegateEndpointConventionBuilder builder,
+            string contentType, params string[] additionalContentTypes)
         {
             Accepts(builder, typeof(TRequest), contentType, additionalContentTypes);
 
@@ -146,8 +147,8 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="contentType">The response content type that the endpoint accepts.</param>
         /// <param name="additionalContentTypes">Additional response content types the endpoint accepts</param>
         /// <returns>A <see cref="DelegateEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static DelegateEndpointConventionBuilder Accepts(this DelegateEndpointConventionBuilder builder, Type requestType,
-            string contentType, params string[] additionalContentTypes)
+        public static DelegateEndpointConventionBuilder Accepts(this DelegateEndpointConventionBuilder builder,
+            Type requestType, string contentType, params string[] additionalContentTypes)
         {
             builder.WithMetadata(new ConsumesAttribute(requestType, contentType, additionalContentTypes));
             return builder;


### PR DESCRIPTION
Backport of #35654 to release/6.0-rc1

## Customer Impact

This PR will make it possible  for customers to view the incoming request body schemas and media types for Minimal endpoints in the API explorer (Swagger)

## Regression?
- [ ] Yes
- [X] No

## Risk
- [ ] High
- [ ] Medium
- [X] Low

No change in functionality, just a change to namespace.

## Verification
- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A

Fixes #35421 
