### PR TITLE
Simplify Guid reading/writing code in DataProtection

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
@@ -304,7 +304,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         {
 #if NETCOREAPP
             var span = new Span<byte>(ptr, sizeof(Guid)); // performs appropriate endianness fixups
-            value.TryWriteBytes(span);
+            var success = value.TryWriteBytes(span);
+            Debug.Assert(success, "Failed to write Guid.");
 #elif NETSTANDARD2_0 || NET461
             // netstandard & netfx assumes little-endian, so this is fine
             Unsafe.WriteUnaligned<Guid>(ptr, value);

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             // Performs appropriate endianness fixups
             return new Guid(new ReadOnlySpan<byte>(ptr, sizeof(Guid)));
 #elif NETSTANDARD2_0 || NETFRAMEWORK
-            // netstandard/netfx assumes little-endian
+            Debug.Assert(BitConverter.IsLittleEndian);
             return Unsafe.ReadUnaligned<Guid>(ptr);
 #else
 #error Update target frameworks
@@ -303,11 +303,13 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
         private static void WriteGuid(void* ptr, Guid value)
         {
 #if NETCOREAPP
-            var span = new Span<byte>(ptr, sizeof(Guid)); // performs appropriate endianness fixups
+            var span = new Span<byte>(ptr, sizeof(Guid));
+
+            // Performs appropriate endianness fixups
             var success = value.TryWriteBytes(span);
             Debug.Assert(success, "Failed to write Guid.");
 #elif NETSTANDARD2_0 || NETFRAMEWORK
-            // netstandard/netfx assumes little-endian
+            Debug.Assert(BitConverter.IsLittleEndian);
             Unsafe.WriteUnaligned<Guid>(ptr, value);
 #else
 #error Update target frameworks

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
 #if NETCOREAPP
             // Performs appropriate endianness fixups
             return new Guid(new ReadOnlySpan<byte>(ptr, sizeof(Guid)));
-#elif NETSTANDARD2_0 || NET461
+#elif NETSTANDARD2_0 || NETFRAMEWORK
             // netstandard/netfx assumes little-endian
             return Unsafe.ReadUnaligned<Guid>(ptr);
 #else
@@ -306,8 +306,8 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement
             var span = new Span<byte>(ptr, sizeof(Guid)); // performs appropriate endianness fixups
             var success = value.TryWriteBytes(span);
             Debug.Assert(success, "Failed to write Guid.");
-#elif NETSTANDARD2_0 || NET461
-            // netstandard & netfx assumes little-endian, so this is fine
+#elif NETSTANDARD2_0 || NETFRAMEWORK
+            // netstandard/netfx assumes little-endian
             Unsafe.WriteUnaligned<Guid>(ptr, value);
 #else
 #error Update target frameworks


### PR DESCRIPTION
This change simplifies GUID reading code in KeyRingBasedDataProtector by relying on the Span-based constructor for Guid on Core which handles endianness fixups for us. On other frameworks, we can assume little endian and rely on Unsafe.ReadUnaligned.

Thanks to @GrabYourPitchforks for the suggestion: https://github.com/dotnet/aspnetcore/pull/35715#issuecomment-915592601