### PR TITLE
onBoard package validation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,12 @@
     <AnalysisMode>Default</AnalysisMode>
   </PropertyGroup>
 
+  <!-- Properties for Package Validation -->
+  <PropertyGroup>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <DisablePackageBaselineValidation Condition="'$(IsServicingBuild)' != 'true'">true</DisablePackageBaselineValidation>
+  </PropertyGroup>
+
   <!-- Defines project type conventions. -->
   <PropertyGroup>
     <RepoRelativeProjectDir>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</RepoRelativeProjectDir>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,7 @@
   <PropertyGroup>
     <EnablePackageValidation>true</EnablePackageValidation>
     <DisablePackageBaselineValidation Condition="'$(IsServicingBuild)' != 'true'">true</DisablePackageBaselineValidation>
+    <GenerateCompatibilitySuppressionFile>true</GenerateCompatibilitySuppressionFile>
   </PropertyGroup>
 
   <!-- Defines project type conventions. -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,13 +15,6 @@
     <AnalysisMode>Default</AnalysisMode>
   </PropertyGroup>
 
-  <!-- Properties for Package Validation -->
-  <PropertyGroup>
-    <EnablePackageValidation>true</EnablePackageValidation>
-    <DisablePackageBaselineValidation Condition="'$(IsServicingBuild)' != 'true'">true</DisablePackageBaselineValidation>
-    <GenerateCompatibilitySuppressionFile>true</GenerateCompatibilitySuppressionFile>
-  </PropertyGroup>
-
   <!-- Defines project type conventions. -->
   <PropertyGroup>
     <RepoRelativeProjectDir>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</RepoRelativeProjectDir>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -169,6 +169,13 @@
     <BuildDependsOn>$(BuildDependsOn);_CopySymbolsToArtifacts</BuildDependsOn>
   </PropertyGroup>
 
+  <!-- Properties for Package Validation -->
+  <PropertyGroup Condition="'$(ExcludeFromSourceBuild)' != 'true'">
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <DisablePackageBaselineValidation Condition="'$(IsServicingBuild)' != 'true'">true</DisablePackageBaselineValidation>
+    <GenerateCompatibilitySuppressionFile>true</GenerateCompatibilitySuppressionFile>
+  </PropertyGroup>
+
   <Target Name="_CopySymbolsToArtifacts">
     <Copy SourceFiles="$([System.IO.Path]::ChangeExtension('$(TargetPath)', 'pdb'))"
         DestinationFolder="$(SymbolsOutputPath)$(TargetFramework)"

--- a/src/Caching/SqlServer/src/CompatibilitySuppressions.xml
+++ b/src/Caching/SqlServer/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>System.ServiceModel.Internals.dll</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>SMDiagnostics.dll</Target>
+  </Suppression>
+</Suppressions>

--- a/src/DataProtection/DataProtection/src/CompatibilitySuppressions.xml
+++ b/src/DataProtection/DataProtection/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>System.ServiceModel.Internals.dll</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>SMDiagnostics.dll</Target>
+  </Suppression>
+</Suppressions>

--- a/src/DataProtection/Extensions/src/CompatibilitySuppressions.xml
+++ b/src/DataProtection/Extensions/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>System.ServiceModel.Internals.dll</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>SMDiagnostics.dll</Target>
+  </Suppression>
+</Suppressions>

--- a/src/DataProtection/StackExchangeRedis/src/CompatibilitySuppressions.xml
+++ b/src/DataProtection/StackExchangeRedis/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>System.ServiceModel.Internals.dll</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>SMDiagnostics.dll</Target>
+  </Suppression>
+</Suppressions>

--- a/src/Features/JsonPatch/src/CompatibilitySuppressions.xml
+++ b/src/Features/JsonPatch/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>System.ServiceModel.Internals.dll</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>SMDiagnostics.dll</Target>
+  </Suppression>
+</Suppressions>

--- a/src/FileProviders/Embedded/src/CompatibilitySuppressions.xml
+++ b/src/FileProviders/Embedded/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>System.ServiceModel.Internals.dll</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>SMDiagnostics.dll</Target>
+  </Suppression>
+</Suppressions>

--- a/src/SignalR/common/Protocols.MessagePack/src/CompatibilitySuppressions.xml
+++ b/src/SignalR/common/Protocols.MessagePack/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>System.ServiceModel.Internals.dll</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>SMDiagnostics.dll</Target>
+  </Suppression>
+</Suppressions>

--- a/src/SignalR/common/Protocols.NewtonsoftJson/src/CompatibilitySuppressions.xml
+++ b/src/SignalR/common/Protocols.NewtonsoftJson/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>System.ServiceModel.Internals.dll</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP1002</DiagnosticId>
+    <Target>SMDiagnostics.dll</Target>
+  </Suppression>
+</Suppressions>


### PR DESCRIPTION
Fixes #33981

> How/When can we get this version updated automatically? I believe it comes from dotnet/sdk right now - we could add a back-edge subscription that only fires once a week or so?

yes adding a toolset dependency to dotnet/sdk would be the best way to get the most recent changes. This tool is now part of the sdk as well so you can get that by using the daily sdk bits as well

> What else should we do to validate that this is doing what we expect? I see the below in a binlog of one of our shipping projects

sadly there is no other way that to check the logs to verify. We talked about adding something but it the eventual decision there was no

The file contention issues faced earlier in https://github.com/dotnet/aspnetcore/pull/34122 got resolved by https://github.com/dotnet/sdk/pull/20136

we should also port this change to release/6.0 branch

We will need an updated sdk for this one