### PR TITLE
Handle ERROR_CONNECTION_INVALID after ERROR_MORE_DATA 

### DIFF
--- a/src/Servers/HttpSys/src/AsyncAcceptContext.cs
+++ b/src/Servers/HttpSys/src/AsyncAcceptContext.cs
@@ -131,8 +131,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                     && _requestContext.RequestId != 0)
                 {
                     // ERROR_CONNECTION_INVALID:
-                    // The client reset the connection between the time we got the MORE_DATA error and when called HttpReceiveHttpRequest
-                    // with the new new buffer. We can clear the request id and move on to the next request.
+                    // The client reset the connection between the time we got the MORE_DATA error and when we called HttpReceiveHttpRequest
+                    // with the new buffer. We can clear the request id and move on to the next request.
                     //
                     // ERROR_INVALID_PARAMETER: Historical check from HttpListener.
                     // https://referencesource.microsoft.com/#System/net/System/Net/_ListenerAsyncResult.cs,137


### PR DESCRIPTION
Fixes #35892
6.0-rc2 candidate.

HttpSys uses 4kb buffers to dequeue requests from the native queue. When a request is too large HttpReceiveHttpRequest returns ERROR_MORE_DATA with the real size, we allocate a new buffer and call HttpReceiveHttpRequest again with the specific request id.

Problem: The client can disconnect between the two calls to HttpReceiveHttpRequest. In that case the second call to HttpReceiveHttpRequest will return ERROR_CONNECTION_INVALID. This wasn't an expected error code so it bubbled up the stack and got logged at the Error level. The server tried again and remained healthy so the issue is only log noise.

This is a 6.0 candidate because unexpected Error level logs automatically trigger investigations for partner services.

There's no unit test for this because it's a very tight race condition and once it's handled there are no observable affects. See https://github.com/dotnet/aspnetcore/issues/35892#issuecomment-912674663 for the manual repro instructions.