### PR TITLE
Create .rpm's for Linux Mariner

### DIFF
--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -78,5 +78,13 @@
     </ItemGroup>
 
     <Exec Command="fpm @(FpmArgs,' ')" />
+
+    <Copy SourceFiles="$(TargetPath)"
+          DestinationFiles="$(CblMarinerTargetPath)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Message Text="$(TargetPath) -> $(CblMarinerTargetPath)" Importance="high" />
   </Target>
 </Project>

--- a/src/Installers/Rpm/Runtime/Rpm.Runtime.rpmproj
+++ b/src/Installers/Rpm/Runtime/Rpm.Runtime.rpmproj
@@ -13,6 +13,8 @@
 
   <PropertyGroup>
     <TargetFileName>$(RuntimeInstallerBaseName)-$(SharedFxVersion)-x64.rpm</TargetFileName>
+    <CblMarinerTargetFileName>$(RuntimeInstallerBaseName)-$(SharedFxVersion)-cm.1-x64.rpm</CblMarinerTargetFileName>
     <TargetPath>$(InstallersOutputPath)$(TargetFileName)</TargetPath>
+    <CblMarinerTargetPath>$(InstallersOutputPath)$(CblMarinerTargetFileName)</CblMarinerTargetPath>
   </PropertyGroup>
 </Project>

--- a/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
+++ b/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
@@ -30,8 +30,10 @@
 
   <PropertyGroup>
     <TargetFileName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion).rpm</TargetFileName>
+    <CblMarinerTargetFileName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion)-cm.1.rpm</CblMarinerTargetFileName>
     <TargetPath>$(InstallersOutputPath)$(TargetFileName)</TargetPath>
-
+    <CblMarinerTargetPath>$(InstallersOutputPath)$(CblMarinerTargetFileName)</CblMarinerTargetPath>
+    
     <PackageVersion>$(TargetingPackVersionPrefix)</PackageVersion>
 
     <!-- Set package revision to '1' for RTM releases, but include the build number in pre-releases -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35725 (will need to be backported to 6.0)

We don't use the Arcade Installers package to generate these, so need to roll our own solution. I just copy the existing .rpm's with the new name (which is what Arcade does too: https://github.com/dotnet/arcade/pull/7812).

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1338101&view=results