### PR TITLE
Run user defined hosted services before the server starts.

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -77,8 +77,14 @@ namespace Microsoft.AspNetCore.Builder
 
             Configuration = new();
 
+            // Collect the hosted services separately since we want those to run after the user's hosted services
+            _services.TrackHostedServices = true;
+
             // This is the application configuration
             var hostContext = _bootstrapHostBuilder.RunDefaultCallbacks(Configuration, _hostBuilder);
+
+            // Stop tracking here
+            _services.TrackHostedServices = false;
 
             // Grab the WebHostBuilderContext from the property bag to use in the ConfigureWebHostBuilder
             var webHostContext = (WebHostBuilderContext)hostContext.Properties[typeof(WebHostBuilderContext)];
@@ -154,6 +160,17 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     services.Add(s);
                 }
+
+                // Add the hosted services that were initially added last
+                // this makes sure any hosted services that are added run after the initial set
+                // of hosted services. This means hosted services run before the web host starts.
+                foreach (var s in _services.HostedServices)
+                {
+                    services.Add(s);
+                }
+
+                // Clear the hosted services list out
+                _services.HostedServices.Clear();
 
                 // Add any services to the user visible service collection so that they are observable
                 // just in case users capture the Services property. Orchard does this to get a "blueprint"

--- a/src/DefaultBuilder/src/WebApplicationServiceCollection.cs
+++ b/src/DefaultBuilder/src/WebApplicationServiceCollection.cs
@@ -1,19 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.AspNetCore
 {
     internal sealed class WebApplicationServiceCollection : IServiceCollection
     {
         private IServiceCollection _services = new ServiceCollection();
+
+        public List<ServiceDescriptor> HostedServices { get; } = new();
+
+        public bool TrackHostedServices { get; set; }
 
         public ServiceDescriptor this[int index]
         {
@@ -42,7 +42,14 @@ namespace Microsoft.AspNetCore
         {
             CheckServicesAccess();
 
-            _services.Add(item);
+            if (TrackHostedServices && item.ServiceType == typeof(IHostedService))
+            {
+                HostedServices.Add(item);
+            }
+            else
+            {
+                _services.Add(item);
+            }
         }
 
         public void Clear()

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -140,6 +140,67 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task HostedServicesRunBeforeTheServerStarts()
+        {
+            var builder = WebApplication.CreateBuilder();
+            var startOrder = new List<object>();
+            var server = new MockServer(startOrder);
+            var hostedService = new HostedService(startOrder);
+            builder.Services.AddSingleton<IHostedService>(hostedService);
+            builder.Services.AddSingleton<IServer>(server);
+            await using var app = builder.Build();
+
+            await app.StartAsync();
+
+            Assert.Equal(2, startOrder.Count);
+            Assert.Same(hostedService, startOrder[0]);
+            Assert.Same(server, startOrder[1]);
+        }
+
+        class HostedService : IHostedService
+        {
+            private readonly List<object> _startOrder;
+
+            public HostedService(List<object> startOrder)
+            {
+                _startOrder = startOrder;
+            }
+
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                _startOrder.Add(this);
+                return Task.CompletedTask;
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        class MockServer : IServer
+        {
+            private readonly List<object> _startOrder;
+
+            public MockServer(List<object> startOrder)
+            {
+                _startOrder = startOrder;
+            }
+
+            public IFeatureCollection Features { get; } = new FeatureCollection();
+
+            public void Dispose() { }
+
+            public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken) where TContext : notnull
+            {
+                _startOrder.Add(this);
+                return Task.CompletedTask;
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
         public async Task WebApplicationRunUrls_ThrowsInvalidOperationExceptionIfThereIsNoIServerAddressesFeature()
         {
             var builder = WebApplication.CreateBuilder();
@@ -364,9 +425,9 @@ namespace Microsoft.AspNetCore.Tests
                     // Verify the defaults observed by the boostrap host builder we use internally to populate
                     // the defaults
                     bootstrapBuilder.ConfigureAppConfiguration((context, config) =>
-                    {
-                        Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
-                    });
+                {
+                    Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+                });
                 });
 
             Assert.Equal(assemblyName, builder.Environment.ApplicationName);
@@ -405,9 +466,9 @@ namespace Microsoft.AspNetCore.Tests
                     // Verify the defaults observed by the boostrap host builder we use internally to populate
                     // the defaults
                     bootstrapBuilder.ConfigureAppConfiguration((context, config) =>
-                    {
-                        Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
-                    });
+                {
+                    Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+                });
                 });
 
             Assert.Equal(assemblyName, builder.Environment.ApplicationName);

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -425,9 +425,9 @@ namespace Microsoft.AspNetCore.Tests
                     // Verify the defaults observed by the boostrap host builder we use internally to populate
                     // the defaults
                     bootstrapBuilder.ConfigureAppConfiguration((context, config) =>
-                {
-                    Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
-                });
+                    {
+                        Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+                    });
                 });
 
             Assert.Equal(assemblyName, builder.Environment.ApplicationName);
@@ -466,9 +466,9 @@ namespace Microsoft.AspNetCore.Tests
                     // Verify the defaults observed by the boostrap host builder we use internally to populate
                     // the defaults
                     bootstrapBuilder.ConfigureAppConfiguration((context, config) =>
-                {
-                    Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
-                });
+                    {
+                        Assert.Equal(assemblyName, context.HostingEnvironment.ApplicationName);
+                    });
                 });
 
             Assert.Equal(assemblyName, builder.Environment.ApplicationName);


### PR DESCRIPTION
- The generic web hosted service is added before any user code runs, as a result it's impossible to write a hosted services that run before server startup. This behavior differs from what happens when you use the Startup class today. We call ConfigureServices then we add the IHostedService implementation that starts the server. This change mimics that behavior by adding the initial set of hosted services after your code runs.
- Added a test

Fixes #35454 