### PR TITLE
Un-redact safe request/response headers in HttpLoggingMiddleware

### DIFF
--- a/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
@@ -45,6 +45,8 @@ namespace Microsoft.AspNetCore.HttpLogging
             HeaderNames.Host,
             HeaderNames.MaxForwards,
             HeaderNames.Range,
+            HeaderNames.SecWebSocketExtensions,
+            HeaderNames.SecWebSocketVersion,
             HeaderNames.TE,
             HeaderNames.Trailer,
             HeaderNames.TransferEncoding,
@@ -70,6 +72,7 @@ namespace Microsoft.AspNetCore.HttpLogging
             HeaderNames.Age,
             HeaderNames.Allow,
             HeaderNames.AltSvc,
+            HeaderNames.Connection,
             HeaderNames.ContentDisposition,
             HeaderNames.ContentLanguage,
             HeaderNames.ContentLength,
@@ -83,6 +86,7 @@ namespace Microsoft.AspNetCore.HttpLogging
             HeaderNames.Server,
             HeaderNames.Status,
             HeaderNames.TransferEncoding,
+            HeaderNames.Upgrade,
             HeaderNames.XPoweredBy
         };
 

--- a/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
@@ -30,14 +30,29 @@ namespace Microsoft.AspNetCore.HttpLogging
         internal HashSet<string> _internalRequestHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             HeaderNames.Accept,
+            HeaderNames.AcceptCharset,
             HeaderNames.AcceptEncoding,
             HeaderNames.AcceptLanguage,
             HeaderNames.Allow,
+            HeaderNames.CacheControl,
             HeaderNames.Connection,
+            HeaderNames.ContentEncoding,
             HeaderNames.ContentLength,
             HeaderNames.ContentType,
+            HeaderNames.Date,
+            HeaderNames.DNT,
+            HeaderNames.Expect,
             HeaderNames.Host,
-            HeaderNames.UserAgent
+            HeaderNames.MaxForwards,
+            HeaderNames.Range,
+            HeaderNames.TE,
+            HeaderNames.Trailer,
+            HeaderNames.TransferEncoding,
+            HeaderNames.Upgrade,
+            HeaderNames.UserAgent,
+            HeaderNames.Warning,
+            HeaderNames.XRequestedWith,
+            HeaderNames.XUACompatible
         };
 
         /// <summary>
@@ -51,9 +66,24 @@ namespace Microsoft.AspNetCore.HttpLogging
 
         internal HashSet<string> _internalResponseHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
+            HeaderNames.AcceptRanges,
+            HeaderNames.Age,
+            HeaderNames.Allow,
+            HeaderNames.AltSvc,
+            HeaderNames.ContentDisposition,
+            HeaderNames.ContentLanguage,
             HeaderNames.ContentLength,
+            HeaderNames.ContentLocation,
+            HeaderNames.ContentRange,
             HeaderNames.ContentType,
-            HeaderNames.TransferEncoding
+            HeaderNames.Date,
+            HeaderNames.Expires,
+            HeaderNames.LastModified,
+            HeaderNames.Location,
+            HeaderNames.Server,
+            HeaderNames.Status,
+            HeaderNames.TransferEncoding,
+            HeaderNames.XPoweredBy
         };
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/36156 based on decisions made about safe headers for Yarp by @samsp-msft. Here's an example console log, from the SignalR SocialWeather sample:

> info: Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware[1]
      Request:
      Protocol: HTTP/1.1
      Method: GET
      Scheme: http
      PathBase:
      Path: /weather
      Connection: Upgrade
      Host: localhost:5000
      User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36
      Accept-Encoding: gzip, deflate, br
      Accept-Language: en-US,en;q=0.9
      Cache-Control: no-cache
      Origin: [Redacted]
      Pragma: [Redacted]
      Upgrade: websocket
      Sec-WebSocket-Version: [Redacted]
      Sec-WebSocket-Key: [Redacted]
      Sec-WebSocket-Extensions: [Redacted]

> info: Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware[2]
      Response:
      StatusCode: 101
      Connection: [Redacted]
      Date: Wed, 08 Sep 2021 22:42:54 GMT
      Server: Kestrel
      Upgrade: [Redacted]
      Sec-WebSocket-Accept: [Redacted]