### PR TITLE
Revert "Upgrade Selenium Version"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -249,7 +249,7 @@
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.2</PollyVersion>
     <SeleniumSupportVersion>4.0.0-beta4</SeleniumSupportVersion>
-    <SeleniumWebDriverChromeDriverVersion>92.0.4515.10700</SeleniumWebDriverChromeDriverVersion>
+    <SeleniumWebDriverChromeDriverVersion>91.0.4472.1900</SeleniumWebDriverChromeDriverVersion>
     <SeleniumWebDriverVersion>4.0.0-beta4</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>


### PR DESCRIPTION
Reverts dotnet/aspnetcore#35949

Looks like it broke the quarantined tests pipeline. Timestamps of merge/failing builds line up:

![image](https://user-images.githubusercontent.com/14852843/131707129-f3c9ac2b-eff9-4743-beb6-7f317d35346e.png)
