### PR TITLE
Correct the docs on ISession.IsAvailable 

### DIFF
--- a/src/Http/Http.Features/src/ISession.cs
+++ b/src/Http/Http.Features/src/ISession.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Http
     public interface ISession
     {
         /// <summary>
-        /// Indicate whether the current session has loaded.
+        /// Indicates whether the current session loaded successfully. Accessing this property before the session is loaded will cause it to be loaded inline.
         /// </summary>
         bool IsAvailable { get; }
 


### PR DESCRIPTION
Fixes #27733

IsAvailable does not mean "has the session been loaded yet?", it means "did it load without error?"