### PR TITLE
Update gitattributes to fix bootstrap CDN SRI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -77,3 +77,10 @@ gradlew eol=lf
 ###############################################################################
 jquery*.js eol=lf
 jquery*.map eol=lf
+
+###############################################################################
+# Make sure bootstrap files always have LF as line endings (to pass SRI checks)
+###############################################################################
+bootstrap*.js eol=lf
+bootstrap*.map eol=lf
+bootstrap*.css eol=lf


### PR DESCRIPTION
CDN integrity checks require byte for byte exact, so line endings are currently causing our CDN checks to fail

I reupdated the files in my repo but it didn't generate any diffs, so hopefully this will fix on a new build

Fixes: https://github.com/aspnet/AspNetCore-ManualTests/issues/865