### PR TITLE
Update Program.cs

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
@@ -7,4 +7,4 @@ IHost host = Host.CreateDefaultBuilder(args)
     })
     .Build();
 
-await host.RunAsync();
+host.Run();


### PR DESCRIPTION
I think most of the other top-level programs/templates call `Run()` instead of `await RunAsync()`. For the sake of consistency we should probably use `Run`.

Related to the evolution of templates with .NET 6:

- #33853

/cc @DamianEdwards @bradygaster @davidfowl and @shirhatti