### PR TITLE
Update facebook oauth to v11.0

### DIFF
--- a/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
@@ -24,16 +24,16 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         /// <remarks>
         /// For more details about this endpoint, see https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login.
         /// </remarks>
-        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v8.0/dialog/oauth";
+        public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v11.0/dialog/oauth";
 
         /// <summary>
         /// The OAuth endpoint used to retrieve access tokens.
         /// </summary>
-        public static readonly string TokenEndpoint = "https://graph.facebook.com/v8.0/oauth/access_token";
+        public static readonly string TokenEndpoint = "https://graph.facebook.com/v11.0/oauth/access_token";
 
         /// <summary>
         /// The Facebook Graph API endpoint that is used to gather additional user information.
         /// </summary>
-        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v8.0/me";
+        public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v11.0/me";
     }
 }

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/base/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v8.0/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v11.0/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/base/signin-facebook"), location);
@@ -266,7 +266,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/login");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v8.0/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v11.0/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/signin-facebook"), location);
@@ -301,7 +301,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             var transaction = await server.SendAsync("http://example.com/challenge");
             Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            Assert.Contains("https://www.facebook.com/v8.0/dialog/oauth", location);
+            Assert.Contains("https://www.facebook.com/v11.0/dialog/oauth", location);
             Assert.Contains("response_type=code", location);
             Assert.Contains("client_id=", location);
             Assert.Contains("redirect_uri=", location);


### PR DESCRIPTION
Contributes to #4684

We update these values to their latest each release to prevent warnings from using outdated versions. No behavior changes were observed.

I also tested Twitter, Google, and Microsoft, but no updates were required there.

Backport to .NET 6