### PR TITLE
Capture `dotnet` dumps

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -661,10 +661,6 @@ stages:
         - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
           displayName: Setup IISExpress test certificates and schema
         artifacts:
-        - name: Windows_Test_Dumps
-          path: artifacts/dumps/
-          publishOnError: true
-          includeForks: true
         - name: Windows_Test_Logs
           path: artifacts/log/
           publishOnError: true

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -279,7 +279,7 @@ jobs:
       condition: always()
       continueOnError: true
       inputs:
-        contents: *.core
+        contents: '*.core'
         sourceFolder: $(System.DefaultWorkingDirectory)
         targetFolder: artifacts/dumps/
     - task: PublishBuildArtifacts@1

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -138,6 +138,8 @@ jobs:
       - BuildDirectory: $(System.DefaultWorkingDirectory)
     - ${{ if ne(parameters.buildDirectory, '') }}:
       - BuildDirectory: ${{ parameters.buildDirectory }}
+    - COMPlus_DbgEnableMiniDump: 1
+    - COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
     - DOTNET_CLI_HOME: $(System.DefaultWorkingDirectory)
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - TeamName: AspNetCore
@@ -267,23 +269,28 @@ jobs:
         condition: always()
 
     # Run component detection after all successful Build:* jobs unless overridden e.g. for Alpine build.
-    # Disabled for now because detector limits some error handling to the auto-injected task. Will re-enable once fixed.
-    - ${{ if and(startsWith(parameters.jobDisplayName, 'Build:'), eq(parameters.agentOs, 'NotARealOperatingSystem'), ne(variables['skipComponentGovernanceDetection'], 'true'), ne(parameters.skipComponentGovernanceDetection, 'true'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-        condition: and(succeeded(), ne(variables['CG_RAN'], 'true'))
-        displayName: 'Component Detection'
-        inputs:
-          ${{ if eq(parameters.agentOs, 'Windows') }}:
-            ignoreDirectories: '.dotnet,.packages,artifacts\log,artifacts\symbols,artifacts\tmp'
-          ${{ if ne(parameters.agentOs, 'Windows') }}:
-            ignoreDirectories: '.dotnet,.packages,artifacts/log,artifacts/symbols,artifacts/tmp'
-          sourceScanPath: $(Build.SourcesDirectory)
-          verbosity: Verbose
     # Make sure auto-injected component detection does _not_ execute in other jobs nor when overridden.
-    # No need to recheck variables or build reason because auto-injected component detection honors those values.
     - ${{ if or(not(startsWith(parameters.jobDisplayName, 'Build:')), eq(parameters.skipComponentGovernanceDetection, 'true')) }}:
       - script:  echo "##vso[task.setvariable variable=CG_RAN]true"
         displayName: 'Skip Component Detection'
+
+    - task: CopyFiles@2
+      displayName: Create dump directory
+      condition: always()
+      continueOnError: true
+      inputs:
+        contents: *.core
+        sourceFolder: "$(System.DefaultWorkingDirectory)
+        targetFolder: artifacts/dumps/
+    - task: PublishBuildArtifacts@1
+      displayName: Upload dump files
+      condition: always()
+      continueOnError: true
+      inputs:
+        artifactName: ${{ coalesce(parameters.jobName, parameters.agentOs) }}_Dumps
+        artifactType: Container
+        parallel: true
+        pathtoPublish: artifacts/dumps/
 
     - ${{ each artifact in parameters.artifacts }}:
       - task: PublishBuildArtifacts@1

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -280,7 +280,7 @@ jobs:
       continueOnError: true
       inputs:
         contents: *.core
-        sourceFolder: "$(System.DefaultWorkingDirectory)
+        sourceFolder: $(System.DefaultWorkingDirectory)
         targetFolder: artifacts/dumps/
     - task: PublishBuildArtifacts@1
       displayName: Upload dump files


### PR DESCRIPTION
- builds are failing soon after `dotnet msbuild` launch

nit: Remove disabled explicit component detection job