### PR TITLE
Improve the errors around UseStartup/Configure

### DIFF
--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.Builder
 
         IHostBuilder ISupportsConfigureWebHost.ConfigureWebHost(Action<IWebHostBuilder> configure, Action<WebHostBuilderOptions> configureOptions)
         {
-            throw new NotSupportedException($"ConfigureWebHost() is not supported by WebApplicationBuilder.Host. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
+            throw new NotSupportedException("ConfigureWebHost() is not supported by WebApplicationBuilder.Host. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
         }
     }
 }

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -150,19 +150,24 @@ namespace Microsoft.AspNetCore.Builder
             return this;
         }
 
+        IWebHostBuilder ISupportsStartup.Configure(Action<IApplicationBuilder> configure)
+        {
+            throw new NotSupportedException("Configure() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
+        }
+
         IWebHostBuilder ISupportsStartup.Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure)
         {
-            throw new NotSupportedException($"Configure() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
+            throw new NotSupportedException("Configure() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
         }
 
         IWebHostBuilder ISupportsStartup.UseStartup(Type startupType)
         {
-            throw new NotSupportedException($"UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
+            throw new NotSupportedException("UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
         }
 
         IWebHostBuilder ISupportsStartup.UseStartup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TStartup>(Func<WebHostBuilderContext, TStartup> startupFactory)
         {
-            throw new NotSupportedException($"UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
+            throw new NotSupportedException("UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.");
         }
     }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -991,13 +991,25 @@ namespace Microsoft.AspNetCore.Tests
         {
             var builder = WebApplication.CreateBuilder();
 
-            Assert.Throws<NotSupportedException>(() => builder.WebHost.Configure(app => { }));
-            Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup<MyStartup>());
-            Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup(typeof(MyStartup)));
+            var ex = Assert.Throws<NotSupportedException>(() => builder.WebHost.Configure(app => { }));
+            var ex1 = Assert.Throws<NotSupportedException>(() => builder.WebHost.Configure((context, app) => { }));
+            var ex2 = Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup<MyStartup>());
+            var ex3 = Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup(typeof(MyStartup)));
+            var ex4 = Assert.Throws<NotSupportedException>(() => builder.WebHost.UseStartup(context => new MyStartup()));
 
-            Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHost(webHostBuilder => { }));
-            Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHost(webHostBuilder => { }, options => { }));
-            Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHostDefaults(webHostBuilder => { }));
+            Assert.Equal("Configure() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.", ex.Message);
+            Assert.Equal("Configure() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.", ex1.Message);
+            Assert.Equal("UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.", ex2.Message);
+            Assert.Equal("UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.", ex3.Message);
+            Assert.Equal("UseStartup() is not supported by WebApplicationBuilder.WebHost. Use the WebApplication returned by WebApplicationBuilder.Build() instead.", ex4.Message);
+
+            var ex5 = Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHost(webHostBuilder => { }));
+            var ex6 = Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHost(webHostBuilder => { }, options => { }));
+            var ex7 = Assert.Throws<NotSupportedException>(() => builder.Host.ConfigureWebHostDefaults(webHostBuilder => { }));
+
+            Assert.Equal("ConfigureWebHost() is not supported by WebApplicationBuilder.Host. Use the WebApplication returned by WebApplicationBuilder.Build() instead.", ex5.Message);
+            Assert.Equal("ConfigureWebHost() is not supported by WebApplicationBuilder.Host. Use the WebApplication returned by WebApplicationBuilder.Build() instead.", ex6.Message);
+            Assert.Equal("ConfigureWebHost() is not supported by WebApplicationBuilder.Host. Use the WebApplication returned by WebApplicationBuilder.Build() instead.", ex7.Message);
         }
 
         [Fact]

--- a/src/Hosting/Hosting/src/GenericHost/HostingStartupWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/HostingStartupWebHostBuilder.cs
@@ -68,6 +68,11 @@ namespace Microsoft.AspNetCore.Hosting
             return _builder.UseDefaultServiceProvider(configure);
         }
 
+        public IWebHostBuilder Configure(Action<IApplicationBuilder> configure)
+        {
+            return _builder.Configure(configure);
+        }
+
         public IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure)
         {
             return _builder.Configure(configure);

--- a/src/Hosting/Hosting/src/Infrastructure/ISupportsStartup.cs
+++ b/src/Hosting/Hosting/src/Infrastructure/ISupportsStartup.cs
@@ -20,6 +20,13 @@ namespace Microsoft.AspNetCore.Hosting.Infrastructure
         /// </summary>
         /// <param name="configure">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
         /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
+        IWebHostBuilder Configure(Action<IApplicationBuilder> configure);
+
+        /// <summary>
+        /// Specify the startup method to be used to configure the web application.
+        /// </summary>
+        /// <param name="configure">The delegate that configures the <see cref="IApplicationBuilder"/>.</param>
+        /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
         IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure);
 
         /// <summary>

--- a/src/Hosting/Hosting/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/Hosting/src/PublicAPI.Unshipped.txt
@@ -11,6 +11,7 @@ Microsoft.AspNetCore.Hosting.Builder.IApplicationBuilderFactory.CreateBuilder(Mi
 Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsConfigureWebHost
 Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsConfigureWebHost.ConfigureWebHost(System.Action<Microsoft.AspNetCore.Hosting.IWebHostBuilder!>! configure, System.Action<Microsoft.Extensions.Hosting.WebHostBuilderOptions!>! configureOptions) -> Microsoft.Extensions.Hosting.IHostBuilder!
 Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup
+Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup.Configure(System.Action<Microsoft.AspNetCore.Builder.IApplicationBuilder!>! configure) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup.Configure(System.Action<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, Microsoft.AspNetCore.Builder.IApplicationBuilder!>! configure) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup.UseStartup(System.Type! startupType) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
 Microsoft.AspNetCore.Hosting.Infrastructure.ISupportsStartup.UseStartup<TStartup>(System.Func<Microsoft.AspNetCore.Hosting.WebHostBuilderContext!, TStartup>! startupFactory) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!

--- a/src/Hosting/Hosting/test/Fakes/GenericWebHostBuilderWrapper.cs
+++ b/src/Hosting/Hosting/test/Fakes/GenericWebHostBuilderWrapper.cs
@@ -27,6 +27,12 @@ namespace Microsoft.AspNetCore.Hosting.Tests.Fakes
             return new GenericWebHost(_hostBuilder.Build());
         }
 
+        public IWebHostBuilder Configure(Action<IApplicationBuilder> configure)
+        {
+            _builder.Configure(configure);
+            return this;
+        }
+
         public IWebHostBuilder Configure(Action<WebHostBuilderContext, IApplicationBuilder> configure)
         {
             _builder.Configure(configure);


### PR DESCRIPTION
- Today we throw a NotSupportedException when you try to call any of the methods that register callbacks for wiring up the ASP.NET Core pipeline. Unfortunately, this conflicts with another NotSupportedException that doesn't make much sense. We fix this by delegating to ISupportsStartup before attempting to set the application name.
- Improved the existing test

This adds an API:

```diff
public interface ISupportsStartup
{
+    public void Configure(Action<IApplicationBuilder> configure);
}
```

Fixes #35830