### PR TITLE
Fix sample usage for --format argument

### DIFF
--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -39,8 +39,8 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
 'dotnet dev-certs https --clean --import ./certificate.pfx -p password'
 'dotnet dev-certs https --check --trust'
 'dotnet dev-certs https -ep ./certificate.pfx -p password --trust'
-'dotnet dev-certs https -ep ./certificate.crt --trust --key-format Pem'
-'dotnet dev-certs https -ep ./certificate.crt -p password --trust --key-format Pem'";
+'dotnet dev-certs https -ep ./certificate.crt --trust --format Pem'
+'dotnet dev-certs https -ep ./certificate.crt -p password --trust --format Pem'";
 
         public static readonly TimeSpan HttpsCertificateValidity = TimeSpan.FromDays(365);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
The argument `--key-format` was changed to `--format` in #23803, but the example usage wasn't updated. This PR updates that argument in the example usage.

**PR Description**

Fixes #36008
