### PR TITLE
Ensure _Dumps artifacts aren't empty

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -279,7 +279,9 @@ jobs:
       condition: always()
       continueOnError: true
       inputs:
-        contents: '*.core'
+        contents: |
+          '*.core'
+          restore.sh
         sourceFolder: $(System.DefaultWorkingDirectory)
         targetFolder: artifacts/dumps/
     - task: PublishBuildArtifacts@1


### PR DESCRIPTION
- avoid yellow builds due to `PublishBuildArtifacts@1` warnings
- always include a small file