### PR TITLE
[release/6.0] Fix ambiguous Map method with minimal APIs

### DIFF
--- a/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs
@@ -20,6 +20,19 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="pathMatch">The request path to match.</param>
         /// <param name="configuration">The branch to take for positive path matches.</param>
         /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
+        public static IApplicationBuilder Map(this IApplicationBuilder app, string pathMatch, Action<IApplicationBuilder> configuration)
+        {
+            return Map(app, pathMatch, preserveMatchedPathSegment: false, configuration);
+        }
+
+        /// <summary>
+        /// Branches the request pipeline based on matches of the given request path. If the request path starts with
+        /// the given path, the branch is executed.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/> instance.</param>
+        /// <param name="pathMatch">The request path to match.</param>
+        /// <param name="configuration">The branch to take for positive path matches.</param>
+        /// <returns>The <see cref="IApplicationBuilder"/> instance.</returns>
         public static IApplicationBuilder Map(this IApplicationBuilder app, PathString pathMatch, Action<IApplicationBuilder> configuration)
         {
             return Map(app, pathMatch, preserveMatchedPathSegment: false, configuration);

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -28,6 +28,7 @@ Microsoft.AspNetCore.Http.RequestDelegateResult.EndpointMetadata.get -> System.C
 Microsoft.AspNetCore.Http.RequestDelegateResult.RequestDelegate.get -> Microsoft.AspNetCore.Http.RequestDelegate!
 Microsoft.AspNetCore.Http.RequestDelegateResult.RequestDelegateResult(Microsoft.AspNetCore.Http.RequestDelegate! requestDelegate, System.Collections.Generic.IReadOnlyList<object!>! metadata) -> void
 Microsoft.AspNetCore.Routing.RouteValueDictionary.TryAdd(string! key, object? value) -> bool
+static Microsoft.AspNetCore.Builder.MapExtensions.Map(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, string! pathMatch, System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder!>! configuration) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static readonly Microsoft.AspNetCore.Http.HttpProtocol.Http09 -> string!
 static Microsoft.AspNetCore.Http.HttpProtocol.IsHttp09(string! protocol) -> bool
 abstract Microsoft.AspNetCore.Http.HttpRequest.ContentType.get -> string?

--- a/src/Http/Http.Abstractions/test/MapPathMiddlewareTests.cs
+++ b/src/Http/Http.Abstractions/test/MapPathMiddlewareTests.cs
@@ -1,11 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder.Internal;
 using Microsoft.AspNetCore.Http;
-using Xunit;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Builder.Extensions
 {
@@ -214,12 +212,62 @@ namespace Microsoft.AspNetCore.Builder.Extensions
             Assert.Equal("/route2/subroute2/subsub2", context.Request.Path.Value);
         }
 
+        [Fact]
+        public void ApplicationBuilderMapOverloadPreferredOverEndpointBuilderGivenStringPathAndImplicitLambdaParameterType()
+        {
+            var mockWebApplication = new MockWebApplication();
+
+            mockWebApplication.Map("/foo", app => { });
+
+            Assert.True(mockWebApplication.UseCalled);
+        }
+
+        [Fact]
+        public void ApplicationBuilderMapOverloadPreferredOverEndpointBuilderGivenStringPathAndExplicitLambdaParameterType()
+        {
+            var mockWebApplication = new MockWebApplication();
+
+            mockWebApplication.Map("/foo", (IApplicationBuilder app) => { });
+
+            Assert.True(mockWebApplication.UseCalled);
+        }
+
         private HttpContext CreateRequest(string basePath, string requestPath)
         {
             HttpContext context = new DefaultHttpContext();
             context.Request.PathBase = new PathString(basePath);
             context.Request.Path = new PathString(requestPath);
             return context;
+        }
+
+        private class MockWebApplication : IApplicationBuilder, IEndpointRouteBuilder
+        {
+            public bool UseCalled { get; set; }
+
+            public IServiceProvider ApplicationServices { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public IFeatureCollection ServerFeatures => throw new NotImplementedException();
+
+            public IDictionary<string, object?> Properties => throw new NotImplementedException();
+
+            public IServiceProvider ServiceProvider => throw new NotImplementedException();
+
+            public ICollection<EndpointDataSource> DataSources => throw new NotImplementedException();
+
+            public IApplicationBuilder CreateApplicationBuilder() => throw new NotImplementedException();
+
+            public IApplicationBuilder New() => this;
+
+            public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware)
+            {
+                UseCalled = true;
+                return this;
+            }
+
+            public RequestDelegate Build()
+            {
+                return context => Task.CompletedTask;
+            }
         }
     }
 }

--- a/src/Http/Http.Abstractions/test/Microsoft.AspNetCore.Http.Abstractions.Tests.csproj
+++ b/src/Http/Http.Abstractions/test/Microsoft.AspNetCore.Http.Abstractions.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http" />
+    <Reference Include="Microsoft.AspNetCore.Routing" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Backport of #35631 to release/6.0

## Customer Impact

When using minimal there is ambiguity when using `app.Map("/", builder => {});`
between `IApplicationBuilder Map(this IApplicationBuilder app, PathString pathMatch, Action<IApplicationBuilder> configuration)`
https://github.com/dotnet/aspnetcore/blob/ff51fd7105a9003841215f1f3b0b8fc9e2998a67/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs#L23
and `public static MinimalActionEndpointConventionBuilder Map(this IEndpointRouteBuilder endpoints, string pattern, Delegate action)`
https://github.com/dotnet/aspnetcore/blob/ff51fd7105a9003841215f1f3b0b8fc9e2998a67/src/Http/Routing/src/Builder/MinimalActionEndpointRouteBuilderExtensions.cs#L123

![image](https://user-images.githubusercontent.com/7574801/129303112-b1201e00-4ae7-4f43-ab48-7b9bf9caea31.png)

## Testing

Existing automated tests use this overload heavily since they rarely new up a PathString.

## Risk

The one risk I see with the new IApplicationBuilder Map overload is if something has both an implicit conversion to both `string` and `PathString` and it's used as the `pathMatch` parameter to Map, it's source-breaking as the overload becomes ambiguous:

![image](https://user-images.githubusercontent.com/54385/130532269-4cac803e-bf7b-4be8-8086-6b0109c6d74e.png)

We think the scenario where a custom type with an implicit conversion to both `string` and `PathString` and it's used as the `pathMatch` parameter to Map is unlikely however.