### PR TITLE
Add build troubleshooting suggestion

### DIFF
--- a/docs/BuildErrors.md
+++ b/docs/BuildErrors.md
@@ -99,7 +99,7 @@ or
 ./build.sh --projects "$PWD/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj"
 ```
 
-## Miscellaneous other errors
+## Errors when restoring older clones
 
 If you have build errors trying to run `restore.cmd` and you cloned the repository some time ago,
 try deleting the `.dotnet` and `.tools` directories in your local repo directory. It may resolve

--- a/docs/BuildErrors.md
+++ b/docs/BuildErrors.md
@@ -98,3 +98,9 @@ or
 ```bash
 ./build.sh --projects "$PWD/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj"
 ```
+
+## Miscellaneous other errors
+
+If you have build errors trying to run `restore.cmd` and you cloned the repository some time ago,
+try deleting the `.dotnet` and `.tools` directories in your local repo directory. It may resolve
+the problem if older versions of the .NET SDK are causing an incompatibility with the latest version.

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -211,10 +211,6 @@ to open the .sln file or one of the project specific .slnf files to work on the 
 > :bulb: Rerunning the above command or, perhaps, the quicker `.\build.cmd -noBuildNative -noBuildManaged` may be
 > necessary after switching branches, especially if the `$(DefaultNetCoreTargetFramework)` value changes.
 
-
-> :bulb: If you have build errors trying to run `restore.cmd` and you cloned the repository some time ago,
-> try deleting the `.dotnet` and `.tools` directories in your local repo folder. It may resolve the problem.
-
 Typically, you want to focus on a single project within this large repo. For example,
 if you want to work on Blazor WebAssembly, you'll need to launch the solution file for that project by changing into the `src/Components`
 directory and executing `startvs.cmd` in that directory like so:

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -211,6 +211,10 @@ to open the .sln file or one of the project specific .slnf files to work on the 
 > :bulb: Rerunning the above command or, perhaps, the quicker `.\build.cmd -noBuildNative -noBuildManaged` may be
 > necessary after switching branches, especially if the `$(DefaultNetCoreTargetFramework)` value changes.
 
+
+> :bulb: If you have build errors trying to run `restore.cmd` and you cloned the repository some time ago,
+> try deleting the `.dotnet` and `.tools` directories in your local repo folder. It may resolve the problem.
+
 Typically, you want to focus on a single project within this large repo. For example,
 if you want to work on Blazor WebAssembly, you'll need to launch the solution file for that project by changing into the `src/Components`
 directory and executing `startvs.cmd` in that directory like so:


### PR DESCRIPTION
**PR Title**

Add local build troubleshooting suggestion

**PR Description**

Add a note about deleting SDK and tools locally if `restore.cmd` fails.

After syncing my local branch with main since it updated from RC1 to RC2/7.0, `restore.cmd` was failing for me with errors about not being able to find a `WorkloadManifest.json` file.

After some tinkering and trying a build and clone on a different machine, I found that deleting the `.dotnet` and `.tools` folders resolved the problem. I guess something left over from an earlier 6.0 SDK was conflicting with the latest.
