### PR TITLE
Add nullable support to BindAsync

### DIFF
--- a/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
+++ b/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>ASP.NET Core common extension methods for HTTP abstractions, HTTP headers, HTTP request/response, and session state.</Description>
@@ -12,12 +12,12 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)ObjectMethodExecutor\**\*.cs" LinkBase="Shared"/>
-    <Compile Include="$(SharedSourceRoot)TryParseMethodCache.cs" LinkBase="Shared"/>
+    <Compile Include="$(SharedSourceRoot)ParameterBindingMethodCache.cs" LinkBase="Shared"/>
     <Compile Include="..\..\Shared\StreamCopyOperationInternal.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ProblemDetailsJsonConverter.cs" LinkBase="Shared"/>
     <Compile Include="$(SharedSourceRoot)HttpValidationProblemDetailsJsonConverter.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)RoutingMetadata\AcceptsMetadata.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)TypeNameHelper/TypeNameHelper.cs" LinkBase="Shared"/>
+    <Compile Include="$(SharedSourceRoot)TypeNameHelper\TypeNameHelper.cs" LinkBase="Shared"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Http
     /// </summary>
     public static partial class RequestDelegateFactory
     {
-        private static readonly TryParseMethodCache TryParseMethodCache = new();
+        private static readonly ParameterBindingMethodCache ParameterBindingMethodCache = new();
 
         private static readonly MethodInfo ExecuteTaskOfTMethod = typeof(RequestDelegateFactory).GetMethod(nameof(ExecuteTask), BindingFlags.NonPublic | BindingFlags.Static)!;
         private static readonly MethodInfo ExecuteTaskOfStringMethod = typeof(RequestDelegateFactory).GetMethod(nameof(ExecuteTaskOfString), BindingFlags.NonPublic | BindingFlags.Static)!;
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Http
         private static readonly ParameterExpression WasParamCheckFailureExpr = Expression.Variable(typeof(bool), "wasParamCheckFailure");
         private static readonly ParameterExpression BoundValuesArrayExpr = Expression.Parameter(typeof(object[]), "boundValues");
 
-        private static ParameterExpression HttpContextExpr => TryParseMethodCache.HttpContextExpr;
+        private static readonly ParameterExpression HttpContextExpr = ParameterBindingMethodCache.HttpContextExpr;
         private static readonly MemberExpression RequestServicesExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.RequestServices))!);
         private static readonly MemberExpression HttpRequestExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.Request))!);
         private static readonly MemberExpression HttpResponseExpr = Expression.Property(HttpContextExpr, typeof(HttpContext).GetProperty(nameof(HttpContext.Response))!);
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Http
         private static readonly MemberExpression StatusCodeExpr = Expression.Property(HttpResponseExpr, typeof(HttpResponse).GetProperty(nameof(HttpResponse.StatusCode))!);
         private static readonly MemberExpression CompletedTaskExpr = Expression.Property(null, (PropertyInfo)GetMemberInfo<Func<Task>>(() => Task.CompletedTask));
 
-        private static ParameterExpression TempSourceStringExpr => TryParseMethodCache.TempSourceStringExpr;
+        private static readonly ParameterExpression TempSourceStringExpr = ParameterBindingMethodCache.TempSourceStringExpr;
         private static readonly BinaryExpression TempSourceStringNotNullExpr = Expression.NotEqual(TempSourceStringExpr, Expression.Constant(null));
         private static readonly BinaryExpression TempSourceStringNullExpr = Expression.Equal(TempSourceStringExpr, Expression.Constant(null));
         private static readonly string[] DefaultAcceptsContentType = new[] { "application/json" };
@@ -254,11 +254,11 @@ namespace Microsoft.AspNetCore.Http
             {
                 return RequestAbortedExpr;
             }
-            else if (TryParseMethodCache.HasBindAsyncMethod(parameter))
+            else if (ParameterBindingMethodCache.HasBindAsyncMethod(parameter))
             {
                 return BindParameterFromBindAsync(parameter, factoryContext);
             }
-            else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseStringMethod(parameter))
+            else if (parameter.ParameterType == typeof(string) || ParameterBindingMethodCache.HasTryParseMethod(parameter))
             {
                 // 1. We bind from route values only, if route parameters are non-null and the parameter name is in that set.
                 // 2. We bind from query only, if route parameters are non-null and the parameter name is NOT in that set.
@@ -703,7 +703,7 @@ namespace Microsoft.AspNetCore.Http
             var isNotNullable = underlyingNullableType is null;
 
             var nonNullableParameterType = underlyingNullableType ?? parameter.ParameterType;
-            var tryParseMethodCall = TryParseMethodCache.FindTryParseStringMethod(nonNullableParameterType);
+            var tryParseMethodCall = ParameterBindingMethodCache.FindTryParseMethod(nonNullableParameterType);
 
             if (tryParseMethodCall is null)
             {
@@ -829,7 +829,7 @@ namespace Microsoft.AspNetCore.Http
             var isOptional = IsOptionalParameter(parameter, factoryContext);
 
             // Get the BindAsync method for the type.
-            var bindAsyncExpression = TryParseMethodCache.FindBindAsyncMethod(parameter);
+            var bindAsyncExpression = ParameterBindingMethodCache.FindBindAsyncMethod(parameter);
             // We know BindAsync exists because there's no way to opt-in without defining the method on the type.
             Debug.Assert(bindAsyncExpression is not null);
 

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 
 namespace Microsoft.AspNetCore.Http.Extensions.Tests
 {
-    public class TryParseMethodCacheTests
+    public class ParameterBindingMethodCacheTests
     {
         [Theory]
         [InlineData(typeof(int))]
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [InlineData(typeof(ulong))]
         public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCulture(Type type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
+            var methodFound = new ParameterBindingMethodCache().FindTryParseMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [InlineData(typeof(TimeSpan))]
         public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureDateType(Type type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
+            var methodFound = new ParameterBindingMethodCache().FindTryParseMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -78,7 +78,7 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [InlineData(typeof(TryParseStringStruct))]
         public void FindTryParseStringMethod_ReturnsTheExpectedTryParseMethodWithInvariantCultureCustomType(Type type)
         {
-            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(@type);
+            var methodFound = new ParameterBindingMethodCache().FindTryParseMethod(@type);
 
             Assert.NotNull(methodFound);
 
@@ -119,14 +119,14 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [MemberData(nameof(TryParseStringParameterInfoData))]
         public void HasTryParseStringMethod_ReturnsTrueWhenMethodExists(ParameterInfo parameterInfo)
         {
-            Assert.True(new TryParseMethodCache().HasTryParseStringMethod(parameterInfo));
+            Assert.True(new ParameterBindingMethodCache().HasTryParseMethod(parameterInfo));
         }
 
         [Fact]
         public void FindTryParseStringMethod_WorksForEnums()
         {
             var type = typeof(Choice);
-            var methodFound = new TryParseMethodCache().FindTryParseStringMethod(type);
+            var methodFound = new ParameterBindingMethodCache().FindTryParseMethod(type);
 
             Assert.NotNull(methodFound);
 
@@ -146,8 +146,8 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         public void FindTryParseStringMethod_WorksForEnumsWhenNonGenericEnumParseIsUsed()
         {
             var type = typeof(Choice);
-            var cache = new TryParseMethodCache(preferNonGenericEnumParseOverload: true);
-            var methodFound = cache.FindTryParseStringMethod(type);
+            var cache = new ParameterBindingMethodCache(preferNonGenericEnumParseOverload: true);
+            var methodFound = cache.FindTryParseMethod(type);
 
             Assert.NotNull(methodFound);
 
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
 
             var parseEnum = Expression.Lambda<Func<string, Choice>>(Expression.Block(new[] { parsedValue },
                 block,
-                parsedValue), cache.TempSourceStringExpr).Compile();
+                parsedValue), ParameterBindingMethodCache.TempSourceStringExpr).Compile();
 
             Assert.Equal(Choice.One, parseEnum("One"));
             Assert.Equal(Choice.Two, parseEnum("Two"));
@@ -169,7 +169,7 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         public async Task FindBindAsyncMethod_FindsCorrectMethodOnClass()
         {
             var type = typeof(BindAsyncRecord);
-            var cache = new TryParseMethodCache();
+            var cache = new ParameterBindingMethodCache();
             var parameter = new MockParameterInfo(type, "bindAsyncRecord");
             var methodFound = cache.FindBindAsyncMethod(parameter);
 
@@ -179,7 +179,7 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
 
             var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object>>>(
                 Expression.Block(new[] { parsedValue }, methodFound!),
-                cache.HttpContextExpr).Compile();
+                ParameterBindingMethodCache.HttpContextExpr).Compile();
 
             var httpContext = new DefaultHttpContext
             {
@@ -217,21 +217,21 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         [MemberData(nameof(BindAsyncParameterInfoData))]
         public void HasBindAsyncMethod_ReturnsTrueWhenMethodExists(ParameterInfo parameterInfo)
         {
-            Assert.True(new TryParseMethodCache().HasBindAsyncMethod(parameterInfo));
+            Assert.True(new ParameterBindingMethodCache().HasBindAsyncMethod(parameterInfo));
         }
 
         [Fact]
-        public void HasBindAsyncMethod_ReturnsFalseForNullableReturningBindAsyncStructMethod()
+        public void HasBindAsyncMethod_ReturnsTrueForNullableReturningBindAsyncStructMethod()
         {
             var parameterInfo = GetFirstParameter((NullableReturningBindAsyncStruct arg) => NullableReturningBindAsyncStructMethod(arg));
-            Assert.False(new TryParseMethodCache().HasBindAsyncMethod(parameterInfo));
+            Assert.True(new ParameterBindingMethodCache().HasBindAsyncMethod(parameterInfo));
         }
 
         [Fact]
-        public void FindBindAsyncMethod_DoesNotFindMethodGivenNullableType()
+        public void FindBindAsyncMethod_FindsNonNullableReturningBindAsyncMethodGivenNullableType()
         {
             var parameterInfo = GetFirstParameter((BindAsyncStruct? arg) => BindAsyncNullableStructMethod(arg));
-            Assert.False(new TryParseMethodCache().HasBindAsyncMethod(parameterInfo));
+            Assert.True(new ParameterBindingMethodCache().HasBindAsyncMethod(parameterInfo));
         }
 
         enum Choice
@@ -249,7 +249,6 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         private static void BindAsyncStructMethod(BindAsyncStruct arg) { }
         private static void BindAsyncNullableStructMethod(BindAsyncStruct? arg) { }
         private static void NullableReturningBindAsyncStructMethod(NullableReturningBindAsyncStruct arg) { }
-
 
         private static ParameterInfo GetFirstParameter<T>(Expression<Action<T>> expr)
         {
@@ -321,7 +320,7 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
 
         private record struct NullableReturningBindAsyncStruct(int Value)
         {
-            public static ValueTask<BindAsyncStruct?> BindAsync(HttpContext context, ParameterInfo parameter) =>
+            public static ValueTask<NullableReturningBindAsyncStruct?> BindAsync(HttpContext context, ParameterInfo parameter) =>
                 throw new NotImplementedException();
         }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -489,7 +489,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                     new object[] { (Action<HttpContext, AssemblyFlags>)Store, "PublicKey,Retargetable", AssemblyFlags.PublicKey | AssemblyFlags.Retargetable },
                     new object[] { (Action<HttpContext, int?>)Store, "42", 42 },
                     new object[] { (Action<HttpContext, MyEnum>)Store, "ValueB", MyEnum.ValueB },
-                    new object[] { (Action<HttpContext, MyTryParseStringRecord>)Store, "https://example.org", new MyTryParseStringRecord(new Uri("https://example.org")) },
+                    new object[] { (Action<HttpContext, MyTryParseRecord>)Store, "https://example.org", new MyTryParseRecord(new Uri("https://example.org")) },
                     new object?[] { (Action<HttpContext, int?>)Store, null, null },
                 };
             }
@@ -497,9 +497,9 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
         private enum MyEnum { ValueA, ValueB, }
 
-        private record MyTryParseStringRecord(Uri Uri)
+        private record MyTryParseRecord(Uri Uri)
         {
-            public static bool TryParse(string? value, out MyTryParseStringRecord? result)
+            public static bool TryParse(string? value, out MyTryParseRecord? result)
             {
                 if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
                 {
@@ -507,17 +507,15 @@ namespace Microsoft.AspNetCore.Routing.Internal
                     return false;
                 }
 
-                result = new MyTryParseStringRecord(uri);
+                result = new MyTryParseRecord(uri);
                 return true;
             }
         }
 
         private class MyBindAsyncTypeThatThrows
         {
-            public static ValueTask<MyBindAsyncTypeThatThrows?> BindAsync(HttpContext context, ParameterInfo parameter)
-            {
+            public static ValueTask<MyBindAsyncTypeThatThrows?> BindAsync(HttpContext context, ParameterInfo parameter) =>
                 throw new InvalidOperationException("BindAsync failed");
-            }
         }
 
         private record MyBindAsyncRecord(Uri Uri)
@@ -535,11 +533,25 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 return new(result: new(uri));
             }
 
-            // TryParse(HttpContext, ...) should be preferred over TryParse(string, ...) if there's
+            // BindAsync(HttpContext, ParameterInfo) should be preferred over TryParse(string, ...) if there's
             // no [FromRoute] or [FromQuery] attributes.
-            public static bool TryParse(string? value, out MyBindAsyncRecord? result)
-            {
+            public static bool TryParse(string? value, out MyBindAsyncRecord? result) =>
                 throw new NotImplementedException();
+        }
+
+        private record struct MyNullableBindAsyncStruct(Uri Uri)
+        {
+            public static ValueTask<MyNullableBindAsyncStruct?> BindAsync(HttpContext context, ParameterInfo parameter)
+            {
+                Assert.True(parameter.ParameterType == typeof(MyNullableBindAsyncStruct) || parameter.ParameterType == typeof(MyNullableBindAsyncStruct?));
+                Assert.Equal("myNullableBindAsyncStruct", parameter.Name);
+
+                if (!Uri.TryCreate(context.Request.Headers.Referer, UriKind.Absolute, out var uri))
+                {
+                    return new(result: null);
+                }
+
+                return new(result: new(uri));
             }
         }
 
@@ -547,7 +559,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             public static ValueTask<MyBindAsyncStruct> BindAsync(HttpContext context, ParameterInfo parameter)
             {
-                Assert.Equal(typeof(MyBindAsyncStruct), parameter.ParameterType);
+                Assert.True(parameter.ParameterType == typeof(MyBindAsyncStruct) || parameter.ParameterType == typeof(MyBindAsyncStruct?));
                 Assert.Equal("myBindAsyncStruct", parameter.Name);
 
                 if (!Uri.TryCreate(context.Request.Headers.Referer, UriKind.Absolute, out var uri))
@@ -558,7 +570,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 return new(result: new(uri));
             }
 
-            // TryParse(HttpContext, ...) should be preferred over TryParse(string, ...) if there's
+            // BindAsync(HttpContext, ParameterInfo) should be preferred over TryParse(string, ...) if there's
             // no [FromRoute] or [FromQuery] attributes.
             public static bool TryParse(string? value, out MyBindAsyncStruct result) =>
                 throw new NotImplementedException();
@@ -658,7 +670,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Fact]
-        public async Task RequestDelegatePrefersBindAsyncOverTryParseString()
+        public async Task RequestDelegatePrefersBindAsyncOverTryParse()
         {
             var httpContext = CreateHttpContext();
 
@@ -677,7 +689,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Fact]
-        public async Task RequestDelegatePrefersBindAsyncOverTryParseStringForNonNullableStruct()
+        public async Task RequestDelegatePrefersBindAsyncOverTryParseForNonNullableStruct()
         {
             var httpContext = CreateHttpContext();
 
@@ -695,7 +707,25 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Fact]
-        public async Task RequestDelegateUsesTryParseStringoOverBindAsyncGivenExplicitAttribute()
+        public async Task RequestDelegateUsesBindAsyncOverTryParseGivenNullableStruct()
+        {
+            var httpContext = CreateHttpContext();
+
+            httpContext.Request.Headers.Referer = "https://example.org";
+
+            var resultFactory = RequestDelegateFactory.Create((HttpContext httpContext, MyBindAsyncStruct? myBindAsyncStruct) =>
+            {
+                httpContext.Items["myBindAsyncStruct"] = myBindAsyncStruct;
+            });
+
+            var requestDelegate = resultFactory.RequestDelegate;
+            await requestDelegate(httpContext);
+
+            Assert.Equal(new MyBindAsyncStruct(new Uri("https://example.org")), httpContext.Items["myBindAsyncStruct"]);
+        }
+
+        [Fact]
+        public async Task RequestDelegateUsesTryParseOverBindAsyncGivenExplicitAttribute()
         {
             var fromRouteFactoryResult = RequestDelegateFactory.Create((HttpContext httpContext, [FromRoute] MyBindAsyncRecord myBindAsyncRecord) => { });
             var fromQueryFactoryResult = RequestDelegateFactory.Create((HttpContext httpContext, [FromQuery] MyBindAsyncRecord myBindAsyncRecord) => { });
@@ -713,18 +743,6 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             await Assert.ThrowsAsync<NotImplementedException>(() => fromRouteRequestDelegate(httpContext));
             await Assert.ThrowsAsync<NotImplementedException>(() => fromQueryRequestDelegate(httpContext));
-        }
-
-        [Fact]
-        public async Task RequestDelegateUsesTryParseStringOverBindAsyncGivenNullableStruct()
-        {
-            var fromRouteFactoryResult = RequestDelegateFactory.Create((HttpContext httpContext, MyBindAsyncStruct? myBindAsyncRecord) => { });
-
-            var httpContext = CreateHttpContext();
-            httpContext.Request.RouteValues["myBindAsyncRecord"] = "foo";
-
-            var fromRouteRequestDelegate = fromRouteFactoryResult.RequestDelegate;
-            await Assert.ThrowsAsync<NotImplementedException>(() => fromRouteRequestDelegate(httpContext));
         }
 
         [Fact]
@@ -914,9 +932,9 @@ namespace Microsoft.AspNetCore.Routing.Internal
         }
 
         [Fact]
-        public async Task BindAsyncExceptionsThrowException()
+        public async Task BindAsyncExceptionsAreUncaught()
         {
-            // Not supplying any headers will cause the HttpContext TryParse overload to fail.
+            // Not supplying any headers will cause the HttpContext BindAsync overload to fail.
             var httpContext = CreateHttpContext();
 
             var factoryResult = RequestDelegateFactory.Create((MyBindAsyncTypeThatThrows arg1) => { });
@@ -2122,22 +2140,107 @@ namespace Microsoft.AspNetCore.Routing.Internal
             }
         }
 
-        [Fact]
-        public async Task RequestDelegateDoesSupportBindAsyncOptionality()
+        public static IEnumerable<object?[]> BindAsyncParamOptionalityData
+        {
+            get
+            {
+                void requiredReferenceType(HttpContext context, MyBindAsyncRecord myBindAsyncRecord)
+                {
+                    context.Items["uri"] = myBindAsyncRecord.Uri;
+                }
+                void defaultReferenceType(HttpContext context, MyBindAsyncRecord? myBindAsyncRecord = null)
+                {
+                    context.Items["uri"] = myBindAsyncRecord?.Uri;
+                }
+                void nullableReferenceType(HttpContext context, MyBindAsyncRecord? myBindAsyncRecord)
+                {
+                    context.Items["uri"] = myBindAsyncRecord?.Uri;
+                }
+
+
+                void requiredValueType(HttpContext context, MyNullableBindAsyncStruct myNullableBindAsyncStruct)
+                {
+                    context.Items["uri"] = myNullableBindAsyncStruct.Uri;
+                }
+                void defaultValueType(HttpContext context, MyNullableBindAsyncStruct? myNullableBindAsyncStruct = null)
+                {
+                    context.Items["uri"] = myNullableBindAsyncStruct?.Uri;
+                }
+                void nullableValueType(HttpContext context, MyNullableBindAsyncStruct? myNullableBindAsyncStruct)
+                {
+                    context.Items["uri"] = myNullableBindAsyncStruct?.Uri;
+                }
+
+                return new object?[][]
+                {
+                    new object?[] { (Action<HttpContext, MyBindAsyncRecord>)requiredReferenceType, false, true, false },
+                    new object?[] { (Action<HttpContext, MyBindAsyncRecord>)requiredReferenceType, true, false, false, },
+
+                    new object?[] { (Action<HttpContext, MyBindAsyncRecord?>)defaultReferenceType, false, false, false, },
+                    new object?[] { (Action<HttpContext, MyBindAsyncRecord?>)defaultReferenceType, true, false, false },
+
+                    new object?[] { (Action<HttpContext, MyBindAsyncRecord?>)nullableReferenceType, false, false, false },
+                    new object?[] { (Action<HttpContext, MyBindAsyncRecord?>)nullableReferenceType, true, false, false },
+
+                    new object?[] { (Action<HttpContext, MyNullableBindAsyncStruct>)requiredValueType, false, true, true },
+                    new object?[] { (Action<HttpContext, MyNullableBindAsyncStruct>)requiredValueType, true, false, true },
+
+                    new object?[] { (Action<HttpContext, MyNullableBindAsyncStruct?>)defaultValueType, false, false, true },
+                    new object?[] { (Action<HttpContext, MyNullableBindAsyncStruct?>)defaultValueType, true, false, true },
+
+                    new object?[] { (Action<HttpContext, MyNullableBindAsyncStruct?>)nullableValueType, false, false, true },
+                    new object?[] { (Action<HttpContext, MyNullableBindAsyncStruct?>)nullableValueType, true, false, true },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(BindAsyncParamOptionalityData))]
+        public async Task RequestDelegateHandlesBindAsyncOptionality(Delegate routeHandler, bool includeReferer, bool isInvalid, bool isStruct)
         {
             var httpContext = CreateHttpContext();
-            var invoked = false;
 
-            var factoryResult = RequestDelegateFactory.Create((MyBindAsyncRecord? myBindAsyncRecord) =>
+            if (includeReferer)
             {
-                Assert.Null(myBindAsyncRecord);
-                invoked = true;
-            });
+                httpContext.Request.Headers.Referer = "https://example.org";
+            }
+
+            var factoryResult = RequestDelegateFactory.Create(routeHandler);
 
             var requestDelegate = factoryResult.RequestDelegate;
             await requestDelegate(httpContext);
 
-            Assert.True(invoked);
+            Assert.False(httpContext.RequestAborted.IsCancellationRequested);
+
+            if (isInvalid)
+            {
+                Assert.Equal(400, httpContext.Response.StatusCode);
+                var log = Assert.Single(TestSink.Writes);
+                Assert.Equal(LogLevel.Debug, log.LogLevel);
+                Assert.Equal(new EventId(4, "RequiredParameterNotProvided"), log.EventId);
+
+                if (isStruct)
+                {
+                    Assert.Equal(@"Required parameter ""MyNullableBindAsyncStruct myNullableBindAsyncStruct"" was not provided from MyNullableBindAsyncStruct.BindAsync(HttpContext, ParameterInfo).", log.Message);
+                }
+                else
+                {
+                    Assert.Equal(@"Required parameter ""MyBindAsyncRecord myBindAsyncRecord"" was not provided from MyBindAsyncRecord.BindAsync(HttpContext, ParameterInfo).", log.Message);
+                }
+            }
+            else
+            {
+                Assert.Equal(200, httpContext.Response.StatusCode);
+
+                if (includeReferer)
+                {
+                    Assert.Equal(new Uri("https://example.org"), httpContext.Items["uri"]);
+                }
+                else
+                {
+                    Assert.Null(httpContext.Items["uri"]);
+                }
+            }
         }
 
         public static IEnumerable<object?[]> ServiceParamOptionalityData

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         private readonly EndpointDataSource _endpointDataSource;
         private readonly IHostEnvironment _environment;
         private readonly IServiceProviderIsService? _serviceProviderIsService;
-        private readonly TryParseMethodCache TryParseMethodCache = new();
+        private readonly ParameterBindingMethodCache ParameterBindingMethodCache = new();
 
         // Executes before MVC's DefaultApiDescriptionProvider and GrpcHttpApiDescriptionProvider for no particular reason.
         public int Order => -1100;
@@ -202,12 +202,12 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                      parameter.ParameterType == typeof(HttpResponse) ||
                      parameter.ParameterType == typeof(ClaimsPrincipal) ||
                      parameter.ParameterType == typeof(CancellationToken) ||
-                     TryParseMethodCache.HasBindAsyncMethod(parameter) ||
+                     ParameterBindingMethodCache.HasBindAsyncMethod(parameter) ||
                      _serviceProviderIsService?.IsService(parameter.ParameterType) == true)
             {
                 return (BindingSource.Services, parameter.Name ?? string.Empty, false);
             }
-            else if (parameter.ParameterType == typeof(string) || TryParseMethodCache.HasTryParseStringMethod(parameter))
+            else if (parameter.ParameterType == typeof(string) || ParameterBindingMethodCache.HasTryParseMethod(parameter))
             {
                 // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
                 if (parameter.Name is { } name && pattern.GetParameter(name) is not null)

--- a/src/Mvc/Mvc.ApiExplorer/src/Microsoft.AspNetCore.Mvc.ApiExplorer.csproj
+++ b/src/Mvc/Mvc.ApiExplorer/src/Microsoft.AspNetCore.Mvc.ApiExplorer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(SharedSourceRoot)TryParseMethodCache.cs" />
+    <Compile Include="$(SharedSourceRoot)ParameterBindingMethodCache.cs" />
     <Compile Include="$(SharedSourceRoot)RoslynUtils\TypeHelper.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Today, if you want to support an optional parameter with BindAsync, you cannot use a nullable struct. This PR changes it so nullable structs are supported just like nullable reference types.

```C#
var builder = WebApplication.CreateBuilder(args);
var app = builder.Build();

// This will now use BindAsync rather than try to deserialize the struct from the request body as JSON.
app.MapGet("/webhook", (CloudEventStruct? cloudEvent) =>
{
    redis.Publish(cloudEvent);
});

app.Run();

public struct CloudEventStruct
{
	// This will now be matched because even though it returns returns a ValueTask<CloudEventStruct?>
    // instead of ValueTask<CloudEventStruct>
    public static async ValueTask<CloudEventStruct?> BindAsync(HttpContext context, ParameterInfo parameter)
    {
        return await CloudEventParser.ReadEventAsync(context, parameter.Name);
    }
}
```


Fixes #35839
