### PR TITLE
Expose ParameterInfo for Minimal Actions API Explorer

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
-using System.Threading;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -162,6 +160,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             var nullabilityContext = new NullabilityInfoContext();
             var nullability = nullabilityContext.Create(parameter);
             var isOptional = parameter.HasDefaultValue || nullability.ReadState != NullabilityState.NotNull || allowEmpty;
+            var parameterDescriptor = CreateParameterDescriptor(parameter);
 
             return new ApiParameterDescription
             {
@@ -170,9 +169,18 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 Source = source,
                 DefaultValue = parameter.DefaultValue,
                 Type = parameter.ParameterType,
-                IsRequired = !isOptional
+                IsRequired = !isOptional,
+                ParameterDescriptor = parameterDescriptor
             };
         }
+
+        private static ParameterDescriptor CreateParameterDescriptor(ParameterInfo parameter)
+            => new EndpointParameterDescriptor
+            {
+                Name = parameter.Name ?? string.Empty,
+                ParameterInfo = parameter,
+                ParameterType = parameter.ParameterType,
+            };
 
         // TODO: Share more of this logic with RequestDelegateFactory.CreateArgument(...) using RequestDelegateFactoryUtilities
         // which is shared source.

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointParameterDescriptor.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointParameterDescriptor.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+internal sealed class EndpointParameterDescriptor : ParameterDescriptor, IParameterInfoParameterDescriptor
+{
+    public ParameterInfo ParameterInfo { get; set; } = default!;
+}

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointParameterDescriptor.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointParameterDescriptor.cs
@@ -5,9 +5,10 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 
-namespace Microsoft.AspNetCore.Mvc.ApiExplorer;
-
-internal sealed class EndpointParameterDescriptor : ParameterDescriptor, IParameterInfoParameterDescriptor
+namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 {
-    public ParameterInfo ParameterInfo { get; set; } = default!;
+    internal sealed class EndpointParameterDescriptor : ParameterDescriptor, IParameterInfoParameterDescriptor
+    {
+        public ParameterInfo ParameterInfo { get; set; } = default!;
+    }
 }

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
 using System.Reflection;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
@@ -264,7 +266,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         }
 
         [Fact]
-        public void AddsFromRouteParameterAsPathWithCustomTypep()
+        public void AddsFromRouteParameterAsPathWithCustomType()
         {
             static void AssertPathParameter(ApiDescription apiDescription)
             {
@@ -417,6 +419,32 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             Assert.Equal(typeof(int), barParam.ModelMetadata.ModelType);
             Assert.Equal(BindingSource.Query, barParam.Source);
             Assert.True(barParam.IsRequired);
+        }
+
+        [Fact]
+        public void TestParameterAttributesCanBeInspected()
+        {
+            var apiDescription = GetApiDescription(([Description("The name.")] string name) => { });
+            Assert.Equal(1, apiDescription.ParameterDescriptions.Count);
+
+            var nameParam = apiDescription.ParameterDescriptions[0];
+            Assert.Equal(typeof(string), nameParam.Type);
+            Assert.Equal(typeof(string), nameParam.ModelMetadata.ModelType);
+            Assert.Equal(BindingSource.Query, nameParam.Source);
+            Assert.False(nameParam.IsRequired);
+
+            Assert.NotNull(nameParam.ParameterDescriptor);
+            Assert.Equal("name", nameParam.ParameterDescriptor.Name);
+            Assert.Equal(typeof(string), nameParam.ParameterDescriptor.ParameterType);
+
+            var descriptor = Assert.IsAssignableFrom<IParameterInfoParameterDescriptor>(nameParam.ParameterDescriptor);
+
+            Assert.NotNull(descriptor.ParameterInfo);
+
+            var description = Assert.Single(descriptor.ParameterInfo.GetCustomAttributes<DescriptionAttribute>());
+
+            Assert.NotNull(description);
+            Assert.Equal("The name.", description.Description);
         }
 
         [Fact]


### PR DESCRIPTION
**PR Title**

Expose ParameterInfo for Minimal Actions API Explorer

**PR Description**

Populate the `ParameterDescriptor` for Minimal Actions parameters with a type that implements `IParameterInfoParameterDescriptor` so that any custom attributes on the parameter can be inspected.

Relates to #36438
