### PR TITLE
Avoid pinning JSInterop code when unused

### DIFF
--- a/src/Components/ComponentsNoDeps.slnf
+++ b/src/Components/ComponentsNoDeps.slnf
@@ -54,7 +54,8 @@
       "src\\Components\\test\\testassets\\ComponentsApp.Server\\ComponentsApp.Server.csproj",
       "src\\Components\\test\\testassets\\GlobalizationWasmApp\\GlobalizationWasmApp.csproj",
       "src\\Components\\test\\testassets\\TestContentPackage\\TestContentPackage.csproj",
-      "src\\Components\\test\\testassets\\TestServer\\Components.TestServer.csproj"
+      "src\\Components\\test\\testassets\\TestServer\\Components.TestServer.csproj",
+      "src\\JSInterop\\Microsoft.JSInterop\\src\\Microsoft.JSInterop.csproj"
     ]
   }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetStreamReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetStreamReference.cs
@@ -1,11 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
+using Microsoft.JSInterop.Infrastructure;
+
 namespace Microsoft.JSInterop
 {
     /// <summary>
     /// Represents the reference to a .NET stream sent to JavaScript.
     /// </summary>
+    [JsonConverter(typeof(DotNetStreamReferenceJsonConverter))]
     public sealed class DotNetStreamReference : IDisposable
     {
         /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/IJSObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/IJSObjectReference.cs
@@ -1,10 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+using Microsoft.JSInterop.Infrastructure;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.JSInterop
@@ -12,6 +11,7 @@ namespace Microsoft.JSInterop
     /// <summary>
     /// Represents a reference to a JavaScript object.
     /// </summary>
+    [JsonConverter(typeof(JSObjectReferenceJsonConverter))]
     public interface IJSObjectReference : IAsyncDisposable
     {
         /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/IJSStreamReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/IJSStreamReference.cs
@@ -1,16 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop
 {
     /// <summary>
     /// Represents a reference to JavaScript data to be consumed through a <see cref="Stream"/>.
     /// </summary>
+    [JsonConverter(typeof(JSStreamReferenceJsonConverter))]
     public interface IJSStreamReference : IAsyncDisposable
     {
         /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSObjectReference.cs
@@ -1,10 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+using Microsoft.JSInterop.Infrastructure;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.JSInterop.Implementation
@@ -12,6 +11,7 @@ namespace Microsoft.JSInterop.Implementation
     /// <summary>
     /// Implements functionality for <see cref="IJSObjectReference"/>.
     /// </summary>
+    [JsonConverter(typeof(JSObjectReferenceJsonConverter))]
     public class JSObjectReference : IJSObjectReference
     {
         private readonly JSRuntime _jsRuntime;

--- a/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSStreamReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Implementation/JSStreamReference.cs
@@ -1,16 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop.Implementation
 {
     /// <summary>
     /// Implements functionality for <see cref="IJSStreamReference"/>.
     /// </summary>
+    [JsonConverter(typeof(JSStreamReferenceJsonConverter))]
     public sealed class JSStreamReference : JSObjectReference, IJSStreamReference
     {
         private readonly JSRuntime _jsRuntime;

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSObjectReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSObjectReferenceJsonConverter.cs
@@ -10,20 +10,15 @@ namespace Microsoft.JSInterop.Infrastructure
 {
     internal sealed class JSObjectReferenceJsonConverter : JsonConverter<IJSObjectReference>
     {
-        private readonly JSRuntime _jsRuntime;
-
-        public JSObjectReferenceJsonConverter(JSRuntime jsRuntime)
-        {
-            _jsRuntime = jsRuntime;
-        }
-
         public override bool CanConvert(Type typeToConvert)
             => typeToConvert == typeof(IJSObjectReference) || typeToConvert == typeof(JSObjectReference);
 
         public override IJSObjectReference? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            var jsRuntime = JSRuntimeProvider.GetJSRuntime(options);
+
             var id = JSObjectReferenceJsonWorker.ReadJSObjectReferenceIdentifier(ref reader);
-            return new JSObjectReference(_jsRuntime, id);
+            return new JSObjectReference(jsRuntime, id);
         }
 
         public override void Write(Utf8JsonWriter writer, IJSObjectReference value, JsonSerializerOptions options)

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSRuntimeProvider.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSRuntimeProvider.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.JSInterop.Infrastructure
+{
+    internal sealed class JSRuntimeProvider : JsonConverter<JSRuntime>
+    {
+        public JSRuntimeProvider(JSRuntime jsRuntime) => JSRuntime = jsRuntime;
+
+        public JSRuntime JSRuntime { get; }
+
+        public override bool CanConvert(Type typeToConvert) => false;
+
+        public override JSRuntime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, JSRuntime value, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        internal static JSRuntime GetJSRuntime(JsonSerializerOptions options)
+        {
+            for (var i = 0; i < options.Converters.Count; i++)
+            {
+                if (options.Converters[i] is JSRuntimeProvider jsRuntimeProvider)
+                {
+                    return jsRuntimeProvider.JSRuntime;
+                }
+            }
+
+            throw new InvalidOperationException("Unable to find JSRuntimeProvider in the configured options.");
+        }
+    }
+}

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSStreamReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSStreamReferenceJsonConverter.cs
@@ -12,18 +12,13 @@ namespace Microsoft.JSInterop.Infrastructure
     {
         private static readonly JsonEncodedText _jsStreamReferenceLengthKey = JsonEncodedText.Encode("__jsStreamReferenceLength");
 
-        private readonly JSRuntime _jsRuntime;
-
-        public JSStreamReferenceJsonConverter(JSRuntime jsRuntime)
-        {
-            _jsRuntime = jsRuntime;
-        }
-
         public override bool CanConvert(Type typeToConvert)
             => typeToConvert == typeof(IJSStreamReference) || typeToConvert == typeof(JSStreamReference);
 
         public override IJSStreamReference? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            var jsRuntime = JSRuntimeProvider.GetJSRuntime(options);
+
             long? id = null;
             long? length = null;
 
@@ -62,7 +57,7 @@ namespace Microsoft.JSInterop.Infrastructure
                 throw new JsonException($"Required property {_jsStreamReferenceLengthKey} not found.");
             }
 
-            return new JSStreamReference(_jsRuntime, id.Value, length.Value);
+            return new JSStreamReference(jsRuntime, id.Value, length.Value);
         }
 
         public override void Write(Utf8JsonWriter writer, IJSStreamReference value, JsonSerializerOptions options)

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -35,10 +35,8 @@ namespace Microsoft.JSInterop
                 PropertyNameCaseInsensitive = true,
                 Converters =
                 {
+                    new JSRuntimeProvider(this),
                     new DotNetObjectReferenceJsonConverterFactory(this),
-                    new JSObjectReferenceJsonConverter(this),
-                    new JSStreamReferenceJsonConverter(this),
-                    new DotNetStreamReferenceJsonConverter(this),
                     new ByteArrayJsonConverter(this),
                 }
             };


### PR DESCRIPTION
In our current usage, JSStreamReference and it's associated code gets pinned because the converter is registered by default
in the JSRuntime rooting the code. By moving the declaration to the type using a JsonConverterAttribute, we're able to trim this
code if it's not used by the application.

Numbers from trimming WebAssembly/testassets/StandaloneApp:

Size on disk before:
Microsoft.JSInterop.dll.br 14.0 KB (14,371 bytes)
Microsoft.AspNetCore.Components.WebAssembly.dll.br 16.7 KB (17,130 bytes)

Size on disk after:
Microsoft.JSInterop.dll.br 13.9 KB (14,327 bytes)
Microsoft.AspNetCore.Components.WebAssembly.dll.br 15.7 KB (16,151 bytes)

Fixes https://github.com/dotnet/aspnetcore/issues/35186
