### PR TITLE
[release/3.1] Align CODEOWNERS with 'main'

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,25 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-/global.json                    @aspnet/build
-/.azure/                        @aspnet/build
-/.config/                       @aspnet/build
-/build/                         @aspnet/build
-/eng/                           @aspnet/build
+/global.json                    @dotnet/aspnet-build
+/.azure/                        @dotnet/aspnet-build
+/.config/                       @dotnet/aspnet-build
+/.github/                       @dotnet/aspnet-build
+/.github/*_TEMPLATE/            @dotnet/aspnet-build @mkArtakMSFT
+/build/                         @dotnet/aspnet-build
+/eng/                           @dotnet/aspnet-build
 /eng/common/                    @dotnet-maestro-bot
 /eng/Versions.props             @dotnet-maestro-bot @dougbu
 /eng/Version.Details.xml        @dotnet-maestro-bot @dougbu
-/src/Components/                @SteveSandersonMS
-/src/DefaultBuilder/            @tratcher @anurse
-/src/Hosting/                   @tratcher @anurse
-/src/Http/                      @tratcher @jkotalik @anurse
-/src/Middleware/                @tratcher @anurse
-/src/ProjectTemplates/          @ryanbrandenburg
-/src/Security/                  @tratcher @anurse
-/src/Servers/                   @tratcher @jkotalik @anurse @halter73
-/src/Middleware/Rewrite         @jkotalik @anurse
-/src/Middleware/HttpsPolicy     @jkotalik @anurse
-/src/SignalR/                   @BrennanConroy @halter73 @anurse
+/src/**/ref/                    @dotnet/aspnet-api-review
+/src/Components/                @dotnet/aspnet-blazor-eng
+/src/DefaultBuilder/            @tratcher
+/src/Hosting/                   @tratcher
+/src/Http/                      @tratcher @BrennanConroy
+/src/Http/Routing/              @javiercn
+/src/Middleware/                @tratcher @BrennanConroy
+/src/Mvc/                       @pranavkm @javiercn
+/src/Security/                  @tratcher
+/src/Servers/                   @tratcher @halter73 @BrennanConroy
+/src/SignalR/                   @BrennanConroy @halter73
+/src/submodules                 @dotnet/aspnet-build @dougbu @wtgodbe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
+*                               @Pilchie
 /global.json                    @dotnet/aspnet-build
 /.azure/                        @dotnet/aspnet-build
 /.config/                       @dotnet/aspnet-build


### PR DESCRIPTION
- add and remove many assignments

This is general cleanup but I added a few assignments too.