### PR TITLE
HTTP/3: Support canceling requests that aren't reading a body

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/IProtocolErrorCodeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IProtocolErrorCodeFeature.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Connections.Features
     public interface IProtocolErrorCodeFeature
     {
         /// <summary>
-        /// Gets or sets the error code.
+        /// Gets or sets the error code. The property returns -1 if the error code hasn't been set.
         /// </summary>
         long Error { get; set; }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -134,6 +134,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public void Abort(ConnectionAbortedException abortReason, Http3ErrorCode errorCode)
         {
+            AbortCore(abortReason, errorCode);
+        }
+
+        private void AbortCore(Exception exception, Http3ErrorCode errorCode)
+        {
             lock (_completionLock)
             {
                 if (IsCompleted)
@@ -148,26 +153,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     return;
                 }
 
+                if (!(exception is ConnectionAbortedException abortReason))
+                {
+                    abortReason = new ConnectionAbortedException(exception.Message, exception);
+                }
+
                 Log.Http3StreamAbort(TraceIdentifier, errorCode, abortReason);
 
+                // Call _http3Output.Stop() prior to poisoning the request body stream or pipe to
+                // ensure that an app that completes early due to the abort doesn't result in header frames being sent.
+                _http3Output.Stop();
+
+                CancelRequestAbortedToken();
+
+                // Unblock the request body.
+                PoisonBody(exception);
+                RequestBodyPipe.Writer.Complete(exception);
+
+                // Abort framewriter and underlying transport after stopping output.
                 _errorCodeFeature.Error = (long)errorCode;
                 _frameWriter.Abort(abortReason);
-
-                AbortCore(abortReason);
             }
-        }
-
-        private void AbortCore(Exception exception)
-        {
-            // Call _http3Output.Stop() prior to poisoning the request body stream or pipe to
-            // ensure that an app that completes early due to the abort doesn't result in header frames being sent.
-            _http3Output.Stop();
-
-            CancelRequestAbortedToken();
-
-            // Unblock the request body.
-            PoisonBody(exception);
-            RequestBodyPipe.Writer.Complete(exception);
         }
 
         protected override void OnErrorAfterResponseStarted()
@@ -470,7 +476,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             catch (ConnectionResetException ex)
             {
                 error = ex;
-                AbortCore(new IOException(CoreStrings.HttpStreamResetByClient, ex));
+                var resolvedErrorCode = _errorCodeFeature.Error >= 0 ? _errorCodeFeature.Error : 0;
+                AbortCore(new IOException(CoreStrings.HttpStreamResetByClient, ex), (Http3ErrorCode)resolvedErrorCode);
             }
             catch (Exception ex)
             {
@@ -484,10 +491,41 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
                 await Input.CompleteAsync();
 
-                // Make sure application func is completed before completing writer.
-                if (_appCompleted != null)
+                var appCompleted = _appCompleted?.Task ?? Task.CompletedTask;
+                if (!appCompleted.IsCompletedSuccessfully)
                 {
-                    await _appCompleted.Task;
+                    // At this point in the stream's read-side is complete. However, with HTTP/3
+                    // the write-side of the stream can still be aborted by the client on request
+                    // aborted.
+                    //
+                    // To get notification of request aborted we register to connection closed
+                    // token. It will notify this type that the client has aborted the request
+                    // and Kestrel will complete pipes and cancel the RequestAborted token.
+                    //
+                    // Only subscribe to this event after the stream's read-side is complete to
+                    // avoid interactions between reading that is in-progress and an abort.
+                    // This means while reading, read-side abort will handle getting abort notifications.
+                    //
+                    // TODO: Consider a better way to provide this notification. For perf we want to
+                    // make the ConnectionClosed CTS pay-for-play, and change this event to use
+                    // something that is more lightweight than a CTS.
+                    _context.StreamContext.ConnectionClosed.Register(static s =>
+                    {
+                        var stream = (Http3Stream)s!;
+
+                        if (!stream.IsCompleted)
+                        {
+                            // An error code value other than -1 indicates a value was set and the request didn't gracefully complete.
+                            var errorCode = stream._errorCodeFeature.Error;
+                            if (errorCode >= 0)
+                            {
+                                stream.AbortCore(new IOException(CoreStrings.HttpStreamResetByClient), (Http3ErrorCode)errorCode);
+                            }
+                        }
+                    }, this);
+
+                    // Make sure application func is completed before completing writer.
+                    await appCompleted;
                 }
 
                 try

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -506,6 +506,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     // avoid interactions between reading that is in-progress and an abort.
                     // This means while reading, read-side abort will handle getting abort notifications.
                     //
+                    // We don't need to hang on to the CancellationTokenRegistration from register.
+                    // The CTS is cleaned up in StreamContext.DisposeAsync.
+                    //
                     // TODO: Consider a better way to provide this notification. For perf we want to
                     // make the ConnectionClosed CTS pay-for-play, and change this event to use
                     // something that is more lightweight than a CTS.

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
@@ -19,7 +19,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         void StreamPause(QuicStreamContext streamContext);
         void StreamResume(QuicStreamContext streamContext);
         void StreamShutdownWrite(QuicStreamContext streamContext, string reason);
-        void StreamAborted(QuicStreamContext streamContext, long errorCode, Exception ex);
+        void StreamAbortedRead(QuicStreamContext streamContext, long errorCode);
+        void StreamAbortedWrite(QuicStreamContext streamContext, long errorCode);
         void StreamAbort(QuicStreamContext streamContext, long errorCode, string reason);
         void StreamAbortRead(QuicStreamContext streamContext, long errorCode, string reason);
         void StreamAbortWrite(QuicStreamContext streamContext, long errorCode, string reason);

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.FeatureCollection.cs
@@ -16,8 +16,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
     {
         private X509Certificate2? _clientCert;
         private Task<X509Certificate2?>? _clientCertTask;
+        private long? _error;
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public X509Certificate2? ClientCertificate
         {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -83,9 +83,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                     return;
                 }
 
+                var resolvedErrorCode = _error ?? 0;
                 _abortReason = ExceptionDispatchInfo.Capture(abortReason);
-                _log.ConnectionAbort(this, Error, abortReason.Message);
-                _closeTask = _connection.CloseAsync(errorCode: Error).AsTask();
+                _log.ConnectionAbort(this, resolvedErrorCode, abortReason.Message);
+                _closeTask = _connection.CloseAsync(errorCode: resolvedErrorCode).AsTask();
             }
         }
 
@@ -127,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicConnectionAbortedException ex)
             {
                 // Shutdown initiated by peer, abortive.
-                Error = ex.ErrorCode;
+                _error = ex.ErrorCode;
                 _log.ConnectionAborted(this, ex.ErrorCode, ex);
 
                 ThreadPool.UnsafeQueueUserWorkItem(state =>

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
@@ -9,11 +9,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
     internal sealed partial class QuicStreamContext : IPersistentStateFeature, IStreamDirectionFeature, IProtocolErrorCodeFeature, IStreamIdFeature, IStreamAbortFeature
     {
         private IDictionary<object, object?>? _persistentState;
+        private long? _error;
 
         public bool CanRead { get; private set; }
         public bool CanWrite { get; private set; }
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public long StreamId { get; private set; }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -132,18 +132,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(11, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
-        private static partial void StreamAborted(ILogger logger, string connectionId, long errorCode, Exception ex);
+        [LoggerMessage(11, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
+        private static partial void StreamAbortedRead(ILogger logger, string connectionId, long errorCode);
 
-        public void StreamAborted(QuicStreamContext streamContext, long errorCode, Exception ex)
+        public void StreamAbortedRead(QuicStreamContext streamContext, long errorCode)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                StreamAborted(_logger, streamContext.ConnectionId, errorCode, ex);
+                StreamAbortedRead(_logger, streamContext.ConnectionId, errorCode);
             }
         }
 
-        [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by application with error code {ErrorCode} because: ""{Reason}"".", EventName = "StreamAbort", SkipEnabledCheck = true)]
+        [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
+        private static partial void StreamAbortedWrite(ILogger logger, string connectionId, long errorCode);
+
+        public void StreamAbortedWrite(QuicStreamContext streamContext, long errorCode)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                StreamAbortedWrite(_logger, streamContext.ConnectionId, errorCode);
+            }
+        }
+
+        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by application with error code {ErrorCode} because: ""{Reason}"".", EventName = "StreamAbort", SkipEnabledCheck = true)]
         private static partial void StreamAbort(ILogger logger, string connectionId, long errorCode, string reason);
 
         public void StreamAbort(QuicStreamContext streamContext, long errorCode, string reason)
@@ -154,7 +165,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
+        [LoggerMessage(14, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
         private static partial void StreamAbortRead(ILogger logger, string connectionId, long errorCode, string reason);
 
         public void StreamAbortRead(QuicStreamContext streamContext, long errorCode, string reason)
@@ -165,7 +176,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(14, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
+        [LoggerMessage(15, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
         private static partial void StreamAbortWrite(ILogger logger, string connectionId, long errorCode, string reason);
         
         public void StreamAbortWrite(QuicStreamContext streamContext, long errorCode, string reason)

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -181,6 +181,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             read = await serverStream.Transport.Input.ReadAsync().DefaultTimeout();
             Assert.True(read.IsCompleted);
 
+            await serverStream.Transport.Output.CompleteAsync();
+
             await closedTcs.Task.DefaultTimeout();
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -112,10 +112,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 
             var qex = await Assert.ThrowsAsync<QuicException>(async () => await clientConnection.ConnectAsync().DefaultTimeout());
             Assert.Equal("Connection has been shutdown by transport. Error Code: 0x80410100", qex.Message);
-
-            // https://github.com/dotnet/runtime/issues/57246 The accept still completes even though the connection was rejected, but it's already failed.
-            var serverContext = await connectionListener.AcceptAndAddFeatureAsync().DefaultTimeout();
-            await Assert.ThrowsAsync<QuicException>(() => serverContext.ConnectAsync().DefaultTimeout());
         }
     }
 }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -923,7 +923,7 @@ namespace Microsoft.AspNetCore.Testing
         });
 
         private readonly Http3InMemory _testBase;
-        private long _error;
+        private long? _error;
 
         public TestMultiplexedConnectionContext(Http3InMemory testBase)
         {
@@ -947,7 +947,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public long Error
         {
-            get => _error;
+            get => _error ?? -1;
             set => _error = value;
         }
 
@@ -1020,6 +1020,7 @@ namespace Microsoft.AspNetCore.Testing
 
         private TaskCompletionSource _disposingTcs;
         private TaskCompletionSource _disposedTcs;
+        internal long? _error;
 
         public TestStreamContext(bool canRead, bool canWrite, Http3InMemory testBase)
         {
@@ -1073,6 +1074,7 @@ namespace Microsoft.AspNetCore.Testing
             ConnectionId = "TEST:" + streamId.ToString(CultureInfo.InvariantCulture);
             AbortReadException = null;
             AbortWriteException = null;
+            _error = null;
 
             _disposedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _disposingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1113,7 +1115,11 @@ namespace Microsoft.AspNetCore.Testing
 
         public bool CanWrite { get; }
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public override void Abort(ConnectionAbortedException abortReason)
         {

--- a/src/Servers/Kestrel/shared/test/StreamExtensions.cs
+++ b/src/Servers/Kestrel/shared/test/StreamExtensions.cs
@@ -46,7 +46,7 @@ namespace System.IO
             return offset;
         }
 
-        public static async Task<byte[]> ReadAtLeastLengthAsync(this Stream stream, int length, int bufferLength = 1024, CancellationToken cancellationToken = default)
+        public static async Task<byte[]> ReadAtLeastLengthAsync(this Stream stream, int length, int bufferLength = 1024, bool allowEmpty = false, CancellationToken cancellationToken = default)
         {
             var buffer = new byte[bufferLength];
             var data = new List<byte>();
@@ -57,7 +57,15 @@ namespace System.IO
                 var read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
                 offset += read;
 
-                Assert.NotEqual(0, read);
+                if (read == 0)
+                {
+                    if (allowEmpty && offset == 0)
+                    {
+                        return null;
+                    }
+
+                    throw new Exception("Stream read 0.");
+                }
 
                 data.AddRange(buffer.AsMemory(0, read).ToArray());
             }

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Testing
                 localEndPoint: localEndPoint,
                 remoteEndPoint: remoteEndPoint,
                 streamLifetimeHandler: streamLifetimeHandler,
-                streamContext: null,
+                streamContext: new DefaultConnectionContext(),
                 clientPeerSettings: new Http3PeerSettings(),
                 serverPeerSettings: null
             );

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
@@ -263,10 +263,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await requestStream.OnDisposingTask.DefaultTimeout();
 
             Http3Api.TriggerTick(now);
-            Assert.Equal(0, requestStream.Error);
+            Assert.Null(requestStream.StreamContext._error);
 
             Http3Api.TriggerTick(now + TimeSpan.FromTicks(1));
-            Assert.Equal(0, requestStream.Error);
+            Assert.Null(requestStream.StreamContext._error);
 
             Http3Api.TriggerTick(now + limits.MinResponseDataRate.GracePeriod + TimeSpan.FromTicks(1));
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Tracing;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Interop.FunctionalTests.Http3
+{
+    public sealed class HttpEventSourceListener : EventListener
+    {
+        private readonly StringBuilder _messageBuilder = new StringBuilder();
+        private readonly ILogger _logger;
+        private readonly object _lock = new object();
+        private bool _disposed;
+
+        public HttpEventSourceListener(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger(nameof(HttpEventSourceListener));
+            _logger.LogDebug($"Starting {nameof(HttpEventSourceListener)}.");
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            base.OnEventSourceCreated(eventSource);
+
+            if (eventSource.Name.Contains("System.Net.Quic") ||
+                eventSource.Name.Contains("System.Net.Http"))
+            {
+                lock (_lock)
+                {
+                    if (!_disposed)
+                    {
+                        EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.All);
+                    }
+                }
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            base.OnEventWritten(eventData);
+
+            string message;
+            lock (_messageBuilder)
+            {
+                _messageBuilder.Append("<- Event ");
+                _messageBuilder.Append(eventData.EventSource.Name);
+                _messageBuilder.Append(" - ");
+                _messageBuilder.Append(eventData.EventName);
+                _messageBuilder.Append(" : ");
+                _messageBuilder.AppendJoin(',', eventData.Payload!);
+                _messageBuilder.Append(" ->");
+                message = _messageBuilder.ToString();
+                _messageBuilder.Clear();
+            }
+
+            // We don't know the state of the logger after dispose.
+            // Ensure that any messages written in the background aren't
+            // logged after the listener has been disposed in the test.
+            lock (_lock)
+            {
+                if (!_disposed)
+                {
+                    // EventListener base constructor subscribes to events.
+                    // It is possible to start getting events before the
+                    // super constructor is run and logger is assigned.
+                    _logger?.LogDebug(message);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return _messageBuilder.ToString();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            lock (_lock)
+            {
+                if (!_disposed)
+                {
+                    _logger?.LogDebug($"Stopping {nameof(HttpEventSourceListener)}.");
+                    _disposed = true;
+                }
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
@@ -24,8 +24,7 @@ namespace Interop.FunctionalTests.Http3
         {
             base.OnEventSourceCreated(eventSource);
 
-            if (eventSource.Name.Contains("System.Net.Quic") ||
-                eventSource.Name.Contains("System.Net.Http"))
+            if (IsHttpEventSource(eventSource))
             {
                 lock (_lock)
                 {
@@ -37,9 +36,19 @@ namespace Interop.FunctionalTests.Http3
             }
         }
 
+        private static bool IsHttpEventSource(EventSource eventSource)
+        {
+            return eventSource.Name.Contains("System.Net.Quic") || eventSource.Name.Contains("System.Net.Http");
+        }
+
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             base.OnEventWritten(eventData);
+
+            if (!IsHttpEventSource(eventData.EventSource))
+            {
+                return;
+            }
 
             string message;
             lock (_messageBuilder)


### PR DESCRIPTION
* Fix HTTP/3 layer not being notified of client abort after it has finished reads. Subscribe to a cancellation token for the notification. Driven by new `QuicStream.WaitForSendCompleteAsync` API.
* Fix unexpected errors in Http3OutputProducer.WriteDataFrames loop from QuicStream writes being aborted.
* `IProtocolErrorCodeFeature.Error` defaults to -1 when unset.
* Aborts throw `IOException` to app in Kestrel in more scenarios. This matches HTTP/2 behavior.
* Different log messages for aborting a streams reads and aborting writes.

Build fails because `QuicStream.WaitForSendCompleteAsync` is not available yet.