### PR TITLE
Have kestrel filter out pseudo headers 

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -227,7 +227,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x2L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x2L;
+                }
+                else
+                {
+                    _bits &= ~0x2L;
+                }
                 _headers._Connection = value; 
             }
         }
@@ -244,7 +251,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x4L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x4L;
+                }
+                else
+                {
+                    _bits &= ~0x4L;
+                }
                 _headers._Host = value; 
             }
         }
@@ -261,7 +275,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x10L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x10L;
+                }
+                else
+                {
+                    _bits &= ~0x10L;
+                }
                 _headers._Authority = value; 
             }
         }
@@ -278,7 +299,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x20L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x20L;
+                }
+                else
+                {
+                    _bits &= ~0x20L;
+                }
                 _headers._Method = value; 
             }
         }
@@ -295,7 +323,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x40L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x40L;
+                }
+                else
+                {
+                    _bits &= ~0x40L;
+                }
                 _headers._Path = value; 
             }
         }
@@ -312,7 +347,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x80L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x80L;
+                }
+                else
+                {
+                    _bits &= ~0x80L;
+                }
                 _headers._Scheme = value; 
             }
         }
@@ -329,7 +371,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x20000000000L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x20000000000L;
+                }
+                else
+                {
+                    _bits &= ~0x20000000000L;
+                }
                 _headers._TransferEncoding = value; 
             }
         }
@@ -8234,7 +8283,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x1L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x1L;
+                }
+                else
+                {
+                    _bits &= ~0x1L;
+                }
                 _headers._Connection = value; 
                 _headers._rawConnection = null;
             }
@@ -8252,7 +8308,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x1000L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x1000L;
+                }
+                else
+                {
+                    _bits &= ~0x1000L;
+                }
                 _headers._Allow = value; 
             }
         }
@@ -8269,7 +8332,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x2000L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x2000L;
+                }
+                else
+                {
+                    _bits &= ~0x2000L;
+                }
                 _headers._AltSvc = value; 
                 _headers._rawAltSvc = null;
             }
@@ -8287,7 +8357,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
             set
             {
-                _bits |= 0x100000000L;
+                if (!StringValues.IsNullOrEmpty(value))
+                {
+                    _bits |= 0x100000000L;
+                }
+                else
+                {
+                    _bits &= ~0x100000000L;
+                }
                 _headers._TransferEncoding = value; 
                 _headers._rawTransferEncoding = null;
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -248,13 +248,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // enabling the use of HTTP to interact with non - HTTP services.
             // A common example is TLS termination.
             var headerScheme = HttpRequestHeaders.HeaderScheme.ToString();
+            HttpRequestHeaders.HeaderScheme = default; // Suppress pseduo headers from the public headers collection.
             if (!ReferenceEquals(headerScheme, Scheme) &&
                 !string.Equals(headerScheme, Scheme, StringComparison.OrdinalIgnoreCase))
             {
                 if (!ServerOptions.AllowAlternateSchemes || !Uri.CheckSchemeName(headerScheme))
                 {
                     ResetAndAbort(new ConnectionAbortedException(
-                        CoreStrings.FormatHttp2StreamErrorSchemeMismatch(HttpRequestHeaders.HeaderScheme, Scheme)), Http2ErrorCode.PROTOCOL_ERROR);
+                        CoreStrings.FormatHttp2StreamErrorSchemeMismatch(headerScheme, Scheme)), Http2ErrorCode.PROTOCOL_ERROR);
                     return false;
                 }
 
@@ -264,6 +265,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // :path (and query) - Required
             // Must start with / except may be * for OPTIONS
             var path = HttpRequestHeaders.HeaderPath.ToString();
+            HttpRequestHeaders.HeaderPath = default; // Suppress pseduo headers from the public headers collection.
             RawTarget = path;
 
             // OPTIONS - https://tools.ietf.org/html/rfc7540#section-8.1.2.3
@@ -301,6 +303,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             // :method
             _methodText = HttpRequestHeaders.HeaderMethod.ToString();
+            HttpRequestHeaders.HeaderMethod = default; // Suppress pseduo headers from the public headers collection.
             Method = HttpUtilities.GetKnownMethod(_methodText);
 
             if (Method == HttpMethod.None)
@@ -327,6 +330,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             // Prefer this over Host
 
             var authority = HttpRequestHeaders.HeaderAuthority;
+            HttpRequestHeaders.HeaderAuthority = default; // Suppress pseduo headers from the public headers collection.
             var host = HttpRequestHeaders.HeaderHost;
             if (!StringValues.IsNullOrEmpty(authority))
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -787,12 +787,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             // proxy or gateway can translate requests for non - HTTP schemes,
             // enabling the use of HTTP to interact with non - HTTP services.
             var headerScheme = HttpRequestHeaders.HeaderScheme.ToString();
+            HttpRequestHeaders.HeaderScheme = default; // Suppress pseduo headers from the public headers collection.
             if (!ReferenceEquals(headerScheme, Scheme) &&
                 !string.Equals(headerScheme, Scheme, StringComparison.OrdinalIgnoreCase))
             {
                 if (!ServerOptions.AllowAlternateSchemes || !Uri.CheckSchemeName(headerScheme))
                 {
-                    var str = CoreStrings.FormatHttp3StreamErrorSchemeMismatch(RequestHeaders[HeaderNames.Scheme], Scheme);
+                    var str = CoreStrings.FormatHttp3StreamErrorSchemeMismatch(headerScheme, Scheme);
                     Abort(new ConnectionAbortedException(str), Http3ErrorCode.ProtocolError);
                     return false;
                 }
@@ -802,7 +803,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
             // :path (and query) - Required
             // Must start with / except may be * for OPTIONS
-            var path = RequestHeaders[HeaderNames.Path].ToString();
+            var path = HttpRequestHeaders.HeaderPath.ToString();
+            HttpRequestHeaders.HeaderPath = default; // Suppress pseduo headers from the public headers collection.
             RawTarget = path;
 
             // OPTIONS - https://tools.ietf.org/html/rfc7540#section-8.1.2.3
@@ -840,7 +842,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         private bool TryValidateMethod()
         {
             // :method
-            _methodText = RequestHeaders[HeaderNames.Method].ToString();
+            _methodText = HttpRequestHeaders.HeaderMethod.ToString();
+            HttpRequestHeaders.HeaderMethod = default; // Suppress pseduo headers from the public headers collection.
             Method = HttpUtilities.GetKnownMethod(_methodText);
 
             if (Method == Http.HttpMethod.None)
@@ -866,7 +869,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             // :authority (optional)
             // Prefer this over Host
 
-            var authority = RequestHeaders[HeaderNames.Authority];
+            var authority = HttpRequestHeaders.HeaderAuthority;
+            HttpRequestHeaders.HeaderAuthority = default; // Suppress pseduo headers from the public headers collection.
             var host = HttpRequestHeaders.HeaderHost;
             if (!StringValues.IsNullOrEmpty(authority))
             {

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -843,7 +843,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }}
             set
             {{
-                {header.SetBit()};
+                if (!StringValues.IsNullOrEmpty(value))
+                {{
+                    {header.SetBit()};
+                }}
+                else
+                {{
+                    {header.ClearBit()};
+                }}
                 _headers._{header.Identifier} = value; {(header.EnhancedSetter == false ? "" : $@"
                 _headers._raw{header.Identifier} = null;")}
             }}")}

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -432,6 +432,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await InitializeConnectionAsync(context =>
             {
                 Assert.Equal(scheme, context.Request.Scheme);
+                Assert.False(context.Request.Headers.ContainsKey(HeaderNames.Scheme));
                 return Task.CompletedTask;
             });
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -136,6 +136,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected readonly Dictionary<string, string> _receivedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         protected readonly Dictionary<string, string> _receivedTrailers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         protected readonly Dictionary<string, string> _decodedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        protected readonly RequestFields _receivedRequestFields = new RequestFields();
         protected readonly HashSet<int> _abortedStreamIds = new HashSet<int>();
         protected readonly object _abortedStreamIdsLock = new object();
         protected readonly TaskCompletionSource _closingStateReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -195,6 +196,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _readHeadersApplication = context =>
             {
+                _receivedRequestFields.Method = context.Request.Method;
+                _receivedRequestFields.Scheme = context.Request.Scheme;
+                _receivedRequestFields.Path = context.Request.Path.Value;
+                _receivedRequestFields.RawTarget = context.Features.Get<IHttpRequestFeature>().RawTarget;
                 foreach (var header in context.Request.Headers)
                 {
                     _receivedHeaders[header.Key] = header.Value.ToString();
@@ -217,6 +222,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 Assert.True(context.Request.SupportsTrailers(), "SupportsTrailers");
                 Assert.True(context.Request.CheckTrailersAvailable(), "SupportsTrailers");
 
+                _receivedRequestFields.Method = context.Request.Method;
+                _receivedRequestFields.Scheme = context.Request.Scheme;
+                _receivedRequestFields.Path = context.Request.Path.Value;
+                _receivedRequestFields.RawTarget = context.Features.Get<IHttpRequestFeature>().RawTarget;
                 foreach (var header in context.Request.Headers)
                 {
                     _receivedHeaders[header.Key] = header.Value.ToString();
@@ -350,6 +359,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             _echoMethodNoBody = context =>
             {
                 Assert.False(context.Request.CanHaveBody());
+                Assert.False(context.Request.Headers.ContainsKey(HeaderNames.Method));
                 context.Response.Headers["Method"] = context.Request.Method;
 
                 return Task.CompletedTask;
@@ -357,6 +367,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _echoHost = context =>
             {
+                Assert.False(context.Request.Headers.ContainsKey(HeaderNames.Authority));
                 context.Response.Headers.Host = context.Request.Headers.Host;
 
                 return Task.CompletedTask;
@@ -364,6 +375,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
 
             _echoPath = context =>
             {
+                Assert.False(context.Request.Headers.ContainsKey(HeaderNames.Path));
                 context.Response.Headers["path"] = context.Request.Path.ToString();
                 context.Response.Headers["rawtarget"] = context.Features.Get<IHttpRequestFeature>().RawTarget;
 
@@ -1240,8 +1252,28 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             foreach (var header in expectedHeaders)
             {
-                Assert.True(_receivedHeaders.TryGetValue(header.Key, out var value), header.Key);
-                Assert.Equal(header.Value, value, ignoreCase: true);
+                if (header.Key == HeaderNames.Method)
+                {
+                    Assert.Equal(header.Value, _receivedRequestFields.Method);
+                }
+                else if (header.Key == HeaderNames.Authority)
+                {
+                    Assert.True(_receivedHeaders.TryGetValue(HeaderNames.Host, out var host), header.Key);
+                    Assert.Equal(header.Value, host);
+                }
+                else if (header.Key == HeaderNames.Scheme)
+                {
+                    Assert.Equal(header.Value, _receivedRequestFields.Scheme);
+                }
+                else if (header.Key == HeaderNames.Path)
+                {
+                    Assert.Equal(header.Value, _receivedRequestFields.RawTarget);
+                }
+                else
+                {
+                    Assert.True(_receivedHeaders.TryGetValue(header.Key, out var value), header.Key);
+                    Assert.Equal(header.Value, value, ignoreCase: true);
+                }
             }
         }
 
@@ -1389,6 +1421,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             {
                 return _realTimeoutControl.GetResponseDrainDeadline(ticks, minRate);
             }
+        }
+
+        public class RequestFields
+        {
+            public string Method { get; set; }
+            public string Scheme { get; set; }
+            public string Path { get; set; }
+            public string RawTarget { get; set; }
         }
     }
 }


### PR DESCRIPTION
Fixes #30417
6.0 rc2 candidate: interoperability

HTTP/2 & 3 use pseudo headers for special values like method, path, authority, scheme, etc., but they have lots of constraints about where they can be placed, only using reserved ones, etc.. These fields are also available elsewhere in the request.

https://tools.ietf.org/html/rfc7540#section-8.1.2.1
> Pseudo-header fields are not HTTP header fields. 

As a result, other http header APIs won't accept them as input. E.g. HttpRequestMessage, WebHeaderCollection, etc.. This means components that copy request headers from Kestrel have to filter these out. E.g. YARP, WCF, gateways, etc..

https://github.com/microsoft/reverse-proxy/blob/a3247ba1168325f46ab0ee4a24d3de1d9acdd853/src/ReverseProxy/Service/Proxy/HttpTransformer.cs#L49-L53
```C#
// Filter out HTTP/2 pseudo headers like ":method" and ":path", those go into other fields.
if (headerName.Length > 0 && headerName[0] == ':')
{
    continue;
}
```

Http.Sys and IIS also filter out pseudo headers.

Side note: I noticed that the new header properties don't support removal. I've updated them.