### PR TITLE
Support platforms where crossgen2 is not available

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -42,7 +42,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- Pack .ni.r2rmap files in symbols package (native symbols for Linux) -->
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder);.r2rmap</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
 
-    <!-- Optimize the framework using the crossgen2 tool -->
+    <!-- Optimize the framework using the crossgen2 tool. Crossgen2 is not currently supported on s390x. -->
+    <CrossgenOutput Condition=" '$(TargetArchitecture)' == 's390x' ">false</CrossgenOutput>
     <CrossgenOutput Condition=" '$(CrossgenOutput)' == '' AND '$(Configuration)' != 'Debug' ">true</CrossgenOutput>
 
     <!-- Produce crossgen2 profiling symbols (.ni.pdb or .r2rmap files). -->
@@ -128,7 +129,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <Reference Include="System.Security.Permissions" ExcludeAssets="All" />
     <Reference Include="System.Windows.Extensions" ExcludeAssets="All" />
 
-    <Reference Include="Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)"
+    <Reference Condition="'$(CrossgenOutput)' == 'true'"
+        Include="Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)"
         ExcludeAssets="All"
         PrivateAssets="All"
         GeneratePathProperty="true" />
@@ -137,7 +139,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       This package contains the crossgen2 tool. Unfortunately, it doesn't make the tool easy to use.
       $(GeneratePathProperty) and hacks in the _ExpandRuntimePackageRoot target work around the gaps.
     -->
-    <Reference Include="Microsoft.NETCore.App.Crossgen2.$(BuildOsName)-$(Crossgen2BuildArchitecture)"
+    <Reference Condition="'$(CrossgenOutput)' == 'true'"
+        Include="Microsoft.NETCore.App.Crossgen2.$(BuildOsName)-$(Crossgen2BuildArchitecture)"
         ExcludeAssets="All"
         PrivateAssets="All"
         GeneratePathProperty="true" />


### PR DESCRIPTION
**PR Title**
Support platforms where crossgen2 is not available

**PR Description**
On s390x, we currently do not support crossgen2, neither as build nor as target architecture.  It should still be possible to build aspnetcore by specifying `/p:CrossgenOutput=false`, but that runs into the problem that the build still tries to restore the following packages that are not available:
- "Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)" - the linux-s390x runtime is not currently built by default and therefore not available in the default repos
- "Microsoft.NETCore.App.Crossgen2.$(BuildOsName)-$(Crossgen2BuildArchitecture)" - we don't support s390x as crossgen2 build architecture

However, those packages are not acually **needed** when using `/p:CrossgenOutput=false`, so by simply making the package reference conditional, the build succeeds on s390x.
