### PR TITLE
Fix https://github.com/aspnet/AspNetCore-ManualTests/issues/828

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Controllers/WeatherForecastController.cs
@@ -21,8 +21,10 @@ namespace ComponentsWebAssembly_CSharp.Server.Controllers;
 #endif
 [ApiController]
 [Route("[controller]")]
-#if (OrganizationalAuth || IndividualB2CAuth)
+#if (OrganizationalAuth)
 [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]
+#elseif (IndividualB2CAuth)
+[RequiredScope(RequiredScopesConfigurationKey = "AzureAdB2C:Scopes")]
 #endif
 public class WeatherForecastController : ControllerBase
 {


### PR DESCRIPTION
Fix https://github.com/aspnet/AspNetCore-ManualTests/issues/828#issuecomment-916732011


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ x] You've included unit or integration tests for your change, where applicable (tested by the CTI)
- [ x] You've included inline docs for your change, where applicable.
- [ x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue: https://github.com/aspnet/AspNetCore-ManualTests/issues/828

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Fixes the required scopes in the controller for b2c in the Blasorwasm hosted server

**PR Description**
Fixes the scopes in the controller in the Blasorwasm hosted server (the resource is in the b2c section).
Without this fix, when creating a b2c blazorwasm hosted application the controller won't find the resource as it's in the "AzureADB2C" section, whereas it was searched in the "AzureAD" section.

For repros and details see: Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/828

@Claire-kangkang, @HaoK 