### PR TITLE
PR benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,189 @@
+name: Run PR Benchmarks
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  benchmark:
+    # comments can be triggered on issues and prs, ensure this is a PR
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/benchmark')
+    # Comment out this line to test the scripts in a fork
+    # if: github.repository == 'dotnet/aspnetcore'
+    name: Benchmark Kestrel
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract benchmark argument
+      uses: actions/github-script@v4
+      id: benchmark-argument
+      with:
+        result-encoding: string
+        script: |
+          if (context.eventName !== "issue_comment") throw "Error: This action only works on issue_comment events.";
+
+          // extract the benchmark domain from the trigger phrase containing these characters: a-z, A-Z, digits, forward slash, dot, hyphen, underscore
+          const regex = /\/benchmark ([a-zA-Z\d\/\.\-\_]+)/;
+          benchmark_argument = regex.exec(context.payload.comment.body);
+          if (benchmark_argument == null || (benchmark_argument[1] != "kestrel" && benchmark_argument[1] != "mvc")) {
+              await github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "The `/benchmark` command must contain a domain from like __kestrel__, __mvc__. e.g., `/benchmark kestrel`"
+              });
+              throw `Error: Invalid benchmark command argument '${benchmark_argument[1]}'`;
+          }
+
+          return benchmark_argument[1];
+
+    - name: Check user's organization
+      uses: actions/github-script@v4
+      with:
+        script: |
+
+          const repo_owner = context.payload.repository.owner.login;
+          const repo_name = context.payload.repository.name;
+          const comment_user = context.payload.comment.user.login;
+
+          var membership = await github.repos.checkCollaborator({
+            owner: repo_owner,
+            repo: repo_name,
+            username: comment_user
+          });
+
+          console.log(`Verified ${comment_user} is a repo collaborator.`);
+
+    - name: Extract target branch
+      uses: actions/github-script@v4
+      id: target-branch-extractor
+      with:
+        script: |
+          const result = await github.request(context.payload.issue.pull_request.url)
+          const pull_request = result.data;
+          return pull_request.base.ref;
+
+    - name: Extract source repository
+      uses: actions/github-script@v4
+      id: source-repo-extractor
+      with:
+        script: |
+          const result = await github.request(context.payload.issue.pull_request.url)
+          const pull_request = result.data;
+          return pull_request.head.repo.clone_url;
+
+    - name: Extract source branch
+      uses: actions/github-script@v4
+      id: source-branch-extractor
+      with:
+        script: |
+          const result = await github.request(context.payload.issue.pull_request.url)
+          const pull_request = result.data;
+          return pull_request.head.ref;
+
+    - name: Checkout
+      run: |
+        rm -rf aspnetcore
+        git clone --recursive ${{ github.event.repository.clone_url }} aspnetcore
+
+    - name: Install crank
+      run: |
+        dotnet tool install Microsoft.Crank.Controller --version "0.2.0-*" --global
+
+    - name: Build base
+      working-directory: ./aspnetcore
+      run: |
+        git checkout ${{ steps.target-branch-extractor.outputs.result }}
+
+        if [ "${{ steps.benchmark-argument.outputs.result }}" = "kestrel" ]
+        then
+          echo "Building Kestrel"
+          cd ./src/Servers/Kestrel
+          ./build.sh -c release
+        elif [ "${{ steps.benchmark-argument.outputs.result }}" = "mvc" ]
+        then
+          echo "Building Mvc"
+          cd ./src/Mvc
+          ./build.sh -c release -NoBuildNodeJS
+        fi
+
+    - name: Benchmark base
+      working-directory: ./aspnetcore
+      env:
+        AZURE_RELAY: ${{ secrets.AZURE_RELAY }}
+      run: |
+        if [ "${{ steps.benchmark-argument.outputs.result }}" = "kestrel" ]
+        then
+          ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net6.0/"
+        elif [ "${{ steps.benchmark-argument.outputs.result }}" = "mvc" ]
+        then
+          ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario mvc --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Mvc.IntegrationTests/release/net6.0/"
+        fi
+
+        crank --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --profile aspnet-azure-lin-relay --relay AZURE_RELAY --json ../base.json $ARGUMENTS
+
+    - name: Build head
+      working-directory: ./aspnetcore
+      run: |
+        git fetch origin pull/${{ github.event.issue.number }}/head
+        git config --global user.name "user"
+        git config --global user.email "user@company.com"
+        git merge FETCH_HEAD
+
+        if [ "${{ steps.benchmark-argument.outputs.result }}" = "kestrel" ]
+        then
+          echo "Building Kestrel"
+          cd ./src/Servers/Kestrel
+          ./build.sh -c release
+        elif [ "${{ steps.benchmark-argument.outputs.result }}" = "mvc" ]
+        then
+          echo "Building Mvc"
+          cd ./src/Mvc
+          ./build.sh -c release -NoBuildNodeJS
+        fi
+
+    - name: Benchmark head
+      working-directory: ./aspnetcore
+      id: arguments
+      env:
+        AZURE_RELAY: ${{ secrets.AZURE_RELAY }}
+      run: |
+        if [ "${{ steps.benchmark-argument.outputs.result }}" = "kestrel" ]
+        then
+          ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net6.0/"
+        elif [ "${{ steps.benchmark-argument.outputs.result }}" = "mvc" ]
+        then
+          ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario mvc --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Mvc.IntegrationTests/release/net6.0/"
+        fi
+
+        crank --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --profile aspnet-azure-lin-relay --relay AZURE_RELAY --json ../head.json $ARGUMENTS
+        echo "::set-output name=result::$ARGUMENTS"
+    - name: Compare benchmarks
+      id: benchmark
+      run: |
+        crank compare base.json head.json > results.txt
+
+        cat results.txt
+
+        export RESULT=$'Arguments:\n```\n'"${{ steps.arguments.outputs.result }}"$'\n```\nResults:\n```\n'$(cat results.txt)$'\n```\n'
+
+        RESULT="${RESULT//'%'/'%25'}"
+        RESULT="${RESULT//$'\n'/'%0A'}"
+        RESULT="${RESULT//$'\r'/'%0D'}"
+        RESULT="${RESULT//$'`'/'\`'}"
+        echo $RESULT
+        echo "::set-output name=result::$(echo "$RESULT")"
+
+    - name: Report results
+      uses: actions/github-script@v4
+      with:
+        script: |
+          // The result contains new lines, so the generated script needs to wrap it in back-ticks
+          const body = `${{ steps.benchmark.outputs.result }}`;
+
+          await github.issues.createComment({
+            issue_number: context.payload.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          });
+
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,13 +29,6 @@ jobs:
           const repo_name = context.payload.repository.name;
           const comment_user = context.payload.comment.user.login;
 
-          core.info(`Loading ${context.payload.issue.pull_request.url}.`);
-
-          const pull_request = (await github.request(context.payload.issue.pull_request.url)).data;
-          const target_branch = pull_request.base.ref;
-          const source_repository = pull_request.head.repo.clone_url;
-          const source_branch = pull_request.head.ref;
-
           try {
             var membership = await github.repos.checkCollaborator({
               owner: repo_owner,

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
 
           core.info(`Verified ${comment_user} is a repo collaborator.`);
 
-          // Verify this action is and PR comment
+          // Verify this action is a PR comment
 
           if (context.eventName !== "issue_comment") throw "Error: This action only works on issue_comment events.";
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ jobs:
   benchmark:
     # Comments can be triggered on issues and prs, ensure this is a PR
     if: github.repository == 'dotnet/aspnetcore' && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/benchmark')
-    name: Benchmark Kestrel
+    name: Benchmark PR
     runs-on: ubuntu-latest
     steps:
     - name: Extract benchmark argument
@@ -21,6 +21,7 @@ jobs:
           const availableProfiles = {
             "kestrel": "Runs Plaintext on Kestrel changes.",
             "mvc": "Runs Plaintext on Mvc changes.",
+            "yarp": "Runs Yarp on Kestrel changes.",
           };
 
           // Verify the user is a collaborator
@@ -107,7 +108,42 @@ jobs:
       run: |
         CRANK_PROFILE="aspnet-perf-lin-relay"
         CRANK_CONFIGS="--config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true "
-        CRANK_ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net6.0/"
+        CRANK_ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net7.0/"
+
+        git checkout $GITHUB_BASE_REF
+
+        echo "Building Kestrel"
+        ./src/Servers/Kestrel/build.sh -c release
+
+        crank $CRANK_CONFIGS --profile $CRANK_PROFILE --relay AZURE_RELAY --json "$GITHUB_WORKSPACE/base.json" $CRANK_ARGUMENTS
+
+        git fetch origin pull/${{ github.event.issue.number }}/head
+        git config --global user.name "user"
+        git config --global user.email "user@company.com"
+        git merge FETCH_HEAD
+
+        echo "Building Kestrel"
+        ./src/Servers/Kestrel/build.sh -c release
+
+        crank $CRANK_CONFIGS --profile $CRANK_PROFILE --relay AZURE_RELAY --json "$GITHUB_WORKSPACE/head.json" $CRANK_ARGUMENTS
+
+        cd $GITHUB_WORKSPACE
+        echo "Arguments:"$'\n```\n'$"$CRANK_ARGUMENTS"$'\n```\n' >> results.txt
+        echo "Results:"$'\n```\n' >> results.txt
+        crank compare base.json head.json >> results.txt
+        echo $'\n```\n' >> results.txt
+
+        cat results.txt
+
+    - name: Benchmark Yarp
+      working-directory: ./aspnetcore
+      env:
+        AZURE_RELAY: ${{ secrets.AZURE_RELAY }}
+      if: ${{ steps.benchmark-argument.outputs.result == 'yarp' }}
+      run: |
+        CRANK_PROFILE="aspnet-perf-lin-relay"
+        CRANK_CONFIGS="--config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true "
+        CRANK_ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/proxy.benchmarks.yml --scenario proxy-yarp --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net7.0/"
 
         git checkout $GITHUB_BASE_REF
 
@@ -142,7 +178,7 @@ jobs:
       run: |
         CRANK_PROFILE="aspnet-perf-lin-relay"
         CRANK_CONFIGS="--config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true "
-        CRANK_ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario mvc --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Mvc.IntegrationTests/release/net6.0/"
+        CRANK_ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario mvc --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Mvc.IntegrationTests/release/net7.0/"
 
         git checkout $GITHUB_BASE_REF
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,10 +5,8 @@ on:
 
 jobs:
   benchmark:
-    # comments can be triggered on issues and prs, ensure this is a PR
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/benchmark')
-    # Comment out this line to test the scripts in a fork
-    # if: github.repository == 'dotnet/aspnetcore'
+    # Comments can be triggered on issues and prs, ensure this is a PR
+    if: github.repository == 'dotnet/aspnetcore' && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/benchmark')
     name: Benchmark Kestrel
     runs-on: ubuntu-latest
     steps:
@@ -18,31 +16,25 @@ jobs:
       with:
         result-encoding: string
         script: |
-          if (context.eventName !== "issue_comment") throw "Error: This action only works on issue_comment events.";
 
-          // extract the benchmark domain from the trigger phrase containing these characters: a-z, A-Z, digits, forward slash, dot, hyphen, underscore
-          const regex = /\/benchmark ([a-zA-Z\d\/\.\-\_]+)/;
-          benchmark_argument = regex.exec(context.payload.comment.body);
-          if (benchmark_argument == null || (benchmark_argument[1] != "kestrel" && benchmark_argument[1] != "mvc")) {
-              await github.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "The `/benchmark` command must contain a domain from like __kestrel__, __mvc__. e.g., `/benchmark kestrel`"
-              });
-              throw `Error: Invalid benchmark command argument '${benchmark_argument[1]}'`;
-          }
+          // Documents all available commands
+          const availableProfiles = {
+            "kestrel": "Runs Plaintext on Kestrel changes.",
+            "mvc": "Runs Plaintext on Mvc changes.",
+          };
 
-          return benchmark_argument[1];
-
-    - name: Check user's organization
-      uses: actions/github-script@v4
-      with:
-        script: |
+          // Verify the user is a collaborator
 
           const repo_owner = context.payload.repository.owner.login;
           const repo_name = context.payload.repository.name;
           const comment_user = context.payload.comment.user.login;
+
+          core.info(`Loading ${context.payload.issue.pull_request.url}.`);
+
+          const pull_request = (await github.request(context.payload.issue.pull_request.url)).data;
+          const target_branch = pull_request.base.ref;
+          const source_repository = pull_request.head.repo.clone_url;
+          const source_branch = pull_request.head.ref;
 
           var membership = await github.repos.checkCollaborator({
             owner: repo_owner,
@@ -50,140 +42,137 @@ jobs:
             username: comment_user
           });
 
-          console.log(`Verified ${comment_user} is a repo collaborator.`);
+          core.info(`Verified ${comment_user} is a repo collaborator.`);
 
-    - name: Extract target branch
-      uses: actions/github-script@v4
-      id: target-branch-extractor
-      with:
-        script: |
-          const result = await github.request(context.payload.issue.pull_request.url)
-          const pull_request = result.data;
-          return pull_request.base.ref;
+          // Verify this action is and PR comment
 
-    - name: Extract source repository
-      uses: actions/github-script@v4
-      id: source-repo-extractor
-      with:
-        script: |
-          const result = await github.request(context.payload.issue.pull_request.url)
-          const pull_request = result.data;
-          return pull_request.head.repo.clone_url;
+          if (context.eventName !== "issue_comment") throw "Error: This action only works on issue_comment events.";
 
-    - name: Extract source branch
-      uses: actions/github-script@v4
-      id: source-branch-extractor
-      with:
-        script: |
-          const result = await github.request(context.payload.issue.pull_request.url)
-          const pull_request = result.data;
-          return pull_request.head.ref;
+          // Verify command arguments
+
+          // Extract the benchmark arguments from the trigger phrase containing these characters: a-z, A-Z, digits, forward slash, dot, hyphen, underscore
+          const regex = /\/benchmark ([a-zA-Z\d\/\.\-\_]+)/;
+          const arguments = regex.exec(context.payload.comment.body);
+
+          // Generate help text with all available commands
+          if (arguments == null || arguments.length < 2 || !availableProfiles.hasOwnProperty(arguments[1])) {
+              var body = 'The `/benchmark` command accepts these profiles:\n';
+              for (var key in availableProfiles) {
+                body += `- \`/benchmark ${key}\`: ${availableProfiles[key]}\n`;
+              }
+
+              await github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+
+              throw "Error: Invalid arguments, workflow stopped.";
+          }
+
+          const profile = arguments[1];
+          core.info(`Profile: ${profile}`);
+
+          const start_body = `Started benchmarking https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+          await github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: start_body
+          });
+
+          return profile;
+
+    - name: Install crank
+      run: |
+        dotnet tool install Microsoft.Crank.Controller --version "0.2.0-*" --global
 
     - name: Checkout
       run: |
         rm -rf aspnetcore
         git clone --recursive ${{ github.event.repository.clone_url }} aspnetcore
 
-    - name: Install crank
-      run: |
-        dotnet tool install Microsoft.Crank.Controller --version "0.2.0-*" --global
-
-    - name: Build base
-      working-directory: ./aspnetcore
-      run: |
-        git checkout ${{ steps.target-branch-extractor.outputs.result }}
-
-        if [ "${{ steps.benchmark-argument.outputs.result }}" = "kestrel" ]
-        then
-          echo "Building Kestrel"
-          cd ./src/Servers/Kestrel
-          ./build.sh -c release
-        elif [ "${{ steps.benchmark-argument.outputs.result }}" = "mvc" ]
-        then
-          echo "Building Mvc"
-          cd ./src/Mvc
-          ./build.sh -c release -NoBuildNodeJS
-        fi
-
-    - name: Benchmark base
+    - name: Benchmark Kestrel
       working-directory: ./aspnetcore
       env:
         AZURE_RELAY: ${{ secrets.AZURE_RELAY }}
+      if: ${{ steps.benchmark-argument.outputs.result == 'kestrel' }}
       run: |
-        if [ "${{ steps.benchmark-argument.outputs.result }}" = "kestrel" ]
-        then
-          ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net6.0/"
-        elif [ "${{ steps.benchmark-argument.outputs.result }}" = "mvc" ]
-        then
-          ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario mvc --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Mvc.IntegrationTests/release/net6.0/"
-        fi
+        CRANK_PROFILE="aspnet-perf-lin-relay"
+        CRANK_CONFIGS="--config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true "
+        CRANK_ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net6.0/"
 
-        crank --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --profile aspnet-azure-lin-relay --relay AZURE_RELAY --json ../base.json $ARGUMENTS
+        git checkout $GITHUB_BASE_REF
 
-    - name: Build head
-      working-directory: ./aspnetcore
-      run: |
+        echo "Building Kestrel"
+        ./src/Servers/Kestrel/build.sh -c release
+
+        crank $CRANK_CONFIGS --profile $CRANK_PROFILE --relay AZURE_RELAY --json "$GITHUB_WORKSPACE/base.json" $CRANK_ARGUMENTS
+
         git fetch origin pull/${{ github.event.issue.number }}/head
         git config --global user.name "user"
         git config --global user.email "user@company.com"
         git merge FETCH_HEAD
 
-        if [ "${{ steps.benchmark-argument.outputs.result }}" = "kestrel" ]
-        then
-          echo "Building Kestrel"
-          cd ./src/Servers/Kestrel
-          ./build.sh -c release
-        elif [ "${{ steps.benchmark-argument.outputs.result }}" = "mvc" ]
-        then
-          echo "Building Mvc"
-          cd ./src/Mvc
-          ./build.sh -c release -NoBuildNodeJS
-        fi
+        echo "Building Kestrel"
+        ./src/Servers/Kestrel/build.sh -c release
 
-    - name: Benchmark head
-      working-directory: ./aspnetcore
-      id: arguments
-      env:
-        AZURE_RELAY: ${{ secrets.AZURE_RELAY }}
-      run: |
-        if [ "${{ steps.benchmark-argument.outputs.result }}" = "kestrel" ]
-        then
-          ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net6.0/"
-        elif [ "${{ steps.benchmark-argument.outputs.result }}" = "mvc" ]
-        then
-          ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario mvc --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Mvc.IntegrationTests/release/net6.0/"
-        fi
+        crank $CRANK_CONFIGS --profile $CRANK_PROFILE --relay AZURE_RELAY --json "$GITHUB_WORKSPACE/head.json" $CRANK_ARGUMENTS
 
-        crank --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --profile aspnet-azure-lin-relay --relay AZURE_RELAY --json ../head.json $ARGUMENTS
-        echo "::set-output name=result::$ARGUMENTS"
-    - name: Compare benchmarks
-      id: benchmark
-      run: |
-        crank compare base.json head.json > results.txt
+        cd $GITHUB_WORKSPACE
+        echo "Arguments:"$'\n```\n'$"$CRANK_ARGUMENTS"$'\n```\n' >> results.txt
+        echo "Results:"$'\n```\n' >> results.txt
+        crank compare base.json head.json >> results.txt
+        echo $'\n```\n' >> results.txt
 
         cat results.txt
 
-        export RESULT=$'Arguments:\n```\n'"${{ steps.arguments.outputs.result }}"$'\n```\nResults:\n```\n'$(cat results.txt)$'\n```\n'
+    - name: Benchmark Mvc
+      working-directory: ./aspnetcore
+      env:
+        AZURE_RELAY: ${{ secrets.AZURE_RELAY }}
+      if: ${{ steps.benchmark-argument.outputs.result == 'mvc' }}
+      run: |
+        CRANK_PROFILE="aspnet-perf-lin-relay"
+        CRANK_CONFIGS="--config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true "
+        CRANK_ARGUMENTS="--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario mvc --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Mvc.IntegrationTests/release/net6.0/"
 
-        RESULT="${RESULT//'%'/'%25'}"
-        RESULT="${RESULT//$'\n'/'%0A'}"
-        RESULT="${RESULT//$'\r'/'%0D'}"
-        RESULT="${RESULT//$'`'/'\`'}"
-        echo $RESULT
-        echo "::set-output name=result::$(echo "$RESULT")"
+        git checkout $GITHUB_BASE_REF
+
+        echo "Building Mvc"
+        ./src/Mvc/build.sh -c release -NoBuildNodeJS
+
+        crank $CRANK_CONFIGS --profile $CRANK_PROFILE --relay AZURE_RELAY --json "$GITHUB_WORKSPACE/base.json" $CRANK_ARGUMENTS
+
+        git fetch origin pull/${{ github.event.issue.number }}/head
+        git config --global user.name "user"
+        git config --global user.email "user@company.com"
+        git merge FETCH_HEAD
+
+        echo "Building Mvc"
+        ./src/Mvc/build.sh -c release -NoBuildNodeJS
+
+        crank $CRANK_CONFIGS --profile $CRANK_PROFILE --relay AZURE_RELAY --json "$GITHUB_WORKSPACE/head.json" $CRANK_ARGUMENTS
+
+        cd $GITHUB_WORKSPACE
+        echo "Arguments:"$'\n```\n'$"$CRANK_ARGUMENTS"$'\n```\n' >> results.txt
+        echo "Results:"$'\n```\n' >> results.txt
+        crank compare base.json head.json >> results.txt
+        echo $'\n```\n' >> results.txt
+
+        cat results.txt
 
     - name: Report results
       uses: actions/github-script@v4
       with:
         script: |
-          // The result contains new lines, so the generated script needs to wrap it in back-ticks
-          const body = `${{ steps.benchmark.outputs.result }}`;
+          const fs = require("fs");
+          const results = fs.readFileSync("results.txt", "utf8");
 
           await github.issues.createComment({
             issue_number: context.payload.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: body
+            body: results
           });
-
-

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,11 +36,24 @@ jobs:
           const source_repository = pull_request.head.repo.clone_url;
           const source_branch = pull_request.head.ref;
 
-          var membership = await github.repos.checkCollaborator({
-            owner: repo_owner,
-            repo: repo_name,
-            username: comment_user
-          });
+          try {
+            var membership = await github.repos.checkCollaborator({
+              owner: repo_owner,
+              repo: repo_name,
+              username: comment_user
+            });
+          } catch (error) {
+            var message = `Error: @${comment_user} is not a repo collaborator, benchmarking is not allowed.`;
+
+            await github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: message
+              });
+
+            throw message;
+          }
 
           core.info(`Verified ${comment_user} is a repo collaborator.`);
 

--- a/docs/PRBenchmarks.md
+++ b/docs/PRBenchmarks.md
@@ -1,7 +1,8 @@
 # Pull Request Benchmarks
 
 Pull requests that may impact performance should be benchmarked to ensure no regression is introduced.
-The most common way is to build the PR on your development machine and submit the binaries to an existing [scenario](https://github.com/aspnet/Benchmarks/tree/main/scenarios). To simplify this process this repository can do it automatically using GitHub Actions.
+The most common way is to build the PR on your development machine and submit the binaries to an existing [scenario](https://github.com/aspnet/Benchmarks/tree/main/scenarios). For simplicity, this process can be done automatically via GitHub Actions.
+
 
 ## Submitting a PR for benchmarking
 

--- a/docs/PRBenchmarks.md
+++ b/docs/PRBenchmarks.md
@@ -1,13 +1,13 @@
 # Pull Request Benchmarks
 
 Pull requests that may impact performance should be benchmarked to ensure no regression is introduced.
-The most common way is to build a the PR on yourd development machine, and submit the binaries to an existing [scenario](https://github.com/aspnet/Benchmarks/tree/main/scenarios). To simplify this process this repository can do it automatically using GitHub Actions.
+The most common way is to build the PR on your development machine and submit the binaries to an existing [scenario](https://github.com/aspnet/Benchmarks/tree/main/scenarios). To simplify this process this repository can do it automatically using GitHub Actions.
 
 ## Submitting a PR for benchmarking
 
-A special set of comments are recognized by this repository in order to trigger a benchmark. The command starts with `/benchmark` and take the name of the benchmark command as an argument. For instance, `/benchmark kestrel` will build the Kestrel components, and submit a `plaintext` scenario benchmark to dedicated machines.
+A special set of comments are recognized by this repository in order to trigger a benchmark. The comment starts with `/benchmark` and takes the name of the benchmark command as an argument. For instance, `/benchmark kestrel` will build the Kestrel components and submit a `plaintext` scenario benchmark to dedicated machines.
 
-Once the benchmark is executed, the results are displayed as a new comment on the original PR.
+Once the benchmark is executed, the results are displayed in new comment on the original PR.
 
 If the comment contains a wrong command, the list of available commands is listed as a new comment. The currently available commands are:
 
@@ -17,6 +17,6 @@ If the comment contains a wrong command, the list of available commands is liste
 
 ## Security
 
-- Submitting a PR benchmark is only permitted to the contributors of the repository. This prevents malicious code from being executed. For this reason he code that is benchmarked needs the same level of scrutiny as if it were to be merged.
+- Submitting a PR benchmark is only permitted to the collaborators of the repository. This prevents malicious code from being executed. For this reason the code that is benchmarked needs the same level of scrutiny as if it were to be merged.
 
 - No generated artifacts are stored or made available. Each benchmark rebuilds a new set of binaries.

--- a/docs/PRBenchmarks.md
+++ b/docs/PRBenchmarks.md
@@ -1,0 +1,22 @@
+# Pull Request Benchmarks
+
+Pull requests that may impact performance should be benchmarked to ensure no regression is introduced.
+The most common way is to build a the PR on yourd development machine, and submit the binaries to an existing [scenario](https://github.com/aspnet/Benchmarks/tree/main/scenarios). To simplify this process this repository can do it automatically using GitHub Actions.
+
+## Submitting a PR for benchmarking
+
+A special set of comments are recognized by this repository in order to trigger a benchmark. The command starts with `/benchmark` and take the name of the benchmark command as an argument. For instance, `/benchmark kestrel` will build the Kestrel components, and submit a `plaintext` scenario benchmark to dedicated machines.
+
+Once the benchmark is executed, the results are displayed as a new comment on the original PR.
+
+If the comment contains a wrong command, the list of available commands is listed as a new comment. The currently available commands are:
+
+- `/benchmark kestrel`: Builds Kestrel and runs the Plaintext scenario
+- `/benchmark yarp`: Builds Kestrel and runs Yarp on http-http
+- `/benchmark mvc`: Builds MVC and runs the Plaintext scenario
+
+## Security
+
+- Submitting a PR benchmark is only permitted to the contributors of the repository. This prevents malicious code from being executed. For this reason he code that is benchmarked needs the same level of scrutiny as if it were to be merged.
+
+- No generated artifacts are stored or made available. Each benchmark rebuilds a new set of binaries.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,3 +24,4 @@ The table below outlines the different docs in this folder and what they are hel
 | [Shared framework](SharedFramework.md)         | Overview of the ASP.NET Core Shared framework | Anyone looking to understand the policies in place for managing the code of the shared framework         |
 | Submodules           | Documentation on working with submodules in Git     |   Anyone working with submodules in the repo     |
 | [Triage process](TriageProcess.md)| Overview of the issue triage process used in the repo     | Anyone looking to understand the triage process on the repo  |
+| [PR benchmarks](PRBenchmarks.md)| Document on how to use the Pull Request benchmarks | Collaborators who need to benchmark a PR  |


### PR DESCRIPTION
Submitting for comments. I am thinking of creating a separate file that will contain which "targets" we want to support, which will include the components to builds, and the scenarios to execute. Right now it supports `/benchmark kestrel` and `/benchmark mvc`.

I also think a comment should be created to acknowledge the benchmark is running with a link to the running workflow like the backport command is doing. 

The results look like this right now:

Arguments:
```
--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/plaintext.benchmarks.yml --scenario plaintext --application.framework net6.0 --application.options.outputFiles ./artifacts/bin/Microsoft.AspNetCore.Server.Kestrel/release/net6.0/
```
Results:
```

| application           | base                  | head                  |         |
| --------------------- | --------------------- | --------------------- | ------- |
| CPU Usage (%)         |                    99 |                    99 |   0.00% |
| Cores usage (%)       |                   397 |                   396 |  -0.25% |
| Working Set (MB)      |                    91 |                    93 |  +2.20% |
| Private Memory (MB)   |                   303 |                   311 |  +2.64% |
| Build Time (ms)       |                23,507 |                 4,342 | -81.53% |
| Start Time (ms)       |                   293 |                   295 |  +0.68% |
| Published Size (KB)   |               108,558 |               108,558 |   0.00% |
| .NET Core SDK Version | 6.0.100-rc.1.21417.19 | 6.0.100-rc.1.21417.19 |         |


| load                   | base       | head       |         |
| ---------------------- | ---------- | ---------- | ------- |
| CPU Usage (%)          |         57 |         59 |  +3.51% |
| Cores usage (%)        |        227 |        237 |  +4.41% |
| Working Set (MB)       |         40 |         42 |  +5.00% |
| Private Memory (MB)    |        358 |        358 |   0.00% |
| Start Time (ms)        |          0 |          0 |         |
| First Request (ms)     |        167 |        225 | +34.73% |
| Requests/sec           |    783,294 |    816,098 |  +4.19% |
| Requests               | 11,824,795 | 12,321,760 |  +4.20% |
| Mean latency (ms)      |       3.14 |       3.14 |   0.00% |
| Max latency (ms)       |      50.25 |      82.87 | +64.92% |
| Bad responses          |          0 |          0 |         |
| Socket errors          |          0 |          0 |         |
| Read throughput (MB/s) |      98.60 |     102.73 |  +4.19% |
| Latency 50th (ms)      |       2.84 |       2.73 |  -3.87% |
| Latency 75th (ms)      |       4.21 |       4.05 |  -3.80% |
| Latency 90th (ms)      |       5.44 |       5.28 |  -2.94% |
| Latency 99th (ms)      |      11.29 |      12.63 | +11.87% |
```
