### PR TITLE
[release/5.0] Align CODEOWNERS with 'main'

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
+*                                                                                 @Pilchie
 /global.json                                                                      @dotnet/aspnet-build
 /.azure/                                                                          @dotnet/aspnet-build
 /.config/                                                                         @dotnet/aspnet-build

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,40 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-/global.json                    @aspnet/build
-/.azure/                        @aspnet/build
-/.config/                       @aspnet/build
-/build/                         @aspnet/build
-/eng/                           @aspnet/build
-/eng/common/                    @dotnet-maestro-bot
-/eng/Versions.props             @dotnet-maestro-bot @dougbu
-/eng/Version.Details.xml        @dotnet-maestro-bot @dougbu
-/src/Components/                @SteveSandersonMS @dotnet/aspnet-blazor-eng
-/src/DefaultBuilder/            @tratcher
-/src/Hosting/                   @tratcher
-/src/Http/                      @tratcher @jkotalik
-/src/Http/Routing/              @javiercn
-/src/Middleware/                @tratcher
-/src/Middleware/HttpsPolicy/    @jkotalik
-/src/Middleware/Rewrite/        @jkotalik
-# /src/ProjectTemplates/        @ryanbrandenburg
-/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/  @dotnet/aspnet-blazor-eng
+/global.json                                                                      @dotnet/aspnet-build
+/.azure/                                                                          @dotnet/aspnet-build
+/.config/                                                                         @dotnet/aspnet-build
+/.devcontainer/                                                                   @captainsafia
+/.github/                                                                         @dotnet/aspnet-build
+/.github/*_TEMPLATE/                                                              @dotnet/aspnet-build @mkArtakMSFT
+/.github/workflows/                                                               @dotnet/aspnet-build @tratcher
+/docs/                                                                            @captainsafia @mkArtakMSFT
+/eng/                                                                             @dotnet/aspnet-build
+/eng/common/                                                                      @dotnet-maestro-bot
+/eng/Versions.props                                                               @dotnet-maestro-bot @dougbu
+/eng/Version.Details.xml                                                          @dotnet-maestro-bot @dougbu
+/src/Components/                                                                  @dotnet/aspnet-blazor-eng @SteveSandersonMS
+/src/Components/**/PublicAPI.*Shipped.txt                                         @dotnet/aspnet-api-review @dotnet/aspnet-blazor-eng
+/src/DefaultBuilder/                                                              @tratcher
+/src/DefaultBuilder/**/PublicAPI.*Shipped.txt                                     @dotnet/aspnet-api-review @tratcher
+/src/Hosting/                                                                     @tratcher
+/src/Hosting/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @tratcher
+/src/Http/                                                                        @tratcher @BrennanConroy
+/src/Http/**/PublicAPI.*Shipped.txt                                               @dotnet/aspnet-api-review @tratcher @BrennanConroy
+/src/Http/Routing/                                                                @javiercn
+/src/Http/Routing/**/PublicAPI.*Shipped.txt                                       @dotnet/aspnet-api-review @javiercn
+/src/Middleware/                                                                  @tratcher @BrennanConroy
+/src/Middleware/**/PublicAPI.*Shipped.txt                                         @dotnet/aspnet-api-review @tratcher @BrennanConroy
+/src/Mvc/                                                                         @pranavkm @javiercn
+/src/Mvc/**/PublicAPI.*Shipped.txt                                                @dotnet/aspnet-api-review @pranavkm @javiercn
+/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/        @dotnet/aspnet-blazor-eng
 /src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/  @dotnet/aspnet-blazor-eng
-/src/Security/                  @tratcher
-/src/Servers/                   @tratcher @jkotalik @halter73
-/src/Shared/runtime/            @dotnet/http
-/src/Shared/test/Shared.Tests/runtime/ @dotnet/http
-/src/SignalR/                   @BrennanConroy @halter73
+/src/Security/                                                                    @tratcher
+/src/Security/**/PublicAPI.*Shipped.txt                                           @dotnet/aspnet-api-review @tratcher
+/src/Servers/                                                                     @tratcher @halter73 @BrennanConroy
+/src/Servers/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @tratcher @halter73 @BrennanConroy
+/src/Shared/runtime/                                                              @dotnet/http
+/src/Shared/test/Shared.Tests/runtime/                                            @dotnet/http
+/src/SignalR/                                                                     @BrennanConroy @halter73
+/src/SignalR/**/PublicAPI.*Shipped.txt                                            @dotnet/aspnet-api-review @BrennanConroy @halter73
+/src/submodules                                                                   @dotnet/aspnet-build @dougbu @wtgodbe


### PR DESCRIPTION
- add and remove many assignments
- mostly match 'main' version less missing directories