### PR TITLE
Unquarantine Settings_MaxConcurrentStreamsPost_Server

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -1244,7 +1244,6 @@ namespace Interop.FunctionalTests
         }
 
         [Theory]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/27370")]
         [MemberData(nameof(SupportedSchemes))]
         public async Task Settings_MaxConcurrentStreamsPost_Server(string scheme)
         {


### PR DESCRIPTION
The runtime issue (https://github.com/dotnet/runtime/issues/42472) was fixed and the test seems to be passing consistently.

Fixes https://github.com/dotnet/aspnetcore/issues/27370