### PR TITLE
Avoid creating StaticFileResponseContext if OnPrepareResponse has not been set

### DIFF
--- a/src/Middleware/StaticFiles/src/StaticFileContext.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileContext.cs
@@ -265,7 +265,10 @@ namespace Microsoft.AspNetCore.StaticFiles
                 _response.ContentLength = _length;
             }
 
-            _options.OnPrepareResponse(new StaticFileResponseContext(_context, _fileInfo));
+            if (_options.OnPrepareResponse != StaticFileOptions._defaultOnPrepareResponse)
+            {
+                _options.OnPrepareResponse(new StaticFileResponseContext(_context, _fileInfo));
+            }
         }
 
         public PreconditionState GetPreconditionState()

--- a/src/Middleware/StaticFiles/src/StaticFileOptions.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileOptions.cs
@@ -13,6 +13,8 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public class StaticFileOptions : SharedOptionsBase
     {
+        internal static readonly Action<StaticFileResponseContext> _defaultOnPrepareResponse = _ => { };
+
         /// <summary>
         /// Defaults to all request paths
         /// </summary>
@@ -26,7 +28,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="sharedOptions"></param>
         public StaticFileOptions(SharedOptions sharedOptions) : base(sharedOptions)
         {
-            OnPrepareResponse = _ => { };
+            OnPrepareResponse = _defaultOnPrepareResponse;
         }
 
         /// <summary>


### PR DESCRIPTION
The allocation of `StaticFileResponseContext` could be avoided if `OnPrepareResponse` is the default value.

I think also the allocation could be completely avoided by changing `StaticFileResponseContext` to `readonly struct`, but that would be a breaking change. Although it could be done by obsoleting `OnPrepareResponse` and creating a new property.