### PR TITLE
[release/3.1] Handle shortened JSON file in `dotnet openapi`

### DIFF
--- a/src/Tools/Microsoft.dotnet-openapi/src/Commands/BaseCommand.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Commands/BaseCommand.cs
@@ -569,7 +569,7 @@ namespace Microsoft.DotNet.OpenApi.Commands
 
                 // Create or overwrite the destination file.
                 reachedCopy = true;
-                using var fileStream = new FileStream(destinationPath, FileMode.OpenOrCreate, FileAccess.Write);
+                using var fileStream = new FileStream(destinationPath, FileMode.Create, FileAccess.Write);
                 fileStream.Seek(0, SeekOrigin.Begin);
                 if (content.CanSeek)
                 {

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRefreshTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRefreshTests.cs
@@ -20,20 +20,20 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
         {
             CreateBasicProject(withOpenApi: false);
 
+            // Add <OpenApiReference/> to the project. Ignore initial filename.json content.
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
             Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
             Assert.Equal(0, run);
 
+            // File will grow after the refresh.
             var expectedJsonPath = Path.Combine(_tempDir.Root, "filename.json");
-            var json = await File.ReadAllTextAsync(expectedJsonPath);
-            json += "trash";
-            await File.WriteAllTextAsync(expectedJsonPath, json);
+            await File.WriteAllTextAsync(expectedJsonPath, "trash");
 
             var firstWriteTime = File.GetLastWriteTime(expectedJsonPath);
 
-            Thread.Sleep(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(1));
 
             app = GetApplication();
             run = app.Execute(new[] { "refresh", FakeOpenApiUrl });
@@ -43,6 +43,63 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
 
             var secondWriteTime = File.GetLastWriteTime(expectedJsonPath);
             Assert.True(firstWriteTime < secondWriteTime, $"File wasn't updated! {firstWriteTime} {secondWriteTime}");
+            Assert.Equal(Content, await File.ReadAllTextAsync(expectedJsonPath), ignoreLineEndingDifferences: true);
+        }
+
+        // Regression test for #35767 scenario.
+        [Fact]
+        public async Task OpenApi_Refresh_MuchShorterFile()
+        {
+            CreateBasicProject(withOpenApi: false);
+
+            // Add <OpenApiReference/> to the project. Ignore initial filename.json content.
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
+
+            AssertNoErrors(run);
+
+            // File will shrink after the refresh.
+            var expectedJsonPath = Path.Combine(_tempDir.Root, "filename.json");
+            await File.WriteAllTextAsync(expectedJsonPath, PackageUrlContent);
+
+            var firstWriteTime = File.GetLastWriteTime(expectedJsonPath);
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            app = GetApplication();
+            run = app.Execute(new[] { "refresh", FakeOpenApiUrl });
+
+            AssertNoErrors(run);
+
+            var secondWriteTime = File.GetLastWriteTime(expectedJsonPath);
+            Assert.True(firstWriteTime < secondWriteTime, $"File wasn't updated! {firstWriteTime} {secondWriteTime}");
+            Assert.Equal(Content, await File.ReadAllTextAsync(expectedJsonPath), ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
+        public async Task OpenApi_Refresh_UnchangedFile()
+        {
+            CreateBasicProject(withOpenApi: false);
+
+            // Add <OpenApiReference/> to the project and write the filename.json file.
+            var app = GetApplication();
+            var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
+
+            AssertNoErrors(run);
+
+            var expectedJsonPath = Path.Combine(_tempDir.Root, "filename.json");
+            var firstWriteTime = File.GetLastWriteTime(expectedJsonPath);
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            app = GetApplication();
+            run = app.Execute(new[] { "refresh", FakeOpenApiUrl });
+
+            AssertNoErrors(run);
+
+            var secondWriteTime = File.GetLastWriteTime(expectedJsonPath);
+            Assert.Equal(firstWriteTime, secondWriteTime);
+            Assert.Equal(Content, await File.ReadAllTextAsync(expectedJsonPath));
         }
     }
 }

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRefreshTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiRefreshTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.OpenApi.Tests;
 using Xunit;
@@ -24,7 +23,7 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error}");
             Assert.Equal(0, run);
 
             // File will grow after the refresh.
@@ -38,7 +37,7 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
             app = GetApplication();
             run = app.Execute(new[] { "refresh", FakeOpenApiUrl });
 
-            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error.ToString()}");
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error}");
             Assert.Equal(0, run);
 
             var secondWriteTime = File.GetLastWriteTime(expectedJsonPath);
@@ -56,7 +55,8 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            AssertNoErrors(run);
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error}");
+            Assert.Equal(0, run);
 
             // File will shrink after the refresh.
             var expectedJsonPath = Path.Combine(_tempDir.Root, "filename.json");
@@ -69,7 +69,8 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
             app = GetApplication();
             run = app.Execute(new[] { "refresh", FakeOpenApiUrl });
 
-            AssertNoErrors(run);
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error}");
+            Assert.Equal(0, run);
 
             var secondWriteTime = File.GetLastWriteTime(expectedJsonPath);
             Assert.True(firstWriteTime < secondWriteTime, $"File wasn't updated! {firstWriteTime} {secondWriteTime}");
@@ -85,7 +86,8 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
             var app = GetApplication();
             var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl });
 
-            AssertNoErrors(run);
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error}");
+            Assert.Equal(0, run);
 
             var expectedJsonPath = Path.Combine(_tempDir.Root, "filename.json");
             var firstWriteTime = File.GetLastWriteTime(expectedJsonPath);
@@ -95,7 +97,8 @@ namespace Microsoft.DotNet.OpenApi.Refresh.Tests
             app = GetApplication();
             run = app.Execute(new[] { "refresh", FakeOpenApiUrl });
 
-            AssertNoErrors(run);
+            Assert.True(string.IsNullOrEmpty(_error.ToString()), $"Threw error: {_error}");
+            Assert.Equal(0, run);
 
             var secondWriteTime = File.GetLastWriteTime(expectedJsonPath);
             Assert.Equal(firstWriteTime, secondWriteTime);


### PR DESCRIPTION
- manual backport of e23fd047b4ba (without VS fixes)
  - also, no need to remove non-existent #32686 test skips
- an existing JSON file must be truncated
- extend `dotnet openapi refresh` tests
  - include regression test for #35767

## Addresses

#35767

## Description

From #35767:
> When `dotnet-openapi` is used to refresh a swagger.json document, if the new document is shorter than the old document, the file is not truncated to the new size leaving invalid trailing bytes that render it un-parsable, causing build errors.

## Customer Impact

`dotnet openapi refresh` is very difficult to use (or justify using) in this scenario.

While the download numbers for Microsoft.dotnet-openapi aren't incredibly high (max. ~6500 for 5.0.6), this problem likely wasn't reported earlier _only_ because OpenAPI documents tend to grow, not shrink. But, when customers hit this issue, they need to manually edit the extra-long file and rebuild. Not a positive experience.

## Regression?

- [ ] Yes
- [x] No

This has been a problem since the tool was first introduced in the run-up to v3.0.0.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

 Just correct the `FileMode` and we're done.

## Verification

- [x] Manual (required)
- [x] Automated (new tests added)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A