### PR TITLE
Stop using unencrypted git protocol in build.gradle

### DIFF
--- a/src/SignalR/clients/java/signalr/core/build.gradle
+++ b/src/SignalR/clients/java/signalr/core/build.gradle
@@ -40,9 +40,9 @@ task generatePOM {
                 }
             }
             scm {
-                connection 'scm:git:git://github.com/dotnet/aspnetcore.git'
-                developerConnection 'scm:git:git://github.com/dotnet/aspnetcore.git'
-                url 'http://github.com/dotnet/aspnetcore/tree/main'
+                connection 'scm:git:https://github.com/dotnet/aspnetcore.git'
+                developerConnection 'scm:git:https://github.com/dotnet/aspnetcore.git'
+                url 'https://github.com/dotnet/aspnetcore/tree/main'
             }
             developers {
                 developer {

--- a/src/SignalR/clients/java/signalr/messagepack/build.gradle
+++ b/src/SignalR/clients/java/signalr/messagepack/build.gradle
@@ -39,9 +39,9 @@ task generatePOM {
                 }
             }
             scm {
-                connection 'scm:git:git://github.com/dotnet/aspnetcore.git'
-                developerConnection 'scm:git:git://github.com/dotnet/aspnetcore.git'
-                url 'http://github.com/dotnet/aspnetcore/tree/main'
+                connection 'scm:git:https://github.com/dotnet/aspnetcore.git'
+                developerConnection 'scm:git:https://github.com/dotnet/aspnetcore.git'
+                url 'https://github.com/dotnet/aspnetcore/tree/main'
             }
             developers {
                 developer {


### PR DESCRIPTION
GitHub is removing support for unencrypted git soon: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
