### PR TITLE
Use one-shot static hash methods

### DIFF
--- a/src/Mvc/shared/Mvc.Views.TestCommon/TestRazorCompiledItem.cs
+++ b/src/Mvc/shared/Mvc.Views.TestCommon/TestRazorCompiledItem.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -49,20 +46,8 @@ namespace Microsoft.AspNetCore.Razor.Hosting
 
         public static string GetChecksum(string content)
         {
-            byte[] bytes;
-            using (var sha = SHA1.Create())
-            {
-                bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(content));
-            }
-
-            var result = new StringBuilder(bytes.Length);
-            for (var i = 0; i < bytes.Length; i++)
-            {
-                // The x2 format means lowercase hex, where each byte is a 2-character string.
-                result.Append(bytes[i].ToString("x2", CultureInfo.InvariantCulture));
-            }
-
-            return result.ToString();
+            var bytes = SHA1.HashData(Encoding.UTF8.GetBytes(content));
+            return Convert.ToHexString(bytes).ToLowerInvariant();
         }
     }
 }

--- a/src/Security/Authentication/Facebook/src/FacebookHandler.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookHandler.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
 using System.Security.Claims;
@@ -9,7 +8,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
@@ -60,16 +58,15 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
 
         private string GenerateAppSecretProof(string accessToken)
         {
-            using (var algorithm = new HMACSHA256(Encoding.ASCII.GetBytes(Options.AppSecret)))
+            var key = Encoding.ASCII.GetBytes(Options.AppSecret);
+            var tokenBytes = Encoding.ASCII.GetBytes(accessToken);
+            var hash = HMACSHA256.HashData(key, tokenBytes);
+            var builder = new StringBuilder();
+            for (int i = 0; i < hash.Length; i++)
             {
-                var hash = algorithm.ComputeHash(Encoding.ASCII.GetBytes(accessToken));
-                var builder = new StringBuilder();
-                for (int i = 0; i < hash.Length; i++)
-                {
-                    builder.Append(hash[i].ToString("x2", CultureInfo.InvariantCulture));
-                }
-                return builder.ToString();
+                builder.Append(hash[i].ToString("x2", CultureInfo.InvariantCulture));
             }
+            return builder.ToString();
         }
 
         /// <inheritdoc />

--- a/src/Security/Authentication/Facebook/src/FacebookOptions.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookOptions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
         /// <summary>
         /// Gets or sets if the <c>appsecret_proof</c> should be generated and sent with Facebook API calls.
         /// </summary>
-        /// <remarks>See https://developers.facebook.com/docs/graph-api/securing-requests/#appsecret_proof for more details.</remarks>
+        /// <remarks>See https://developers.facebook.com/docs/graph-api/security#appsecret_proof for more details.</remarks>
         /// <value>Defaults to <see langword="true"/>.</value>
         public bool SendAppSecretProof { get; set; }
 

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -283,7 +283,7 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
         private async Task<AccessToken> ObtainAccessTokenAsync(RequestToken token, string verifier)
         {
-            // https://dev.twitter.com/docs/api/1/post/oauth/access_token
+            // https://developer.twitter.com/en/docs/authentication/api-reference/access_token
 
             Logger.ObtainAccessToken();
 

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -1,20 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using System.Threading.Tasks;
-using System.Xml;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
@@ -342,16 +335,13 @@ namespace Microsoft.AspNetCore.Authentication.Twitter
 
         private static string ComputeSignature(string consumerSecret, string? tokenSecret, string signatureData)
         {
-            using (var algorithm = new HMACSHA1())
-            {
-                algorithm.Key = Encoding.ASCII.GetBytes(
-                    string.Format(CultureInfo.InvariantCulture,
-                        "{0}&{1}",
-                        Uri.EscapeDataString(consumerSecret),
-                        string.IsNullOrEmpty(tokenSecret) ? string.Empty : Uri.EscapeDataString(tokenSecret)));
-                var hash = algorithm.ComputeHash(Encoding.ASCII.GetBytes(signatureData));
-                return Convert.ToBase64String(hash);
-            }
+            var key = Encoding.ASCII.GetBytes(
+                string.Format(CultureInfo.InvariantCulture,
+                    "{0}&{1}",
+                    Uri.EscapeDataString(consumerSecret),
+                    string.IsNullOrEmpty(tokenSecret) ? string.Empty : Uri.EscapeDataString(tokenSecret)));
+            var hash = HMACSHA1.HashData(key, Encoding.ASCII.GetBytes(signatureData));
+            return Convert.ToBase64String(hash);
         }
 
         // https://developer.twitter.com/en/docs/apps/callback-urls

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -369,6 +369,7 @@ namespace Microsoft.AspNetCore.Authentication.Facebook
             Assert.Equal(1, finalUserInfoEndpoint.Count(c => c == '?'));
             Assert.Contains("fields=email,timezone,picture", finalUserInfoEndpoint);
             Assert.Contains("&access_token=", finalUserInfoEndpoint);
+            Assert.Contains("&appsecret_proof=b7fb6d5a4510926b4af6fe080497827d791dc45fe6541d88ba77bdf6e8e208c6&", finalUserInfoEndpoint);
         }
 
         private static async Task<IHost> CreateHost(Action<IApplicationBuilder> configure, Action<IServiceCollection> configureServices, Func<HttpContext, Task<bool>> handler)

--- a/src/Servers/IIS/IIS/test/testassets/shared/WebSockets/HandshakeHelpers.cs
+++ b/src/Servers/IIS/IIS/test/testassets/shared/WebSockets/HandshakeHelpers.cs
@@ -29,13 +29,10 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
                 throw new ArgumentNullException(nameof(requestKey));
             }
 
-            using (var algorithm = SHA1.Create())
-            {
-                string merged = requestKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-                byte[] mergedBytes = Encoding.UTF8.GetBytes(merged);
-                byte[] hashedBytes = algorithm.ComputeHash(mergedBytes);
-                return Convert.ToBase64String(hashedBytes);
-            }
+            string merged = requestKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+            byte[] mergedBytes = Encoding.UTF8.GetBytes(merged);
+            byte[] hashedBytes = SHA1.HashData(mergedBytes);
+            return Convert.ToBase64String(hashedBytes);
         }
     }
 }


### PR DESCRIPTION
**PR Title**

Use one-shot static hash methods

**PR Description**

* Use one-shot static `HashData()` methods for `SHA1` and `HMACSHA*`.
* Fix or update some documentation links.
* Expand the test coverage for the `TwitterHandler` class based on the Facebook handler's tests.
* Minor readability change to use `Convert.ToHexString()` in a test helper.
