### PR TITLE
Add minimal option to webapi template

### DIFF
--- a/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
+++ b/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
@@ -109,6 +109,7 @@ namespace Templates.Test.Helpers
 
             await VerifyCannotFindTemplateAsync(output, "web");
             await VerifyCannotFindTemplateAsync(output, "webapp");
+            await VerifyCannotFindTemplateAsync(output, "webapi");
             await VerifyCannotFindTemplateAsync(output, "mvc");
             await VerifyCannotFindTemplateAsync(output, "react");
             await VerifyCannotFindTemplateAsync(output, "reactredux");
@@ -123,6 +124,7 @@ namespace Templates.Test.Helpers
 
             await VerifyCanFindTemplate(output, "webapp");
             await VerifyCanFindTemplate(output, "web");
+            await VerifyCanFindTemplate(output, "webapi");
             await VerifyCanFindTemplate(output, "react");
         }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -4,6 +4,10 @@
     "UseLocalDB": {
       "longName": "use-local-db"
     },
+    "UseMinimalAPIs": {
+      "longName": "use-minimal-apis",
+      "shortName": "minimal"
+    },
     "AADInstance": {
       "longName": "aad-instance",
       "shortName": ""

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/ide.host.json
@@ -43,6 +43,15 @@
       "invertBoolean": true,
       "isVisible": true,
       "defaultValue": true
+    },
+    {
+      "id": "UseMinimalAPIs",
+      "name": {
+        "text": "Use controllers (uncheck to use minimal APIs)"
+      },
+      "invertBoolean": true,
+      "isVisible": true,
+      "defaultValue": true
     }
   ],
   "disableHttpsSymbol": "NoHttps"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -36,6 +36,39 @@
           "exclude": [
             "Properties/launchSettings.json"
           ]
+        },
+        {
+          "condition": "(UseMinimalAPIs)",
+          "exclude": [
+            "Controllers/WeatherForecastController.cs",
+            "Program.cs",
+            "WeatherForecast.cs"
+          ]
+        },
+        {
+          "condition": "(UseMinimalAPIs && (NoAuth || WindowsAuth))",
+          "rename": {
+            "Program.MinimalAPIs.WindowsOrNoAuth.cs": "Program.cs"
+          },
+          "exclude": [
+            "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs"
+          ]
+        },
+        {
+          "condition": "(UseMinimalAPIs && (IndividualAuth || OrganizationalAuth))",
+          "rename": {
+            "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs": "Program.cs"
+          },
+          "exclude": [
+            "Program.MinimalAPIs.WindowsOrNoAuth.cs"
+          ]
+        },
+        {
+          "condition": "(UseControllers)",
+          "exclude": [
+            "Program.MinimalAPIs.WindowsOrNoAuth.cs",
+            "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs"
+          ]
         }
       ]
     }
@@ -254,6 +287,12 @@
       "defaultValue": "false",
       "description": "Whether to use LocalDB instead of SQLite. This option only applies if --auth Individual or --auth IndividualB2C is specified."
     },
+    "UseMinimalAPIs": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to use mininmal APIs instead of Controllers."
+    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",
@@ -321,6 +360,10 @@
     "EnableOpenAPI": {
       "type": "computed",
       "value": "(!DisableOpenAPI)"
+    },
+    "UseControllers": {
+      "type": "computed",
+      "value": "(!UseMinimalAPIs)"
     }
   },
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -291,7 +291,7 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Whether to use mininmal APIs instead of Controllers."
+      "description": "Whether to use mininmal APIs instead of controllers."
     },
     "Framework": {
       "type": "parameter",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Controllers/WeatherForecastController.cs
@@ -40,11 +40,15 @@ public class WeatherForecastController : ControllerBase
     public WeatherForecastController(ILogger<WeatherForecastController> logger,
                             IDownstreamWebApi downstreamWebApi)
     {
-            _logger = logger;
+        _logger = logger;
         _downstreamWebApi = downstreamWebApi;
     }
 
+#if (EnableOpenAPI)
+    [HttpGet(Name = "GetWeatherForecast")]
+#else
     [HttpGet]
+#endif
     public async Task<IEnumerable<WeatherForecast>> Get()
     {
         using var response = await _downstreamWebApi.CallWebApiForUserAsync("DownstreamApi").ConfigureAwait(false);
@@ -74,11 +78,15 @@ public class WeatherForecastController : ControllerBase
     public WeatherForecastController(ILogger<WeatherForecastController> logger,
                                         GraphServiceClient graphServiceClient)
     {
-            _logger = logger;
+        _logger = logger;
         _graphServiceClient = graphServiceClient;
     }
 
+#if (EnableOpenAPI)
+    [HttpGet(Name = "GetWeatherForecast")]
+#else
     [HttpGet]
+#endif
     public async Task<IEnumerable<WeatherForecast>> Get()
     {
         var user = await _graphServiceClient.Me.Request().GetAsync();
@@ -97,7 +105,11 @@ public class WeatherForecastController : ControllerBase
         _logger = logger;
     }
 
+#if (EnableOpenAPI)
+    [HttpGet(Name = "GetWeatherForecast")]
+#else
     [HttpGet]
+#endif
     public IEnumerable<WeatherForecast> Get()
     {
         return Enumerable.Range(1, 5).Select(index => new WeatherForecast

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -1,0 +1,150 @@
+#if (GenerateApi)
+using System.Net.Http;
+#endif
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+#if (GenerateGraph)
+using Graph = Microsoft.Graph;
+#endif
+using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.Resource;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+#if (OrganizationalAuth)
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+#if (GenerateApiOrGraph)
+    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
+        .EnableTokenAcquisitionToCallDownstreamApi()
+#if (GenerateApi)
+            .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
+#endif
+#if (GenerateGraph)
+            .AddMicrosoftGraph(builder.Configuration.GetSection("DownstreamApi"))
+#endif
+            .AddInMemoryTokenCaches();
+#else
+    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+#endif
+#elif (IndividualB2CAuth)
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+#if (GenerateApi)
+    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"))
+        .EnableTokenAcquisitionToCallDownstreamApi()
+            .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
+            .AddInMemoryTokenCaches();
+#else
+    .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"));
+#endif
+#endif
+builder.Services.AddAuthorization();
+
+#if (EnableOpenAPI)
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+#endif
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+#if (EnableOpenAPI)
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+#endif
+#if (RequiresHttps)
+
+app.UseHttpsRedirection();
+#endif
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+var scopeRequiredByApi = app.Configuration["AzureAd:Scopes"];
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+#if (GenerateApi)
+app.MapGet("/weatherforecast", (HttpContext httpContext, IDownstreamWebApi downstreamWebApi) =>
+{
+    httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+    using var response = await downstreamWebApi.CallWebApiForUserAsync("DownstreamApi").ConfigureAwait(false);
+    if (response.StatusCode == System.Net.HttpStatusCode.OK)
+    {
+        var apiResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        // Do something
+    }
+    else
+    {
+        var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}: {error}");
+    }
+
+    var forecast = Enumerable.Range(1, 5).Select(index => new WeatherForecast
+    {
+        Date = DateTime.Now.AddDays(index),
+        TemperatureC = Random.Shared.Next(-20, 55),
+        Summary = summaries[Random.Shared.Next(summaries.Length)]
+    })
+    .ToArray();
+
+    return forecast;
+})
+#elseif (GenerateGraph)
+app.MapGet("/weahterforecast", (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
+{
+    httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+    var user = await _graphServiceClient.Me.Request().GetAsync();
+
+    var forecast =  Enumerable.Range(1, 5).Select(index => new WeatherForecast
+    {
+        Date = DateTime.Now.AddDays(index),
+        TemperatureC = Random.Shared.Next(-20, 55),
+        Summary = summaries[Random.Shared.Next(summaries.Length)]
+    })
+    .ToArray();
+
+    return forecast;
+})
+#else
+app.MapGet("/weatherforecast", (HttpContext httpContext) =>
+{
+    httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+    var forecast =  Enumerable.Range(1, 5).Select(index => new WeatherForecast
+    {
+        Date = DateTime.Now.AddDays(index),
+        TemperatureC = Random.Shared.Next(-20, 55),
+        Summary = summaries[Random.Shared.Next(summaries.Length)]
+    })
+    .ToArray();
+    return forecast;
+#endif
+#if (EnableOpenAPI)
+})
+.WithName("GetWeatherForecast")
+.RequireAuthorization();
+#else
+})
+.RequireAuthorization();
+#endif
+
+app.Run();
+
+class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -86,13 +86,14 @@ app.MapGet("/weatherforecast", (HttpContext httpContext, IDownstreamWebApi downs
         throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}: {error}");
     }
 
-    var forecast = Enumerable.Range(1, 5).Select(index => new WeatherForecast
-    {
-        Date = DateTime.Now.AddDays(index),
-        TemperatureC = Random.Shared.Next(-20, 55),
-        Summary = summaries[Random.Shared.Next(summaries.Length)]
-    })
-    .ToArray();
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateTime.Now.AddDays(index),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
 
     return forecast;
 })
@@ -103,13 +104,14 @@ app.MapGet("/weahterforecast", (HttpContext httpContext, GraphServiceClient grap
 
     var user = await _graphServiceClient.Me.Request().GetAsync();
 
-    var forecast =  Enumerable.Range(1, 5).Select(index => new WeatherForecast
-    {
-        Date = DateTime.Now.AddDays(index),
-        TemperatureC = Random.Shared.Next(-20, 55),
-        Summary = summaries[Random.Shared.Next(summaries.Length)]
-    })
-    .ToArray();
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateTime.Now.AddDays(index),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
 
     return forecast;
 })
@@ -118,13 +120,14 @@ app.MapGet("/weatherforecast", (HttpContext httpContext) =>
 {
     httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
-    var forecast =  Enumerable.Range(1, 5).Select(index => new WeatherForecast
-    {
-        Date = DateTime.Now.AddDays(index),
-        TemperatureC = Random.Shared.Next(-20, 55),
-        Summary = summaries[Random.Shared.Next(summaries.Length)]
-    })
-    .ToArray();
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateTime.Now.AddDays(index),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
     return forecast;
 #endif
 #if (EnableOpenAPI)
@@ -138,13 +141,7 @@ app.MapGet("/weatherforecast", (HttpContext httpContext) =>
 
 app.Run();
 
-class WeatherForecast
+record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
 {
-    public DateTime Date { get; set; }
-
-    public int TemperatureC { get; set; }
-
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-
-    public string? Summary { get; set; }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
@@ -1,0 +1,57 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+#if (EnableOpenAPI)
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+#endif
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+#if (EnableOpenAPI)
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+#endif
+#if (RequiresHttps)
+
+app.UseHttpsRedirection();
+#endif
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast =  Enumerable.Range(1, 5).Select(index => new WeatherForecast
+    {
+        Date = DateTime.Now.AddDays(index),
+        TemperatureC = Random.Shared.Next(-20, 55),
+        Summary = summaries[Random.Shared.Next(summaries.Length)]
+    })
+    .ToArray();
+    return forecast;
+#if (EnableOpenAPI)
+})
+.WithName("GetWeatherForecast");
+#else
+});
+#endif
+
+app.Run();
+
+class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
@@ -28,13 +28,14 @@ var summaries = new[]
 
 app.MapGet("/weatherforecast", () =>
 {
-    var forecast =  Enumerable.Range(1, 5).Select(index => new WeatherForecast
-    {
-        Date = DateTime.Now.AddDays(index),
-        TemperatureC = Random.Shared.Next(-20, 55),
-        Summary = summaries[Random.Shared.Next(summaries.Length)]
-    })
-    .ToArray();
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateTime.Now.AddDays(index),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
     return forecast;
 #if (EnableOpenAPI)
 })
@@ -45,13 +46,7 @@ app.MapGet("/weatherforecast", () =>
 
 app.Run();
 
-class WeatherForecast
+record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
 {
-    public DateTime Date { get; set; }
-
-    public int TemperatureC { get; set; }
-
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-
-    public string? Summary { get; set; }
 }

--- a/src/ProjectTemplates/scripts/.gitignore
+++ b/src/ProjectTemplates/scripts/.gitignore
@@ -5,11 +5,13 @@ angular/
 blazorserver/
 blazorwasm/
 mvc/
+mvcorgauth/
 razor/
 react/
 reactredux/
 web/
 webapp/
 webapi/
+webapimin/
 worker/
 grpc/

--- a/src/ProjectTemplates/scripts/Run-WebApiMinimal-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-WebApiMinimal-Locally.ps1
@@ -1,0 +1,12 @@
+#!/usr/bin/env pwsh
+#requires -version 4
+
+[CmdletBinding(PositionalBinding = $false)]
+param()
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+. $PSScriptRoot\Test-Template.ps1
+
+Test-Template "webapimin" "webapi -minimal" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Testing;
 using Newtonsoft.Json;
@@ -17,20 +17,7 @@ namespace Templates.Test
 {
     public class BaselineTest : LoggedTest
     {
-        private static readonly Regex TemplateNameRegex = new Regex(
-            "new (?<template>[a-zA-Z]+)",
-            RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.Singleline,
-            TimeSpan.FromSeconds(1));
-
-        private static readonly Regex AuthenticationOptionRegex = new Regex(
-            "-au (?<auth>[a-zA-Z]+)",
-            RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.Singleline,
-            TimeSpan.FromSeconds(1));
-
-        private static readonly Regex LanguageRegex = new Regex(
-            "--language (?<language>\\w+)",
-            RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.Singleline,
-            TimeSpan.FromSeconds(1));
+        private static readonly string BaselineDefinitionFileResourceName = "ProjectTemplates.Tests.template-baselines.json";
 
         public BaselineTest(ProjectFactoryFixture projectFactory)
         {
@@ -43,7 +30,7 @@ namespace Templates.Test
         {
             get
             {
-                using (var stream = typeof(BaselineTest).Assembly.GetManifestResourceStream("ProjectTemplates.Tests.template-baselines.json"))
+                using (var stream = typeof(BaselineTest).Assembly.GetManifestResourceStream(BaselineDefinitionFileResourceName))
                 {
                     using (var jsonReader = new JsonTextReader(new StreamReader(stream)))
                     {
@@ -84,7 +71,7 @@ namespace Templates.Test
         [MemberData(nameof(TemplateBaselines))]
         public async Task Template_Produces_The_Right_Set_Of_FilesAsync(string arguments, string[] expectedFiles)
         {
-            Project = await ProjectFactory.GetOrCreateProject("baseline" + SanitizeArgs(arguments), Output);
+            Project = await ProjectFactory.GetOrCreateProject(CreateProjectKey(arguments), Output);
             var createResult = await Project.RunDotNetNewRawAsync(arguments);
             Assert.True(createResult.ExitCode == 0, createResult.GetFormattedOutput());
 
@@ -116,37 +103,58 @@ namespace Templates.Test
             }
         }
 
-        private string SanitizeArgs(string arguments)
+        private static ConcurrentDictionary<string, object> _projectKeys = new();
+
+        private string CreateProjectKey(string arguments)
         {
-            var text = TemplateNameRegex.Match(arguments)
-                .Groups.TryGetValue("template", out var template) ? template.Value : "";
+            var text = "baseline";
 
-            text += AuthenticationOptionRegex.Match(arguments)
-                .Groups.TryGetValue("auth", out var auth) ? auth.Value : "";
+            // Turn string like "new templatename -minimal -au SingleOrg --another-option OptionValue"
+            // into array like [ "new templatename", "minimal", "au SingleOrg", "another-option OptionValue" ]
+            var argumentsArray = arguments
+                .Split(" --", int.MaxValue, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .SelectMany(e => e.Split(" -", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                .ToArray();
 
-            text += arguments.Contains("--uld") ? "uld" : "";
+            // Add template name, value has form of "new name"
+            text += argumentsArray[0].Substring("new ".Length);
 
-            text += LanguageRegex.Match(arguments)
-                .Groups.TryGetValue("language", out var language) ? language.Value.Replace("#", "Sharp") : "";
-
-            if (arguments.Contains("--support-pages-and-views true"))
+            foreach (var argValue in argumentsArray)
             {
-                text += "supportpagesandviewstrue";
+                var argSegments = argValue.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+                if (argSegments.Length == 0)
+                {
+                    continue;
+                }
+                else if (argSegments.Length == 1)
+                {
+                    text += argSegments[0] switch
+                    {
+                        "ho" => "hosted",
+                        "p" => "pwa",
+                        _ => argSegments[0].Replace("-","")
+                    };
+                }
+                else
+                {
+                    text += argSegments[0] switch
+                    {
+                        "au" => argSegments[1],
+                        "uld" => "uld",
+                        "language" => argSegments[1].Replace("#", "Sharp"),
+                        "support-pages-and-views" when argSegments[1] == "true" => "supportpagesandviewstrue",
+                        _ => ""
+                    };
+                }
             }
 
-            if (arguments.Contains("-ho"))
+            if (!_projectKeys.TryAdd(text, null))
             {
-                text += "hosted";
-            }
-
-            if (arguments.Contains("--pwa"))
-            {
-                text += "pwa";
-            }
-
-            if (arguments.Contains("-minimal"))
-            {
-                text += "Minimal";
+                throw new InvalidOperationException(
+                    $"Project key for template with args '{arguments}' already exists. " +
+                    $"Check that the metadata specified in {BaselineDefinitionFileResourceName} is correct and that " +
+                    $"the {nameof(CreateProjectKey)} method is considering enough template arguments to ensure uniqueness.");
             }
 
             return text;

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -112,8 +112,7 @@ namespace Templates.Test
             // Turn string like "new templatename -minimal -au SingleOrg --another-option OptionValue"
             // into array like [ "new templatename", "minimal", "au SingleOrg", "another-option OptionValue" ]
             var argumentsArray = arguments
-                .Split(" --", int.MaxValue, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                .SelectMany(e => e.Split(" -", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                .Split(new[] { " --", " -" }, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
                 .ToArray();
 
             // Add template name, value has form of "new name"

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -51,11 +51,11 @@ namespace Templates.Test
                         var data = new TheoryData<string, string[]>();
                         foreach (var template in baseline)
                         {
-                            foreach (var authOption in (JObject)template.Value)
+                            foreach (var scenarioName in (JObject)template.Value)
                             {
                                 data.Add(
-                                    (string)authOption.Value["Arguments"],
-                                    ((JArray)authOption.Value["Files"]).Select(s => (string)s).ToArray());
+                                    (string)scenarioName.Value["Arguments"],
+                                    ((JArray)scenarioName.Value["Files"]).Select(s => (string)s).ToArray());
                             }
                         }
 
@@ -142,6 +142,11 @@ namespace Templates.Test
             if (arguments.Contains("--pwa"))
             {
                 text += "pwa";
+            }
+
+            if (arguments.Contains("-minimal"))
+            {
+                text += "Minimal";
             }
 
             return text;

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -119,6 +119,9 @@ namespace Templates.Test
             // Add template name, value has form of "new name"
             text += argumentsArray[0].Substring("new ".Length);
 
+            // Sort arguments to ensure definitions that differ only by arguments order are caught
+            Array.Sort(argumentsArray, StringComparer.Ordinal);
+
             foreach (var argValue in argumentsArray)
             {
                 var argSegments = argValue.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);

--- a/src/ProjectTemplates/test/template-baselines.json
+++ b/src/ProjectTemplates/test/template-baselines.json
@@ -569,7 +569,7 @@
     },
     "MinimalIndividualB2C": {
       "Template": "webapi",
-      "Arguments": "new webapi -au IndividualB2C --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn -minimal",
+      "Arguments": "new webapi -minimal -au IndividualB2C --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn",
       "Files": [
         "appsettings.Development.json",
         "appsettings.json",
@@ -580,7 +580,7 @@
     },
     "MinimalSingleOrg": {
       "Template": "webapi",
-      "Arguments": "new webapi -au SingleOrg --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa -minimal",
+      "Arguments": "new webapi -minimal -au SingleOrg --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa",
       "Files": [
         "appsettings.Development.json",
         "appsettings.json",
@@ -591,7 +591,7 @@
     },
     "Minimal": {
       "Template": "webapi",
-      "Arguments": "new webapi -au None -minimal",
+      "Arguments": "new webapi -minimal -au None",
       "Files": [
         "appsettings.Development.json",
         "appsettings.json",

--- a/src/ProjectTemplates/test/template-baselines.json
+++ b/src/ProjectTemplates/test/template-baselines.json
@@ -567,6 +567,39 @@
       ],
       "AuthOption": "None"
     },
+    "MinimalIndividualB2C": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au IndividualB2C --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn -minimal",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "IndividualB2C"
+    },
+    "MinimalSingleOrg": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au SingleOrg --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa -minimal",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "SingleOrg"
+    },
+    "Minimal": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au None -minimal",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "None"
+    },
     "Windows": {
       "Template": "webapi",
       "Arguments": "new webapi -au Windows",
@@ -576,6 +609,17 @@
         "Program.cs",
         "WeatherForecast.cs",
         "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "Windows"
+    },
+    "MinimalWindows": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal -au Windows",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "Windows"


### PR DESCRIPTION
- Add "minimal" option to webapi project template
- Factor Program.cs into multiple files and update template manifest to exclude/rename dependent on selected options
- Updated controller and minimal versions to set endpoint/route name when EnableOpenAPI is true
- Configure webapi template minimal option for VS display as "Use controllers"

Fixes #35996
