### PR TITLE
[release/6.0] HTTP/3: Support canceling requests that aren't reading a body

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/IProtocolErrorCodeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IProtocolErrorCodeFeature.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Connections.Features
     public interface IProtocolErrorCodeFeature
     {
         /// <summary>
-        /// Gets or sets the error code.
+        /// Gets or sets the error code. The property returns -1 if the error code hasn't been set.
         /// </summary>
         long Error { get; set; }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -134,6 +134,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public void Abort(ConnectionAbortedException abortReason, Http3ErrorCode errorCode)
         {
+            AbortCore(abortReason, errorCode);
+        }
+
+        private void AbortCore(Exception exception, Http3ErrorCode errorCode)
+        {
             lock (_completionLock)
             {
                 if (IsCompleted)
@@ -148,26 +153,27 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     return;
                 }
 
+                if (!(exception is ConnectionAbortedException abortReason))
+                {
+                    abortReason = new ConnectionAbortedException(exception.Message, exception);
+                }
+
                 Log.Http3StreamAbort(TraceIdentifier, errorCode, abortReason);
 
+                // Call _http3Output.Stop() prior to poisoning the request body stream or pipe to
+                // ensure that an app that completes early due to the abort doesn't result in header frames being sent.
+                _http3Output.Stop();
+
+                CancelRequestAbortedToken();
+
+                // Unblock the request body.
+                PoisonBody(exception);
+                RequestBodyPipe.Writer.Complete(exception);
+
+                // Abort framewriter and underlying transport after stopping output.
                 _errorCodeFeature.Error = (long)errorCode;
                 _frameWriter.Abort(abortReason);
-
-                AbortCore(abortReason);
             }
-        }
-
-        private void AbortCore(Exception exception)
-        {
-            // Call _http3Output.Stop() prior to poisoning the request body stream or pipe to
-            // ensure that an app that completes early due to the abort doesn't result in header frames being sent.
-            _http3Output.Stop();
-
-            CancelRequestAbortedToken();
-
-            // Unblock the request body.
-            PoisonBody(exception);
-            RequestBodyPipe.Writer.Complete(exception);
         }
 
         protected override void OnErrorAfterResponseStarted()
@@ -470,7 +476,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             catch (ConnectionResetException ex)
             {
                 error = ex;
-                AbortCore(new IOException(CoreStrings.HttpStreamResetByClient, ex));
+                var resolvedErrorCode = _errorCodeFeature.Error >= 0 ? _errorCodeFeature.Error : 0;
+                AbortCore(new IOException(CoreStrings.HttpStreamResetByClient, ex), (Http3ErrorCode)resolvedErrorCode);
             }
             catch (Exception ex)
             {
@@ -484,10 +491,41 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
                 await Input.CompleteAsync();
 
-                // Make sure application func is completed before completing writer.
-                if (_appCompleted != null)
+                var appCompleted = _appCompleted?.Task ?? Task.CompletedTask;
+                if (!appCompleted.IsCompletedSuccessfully)
                 {
-                    await _appCompleted.Task;
+                    // At this point in the stream's read-side is complete. However, with HTTP/3
+                    // the write-side of the stream can still be aborted by the client on request
+                    // aborted.
+                    //
+                    // To get notification of request aborted we register to connection closed
+                    // token. It will notify this type that the client has aborted the request
+                    // and Kestrel will complete pipes and cancel the RequestAborted token.
+                    //
+                    // Only subscribe to this event after the stream's read-side is complete to
+                    // avoid interactions between reading that is in-progress and an abort.
+                    // This means while reading, read-side abort will handle getting abort notifications.
+                    //
+                    // TODO: Consider a better way to provide this notification. For perf we want to
+                    // make the ConnectionClosed CTS pay-for-play, and change this event to use
+                    // something that is more lightweight than a CTS.
+                    _context.StreamContext.ConnectionClosed.Register(static s =>
+                    {
+                        var stream = (Http3Stream)s!;
+
+                        if (!stream.IsCompleted)
+                        {
+                            // An error code value other than -1 indicates a value was set and the request didn't gracefully complete.
+                            var errorCode = stream._errorCodeFeature.Error;
+                            if (errorCode >= 0)
+                            {
+                                stream.AbortCore(new IOException(CoreStrings.HttpStreamResetByClient), (Http3ErrorCode)errorCode);
+                            }
+                        }
+                    }, this);
+
+                    // Make sure application func is completed before completing writer.
+                    await appCompleted;
                 }
 
                 try

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -506,6 +506,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
                     // avoid interactions between reading that is in-progress and an abort.
                     // This means while reading, read-side abort will handle getting abort notifications.
                     //
+                    // We don't need to hang on to the CancellationTokenRegistration from register.
+                    // The CTS is cleaned up in StreamContext.DisposeAsync.
+                    //
                     // TODO: Consider a better way to provide this notification. For perf we want to
                     // make the ConnectionClosed CTS pay-for-play, and change this event to use
                     // something that is more lightweight than a CTS.

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/IQuicTrace.cs
@@ -19,7 +19,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         void StreamPause(QuicStreamContext streamContext);
         void StreamResume(QuicStreamContext streamContext);
         void StreamShutdownWrite(QuicStreamContext streamContext, string reason);
-        void StreamAborted(QuicStreamContext streamContext, long errorCode, Exception ex);
+        void StreamAbortedRead(QuicStreamContext streamContext, long errorCode);
+        void StreamAbortedWrite(QuicStreamContext streamContext, long errorCode);
         void StreamAbort(QuicStreamContext streamContext, long errorCode, string reason);
         void StreamAbortRead(QuicStreamContext streamContext, long errorCode, string reason);
         void StreamAbortWrite(QuicStreamContext streamContext, long errorCode, string reason);

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.FeatureCollection.cs
@@ -16,8 +16,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
     {
         private X509Certificate2? _clientCert;
         private Task<X509Certificate2?>? _clientCertTask;
+        private long? _error;
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public X509Certificate2? ClientCertificate
         {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -83,9 +83,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                     return;
                 }
 
+                var resolvedErrorCode = _error ?? 0;
                 _abortReason = ExceptionDispatchInfo.Capture(abortReason);
-                _log.ConnectionAbort(this, Error, abortReason.Message);
-                _closeTask = _connection.CloseAsync(errorCode: Error).AsTask();
+                _log.ConnectionAbort(this, resolvedErrorCode, abortReason.Message);
+                _closeTask = _connection.CloseAsync(errorCode: resolvedErrorCode).AsTask();
             }
         }
 
@@ -127,7 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicConnectionAbortedException ex)
             {
                 // Shutdown initiated by peer, abortive.
-                Error = ex.ErrorCode;
+                _error = ex.ErrorCode;
                 _log.ConnectionAborted(this, ex.ErrorCode, ex);
 
                 ThreadPool.UnsafeQueueUserWorkItem(state =>

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
@@ -9,11 +9,16 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
     internal sealed partial class QuicStreamContext : IPersistentStateFeature, IStreamDirectionFeature, IProtocolErrorCodeFeature, IStreamIdFeature, IStreamAbortFeature
     {
         private IDictionary<object, object?>? _persistentState;
+        private long? _error;
 
         public bool CanRead { get; private set; }
         public bool CanWrite { get; private set; }
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public long StreamId { get; private set; }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
 using System.Net.Quic;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
@@ -38,6 +39,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
         private volatile Exception? _shutdownReadReason;
         private volatile Exception? _shutdownWriteReason;
         private volatile Exception? _shutdownReason;
+        private volatile Exception? _writeAbortException;
         private bool _streamClosed;
         private bool _serverAborted;
         private bool _clientAbort;
@@ -95,7 +97,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             CanRead = _stream.CanRead;
             CanWrite = _stream.CanWrite;
-            Error = 0;
+            _error = null;
             StreamId = _stream.StreamId;
             PoolExpirationTicks = 0;
 
@@ -107,6 +109,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             _connectionId = null;
             _shutdownReason = null;
+            _writeAbortException = null;
             _streamClosed = false;
             _serverAborted = false;
             _clientAbort = false;
@@ -162,10 +165,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 // Now wait for both to complete
                 await receiveTask;
                 await sendTask;
+
+                await FireStreamClosedAsync();
             }
             catch (Exception ex)
             {
                 _log.LogError(0, ex, $"Unexpected exception in {nameof(QuicStreamContext)}.{nameof(StartAsync)}.");
+            }
+        }
+
+        private async Task WaitForWritesCompleted()
+        {
+            Debug.Assert(_stream != null);
+
+            try
+            {
+                await _stream.WaitForWriteCompletionAsync();
+            }
+            catch (Exception ex)
+            {
+                // Send error to DoSend loop.
+                _writeAbortException = ex;
+            }
+            finally
+            {
+                Output.CancelPendingRead();
             }
         }
 
@@ -180,7 +204,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 var input = Input;
                 while (true)
                 {
-                    var buffer = Input.GetMemory(MinAllocBufferSize);
+                    var buffer = input.GetMemory(MinAllocBufferSize);
                     var bytesReceived = await _stream.ReadAsync(buffer);
 
                     if (bytesReceived == 0)
@@ -200,10 +224,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                         //
                         // Getting data and complete together is important for HTTP/3 when parsing headers.
                         // It is important that it knows that there is no body after the headers.
-                        var completeTask = input.CompleteAsync(ResolveCompleteReceiveException(error));
+                        var completeTask = input.CompleteAsync();
                         if (completeTask.IsCompletedSuccessfully)
                         {
                             // Fast path. CompleteAsync completed immediately.
+                            // Most implementations of ValueTask reset state in GetResult.
+                            completeTask.GetAwaiter().GetResult();
+
                             flushTask = ValueTask.FromResult(new FlushResult(isCanceled: false, isCompleted: true));
                         }
                         else
@@ -240,8 +267,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicStreamAbortedException ex)
             {
                 // Abort from peer.
-                Error = ex.ErrorCode;
-                _log.StreamAborted(this, ex.ErrorCode, ex);
+                _error = ex.ErrorCode;
+                _log.StreamAbortedRead(this, ex.ErrorCode);
+
+                // This could be ignored if _shutdownReason is already set.
+                error = new ConnectionResetException(ex.Message, ex);
+
+                _clientAbort = true;
+            }
+            catch (QuicConnectionAbortedException ex)
+            {
+                // Abort from peer.
+                _error = ex.ErrorCode;
+                _log.StreamAbortedRead(this, ex.ErrorCode);
 
                 // This could be ignored if _shutdownReason is already set.
                 error = new ConnectionResetException(ex.Message, ex);
@@ -253,11 +291,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 // AbortRead has been called for the stream.
                 error = new ConnectionAbortedException(ex.Message, ex);
             }
-            catch (QuicConnectionAbortedException ex)
-            {
-                // Connection has aborted.
-                error = ex;
-            }
             catch (Exception ex)
             {
                 // This is unexpected.
@@ -268,10 +301,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             {
                 // If Shutdown() has already bee called, assume that was the reason ProcessReceives() exited.
                 Input.Complete(ResolveCompleteReceiveException(error));
-
-                FireStreamClosed();
-
-                await _waitForConnectionClosedTcs.Task;
             }
 
             async static ValueTask<FlushResult> AwaitCompleteTaskAsync(ValueTask completeTask)
@@ -286,12 +315,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             return _shutdownReadReason ?? _shutdownReason ?? error;
         }
 
-        private void FireStreamClosed()
+        private Task FireStreamClosedAsync()
         {
             // Guard against scheduling this multiple times
             if (_streamClosed)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             _streamClosed = true;
@@ -304,6 +333,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             },
             this,
             preferLocal: false);
+
+            return _waitForConnectionClosedTcs.Task;
         }
 
         private void CancelConnectionClosedToken()
@@ -325,6 +356,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             Exception? shutdownReason = null;
             Exception? unexpectedError = null;
 
+            var sendCompletedTask = WaitForWritesCompleted();
+
             try
             {
                 // Resolve `output` PipeReader via the IDuplexPipe interface prior to loop start for performance.
@@ -335,6 +368,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
                     if (result.IsCanceled)
                     {
+                        // WaitForWritesCompleted provides immediate notification that write-side of stream has completed.
+                        // If the stream or connection is aborted then exception will be available to rethrow.
+                        if (_writeAbortException != null)
+                        {
+                            ExceptionDispatchInfo.Throw(_writeAbortException);
+                        }
+
                         break;
                     }
 
@@ -359,8 +399,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicStreamAbortedException ex)
             {
                 // Abort from peer.
-                Error = ex.ErrorCode;
-                _log.StreamAborted(this, ex.ErrorCode, ex);
+                _error = ex.ErrorCode;
+                _log.StreamAbortedWrite(this, ex.ErrorCode);
 
                 // This could be ignored if _shutdownReason is already set.
                 shutdownReason = new ConnectionResetException(ex.Message, ex);
@@ -370,8 +410,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             catch (QuicConnectionAbortedException ex)
             {
                 // Abort from peer.
-                Error = ex.ErrorCode;
-                _log.StreamAborted(this, ex.ErrorCode, ex);
+                _error = ex.ErrorCode;
+                _log.StreamAbortedWrite(this, ex.ErrorCode);
 
                 // This could be ignored if _shutdownReason is already set.
                 shutdownReason = new ConnectionResetException(ex.Message, ex);
@@ -383,7 +423,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 // AbortWrite has been called for the stream.
                 // Possibily might also get here from connection closing.
                 // System.Net.Quic exception handling not finalized.
-                unexpectedError = ex;
+                shutdownReason = new ConnectionResetException(ex.Message, ex);
             }
             catch (Exception ex)
             {
@@ -394,9 +434,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             finally
             {
                 ShutdownWrite(_shutdownWriteReason ?? _shutdownReason ?? shutdownReason);
+                await sendCompletedTask;
 
-                // Complete the output after disposing the stream
-                Output.Complete(unexpectedError ?? shutdownReason);
+                // Complete the output after completing stream sends
+                Output.Complete(unexpectedError);
 
                 // Cancel any pending flushes so that the input loop is un-paused
                 Input.CancelPendingFlush();
@@ -415,7 +456,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             _serverAborted = true;
             _shutdownReason = abortReason;
 
-            _log.StreamAbort(this, Error, abortReason.Message);
+            var resolvedErrorCode = _error ?? 0;
+            _log.StreamAbort(this, resolvedErrorCode, abortReason.Message);
 
             lock (_shutdownLock)
             {
@@ -423,11 +465,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
                 {
                     if (_stream.CanRead)
                     {
-                        _stream.AbortRead(Error);
+                        _stream.AbortRead(resolvedErrorCode);
                     }
                     if (_stream.CanWrite)
                     {
-                        _stream.AbortWrite(Error);
+                        _stream.AbortWrite(resolvedErrorCode);
                     }
                 }
             }
@@ -464,16 +506,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             {
                 return;
             }
-            
-            // Be conservative about what can be pooled.
-            // Only pool bidirectional streams whose pipes have completed successfully and haven't been aborted.
-            CanReuse = _stream.CanRead && _stream.CanWrite
-                && _transportPipeReader.IsCompletedSuccessfully
-                && _transportPipeWriter.IsCompletedSuccessfully
-                && !_clientAbort
-                && !_serverAborted
-                && _shutdownReadReason == null
-                && _shutdownWriteReason == null;
 
             _originalTransport.Input.Complete();
             _originalTransport.Output.Complete();
@@ -482,6 +514,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
 
             lock (_shutdownLock)
             {
+                // CanReuse must not be calculated while draining stream. It is possible for
+                // an abort to be received while any methods are still running.
+                // It is safe to calculate CanReuse after processing is completed.
+                //
+                // Be conservative about what can be pooled.
+                // Only pool bidirectional streams whose pipes have completed successfully and haven't been aborted.
+                CanReuse = _stream.CanRead && _stream.CanWrite
+                    && _transportPipeReader.IsCompletedSuccessfully
+                    && _transportPipeWriter.IsCompletedSuccessfully
+                    && !_clientAbort
+                    && !_serverAborted
+                    && _shutdownReadReason == null
+                    && _shutdownWriteReason == null;
+
                 if (!CanReuse)
                 {
                     DisposeCore();

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicTrace.cs
@@ -132,18 +132,29 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(11, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
-        private static partial void StreamAborted(ILogger logger, string connectionId, long errorCode, Exception ex);
+        [LoggerMessage(11, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
+        private static partial void StreamAbortedRead(ILogger logger, string connectionId, long errorCode);
 
-        public void StreamAborted(QuicStreamContext streamContext, long errorCode, Exception ex)
+        public void StreamAbortedRead(QuicStreamContext streamContext, long errorCode)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                StreamAborted(_logger, streamContext.ConnectionId, errorCode, ex);
+                StreamAbortedRead(_logger, streamContext.ConnectionId, errorCode);
             }
         }
 
-        [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by application with error code {ErrorCode} because: ""{Reason}"".", EventName = "StreamAbort", SkipEnabledCheck = true)]
+        [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
+        private static partial void StreamAbortedWrite(ILogger logger, string connectionId, long errorCode);
+
+        public void StreamAbortedWrite(QuicStreamContext streamContext, long errorCode)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                StreamAbortedWrite(_logger, streamContext.ConnectionId, errorCode);
+            }
+        }
+
+        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" aborted by application with error code {ErrorCode} because: ""{Reason}"".", EventName = "StreamAbort", SkipEnabledCheck = true)]
         private static partial void StreamAbort(ILogger logger, string connectionId, long errorCode, string reason);
 
         public void StreamAbort(QuicStreamContext streamContext, long errorCode, string reason)
@@ -154,7 +165,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(13, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
+        [LoggerMessage(14, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
         private static partial void StreamAbortRead(ILogger logger, string connectionId, long errorCode, string reason);
 
         public void StreamAbortRead(QuicStreamContext streamContext, long errorCode, string reason)
@@ -165,7 +176,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal
             }
         }
 
-        [LoggerMessage(14, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
+        [LoggerMessage(15, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write side aborted by application with error code {ErrorCode} because: ""{Reason}"".", SkipEnabledCheck = true)]
         private static partial void StreamAbortWrite(ILogger logger, string connectionId, long errorCode, string reason);
         
         public void StreamAbortWrite(QuicStreamContext streamContext, long errorCode, string reason)

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -181,6 +181,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             read = await serverStream.Transport.Input.ReadAsync().DefaultTimeout();
             Assert.True(read.IsCompleted);
 
+            await serverStream.Transport.Output.CompleteAsync();
+
             await closedTcs.Task.DefaultTimeout();
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -112,10 +112,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 
             var qex = await Assert.ThrowsAsync<QuicException>(async () => await clientConnection.ConnectAsync().DefaultTimeout());
             Assert.Equal("Connection has been shutdown by transport. Error Code: 0x80410100", qex.Message);
-
-            // https://github.com/dotnet/runtime/issues/57246 The accept still completes even though the connection was rejected, but it's already failed.
-            var serverContext = await connectionListener.AcceptAndAddFeatureAsync().DefaultTimeout();
-            await Assert.ThrowsAsync<QuicException>(() => serverContext.ConnectAsync().DefaultTimeout());
         }
     }
 }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -922,7 +922,7 @@ namespace Microsoft.AspNetCore.Testing
         });
 
         private readonly Http3InMemory _testBase;
-        private long _error;
+        private long? _error;
 
         public TestMultiplexedConnectionContext(Http3InMemory testBase)
         {
@@ -946,7 +946,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public long Error
         {
-            get => _error;
+            get => _error ?? -1;
             set => _error = value;
         }
 
@@ -1019,6 +1019,7 @@ namespace Microsoft.AspNetCore.Testing
 
         private TaskCompletionSource _disposingTcs;
         private TaskCompletionSource _disposedTcs;
+        internal long? _error;
 
         public TestStreamContext(bool canRead, bool canWrite, Http3InMemory testBase)
         {
@@ -1072,6 +1073,7 @@ namespace Microsoft.AspNetCore.Testing
             ConnectionId = "TEST:" + streamId.ToString();
             AbortReadException = null;
             AbortWriteException = null;
+            _error = null;
 
             _disposedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             _disposingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1112,7 +1114,11 @@ namespace Microsoft.AspNetCore.Testing
 
         public bool CanWrite { get; }
 
-        public long Error { get; set; }
+        public long Error
+        {
+            get => _error ?? -1;
+            set => _error = value;
+        }
 
         public override void Abort(ConnectionAbortedException abortReason)
         {

--- a/src/Servers/Kestrel/shared/test/StreamExtensions.cs
+++ b/src/Servers/Kestrel/shared/test/StreamExtensions.cs
@@ -46,7 +46,7 @@ namespace System.IO
             return offset;
         }
 
-        public static async Task<byte[]> ReadAtLeastLengthAsync(this Stream stream, int length, int bufferLength = 1024, CancellationToken cancellationToken = default)
+        public static async Task<byte[]> ReadAtLeastLengthAsync(this Stream stream, int length, int bufferLength = 1024, bool allowEmpty = false, CancellationToken cancellationToken = default)
         {
             var buffer = new byte[bufferLength];
             var data = new List<byte>();
@@ -57,7 +57,15 @@ namespace System.IO
                 var read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
                 offset += read;
 
-                Assert.NotEqual(0, read);
+                if (read == 0)
+                {
+                    if (allowEmpty && offset == 0)
+                    {
+                        return null;
+                    }
+
+                    throw new Exception("Stream read 0.");
+                }
 
                 data.AddRange(buffer.AsMemory(0, read).ToArray());
             }

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Testing
                 localEndPoint: localEndPoint,
                 remoteEndPoint: remoteEndPoint,
                 streamLifetimeHandler: streamLifetimeHandler,
-                streamContext: null,
+                streamContext: new DefaultConnectionContext(),
                 clientPeerSettings: new Http3PeerSettings(),
                 serverPeerSettings: null
             );

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
@@ -263,10 +263,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await requestStream.OnDisposingTask.DefaultTimeout();
 
             Http3Api.TriggerTick(now);
-            Assert.Equal(0, requestStream.Error);
+            Assert.Null(requestStream.StreamContext._error);
 
             Http3Api.TriggerTick(now + TimeSpan.FromTicks(1));
-            Assert.Equal(0, requestStream.Error);
+            Assert.Null(requestStream.StreamContext._error);
 
             Http3Api.TriggerTick(now + limits.MinResponseDataRate.GracePeriod + TimeSpan.FromTicks(1));
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Tracing;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Interop.FunctionalTests.Http3
+{
+    public sealed class HttpEventSourceListener : EventListener
+    {
+        private readonly StringBuilder _messageBuilder = new StringBuilder();
+        private readonly ILogger _logger;
+        private readonly object _lock = new object();
+        private bool _disposed;
+
+        public HttpEventSourceListener(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger(nameof(HttpEventSourceListener));
+            _logger.LogDebug($"Starting {nameof(HttpEventSourceListener)}.");
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            base.OnEventSourceCreated(eventSource);
+
+            if (eventSource.Name.Contains("System.Net.Quic") ||
+                eventSource.Name.Contains("System.Net.Http"))
+            {
+                lock (_lock)
+                {
+                    if (!_disposed)
+                    {
+                        EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.All);
+                    }
+                }
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            base.OnEventWritten(eventData);
+
+            string message;
+            lock (_messageBuilder)
+            {
+                _messageBuilder.Append("<- Event ");
+                _messageBuilder.Append(eventData.EventSource.Name);
+                _messageBuilder.Append(" - ");
+                _messageBuilder.Append(eventData.EventName);
+                _messageBuilder.Append(" : ");
+                _messageBuilder.AppendJoin(',', eventData.Payload!);
+                _messageBuilder.Append(" ->");
+                message = _messageBuilder.ToString();
+                _messageBuilder.Clear();
+            }
+
+            // We don't know the state of the logger after dispose.
+            // Ensure that any messages written in the background aren't
+            // logged after the listener has been disposed in the test.
+            lock (_lock)
+            {
+                if (!_disposed)
+                {
+                    // EventListener base constructor subscribes to events.
+                    // It is possible to start getting events before the
+                    // super constructor is run and logger is assigned.
+                    _logger?.LogDebug(message);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return _messageBuilder.ToString();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            lock (_lock)
+            {
+                if (!_disposed)
+                {
+                    _logger?.LogDebug($"Stopping {nameof(HttpEventSourceListener)}.");
+                    _disposed = true;
+                }
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/HttpEventSourceListener.cs
@@ -24,8 +24,7 @@ namespace Interop.FunctionalTests.Http3
         {
             base.OnEventSourceCreated(eventSource);
 
-            if (eventSource.Name.Contains("System.Net.Quic") ||
-                eventSource.Name.Contains("System.Net.Http"))
+            if (IsHttpEventSource(eventSource))
             {
                 lock (_lock)
                 {
@@ -37,9 +36,19 @@ namespace Interop.FunctionalTests.Http3
             }
         }
 
+        private static bool IsHttpEventSource(EventSource eventSource)
+        {
+            return eventSource.Name.Contains("System.Net.Quic") || eventSource.Name.Contains("System.Net.Http");
+        }
+
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             base.OnEventWritten(eventData);
+
+            if (!IsHttpEventSource(eventData.EventSource))
+            {
+                return;
+            }
 
             string message;
             lock (_messageBuilder)


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/36017 to release/6.0

## Customer Impact

HTTP/3 requests that have been canceled or aborted after the incoming request body is read weren't being correctly removed on the server. This could cause some canceled HTTP requests to hang around on the server, using up resources and creating a memory leak. There is the opportunity for malicious clients to use this to DOS attack the server.

## Testing

Functional tests. Also tested with grpc-dotnet.

## Risk

Medium-Low. The HTTP/3 abort logic has non-trivial changes. To account for this, the changes have been well tested and reviewed by Kestrel SMEs.

Change is constrained to HTTP/3.