### PR TITLE
Fix issues with hosting startups

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -57,10 +57,6 @@ namespace Microsoft.AspNetCore.Builder
                 // Runs inline.
                 webHostBuilder.Configure(ConfigureApplication);
 
-                // We need to override the application name since the call to Configure will set it to
-                // be the calling assembly's name.
-                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, (Assembly.GetEntryAssembly())?.GetName()?.Name ?? string.Empty);
-
                 // Attempt to set the application name from options
                 options.ApplyApplicationName(webHostBuilder);
             });

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -60,6 +60,9 @@ namespace Microsoft.AspNetCore.Builder
                 // We need to override the application name since the call to Configure will set it to
                 // be the calling assembly's name.
                 webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, (Assembly.GetEntryAssembly())?.GetName()?.Name ?? string.Empty);
+
+                // Attempt to set the application name from options
+                options.ApplyApplicationName(webHostBuilder);
             });
 
             // Apply the args to host configuration last since ConfigureWebHostDefaults overrides a host specific setting (the application name).

--- a/src/DefaultBuilder/src/WebApplicationOptions.cs
+++ b/src/DefaultBuilder/src/WebApplicationOptions.cs
@@ -64,5 +64,38 @@ namespace Microsoft.AspNetCore.Builder
                 builder.AddInMemoryCollection(config);
             }
         }
+
+        internal void ApplyApplicationName(IWebHostBuilder webHostBuilder)
+        {
+            string? applicationName = null;
+
+            if (ApplicationName is not null)
+            {
+                applicationName = ApplicationName;
+            }
+
+            // We need to "parse" the args here since
+            // we need to set the application name via UseSetting
+            if (Args is not null)
+            {
+                var config = new ConfigurationBuilder()
+                        .AddCommandLine(Args)
+                        .Build();
+
+                applicationName = config[WebHostDefaults.ApplicationKey];
+
+                // This isn't super important since we're not adding any disposable sources
+                // but just in case
+                if (config is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+
+            if (applicationName is not null)
+            {
+                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, applicationName);
+            }
+        }
     }
 }

--- a/src/DefaultBuilder/src/WebApplicationOptions.cs
+++ b/src/DefaultBuilder/src/WebApplicationOptions.cs
@@ -69,11 +69,6 @@ namespace Microsoft.AspNetCore.Builder
         {
             string? applicationName = null;
 
-            if (ApplicationName is not null)
-            {
-                applicationName = ApplicationName;
-            }
-
             // We need to "parse" the args here since
             // we need to set the application name via UseSetting
             if (Args is not null)
@@ -90,6 +85,12 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     disposable.Dispose();
                 }
+            }
+
+            // Application name overrides args
+            if (ApplicationName is not null)
+            {
+                applicationName = ApplicationName;
             }
 
             if (applicationName is not null)

--- a/src/DefaultBuilder/src/WebApplicationOptions.cs
+++ b/src/DefaultBuilder/src/WebApplicationOptions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -93,10 +94,11 @@ namespace Microsoft.AspNetCore.Builder
                 applicationName = ApplicationName;
             }
 
-            if (applicationName is not null)
-            {
-                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, applicationName);
-            }
+            // We need to override the application name since the call to Configure will set it to
+            // be the calling assembly's name.
+            applicationName ??= Assembly.GetEntryAssembly()?.GetName()?.Name ?? string.Empty;
+
+            webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, applicationName);
         }
     }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Tests;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -23,6 +24,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
+
+[assembly: HostingStartup(typeof(WebApplicationTests.TestHostingStartup))]
 
 namespace Microsoft.AspNetCore.Tests
 {
@@ -1217,6 +1220,24 @@ namespace Microsoft.AspNetCore.Tests
             Assert.Equal("BOOM", ex.Message);
         }
 
+        [Fact]
+        public async Task HostingStartupRunsWhenApplicationIsNotEntryPoint()
+        {
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions { ApplicationName = typeof(WebApplicationTests).Assembly.FullName });
+            await using var app = builder.Build();
+
+            Assert.Equal("value", app.Configuration["testhostingstartup:config"]);
+        }
+
+        [Fact]
+        public async Task HostingStartupRunsWhenApplicationIsNotEntryPointWithArgs()
+        {
+            var builder = WebApplication.CreateBuilder(new[] { "--applicationName", typeof(WebApplicationTests).Assembly.FullName });
+            await using var app = builder.Build();
+
+            Assert.Equal("value", app.Configuration["testhostingstartup:config"]);
+        }
+
         class ThrowingStartupFilter : IStartupFilter
         {
             public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
@@ -1230,6 +1251,19 @@ namespace Microsoft.AspNetCore.Tests
 
                     next(app);
                 };
+            }
+        }
+
+        public class TestHostingStartup : IHostingStartup
+        {
+            public void Configure(IWebHostBuilder builder)
+            {
+                builder
+                    .ConfigureAppConfiguration((context, configurationBuilder) => configurationBuilder.AddInMemoryCollection(
+                        new[]
+                        {
+                            new KeyValuePair<string,string>("testhostingstartup:config", "value")
+                        }));
             }
         }
 

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1238,6 +1238,20 @@ namespace Microsoft.AspNetCore.Tests
             Assert.Equal("value", app.Configuration["testhostingstartup:config"]);
         }
 
+        [Fact]
+        public async Task HostingStartupRunsWhenApplicationIsNotEntryPointApplicationNameWinsOverArgs()
+        {
+            var options = new WebApplicationOptions
+            {
+                Args = new[] { "--applicationName", typeof(WebApplication).Assembly.FullName },
+                ApplicationName = typeof(WebApplicationTests).Assembly.FullName,
+            };
+            var builder = WebApplication.CreateBuilder(options);
+            await using var app = builder.Build();
+
+            Assert.Equal("value", app.Configuration["testhostingstartup:config"]);
+        }
+
         class ThrowingStartupFilter : IStartupFilter
         {
             public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)


### PR DESCRIPTION
- When the WebApplications's application name is specified we need to set the it on the internal web host builder so that hosting startups can see the new name. This allows the logic to find hosting startups in the specified application name instead of the entry assembly. When running inside of test projects, the entry assembly is always the test host, that's why it showed it when running tests.
- Added tests

Fixes #35956