### PR TITLE
Improve error messages for missing body and services

### DIFF
--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -158,8 +158,8 @@ Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetCookie.set -> void
 Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetList<T>(string! name, System.Collections.Generic.IList<T>? values) -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactory
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableImplicitFromBody.get -> bool
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableImplicitFromBody.set -> void
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferredBody.get -> bool
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferredBody.set -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RequestDelegateFactoryOptions() -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.get -> System.Collections.Generic.IEnumerable<string!>?
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.init -> void

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -158,6 +158,8 @@ Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetCookie.set -> void
 Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetList<T>(string! name, System.Collections.Generic.IList<T>? values) -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactory
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.AllowImplicitFromBody.get -> bool
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.AllowImplicitFromBody.set -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RequestDelegateFactoryOptions() -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.get -> System.Collections.Generic.IEnumerable<string!>?
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.init -> void

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -158,8 +158,8 @@ Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetCookie.set -> void
 Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetList<T>(string! name, System.Collections.Generic.IList<T>? values) -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactory
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.AllowImplicitFromBody.get -> bool
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.AllowImplicitFromBody.set -> void
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableImplicitFromBody.get -> bool
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableImplicitFromBody.set -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RequestDelegateFactoryOptions() -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.get -> System.Collections.Generic.IEnumerable<string!>?
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.init -> void

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -159,7 +159,7 @@ Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetList<T>(string! name, Syste
 Microsoft.AspNetCore.Http.RequestDelegateFactory
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferredBody.get -> bool
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferredBody.set -> void
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferredBody.init -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RequestDelegateFactoryOptions() -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.get -> System.Collections.Generic.IEnumerable<string!>?
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.init -> void

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -158,8 +158,8 @@ Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetCookie.set -> void
 Microsoft.AspNetCore.Http.Headers.ResponseHeaders.SetList<T>(string! name, System.Collections.Generic.IList<T>? values) -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactory
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferredBody.get -> bool
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferredBody.init -> void
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferBodyFromParameters.get -> bool
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.DisableInferBodyFromParameters.init -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RequestDelegateFactoryOptions() -> void
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.get -> System.Collections.Generic.IEnumerable<string!>?
 Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.RouteParameterNames.init -> void

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1313,7 +1313,7 @@ namespace Microsoft.AspNetCore.Http
             errorMessage.AppendLine("Failure to infer one or more parameters.");
             errorMessage.AppendLine("Below is the list of parameters that we found: ");
             errorMessage.AppendLine();
-            errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}|{"Source",-30}"));
+            errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}| {"Source",-30}"));
             errorMessage.AppendLine("---------------------------------------------------------------------------------");
 
             foreach (var kv in factoryContext.TrackedParameters)
@@ -1332,7 +1332,7 @@ namespace Microsoft.AspNetCore.Http
             errorMessage.AppendLine("Body was inferred but the method does not allow inferred body parameters.");
             errorMessage.AppendLine("Below is the list of parameters that we found: ");
             errorMessage.AppendLine();
-            errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}|{"Source",-30}"));
+            errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}| {"Source",-30}"));
             errorMessage.AppendLine("---------------------------------------------------------------------------------");
 
             foreach (var kv in factoryContext.TrackedParameters)
@@ -1351,7 +1351,7 @@ namespace Microsoft.AspNetCore.Http
             errorMessage.AppendLine("Parameter must be a service but no service was found.");
             errorMessage.AppendLine("Below is the list of parameters that we found: ");
             errorMessage.AppendLine();
-            errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}|{"Source",-30}"));
+            errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}| {"Source",-30}"));
             errorMessage.AppendLine("---------------------------------------------------------------------------------");
 
             foreach (var kv in factoryContext.TrackedParameters)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Http
                 ServiceProviderIsService = options?.ServiceProvider?.GetService<IServiceProviderIsService>(),
                 RouteParameters = options?.RouteParameterNames?.ToList(),
                 ThrowOnBadRequest = options?.ThrowOnBadRequest ?? false,
-                DisableInferredFromBody = options?.DisableInferredBody ?? false,
+                DisableInferredFromBody = options?.DisableInferBodyFromParameters ?? false,
             };
 
         private static Func<object?, HttpContext, Task> CreateTargetableRequestDelegate(MethodInfo methodInfo, Expression? targetExpression, FactoryContext factoryContext)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Http
                 ServiceProviderIsService = options?.ServiceProvider?.GetService<IServiceProviderIsService>(),
                 RouteParameters = options?.RouteParameterNames?.ToList(),
                 ThrowOnBadRequest = options?.ThrowOnBadRequest ?? false,
-                AllowImplicitFromBody = !options?.DisableInferredBody ?? true,
+                DisableInferredFromBody = options?.DisableInferredBody ?? false,
             };
 
         private static Func<object?, HttpContext, Task> CreateTargetableRequestDelegate(MethodInfo methodInfo, Expression? targetExpression, FactoryContext factoryContext)
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Http
                 args[i] = CreateArgument(parameters[i], factoryContext);
             }
 
-            if (factoryContext.HasImplicitBody && !factoryContext.AllowImplicitFromBody)
+            if (factoryContext.HasInferredBody && factoryContext.DisableInferredFromBody)
             {
                 var errorMessage = BuildErrorMessageForInferredBodyParameter(factoryContext);
                 throw new InvalidOperationException(errorMessage);
@@ -302,7 +302,7 @@ namespace Microsoft.AspNetCore.Http
                     }
                 }
 
-                factoryContext.HasImplicitBody = true;
+                factoryContext.HasInferredBody = true;
                 factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.BodyParameter);
                 return BindParameterFromBody(parameter, allowEmpty: false, factoryContext);
             }
@@ -897,7 +897,7 @@ namespace Microsoft.AspNetCore.Http
 
             if (!factoryContext.AllowEmptyRequestBody)
             {
-                if (factoryContext.HasImplicitBody)
+                if (factoryContext.HasInferredBody)
                 {
                     // if (bodyValue == null)
                     // {
@@ -1160,7 +1160,7 @@ namespace Microsoft.AspNetCore.Http
             public IServiceProviderIsService? ServiceProviderIsService { get; init; }
             public List<string>? RouteParameters { get; init; }
             public bool ThrowOnBadRequest { get; init; }
-            public bool AllowImplicitFromBody { get; init; }
+            public bool DisableInferredFromBody { get; init; }
 
             // Temporary State
             public Type? JsonRequestBodyType { get; set; }
@@ -1173,7 +1173,7 @@ namespace Microsoft.AspNetCore.Http
 
             public Dictionary<string, string> TrackedParameters { get; } = new();
             public bool HasMultipleBodyParameters { get; set; }
-            public bool HasImplicitBody { get; set; }
+            public bool HasInferredBody { get; set; }
 
             public List<object> Metadata { get; } = new();
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -647,21 +647,7 @@ namespace Microsoft.AspNetCore.Http
             {
                 return Expression.Call(GetServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
             }
-            if (factoryContext.ServiceProviderIsService is IServiceProviderIsService serviceProviderIsService)
-            {
-                if (serviceProviderIsService.IsService(parameter.ParameterType))
-                {
-                    return Expression.Call(GetRequiredServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
-                }
-            }
-            else
-            {
-                // If the DI container does not implement IServiceProviderIsService then we can't error early about the service not being in the container
-                return Expression.Call(GetRequiredServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
-            }
-
-            var errorMessage = BuildErrorMessageForMissingService(factoryContext);
-            throw new InvalidOperationException(errorMessage);
+            return Expression.Call(GetRequiredServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
         }
 
         private static Expression BindParameterFromValue(ParameterInfo parameter, Expression valueExpression, FactoryContext factoryContext, string source)
@@ -1374,25 +1360,6 @@ namespace Microsoft.AspNetCore.Http
             }
             errorMessage.AppendLine().AppendLine();
             errorMessage.AppendLine("Did you mean to register the \"Body (Inferred)\" parameter(s) as a Service or apply the [FromService] or [FromBody] attribute?")
-                .AppendLine();
-            return errorMessage.ToString();
-        }
-
-        private static string BuildErrorMessageForMissingService(FactoryContext factoryContext)
-        {
-            var errorMessage = new StringBuilder();
-            errorMessage.AppendLine("Parameter must be a service but no service was found.");
-            errorMessage.AppendLine("Below is the list of parameters that we found: ");
-            errorMessage.AppendLine();
-            errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}| {"Source",-30}"));
-            errorMessage.AppendLine("---------------------------------------------------------------------------------");
-
-            foreach (var kv in factoryContext.TrackedParameters)
-            {
-                errorMessage.AppendLine(FormattableString.Invariant($"{kv.Key,-19} | {kv.Value,-15}"));
-            }
-            errorMessage.AppendLine().AppendLine();
-            errorMessage.AppendLine("Did you mean to register the \"Service (Attribute)\" parameter(s) as a Service?")
                 .AppendLine();
             return errorMessage.ToString();
         }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -41,6 +41,8 @@ namespace Microsoft.AspNetCore.Http
             Log.ParameterBindingFailed(httpContext, parameterType, parameterName, sourceValue, shouldThrow));
         private static readonly MethodInfo LogRequiredParameterNotProvidedMethod = GetMethodInfo<Action<HttpContext, string, string, string, bool>>((httpContext, parameterType, parameterName, source, shouldThrow) =>
             Log.RequiredParameterNotProvided(httpContext, parameterType, parameterName, source, shouldThrow));
+        private static readonly MethodInfo LogImplicitBodyNotProvidedMethod = GetMethodInfo<Action<HttpContext, string, bool>>((httpContext, parameterName, shouldThrow) =>
+            Log.ImplicitBodyNotProvided(httpContext, parameterName, shouldThrow));
 
         private static readonly ParameterExpression TargetExpr = Expression.Parameter(typeof(object), "target");
         private static readonly ParameterExpression BodyValueExpr = Expression.Parameter(typeof(object), "bodyValue");
@@ -138,6 +140,7 @@ namespace Microsoft.AspNetCore.Http
                 ServiceProviderIsService = options?.ServiceProvider?.GetService<IServiceProviderIsService>(),
                 RouteParameters = options?.RouteParameterNames?.ToList(),
                 ThrowOnBadRequest = options?.ThrowOnBadRequest ?? false,
+                AllowImplicitFromBody = !options?.DisableInferredBody ?? true,
             };
 
         private static Func<object?, HttpContext, Task> CreateTargetableRequestDelegate(MethodInfo methodInfo, Expression? targetExpression, FactoryContext factoryContext)
@@ -158,7 +161,7 @@ namespace Microsoft.AspNetCore.Http
             //     return default;
             // }
 
-            var arguments = CreateArguments(methodInfo.GetParameters(), factoryContext, options);
+            var arguments = CreateArguments(methodInfo.GetParameters(), factoryContext);
 
             var responseWritingMethodCall = factoryContext.ParamCheckExpressions.Count > 0 ?
                 CreateParamCheckingResponseWritingMethodCall(methodInfo, targetExpression, arguments, factoryContext) :
@@ -172,7 +175,7 @@ namespace Microsoft.AspNetCore.Http
             return HandleRequestBodyAndCompileRequestDelegate(responseWritingMethodCall, factoryContext);
         }
 
-        private static Expression[] CreateArguments(ParameterInfo[]? parameters, FactoryContext factoryContext, RequestDelegateFactoryOptions? options)
+        private static Expression[] CreateArguments(ParameterInfo[]? parameters, FactoryContext factoryContext)
         {
             if (parameters is null || parameters.Length == 0)
             {
@@ -186,7 +189,7 @@ namespace Microsoft.AspNetCore.Http
                 args[i] = CreateArgument(parameters[i], factoryContext);
             }
 
-            if (factoryContext.HasImplicitBody && (options?.DisableImplicitFromBody ?? false))
+            if (factoryContext.HasImplicitBody && !factoryContext.AllowImplicitFromBody)
             {
                 var errorMessage = BuildErrorMessageForInferredBodyParameter(factoryContext);
                 throw new InvalidOperationException(errorMessage);
@@ -907,13 +910,19 @@ namespace Microsoft.AspNetCore.Http
                 {
                     // if (bodyValue == null)
                     // {
-                    //    throw new InvalidOperationException("Implicit body inferred but no body was provided. Did you mean to use a Service instead?");
+                    //    wasParamCheckFailure = true;
+                    //    Log.ImplicitBodyNotProvided(httpContext, "todo", ThrowOnBadRequest);
                     // }
                     factoryContext.ParamCheckExpressions.Add(Expression.Block(
                         Expression.IfThen(
                             Expression.Equal(BodyValueExpr, Expression.Constant(null)),
                             Expression.Block(
-                                Expression.Throw(Expression.Constant(new InvalidOperationException("Implicit body inferred but no body was provided. Did you mean to use a Service instead?")))
+                                Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
+                                Expression.Call(LogImplicitBodyNotProvidedMethod,
+                                    HttpContextExpr,
+                                    Expression.Constant(parameter.Name),
+                                    Expression.Constant(factoryContext.ThrowOnBadRequest)
+                                )
                             )
                         )
                     ));
@@ -926,7 +935,7 @@ namespace Microsoft.AspNetCore.Http
                     // if (bodyValue == null)
                     // {
                     //      wasParamCheckFailure = true;
-                    //      Log.RequiredParameterNotProvided(httpContext, "Todo", "body");
+                    //      Log.RequiredParameterNotProvided(httpContext, "Todo", "todo", "body", ThrowOnBadRequest);
                     // }
                     var checkRequiredBodyBlock = Expression.Block(
                         Expression.IfThen(
@@ -1160,6 +1169,7 @@ namespace Microsoft.AspNetCore.Http
             public IServiceProviderIsService? ServiceProviderIsService { get; init; }
             public List<string>? RouteParameters { get; init; }
             public bool ThrowOnBadRequest { get; init; }
+            public bool AllowImplicitFromBody { get; init; }
 
             // Temporary State
             public Type? JsonRequestBodyType { get; set; }
@@ -1205,6 +1215,8 @@ namespace Microsoft.AspNetCore.Http
 
             private const string UnexpectedContentTypeLogMessage = @"Expected a supported JSON media type but got ""{ContentType}"".";
             private const string UnexpectedContentTypeExceptionMessage = @"Expected a supported JSON media type but got ""{0}"".";
+            private const string ImplicitBodyNotProvidedLogMessage = @"Implicit body inferred for parameter ""{ParameterName}"" but no body was provided. Did you mean to use a Service instead?";
+            private const string ImplicitBodyNotProvidedExceptionMessage = @"Implicit body inferred for parameter ""{0}"" but no body was provided. Did you mean to use a Service instead?";
 
             // This doesn't take a shouldThrow parameter because an IOException indicates an aborted request rather than a "bad" request so
             // a BadHttpRequestException feels wrong. The client shouldn't be able to read the Developer Exception Page at any rate.
@@ -1265,6 +1277,22 @@ namespace Microsoft.AspNetCore.Http
 
                 UnexpectedContentType(GetLogger(httpContext), contentType ?? "(none)");
             }
+            public static void ImplicitBodyNotProvided(HttpContext httpContext, string parameterName, bool shouldThrow)
+            {
+                if (shouldThrow)
+                {
+                    var message = string.Format(CultureInfo.InvariantCulture, ImplicitBodyNotProvidedExceptionMessage, parameterName);
+                    throw new BadHttpRequestException(message);
+                }
+
+                ImplicitBodyNotProvided(GetLogger(httpContext), parameterName);
+            }
+
+            [LoggerMessage(5, LogLevel.Debug, ImplicitBodyNotProvidedLogMessage, EventName = "ImplicitBodyNotProvided")]
+            private static partial void ImplicitBodyNotProvided(ILogger logger, string parameterName);
+
+            public static void UnexpectedContentType(HttpContext httpContext, string? contentType)
+                => UnexpectedContentType(GetLogger(httpContext), contentType ?? "(none)");
 
             [LoggerMessage(6, LogLevel.Debug, UnexpectedContentTypeLogMessage, EventName = "UnexpectedContentType")]
             private static partial void UnexpectedContentType(ILogger logger, string contentType);
@@ -1359,7 +1387,7 @@ namespace Microsoft.AspNetCore.Http
                 errorMessage.AppendLine(FormattableString.Invariant($"{kv.Key,-19} | {kv.Value,-15}"));
             }
             errorMessage.AppendLine().AppendLine();
-            errorMessage.AppendLine("Did you mean to register the \"Service (Attribute)\" parameter(s) as a Service or does your DI container not support IServiceProviderIsService?")
+            errorMessage.AppendLine("Did you mean to register the \"Service (Attribute)\" parameter(s) as a Service?")
                 .AppendLine();
             return errorMessage.ToString();
         }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Http
                 args[i] = CreateArgument(parameters[i], factoryContext);
             }
 
-            if (factoryContext.HasImplicitBody && (!options?.AllowImplicitFromBody ?? false))
+            if (factoryContext.HasImplicitBody && (options?.DisableImplicitFromBody ?? false))
             {
                 var errorMessage = BuildErrorMessageForInferredBodyParameter(factoryContext);
                 throw new InvalidOperationException(errorMessage);

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -654,6 +654,11 @@ namespace Microsoft.AspNetCore.Http
                     return Expression.Call(GetRequiredServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
                 }
             }
+            else
+            {
+                // If the DI container does not implement IServiceProviderIsService then we can't error early about the service not being in the container
+                return Expression.Call(GetRequiredServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr);
+            }
 
             var errorMessage = BuildErrorMessageForMissingService(factoryContext);
             throw new InvalidOperationException(errorMessage);

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Http
@@ -27,8 +28,8 @@ namespace Microsoft.AspNetCore.Http
         public bool ThrowOnBadRequest { get; init; }
 
         /// <summary>
-        /// Prevent the <see cref="RequestDelegateFactory" /> from inferring a parameter should be bound from the request body without an attribute.
+        /// Prevent the <see cref="RequestDelegateFactory" /> from inferring a parameter should be bound from the request body without an attribute that implements <see cref="IFromBodyMetadata"/>.
         /// </summary>
-        public bool DisableImplicitFromBody { get; set; }
+        public bool DisableInferredBody { get; set; }
     }
 }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
@@ -30,6 +30,6 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Prevent the <see cref="RequestDelegateFactory" /> from inferring a parameter should be bound from the request body without an attribute that implements <see cref="IFromBodyMetadata"/>.
         /// </summary>
-        public bool DisableInferredBody { get; set; }
+        public bool DisableInferredBody { get; init; }
     }
 }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.Http
         public bool ThrowOnBadRequest { get; init; }
 
         /// <summary>
-        /// Allow the delegate to infer a parameter as from the request body.
+        /// Prevent the <see cref="RequestDelegateFactory" /> from inferring a parameter should be bound from the request body without an attribute.
         /// </summary>
-        public bool AllowImplicitFromBody { get; set; }
+        public bool DisableImplicitFromBody { get; set; }
     }
 }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
@@ -25,5 +25,10 @@ namespace Microsoft.AspNetCore.Http
         /// writing a <see cref="LogLevel.Debug"/> log when handling invalid requests.
         /// </summary>
         public bool ThrowOnBadRequest { get; init; }
+
+        /// <summary>
+        /// Allow the delegate to infer a parameter as from the request body.
+        /// </summary>
+        public bool AllowImplicitFromBody { get; set; }
     }
 }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
@@ -30,6 +30,6 @@ namespace Microsoft.AspNetCore.Http
         /// <summary>
         /// Prevent the <see cref="RequestDelegateFactory" /> from inferring a parameter should be bound from the request body without an attribute that implements <see cref="IFromBodyMetadata"/>.
         /// </summary>
-        public bool DisableInferredBody { get; init; }
+        public bool DisableInferBodyFromParameters { get; init; }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1492,29 +1492,9 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
         [Theory]
         [MemberData(nameof(ExplicitFromServiceActions))]
-        public void RequestDelegateWithExplicitFromServiceParametersAndIsServiceContainer(Delegate action)
+        public async Task RequestDelegateWithExplicitFromServiceParameters(Delegate action)
         {
-            // IEnumerable<T> always resolves from DI, so ignore it in this test
-            if (action.Method.Name.Contains("TestExplicitFromIEnumerableService", StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            var httpContext = CreateHttpContext();
-
-            var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(action, new RequestDelegateFactoryOptions()
-            {
-                // pass a service container in so the IServiceProviderIsService check is tested
-                ServiceProvider = httpContext.RequestServices
-            }));
-            Assert.Contains("Parameter must be a service but no service was found.", ex.Message);
-        }
-
-        [Theory]
-        [MemberData(nameof(ExplicitFromServiceActions))]
-        public async Task RequestDelegateWithExplicitFromServiceParametersAndNoIsServiceContainer(Delegate action)
-        {
-            // IEnumerable<T> always resolves from DI, so ignore it in this test
+            // IEnumerable<T> always resolves from DI but is empty and throws from test method
             if (action.Method.Name.Contains("TestExplicitFromIEnumerableService", StringComparison.Ordinal))
             {
                 return;
@@ -2386,12 +2366,6 @@ namespace Microsoft.AspNetCore.Routing.Internal
             httpContext.RequestServices = services;
             RequestDelegateFactoryOptions options = new() { ServiceProvider = services };
 
-            if (!hasService && isInvalid)
-            {
-                var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(@delegate, options));
-                Assert.Contains("Parameter must be a service but no service was found.", ex.Message);
-                return;
-            }
             var factoryResult = RequestDelegateFactory.Create(@delegate, options);
             var requestDelegate = factoryResult.RequestDelegate;
 

--- a/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Builder
             this IEndpointRouteBuilder endpoints,
             RoutePattern pattern,
             Delegate handler,
-            bool disableImplicitFromBody)
+            bool disableInferredBody)
         {
             if (endpoints is null)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Builder
                 ServiceProvider = endpoints.ServiceProvider,
                 RouteParameterNames = routeParams,
                 ThrowOnBadRequest = routeHandlerOptions?.Value.ThrowOnBadRequest ?? false,
-                DisableImplicitFromBody = disableImplicitFromBody,
+                DisableInferredBody = disableInferredBody,
             };
 
             var requestDelegateResult = RequestDelegateFactory.Create(handler, options);
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(httpMethods));
             }
 
-            var disableImplicitFromBody = false;
+            var disableInferredBody = false;
             // GET, DELETE, HEAD, CONNECT, TRACE, and OPTIONS normally do not contain bodies
             if (!httpMethods.Any(method => !(method.Equals(HttpMethods.Get, StringComparison.Ordinal) ||
                 method.Equals(HttpMethods.Delete, StringComparison.Ordinal) ||
@@ -216,10 +216,10 @@ namespace Microsoft.AspNetCore.Builder
                 method.Equals(HttpMethods.Trace, StringComparison.Ordinal) ||
                 method.Equals(HttpMethods.Connect, StringComparison.Ordinal))))
             {
-                disableImplicitFromBody = true;
+                disableInferredBody = true;
             }
 
-            var builder = endpoints.Map(RoutePatternFactory.Parse(pattern), handler, disableImplicitFromBody);
+            var builder = endpoints.Map(RoutePatternFactory.Parse(pattern), handler, disableInferredBody);
             // Prepends the HTTP method to the DisplayName produced with pattern + method name
             builder.Add(b => b.DisplayName = $"HTTP: {string.Join(", ", httpMethods)} {b.DisplayName}");
             builder.WithMetadata(new HttpMethodMetadata(httpMethods));
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Builder
             RoutePattern pattern,
             Delegate handler)
         {
-            return Map(endpoints, pattern, handler, disableImplicitFromBody: false);
+            return Map(endpoints, pattern, handler, disableInferredBody: false);
         }
 
         /// <summary>

--- a/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Builder
             string pattern,
             Delegate handler)
         {
-            return MapMethods(endpoints, pattern, GetVerb, handler, allowImplicitFromBody: false);
+            return MapMethods(endpoints, pattern, GetVerb, handler);
         }
 
         /// <summary>
@@ -88,14 +88,14 @@ namespace Microsoft.AspNetCore.Builder
             string pattern,
             Delegate handler)
         {
-            return MapMethods(endpoints, pattern, DeleteVerb, handler, allowImplicitFromBody: false);
+            return MapMethods(endpoints, pattern, DeleteVerb, handler);
         }
 
         private static DelegateEndpointConventionBuilder Map(
             this IEndpointRouteBuilder endpoints,
             RoutePattern pattern,
             Delegate handler,
-            bool allowImplicitFromBody)
+            bool disableImplicitFromBody)
         {
             if (endpoints is null)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Builder
                 ServiceProvider = endpoints.ServiceProvider,
                 RouteParameterNames = routeParams,
                 ThrowOnBadRequest = routeHandlerOptions?.Value.ThrowOnBadRequest ?? false,
-                AllowImplicitFromBody = allowImplicitFromBody,
+                DisableImplicitFromBody = disableImplicitFromBody,
             };
 
             var requestDelegateResult = RequestDelegateFactory.Create(handler, options);
@@ -202,22 +202,24 @@ namespace Microsoft.AspNetCore.Builder
            IEnumerable<string> httpMethods,
            Delegate handler)
         {
-            return MapMethods(endpoints, pattern, httpMethods, handler, allowImplicitFromBody: true);
-        }
-
-        private static DelegateEndpointConventionBuilder MapMethods(
-           this IEndpointRouteBuilder endpoints,
-           string pattern,
-           IEnumerable<string> httpMethods,
-           Delegate handler,
-           bool allowImplicitFromBody)
-        {
             if (httpMethods is null)
             {
                 throw new ArgumentNullException(nameof(httpMethods));
             }
 
-            var builder = endpoints.Map(RoutePatternFactory.Parse(pattern), handler, allowImplicitFromBody);
+            var disableImplicitFromBody = false;
+            // GET, DELETE, HEAD, CONNECT, TRACE, and OPTIONS normally do not contain bodies
+            if (!httpMethods.Any(method => !(method.Equals(HttpMethods.Get, StringComparison.Ordinal) ||
+                method.Equals(HttpMethods.Delete, StringComparison.Ordinal) ||
+                method.Equals(HttpMethods.Head, StringComparison.Ordinal) ||
+                method.Equals(HttpMethods.Options, StringComparison.Ordinal) ||
+                method.Equals(HttpMethods.Trace, StringComparison.Ordinal) ||
+                method.Equals(HttpMethods.Connect, StringComparison.Ordinal))))
+            {
+                disableImplicitFromBody = true;
+            }
+
+            var builder = endpoints.Map(RoutePatternFactory.Parse(pattern), handler, disableImplicitFromBody);
             // Prepends the HTTP method to the DisplayName produced with pattern + method name
             builder.Add(b => b.DisplayName = $"HTTP: {string.Join(", ", httpMethods)} {b.DisplayName}");
             builder.WithMetadata(new HttpMethodMetadata(httpMethods));
@@ -253,7 +255,7 @@ namespace Microsoft.AspNetCore.Builder
             RoutePattern pattern,
             Delegate handler)
         {
-            return Map(endpoints, pattern, handler, allowImplicitFromBody: true);
+            return Map(endpoints, pattern, handler, disableImplicitFromBody: false);
         }
 
         /// <summary>

--- a/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Builder
             string pattern,
             Delegate handler)
         {
-            return MapMethods(endpoints, pattern, GetVerb, handler);
+            return MapMethods(endpoints, pattern, GetVerb, handler, allowImplicitFromBody: false);
         }
 
         /// <summary>
@@ -88,64 +88,14 @@ namespace Microsoft.AspNetCore.Builder
             string pattern,
             Delegate handler)
         {
-            return MapMethods(endpoints, pattern, DeleteVerb, handler);
+            return MapMethods(endpoints, pattern, DeleteVerb, handler, allowImplicitFromBody: false);
         }
 
-        /// <summary>
-        /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP requests
-        /// for the specified HTTP methods and pattern.
-        /// </summary>
-        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
-        /// <param name="pattern">The route pattern.</param>
-        /// <param name="handler">The delegate executed when the endpoint is matched.</param>
-        /// <param name="httpMethods">HTTP methods that the endpoint will match.</param>
-        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static DelegateEndpointConventionBuilder MapMethods(
-           this IEndpointRouteBuilder endpoints,
-           string pattern,
-           IEnumerable<string> httpMethods,
-           Delegate handler)
-        {
-            if (httpMethods is null)
-            {
-                throw new ArgumentNullException(nameof(httpMethods));
-            }
-
-            var builder = endpoints.Map(RoutePatternFactory.Parse(pattern), handler);
-            // Prepends the HTTP method to the DisplayName produced with pattern + method name
-            builder.Add(b => b.DisplayName = $"HTTP: {string.Join(", ", httpMethods)} {b.DisplayName}");
-            builder.WithMetadata(new HttpMethodMetadata(httpMethods));
-            return builder;
-        }
-
-        /// <summary>
-        /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP requests
-        /// for the specified pattern.
-        /// </summary>
-        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
-        /// <param name="pattern">The route pattern.</param>
-        /// <param name="handler">The delegate executed when the endpoint is matched.</param>
-        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static DelegateEndpointConventionBuilder Map(
-            this IEndpointRouteBuilder endpoints,
-            string pattern,
-            Delegate handler)
-        {
-            return Map(endpoints, RoutePatternFactory.Parse(pattern), handler);
-        }
-
-        /// <summary>
-        /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP requests
-        /// for the specified pattern.
-        /// </summary>
-        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
-        /// <param name="pattern">The route pattern.</param>
-        /// <param name="handler">The delegate executed when the endpoint is matched.</param>
-        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
-        public static DelegateEndpointConventionBuilder Map(
+        private static DelegateEndpointConventionBuilder Map(
             this IEndpointRouteBuilder endpoints,
             RoutePattern pattern,
-            Delegate handler)
+            Delegate handler,
+            bool allowImplicitFromBody)
         {
             if (endpoints is null)
             {
@@ -177,6 +127,7 @@ namespace Microsoft.AspNetCore.Builder
                 ServiceProvider = endpoints.ServiceProvider,
                 RouteParameterNames = routeParams,
                 ThrowOnBadRequest = routeHandlerOptions?.Value.ThrowOnBadRequest ?? false,
+                AllowImplicitFromBody = allowImplicitFromBody,
             };
 
             var requestDelegateResult = RequestDelegateFactory.Create(handler, options);
@@ -234,6 +185,75 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             return new DelegateEndpointConventionBuilder(dataSource.AddEndpointBuilder(builder));
+        }
+
+        /// <summary>
+        /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP requests
+        /// for the specified HTTP methods and pattern.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
+        /// <param name="handler">The delegate executed when the endpoint is matched.</param>
+        /// <param name="httpMethods">HTTP methods that the endpoint will match.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        public static DelegateEndpointConventionBuilder MapMethods(
+           this IEndpointRouteBuilder endpoints,
+           string pattern,
+           IEnumerable<string> httpMethods,
+           Delegate handler)
+        {
+            return MapMethods(endpoints, pattern, httpMethods, handler, allowImplicitFromBody: true);
+        }
+
+        private static DelegateEndpointConventionBuilder MapMethods(
+           this IEndpointRouteBuilder endpoints,
+           string pattern,
+           IEnumerable<string> httpMethods,
+           Delegate handler,
+           bool allowImplicitFromBody)
+        {
+            if (httpMethods is null)
+            {
+                throw new ArgumentNullException(nameof(httpMethods));
+            }
+
+            var builder = endpoints.Map(RoutePatternFactory.Parse(pattern), handler, allowImplicitFromBody);
+            // Prepends the HTTP method to the DisplayName produced with pattern + method name
+            builder.Add(b => b.DisplayName = $"HTTP: {string.Join(", ", httpMethods)} {b.DisplayName}");
+            builder.WithMetadata(new HttpMethodMetadata(httpMethods));
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP requests
+        /// for the specified pattern.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
+        /// <param name="handler">The delegate executed when the endpoint is matched.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        public static DelegateEndpointConventionBuilder Map(
+            this IEndpointRouteBuilder endpoints,
+            string pattern,
+            Delegate handler)
+        {
+            return Map(endpoints, RoutePatternFactory.Parse(pattern), handler);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP requests
+        /// for the specified pattern.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
+        /// <param name="handler">The delegate executed when the endpoint is matched.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+        public static DelegateEndpointConventionBuilder Map(
+            this IEndpointRouteBuilder endpoints,
+            RoutePattern pattern,
+            Delegate handler)
+        {
+            return Map(endpoints, pattern, handler, allowImplicitFromBody: true);
         }
 
         /// <summary>

--- a/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointRouteBuilderExtensions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Builder
             this IEndpointRouteBuilder endpoints,
             RoutePattern pattern,
             Delegate handler,
-            bool disableInferredBody)
+            bool DisableInferBodyFromParameters)
         {
             if (endpoints is null)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Builder
                 ServiceProvider = endpoints.ServiceProvider,
                 RouteParameterNames = routeParams,
                 ThrowOnBadRequest = routeHandlerOptions?.Value.ThrowOnBadRequest ?? false,
-                DisableInferredBody = disableInferredBody,
+                DisableInferBodyFromParameters = DisableInferBodyFromParameters,
             };
 
             var requestDelegateResult = RequestDelegateFactory.Create(handler, options);
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Builder
             // Add delegate attributes as metadata
             var attributes = handler.Method.GetCustomAttributes();
 
-            // Add add request delegate metadata 
+            // Add add request delegate metadata
             foreach (var metadata in requestDelegateResult.EndpointMetadata)
             {
                 builder.Metadata.Add(metadata);
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(httpMethods));
             }
 
-            var disableInferredBody = false;
+            var DisableInferBodyFromParameters = false;
             // GET, DELETE, HEAD, CONNECT, TRACE, and OPTIONS normally do not contain bodies
             if (!httpMethods.Any(method => !(method.Equals(HttpMethods.Get, StringComparison.Ordinal) ||
                 method.Equals(HttpMethods.Delete, StringComparison.Ordinal) ||
@@ -216,10 +216,10 @@ namespace Microsoft.AspNetCore.Builder
                 method.Equals(HttpMethods.Trace, StringComparison.Ordinal) ||
                 method.Equals(HttpMethods.Connect, StringComparison.Ordinal))))
             {
-                disableInferredBody = true;
+                DisableInferBodyFromParameters = true;
             }
 
-            var builder = endpoints.Map(RoutePatternFactory.Parse(pattern), handler, disableInferredBody);
+            var builder = endpoints.Map(RoutePatternFactory.Parse(pattern), handler, DisableInferBodyFromParameters);
             // Prepends the HTTP method to the DisplayName produced with pattern + method name
             builder.Add(b => b.DisplayName = $"HTTP: {string.Join(", ", httpMethods)} {b.DisplayName}");
             builder.WithMetadata(new HttpMethodMetadata(httpMethods));
@@ -255,7 +255,7 @@ namespace Microsoft.AspNetCore.Builder
             RoutePattern pattern,
             Delegate handler)
         {
-            return Map(endpoints, pattern, handler, disableInferredBody: false);
+            return Map(endpoints, pattern, handler, DisableInferBodyFromParameters: false);
         }
 
         /// <summary>

--- a/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
@@ -227,10 +227,10 @@ namespace Microsoft.AspNetCore.Builder
             var methodMetadata = endpoint.Metadata.GetMetadata<IHttpMethodMetadata>();
             Assert.NotNull(methodMetadata);
             var method = Assert.Single(methodMetadata!.HttpMethods);
-            Assert.Equal("GET", method);
+            Assert.Equal("DELETE", method);
 
             var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
-            Assert.Equal("HTTP: GET /", routeEndpointBuilder.DisplayName);
+            Assert.Equal("HTTP: DELETE /", routeEndpointBuilder.DisplayName);
             Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
         }
 
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapGet_ExplicitFromService()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<Todo>().BuildServiceProvider()));
             _ = builder.MapGet("/", ([TestFromServiceAttribute] Todo todo) => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
@@ -261,7 +261,7 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapDelete_ExplicitFromService()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<Todo>().BuildServiceProvider()));
             _ = builder.MapDelete("/", ([TestFromServiceAttribute] Todo todo) => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);

--- a/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
@@ -194,6 +194,32 @@ namespace Microsoft.AspNetCore.Builder
             Assert.Contains("Did you mean to register the \"Body (Inferred)\" parameter(s) as a Service or apply the [FromService] or [FromBody] attribute?", ex.Message);
         }
 
+        public static object[][] NonImplicitFromBodyMethods
+        {
+            get
+            {
+                return new[]
+                {
+                    new[] { HttpMethods.Delete },
+                    new[] { HttpMethods.Connect },
+                    new[] { HttpMethods.Trace },
+                    new[] { HttpMethods.Get },
+                    new[] { HttpMethods.Head },
+                    new[] { HttpMethods.Options },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(NonImplicitFromBodyMethods))]
+        public void MapVerb_ThrowsWithImplicitFromBody(string method)
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
+            var ex = Assert.Throws<InvalidOperationException>(() => builder.MapMethods("/", new[] { method }, (Todo todo) => { }));
+            Assert.Contains("Body was inferred but the method does not allow inferred body parameters.", ex.Message);
+            Assert.Contains("Did you mean to register the \"Body (Inferred)\" parameter(s) as a Service or apply the [FromService] or [FromBody] attribute?", ex.Message);
+        }
+
         [Fact]
         public void MapGet_ImplicitFromService()
         {

--- a/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/DelegateEndpointRouteBuilderExtensionsTest.cs
@@ -223,8 +223,8 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapGet_ImplicitFromService()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<Todo>().BuildServiceProvider()));
-            _ = builder.MapGet("/", (Todo todo) => { });
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<TodoService>().BuildServiceProvider()));
+            _ = builder.MapGet("/", (TodoService todo) => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
             // Trigger Endpoint build by calling getter.
@@ -243,8 +243,8 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapDelete_ImplicitFromService()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<Todo>().BuildServiceProvider()));
-            _ = builder.MapDelete("/", (Todo todo) => { });
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<TodoService>().BuildServiceProvider()));
+            _ = builder.MapDelete("/", (TodoService todo) => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
             // Trigger Endpoint build by calling getter.
@@ -267,8 +267,8 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapGet_ExplicitFromService()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<Todo>().BuildServiceProvider()));
-            _ = builder.MapGet("/", ([TestFromServiceAttribute] Todo todo) => { });
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<TodoService>().BuildServiceProvider()));
+            _ = builder.MapGet("/", ([TestFromServiceAttribute] TodoService todo) => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
             // Trigger Endpoint build by calling getter.
@@ -287,8 +287,8 @@ namespace Microsoft.AspNetCore.Builder
         [Fact]
         public void MapDelete_ExplicitFromService()
         {
-            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<Todo>().BuildServiceProvider()));
-            _ = builder.MapDelete("/", ([TestFromServiceAttribute] Todo todo) => { });
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<TodoService>().BuildServiceProvider()));
+            _ = builder.MapDelete("/", ([TestFromServiceAttribute] TodoService todo) => { });
 
             var dataSource = GetBuilderEndpointDataSource(builder);
             // Trigger Endpoint build by calling getter.
@@ -748,6 +748,13 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         class Todo
+        {
+
+        }
+
+        // Here to more easily disambiguate when ToDo is
+        // intended to be validated as an implicit service in tests
+        class TodoService
         {
 
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35405

Currently we only have `MapGet` and `MapDelete`, no `MapOptions` or `MapHead`. I didn't do any http method matching to set the `DisableInferredBody` property to simplify things, and also kept the methods for flowing the new property internal so as to not complicate API review.

```diff
public sealed class RequestDelegateFactoryOptions
{
+   public bool DisableInferredBody { get; set; }
}
```

### Scenario 1
```csharp
// Todo not a registered service
app.MapGet("/test", (Todo todo) => "todo");
```
**Before:**
400 http status code

**After:**
Exception thrown from `MapGet`:
```
Unhandled exception. System.InvalidOperationException: Body was inferred but the method does not allow inferred body parameters.
Below is the list of parameters that we found:

Parameter           | Source
---------------------------------------------------------------------------------
todo                | Body (Inferred)


Did you mean to register the "Body (Inferred)" parameter(s) as a Service or apply the [FromService] or [FromBody] attribute?
```

### Scenario 2
```csharp
// Todo not a registered service
app.MapGet("/test", ([FromService] Todo todo) => "todo");
```

**Unchanged**
![image](https://user-images.githubusercontent.com/7574801/131756703-3205aff2-6366-4d7d-adf1-e7e64e8f899b.png)


### Scenario 3
```csharp
// Post without a body sent
// Todo not a registered service
app.MapPost("/test", ((Todo todo) => "Hello, World!"));
```

**Before:**
Log
`Microsoft.AspNetCore.Http.BadHttpRequestException: Required parameter "Todo todo" was not provided from body.`

**After:**
Log
`Microsoft.AspNetCore.Http.BadHttpRequestException: Implicit body inferred for parameter "todo" but no body was provided. Did you mean to use a Service instead?`