### PR TITLE
Fixed duplicate metadata in ModelDataSource

### DIFF
--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns>The <see cref="IEndpointConventionBuilder"/>.</returns>
         public static TBuilder WithName<TBuilder>(this TBuilder builder, string endpointName) where TBuilder : IEndpointConventionBuilder
         {
-            builder.WithMetadata(new EndpointNameAttribute(endpointName), new RouteNameMetadata(endpointName));
+            builder.WithMetadata(new EndpointNameMetadata(endpointName), new RouteNameMetadata(endpointName));
             return builder;
         }
 

--- a/src/Http/Routing/src/DefaultEndpointConventionBuilder.cs
+++ b/src/Http/Routing/src/DefaultEndpointConventionBuilder.cs
@@ -12,24 +12,37 @@ namespace Microsoft.AspNetCore.Routing
     {
         internal EndpointBuilder EndpointBuilder { get; }
 
-        private readonly List<Action<EndpointBuilder>> _conventions;
+        private List<Action<EndpointBuilder>>? _conventions;
 
         public DefaultEndpointConventionBuilder(EndpointBuilder endpointBuilder)
         {
             EndpointBuilder = endpointBuilder;
-            _conventions = new List<Action<EndpointBuilder>>();
+            _conventions = new();
         }
 
         public void Add(Action<EndpointBuilder> convention)
         {
-            _conventions.Add(convention);
+            var conventions = _conventions;
+
+            if (conventions is null)
+            {
+                throw new InvalidOperationException("Conventions cannot be added after building the endpoint");
+            }
+
+            conventions.Add(convention);
         }
 
         public Endpoint Build()
         {
-            foreach (var convention in _conventions)
+            // Only apply the conventions once
+            var conventions = Interlocked.Exchange(ref _conventions, null);
+
+            if (conventions != null)
             {
-                convention(EndpointBuilder);
+                foreach (var convention in conventions)
+                {
+                    convention(EndpointBuilder);
+                }
             }
 
             return EndpointBuilder.Build();

--- a/src/Http/Routing/src/DefaultEndpointConventionBuilder.cs
+++ b/src/Http/Routing/src/DefaultEndpointConventionBuilder.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Routing
             // Only apply the conventions once
             var conventions = Interlocked.Exchange(ref _conventions, null);
 
-            if (conventions != null)
+            if (conventions is not null)
             {
                 foreach (var convention in conventions)
                 {


### PR DESCRIPTION
- Today when we make endpoints for the ModelDataSource, we apply the callbacks to the EndpointBuilder before creating the endpoint. This happens every time anyone accesses the endpoints property. Instead of re-applying the conventions, we do it once on Build. We also throw if more conventions are added after building.
- Added tests

Fixes https://github.com/dotnet/aspnetcore/issues/34199