### PR TITLE
Retarget DOTNETHOME when installing x64 on ARM64

### DIFF
--- a/src/Installers/Windows/Common/dotnethome_x64.wxs
+++ b/src/Installers/Windows/Common/dotnethome_x64.wxs
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?ifndef Platform ?>
+    <?define Platform = "$(sys.BUILDARCH)" ?>
+  <?endif ?>
+
+  <!-- The following match the expected values for PROCESSOR_ARCHITECTURE
+          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+  <?if $(var.Platform)=x86?>
+    <?define InstallerArchitecture="X86"?>
+  <?elseif $(var.Platform)=x64?>
+    <?define InstallerArchitecture="AMD64"?>
+  <?elseif $(var.Platform)=ARM64?>
+    <?define InstallerArchitecture="ARM64"?>
+  <?endif?>
+
+  <Fragment>
+    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE does not match the installer architecture
+          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <SetProperty Action="Set_INSTALLING_IN_EMULATION" Id="INSTALLING_IN_EMULATION" Value="true" Before="CostFinalize">
+      NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
+    </SetProperty>
+  </Fragment>
+    
+  <?if $(var.Platform)=x64?>
+  <Fragment>
+    <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
+    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_INSTALLING_IN_EMULATION">
+      INSTALLING_IN_EMULATION AND NOT DOTNETHOME
+    </SetProperty>
+  </Fragment>
+  <?endif?>
+</Wix>

--- a/src/Installers/Windows/Common/dotnethome_x64.wxs
+++ b/src/Installers/Windows/Common/dotnethome_x64.wxs
@@ -7,11 +7,11 @@
 
   <!-- The following match the expected values for PROCESSOR_ARCHITECTURE
           https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
-  <?if $(var.Platform)=x86?>
+  <?if $(var.Platform)~=x86?>
     <?define InstallerArchitecture="X86"?>
-  <?elseif $(var.Platform)=x64?>
+  <?elseif $(var.Platform)~=x64?>
     <?define InstallerArchitecture="AMD64"?>
-  <?elseif $(var.Platform)=ARM64?>
+  <?elseif $(var.Platform)~=arm64?>
     <?define InstallerArchitecture="ARM64"?>
   <?endif?>
 
@@ -22,7 +22,7 @@
       NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
     </SetProperty>
   </Fragment>
-    
+
   <?if $(var.Platform)=x64?>
   <Fragment>
     <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->

--- a/src/Installers/Windows/Common/dotnethome_x64.wxs
+++ b/src/Installers/Windows/Common/dotnethome_x64.wxs
@@ -1,33 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <?ifndef Platform ?>
-    <?define Platform = "$(sys.BUILDARCH)" ?>
-  <?endif ?>
+  <?ifndef Platform?>
+    <?define Platform = "$(sys.BUILDARCH)"?>
+  <?endif?>
 
-  <!-- The following match the expected values for PROCESSOR_ARCHITECTURE
-          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+  <!-- InstallerArchitecture matches the expected values for PROCESSOR_ARCHITECTURE
+       https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details  -->
   <?if $(var.Platform)~=x86?>
     <?define InstallerArchitecture="X86"?>
   <?elseif $(var.Platform)~=x64?>
     <?define InstallerArchitecture="AMD64"?>
   <?elseif $(var.Platform)~=arm64?>
     <?define InstallerArchitecture="ARM64"?>
+  <?else?>
+    <?error Unknown platform, $(var.Platform) ?>?
   <?endif?>
 
   <Fragment>
     <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE does not match the installer architecture
           https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
-    <SetProperty Action="Set_INSTALLING_IN_EMULATION" Id="INSTALLING_IN_EMULATION" Value="true" Before="CostFinalize">
+    <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize">
       NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
     </SetProperty>
   </Fragment>
 
-  <?if $(var.Platform)=x64?>
+  <?if $(var.Platform)~=x64?>
   <Fragment>
-    <!-- When running in x64 emulation and user hasn't specified install directory, install to an x64 subdirectory-->
-    <SetProperty Action="Set_DOTNETHOME_x64" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_INSTALLING_IN_EMULATION">
-      INSTALLING_IN_EMULATION AND NOT DOTNETHOME
+    <!-- When running in a non-native architecture and user hasn't specified install directory,
+         install to an x64 subdirectory.
+         This is only define for x64, since x86 has redirection and no other native architecture can install ARM64 today -->
+    <SetProperty Action="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE">
+      NON_NATIVE_ARCHITECTURE AND NOT DOTNETHOME
     </SetProperty>
   </Fragment>
   <?endif?>

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -56,6 +56,10 @@
             <ComponentRef Id="C_eula.rtf" />
             <ComponentRef Id="C_ProductVersion"/>
             <ComponentRef Id="C_ProductInstallDir"/>
+            <?if $(var.Platform)=x64 ?>
+            <ComponentRef Id="C_ProductVersion_NonNative" />
+            <ComponentRef Id="C_ProductInstallDir_NonNative" />
+            <?endif?>
         </ComponentGroup>
 
         <DirectoryRef Id="SharedFolder">
@@ -67,23 +71,44 @@
             <?undef ProductVersionKey?>
             <?endif?>
 
-            <!-- TODO: the following keys will collide between x64 and ARM64.
-                 They are actually *already* colliding between x86 and x64 since these will be writing to the x86 registry hive.
-                 Any interest in fixing this? -->
-
             <?define ProductVersionKey=SOFTWARE\Microsoft\ASP.NET Core\Shared Framework\v$(var.MajorVersion).$(var.MinorVersion)\$(var.PackageVersion)?>
 
             <Component Id="C_ProductVersion">
+                <?if $(var.Platform)=x64 ?>
+                <!-- Only install when actually on native architecture -->
+                <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+                <?endif?>
                 <RegistryKey Key="$(var.ProductVersionKey)" Root="HKLM">
                     <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
                 </RegistryKey>
             </Component>
 
             <Component Id="C_ProductInstallDir">
+                <?if $(var.Platform)=x64 ?>
+                <!-- Only install when actually on native architecture -->
+                <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+                <?endif?>
                 <RegistryKey Key="SOFTWARE\Microsoft\ASP.NET Core\Shared Framework" Root="HKLM">
                     <RegistryValue Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
                 </RegistryKey>
             </Component>
+
+            <?if $(var.Platform)=x64 ?>
+            <!-- Install keys to a different path when not native architecture -->
+            <Component Id="C_ProductVersion_NonNative">
+                <Condition>NON_NATIVE_ARCHITECTURE</Condition>
+                <RegistryKey Key="$(var.ProductVersionKey)\$(var.Platform)" Root="HKLM">
+                    <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="C_ProductInstallDir_NonNative">
+                <Condition>NON_NATIVE_ARCHITECTURE</Condition>
+                <RegistryKey Key="SOFTWARE\Microsoft\ASP.NET Core\Shared Framework\$(var.Platform)" Root="HKLM">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
+                </RegistryKey>
+            </Component>
+            <?endif?>
         </DirectoryRef>
     </Fragment>
 </Wix>

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -35,6 +35,10 @@
                 </Directory>
             </Directory>
         </Directory>
+
+        <?if $(var.Platform) = x64 ?>
+        <CustomActionRef Id="Set_DOTNETHOME_x64" />
+        <?endif?>
     </Fragment>
 
     <Fragment>
@@ -62,6 +66,10 @@
             <?ifdef ProductVersionKey?>
             <?undef ProductVersionKey?>
             <?endif?>
+
+            <!-- TODO: the following keys will collde between x64 and ARM64.
+                 They are actually *already* colliding between x86 and x64 since these will be writing to the x86 registry hive.
+                 Any interest in fixing this? -->
 
             <?define ProductVersionKey=SOFTWARE\Microsoft\ASP.NET Core\Shared Framework\v$(var.MajorVersion).$(var.MinorVersion)\$(var.PackageVersion)?>
 

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -36,8 +36,8 @@
             </Directory>
         </Directory>
 
-        <?if $(var.Platform) = x64 ?>
-        <CustomActionRef Id="Set_DOTNETHOME_x64" />
+        <?if $(var.Platform)=x64?>
+        <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
         <?endif?>
     </Fragment>
 
@@ -67,7 +67,7 @@
             <?undef ProductVersionKey?>
             <?endif?>
 
-            <!-- TODO: the following keys will collde between x64 and ARM64.
+            <!-- TODO: the following keys will collide between x64 and ARM64.
                  They are actually *already* colliding between x86 and x64 since these will be writing to the x86 registry hive.
                  Any interest in fixing this? -->
 

--- a/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
+++ b/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="DependencyProvider.wxs" />
     <Compile Include="Product.wxs" />
+    <Compile Include="..\Common\dotnethome_x64.wxs" Link="dotnethome_x64.wxs" />
     <EmbeddedResource Include="Strings.wxl" />
   </ItemGroup>
 

--- a/src/Installers/Windows/TargetingPack/Product.wxs
+++ b/src/Installers/Windows/TargetingPack/Product.wxs
@@ -39,6 +39,10 @@
                 <Directory Id="DOTNETHOME" Name="dotnet" />
             </Directory>
         </Directory>
+
+        <?if $(var.Platform) = x64 ?>
+        <CustomActionRef Id="Set_DOTNETHOME_x64" />
+        <?endif?>
     </Fragment>
 
     <Fragment>
@@ -61,6 +65,10 @@
             <?ifdef ProductVersionKey?>
             <?undef ProductVersionKey?>
             <?endif?>
+
+            <!-- TODO: the following keys will collde between x64 and ARM64.
+                 They are actually *already* colliding between x86 and x64 since these will be writing to the x86 registry hive.
+                 Any interest in fixing this? -->
 
             <?define ProductVersionKey=SOFTWARE\Microsoft\ASP.NET Core\Targeting Pack\v$(var.MajorVersion).$(var.MinorVersion)\$(var.PackageVersion)?>
 

--- a/src/Installers/Windows/TargetingPack/Product.wxs
+++ b/src/Installers/Windows/TargetingPack/Product.wxs
@@ -59,6 +59,10 @@
         <ComponentGroup Id="CG_ProductInfo">
             <ComponentRef Id="C_ProductVersion"/>
             <ComponentRef Id="C_ProductInstallDir"/>
+            <?if $(var.Platform)=x64 ?>
+            <ComponentRef Id="C_ProductVersion_NonNative"/>
+            <ComponentRef Id="C_ProductInstallDir_NonNative"/>
+            <?endif?>
         </ComponentGroup>
 
         <DirectoryRef Id="DOTNETHOME">
@@ -66,23 +70,44 @@
             <?undef ProductVersionKey?>
             <?endif?>
 
-            <!-- TODO: the following keys will collide between x64 and ARM64.
-                 They are actually *already* colliding between x86 and x64 since these will be writing to the x86 registry hive.
-                 Any interest in fixing this? -->
-
             <?define ProductVersionKey=SOFTWARE\Microsoft\ASP.NET Core\Targeting Pack\v$(var.MajorVersion).$(var.MinorVersion)\$(var.PackageVersion)?>
 
             <Component Id="C_ProductVersion">
+                <?if $(var.Platform)=x64 ?>
+                <!-- Only install when actually on native architecture -->
+                <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+                <?endif?>
                 <RegistryKey Key="$(var.ProductVersionKey)" Root="HKLM">
                     <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
                 </RegistryKey>
             </Component>
 
             <Component Id="C_ProductInstallDir">
+                <?if $(var.Platform)=x64 ?>
+                <!-- Only install when actually on native architecture -->
+                <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+                <?endif?>
                 <RegistryKey Key="SOFTWARE\Microsoft\ASP.NET Core\Targeting Pack" Root="HKLM">
                     <RegistryValue Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
                 </RegistryKey>
             </Component>
+
+
+            <?if $(var.Platform)=x64 ?>
+            <!-- Install keys to a different path when not native architecture -->
+            <Component Id="C_ProductVersion_NonNative">
+                <Condition>NON_NATIVE_ARCHITECTURE</Condition>
+                <RegistryKey Key="$(var.ProductVersionKey)\$(var.Platform)" Root="HKLM">
+                    <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
+                </RegistryKey>
+            </Component>
+            <Component Id="C_ProductInstallDir_NonNative">
+                <Condition>NON_NATIVE_ARCHITECTURE</Condition>
+                <RegistryKey Key="SOFTWARE\Microsoft\ASP.NET Core\Targeting Pack\$(var.Platform)" Root="HKLM">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
+                </RegistryKey>
+            </Component>
+            <?endif?>
         </DirectoryRef>
     </Fragment>
 </Wix>

--- a/src/Installers/Windows/TargetingPack/Product.wxs
+++ b/src/Installers/Windows/TargetingPack/Product.wxs
@@ -40,8 +40,8 @@
             </Directory>
         </Directory>
 
-        <?if $(var.Platform) = x64 ?>
-        <CustomActionRef Id="Set_DOTNETHOME_x64" />
+        <?if $(var.Platform)=x64?>
+        <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
         <?endif?>
     </Fragment>
 
@@ -66,7 +66,7 @@
             <?undef ProductVersionKey?>
             <?endif?>
 
-            <!-- TODO: the following keys will collde between x64 and ARM64.
+            <!-- TODO: the following keys will collide between x64 and ARM64.
                  They are actually *already* colliding between x86 and x64 since these will be writing to the x86 registry hive.
                  Any interest in fixing this? -->
 

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="DependencyProvider.wxs" />
     <Compile Include="Product.wxs" />
+    <Compile Include="..\Common\dotnethome_x64.wxs" Link="dotnethome_x64.wxs" />
     <EmbeddedResource Include="Strings.wxl" />
   </ItemGroup>
 


### PR DESCRIPTION
Draft that enables installing x64 product on ARM64.

Related PRs: 
https://github.com/dotnet/arcade/pull/7785
https://github.com/dotnet/runtime/pull/58669
https://github.com/dotnet/installer/pull/11843