### PR TITLE
Throw for bad requests intended for minimal route handlers in development

### DIFF
--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1297,7 +1297,6 @@ namespace Microsoft.AspNetCore.Tests
 
             app.MapGet("/{parameterName}", (int parameterName) => { });
 
-
             await app.StartAsync();
 
             var client = app.GetTestClient();

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1264,6 +1264,54 @@ namespace Microsoft.AspNetCore.Tests
             Assert.Equal("value", app.Configuration["testhostingstartup:config"]);
         }
 
+        [Fact]
+        public async Task DeveloperExceptionPageWritesBadRequestDetailsToResponseByDefaltInDevelopment()
+        {
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions() { EnvironmentName = Environments.Development });
+            builder.WebHost.UseTestServer();
+            await using var app = builder.Build();
+
+            app.MapGet("/{parameterName}", (int parameterName) => { });
+
+            await app.StartAsync();
+
+            var client = app.GetTestClient();
+
+            var response = await client.GetAsync("/notAnInt");
+
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("text/plain", response.Content.Headers.ContentType.MediaType);
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Assert.Contains("parameterName", responseBody);
+            Assert.Contains("notAnInt", responseBody);
+        }
+
+        [Fact]
+        public async Task NoExceptionAreThrownForBadRequestsInProduction()
+        {
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions() { EnvironmentName = Environments.Production });
+            builder.WebHost.UseTestServer();
+            await using var app = builder.Build();
+
+            app.MapGet("/{parameterName}", (int parameterName) => { });
+
+
+            await app.StartAsync();
+
+            var client = app.GetTestClient();
+
+            var response = await client.GetAsync("/notAnInt");
+
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Null(response.Content.Headers.ContentType);
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Assert.Equal(string.Empty, responseBody);
+        }
+
         class ThrowingStartupFilter : IStartupFilter
         {
             public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)

--- a/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
+++ b/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
@@ -17,6 +17,7 @@
     <Compile Include="$(SharedSourceRoot)ProblemDetailsJsonConverter.cs" LinkBase="Shared"/>
     <Compile Include="$(SharedSourceRoot)HttpValidationProblemDetailsJsonConverter.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)RoutingMetadata\AcceptsMetadata.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)TypeNameHelper/TypeNameHelper.cs" LinkBase="Shared"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -163,6 +163,8 @@ Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.get 
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.init -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.ServiceProvider.get -> System.IServiceProvider?
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.ServiceProvider.init -> void
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.ThrowOnBadRequest.get -> bool
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.ThrowOnBadRequest.init -> void
 Microsoft.AspNetCore.Mvc.ProblemDetails
 Microsoft.AspNetCore.Mvc.ProblemDetails.Detail.get -> string?
 Microsoft.AspNetCore.Mvc.ProblemDetails.Detail.set -> void

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -635,7 +635,7 @@ namespace Microsoft.AspNetCore.Http
 
             var argument = Expression.Variable(parameter.ParameterType, $"{parameter.Name}_local");
 
-            var parameterTypeNameConstant = Expression.Constant(parameter.ParameterType.Name);
+            var parameterTypeNameConstant = Expression.Constant(TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false));
             var parameterNameConstant = Expression.Constant(parameter.Name);
             var sourceConstant = Expression.Constant(source);
 
@@ -697,7 +697,8 @@ namespace Microsoft.AspNetCore.Http
 
             if (tryParseMethodCall is null)
             {
-                throw new InvalidOperationException($"No public static bool {parameter.ParameterType.Name}.TryParse(string, out {parameter.ParameterType.Name}) method found for {parameter.Name}.");
+                var typeName = TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false);
+                throw new InvalidOperationException($"No public static bool {typeName}.TryParse(string, out {typeName}) method found for {parameter.Name}.");
             }
 
             // string tempSourceString;
@@ -831,6 +832,7 @@ namespace Microsoft.AspNetCore.Http
 
             if (!isOptional)
             {
+                var typeName = TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false);
                 var checkRequiredBodyBlock = Expression.Block(
                         Expression.IfThen(
                         Expression.Equal(boundValueExpr, Expression.Constant(null)),
@@ -838,9 +840,9 @@ namespace Microsoft.AspNetCore.Http
                                 Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
                                 Expression.Call(LogRequiredParameterNotProvidedMethod,
                                         HttpContextExpr,
-                                        Expression.Constant(parameter.ParameterType.Name),
+                                        Expression.Constant(typeName),
                                         Expression.Constant(parameter.Name),
-                                        Expression.Constant($"{parameter.ParameterType.Name}.BindAsync(HttpContext, ParameterInfo)"),
+                                        Expression.Constant($"{typeName}.BindAsync(HttpContext, ParameterInfo)"),
                                         Expression.Constant(factoryContext.ThrowOnBadRequest))
                             )
                         )
@@ -889,7 +891,7 @@ namespace Microsoft.AspNetCore.Http
                             Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
                             Expression.Call(LogRequiredParameterNotProvidedMethod,
                                     HttpContextExpr,
-                                    Expression.Constant(parameter.ParameterType.Name),
+                                    Expression.Constant(TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false)),
                                     Expression.Constant(parameter.Name),
                                     Expression.Constant("body"),
                                     Expression.Constant(factoryContext.ThrowOnBadRequest))

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -39,8 +39,8 @@ namespace Microsoft.AspNetCore.Http
 
         private static readonly MethodInfo LogParameterBindingFailedMethod = GetMethodInfo<Action<HttpContext, string, string, string>>((httpContext, parameterType, parameterName, sourceValue) =>
             Log.ParameterBindingFailed(httpContext, parameterType, parameterName, sourceValue));
-        private static readonly MethodInfo LogRequiredParameterNotProvidedMethod = GetMethodInfo<Action<HttpContext, string, string>>((httpContext, parameterType, parameterName) =>
-            Log.RequiredParameterNotProvided(httpContext, parameterType, parameterName));
+        private static readonly MethodInfo LogRequiredParameterNotProvidedMethod = GetMethodInfo<Action<HttpContext, string, string, string>>((httpContext, parameterType, parameterName, source) =>
+            Log.RequiredParameterNotProvided(httpContext, parameterType, parameterName, source));
 
         private static readonly ParameterExpression TargetExpr = Expression.Parameter(typeof(object), "target");
         private static readonly ParameterExpression BodyValueExpr = Expression.Parameter(typeof(object), "bodyValue");
@@ -218,17 +218,17 @@ namespace Microsoft.AspNetCore.Http
                     throw new InvalidOperationException($"{parameter.Name} is not a route paramter.");
                 }
 
-                return BindParameterFromProperty(parameter, RouteValuesExpr, routeAttribute.Name ?? parameter.Name, factoryContext);
+                return BindParameterFromProperty(parameter, RouteValuesExpr, routeAttribute.Name ?? parameter.Name, factoryContext, "route");
             }
             else if (parameterCustomAttributes.OfType<IFromQueryMetadata>().FirstOrDefault() is { } queryAttribute)
             {
                 factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.QueryAttribue);
-                return BindParameterFromProperty(parameter, QueryExpr, queryAttribute.Name ?? parameter.Name, factoryContext);
+                return BindParameterFromProperty(parameter, QueryExpr, queryAttribute.Name ?? parameter.Name, factoryContext, "query string");
             }
             else if (parameterCustomAttributes.OfType<IFromHeaderMetadata>().FirstOrDefault() is { } headerAttribute)
             {
                 factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.HeaderAttribue);
-                return BindParameterFromProperty(parameter, HeadersExpr, headerAttribute.Name ?? parameter.Name, factoryContext);
+                return BindParameterFromProperty(parameter, HeadersExpr, headerAttribute.Name ?? parameter.Name, factoryContext, "header");
             }
             else if (parameterCustomAttributes.OfType<IFromBodyMetadata>().FirstOrDefault() is { } bodyAttribute)
             {
@@ -277,12 +277,12 @@ namespace Microsoft.AspNetCore.Http
                         // We're in the fallback case and we have a parameter and route parameter match so don't fallback
                         // to query string in this case
                         factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.RouteParameter);
-                        return BindParameterFromProperty(parameter, RouteValuesExpr, parameter.Name, factoryContext);
+                        return BindParameterFromProperty(parameter, RouteValuesExpr, parameter.Name, factoryContext, "route");
                     }
                     else
                     {
                         factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.QueryStringParameter);
-                        return BindParameterFromProperty(parameter, QueryExpr, parameter.Name, factoryContext);
+                        return BindParameterFromProperty(parameter, QueryExpr, parameter.Name, factoryContext, "query string");
                     }
                 }
 
@@ -633,11 +633,15 @@ namespace Microsoft.AspNetCore.Http
                 : Expression.Call(GetRequiredServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
         }
 
-        private static Expression BindParameterFromValue(ParameterInfo parameter, Expression valueExpression, FactoryContext factoryContext)
+        private static Expression BindParameterFromValue(ParameterInfo parameter, Expression valueExpression, FactoryContext factoryContext, string source)
         {
             var isOptional = IsOptionalParameter(parameter);
 
             var argument = Expression.Variable(parameter.ParameterType, $"{parameter.Name}_local");
+
+            var parameterTypeNameConstant = Expression.Constant(parameter.ParameterType.Name);
+            var parameterNameConstant = Expression.Constant(parameter.Name);
+            var sourceConstant = Expression.Constant(source);
 
             if (parameter.ParameterType == typeof(string))
             {
@@ -657,7 +661,7 @@ namespace Microsoft.AspNetCore.Http
                             Expression.Block(
                                 Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
                                 Expression.Call(LogRequiredParameterNotProvidedMethod,
-                                    HttpContextExpr, Expression.Constant(parameter.ParameterType.Name), Expression.Constant(parameter.Name))
+                                    HttpContextExpr, parameterTypeNameConstant, parameterNameConstant, sourceConstant)
                             )
                         )
                     );
@@ -739,9 +743,6 @@ namespace Microsoft.AspNetCore.Http
             // If the parameter is nullable, create a "parsedValue" local to TryParse into since we cannot use the parameter directly.
             var parsedValue = isNotNullable ? argument : Expression.Variable(nonNullableParameterType, "parsedValue");
 
-            var parameterTypeNameConstant = Expression.Constant(parameter.ParameterType.Name);
-            var parameterNameConstant = Expression.Constant(parameter.Name);
-
             var failBlock = Expression.Block(
                 Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
                 Expression.Call(LogParameterBindingFailedMethod,
@@ -762,7 +763,7 @@ namespace Microsoft.AspNetCore.Http
                     Expression.Block(
                         Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
                         Expression.Call(LogRequiredParameterNotProvidedMethod,
-                            HttpContextExpr, parameterTypeNameConstant, parameterNameConstant)
+                            HttpContextExpr, parameterTypeNameConstant, parameterNameConstant, sourceConstant)
                     )
                 )
             );
@@ -801,14 +802,14 @@ namespace Microsoft.AspNetCore.Http
             return argument;
         }
 
-        private static Expression BindParameterFromProperty(ParameterInfo parameter, MemberExpression property, string key, FactoryContext factoryContext) =>
-            BindParameterFromValue(parameter, GetValueFromProperty(property, key), factoryContext);
+        private static Expression BindParameterFromProperty(ParameterInfo parameter, MemberExpression property, string key, FactoryContext factoryContext, string source) =>
+            BindParameterFromValue(parameter, GetValueFromProperty(property, key), factoryContext, source);
 
         private static Expression BindParameterFromRouteValueOrQueryString(ParameterInfo parameter, string key, FactoryContext factoryContext)
         {
             var routeValue = GetValueFromProperty(RouteValuesExpr, key);
             var queryValue = GetValueFromProperty(QueryExpr, key);
-            return BindParameterFromValue(parameter, Expression.Coalesce(routeValue, queryValue), factoryContext);
+            return BindParameterFromValue(parameter, Expression.Coalesce(routeValue, queryValue), factoryContext, "route or query string");
         }
 
         private static Expression BindParameterFromBindAsync(ParameterInfo parameter, FactoryContext factoryContext)
@@ -837,7 +838,10 @@ namespace Microsoft.AspNetCore.Http
                             Expression.Block(
                                 Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
                                 Expression.Call(LogRequiredParameterNotProvidedMethod,
-                                        HttpContextExpr, Expression.Constant(parameter.ParameterType.Name), Expression.Constant(parameter.Name))
+                                        HttpContextExpr,
+                                        Expression.Constant(parameter.ParameterType.Name),
+                                        Expression.Constant(parameter.Name),
+                                        Expression.Constant($"{parameter.ParameterType.Name}.BindAsync(HttpContext, ParameterInfo)"))
                             )
                         )
                     );
@@ -884,7 +888,10 @@ namespace Microsoft.AspNetCore.Http
                         Expression.Block(
                             Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
                             Expression.Call(LogRequiredParameterNotProvidedMethod,
-                                    HttpContextExpr, Expression.Constant(parameter.ParameterType.Name), Expression.Constant(parameter.Name))
+                                    HttpContextExpr,
+                                    Expression.Constant(parameter.ParameterType.Name),
+                                    Expression.Constant(parameter.Name),
+                                    Expression.Constant("body"))
                         )
                     )
                 );
@@ -1154,13 +1161,13 @@ namespace Microsoft.AspNetCore.Http
                 EventName = "ParamaterBindingFailed")]
             private static partial void ParameterBindingFailed(ILogger logger, string parameterType, string parameterName, string sourceValue);
 
-            public static void RequiredParameterNotProvided(HttpContext httpContext, string parameterTypeName, string parameterName)
-                => RequiredParameterNotProvided(GetLogger(httpContext), parameterTypeName, parameterName);
+            public static void RequiredParameterNotProvided(HttpContext httpContext, string parameterTypeName, string parameterName, string source)
+                => RequiredParameterNotProvided(GetLogger(httpContext), parameterTypeName, parameterName, source);
 
             [LoggerMessage(4, LogLevel.Debug,
-                @"Required parameter ""{ParameterType} {ParameterName}"" was not provided.",
+                @"Required parameter ""{ParameterType} {ParameterName}"" was not provided from {Source}.",
                 EventName = "RequiredParameterNotProvided")]
-            private static partial void RequiredParameterNotProvided(ILogger logger, string parameterType, string parameterName);
+            private static partial void RequiredParameterNotProvided(ILogger logger, string parameterType, string parameterName, string source);
 
             public static void ParameterBindingFromHttpContextFailed(HttpContext httpContext, string parameterTypeName, string parameterName)
                 => ParameterBindingFromHttpContextFailed(GetLogger(httpContext), parameterTypeName, parameterName);

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1165,12 +1165,12 @@ namespace Microsoft.AspNetCore.Http
 
             public static void RequestBodyInvalidDataException(HttpContext httpContext, InvalidDataException exception, bool shouldThrow)
             {
-                RequestBodyInvalidDataException(GetLogger(httpContext), exception);
-
                 if (shouldThrow)
                 {
                     throw new BadHttpRequestException(RequestBodyInvalidDataExceptionMessage, exception);
                 }
+
+                RequestBodyInvalidDataException(GetLogger(httpContext), exception);
             }
 
             [LoggerMessage(2, LogLevel.Debug, RequestBodyInvalidDataExceptionMessage, EventName = "RequestBodyInvalidDataException")]
@@ -1178,13 +1178,13 @@ namespace Microsoft.AspNetCore.Http
 
             public static void ParameterBindingFailed(HttpContext httpContext, string parameterTypeName, string parameterName, string sourceValue, bool shouldThrow)
             {
-                ParameterBindingFailed(GetLogger(httpContext), parameterTypeName, parameterName, sourceValue);
-
                 if (shouldThrow)
                 {
                     var message = string.Format(CultureInfo.InvariantCulture, ParameterBindingFailedExceptionMessage, parameterTypeName, parameterName, sourceValue);
                     throw new BadHttpRequestException(message);
                 }
+
+                ParameterBindingFailed(GetLogger(httpContext), parameterTypeName, parameterName, sourceValue);
             }
 
             [LoggerMessage(3, LogLevel.Debug, ParameterBindingFailedLogMessage, EventName = "ParameterBindingFailed")]
@@ -1192,13 +1192,13 @@ namespace Microsoft.AspNetCore.Http
 
             public static void RequiredParameterNotProvided(HttpContext httpContext, string parameterTypeName, string parameterName, string source, bool shouldThrow)
             {
-                RequiredParameterNotProvided(GetLogger(httpContext), parameterTypeName, parameterName, source);
-
                 if (shouldThrow)
                 {
                     var message = string.Format(CultureInfo.InvariantCulture, RequiredParameterNotProvidedExceptionMessage, parameterTypeName, parameterName, source);
                     throw new BadHttpRequestException(message);
                 }
+
+                RequiredParameterNotProvided(GetLogger(httpContext), parameterTypeName, parameterName, source);
             }
 
             [LoggerMessage(4, LogLevel.Debug, RequiredParameterNotProvidedLogMessage, EventName = "RequiredParameterNotProvided")]

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Logging;
+
 namespace Microsoft.AspNetCore.Http
 {
     /// <summary>
-    /// Options for controlling the behavior of <see cref="RequestDelegate" /> when created using <see cref="RequestDelegateFactory" />.
+    /// Options for controlling the behavior of the <see cref="RequestDelegate" /> when created using <see cref="RequestDelegateFactory" />.
     /// </summary>
     public sealed class RequestDelegateFactoryOptions
     {
@@ -17,5 +19,11 @@ namespace Microsoft.AspNetCore.Http
         /// The list of route parameter names that are specified for this handler.
         /// </summary>
         public IEnumerable<string>? RouteParameterNames { get; init; }
+
+        /// <summary>
+        /// Controls whether the <see cref="RequestDelegate"/> should throw a <see cref="BadHttpRequestException"/> in addition to
+        /// writing a <see cref="LogLevel.Debug"/> log when handling invalid requests.
+        /// </summary>
+        public bool ThrowOnBadRequest { get; init; }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -879,11 +879,11 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), logs[0].EventId);
             Assert.Equal(LogLevel.Debug, logs[0].LogLevel);
-            Assert.Equal(@"Required parameter ""MyBindAsyncRecord myBindAsyncRecord1"" was not provided.", logs[0].Message);
+            Assert.Equal(@"Required parameter ""MyBindAsyncRecord myBindAsyncRecord1"" was not provided from MyBindAsyncRecord.BindAsync(HttpContext, ParameterInfo).", logs[0].Message);
 
             Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), logs[1].EventId);
             Assert.Equal(LogLevel.Debug, logs[1].LogLevel);
-            Assert.Equal(@"Required parameter ""MyBindAsyncRecord myBindAsyncRecord2"" was not provided.", logs[1].Message);
+            Assert.Equal(@"Required parameter ""MyBindAsyncRecord myBindAsyncRecord2"" was not provided from MyBindAsyncRecord.BindAsync(HttpContext, ParameterInfo).", logs[1].Message);
         }
 
         [Fact]
@@ -1919,7 +1919,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 Assert.Equal(LogLevel.Debug, log.LogLevel);
                 Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), log.EventId);
                 var expectedType = paramName == "age" ? "Int32 age" : "String name";
-                Assert.Equal($@"Required parameter ""{expectedType}"" was not provided.", log.Message);
+                Assert.Equal($@"Required parameter ""{expectedType}"" was not provided from route or query string.", log.Message);
             }
             else
             {
@@ -1995,7 +1995,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 Assert.Equal(LogLevel.Debug, log.LogLevel);
                 Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), log.EventId);
                 var expectedType = paramName == "age" ? "Int32 age" : "String name";
-                Assert.Equal($@"Required parameter ""{expectedType}"" was not provided.", log.Message);
+                Assert.Equal($@"Required parameter ""{expectedType}"" was not provided from query string.", log.Message);
             }
             else
             {
@@ -2066,7 +2066,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 var log = Assert.Single(logs);
                 Assert.Equal(LogLevel.Debug, log.LogLevel);
                 Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), log.EventId);
-                Assert.Equal(@"Required parameter ""Todo todo"" was not provided.", log.Message);
+                Assert.Equal(@"Required parameter ""Todo todo"" was not provided from body.", log.Message);
             }
             else
             {
@@ -2187,7 +2187,6 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var factoryResult = RequestDelegateFactory.Create(@delegate);
             var requestDelegate = factoryResult.RequestDelegate;
 
-
             await requestDelegate(httpContext);
 
             var logs = TestSink.Writes.ToArray();
@@ -2198,7 +2197,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 var log = Assert.Single(logs);
                 Assert.Equal(LogLevel.Debug, log.LogLevel);
                 Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), log.EventId);
-                Assert.Equal(@"Required parameter ""Todo todo"" was not provided.", log.Message);
+                Assert.Equal(@"Required parameter ""Todo todo"" was not provided from body.", log.Message);
             }
             else
             {

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -770,7 +770,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         public void CreateThrowsInvalidOperationExceptionWhenAttributeRequiresTryParseMethodThatDoesNotExist(Delegate action)
         {
             var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(action));
-            Assert.Equal("No public static bool Object.TryParse(string, out Object) method found for notTryParsable.", ex.Message);
+            Assert.Equal("No public static bool object.TryParse(string, out object) method found for notTryParsable.", ex.Message);
         }
 
         [Fact]
@@ -812,11 +812,11 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             Assert.Equal(new EventId(3, "ParameterBindingFailed"), logs[0].EventId);
             Assert.Equal(LogLevel.Debug, logs[0].LogLevel);
-            Assert.Equal(@"Failed to bind parameter ""Int32 tryParsable"" from ""invalid!"".", logs[0].Message);
+            Assert.Equal(@"Failed to bind parameter ""int tryParsable"" from ""invalid!"".", logs[0].Message);
 
             Assert.Equal(new EventId(3, "ParameterBindingFailed"), logs[1].EventId);
             Assert.Equal(LogLevel.Debug, logs[1].LogLevel);
-            Assert.Equal(@"Failed to bind parameter ""Int32 tryParsable2"" from ""invalid again!"".", logs[1].Message);
+            Assert.Equal(@"Failed to bind parameter ""int tryParsable2"" from ""invalid again!"".", logs[1].Message);
         }
 
         [Fact]
@@ -852,7 +852,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             Assert.Equal(new EventId(3, "ParameterBindingFailed"), logMessage.EventId);
             Assert.Equal(LogLevel.Debug, logMessage.LogLevel);
-            Assert.Equal(@"Failed to bind parameter ""Int32 tryParsable"" from ""invalid!"".", logMessage.Message);
+            Assert.Equal(@"Failed to bind parameter ""int tryParsable"" from ""invalid!"".", logMessage.Message);
 
             Assert.Equal(logMessage.Message, badHttpRequestException.Message);
             Assert.Equal(400, badHttpRequestException.StatusCode);
@@ -1979,7 +1979,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 var log = Assert.Single(logs);
                 Assert.Equal(LogLevel.Debug, log.LogLevel);
                 Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), log.EventId);
-                var expectedType = paramName == "age" ? "Int32 age" : "String name";
+                var expectedType = paramName == "age" ? "int age" : "string name";
                 Assert.Equal($@"Required parameter ""{expectedType}"" was not provided from route or query string.", log.Message);
             }
             else
@@ -2051,7 +2051,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 var log = Assert.Single(logs);
                 Assert.Equal(LogLevel.Debug, log.LogLevel);
                 Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), log.EventId);
-                var expectedType = paramName == "age" ? "Int32 age" : "String name";
+                var expectedType = paramName == "age" ? "int age" : "string name";
                 Assert.Equal($@"Required parameter ""{expectedType}"" was not provided from query string.", log.Message);
             }
             else

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -845,16 +845,10 @@ namespace Microsoft.AspNetCore.Routing.Internal
             Assert.Equal(200, httpContext.Response.StatusCode);
             Assert.False(httpContext.Response.HasStarted);
 
-            // Only the first invalid parameter is currently logged if ThrowOnBadRequest=true
-            // We don't attempt to create an aggregate BadHttpRequestException which would likely be more confusing
-            // than just throwing on the first bad parameter.
-            var logMessage = Assert.Single(TestSink.Writes);
+            // We don't log bad requests when we throw.
+            Assert.Empty(TestSink.Writes);
 
-            Assert.Equal(new EventId(3, "ParameterBindingFailed"), logMessage.EventId);
-            Assert.Equal(LogLevel.Debug, logMessage.LogLevel);
-            Assert.Equal(@"Failed to bind parameter ""int tryParsable"" from ""invalid!"".", logMessage.Message);
-
-            Assert.Equal(logMessage.Message, badHttpRequestException.Message);
+            Assert.Equal(@"Failed to bind parameter ""int tryParsable"" from ""invalid!"".", badHttpRequestException.Message);
             Assert.Equal(400, badHttpRequestException.StatusCode);
         }
 
@@ -912,16 +906,10 @@ namespace Microsoft.AspNetCore.Routing.Internal
             Assert.Equal(200, httpContext.Response.StatusCode);
             Assert.False(httpContext.Response.HasStarted);
 
-            // Only the first invalid parameter is currently logged if ThrowOnBadRequest=true
-            // We don't attempt to create an aggregate BadHttpRequestException which would likely be more confusing
-            // than just throwing on the first bad parameter.
-            var logMessage = Assert.Single(TestSink.Writes);
+            // We don't log bad requests when we throw.
+            Assert.Empty(TestSink.Writes);
 
-            Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), logMessage.EventId);
-            Assert.Equal(LogLevel.Debug, logMessage.LogLevel);
-            Assert.Equal(@"Required parameter ""MyBindAsyncRecord myBindAsyncRecord1"" was not provided from MyBindAsyncRecord.BindAsync(HttpContext, ParameterInfo).", logMessage.Message);
-
-            Assert.Equal(logMessage.Message, badHttpRequestException.Message);
+            Assert.Equal(@"Required parameter ""MyBindAsyncRecord myBindAsyncRecord1"" was not provided from MyBindAsyncRecord.BindAsync(HttpContext, ParameterInfo).", badHttpRequestException.Message);
             Assert.Equal(400, badHttpRequestException.StatusCode);
         }
 
@@ -1276,6 +1264,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var logMessage = Assert.Single(TestSink.Writes);
             Assert.Equal(new EventId(1, "RequestBodyIOException"), logMessage.EventId);
             Assert.Equal(LogLevel.Debug, logMessage.LogLevel);
+            Assert.Equal("Reading the request body failed with an IOException.", logMessage.Message);
             Assert.Same(ioException, logMessage.Exception);
         }
 
@@ -1310,6 +1299,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var logMessage = Assert.Single(TestSink.Writes);
             Assert.Equal(new EventId(2, "RequestBodyInvalidDataException"), logMessage.EventId);
             Assert.Equal(LogLevel.Debug, logMessage.LogLevel);
+            Assert.Equal("Reading the request body failed with an InvalidDataException.", logMessage.Message);
             Assert.Same(invalidDataException, logMessage.Exception);
         }
 
@@ -1343,12 +1333,10 @@ namespace Microsoft.AspNetCore.Routing.Internal
             Assert.Equal(200, httpContext.Response.StatusCode);
             Assert.False(httpContext.Response.HasStarted);
 
-            var logMessage = Assert.Single(TestSink.Writes);
-            Assert.Equal(new EventId(2, "RequestBodyInvalidDataException"), logMessage.EventId);
-            Assert.Equal(LogLevel.Debug, logMessage.LogLevel);
-            Assert.Same(invalidDataException, logMessage.Exception);
+            // We don't log bad requests when we throw.
+            Assert.Empty(TestSink.Writes);
 
-            Assert.Equal(logMessage.Message, badHttpRequestException.Message);
+            Assert.Equal("Reading the request body failed with an InvalidDataException.", badHttpRequestException.Message);
             Assert.Equal(400, badHttpRequestException.StatusCode);
             Assert.Same(invalidDataException, badHttpRequestException.InnerException);
         }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -440,10 +440,6 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = CreateHttpContext();
             httpContext.Request.RouteValues[unmatchedName] = unmatchedRouteParam.ToString(NumberFormatInfo.InvariantInfo);
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(LoggerFactory);
-            httpContext.RequestServices = serviceCollection.BuildServiceProvider();
-
             var factoryResult = RequestDelegateFactory.Create(TestAction);
             var requestDelegate = factoryResult.RequestDelegate;
 
@@ -611,10 +607,6 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = CreateHttpContext();
             httpContext.Request.RouteValues["tryParsable"] = routeValue;
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(LoggerFactory);
-            httpContext.RequestServices = serviceCollection.BuildServiceProvider();
-
             var factoryResult = RequestDelegateFactory.Create(action);
             var requestDelegate = factoryResult.RequestDelegate;
 
@@ -632,10 +624,6 @@ namespace Microsoft.AspNetCore.Routing.Internal
             {
                 ["tryParsable"] = routeValue
             });
-
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(LoggerFactory);
-            httpContext.RequestServices = serviceCollection.BuildServiceProvider();
 
             var factoryResult = RequestDelegateFactory.Create(action);
             var requestDelegate = factoryResult.RequestDelegate;

--- a/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -168,10 +170,14 @@ namespace Microsoft.AspNetCore.Builder
                 routeParams.Add(part.Name);
             }
 
+            // REVIEW: Should we just default ThrowOnBadRequest to false if Options is somehow missing?
+            var routeHandlerOptions = endpoints.ServiceProvider.GetRequiredService<IOptions<RouteHandlerOptions>>();
+
             var options = new RequestDelegateFactoryOptions
             {
                 ServiceProvider = endpoints.ServiceProvider,
-                RouteParameterNames = routeParams
+                RouteParameterNames = routeParams,
+                ThrowOnBadRequest = routeHandlerOptions.Value.ThrowOnBadRequest
             };
 
             var requestDelegateResult = RequestDelegateFactory.Create(handler, options);

--- a/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
@@ -170,14 +170,13 @@ namespace Microsoft.AspNetCore.Builder
                 routeParams.Add(part.Name);
             }
 
-            // REVIEW: Should we just default ThrowOnBadRequest to false if Options is somehow missing?
-            var routeHandlerOptions = endpoints.ServiceProvider.GetRequiredService<IOptions<RouteHandlerOptions>>();
+            var routeHandlerOptions = endpoints.ServiceProvider?.GetService<IOptions<RouteHandlerOptions>>();
 
             var options = new RequestDelegateFactoryOptions
             {
                 ServiceProvider = endpoints.ServiceProvider,
                 RouteParameterNames = routeParams,
-                ThrowOnBadRequest = routeHandlerOptions.Value.ThrowOnBadRequest
+                ThrowOnBadRequest = routeHandlerOptions?.Value.ThrowOnBadRequest ?? false,
             };
 
             var requestDelegateResult = RequestDelegateFactory.Create(handler, options);

--- a/src/Http/Routing/src/ConfigureRouteHandlerOptions.cs
+++ b/src/Http/Routing/src/ConfigureRouteHandlerOptions.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing
 {
-    internal class ConfigureRouteHandlerOptions : IConfigureOptions<RouteHandlerOptions>
+    internal sealed class ConfigureRouteHandlerOptions : IConfigureOptions<RouteHandlerOptions>
     {
         private readonly IHostEnvironment _environment;
 
@@ -22,7 +22,10 @@ namespace Microsoft.AspNetCore.Routing
 
         public void Configure(RouteHandlerOptions options)
         {
-            options.ThrowOnBadRequest = _environment.IsDevelopment();
+            if (_environment.IsDevelopment())
+            {
+                options.ThrowOnBadRequest = true;
+            }
         }
     }
 }

--- a/src/Http/Routing/src/ConfigureRouteHandlerOptions.cs
+++ b/src/Http/Routing/src/ConfigureRouteHandlerOptions.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    internal class ConfigureRouteHandlerOptions : IConfigureOptions<RouteHandlerOptions>
+    {
+        private readonly IHostEnvironment _environment;
+
+        public ConfigureRouteHandlerOptions(IHostEnvironment environment)
+        {
+            _environment = environment;
+        }
+
+        public void Configure(RouteHandlerOptions options)
+        {
+            options.ThrowOnBadRequest = _environment.IsDevelopment();
+        }
+    }
+}

--- a/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<TemplateBinderFactory, DefaultTemplateBinderFactory>();
             services.TryAddSingleton<RoutePatternTransformer, DefaultRoutePatternTransformer>();
 
-            // RouteHandlerOptions.ThrowOnBadRequest = _environment.IsDevelopment();
+            // if (_environment.IsDevelopment()) RouteHandlerOptions.ThrowOnBadRequest = true;
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<RouteHandlerOptions>, ConfigureRouteHandlerOptions>());
 
             return services;

--- a/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<TemplateBinderFactory, DefaultTemplateBinderFactory>();
             services.TryAddSingleton<RoutePatternTransformer, DefaultRoutePatternTransformer>();
 
-            // if (_environment.IsDevelopment()) RouteHandlerOptions.ThrowOnBadRequest = true;
+            // Set RouteHandlerOptions.ThrowOnBadRequest in development
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<RouteHandlerOptions>, ConfigureRouteHandlerOptions>());
 
             return services;

--- a/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -98,6 +98,10 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             services.TryAddSingleton<TemplateBinderFactory, DefaultTemplateBinderFactory>();
             services.TryAddSingleton<RoutePatternTransformer, DefaultRoutePatternTransformer>();
+
+            // RouteHandlerOptions.ThrowOnBadRequest = _environment.IsDevelopment();
+            services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<RouteHandlerOptions>, ConfigureRouteHandlerOptions>());
+
             return services;
         }
 

--- a/src/Http/Routing/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing/src/PublicAPI.Unshipped.txt
@@ -14,6 +14,10 @@ Microsoft.AspNetCore.Routing.IDataTokensMetadata.DataTokens.get -> System.Collec
 Microsoft.AspNetCore.Routing.IRouteNameMetadata.RouteName.get -> string?
 Microsoft.AspNetCore.Routing.Matching.IParameterLiteralNodeMatchingPolicy
 Microsoft.AspNetCore.Routing.Matching.IParameterLiteralNodeMatchingPolicy.MatchesLiteral(string! parameterName, string! literal) -> bool
+Microsoft.AspNetCore.Routing.RouteHandlerOptions
+Microsoft.AspNetCore.Routing.RouteHandlerOptions.RouteHandlerOptions() -> void
+Microsoft.AspNetCore.Routing.RouteHandlerOptions.ThrowOnBadRequest.get -> bool
+Microsoft.AspNetCore.Routing.RouteHandlerOptions.ThrowOnBadRequest.set -> void
 Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteName.get -> string?
 Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteNameMetadata(string? routeName) -> void
 Microsoft.AspNetCore.Routing.IEndpointGroupNameMetadata

--- a/src/Http/Routing/src/RouteHandlerOptions.cs
+++ b/src/Http/Routing/src/RouteHandlerOptions.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    /// <summary>
+    /// Options for controlling the behavior of <see cref="DelegateEndpointRouteBuilderExtensions.MapGet(IEndpointRouteBuilder, string, Delegate)"/>
+    /// and similar methods.
+    /// </summary>
+    public sealed class RouteHandlerOptions
+    {
+        /// <summary>
+        /// Controls whether endpoints should throw a <see cref="BadHttpRequestException"/> in addition to
+        /// writing a <see cref="LogLevel.Debug"/> log when handling invalid requests.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="HostEnvironmentEnvExtensions.IsDevelopment(IHostEnvironment)"/>.
+        /// </remarks>
+        public bool ThrowOnBadRequest { get; set; }
+    }
+}

--- a/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapEndpoint_PrecedenceOfMetadata_BuilderMetadataReturned()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
 
             [HttpMethod("ATTRIBUTE")]
             void TestAction()
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapGet_BuildsEndpointWithCorrectMethod()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapGet("/", () => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public async Task MapGetWithRouteParameter_BuildsEndpointWithRouteSpecificBinding()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapGet("/{id}", (int? id, HttpContext httpContext) =>
             {
                 if (id is not null)
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public async Task MapGetWithoutRouteParameter_BuildsEndpointWithQuerySpecificBinding()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapGet("/", (int? id, HttpContext httpContext) =>
             {
                 if (id is not null)
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Builder
         [MemberData(nameof(MapMethods))]
         public async Task MapVerbWithExplicitRouteParameterIsCaseInsensitive(Action<IEndpointRouteBuilder, string, Delegate> map, string expectedMethod)
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
 
             map(builder, "/{ID}", ([FromRoute] int? id, HttpContext httpContext) =>
             {
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Builder
         [MemberData(nameof(MapMethods))]
         public async Task MapVerbWithRouteParameterDoesNotFallbackToQuery(Action<IEndpointRouteBuilder, string, Delegate> map, string expectedMethod)
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
 
             map(builder, "/{ID}", (int? id, HttpContext httpContext) =>
             {
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapGetWithRouteParameter_ThrowsIfRouteParameterDoesNotExist()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             var ex = Assert.Throws<InvalidOperationException>(() => builder.MapGet("/", ([FromRoute] int id) => { }));
             Assert.Equal("id is not a route paramter.", ex.Message);
         }
@@ -263,7 +263,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapPost_BuildsEndpointWithCorrectMethod()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapPost("/", () => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -283,7 +283,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapPost_BuildsEndpointWithCorrectEndpointMetadata()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapPost("/", [TestConsumesAttribute(typeof(Todo), "application/xml")] (Todo todo) => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -303,7 +303,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapPut_BuildsEndpointWithCorrectMethod()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapPut("/", () => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -323,7 +323,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapDelete_BuildsEndpointWithCorrectMethod()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapDelete("/", () => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -343,7 +343,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapFallback_BuildsEndpointWithLowestRouteOrder()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapFallback("/", () => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -359,7 +359,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapFallbackWithoutPath_BuildsEndpointWithLowestRouteOrder()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapFallback(() => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -381,7 +381,7 @@ namespace Microsoft.AspNetCore.Builder
         public void MapMethod_DoesNotEndpointNameForInnerMethod()
         {
             var name = "InnerGetString";
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             string InnerGetString() => "TestString";
             _ = builder.MapDelete("/", InnerGetString);
 
@@ -401,7 +401,7 @@ namespace Microsoft.AspNetCore.Builder
         public void MapMethod_DoesNotEndpointNameForInnerMethodWithTarget()
         {
             var name = "InnerGetString";
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             var testString = "TestString";
             string InnerGetString() => testString;
             _ = builder.MapDelete("/", InnerGetString);
@@ -423,7 +423,7 @@ namespace Microsoft.AspNetCore.Builder
         public void MapMethod_SetsEndpointNameForMethodGroup()
         {
             var name = "GetString";
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapDelete("/", GetString);
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -442,7 +442,7 @@ namespace Microsoft.AspNetCore.Builder
         public void WithNameOverridesDefaultEndpointName()
         {
             var name = "SomeCustomName";
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapDelete("/", GetString).WithName(name);
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -463,7 +463,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapMethod_DoesNotSetEndpointNameForLambda()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapDelete("/", () => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -477,7 +477,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void WithTags_CanSetTagsForEndpoint()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvdier()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             _ = builder.MapDelete("/", GetString).WithTags("Some", "Test", "Tags");
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -486,6 +486,44 @@ namespace Microsoft.AspNetCore.Builder
 
             var tagsMetadata = endpoint.Metadata.GetMetadata<ITagsMetadata>();
             Assert.Equal(new[] { "Some", "Test", "Tags" }, tagsMetadata?.Tags);
+        }
+
+        [Fact]
+        public void MapMethod_ThrowsIfItCannotResolveRouteHandlerOptions()
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().BuildServiceProvider()));
+            Assert.Throws<InvalidOperationException>(() => builder.Map("/", () => { }));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MapMethod_FlowsThrowOnBadHttpRequest(bool throwOnBadRequest)
+        {
+            var serviceProvider = new EmptyServiceProvider();
+            serviceProvider.RouteHandlerOptions.ThrowOnBadRequest = throwOnBadRequest;
+
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(serviceProvider));
+            _ = builder.Map("/{id}", (int id) => { });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider();
+            httpContext.Request.RouteValues["id"] = "invalid!";
+
+            if (throwOnBadRequest)
+            {
+                var ex = await Assert.ThrowsAsync<BadHttpRequestException>(() => endpoint.RequestDelegate!(httpContext));
+                Assert.Equal(400, ex.StatusCode);
+            }
+            else
+            {
+                await endpoint.RequestDelegate!(httpContext);
+                Assert.Equal(400, httpContext.Response.StatusCode);
+            }
         }
 
         class FromRoute : Attribute, IFromRouteMetadata
@@ -543,15 +581,15 @@ namespace Microsoft.AspNetCore.Builder
             }
         }
 
-        private class EmptyServiceProvdier : IServiceScope, IServiceProvider, IServiceScopeFactory
+        private class EmptyServiceProvider : IServiceScope, IServiceProvider, IServiceScopeFactory
         {
             public IServiceProvider ServiceProvider => this;
 
-            public IOptions<RouteHandlerOptions> RouteHandlerOptions { get; } = Options.Create(new RouteHandlerOptions());
+            public RouteHandlerOptions RouteHandlerOptions { get; set; } = new RouteHandlerOptions();
 
             public IServiceScope CreateScope()
             {
-                return new EmptyServiceProvdier();
+                return this;
             }
 
             public void Dispose()
@@ -566,7 +604,7 @@ namespace Microsoft.AspNetCore.Builder
                 }
                 else if (serviceType == typeof(IOptions<RouteHandlerOptions>))
                 {
-                    return RouteHandlerOptions;
+                    return Options.Create(RouteHandlerOptions);
                 }
 
                 return null;

--- a/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
@@ -3,16 +3,12 @@
 
 #nullable enable
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -551,6 +547,8 @@ namespace Microsoft.AspNetCore.Builder
         {
             public IServiceProvider ServiceProvider => this;
 
+            public IOptions<RouteHandlerOptions> RouteHandlerOptions { get; } = Options.Create(new RouteHandlerOptions());
+
             public IServiceScope CreateScope()
             {
                 return new EmptyServiceProvdier();
@@ -558,7 +556,6 @@ namespace Microsoft.AspNetCore.Builder
 
             public void Dispose()
             {
-
             }
 
             public object? GetService(Type serviceType)
@@ -567,6 +564,11 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     return this;
                 }
+                else if (serviceType == typeof(IOptions<RouteHandlerOptions>))
+                {
+                    return RouteHandlerOptions;
+                }
+
                 return null;
             }
         }

--- a/src/Http/Routing/test/UnitTests/Microsoft.AspNetCore.Routing.Tests.csproj
+++ b/src/Http/Routing/test/UnitTests/Microsoft.AspNetCore.Routing.Tests.csproj
@@ -8,8 +8,9 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.WebEncoders" />
   </ItemGroup>

--- a/src/Http/Routing/test/UnitTests/RouteHandlerOptionsTests.cs
+++ b/src/Http/Routing/test/UnitTests/RouteHandlerOptionsTests.cs
@@ -36,6 +36,30 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [Fact]
+        public void ThrowOnBadRequestIsNotOverwrittenIfNotInDevelopmentEnvironment()
+        {
+            var services = new ServiceCollection();
+
+            services.Configure<RouteHandlerOptions>(options =>
+            {
+                options.ThrowOnBadRequest = true;
+            });
+
+            services.AddSingleton<IHostEnvironment>(new HostEnvironment
+            {
+                EnvironmentName = "Production",
+            });
+
+            services.AddOptions();
+            services.AddRouting();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var options = serviceProvider.GetRequiredService<IOptions<RouteHandlerOptions>>().Value;
+            Assert.True(options.ThrowOnBadRequest);
+        }
+
+        [Fact]
         public void RouteHandlerOptionsFailsToResolveWithoutHostEnvironment()
         {
             var services = new ServiceCollection();

--- a/src/Http/Routing/test/UnitTests/RouteHandlerOptionsTests.cs
+++ b/src/Http/Routing/test/UnitTests/RouteHandlerOptionsTests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    public class RouteHandlerOptionsTests
+    {
+        [Theory]
+        [InlineData("Development", true)]
+        [InlineData("DEVELOPMENT", true)]
+        [InlineData("Production", false)]
+        [InlineData("Custom", false)]
+        public void ThrowOnBadRequestIsTrueIfInDevelopmentEnvironmentFalseOtherwise(string environmentName, bool expectedThrowOnBadRequest)
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.AddRouting();
+            services.AddSingleton<IHostEnvironment>(new HostEnvironment
+            {
+                EnvironmentName = environmentName,
+            });
+            var serviceProvider = services.BuildServiceProvider();
+
+            var options = serviceProvider.GetRequiredService<IOptions<RouteHandlerOptions>>().Value;
+            Assert.Equal(expectedThrowOnBadRequest, options.ThrowOnBadRequest);
+        }
+
+        [Fact]
+        public void RouteHandlerOptionsFailsToResolveWithoutHostEnvironment()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            services.AddRouting();
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.Throws<InvalidOperationException>(() => serviceProvider.GetRequiredService<IOptions<RouteHandlerOptions>>());
+        }
+
+        private class HostEnvironment : IHostEnvironment
+        {
+            public string ApplicationName { get; set; }
+            public IFileProvider ContentRootFileProvider { get; set; }
+            public string ContentRootPath { get; set; }
+            public string EnvironmentName { get; set; }
+        }
+    }
+}

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Diagnostics
             // If the client does not ask for HTML just format the exception as plain text
             if (acceptHeader == null || !acceptHeader.Any(h => h.IsSubsetOf(_textHtmlMediaType)))
             {
-                httpContext.Response.ContentType = "text/plain";
+                httpContext.Response.ContentType = "text/plain; charset=utf-8";
 
                 var sb = new StringBuilder();
                 sb.AppendLine(errorContext.Exception.ToString());

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -106,7 +106,16 @@ namespace Microsoft.AspNetCore.Diagnostics
                 try
                 {
                     context.Response.Clear();
-                    context.Response.StatusCode = 500;
+
+                    // Preserve the status code that would have been written by the server automatically when a BadHttpRequestException is thrown.
+                    if (ex is BadHttpRequestException badHttpRequestException)
+                    {
+                        context.Response.StatusCode = badHttpRequestException.StatusCode;
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 500;
+                    }
 
                     await _exceptionHandler(new ErrorContext(context, ex));
 

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -174,10 +174,7 @@ namespace Microsoft.AspNetCore.Diagnostics
         {
             var model = new CompilationErrorPageModel(_options);
 
-            var errorPage = new CompilationErrorPage
-            {
-                Model = model
-            };
+            var errorPage = new CompilationErrorPage(model);
 
             if (compilationException.CompilationFailures == null)
             {
@@ -257,6 +254,17 @@ namespace Microsoft.AspNetCore.Diagnostics
             }
 
             var request = context.Request;
+            var title = Resources.ErrorPageHtml_Title;
+
+            if (ex is BadHttpRequestException badHttpRequestException)
+            {
+                var badRequestReasonPhrase = WebUtilities.ReasonPhrases.GetReasonPhrase(badHttpRequestException.StatusCode);
+
+                if (!string.IsNullOrEmpty(badRequestReasonPhrase))
+                {
+                    title = badRequestReasonPhrase;
+                }
+            }
 
             var model = new ErrorPageModel
             {
@@ -266,7 +274,8 @@ namespace Microsoft.AspNetCore.Diagnostics
                 Cookies = request.Cookies,
                 Headers = request.Headers,
                 RouteValues = request.RouteValues,
-                Endpoint = endpointModel
+                Endpoint = endpointModel,
+                Title = title,
             };
 
             var errorPage = new ErrorPage(model);

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/CompilationErrorPage.Designer.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/CompilationErrorPage.Designer.cs
@@ -4,42 +4,55 @@ namespace Microsoft.AspNetCore.Diagnostics.RazorViews
 {
     #line hidden
     using System.Threading.Tasks;
+#nullable restore
 #line 1 "CompilationErrorPage.cshtml"
 using System;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 2 "CompilationErrorPage.cshtml"
 using System.Globalization;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 3 "CompilationErrorPage.cshtml"
 using System.Linq;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 4 "CompilationErrorPage.cshtml"
 using System.Net;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 5 "CompilationErrorPage.cshtml"
 using Microsoft.AspNetCore.Diagnostics;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 6 "CompilationErrorPage.cshtml"
 using Microsoft.AspNetCore.Diagnostics.RazorViews;
 
 #line default
 #line hidden
+#nullable disable
     internal class CompilationErrorPage : Microsoft.Extensions.RazorViews.BaseView
     {
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
-#line 11 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 16 "CompilationErrorPage.cshtml"
   
     Response.StatusCode = 500;
     Response.ContentType = "text/html; charset=utf-8";
@@ -47,12 +60,15 @@ using Microsoft.AspNetCore.Diagnostics.RazorViews;
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("<!DOCTYPE html>\r\n<html>\r\n    <head>\r\n        <meta charset=\"utf-8\" />\r\n        <title>");
-#line 20 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 25 "CompilationErrorPage.cshtml"
           Write(Resources.ErrorPageHtml_Title);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(@"</title>
         <style>
             body {
@@ -154,6 +170,12 @@ body .location {
         background-color: #fbfbfb;
     }
 
+#stackpage .frame .source .highlight {
+    border-left: 3px solid red;
+    margin-left: -3px;
+    font-weight: bold;
+}
+
 #stackpage .frame .source .highlight li span {
     color: #FF0000;
 }
@@ -164,7 +186,8 @@ body .location {
 
     #stackpage .source ol.collapsible li span {
         color: #606060;
-    }
+    ");
+            WriteLiteral(@"}
 
 #routingpage .subheader {
     padding: 5px;
@@ -172,8 +195,7 @@ body .location {
 }
 
 .page table {
-    border-collapse");
-            WriteLiteral(@": separate;
+    border-collapse: separate;
     border-spacing: 0;
     margin: 0 0 20px;
 }
@@ -221,7 +243,8 @@ a {
     color: #44c5f2;
     background-color: transparent;
     font-size: 1.2em;
-    text-align: left;
+    text-align: left;");
+            WriteLiteral(@"
     text-decoration: none;
     display: inline-block;
     border: 0;
@@ -229,8 +252,7 @@ a {
 }
 
 .rawExceptionStackTrace {
-    ");
-            WriteLiteral(@"font-size: 1.2em;
+    font-size: 1.2em;
 }
 
 .rawExceptionBlock {
@@ -261,20 +283,25 @@ a {
     </head>
     <body>
         <h1>");
-#line 224 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 235 "CompilationErrorPage.cshtml"
        Write(Resources.ErrorPageHtml_CompilationException);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</h1>\r\n");
-#line 225 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 236 "CompilationErrorPage.cshtml"
           
             var exceptionDetailId = "";
         
 
 #line default
 #line hidden
-#line 228 "CompilationErrorPage.cshtml"
+#nullable disable
+#nullable restore
+#line 239 "CompilationErrorPage.cshtml"
          for (var i = 0; i < Model.ErrorDetails.Count; i++)
         {
             var errorDetail = Model.ErrorDetails[i];
@@ -283,8 +310,10 @@ a {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("            <div id=\"stackpage\" class=\"page\">\r\n");
-#line 234 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 245 "CompilationErrorPage.cshtml"
                   
                     var stackFrameCount = 0;
                     var frameId = "";
@@ -294,39 +323,51 @@ a {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                        <div class=\"titleerror\">");
-#line 240 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 251 "CompilationErrorPage.cshtml"
                                            Write(fileName);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</div>\r\n");
-#line 241 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 252 "CompilationErrorPage.cshtml"
                     }
                 
 
 #line default
 #line hidden
-#line 243 "CompilationErrorPage.cshtml"
+#nullable disable
+#nullable restore
+#line 254 "CompilationErrorPage.cshtml"
                  if (!string.IsNullOrEmpty(errorDetail.ErrorMessage))
                 {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    <div class=\"details\">");
-#line 245 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 256 "CompilationErrorPage.cshtml"
                                     Write(errorDetail.ErrorMessage);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</div>\r\n");
-#line 246 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 257 "CompilationErrorPage.cshtml"
                 }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <br />\r\n                <ul>\r\n");
-#line 249 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 260 "CompilationErrorPage.cshtml"
                  foreach (var frame in errorDetail.StackFrames)
                 {
                     stackFrameCount++;
@@ -335,204 +376,265 @@ a {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    <li class=\"frame\"");
-            BeginWriteAttribute("id", " id=\"", 5287, "\"", 5300, 1);
-#line 254 "CompilationErrorPage.cshtml"
-WriteAttributeValue("", 5292, frameId, 5292, 8, false);
+            BeginWriteAttribute("id", " id=\"", 5519, "\"", 5532, 1);
+#nullable restore
+#line 265 "CompilationErrorPage.cshtml"
+WriteAttributeValue("", 5524, frameId, 5524, 8, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(">\r\n");
-#line 255 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 266 "CompilationErrorPage.cshtml"
                          if (!string.IsNullOrEmpty(frame.ErrorDetails))
                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            <h3>");
-#line 257 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 268 "CompilationErrorPage.cshtml"
                            Write(frame.ErrorDetails);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</h3>\r\n");
-#line 258 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 269 "CompilationErrorPage.cshtml"
                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\r\n");
-#line 260 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 271 "CompilationErrorPage.cshtml"
                          if (frame.Line != 0 && frame.ContextCode.Any())
                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            <button class=\"expandCollapseButton\" data-frameId=\"");
-#line 262 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 273 "CompilationErrorPage.cshtml"
                                                                           Write(frameId);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\">+</button>\r\n                            <div class=\"source\">\r\n");
-#line 264 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 275 "CompilationErrorPage.cshtml"
                                  if (frame.PreContextCode.Any())
                                 {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                    <ol");
-            BeginWriteAttribute("start", " start=\"", 5883, "\"", 5912, 1);
-#line 266 "CompilationErrorPage.cshtml"
-WriteAttributeValue("", 5891, frame.PreContextLine, 5891, 21, false);
+            BeginWriteAttribute("start", " start=\"", 6115, "\"", 6144, 1);
+#nullable restore
+#line 277 "CompilationErrorPage.cshtml"
+WriteAttributeValue("", 6123, frame.PreContextLine, 6123, 21, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" class=\"collapsible\">\r\n");
-#line 267 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 278 "CompilationErrorPage.cshtml"
                                          foreach (var line in frame.PreContextCode)
                                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                            <li><span>");
-#line 269 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 280 "CompilationErrorPage.cshtml"
                                                  Write(line);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</span></li>\r\n");
-#line 270 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 281 "CompilationErrorPage.cshtml"
                                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                    </ol>\r\n");
-#line 272 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 283 "CompilationErrorPage.cshtml"
                                 }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                <ol");
-            BeginWriteAttribute("start", " start=\"", 6293, "\"", 6312, 1);
-#line 273 "CompilationErrorPage.cshtml"
-WriteAttributeValue("", 6301, frame.Line, 6301, 11, false);
+            BeginWriteAttribute("start", " start=\"", 6525, "\"", 6544, 1);
+#nullable restore
+#line 284 "CompilationErrorPage.cshtml"
+WriteAttributeValue("", 6533, frame.Line, 6533, 11, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" class=\"highlight\">\r\n");
-#line 274 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 285 "CompilationErrorPage.cshtml"
                                      foreach (var line in frame.ContextCode)
                                     {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                        <li><span>");
-#line 276 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 287 "CompilationErrorPage.cshtml"
                                              Write(line);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</span></li>\r\n");
-#line 277 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 288 "CompilationErrorPage.cshtml"
                                     }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                </ol>\r\n");
-#line 279 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 290 "CompilationErrorPage.cshtml"
                                  if (frame.PostContextCode.Any())
                                 {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                    <ol");
-            BeginWriteAttribute("start", " start=\'", 6739, "\'", 6764, 1);
-#line 281 "CompilationErrorPage.cshtml"
-WriteAttributeValue("", 6747, frame.Line + 1, 6747, 17, false);
+            BeginWriteAttribute("start", " start=\'", 6971, "\'", 6996, 1);
+#nullable restore
+#line 292 "CompilationErrorPage.cshtml"
+WriteAttributeValue("", 6979, frame.Line + 1, 6979, 17, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" class=\"collapsible\">\r\n");
-#line 282 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 293 "CompilationErrorPage.cshtml"
                                          foreach (var line in frame.PostContextCode)
                                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                            <li><span>");
-#line 284 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 295 "CompilationErrorPage.cshtml"
                                                  Write(line);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</span></li>\r\n");
-#line 285 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 296 "CompilationErrorPage.cshtml"
                                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                    </ol>\r\n");
-#line 287 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 298 "CompilationErrorPage.cshtml"
                                 }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            </div>\r\n");
-#line 289 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 300 "CompilationErrorPage.cshtml"
                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    </li>\r\n");
-#line 291 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 302 "CompilationErrorPage.cshtml"
                 }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                </ul>\r\n                <br />\r\n            </div>\r\n");
-#line 295 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 306 "CompilationErrorPage.cshtml"
              if (!string.IsNullOrEmpty(Model.CompiledContent[i]))
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <div class=\"rawExceptionBlock\">\r\n                    <div class=\"showRawExceptionContainer\">\r\n                        <button class=\"showRawException\" data-exceptionDetailId=\"");
-#line 299 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 310 "CompilationErrorPage.cshtml"
                                                                             Write(exceptionDetailId);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\">Show compilation source</button>\r\n                    </div>\r\n                    <div");
-            BeginWriteAttribute("id", " id=\"", 7666, "\"", 7689, 1);
-#line 301 "CompilationErrorPage.cshtml"
-WriteAttributeValue("", 7671, exceptionDetailId, 7671, 18, false);
+            BeginWriteAttribute("id", " id=\"", 7898, "\"", 7921, 1);
+#nullable restore
+#line 312 "CompilationErrorPage.cshtml"
+WriteAttributeValue("", 7903, exceptionDetailId, 7903, 18, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" class=\"rawExceptionDetails\">\r\n                        <pre class=\"rawExceptionStackTrace\">");
-#line 302 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 313 "CompilationErrorPage.cshtml"
                                                        Write(Model.CompiledContent[i]);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</pre>\r\n                    </div>\r\n                </div>\r\n");
-#line 305 "CompilationErrorPage.cshtml"
+#nullable restore
+#line 316 "CompilationErrorPage.cshtml"
             }
 
 #line default
 #line hidden
-#line 305 "CompilationErrorPage.cshtml"
+#nullable disable
+#nullable restore
+#line 316 "CompilationErrorPage.cshtml"
              
         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(@"
         <script>
             //<!--
@@ -740,12 +842,19 @@ WriteAttributeValue("", 7671, exceptionDetailId, 7671, 18, false);
 ");
         }
         #pragma warning restore 1998
+#nullable restore
 #line 8 "CompilationErrorPage.cshtml"
  
+    public CompilationErrorPage(CompilationErrorPageModel model)
+    {
+        Model = model;
+    }
+
     public CompilationErrorPageModel Model { get; set; }
 
 #line default
 #line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/CompilationErrorPage.cshtml
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/CompilationErrorPage.cshtml
@@ -6,6 +6,11 @@
 @using Microsoft.AspNetCore.Diagnostics.RazorViews
 @functions
 {
+    public CompilationErrorPage(CompilationErrorPageModel model)
+    {
+        Model = model;
+    }
+
     public CompilationErrorPageModel Model { get; set; }
 }
 @{

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.Designer.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.Designer.cs
@@ -4,68 +4,88 @@ namespace Microsoft.AspNetCore.Diagnostics.RazorViews
 {
     #line hidden
     using System.Threading.Tasks;
+#nullable restore
 #line 1 "ErrorPage.cshtml"
 using System;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 2 "ErrorPage.cshtml"
 using System.Globalization;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 3 "ErrorPage.cshtml"
 using System.Linq;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 4 "ErrorPage.cshtml"
 using System.Net;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 5 "ErrorPage.cshtml"
 using System.Reflection;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 6 "ErrorPage.cshtml"
 using Microsoft.AspNetCore.Diagnostics.RazorViews;
 
 #line default
 #line hidden
+#nullable disable
+#nullable restore
 #line 7 "ErrorPage.cshtml"
 using Microsoft.AspNetCore.Diagnostics;
 
 #line default
 #line hidden
+#nullable disable
     internal class ErrorPage : Microsoft.Extensions.RazorViews.BaseView
     {
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
+#nullable restore
 #line 17 "ErrorPage.cshtml"
   
     // TODO: Response.ReasonPhrase = "Internal Server Error";
     Response.ContentType = "text/html; charset=utf-8";
-    string location = string.Empty;
+    string? location = string.Empty;
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("<!DOCTYPE html>\r\n<html");
-            BeginWriteAttribute("lang", " lang=\"", 536, "\"", 597, 1);
+            BeginWriteAttribute("lang", " lang=\"", 537, "\"", 598, 1);
+#nullable restore
 #line 23 "ErrorPage.cshtml"
-WriteAttributeValue("", 543, CultureInfo.CurrentUICulture.TwoLetterISOLanguageName, 543, 54, false);
+WriteAttributeValue("", 544, CultureInfo.CurrentUICulture.TwoLetterISOLanguageName, 544, 54, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" xmlns=\"http://www.w3.org/1999/xhtml\">\r\n    <head>\r\n        <meta charset=\"utf-8\" />\r\n        <title>");
+#nullable restore
 #line 26 "ErrorPage.cshtml"
-          Write(Resources.ErrorPageHtml_Title);
+          Write(Model.Title);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(@"</title>
         <style>
             body {
@@ -167,6 +187,12 @@ body .location {
         background-color: #fbfbfb;
     }
 
+#stackpage .frame .source .highlight {
+    border-left: 3px solid red;
+    margin-left: -3px;
+    font-weight: bold;
+}
+
 #stackpage .frame .source .highlight li span {
     color: #FF0000;
 }
@@ -177,7 +203,8 @@ body .location {
 
     #stackpage .source ol.collapsible li span {
         color: #606060;
-    }
+    ");
+            WriteLiteral(@"}
 
 #routingpage .subheader {
     padding: 5px;
@@ -185,8 +212,7 @@ body .location {
 }
 
 .page table {
-    border-collapse");
-            WriteLiteral(@": separate;
+    border-collapse: separate;
     border-spacing: 0;
     margin: 0 0 20px;
 }
@@ -234,7 +260,8 @@ a {
     color: #44c5f2;
     background-color: transparent;
     font-size: 1.2em;
-    text-align: left;
+    text-align: left;");
+            WriteLiteral(@"
     text-decoration: none;
     display: inline-block;
     border: 0;
@@ -242,8 +269,7 @@ a {
 }
 
 .rawExceptionStackTrace {
-    ");
-            WriteLiteral(@"font-size: 1.2em;
+    font-size: 1.2em;
 }
 
 .rawExceptionBlock {
@@ -274,32 +300,41 @@ a {
     </head>
     <body>
         <h1>");
-#line 230 "ErrorPage.cshtml"
+#nullable restore
+#line 236 "ErrorPage.cshtml"
        Write(Resources.ErrorPageHtml_UnhandledException);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</h1>\r\n");
-#line 231 "ErrorPage.cshtml"
+#nullable restore
+#line 237 "ErrorPage.cshtml"
          foreach (var errorDetail in Model.ErrorDetails)
         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("            <div class=\"titleerror\">");
-#line 233 "ErrorPage.cshtml"
-                               Write(errorDetail.Error.GetType().Name);
+#nullable restore
+#line 239 "ErrorPage.cshtml"
+                               Write(errorDetail.Error!.GetType().Name);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(": ");
-#line 233 "ErrorPage.cshtml"
-                                                                          Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); 
+#nullable restore
+#line 239 "ErrorPage.cshtml"
+                                                                           Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); 
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</div>\r\n");
-#line 234 "ErrorPage.cshtml"
+#nullable restore
+#line 240 "ErrorPage.cshtml"
 
             var firstFrame = errorDetail.StackFrames.FirstOrDefault();
             if (firstFrame != null)
@@ -311,62 +346,80 @@ a {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <p class=\"location\">");
-#line 242 "ErrorPage.cshtml"
+#nullable restore
+#line 248 "ErrorPage.cshtml"
                                Write(location);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(" in <code");
-            BeginWriteAttribute("title", " title=\"", 4957, "\"", 4981, 1);
-#line 242 "ErrorPage.cshtml"
-WriteAttributeValue("", 4965, firstFrame.File, 4965, 16, false);
+            BeginWriteAttribute("title", " title=\"", 5067, "\"", 5091, 1);
+#nullable restore
+#line 248 "ErrorPage.cshtml"
+WriteAttributeValue("", 5075, firstFrame.File, 5075, 16, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(">");
-#line 242 "ErrorPage.cshtml"
+#nullable restore
+#line 248 "ErrorPage.cshtml"
                                                                            Write(System.IO.Path.GetFileName(firstFrame.File));
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</code>, line ");
-#line 242 "ErrorPage.cshtml"
+#nullable restore
+#line 248 "ErrorPage.cshtml"
                                                                                                                                      Write(firstFrame.Line);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</p>\r\n");
-#line 243 "ErrorPage.cshtml"
+#nullable restore
+#line 249 "ErrorPage.cshtml"
             }
             else if (!string.IsNullOrEmpty(location))
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <p class=\"location\">");
-#line 246 "ErrorPage.cshtml"
+#nullable restore
+#line 252 "ErrorPage.cshtml"
                                Write(location);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</p>\r\n");
-#line 247 "ErrorPage.cshtml"
+#nullable restore
+#line 253 "ErrorPage.cshtml"
             }
             else
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <p class=\"location\">");
-#line 250 "ErrorPage.cshtml"
+#nullable restore
+#line 256 "ErrorPage.cshtml"
                                Write(Resources.ErrorPageHtml_UnknownLocation);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</p>\r\n");
-#line 251 "ErrorPage.cshtml"
+#nullable restore
+#line 257 "ErrorPage.cshtml"
             }
 
             var reflectionTypeLoadException = errorDetail.Error as ReflectionTypeLoadException;
@@ -377,65 +430,85 @@ WriteAttributeValue("", 4965, firstFrame.File, 4965, 16, false);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    <h3>Loader Exceptions:</h3>\r\n                    <ul>\r\n");
-#line 260 "ErrorPage.cshtml"
+#nullable restore
+#line 266 "ErrorPage.cshtml"
                          foreach (var ex in reflectionTypeLoadException.LoaderExceptions)
                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            <li>");
-#line 262 "ErrorPage.cshtml"
-                           Write(ex.Message);
+#nullable restore
+#line 268 "ErrorPage.cshtml"
+                           Write(ex!.Message);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</li>\r\n");
-#line 263 "ErrorPage.cshtml"
+#nullable restore
+#line 269 "ErrorPage.cshtml"
                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    </ul>\r\n");
-#line 265 "ErrorPage.cshtml"
+#nullable restore
+#line 271 "ErrorPage.cshtml"
                 }
             }
         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("        <ul id=\"header\">\r\n            <li id=\"stack\" tabindex=\"1\" class=\"selected\">\r\n                ");
-#line 270 "ErrorPage.cshtml"
+#nullable restore
+#line 276 "ErrorPage.cshtml"
            Write(Resources.ErrorPageHtml_StackButton);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\r\n            </li>\r\n            <li id=\"query\" tabindex=\"2\">\r\n                ");
-#line 273 "ErrorPage.cshtml"
+#nullable restore
+#line 279 "ErrorPage.cshtml"
            Write(Resources.ErrorPageHtml_QueryButton);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\r\n            </li>\r\n            <li id=\"cookies\" tabindex=\"3\">\r\n                ");
-#line 276 "ErrorPage.cshtml"
+#nullable restore
+#line 282 "ErrorPage.cshtml"
            Write(Resources.ErrorPageHtml_CookiesButton);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\r\n            </li>\r\n            <li id=\"headers\" tabindex=\"4\">\r\n                ");
-#line 279 "ErrorPage.cshtml"
+#nullable restore
+#line 285 "ErrorPage.cshtml"
            Write(Resources.ErrorPageHtml_HeadersButton);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\r\n            </li>\r\n            <li id=\"routing\" tabindex=\"5\">\r\n                ");
-#line 282 "ErrorPage.cshtml"
+#nullable restore
+#line 288 "ErrorPage.cshtml"
            Write(Resources.ErrorPageHtml_RoutingButton);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\r\n            </li>\r\n        </ul>\r\n\r\n        <div id=\"stackpage\" class=\"page\">\r\n            <ul>\r\n");
-#line 288 "ErrorPage.cshtml"
+#nullable restore
+#line 294 "ErrorPage.cshtml"
                   
                     var exceptionCount = 0;
                     var stackFrameCount = 0;
@@ -445,7 +518,9 @@ WriteAttributeValue("", 4965, firstFrame.File, 4965, 16, false);
 
 #line default
 #line hidden
-#line 294 "ErrorPage.cshtml"
+#nullable disable
+#nullable restore
+#line 300 "ErrorPage.cshtml"
                  foreach (var errorDetail in Model.ErrorDetails)
                 {
                     exceptionCount++;
@@ -454,20 +529,26 @@ WriteAttributeValue("", 4965, firstFrame.File, 4965, 16, false);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    <li>\r\n                        <h2 class=\"stackerror\">");
-#line 300 "ErrorPage.cshtml"
-                                          Write(errorDetail.Error.GetType().Name);
+#nullable restore
+#line 306 "ErrorPage.cshtml"
+                                          Write(errorDetail.Error!.GetType().Name);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(": ");
-#line 300 "ErrorPage.cshtml"
-                                                                             Write(errorDetail.Error.Message);
+#nullable restore
+#line 306 "ErrorPage.cshtml"
+                                                                              Write(errorDetail.Error.Message);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</h2>\r\n                        <ul>\r\n");
-#line 302 "ErrorPage.cshtml"
+#nullable restore
+#line 308 "ErrorPage.cshtml"
                              foreach (var frame in errorDetail.StackFrames)
                             {
                                 stackFrameCount++;
@@ -476,193 +557,250 @@ WriteAttributeValue("", 4965, firstFrame.File, 4965, 16, false);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                <li class=\"frame\"");
-            BeginWriteAttribute("id", " id=\"", 7532, "\"", 7545, 1);
-#line 307 "ErrorPage.cshtml"
-WriteAttributeValue("", 7537, frameId, 7537, 8, false);
+            BeginWriteAttribute("id", " id=\"", 7644, "\"", 7657, 1);
+#nullable restore
+#line 313 "ErrorPage.cshtml"
+WriteAttributeValue("", 7649, frameId, 7649, 8, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(">\r\n");
-#line 308 "ErrorPage.cshtml"
+#nullable restore
+#line 314 "ErrorPage.cshtml"
                                      if (string.IsNullOrEmpty(frame.File))
                                     {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                        <h3>");
-#line 310 "ErrorPage.cshtml"
+#nullable restore
+#line 316 "ErrorPage.cshtml"
                                        Write(frame.Function);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</h3>\r\n");
-#line 311 "ErrorPage.cshtml"
+#nullable restore
+#line 317 "ErrorPage.cshtml"
                                     }
                                     else
                                     {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                        <h3>");
-#line 314 "ErrorPage.cshtml"
+#nullable restore
+#line 320 "ErrorPage.cshtml"
                                        Write(frame.Function);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(" in <code");
-            BeginWriteAttribute("title", " title=\"", 7918, "\"", 7937, 1);
-#line 314 "ErrorPage.cshtml"
-WriteAttributeValue("", 7926, frame.File, 7926, 11, false);
+            BeginWriteAttribute("title", " title=\"", 8030, "\"", 8049, 1);
+#nullable restore
+#line 320 "ErrorPage.cshtml"
+WriteAttributeValue("", 8038, frame.File, 8038, 11, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(">");
-#line 314 "ErrorPage.cshtml"
+#nullable restore
+#line 320 "ErrorPage.cshtml"
                                                                                     Write(System.IO.Path.GetFileName(frame.File));
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</code></h3>\r\n");
-#line 315 "ErrorPage.cshtml"
+#nullable restore
+#line 321 "ErrorPage.cshtml"
                                     }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\r\n");
-#line 317 "ErrorPage.cshtml"
+#nullable restore
+#line 323 "ErrorPage.cshtml"
                                      if (frame.Line != 0 && frame.ContextCode.Any())
                                     {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                        <button class=\"expandCollapseButton\" data-frameId=\"");
-#line 319 "ErrorPage.cshtml"
+#nullable restore
+#line 325 "ErrorPage.cshtml"
                                                                                       Write(frameId);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\">+</button>\r\n                                        <div class=\"source\">\r\n");
-#line 321 "ErrorPage.cshtml"
+#nullable restore
+#line 327 "ErrorPage.cshtml"
                                              if (frame.PreContextCode.Any())
                                             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                                <ol");
-            BeginWriteAttribute("start", " start=\"", 8509, "\"", 8538, 1);
-#line 323 "ErrorPage.cshtml"
-WriteAttributeValue("", 8517, frame.PreContextLine, 8517, 21, false);
+            BeginWriteAttribute("start", " start=\"", 8621, "\"", 8650, 1);
+#nullable restore
+#line 329 "ErrorPage.cshtml"
+WriteAttributeValue("", 8629, frame.PreContextLine, 8629, 21, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" class=\"collapsible\">\r\n");
-#line 324 "ErrorPage.cshtml"
+#nullable restore
+#line 330 "ErrorPage.cshtml"
                                                      foreach (var line in frame.PreContextCode)
                                                     {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                                        <li><span>");
-#line 326 "ErrorPage.cshtml"
+#nullable restore
+#line 332 "ErrorPage.cshtml"
                                                              Write(line);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</span></li>\r\n");
-#line 327 "ErrorPage.cshtml"
+#nullable restore
+#line 333 "ErrorPage.cshtml"
                                                     }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                                </ol>\r\n");
-#line 329 "ErrorPage.cshtml"
+#nullable restore
+#line 335 "ErrorPage.cshtml"
                                             }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\r\n                                            <ol");
-            BeginWriteAttribute("start", " start=\"", 9005, "\"", 9024, 1);
-#line 331 "ErrorPage.cshtml"
-WriteAttributeValue("", 9013, frame.Line, 9013, 11, false);
+            BeginWriteAttribute("start", " start=\"", 9117, "\"", 9136, 1);
+#nullable restore
+#line 337 "ErrorPage.cshtml"
+WriteAttributeValue("", 9125, frame.Line, 9125, 11, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" class=\"highlight\">\r\n");
-#line 332 "ErrorPage.cshtml"
+#nullable restore
+#line 338 "ErrorPage.cshtml"
                                                  foreach (var line in frame.ContextCode)
                                                 {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                                    <li><span>");
-#line 334 "ErrorPage.cshtml"
+#nullable restore
+#line 340 "ErrorPage.cshtml"
                                                          Write(line);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</span></li>\r\n");
-#line 335 "ErrorPage.cshtml"
+#nullable restore
+#line 341 "ErrorPage.cshtml"
                                                 }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                            </ol>\r\n\r\n");
-#line 338 "ErrorPage.cshtml"
+#nullable restore
+#line 344 "ErrorPage.cshtml"
                                              if (frame.PostContextCode.Any())
                                             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                                <ol");
-            BeginWriteAttribute("start", " start=\'", 9549, "\'", 9574, 1);
-#line 340 "ErrorPage.cshtml"
-WriteAttributeValue("", 9557, frame.Line + 1, 9557, 17, false);
+            BeginWriteAttribute("start", " start=\'", 9661, "\'", 9686, 1);
+#nullable restore
+#line 346 "ErrorPage.cshtml"
+WriteAttributeValue("", 9669, frame.Line + 1, 9669, 17, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" class=\"collapsible\">\r\n");
-#line 341 "ErrorPage.cshtml"
+#nullable restore
+#line 347 "ErrorPage.cshtml"
                                                      foreach (var line in frame.PostContextCode)
                                                     {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                                        <li><span>");
-#line 343 "ErrorPage.cshtml"
+#nullable restore
+#line 349 "ErrorPage.cshtml"
                                                              Write(line);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</span></li>\r\n");
-#line 344 "ErrorPage.cshtml"
+#nullable restore
+#line 350 "ErrorPage.cshtml"
                                                     }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                                </ol>\r\n");
-#line 346 "ErrorPage.cshtml"
+#nullable restore
+#line 352 "ErrorPage.cshtml"
                                             }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                        </div>\r\n");
-#line 348 "ErrorPage.cshtml"
+#nullable restore
+#line 354 "ErrorPage.cshtml"
                                     }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                </li>\r\n");
-#line 350 "ErrorPage.cshtml"
+#nullable restore
+#line 356 "ErrorPage.cshtml"
                             }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(@"                        </ul>
                     </li>
                     <li>
@@ -670,52 +808,67 @@ WriteAttributeValue("", 9557, frame.Line + 1, 9557, 17, false);
                         <div class=""rawExceptionBlock"">
                             <div class=""showRawExceptionContainer"">
                                 <button class=""showRawException"" data-exceptionDetailId=""");
-#line 357 "ErrorPage.cshtml"
+#nullable restore
+#line 363 "ErrorPage.cshtml"
                                                                                     Write(exceptionDetailId);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("\">Show raw exception details</button>\r\n                            </div>\r\n                            <div");
-            BeginWriteAttribute("id", " id=\"", 10606, "\"", 10629, 1);
-#line 359 "ErrorPage.cshtml"
-WriteAttributeValue("", 10611, exceptionDetailId, 10611, 18, false);
+            BeginWriteAttribute("id", " id=\"", 10718, "\"", 10741, 1);
+#nullable restore
+#line 365 "ErrorPage.cshtml"
+WriteAttributeValue("", 10723, exceptionDetailId, 10723, 18, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" class=\"rawExceptionDetails\">\r\n                                <pre class=\"rawExceptionStackTrace\">");
-#line 360 "ErrorPage.cshtml"
+#nullable restore
+#line 366 "ErrorPage.cshtml"
                                                                Write(errorDetail.Error.ToString());
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</pre>\r\n                            </div>\r\n                        </div>\r\n                    </li>\r\n");
-#line 364 "ErrorPage.cshtml"
+#nullable restore
+#line 370 "ErrorPage.cshtml"
                 }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("            </ul>\r\n        </div>\r\n\r\n        <div id=\"querypage\" class=\"page\">\r\n");
-#line 369 "ErrorPage.cshtml"
+#nullable restore
+#line 375 "ErrorPage.cshtml"
              if (Model.Query.Any())
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <table>\r\n                    <thead>\r\n                        <tr>\r\n                            <th>");
-#line 374 "ErrorPage.cshtml"
+#nullable restore
+#line 380 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_VariableColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                            <th>");
-#line 375 "ErrorPage.cshtml"
+#nullable restore
+#line 381 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_ValueColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                        </tr>\r\n                    </thead>\r\n                    <tbody>\r\n");
-#line 379 "ErrorPage.cshtml"
+#nullable restore
+#line 385 "ErrorPage.cshtml"
                          foreach (var kv in Model.Query.OrderBy(kv => kv.Key))
                         {
                             foreach (var v in kv.Value)
@@ -723,130 +876,170 @@ WriteAttributeValue("", 10611, exceptionDetailId, 10611, 18, false);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                <tr>\r\n                                    <td>");
-#line 384 "ErrorPage.cshtml"
+#nullable restore
+#line 390 "ErrorPage.cshtml"
                                    Write(kv.Key);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                    <td>");
-#line 385 "ErrorPage.cshtml"
+#nullable restore
+#line 391 "ErrorPage.cshtml"
                                    Write(v);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                </tr>\r\n");
-#line 387 "ErrorPage.cshtml"
+#nullable restore
+#line 393 "ErrorPage.cshtml"
                             }
                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    </tbody>\r\n                </table>\r\n");
-#line 391 "ErrorPage.cshtml"
+#nullable restore
+#line 397 "ErrorPage.cshtml"
             }
             else
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <p>");
-#line 394 "ErrorPage.cshtml"
+#nullable restore
+#line 400 "ErrorPage.cshtml"
               Write(Resources.ErrorPageHtml_NoQueryStringData);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</p>\r\n");
-#line 395 "ErrorPage.cshtml"
+#nullable restore
+#line 401 "ErrorPage.cshtml"
             }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("        </div>\r\n\r\n        <div id=\"cookiespage\" class=\"page\">\r\n");
-#line 399 "ErrorPage.cshtml"
+#nullable restore
+#line 405 "ErrorPage.cshtml"
              if (Model.Cookies.Any())
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <table>\r\n                    <thead>\r\n                        <tr>\r\n                            <th>");
-#line 404 "ErrorPage.cshtml"
+#nullable restore
+#line 410 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_VariableColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                            <th>");
-#line 405 "ErrorPage.cshtml"
+#nullable restore
+#line 411 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_ValueColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                        </tr>\r\n                    </thead>\r\n                    <tbody>\r\n");
-#line 409 "ErrorPage.cshtml"
+#nullable restore
+#line 415 "ErrorPage.cshtml"
                          foreach (var kv in Model.Cookies.OrderBy(kv => kv.Key))
                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            <tr>\r\n                                <td>");
-#line 412 "ErrorPage.cshtml"
+#nullable restore
+#line 418 "ErrorPage.cshtml"
                                Write(kv.Key);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                <td>");
-#line 413 "ErrorPage.cshtml"
+#nullable restore
+#line 419 "ErrorPage.cshtml"
                                Write(kv.Value);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                            </tr>\r\n");
-#line 415 "ErrorPage.cshtml"
+#nullable restore
+#line 421 "ErrorPage.cshtml"
                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    </tbody>\r\n                </table>\r\n");
-#line 418 "ErrorPage.cshtml"
+#nullable restore
+#line 424 "ErrorPage.cshtml"
             }
             else
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <p>");
-#line 421 "ErrorPage.cshtml"
+#nullable restore
+#line 427 "ErrorPage.cshtml"
               Write(Resources.ErrorPageHtml_NoCookieData);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</p>\r\n");
-#line 422 "ErrorPage.cshtml"
+#nullable restore
+#line 428 "ErrorPage.cshtml"
             }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("        </div>\r\n\r\n        <div id=\"headerspage\" class=\"page\">\r\n");
-#line 426 "ErrorPage.cshtml"
+#nullable restore
+#line 432 "ErrorPage.cshtml"
              if (Model.Headers.Any())
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <table>\r\n                    <thead>\r\n                        <tr>\r\n                            <th>");
-#line 431 "ErrorPage.cshtml"
+#nullable restore
+#line 437 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_VariableColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                            <th>");
-#line 432 "ErrorPage.cshtml"
+#nullable restore
+#line 438 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_ValueColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                        </tr>\r\n                    </thead>\r\n                    <tbody>\r\n");
-#line 436 "ErrorPage.cshtml"
+#nullable restore
+#line 442 "ErrorPage.cshtml"
                          foreach (var kv in Model.Headers.OrderBy(kv => kv.Key))
                         {
                             foreach (var v in kv.Value)
@@ -854,245 +1047,322 @@ WriteAttributeValue("", 10611, exceptionDetailId, 10611, 18, false);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                                <tr>\r\n                                    <td>");
-#line 441 "ErrorPage.cshtml"
+#nullable restore
+#line 447 "ErrorPage.cshtml"
                                    Write(kv.Key);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                    <td>");
-#line 442 "ErrorPage.cshtml"
+#nullable restore
+#line 448 "ErrorPage.cshtml"
                                    Write(v);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                </tr>\r\n");
-#line 444 "ErrorPage.cshtml"
+#nullable restore
+#line 450 "ErrorPage.cshtml"
                             }
                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    </tbody>\r\n                </table>\r\n");
-#line 448 "ErrorPage.cshtml"
+#nullable restore
+#line 454 "ErrorPage.cshtml"
             }
             else
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <p>");
-#line 451 "ErrorPage.cshtml"
+#nullable restore
+#line 457 "ErrorPage.cshtml"
               Write(Resources.ErrorPageHtml_NoHeaderData);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</p>\r\n");
-#line 452 "ErrorPage.cshtml"
+#nullable restore
+#line 458 "ErrorPage.cshtml"
             }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("        </div>\r\n\r\n        <div id=\"routingpage\" class=\"page\">\r\n            <h2 class=\"subheader\">");
-#line 456 "ErrorPage.cshtml"
+#nullable restore
+#line 462 "ErrorPage.cshtml"
                              Write(Resources.ErrorPageHtml_Endpoint);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</h2>\r\n");
-#line 457 "ErrorPage.cshtml"
+#nullable restore
+#line 463 "ErrorPage.cshtml"
              if (Model.Endpoint != null)
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <table>\r\n                    <thead>\r\n                        <tr>\r\n                            <th>");
-#line 462 "ErrorPage.cshtml"
+#nullable restore
+#line 468 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_NameColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                            <th>");
-#line 463 "ErrorPage.cshtml"
+#nullable restore
+#line 469 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_ValueColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                        </tr>\r\n                    </thead>\r\n                    <tbody>\r\n                        <tr>\r\n                            <td>");
-#line 468 "ErrorPage.cshtml"
+#nullable restore
+#line 474 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_EndpointDisplayName);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                            <td>");
-#line 469 "ErrorPage.cshtml"
+#nullable restore
+#line 475 "ErrorPage.cshtml"
                            Write(Model.Endpoint.DisplayName);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                        </tr>\r\n");
-#line 471 "ErrorPage.cshtml"
+#nullable restore
+#line 477 "ErrorPage.cshtml"
                          if (!string.IsNullOrEmpty(Model.Endpoint.RoutePattern))
                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            <tr>\r\n                                <td>");
-#line 474 "ErrorPage.cshtml"
+#nullable restore
+#line 480 "ErrorPage.cshtml"
                                Write(Resources.ErrorPageHtml_EndpointRoutePattern);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                <td>");
-#line 475 "ErrorPage.cshtml"
+#nullable restore
+#line 481 "ErrorPage.cshtml"
                                Write(Model.Endpoint.RoutePattern);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                            </tr>\r\n");
-#line 477 "ErrorPage.cshtml"
+#nullable restore
+#line 483 "ErrorPage.cshtml"
                         }
 
 #line default
 #line hidden
-#line 478 "ErrorPage.cshtml"
+#nullable disable
+#nullable restore
+#line 484 "ErrorPage.cshtml"
                          if (Model.Endpoint.Order != null)
                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            <tr>\r\n                                <td>");
-#line 481 "ErrorPage.cshtml"
+#nullable restore
+#line 487 "ErrorPage.cshtml"
                                Write(Resources.ErrorPageHtml_EndpointRouteOrder);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                <td>");
-#line 482 "ErrorPage.cshtml"
+#nullable restore
+#line 488 "ErrorPage.cshtml"
                                Write(Model.Endpoint.Order);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                            </tr>\r\n");
-#line 484 "ErrorPage.cshtml"
+#nullable restore
+#line 490 "ErrorPage.cshtml"
                         }
 
 #line default
 #line hidden
-#line 485 "ErrorPage.cshtml"
+#nullable disable
+#nullable restore
+#line 491 "ErrorPage.cshtml"
                          if (!string.IsNullOrEmpty(Model.Endpoint.HttpMethods))
                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            <tr>\r\n                                <td>");
-#line 488 "ErrorPage.cshtml"
+#nullable restore
+#line 494 "ErrorPage.cshtml"
                                Write(Resources.ErrorPageHtml_EndpointRouteHttpMethod);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                <td>");
-#line 489 "ErrorPage.cshtml"
+#nullable restore
+#line 495 "ErrorPage.cshtml"
                                Write(Model.Endpoint.HttpMethods);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                            </tr>\r\n");
-#line 491 "ErrorPage.cshtml"
+#nullable restore
+#line 497 "ErrorPage.cshtml"
                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    </tbody>\r\n                </table>\r\n");
-#line 494 "ErrorPage.cshtml"
+#nullable restore
+#line 500 "ErrorPage.cshtml"
             }
             else
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <p>");
-#line 497 "ErrorPage.cshtml"
+#nullable restore
+#line 503 "ErrorPage.cshtml"
               Write(Resources.ErrorPageHtml_NoEndpoint);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</p>\r\n");
-#line 498 "ErrorPage.cshtml"
+#nullable restore
+#line 504 "ErrorPage.cshtml"
             }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("            <h2 class=\"subheader\">");
-#line 499 "ErrorPage.cshtml"
+#nullable restore
+#line 505 "ErrorPage.cshtml"
                              Write(Resources.ErrorPageHtml_RouteValues);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</h2>\r\n");
-#line 500 "ErrorPage.cshtml"
+#nullable restore
+#line 506 "ErrorPage.cshtml"
              if (Model.RouteValues != null && Model.RouteValues.Any())
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <table>\r\n                    <thead>\r\n                        <tr>\r\n                            <th>");
-#line 505 "ErrorPage.cshtml"
+#nullable restore
+#line 511 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_VariableColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                            <th>");
-#line 506 "ErrorPage.cshtml"
+#nullable restore
+#line 512 "ErrorPage.cshtml"
                            Write(Resources.ErrorPageHtml_ValueColumn);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</th>\r\n                        </tr>\r\n                    </thead>\r\n                    <tbody>\r\n");
-#line 510 "ErrorPage.cshtml"
+#nullable restore
+#line 516 "ErrorPage.cshtml"
                          foreach (var kv in Model.RouteValues.OrderBy(kv => kv.Key))
                         {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                            <tr>\r\n                                <td>");
-#line 513 "ErrorPage.cshtml"
+#nullable restore
+#line 519 "ErrorPage.cshtml"
                                Write(kv.Key);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                                <td>");
-#line 514 "ErrorPage.cshtml"
-                               Write(kv.Value);
+#nullable restore
+#line 520 "ErrorPage.cshtml"
+                                Write(kv.Value!);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</td>\r\n                            </tr>\r\n");
-#line 516 "ErrorPage.cshtml"
+#nullable restore
+#line 522 "ErrorPage.cshtml"
                         }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                    </tbody>\r\n                </table>\r\n");
-#line 519 "ErrorPage.cshtml"
+#nullable restore
+#line 525 "ErrorPage.cshtml"
             }
             else
             {
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("                <p>");
-#line 522 "ErrorPage.cshtml"
+#nullable restore
+#line 528 "ErrorPage.cshtml"
               Write(Resources.ErrorPageHtml_NoRouteValues);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</p>\r\n");
-#line 523 "ErrorPage.cshtml"
+#nullable restore
+#line 529 "ErrorPage.cshtml"
             }
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(@"        </div>
 
         <script>
@@ -1301,6 +1571,7 @@ WriteAttributeValue("", 10611, exceptionDetailId, 10611, 18, false);
 ");
         }
         #pragma warning restore 1998
+#nullable restore
 #line 9 "ErrorPage.cshtml"
  
     public ErrorPage(ErrorPageModel model)
@@ -1312,6 +1583,7 @@ WriteAttributeValue("", 10611, exceptionDetailId, 10611, 18, false);
 
 #line default
 #line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.cshtml
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.cshtml
@@ -17,13 +17,13 @@
 @{
     // TODO: Response.ReasonPhrase = "Internal Server Error";
     Response.ContentType = "text/html; charset=utf-8";
-    string location = string.Empty;
+    string? location = string.Empty;
 }
 <!DOCTYPE html>
 <html lang="@CultureInfo.CurrentUICulture.TwoLetterISOLanguageName" xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <meta charset="utf-8" />
-        <title>@Resources.ErrorPageHtml_Title</title>
+        <title>@Model.Title</title>
         <style>
             <%$ include: ErrorPage.css %>
         </style>
@@ -32,7 +32,7 @@
         <h1>@Resources.ErrorPageHtml_UnhandledException</h1>
         @foreach (var errorDetail in Model.ErrorDetails)
         {
-            <div class="titleerror">@errorDetail.Error.GetType().Name: @{ Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); }</div>
+            <div class="titleerror">@errorDetail.Error!.GetType().Name: @{ Output.Write(HtmlEncodeAndReplaceLineBreaks(errorDetail.Error.Message)); }</div>
 
             var firstFrame = errorDetail.StackFrames.FirstOrDefault();
             if (firstFrame != null)
@@ -61,7 +61,7 @@
                     <ul>
                         @foreach (var ex in reflectionTypeLoadException.LoaderExceptions)
                         {
-                            <li>@ex.Message</li>
+                            <li>@ex!.Message</li>
                         }
                     </ul>
                 }
@@ -99,7 +99,7 @@
                     exceptionDetailId = "exceptionDetail" + exceptionCount;
 
                     <li>
-                        <h2 class="stackerror">@errorDetail.Error.GetType().Name: @errorDetail.Error.Message</h2>
+                        <h2 class="stackerror">@errorDetail.Error!.GetType().Name: @errorDetail.Error.Message</h2>
                         <ul>
                             @foreach (var frame in errorDetail.StackFrames)
                             {
@@ -313,7 +313,7 @@
                         {
                             <tr>
                                 <td>@kv.Key</td>
-                                <td>@kv.Value</td>
+                                <td>@(kv.Value!)</td>
                             </tr>
                         }
                     </tbody>

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPageModel.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPageModel.cs
@@ -51,5 +51,10 @@ namespace Microsoft.AspNetCore.Diagnostics.RazorViews
         /// Request endpoint.
         /// </summary>
         public EndpointModel Endpoint { get; set; }
+
+        /// <summary>
+        /// The text be inside the HTML title element.
+        /// </summary>
+        public string Title { get; set; }
     }
 }

--- a/src/Middleware/Diagnostics/src/README.md
+++ b/src/Middleware/Diagnostics/src/README.md
@@ -3,9 +3,9 @@ ASP.NET Core Diagnostics
 
 ## Development
 
-Diagnostics middleware like `DeveloperExceptionPage` uses compiled Razor views. After updating the `*.cshtml` file you must run the [RazorPageGenerator](https://github.com/dotnet/aspnetcore-tooling/tree/master/src/Razor/src/RazorPageGenerator) tool to generate an updated compiled Razor view.
+Diagnostics middleware like `DeveloperExceptionPage` uses compiled Razor views. After updating the `*.cshtml` file you must run the [RazorPageGenerator](https://github.com/dotnet/aspnetcore/tree/77599445aabd7bf357feb5cf8dfec7187148f1af/src/Middleware/tools/RazorPageGenerator) tool to generate an updated compiled Razor view.
 
-Run the following command in `AspNetCore-Tooling\src\Razor\src\RazorPageGenerator`:
+Run the following command in `src\Middleware\tools\RazorPageGenerator`:
 
 ```
 dotnet run Microsoft.AspNetCore.Diagnostics.RazorViews path-to-aspnetcore-middleware-diagnostics-src

--- a/src/Middleware/Diagnostics/src/WelcomePage/Views/WelcomePage.Designer.cs
+++ b/src/Middleware/Diagnostics/src/WelcomePage/Views/WelcomePage.Designer.cs
@@ -3,42 +3,52 @@
 namespace Microsoft.AspNetCore.Diagnostics.RazorViews
 {
     #line hidden
+    using System.Threading.Tasks;
+#nullable restore
 #line 1 "WelcomePage.cshtml"
 using System;
 
 #line default
 #line hidden
-    using System.Threading.Tasks;
+#nullable disable
+#nullable restore
 #line 2 "WelcomePage.cshtml"
 using Microsoft.AspNetCore.Diagnostics;
 
 #line default
 #line hidden
+#nullable disable
     internal class WelcomePage : Microsoft.Extensions.RazorViews.BaseView
     {
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
+#nullable restore
 #line 3 "WelcomePage.cshtml"
   
     Response.ContentType = "text/html; charset=utf-8";
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("<!DOCTYPE html>\r\n<html");
             BeginWriteAttribute("lang", " lang=\"", 141, "\"", 223, 1);
+#nullable restore
 #line 7 "WelcomePage.cshtml"
 WriteAttributeValue("", 148, System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName, 148, 75, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(">\r\n<head>\r\n    <meta charset=\"utf-8\" />\r\n    <title>");
+#nullable restore
 #line 10 "WelcomePage.cshtml"
       Write(Resources.WelcomeTitle);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</title>\r\n    <style type=\"text/css\">\r\n        ");
             WriteLiteral(@"@font-face {
             font-family: 'SegoeLight', helvetica, sans-serif;
@@ -205,18 +215,22 @@ WriteAttributeValue("", 148, System.Globalization.CultureInfo.CurrentUICulture.T
             WriteLiteral(@"L3KzWlTiTrdwifwWEXLkt6skWFJN7t6tZ5tm2ayw9fCcnzMQl7Jb6OkW0JE+9VaU96r9AX+9L5zpZclXC5V0iqnxuvPofDps1L2mA1kTwIG69L5z4bXNJclPrkiw1JHD/Pnf9syEWuX1okJC/HZFEVdNMQWzPL+btGhOR1MQlXcdw+z1stS17SCMmvzis3qtHcj+VxiVdphOT/p5JwIpw5EjR0FZfHxROSx5gsjKg0MC31Uq+QvByTcGI4OXhJuF/Em46Q/DEm4QSx+cpzwuTqtgEheZXzyudx+J3NVSFpNJWsN1/FhKcROSv5pjMheXtMvlYuC/MYEW8sQvKmmCziZCImZRMRIRETWrkQkVf8f+IQvM79/f1+/edL/Rg6GsUsZ85L+6YzIdldTE7rx8jRyD4iljNCstWYDONksu9oiAhC0jYmYTIZOxpZWcTljEu8QrLToJzUfw4diSzMKzebCUmHMZnUfz47Ekmb+uyMkPQhJuO41HFFJy0/fjrCp3iFpE8xsQmblmVcythUFZJeBuVT/efIkei18P2qF/ZDhCSFpU7YiHW/iaWMkNB6qRMmk4mj0QvzqvCfjBAS0wmmECERkx/TyaSyd7Jr06rQ3+IVkryDMorTiTtitytcibn0gTshKWG5c1y5VLxpYf/j2jJGSEoLymFc7tg/aScsXW7jryYiJILiaDQPSP24sQ8iJPwalPCwh/KKJUz18OPdAiIkPBOUcQyKTxb/ah6nj5lDISS8PijDGJO/Cl72hOkjhOPWzWRCQvuo7MeoHBQQlVWMx8z0ISSIingICYlEZRSDMo6PlL4TZR4f//g4v5DQv2nlQ/Vws9v7qj83vYX9jUUMx527ToWE9OIyjkugUfV4aXlbl5gXcZkyj3/vwj9zmVZIyH+CWS+H3jdYGq0j8XAimTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHL0rwADANq3ok68n5URAAAAAElFTkSuQm");
             WriteLiteral("CC\"");
             BeginWriteAttribute("alt", "\r\n                    alt=\"", 7518, "\"", 7586, 1);
+#nullable restore
 #line 169 "WelcomePage.cshtml"
 WriteAttributeValue("", 7545, Resources.WelcomePageImageText_LightBulb, 7545, 41, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             BeginWriteAttribute("title", " title=\"", 7587, "\"", 7636, 1);
+#nullable restore
 #line 169 "WelcomePage.cshtml"
 WriteAttributeValue("", 7595, Resources.WelcomePageImageText_LightBulb, 7595, 41, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(@" width=""274"" height=""274"" /></div>
             <div class=""browser"" style=""opacity: 1; visible: true;"">
@@ -230,18 +244,22 @@ WriteAttributeValue("", 7595, Resources.WelcomePageImageText_LightBulb, 7595, 41
             WriteLiteral(@"g0xIC8IPsnajIvmMU/0y6LvQD8EgAjO8HGLS7Thdxzi2hJDFrMC8Tx2RlT/AG8FgAjO6EreUHhltXmYmDFIqogBjbygmprFOLiH87UnNQXAAEw7QrMxYC8oKm8oIpFNJrOubMXAAJgVwzIC7qfF8jNXVjsBYAAWBcD8oJu5wWLJPRlsRcAAmBJDMgLTF6LmUW0dJ4t5AVyvT+2PwAC4KwrMBcDD/KCAosot7vK6goynpz3qf0pi70AEICOiAF5gbu8QHb3ZLEXAALQGTEgL3CTF8wJfQEQgC6Igcu8wIZFtCwGgcZsfvkDbecF8tfjuPjj+wMgAJ3vCszFoNktq5cFpfjVt5EXlAmBFP85vj8AAtBnMSAvMN+yejJfsNgLAAHovxiQF5jlBXK9/wjfHwAB6KsYkBcYCFOqVZJ/7oVs8gaAAAy4KzAXAz/ygn1CXwAEwFcx8DkvEN+fxV4ACIC3YuBrXiCFf8JiLwAEwDcx8D0vkEk/oS8AAkBXYEUM+pMXyJw/8f35NQBAABADfTEYQl4gts+C1BcAAQAzMeh7XiC+/3SB7w+AAICWGAwlL5BZ/2SG7w+AAIC1rsBcDNznBfJf2d4Z4wcAAQAHYmAlL7BhEamD6/3x/QEQAHAkBlbyAgu3uJSburPYCwABgIbFoGt5gcz6Q3b4BEAAoP2uwFwMqucFyVYPrPQFQACg22LQRF4wIfQFQACg+2Jg2yKSa/0JfQEQAOioGDRlEc0jQl8ABAB63RVUEQN5Prd1BEAAYKBiUCQEYv0w9wdAAKDnYmDaFcj1/jg/AAgAeNYViO8/p/oDIADglxiICBD6AiAA4JkYCGzvDOCeU5wCaBuZ+TP3B0AAwDPE92exFwACAJ6xIPQFQADAP6TsE/oCIADgITNCXwAEAHws/pHC9gdAAMAzFoS+AAgA+AeLvQAQAPCUWYTvD4AAgH/FH98fAAEA/2CxFwACAB4idZ/FXgAIAHgIm7wBIADgIVzxA4AAgIfMF/j+AAgAeEeyyRvFHw");
             WriteLiteral(@"ABAL9gkzcABAA8hU3eABAA8LL4s9gLAAEA72CTNwAEADyETd4AEADwFHx/AAQAvCz+kWLuD4AAgGewyRsAAgAewiZvAAgA+Fj8FZu8ASAA4CWEvgAIAHjInMVeAAgA+AebvAEgAOAhLPYCQADAU2YRvj8AAgD+FX98fwAEAPyDxV4ACAB4CIu9ABAA8BQWewEgAOAhXPEDgACAh+D7AyAA4CHJYi9m/wAIAPiFlH2sHwAEADyETd4AEADwsviz2AsAAQDvWBD6AiAA4B9s8gaAAICn4PsDIADgZfGPFHN/AAQAPIPFXgCAAHgIm7wBAALgKWzyBgAIAMUfABAA8IE5i70AAAHwj2STN6o/ACAAfsFiLwBAADxlFuH7AwAC4F/xx/cHAATAP9jkDQAQAA/B9wcABMBT2OQNABAAL4s/m7wBAALgHWzyBgAIgIewyRsAIAA+Fn/FPj8AgAB4CaEvACAAHsImbwCAAHgIm7wBAALgISz2AgAEwFPY5A0AEAAfiz++PwAgAP7BYi8AQAA8hMVeAIAAeAqLvQAAAfAQrvgBAATAQ8T2wfcHAATAM1jsBQAIgIdI2cf6AQAEwEPY5A0AEAAviz+LvQAAAfCOBYu9AKBh1nSe9Ol7b6jZqTOcLQCAHvBkuG1PAH5T82AAANAfsIAAADwWgGucBgAA77hJBwAA4CdbIgD/wnkAAPCL77726jURgJucCgAAr0jq/lEGsMX5AADwhr9PBCBuA6T4X+V8AAB4w9WjDkB4hS4AAMALXokn/reOBeCwC/ij+HGLcwMAMFj+Kq73f3n0P6eP/nHj+k831tdf+F78z0n8uBI/znGuAAAGwbX48c24+P9N+oP/L8AAx5G6SMzC+fMAAAAASUVORK5CYII=""");
             BeginWriteAttribute("alt", "\r\n                     alt=\"", 16724, "\"", 16791, 1);
+#nullable restore
 #line 172 "WelcomePage.cshtml"
 WriteAttributeValue("", 16752, Resources.WelcomePageImageText_Browser, 16752, 39, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             BeginWriteAttribute("title", " title=\"", 16792, "\"", 16839, 1);
+#nullable restore
 #line 172 "WelcomePage.cshtml"
 WriteAttributeValue("", 16800, Resources.WelcomePageImageText_Browser, 16800, 39, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(@" width=""384"" height=""305"" /><div>:-)</div>
             </div>
@@ -254,18 +272,22 @@ WriteAttributeValue("", 16800, Resources.WelcomePageImageText_Browser, 16800, 39
             WriteLiteral(@"rE9ksaKTOn5Qq4m9o19SiFWVyV7CZc+1iuPMMZlsUQZa0tTy3FtTIqFfUo4tlcpOAlK5UXm8J30Uppa+SOMiUZlsuq/9EuaXIBXk4ZdjX8sDBC8SlQnzS/zwQIUi5eK2lkOxID2PnoqDJRiWx+tTvVGIRGUiz+I84vx7Tyvb+vmDC2fSm/Q3Pqo48k/wRy+TSCOr9bVC2PtMJgd6R4XqkLSyruklb3RXNcR8pXV6T8uVj/r/GKatjlqbq6GKRPok0i/Z5HpoLMHk5dAPBUqjXBLf7ogcykYQebxsSiLBiGRMJozkABSXSK0jNJNoh3I01KbHLs31XgHKcty0RIISicrkts5DJgALcVLVsgBRi2RMJrwnBmC+RIKZa9MO8QipZU+4VgAmchqSRIIVicrkEpkAfIc8iBfcS+haoR81Zr8C3JFIkDfXVgxHD5kAhCuRaESCTACJhCuRqESCTCBRTkPsiUQtEpVJV2XC8gNgnZPQRmfMiERlwlomgEQQCTIBmMLtoyKhzFg1LxKVCU8NgzWJHIXw7ExSIhmTyYFjMWmIm0bXE0leJGNCYaU1iBVZx+UkVomYEonKhOFhiI1G1lhFJPNlQhMWYmCkKcTEqnIti2dI+ybyEq4O1ysEiPRD3sbYVE1KJGNC4fWgEBoyN+Q05n5IciJRmXQ0nVDqQNOlzGlMk8wQCaUOUMogkgqFIsPDu6QTqJGLTCCn1neyldpZ1VGdfcdsWKiWoQtocWZEUp1QaMRCZSkk295Za6gikukykZdxHTh6J0AKQSQehELvBJbFxAxVRLK8TEQi8rwOLzOHIvQ1hQxTPgiI5HuhSJnzk6MZC/PLmFMrU9wRSXVC2dFyh5eawzjSQL1IuYxBJOXKncfu6/IE9E/A5PR2RFKvUHYd652kLJB3qfdBEIk/oaypUGjIIhBAJN6E0qXkQSCASHyUPPRQEAgi4RB4E0rXMcoTI7ejMNl2ThMVkYQkFRHKjmNV+9CRR/ovrK4PgkjsCGVNy54uKSWo9NFT");
             WriteLiteral(@"gQw4HIiElAJFkGnskjx6lC+IxIJQ8l5KF6nUUrrk8qB5ikiQCiAPRAJFpNJxzE0pSk+3PvJAJHBXLJsqlC3HokuTUseVpo4+hwORwOJi6ahQRCybiSWWvopjoKmDZikiAY+JZUOlsmEotYg0hnnqYIgWkUD9cpG5KusqlTXdQkwvIxXFcEwaQ6SBSCCOBLOiclnX/70xJpl1t/ykOZHC57E/X+nnTbZ9EoEgC4DE044mHoCJ/F+AAQAgl3zNeDGxuQAAAABJRU5ErkJggg==""");
             BeginWriteAttribute("alt", "\r\n                    alt=\"", 23261, "\"", 23329, 1);
+#nullable restore
 #line 176 "WelcomePage.cshtml"
 WriteAttributeValue("", 23288, Resources.WelcomePageImageText_LightBulb, 23288, 41, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             BeginWriteAttribute("title", " title=\"", 23330, "\"", 23379, 1);
+#nullable restore
 #line 176 "WelcomePage.cshtml"
 WriteAttributeValue("", 23338, Resources.WelcomePageImageText_LightBulb, 23338, 41, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(@" width=""274"" height=""274"" /></div>
             <div class=""bulb"">
@@ -278,18 +300,22 @@ WriteAttributeValue("", 23338, Resources.WelcomePageImageText_LightBulb, 23338, 
             WriteLiteral(@"BJYO6F5k46FL8dCtNaPRCNPQifuGwYyWbmn6yV36ZuB8uIsTWpo6m/VUtXmGhmAxDu+ijpAOsvM3DsTDqgYX/vhldn5qP7PZ5nGfCC0tCWx8R9fIrKmV3jMEQkuzIxvjumtWZEYrtJAmso6Fpde8GEbqyO6IbGe49I3Q0sDIDrPzNVm64b+GQGhpHpHtlokhWIx3hpFyNntoJDoZ2ngI3p5zH9z6Z0FoSbZzeQGs++IVdLevu/Q5QkvanSuep2BgJDovRnYzNMQLZUJLDTtXYRR6Iy4hbJjZXh1aL4YBy4rPXHYNw9XMaDGjZVWcHNyMFkhsyxBcTmhJxcymf941BEJLtSaGoHecGFxoqdgLQ9A7jjoQWqqU53k8mH1qJHrllSEQWqq3bQh65cAQCC3Vz2on4ea5keiFiXeHXfOz4DhaUnPeg17YENor938zWiqZ2W6b2XbatshaOqAZsX0SbjYzh311STzK4GG4b/cMhaUDmvdUKh5v+WF2ftxl3Fz0r13i7DUevvfciWRut3QgtDTeb3/3+3gC8eGF/735pz/+YbLkD8AgcyrHOwVWWBcLravg0t+nc+cnQJkaCVKzRgsgtABCC4DQAggtgNACILQAQgsgtAAILYDQAiC0AEILILQACC2A0AIILQBCCyC0AEJrCACEFkBoARBaAKEFEFoAhBZAaAGEFgChBRBaAIQWQGgBhBYAoQUQWgChBUBoAYQWQGgBEFoAoQVAaAGEFkBoARBaAKEFEFoAhBZAaAEQWgChBRBaAIQWQGgBhBYAoQUQWgChBUBoAYQWAKEFEFoAoQVAaAGEFkBoARBaAKEFQGgBhBZAaAEQWgChBRBaAIQWQGgBhBYAoQUQWgCEFkBoAYQWAKEFEFoAoQVAaAGEFgChBRBaAKEFQGgBhBZAaAEQWgChBRBaAIQWQGgBEFoAoQUQWgCEFkBoAYQWAKEFEFoAhBZAaAGEFgChBRBaAKEFQGgBhBZAaAEQWgChBUBoAYQWQGgBEFoAoQUQWgCE");
             WriteLiteral(@"FkBoARBaAKEFEFoAhBZAaAGEFgChBRBaAKEFQGgBhBYAoQUQWgChBUBoAYQWQGgBEFoAoQVAaAGEFkBoARBaAKEFEFoAhBZAaAGEFgChBRBaAIQWQGgBhBYAoQUQWgChBUBoAYQWAKEFEFoAoQVAaAGEFkBoARBaAKEFEFoAhBZAaAEQWgChBRBaAIQWQGgBhBYAoQUQWgCEFkBoAYQWAKEFEFoAoQVAaAGEFkBoARBaAKEFQGgBhBZAaAEQWgChBRBaAIQWQGgBEFoAoQUQWgCEFkBoAYQWAKEFEFoAoQVAaAGEFgChBRBaAKEFQGgBhBZAaAEQWgChBUBoAYQWQGgBEFoAoQUQWgCEFkBoAYQWAKEFEFoAhBZAaAGEFgChBRBaAKEFQGgBhBYAoQUQWgChBUBoAYQWQGgBEFoAoQUQWgCEFkBoARBaAKEFEFoAhBZAaAGEFgChBRBaAIQWQGgBhBYAoQUQWgChBUBoAYQWQGgBEFoAoQVAaAGEFkBoARBaAKEFEFoAhBZAaAGE1hAACC2A0AIgtABCCyC0AAgtgNACCC0AQgsgtAAILYDQAggtAEILILQAQguA0AIILYDQAiC0AEILgNACCC2A0AIgtABCCyC0AAgtgNACMCcvisIoACT0fwEGAL+BBlr+j4JHAAAAAElFTkSuQmCC""");
             BeginWriteAttribute("alt", "\r\n                     alt=\"", 31229, "\"", 31298, 1);
+#nullable restore
 #line 179 "WelcomePage.cshtml"
 WriteAttributeValue("", 31257, Resources.WelcomePageImageText_LightBulb, 31257, 41, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             BeginWriteAttribute("title", " title=\"", 31299, "\"", 31348, 1);
+#nullable restore
 #line 179 "WelcomePage.cshtml"
 WriteAttributeValue("", 31307, Resources.WelcomePageImageText_LightBulb, 31307, 41, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(@" width=""346"" height=""658"" /></div>
             <div class=""bottom"">
@@ -309,54 +335,68 @@ WriteAttributeValue("", 31307, Resources.WelcomePageImageText_LightBulb, 31307, 
             WriteLiteral(@"Uu/VbV98PRqR6oN513sDigTHx2kWAXAAAA5BGZXi+/+ifKQRfHVgV+h45NrUboEplZ324W7Orxc/ePLWiFHYuWC7heq4AX9bskW9kaGiqUNVsLE0W1StPi9ZFQ9XSvy3dj8frz0W2pyyvXg4M71dCQwy/LdeejGEHxyd8/oSSaBKlEBtjRqaKe7P4qRmIUXRgnPnucml0AAACwxsuvvqEcjGLeLEg1eWxqlBQgBoISWV3f0qfbFm2nyP56R/JSXzdGrwR8p2ENr2w+lWxykqMHHzxIjNq9TlHHa7sU3mj0t0gXozMet1YIK2eG91zVzjJGZzzufjF2YXCg/FsHX5YIeL3rtmM6VA0p59eSytnNMWUztqWsDWy07eooglwio2t4d1iJ7w1zYQAAAID1Xn71IGC1MC+ynZ5VPq+71Yq4sTgIQh0Eo+wguh7Kqj32ZpeZaEBf0FrcXEOyO5vDtge8omq1aUQhrFbP9rp8Ubjebc6GC9KXuVUNi770Tga8XD2AhAh8ndk+vT/tfzKIFJT3zv/mkXlGdk7tZ3OJeQEAAABHHGQ7vWFMom6WCHr992NziSDRa0aQzP7tk1Nw/2f6sl5nh8PPmnVpJOAl2epuNLpRjDjSLW4wVD4R9AqrteFAoO0onR1xU9BLdGcUNbxk266Exks1NezgS4stLk945rwUGVwnjrlqmGAXAAAA3OXlVxuNXvipI8Guz7dpe7/rpKL8tMFfxT3JuSPTyW1XlO8T7AIaBLyy+ZToypikaeRa2jg14tS6RbfG47+LhnrP7jq0Xgi7pp3HIruWLXu1HD3n8MtjIAkAAADAL15+VQS8MorI1vq86H6zgJcopi+6a37bxu6XgKtp3FTbY2k9PurUusNq9US6TVirjslavpsK11tRv+vQWjky/lhk5yMHX57I8PobziYAAADAJw4yzV7fnxbmxb26qD/23SNzfF+fbjuakQa4VLDJTTUku7s95FjASw3UQxG1+nAIvGCgrqnBurRq4cWKqhRKmuNtPB");
             WriteLiteral(@"IqKoNq2bLlFyohpzO8EovLE2RfAgAAAH50MDrkrWO/yxPsAhoj4GWD9+6Pjjq9DUe7NcYkdmc85IY6XmPhXUuXX64HB9fLEadHL53kjAIAAAAAoLVHAl7ZfIpglwVur59yPOAV1SoPC+aHQ/K6Mx5a33G+jtelgU3L1/FZKTbu8Mu8yhkFAAAAAEBrxzO8CHhZ4F5hYMTpbQgFa1EtWAsZP5+WvXzRpbFUUZ18fftdGq22WQk7HfBKLi5PxDirAAAAAABo7njAi4L1kq1sDQ0VylrUDdsS1SoDkVA1EQgolhTccrJ4/fnoti3rKdbURKmmOp3ORmAaAAAAAIAWHga8svmUKIadoEnk+uBBYtQt2yLqeEU1+fW7Dq0VnIsDWTk643H3SgNOZ3kR8AIAAAAAoIWjGV7UBrLAnc1h1wS8omp1OKzVxqxavihcX60FHHltZ8MF29a16fxojRSuBwAAAACghf8vwABfcA5F9k0oGQAAAABJRU5ErkJggg==""");
             BeginWriteAttribute("alt", "\r\n                    alt=\"", 46196, "\"", 46262, 1);
+#nullable restore
 #line 182 "WelcomePage.cshtml"
 WriteAttributeValue("", 46223, Resources.WelcomePageImageText_Skyline, 46223, 39, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             BeginWriteAttribute("title", " title=\"", 46263, "\"", 46310, 1);
+#nullable restore
 #line 182 "WelcomePage.cshtml"
 WriteAttributeValue("", 46271, Resources.WelcomePageImageText_Skyline, 46271, 39, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" width=\"1212\" height=\"202\" /></div>\r\n        </div>\r\n    </div>\r\n\r\n    <div class=\"content\">\r\n        <div class=\"bodyHeadline\">");
+#nullable restore
 #line 187 "WelcomePage.cshtml"
                              Write(Resources.WelcomeHeader);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</div>\r\n        <div class=\"bodyContent\">");
+#nullable restore
 #line 188 "WelcomePage.cshtml"
                             Write(Resources.WelcomeStarted);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral("</div>\r\n        <a class=\"bodyCTA longer\" href=\"http://go.microsoft.com/fwlink/?LinkID=398596&amp;clcid=0x409\">");
+#nullable restore
 #line 189 "WelcomePage.cshtml"
                                                                                                   Write(Resources.WelcomeLearnMicrosoftAspNet);
 
 #line default
 #line hidden
+#nullable disable
             WriteLiteral(@"<div>
             <img src=""data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADoAAAAdCAYAAAD7En+mAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyRpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDozMjVCMDEwM0FBQkExMUUyQjdGNEEwODg0RjhFODY4OCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDozMjVCMDEwNEFBQkExMUUyQjdGNEEwODg0RjhFODY4OCI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOjMyNUIwM");
             WriteLiteral(@"TAxQUFCQTExRTJCN0Y0QTA4ODRGOEU4Njg4IiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjMyNUIwMTAyQUFCQTExRTJCN0Y0QTA4ODRGOEU4Njg4Ii8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+I1MZRAAAA4FJREFUeNq8md1x2kAQx3UaCoAKAg0YkgYQHTgV2KoAeMqjncfkBbsCSAd0AK5AOA1Y6YAOyJ7mf5rV6T4l8M3c2ALd/fZ/u/exh0gCy+VyyeiPrHPtqzPVd6p7IcTJ0rbxTO8FMe++/vIy/xY/TiF9CY+4If1ZUV1SHQb0V1L9Q/WFxJy7CCVxnZkk+hwtlIyTsCcGk53sMZJ8FGcY8Ux7NydB+xihJLI3k8Tug4TCi1uq92zEfpJxu4DwfoShY3y0o3a5Tyi82GKS0buA8G4xqV3uFAqRB4xYAoHPSURBH08IvwosR9omFCIbTDI0iok+GkxdrC5UjuqjHnpdCry7xaOcs2uLkQ2mLfQCBTeY1Ne6JRRzcoPH731EWsQuqM+jYU7WzD4iLWIX1GfFTLVwU+HaG4gQ3WExSRhcDzcVrldhYl63mAJCnwEtybiJx0tjNvETtCk9c/YDq2OuFjUSWjPJuInHSy0mtSk9c7ZmSvEpvntQIxswaGeE2wG1IDEzh1fl+694XLKvejFJzMzh1RZTwMhCdkZGjSJWVr5SnjEHT44o+MDjaPrt91gxyahRxMraYtpORoiCmpmyvesYMfcqCNvEKyNsnkVoq3ezLkx4qcW0eRahXTOl0C94eI9caGxiM0uTEzvVdGI6xHqZAzbJT4aQO8ADoUWJzQ0nqX/sfyuTjO7EpHa54SRVM1Ntwl+rbALf+zTmwDDKJtf7SqYZvwhs92nMATrOTFDbsY2F9gwrITdywVM0Vqbae0YmP7ZZVlMj05KiTXnoqjieRx7vFHAYIDJh28KxK5OJH");
             WriteLiteral(@"AaIbDCFvsc5DO0sku3VMkqEvse5EuauIvF+gSgRqbbHrW7gSX4i2hn2uNUNPNliCi3LkA0nIV6NDPFCz2BYllExQ7waGeIFz2BSlmWUGLHtFUXy/o48TcOed3Umu62omI00DUVl5PdIwK+1t81UUm34vmYiAb8ZUzgS5eq+p4cnN7g5cCbyWqJsvO+J8GSDyXNc0+XYlr18RA5ZRt7/btjSnqsFwXE51mK68k3L/W+DqR8HRcAViFq5Xm1pGBP4wAyu751Crjs1z9ZM1wU1BLaYptsK4VktN9pRq0R9Y5/NMZL8slmC1ioSIu51ezNtkSACQ3HJckjXAX1v8nzsTxLwVBTT99OEiFxkMsNIVpu/J6yjhBpEG5mhv7vI8l+AAQB7WiwH/DuungAAAABJRU5ErkJggg==""");
             BeginWriteAttribute("alt", "\r\n                alt=\"", 49142, "\"", 49206, 1);
+#nullable restore
 #line 191 "WelcomePage.cshtml"
 WriteAttributeValue("", 49165, Resources.WelcomePageImageText_LearnMore, 49165, 41, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             BeginWriteAttribute("title", " title=\"", 49207, "\"", 49256, 1);
+#nullable restore
 #line 191 "WelcomePage.cshtml"
 WriteAttributeValue("", 49215, Resources.WelcomePageImageText_LearnMore, 49215, 41, false);
 
 #line default
 #line hidden
+#nullable disable
             EndWriteAttribute();
             WriteLiteral(" width=\"58\" height=\"29\" /></div>\r\n        </a>\r\n    </div>\r\n\r\n</body>\r\n</html>\r\n");
         }

--- a/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
@@ -119,6 +119,7 @@ namespace Microsoft.AspNetCore.Diagnostics
 
             var responseText = await response.Content.ReadAsStringAsync();
             Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("utf-8", response.Content.Headers.ContentType.CharSet);
             Assert.Contains("Test exception", responseText);
             Assert.DoesNotContain("<html", responseText);
         }
@@ -126,6 +127,8 @@ namespace Microsoft.AspNetCore.Diagnostics
         [Fact]
         public async Task StatusCodeFromBadHttpRequestExceptionIsPreserved()
         {
+            const int statusCode = 418;
+
             // Arrange
             using var host = new HostBuilder()
                 .ConfigureWebHost(webHostBuilder =>
@@ -137,7 +140,7 @@ namespace Microsoft.AspNetCore.Diagnostics
                         app.UseDeveloperExceptionPage();
                         app.Run(context =>
                         {
-                            throw new BadHttpRequestException("Not found!", 404);
+                            throw new BadHttpRequestException("Not found!", statusCode);
                         });
                     });
                 }).Build();
@@ -150,7 +153,7 @@ namespace Microsoft.AspNetCore.Diagnostics
             var response = await server.CreateClient().GetAsync("/path");
 
             // Assert
-            Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+            Assert.Equal(statusCode, (int)response.StatusCode);
 
             var responseText = await response.Content.ReadAsStringAsync();
             Assert.Contains("Not found!", responseText);

--- a/src/Mvc/Mvc/test/MvcServiceCollectionExtensionsTest.cs
+++ b/src/Mvc/Mvc/test/MvcServiceCollectionExtensionsTest.cs
@@ -30,6 +30,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures.Filters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -379,7 +380,9 @@ namespace Microsoft.AspNetCore.Mvc
             // Arrange
             var services = new ServiceCollection();
 
-            services.AddSingleton<IWebHostEnvironment>(GetHostingEnvironment());
+            var hostEnvironment = GetHostingEnvironment();
+            services.AddSingleton<IWebHostEnvironment>(hostEnvironment);
+            services.AddSingleton<IHostEnvironment>(hostEnvironment);
 
             var diagnosticListener = new DiagnosticListener("Microsoft.AspNet");
             services.AddSingleton<DiagnosticSource>(diagnosticListener);


### PR DESCRIPTION
Now instead of having to enable debug logging in development to see why a request is failing with a 400 response, you can easily see why the request is being rejected using the developer exception page or error logs.

This updates the DeveloperExceptionPageMiddleware to preserve the status code requested by the BadHttpRequestException instead of always responding with a 500. This way, the client can still get a 400 response in development but also get more error details.

This also updates the log messages (and the matching Exception messages) to use TypeNameHelper to produce friendlier parameter type names. And this includes the changes from https://github.com/dotnet/aspnetcore/pull/35580 which I'll close in favor of this.

![image](https://user-images.githubusercontent.com/54385/131602591-edf66d1e-4591-4894-a4aa-d7c58bc36fe5.png)

Fixes #35858
Fixes #35857
Fixes #35954