### PR TITLE
Avoid using static NullabilityInfoContext

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Http
     /// </summary>
     public static partial class RequestDelegateFactory
     {
-        private static readonly NullabilityInfoContext NullabilityContext = new();
         private static readonly TryParseMethodCache TryParseMethodCache = new();
 
         private static readonly MethodInfo ExecuteTaskOfTMethod = typeof(RequestDelegateFactory).GetMethod(nameof(ExecuteTask), BindingFlags.NonPublic | BindingFlags.Static)!;
@@ -234,7 +233,7 @@ namespace Microsoft.AspNetCore.Http
             else if (parameter.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)))
             {
                 factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.ServiceAttribue);
-                return BindParameterFromService(parameter);
+                return BindParameterFromService(parameter, factoryContext);
             }
             else if (parameter.ParameterType == typeof(HttpContext))
             {
@@ -620,9 +619,9 @@ namespace Microsoft.AspNetCore.Http
             return Expression.Convert(indexExpression, typeof(string));
         }
 
-        private static Expression BindParameterFromService(ParameterInfo parameter)
+        private static Expression BindParameterFromService(ParameterInfo parameter, FactoryContext factoryContext)
         {
-            var isOptional = IsOptionalParameter(parameter);
+            var isOptional = IsOptionalParameter(parameter, factoryContext);
 
             return isOptional
                 ? Expression.Call(GetServiceMethod.MakeGenericMethod(parameter.ParameterType), RequestServicesExpr)
@@ -631,7 +630,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static Expression BindParameterFromValue(ParameterInfo parameter, Expression valueExpression, FactoryContext factoryContext, string source)
         {
-            var isOptional = IsOptionalParameter(parameter);
+            var isOptional = IsOptionalParameter(parameter, factoryContext);
 
             var argument = Expression.Variable(parameter.ParameterType, $"{parameter.Name}_local");
 
@@ -669,7 +668,7 @@ namespace Microsoft.AspNetCore.Http
                 }
 
                 // Allow nullable parameters that don't have a default value
-                var nullability = NullabilityContext.Create(parameter);
+                var nullability = factoryContext.NullabilityContext.Create(parameter);
                 if (nullability.ReadState != NullabilityState.NotNull && !parameter.HasDefaultValue)
                 {
                     return valueExpression;
@@ -815,8 +814,8 @@ namespace Microsoft.AspNetCore.Http
         private static Expression BindParameterFromBindAsync(ParameterInfo parameter, FactoryContext factoryContext)
         {
             // We reference the boundValues array by parameter index here
-            var nullability = NullabilityContext.Create(parameter);
-            var isOptional = IsOptionalParameter(parameter);
+            var nullability = factoryContext.NullabilityContext.Create(parameter);
+            var isOptional = IsOptionalParameter(parameter, factoryContext);
 
             // Get the BindAsync method for the type.
             var bindAsyncExpression = TryParseMethodCache.FindBindAsyncMethod(parameter);
@@ -869,7 +868,7 @@ namespace Microsoft.AspNetCore.Http
             }
 
             factoryContext.Metadata.Add(DefaultAcceptsMetadata);
-            var isOptional = IsOptionalParameter(parameter);
+            var isOptional = IsOptionalParameter(parameter, factoryContext);
 
             factoryContext.JsonRequestBodyType = parameter.ParameterType;
             factoryContext.AllowEmptyRequestBody = allowEmpty || isOptional;
@@ -913,7 +912,7 @@ namespace Microsoft.AspNetCore.Http
             return Expression.Convert(BodyValueExpr, parameter.ParameterType);
         }
 
-        private static bool IsOptionalParameter(ParameterInfo parameter)
+        private static bool IsOptionalParameter(ParameterInfo parameter, FactoryContext factoryContext)
         {
             // - Parameters representing value or reference types with a default value
             // under any nullability context are treated as optional.
@@ -921,7 +920,7 @@ namespace Microsoft.AspNetCore.Http
             // nullability context are required.
             // - Reference type parameters without a default value in an oblivious
             // nullability context are optional.
-            var nullability = NullabilityContext.Create(parameter);
+            var nullability = factoryContext.NullabilityContext.Create(parameter);
             return parameter.HasDefaultValue
                 || nullability.ReadState != NullabilityState.NotNull;
         }
@@ -1129,6 +1128,8 @@ namespace Microsoft.AspNetCore.Http
             public bool HasMultipleBodyParameters { get; set; }
 
             public List<object> Metadata { get; } = new();
+
+            public NullabilityInfoContext NullabilityContext { get; } = new();
         }
 
         private static class RequestDelegateFactoryConstants

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -27,7 +27,6 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         private readonly IHostEnvironment _environment;
         private readonly IServiceProviderIsService? _serviceProviderIsService;
         private readonly TryParseMethodCache TryParseMethodCache = new();
-        private readonly NullabilityInfoContext NullabilityContext = new();
 
         // Executes before MVC's DefaultApiDescriptionProvider and GrpcHttpApiDescriptionProvider for no particular reason.
         public int Order => -1100;
@@ -122,7 +121,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 apiDescription.ParameterDescriptions.Add(parameterDescription);
             }
 
-            // Get custom attributes for the handler. ConsumesAttribute is one of the examples. 
+            // Get custom attributes for the handler. ConsumesAttribute is one of the examples.
             var acceptsRequestType = routeEndpoint.Metadata.GetMetadata<IAcceptsMetadata>()?.RequestType;
             if (acceptsRequestType is not null)
             {
@@ -157,7 +156,8 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             }
 
             // Determine the "requiredness" based on nullability, default value or if allowEmpty is set
-            var nullability = NullabilityContext.Create(parameter);
+            var nullabilityContext = new NullabilityInfoContext();
+            var nullability = nullabilityContext.Create(parameter);
             var isOptional = parameter.HasDefaultValue || nullability.ReadState != NullabilityState.NotNull || allowEmpty;
 
             return new ApiParameterDescription


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35990.

Validated manually with the following code snippet:

```csharp
void Foo(Product? p) { }
var d = Foo;
Parallel.For(0, 100, _ =>
{
    var d1 = RequestDelegateFactory.Create(d);
});
record Product(int Id, string? Title);
```