### PR TITLE
[release/6.0 Cleanup remaining SSP references

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -121,12 +121,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <ItemGroup>
       <!-- Exclude transitive external dependencies that are not directly referenced in AspNetCore or Runtime. -->
       <_DisallowedReferenceAssemblies Include="
-          Microsoft.Win32.SystemEvents.dll;
-          System.Drawing.Common.dll;
           System.Net.Quic.dll;
-          System.Security.Cryptography.Pkcs.dll;
-          System.Security.Permissions.dll;
-          System.Windows.Extensions.dll" />
+          System.Security.Cryptography.Pkcs.dll" />
       <_AvailableRuntimeRefAssemblies Include="$(RuntimeTransportReferenceDirectory)*.dll"
           Exclude="@(_DisallowedReferenceAssemblies->'$(RuntimeTransportReferenceDirectory)%(Filename)%(Extension)')" />
     </ItemGroup>
@@ -141,13 +137,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Include="@(ReferencePathWithRefAssemblies)"
           Exclude="
             @(_ReferencedRuntimeRefAssemblies);
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'Microsoft.NETCore.App.Ref'));
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'Microsoft.Win32.SystemEvents'));
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Drawing.Common'));
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Net.Quic'));
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Security.Cryptography.Pkcs'));
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Security.Permissions'));
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Windows.Extensions'));" />
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'Microsoft.NETCore.App.Ref'))" />
 
       <AspNetCoreReferenceAssemblyPath
           Include="@(_ReferencedRuntimeRefAssemblies->'$(RuntimeTransportReferenceDirectory)%(FileName)%(Extension)')" />

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -120,9 +120,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           DependsOnTargets="ResolveReferences;FindReferenceAssembliesForReferences">
     <ItemGroup>
       <!-- Exclude transitive external dependencies that are not directly referenced in AspNetCore or Runtime. -->
-      <_DisallowedReferenceAssemblies Include="
-          System.Net.Quic.dll;
-          System.Security.Cryptography.Pkcs.dll" />
+      <_DisallowedReferenceAssemblies Include="System.Net.Quic.dll; System.Security.Cryptography.Pkcs.dll" />
       <_AvailableRuntimeRefAssemblies Include="$(RuntimeTransportReferenceDirectory)*.dll"
           Exclude="@(_DisallowedReferenceAssemblies->'$(RuntimeTransportReferenceDirectory)%(Filename)%(Extension)')" />
     </ItemGroup>
@@ -132,12 +130,22 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </JoinItems>
 
     <ItemGroup>
-      <!-- Again, ignore ref/ assemblies provided in the transport package that we don't want in this package. -->
+      <!--
+        Grab full dependency closure but exclude Microsoft.NETCore.App.Ref assets (avoid duplicates) and
+        Microsoft.Internal.Runtime.AspNetCore.Transport assets (almost all added just below).
+
+        Filename exclusions are due to implementation assemblies creeping into the closure. Reference assemblies
+        for all are available in the transport package though System.Security.Cryptography.Pkcs is excluded.
+      -->
       <AspNetCoreReferenceAssemblyPath
           Include="@(ReferencePathWithRefAssemblies)"
           Exclude="
-            @(_ReferencedRuntimeRefAssemblies);
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'Microsoft.NETCore.App.Ref'))" />
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'Microsoft.NETCore.App.Ref'));
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('NuGetPackageId', 'Microsoft.Internal.Runtime.AspNetCore.Transport'));
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Diagnostics.EventLog'));
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.IO.Pipelines'));
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Security.Cryptography.Pkcs'));
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Security.Cryptography.Xml'))" />
 
       <AspNetCoreReferenceAssemblyPath
           Include="@(_ReferencedRuntimeRefAssemblies->'$(RuntimeTransportReferenceDirectory)%(FileName)%(Extension)')" />

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -119,8 +119,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           BeforeTargets="_GetPackageFiles"
           DependsOnTargets="ResolveReferences;FindReferenceAssembliesForReferences">
     <ItemGroup>
-      <!-- Exclude transitive external dependencies that are not directly referenced in AspNetCore or Runtime. -->
-      <_DisallowedReferenceAssemblies Include="System.Net.Quic.dll; System.Security.Cryptography.Pkcs.dll" />
+      <!-- Exclude a dependency that we don't want to expose. -->
+      <_DisallowedReferenceAssemblies Include="System.Net.Quic.dll" />
       <_AvailableRuntimeRefAssemblies Include="$(RuntimeTransportReferenceDirectory)*.dll"
           Exclude="@(_DisallowedReferenceAssemblies->'$(RuntimeTransportReferenceDirectory)%(Filename)%(Extension)')" />
     </ItemGroup>
@@ -135,7 +135,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
         Microsoft.Internal.Runtime.AspNetCore.Transport assets (almost all added just below).
 
         Filename exclusions are due to implementation assemblies creeping into the closure. Reference assemblies
-        for all are available in the transport package though System.Security.Cryptography.Pkcs is excluded.
+        for all but System.Security.Cryptography.Pkcs are available in the transport package.
       -->
       <AspNetCoreReferenceAssemblyPath
           Include="@(ReferencePathWithRefAssemblies)"


### PR DESCRIPTION
- follow up to e58a6c2
- remove references to System.Security.Permissions or its closure
  - only mentions are in eng/PackageOverrides.txt and eng/PlatformManifest.txt
  - those files will remain unused until we update them in the run-up to 6.0.1
- still indirectly pick up package refs for SSP and its closure but that does not impact targeting pack content

nit: Only need to exclude System.Net.Quic and System.Security.Cryptography.Pkcs from `@(_AvailableRuntimeRefAssemblies)`
  - assemblies are not in `@(ReferencePathWithRefAssemblies)`, just the transport package