### PR TITLE
[release/6.0] HTTP/3: Support canceling requests that aren't reading a body

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/IProtocolErrorCodeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IProtocolErrorCodeFeature.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Connections.Features
     public interface IProtocolErrorCodeFeature
     {
         /// <summary>
-        /// Gets or sets the error code.
+        /// Gets or sets the error code. The property returns -1 if the error code hasn't been set.
         /// </summary>
         long Error { get; set; }
     }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.FeatureCollection.cs
@@ -16,8 +16,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
     {
         private X509Certificate2? _clientCert;
         private Task<X509Certificate2?>? _clientCertTask;
+        private long? _error;
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public X509Certificate2? ClientCertificate
         {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -83,9 +83,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                     return;
                 }
 
+                var resolvedErrorCode = _error ?? 0;
                 _abortReason = ExceptionDispatchInfo.Capture(abortReason);
-                _log.ConnectionAbort(this, Error, abortReason.Message);
-                _closeTask = _connection.CloseAsync(errorCode: Error).AsTask();
+                _log.ConnectionAbort(this, resolvedErrorCode, abortReason.Message);
+                _closeTask = _connection.CloseAsync(errorCode: resolvedErrorCode).AsTask();
             }
         }
 
@@ -127,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicConnectionAbortedException ex)
             {
                 // Shutdown initiated by peer, abortive.
-                Error = ex.ErrorCode;
+                _error = ex.ErrorCode;
                 _log.ConnectionAborted(this, ex.ErrorCode, ex);
 
                 ThreadPool.UnsafeQueueUserWorkItem(state =>

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
@@ -9,11 +9,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
     internal sealed partial class QuicStreamContext : IPersistentStateFeature, IStreamDirectionFeature, IProtocolErrorCodeFeature, IStreamIdFeature, IStreamAbortFeature
     {
         private IDictionary<object, object?>? _persistentState;
+        private long? _error;
 
         public bool CanRead { get; private set; }
         public bool CanWrite { get; private set; }
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public long StreamId { get; private set; }
 

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -181,6 +181,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             read = await serverStream.Transport.Input.ReadAsync().DefaultTimeout();
             Assert.True(read.IsCompleted);
 
+            await serverStream.Transport.Output.CompleteAsync();
+
             await closedTcs.Task.DefaultTimeout();
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -112,10 +112,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 
             var qex = await Assert.ThrowsAsync<QuicException>(async () => await clientConnection.ConnectAsync().DefaultTimeout());
             Assert.Equal("Connection has been shutdown by transport. Error Code: 0x80410100", qex.Message);
-
-            // https://github.com/dotnet/runtime/issues/57246 The accept still completes even though the connection was rejected, but it's already failed.
-            var serverContext = await connectionListener.AcceptAndAddFeatureAsync().DefaultTimeout();
-            await Assert.ThrowsAsync<QuicException>(() => serverContext.ConnectAsync().DefaultTimeout());
         }
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
@@ -139,6 +139,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             await serverStream.Transport.Input.CompleteAsync().DefaultTimeout();
             await serverStream.Transport.Output.CompleteAsync().DefaultTimeout();
 
+            Logger.LogInformation("Client reading until end of stream.");
+            var data = await clientStream.ReadUntilEndAsync().DefaultTimeout();
+            Assert.Equal(testData.Length, data.Length);
+            Assert.Equal(testData, data);
+
             var quicStreamContext = Assert.IsType<QuicStreamContext>(serverStream);
 
             Logger.LogInformation("Server waiting for send and receiving loops to complete.");
@@ -149,11 +154,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             Logger.LogInformation("Server disposing stream.");
             await quicStreamContext.DisposeAsync().DefaultTimeout();
             quicStreamContext.Dispose();
-
-            Logger.LogInformation("Client reading until end of stream.");
-            var data = await clientStream.ReadUntilEndAsync().DefaultTimeout();
-            Assert.Equal(testData.Length, data.Length);
-            Assert.Equal(testData, data);
 
             var quicConnectionContext = Assert.IsType<QuicConnectionContext>(serverConnection);
 
@@ -402,6 +402,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 
             Assert.Equal(TestData, data);
 
+            Logger.LogInformation("Server aborting stream");
             ((IProtocolErrorCodeFeature)serverStream).Error = (long)Http3ErrorCode.InternalError;
             serverStream.Abort(new ConnectionAbortedException("Test message"));
 

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -922,7 +922,7 @@ namespace Microsoft.AspNetCore.Testing
         });
 
         private readonly Http3InMemory _testBase;
-        private long _error;
+        private long? _error;
 
         public TestMultiplexedConnectionContext(Http3InMemory testBase)
         {
@@ -946,7 +946,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public long Error
         {
-            get => _error;
+            get => _error ?? -1;
             set => _error = value;
         }
 
@@ -1019,6 +1019,7 @@ namespace Microsoft.AspNetCore.Testing
 
         private TaskCompletionSource _disposingTcs;
         private TaskCompletionSource _disposedTcs;
+        internal long? _error;
 
         public TestStreamContext(bool canRead, bool canWrite, Http3InMemory testBase)
         {
@@ -1072,6 +1073,7 @@ namespace Microsoft.AspNetCore.Testing
             ConnectionId = "TEST:" + streamId.ToString();
             AbortReadException = null;
             AbortWriteException = null;
+            _error = null;
 
             _disposedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _disposingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1112,7 +1114,11 @@ namespace Microsoft.AspNetCore.Testing
 
         public bool CanWrite { get; }
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public override void Abort(ConnectionAbortedException abortReason)
         {

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Testing
                 localEndPoint: localEndPoint,
                 remoteEndPoint: remoteEndPoint,
                 streamLifetimeHandler: streamLifetimeHandler,
-                streamContext: null,
+                streamContext: new DefaultConnectionContext(),
                 clientPeerSettings: new Http3PeerSettings(),
                 serverPeerSettings: null
             );

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
@@ -263,10 +263,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await requestStream.OnDisposingTask.DefaultTimeout();
 
             Http3Api.TriggerTick(now);
-            Assert.Equal(0, requestStream.Error);
+            Assert.Null(requestStream.StreamContext._error);
 
             Http3Api.TriggerTick(now + TimeSpan.FromTicks(1));
-            Assert.Equal(0, requestStream.Error);
+            Assert.Null(requestStream.StreamContext._error);
 
             Http3Api.TriggerTick(now + limits.MinResponseDataRate.GracePeriod + TimeSpan.FromTicks(1));
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -517,7 +517,7 @@ namespace Interop.FunctionalTests.Http3
         // Verify HTTP/2 and HTTP/3 match behavior
         [ConditionalTheory]
         [MsQuicSupported]
-        [InlineData(HttpProtocols.Http3, Skip = "https://github.com/dotnet/runtime/issues/56129")]
+        [InlineData(HttpProtocols.Http3)]
         [InlineData(HttpProtocols.Http2)]
         public async Task POST_ClientCancellationBidirectional_RequestAbortRaised(HttpProtocols protocol)
         {
@@ -525,6 +525,8 @@ namespace Interop.FunctionalTests.Http3
             var cancelledTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var readAsyncTask = new TaskCompletionSource<Task>(TaskCreationOptions.RunContinuationsAsynchronously);
             var clientHasCancelledSyncPoint = new SyncPoint();
+
+            using var httpEventSource = new HttpEventSourceListener(LoggerFactory);
 
             var builder = CreateHostBuilder(async context =>
             {
@@ -586,6 +588,7 @@ namespace Interop.FunctionalTests.Http3
                 await requestStream.FlushAsync().DefaultTimeout();
                 // Write content
                 await requestStream.WriteAsync(TestData).DefaultTimeout();
+                await requestStream.FlushAsync().DefaultTimeout();
 
                 var response = await responseTask.DefaultTimeout();
 
@@ -620,7 +623,7 @@ namespace Interop.FunctionalTests.Http3
         // Verify HTTP/2 and HTTP/3 match behavior
         [ConditionalTheory]
         [MsQuicSupported]
-        [InlineData(HttpProtocols.Http3, Skip = "https://github.com/dotnet/runtime/issues/56129")]
+        [InlineData(HttpProtocols.Http3)]
         [InlineData(HttpProtocols.Http2)]
         public async Task GET_ClientCancellationAfterResponseHeaders_RequestAbortRaised(HttpProtocols protocol)
         {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Tracing;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Interop.FunctionalTests.Http3
+{
+    public sealed class HttpEventSourceListener : EventListener
+    {
+        private readonly StringBuilder _messageBuilder = new StringBuilder();
+        private readonly ILogger _logger;
+        private readonly object _lock = new object();
+        private bool _disposed;
+
+        public HttpEventSourceListener(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger(nameof(HttpEventSourceListener));
+            _logger.LogDebug($"Starting {nameof(HttpEventSourceListener)}.");
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            base.OnEventSourceCreated(eventSource);
+
+            if (eventSource.Name.Contains("System.Net.Quic") ||
+                eventSource.Name.Contains("System.Net.Http"))
+            {
+                lock (_lock)
+                {
+                    if (!_disposed)
+                    {
+                        EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.All);
+                    }
+                }
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            base.OnEventWritten(eventData);
+
+            string message;
+            lock (_messageBuilder)
+            {
+                _messageBuilder.Append("<- Event ");
+                _messageBuilder.Append(eventData.EventSource.Name);
+                _messageBuilder.Append(" - ");
+                _messageBuilder.Append(eventData.EventName);
+                _messageBuilder.Append(" : ");
+                _messageBuilder.AppendJoin(',', eventData.Payload!);
+                _messageBuilder.Append(" ->");
+                message = _messageBuilder.ToString();
+                _messageBuilder.Clear();
+            }
+
+            // We don't know the state of the logger after dispose.
+            // Ensure that any messages written in the background aren't
+            // logged after the listener has been disposed in the test.
+            lock (_lock)
+            {
+                if (!_disposed)
+                {
+                    // EventListener base constructor subscribes to events.
+                    // It is possible to start getting events before the
+                    // super constructor is run and logger is assigned.
+                    _logger?.LogDebug(message);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return _messageBuilder.ToString();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            lock (_lock)
+            {
+                if (!_disposed)
+                {
+                    _logger?.LogDebug($"Stopping {nameof(HttpEventSourceListener)}.");
+                    _disposed = true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
React to https://github.com/dotnet/runtime/pull/58236.

* New API isn't available yet. Verified it works locally.
* HttpClient cancellation on abort response isn't available in main so used 6.0 branch temporarily.