### PR TITLE
[release/6.0] Backport Fix issues with hosting startups

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -57,9 +57,8 @@ namespace Microsoft.AspNetCore.Builder
                 // Runs inline.
                 webHostBuilder.Configure(ConfigureApplication);
 
-                // We need to override the application name since the call to Configure will set it to
-                // be the calling assembly's name.
-                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, (Assembly.GetEntryAssembly())?.GetName()?.Name ?? string.Empty);
+                // Attempt to set the application name from options
+                options.ApplyApplicationName(webHostBuilder);
             });
 
             // Apply the args to host configuration last since ConfigureWebHostDefaults overrides a host specific setting (the application name).


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/36055

## Customer Impact
Hosting startups in the libraries that don't match the entry point don't run. This affects tests but it also affects libraries.

## Testing

Unit tests.

## Risk

Low