### PR TITLE
Fix root '<PageTitle>' not working when a default, static '<title>' is provided

### DIFF
--- a/src/Components/Components/src/Sections/SectionContent.cs
+++ b/src/Components/Components/src/Sections/SectionContent.cs
@@ -12,10 +12,16 @@ namespace Microsoft.AspNetCore.Components.Sections
         private SectionRegistry _registry = default!;
 
         /// <summary>
-        /// Gets or sets the name that determines which <see cref="SectionOutlet"/> instances will render
+        /// Gets or sets the name that determines which <see cref="SectionOutlet"/> instance will render
         /// the content of this instance.
         /// </summary>
         [Parameter] public string Name { get; set; } = default!;
+
+        /// <summary>
+        /// Gets or sets whether this component should provide the default content for the target
+        /// <see cref="SectionOutlet"/>.
+        /// </summary>
+        [Parameter] public bool IsDefaultContent { get; set; }
 
         /// <summary>
         /// Gets or sets the content to be rendered in corresponding <see cref="SectionOutlet"/> instances.
@@ -45,7 +51,7 @@ namespace Microsoft.AspNetCore.Components.Sections
                     _registry.RemoveProvider(_registeredName, this);
                 }
 
-                _registry.AddProvider(Name, this);
+                _registry.AddProvider(Name, this, IsDefaultContent);
                 _registeredName = Name;
             }
 

--- a/src/Components/Components/src/Sections/SectionRegistry.cs
+++ b/src/Components/Components/src/Sections/SectionRegistry.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.Sections
         private readonly Dictionary<string, ISectionContentSubscriber> _subscribersByName = new();
         private readonly Dictionary<string, List<ISectionContentProvider>> _providersByName = new();
 
-        public void AddProvider(string name, ISectionContentProvider provider)
+        public void AddProvider(string name, ISectionContentProvider provider, bool isDefaultProvider)
         {
             if (!_providersByName.TryGetValue(name, out var providers))
             {
@@ -16,7 +16,14 @@ namespace Microsoft.AspNetCore.Components.Sections
                 _providersByName.Add(name, providers);
             }
 
-            providers.Add(provider);
+            if (isDefaultProvider)
+            {
+                providers.Insert(0, provider);
+            }
+            else
+            {
+                providers.Add(provider);
+            }
         }
 
         public void RemoveProvider(string name, ISectionContentProvider provider)

--- a/src/Components/Web/src/Head/HeadOutlet.cs
+++ b/src/Components/Web/src/Head/HeadOutlet.cs
@@ -45,13 +45,14 @@ namespace Microsoft.AspNetCore.Components.Web
             {
                 builder.OpenComponent<SectionContent>(2);
                 builder.AddAttribute(3, nameof(SectionContent.Name), TitleSectionOutletName);
-                builder.AddAttribute(4, nameof(SectionContent.ChildContent), (RenderFragment)BuildDefaultTitleRenderTree);
+                builder.AddAttribute(4, nameof(SectionContent.IsDefaultContent), true);
+                builder.AddAttribute(5, nameof(SectionContent.ChildContent), (RenderFragment)BuildDefaultTitleRenderTree);
                 builder.CloseComponent();
             }
 
             // Render the rest of the head metadata
-            builder.OpenComponent<SectionOutlet>(5);
-            builder.AddAttribute(6, nameof(SectionOutlet.Name), HeadSectionOutletName);
+            builder.OpenComponent<SectionOutlet>(6);
+            builder.AddAttribute(7, nameof(SectionOutlet.Name), HeadSectionOutletName);
             builder.CloseComponent();
         }
 


### PR DESCRIPTION
**Fix root `<PageTitle>` not working when a default, static `<title>` is provided**
There was an issue in which the root `<PageTitle>`, if rendered just after the application started, would not change the title of the page if a static `<title>` was provided in `index.html`. This PR fixes the issue.

**PR Description**
The problem arose because `HeadOutlet` wouldn't render the default title until it was determined from the statically-rendered title. This gave other `<PageTitle>` components the opportunity to render first, incorrectly serving as the default page title. When the _true_ default title finally rendered, it took priority over the developer-provided `<PageTitle>` (which was rendered first), making it appear to have no effect.

I've added a new `SectionContent` parameter, `IsDefaultContent`. When `true`, the registered section content will take lower priority than all other existing content. This allows the `HeadOutlet` to ensure its own `SectionContent` for the default title will have the lowest priority.

An alternative I considered was to always render the `SectionContent` for the default title, but only render the `<title>` element when the default title is actually determined. This sometimes works, but it breaks in cases like prerendering because `<PageTitle>` elements in the "app" root component still get rendered first.

Fixes #35973
