### PR TITLE
Test in manual internal builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -119,7 +119,7 @@ stages:
   displayName: Build
   jobs:
   # Code check
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
     - template: jobs/default-build.yml
       parameters:
         jobName: Code_check
@@ -642,7 +642,7 @@ stages:
       parameters:
         inputName: Linux_musl_arm64
 
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
     # Test jobs
     - template: jobs/default-build.yml
       parameters:


### PR DESCRIPTION
- make it a bit easier to test _everything_ in one go
  - builds site extensions, publishes to BAR, and runs all aspnetcore-ci tests