### PR TITLE
Remove unusued using statement (fixes #35840)

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
@@ -8,9 +8,6 @@ using Graph = Microsoft.Graph;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.Identity.Web;
 #endif
-#if (EnableOpenAPI)
-using Microsoft.OpenApi.Models;
-#endif
 #if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || EnableOpenAPI)
 
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
@@ -8,7 +8,7 @@ using Graph = Microsoft.Graph;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.Identity.Web;
 #endif
-#if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || EnableOpenAPI)
+#if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph)
 
 #endif
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
**PR Title**
Remove unused using statement in template

**PR Description**
Removing unused `using Microsoft.OpenApi.Models` statement that no longer is needed in default template and removes Roslyn code-fix suggestion 

Fixes #35840
