### PR TITLE
DisposeAsync the FileStream

### DIFF
--- a/src/Http/Http.Extensions/src/SendFileResponseExtensions.cs
+++ b/src/Http/Http.Extensions/src/SendFileResponseExtensions.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Http
             if (string.IsNullOrEmpty(file.PhysicalPath))
             {
                 CheckRange(offset, count, file.Length);
-                using var fileContent = file.CreateReadStream();
+                await using var fileContent = file.CreateReadStream();
 
                 var useRequestAborted = !cancellationToken.CanBeCanceled;
                 var localCancel = useRequestAborted ? response.HttpContext.RequestAborted : cancellationToken;


### PR DESCRIPTION
Is it better to `DisposeAsync` the file stream rather than `Dispose`?