### PR TITLE
Dispose the prior response on retry 

### DIFF
--- a/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -73,6 +73,7 @@ namespace Microsoft.Extensions.Http
     /// </remarks>
     public class PolicyHttpMessageHandler : DelegatingHandler
     {
+        private const string PriorResponseKey = "PolicyHttpMessageHandler.PriorResponse";
         private readonly IAsyncPolicy<HttpResponseMessage> _policy;
         private readonly Func<HttpRequestMessage, IAsyncPolicy<HttpResponseMessage>> _policySelector;
 
@@ -147,7 +148,7 @@ namespace Microsoft.Extensions.Http
         /// <param name="context">The <see cref="Context"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>Returns a <see cref="Task{HttpResponseMessage}"/> that will yield a response when completed.</returns>
-        protected virtual Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, Context context, CancellationToken cancellationToken)
+        protected virtual async Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, Context context, CancellationToken cancellationToken)
         {
             if (request == null)
             {
@@ -159,7 +160,18 @@ namespace Microsoft.Extensions.Http
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return base.SendAsync(request, cancellationToken);
+            if (request.Properties.TryGetValue(PriorResponseKey, out var priorResult) && priorResult is IDisposable disposable)
+            {
+                // This is a retry, dispose the prior response to free up the connection.
+                request.Properties.Remove(PriorResponseKey);
+                disposable.Dispose();
+            }
+
+            var result = await base.SendAsync(request, cancellationToken);
+
+            request.Properties.Add(PriorResponseKey, result);
+
+            return result;
         }
 
         private IAsyncPolicy<HttpResponseMessage> SelectPolicy(HttpRequestMessage request)


### PR DESCRIPTION
Fixes #28384
6.0 rc2 candidate: resource leak / hang

- The HttpResponseMessage needs to be buffered, drained, or disposed to free up the connection for the next request.
- Polly is a generic policy library, it's not aware of HttpRequest/ResponseMessage lifetimes or the need to dispose them on retry. Polly.Extensions.Http is aware of HttpRequest/ResponseMessage but doesn't participate in the retry execution, only the decision on if a retry is recommended.

Fix: Add a reference from the request to the response so that if the request is retried, it can dispose the prior response.