### PR TITLE
Log time-taken more precisely

### DIFF
--- a/src/Middleware/HttpLogging/src/Microsoft.AspNetCore.HttpLogging.csproj
+++ b/src/Middleware/HttpLogging/src/Microsoft.AspNetCore.HttpLogging.csproj
@@ -20,5 +20,6 @@
     <Compile Include="$(RepoRoot)src\Shared\TaskToApm.cs" Link="Internal\TaskToApm.cs" />
     <Compile Include="$(SharedSourceRoot)Buffers\**\*.cs" LinkBase="Internal\" />
     <Compile Include="$(SharedSourceRoot)ValueStringBuilder\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)ValueStopwatch\*.cs" />
   </ItemGroup>
 </Project>

--- a/src/Middleware/HttpLogging/src/W3CLogger.cs
+++ b/src/Middleware/HttpLogging/src/W3CLogger.cs
@@ -48,19 +48,10 @@ namespace Microsoft.AspNetCore.HttpLogging
 
         private string Format(string[] elements)
         {
-            // Need to calculate TimeTaken now, if applicable
-            var date = elements[W3CLoggingMiddleware._dateIndex];
-            var time = elements[W3CLoggingMiddleware._timeIndex];
-            if (!string.IsNullOrEmpty(time))
+            if (_loggingFields.HasFlag(W3CLoggingFields.TimeTaken) && !string.IsNullOrEmpty(elements[W3CLoggingMiddleware._timeTakenIndex]))
             {
-                if (!string.IsNullOrEmpty(date) && _loggingFields.HasFlag(W3CLoggingFields.TimeTaken))
-                {
-                    DateTime start = DateTime.ParseExact(date + time, "yyyy-MM-ddHH:mm:ss.fff", CultureInfo.InvariantCulture);
-                    var elapsed = DateTime.UtcNow.Subtract(start);
-                    elements[W3CLoggingMiddleware._timeTakenIndex] = elapsed.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
-                }
-                // Trim milliseconds off of start-time
-                elements[W3CLoggingMiddleware._timeIndex] = time.Substring(0, 8);
+                // Need to calculate TimeTaken now, if applicable
+                elements[W3CLoggingMiddleware._timeTakenIndex] = (Environment.TickCount - Int32.Parse(elements[W3CLoggingMiddleware._timeTakenIndex])).ToString(CultureInfo.InvariantCulture);
             }
 
             // 200 is around the length of an average cookie-less entry

--- a/src/Middleware/HttpLogging/src/W3CLogger.cs
+++ b/src/Middleware/HttpLogging/src/W3CLogger.cs
@@ -51,11 +51,16 @@ namespace Microsoft.AspNetCore.HttpLogging
             // Need to calculate TimeTaken now, if applicable
             var date = elements[W3CLoggingMiddleware._dateIndex];
             var time = elements[W3CLoggingMiddleware._timeIndex];
-            if (!string.IsNullOrEmpty(date) && !string.IsNullOrEmpty(time) && _loggingFields.HasFlag(W3CLoggingFields.TimeTaken))
+            if (!string.IsNullOrEmpty(time))
             {
-                DateTime start = DateTime.ParseExact(date + time, "yyyy-MM-ddHH:mm:ss", CultureInfo.InvariantCulture);
-                var elapsed = DateTime.UtcNow.Subtract(start);
-                elements[W3CLoggingMiddleware._timeTakenIndex] = elapsed.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+                if (!string.IsNullOrEmpty(date) && _loggingFields.HasFlag(W3CLoggingFields.TimeTaken))
+                {
+                    DateTime start = DateTime.ParseExact(date + time, "yyyy-MM-ddHH:mm:ss.fff", CultureInfo.InvariantCulture);
+                    var elapsed = DateTime.UtcNow.Subtract(start);
+                    elements[W3CLoggingMiddleware._timeTakenIndex] = elapsed.TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+                }
+                // Trim milliseconds off of start-time
+                elements[W3CLoggingMiddleware._timeIndex] = time.Substring(0, 8);
             }
 
             // 200 is around the length of an average cookie-less entry

--- a/src/Middleware/HttpLogging/src/W3CLogger.cs
+++ b/src/Middleware/HttpLogging/src/W3CLogger.cs
@@ -48,12 +48,6 @@ namespace Microsoft.AspNetCore.HttpLogging
 
         private string Format(string[] elements)
         {
-            if (_loggingFields.HasFlag(W3CLoggingFields.TimeTaken) && !string.IsNullOrEmpty(elements[W3CLoggingMiddleware._timeTakenIndex]))
-            {
-                // Need to calculate TimeTaken now, if applicable
-                elements[W3CLoggingMiddleware._timeTakenIndex] = (Environment.TickCount - Int32.Parse(elements[W3CLoggingMiddleware._timeTakenIndex])).ToString(CultureInfo.InvariantCulture);
-            }
-
             // 200 is around the length of an average cookie-less entry
             var sb = new ValueStringBuilder(200);
             var firstElement = true;

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.HttpLogging
             bool shouldLog = false;
 
             var now = DateTime.UtcNow;
-            ValueStopwatch stopWatch = ValueStopwatch.StartNew();
+            var stopWatch = ValueStopwatch.StartNew();
             if (options.LoggingFields.HasFlag(W3CLoggingFields.Date))
             {
                 shouldLog |= AddToList(elements, _dateIndex, now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -98,9 +98,13 @@ namespace Microsoft.AspNetCore.HttpLogging
 
             if (options.LoggingFields.HasFlag(W3CLoggingFields.Time))
             {
-                // Start time will be logged to second precision, but we store it to millisecond precision so we can use it
-                // to calculate time-taken later.
-                shouldLog |= AddToList(elements, _timeIndex, now.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
+                shouldLog |= AddToList(elements, _timeIndex, now.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
+            }
+
+            if (options.LoggingFields.HasFlag(W3CLoggingFields.TimeTaken))
+            {
+                // Time taken will be calculated in W3CLogger based off of this start time
+                shouldLog |= AddToList(elements, _timeTakenIndex, Environment.TickCount.ToString(CultureInfo.InvariantCulture));
             }
 
             if (options.LoggingFields.HasFlag(W3CLoggingFields.ServerName))

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 
@@ -91,6 +92,7 @@ namespace Microsoft.AspNetCore.HttpLogging
             bool shouldLog = false;
 
             var now = DateTime.UtcNow;
+            ValueStopwatch stopWatch = ValueStopwatch.StartNew();
             if (options.LoggingFields.HasFlag(W3CLoggingFields.Date))
             {
                 shouldLog |= AddToList(elements, _dateIndex, now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
@@ -99,12 +101,6 @@ namespace Microsoft.AspNetCore.HttpLogging
             if (options.LoggingFields.HasFlag(W3CLoggingFields.Time))
             {
                 shouldLog |= AddToList(elements, _timeIndex, now.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
-            }
-
-            if (options.LoggingFields.HasFlag(W3CLoggingFields.TimeTaken))
-            {
-                // Time taken will be calculated in W3CLogger based off of this start time
-                shouldLog |= AddToList(elements, _timeTakenIndex, Environment.TickCount.ToString(CultureInfo.InvariantCulture));
             }
 
             if (options.LoggingFields.HasFlag(W3CLoggingFields.ServerName))
@@ -219,6 +215,11 @@ namespace Microsoft.AspNetCore.HttpLogging
             if (options.LoggingFields.HasFlag(W3CLoggingFields.ProtocolStatus))
             {
                 shouldLog |= AddToList(elements, _protocolStatusIndex, response.StatusCode.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (options.LoggingFields.HasFlag(W3CLoggingFields.TimeTaken))
+            {
+                shouldLog |= AddToList(elements, _timeTakenIndex, stopWatch.GetElapsedTime().TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
             }
 
             // Write the log

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -98,7 +98,9 @@ namespace Microsoft.AspNetCore.HttpLogging
 
             if (options.LoggingFields.HasFlag(W3CLoggingFields.Time))
             {
-                shouldLog |= AddToList(elements, _timeIndex, now.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
+                // Start time will be logged to second precision, but we store it to millisecond precision so we can use it
+                // to calculate time-taken later.
+                shouldLog |= AddToList(elements, _timeIndex, now.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
             }
 
             if (options.LoggingFields.HasFlag(W3CLoggingFields.ServerName))

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.HttpLogging
                     var elements = new string[W3CLoggingMiddleware._fieldsLength];
                     now = DateTime.UtcNow;
                     AddToList(elements, W3CLoggingMiddleware._dateIndex, now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-                    AddToList(elements, W3CLoggingMiddleware._timeIndex, now.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
+                    AddToList(elements, W3CLoggingMiddleware._timeIndex, now.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
 
                     logger.Log(elements);
                     await logger.Processor.WaitForWrites(4).DefaultTimeout();

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.HttpLogging
                 {
                     var elements = new string[W3CLoggingMiddleware._fieldsLength];
                     AddToList(elements, W3CLoggingMiddleware._dateIndex, _timestampOne.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-                    AddToList(elements, W3CLoggingMiddleware._timeIndex, _timestampOne.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
+                    AddToList(elements, W3CLoggingMiddleware._timeIndex, _timestampOne.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
 
                     logger.Log(elements);
                     await logger.Processor.WaitForWrites(4).DefaultTimeout();
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.HttpLogging
         public async Task HandlesNullValuesAsync()
         {
             var path = Path.GetTempFileName() + "_";
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             var options = new W3CLoggerOptions()
             {
                 LoggingFields = W3CLoggingFields.UriQuery | W3CLoggingFields.Host | W3CLoggingFields.ProtocolStatus,
@@ -95,6 +95,48 @@ namespace Microsoft.AspNetCore.HttpLogging
 
                     Assert.Equal("#Fields: cs-uri-query sc-status cs-host", lines[2]);
                     Assert.Equal("- - -", lines[3]);
+                }
+            }
+            finally
+            {
+                Helpers.DisposeDirectory(path);
+            }
+        }
+
+        [Fact]
+        public async Task TimeTakenIsInMilliseconds()
+        {
+            var path = Path.GetTempFileName() + "_";
+            DateTime now;
+            var options = new W3CLoggerOptions()
+            {
+                LoggingFields = W3CLoggingFields.Date | W3CLoggingFields.Time | W3CLoggingFields.TimeTaken,
+                LogDirectory = path
+            };
+            try
+            {
+                await using (var logger = new TestW3CLogger(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
+                {
+                    var elements = new string[W3CLoggingMiddleware._fieldsLength];
+                    now = DateTime.UtcNow;
+                    AddToList(elements, W3CLoggingMiddleware._dateIndex, now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                    AddToList(elements, W3CLoggingMiddleware._timeIndex, now.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
+
+                    logger.Log(elements);
+                    await logger.Processor.WaitForWrites(4).DefaultTimeout();
+
+                    var lines = logger.Processor.Lines;
+                    Assert.Equal("#Version: 1.0", lines[0]);
+
+                    Assert.StartsWith("#Start-Date: ", lines[1]);
+                    var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
+                    // Assert that the log was written in the last 10 seconds
+                    Assert.True(now.Subtract(startDate).TotalSeconds < 10);
+
+                    Assert.Equal("#Fields: date time time-taken", lines[2]);
+
+                    // Should be faster than 10 milliseconds
+                    Assert.True(Convert.ToDouble(lines[3].Substring(20)) < 10);
                 }
             }
             finally

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -141,8 +141,8 @@ namespace Microsoft.AspNetCore.HttpLogging
             Assert.True(now.Subtract(startDate).TotalSeconds < 10);
 
             Assert.Equal("#Fields: time-taken", lines[2]);
-            // Time taken should be less than 10 milliseconds
-            Assert.True(Double.Parse(lines[3]) < 10);
+            // Time taken should be less than 50 milliseconds
+            Assert.True(Double.Parse(lines[3], CultureInfo.InvariantCulture) < 50);
         }
 
         private IOptionsMonitor<W3CLoggerOptions> CreateOptionsAccessor()

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -141,8 +141,8 @@ namespace Microsoft.AspNetCore.HttpLogging
             Assert.True(now.Subtract(startDate).TotalSeconds < 10);
 
             Assert.Equal("#Fields: time-taken", lines[2]);
-            // Time taken should be less than 50 milliseconds
-            Assert.True(Double.Parse(lines[3], CultureInfo.InvariantCulture) < 50);
+            double num;
+            Assert.True(Double.TryParse(lines[3], NumberStyles.Number, CultureInfo.InvariantCulture, out num));
         }
 
         private IOptionsMonitor<W3CLoggerOptions> CreateOptionsAccessor()


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35613

`time` is still logged to the second, but it's passed thru to `W3CLogger` with millisecond precision so we can more accurately calculate `time-taken`. Logs for the sample now generally have `time-taken` at under 1 millisecond, rather than how many milliseconds past the second the action occurred at.