### PR TITLE
Make DelegateEndpointConventionBuilder constructors public

### DIFF
--- a/src/Http/Routing/src/Builder/DelegateEndpointConventionBuilder.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointConventionBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <see cref="IEndpointConventionBuilder" />.
         /// </summary>
         /// <param name="endpointConventionBuilder">The <see cref="IEndpointConventionBuilder" /> to instantiate with.</param>
-        public DelegateEndpointConventionBuilder(IEndpointConventionBuilder endpointConventionBuilder)
+        internal DelegateEndpointConventionBuilder(IEndpointConventionBuilder endpointConventionBuilder)
         {
             _endpointConventionBuilders = new List<IEndpointConventionBuilder>() { endpointConventionBuilder };
         }

--- a/src/Http/Routing/src/Builder/DelegateEndpointConventionBuilder.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointConventionBuilder.cs
@@ -13,12 +13,22 @@ namespace Microsoft.AspNetCore.Builder
     {
         private readonly List<IEndpointConventionBuilder> _endpointConventionBuilders;
 
-        internal DelegateEndpointConventionBuilder(IEndpointConventionBuilder endpointConventionBuilder)
+        /// <summary>
+        /// Instantiates a new <see cref="DelegateEndpointConventionBuilder" /> given a single
+        /// <see cref="IEndpointConventionBuilder" />.
+        /// </summary>
+        /// <param name="endpointConventionBuilder">The <see cref="IEndpointConventionBuilder" /> to instantiate with.</param>
+        public DelegateEndpointConventionBuilder(IEndpointConventionBuilder endpointConventionBuilder)
         {
             _endpointConventionBuilders = new List<IEndpointConventionBuilder>() { endpointConventionBuilder };
         }
 
-        internal DelegateEndpointConventionBuilder(List<IEndpointConventionBuilder> endpointConventionBuilders)
+        /// <summary>
+        /// Instantiates a new <see cref="DelegateEndpointConventionBuilder" /> given multiple
+        /// <see cref="IEndpointConventionBuilder" /> instances.
+        /// </summary>
+        /// <param name="endpointConventionBuilders">A list of <see cref="IEndpointConventionBuilder" /> instances.</param>
+        public DelegateEndpointConventionBuilder(List<IEndpointConventionBuilder> endpointConventionBuilders)
         {
             _endpointConventionBuilders = endpointConventionBuilders;
         }

--- a/src/Http/Routing/src/Builder/DelegateEndpointConventionBuilder.cs
+++ b/src/Http/Routing/src/Builder/DelegateEndpointConventionBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public sealed class DelegateEndpointConventionBuilder : IEndpointConventionBuilder
     {
-        private readonly List<IEndpointConventionBuilder> _endpointConventionBuilders;
+        private readonly IEnumerable<IEndpointConventionBuilder> _endpointConventionBuilders;
 
         /// <summary>
         /// Instantiates a new <see cref="DelegateEndpointConventionBuilder" /> given a single
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <see cref="IEndpointConventionBuilder" /> instances.
         /// </summary>
         /// <param name="endpointConventionBuilders">A list of <see cref="IEndpointConventionBuilder" /> instances.</param>
-        public DelegateEndpointConventionBuilder(List<IEndpointConventionBuilder> endpointConventionBuilders)
+        public DelegateEndpointConventionBuilder(IEnumerable<IEndpointConventionBuilder> endpointConventionBuilders)
         {
             _endpointConventionBuilders = endpointConventionBuilders;
         }

--- a/src/Http/Routing/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing/src/PublicAPI.Unshipped.txt
@@ -6,7 +6,6 @@
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteName.get -> string!
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteNameMetadata(string! routeName) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder
-Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.DelegateEndpointConventionBuilder(Microsoft.AspNetCore.Builder.IEndpointConventionBuilder! endpointConventionBuilder) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.DelegateEndpointConventionBuilder(System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!>! endpointConventionBuilders) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.Add(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! convention) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointRouteBuilderExtensions

--- a/src/Http/Routing/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing/src/PublicAPI.Unshipped.txt
@@ -7,7 +7,7 @@
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteNameMetadata(string! routeName) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder
 Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.DelegateEndpointConventionBuilder(Microsoft.AspNetCore.Builder.IEndpointConventionBuilder! endpointConventionBuilder) -> void
-Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.DelegateEndpointConventionBuilder(System.Collections.Generic.List<Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!>! endpointConventionBuilders) -> void
+Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.DelegateEndpointConventionBuilder(System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!>! endpointConventionBuilders) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.Add(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! convention) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointRouteBuilderExtensions
 Microsoft.AspNetCore.Routing.DataTokensMetadata.DataTokens.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!

--- a/src/Http/Routing/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing/src/PublicAPI.Unshipped.txt
@@ -6,6 +6,8 @@
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteName.get -> string!
 *REMOVED*Microsoft.AspNetCore.Routing.RouteNameMetadata.RouteNameMetadata(string! routeName) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder
+Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.DelegateEndpointConventionBuilder(Microsoft.AspNetCore.Builder.IEndpointConventionBuilder! endpointConventionBuilder) -> void
+Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.DelegateEndpointConventionBuilder(System.Collections.Generic.List<Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!>! endpointConventionBuilders) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointConventionBuilder.Add(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! convention) -> void
 Microsoft.AspNetCore.Builder.DelegateEndpointRouteBuilderExtensions
 Microsoft.AspNetCore.Routing.DataTokensMetadata.DataTokens.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!


### PR DESCRIPTION
## Background and Motivation

<!--
We welcome API proposals! We have a process to evaluate the value and shape of new API. There is an overview of our process [here](https://github.com/dotnet/aspnetcore/blob/main/docs/APIReviewProcess.md). This template will help us gather the information we need to start the review process.
First, please describe the purpose and value of the new API here.
-->

For .NET 6, we added support for OpenAPI extension methods on the `DelegateEndpointConventionBuilder` used in minimal apps. The `DelegateEndpointConventionBuilder` is currently implemented as a `public sealed` class with `internal` constructors.

While debugging a scenario, we realized that this posed a problem for scenarios where developers wanted to use the extension methods on a builder returned from a 3rd-party API or external source.

```csharp
// Some library code
public static DelegateEndpointConventionBuilder MapMyFrameworkMethods()
{
...
}

// Some user code that is not possible
app.MapMyFrameworkMethods().ExcludeFromDescription();
```

## Proposed API

```diff
namespace Microsoft.AspNetCore.Builder
{
  public class DelegateEndpointConventionBuilder
  {
-    internal DelegateEndpointConventionBuilder(List<IEndpointConventionBuilder> endpointConventionBuilders)
+    public DelegateEndpointConventionBuilder(List<IEndpointConventionBuilder> endpointConventionBuilders)
}
```

## Usage Examples

```csharp
public static DelegateEndpointConventionBuilder MapToDos(this IEndpointRouteBuilder endpointRouteBuilder)
{
  List<IEndpointConventionBuilder> builders = new();
  builders.Add(endpointRouteBuilder.MapPost("/create", () => { ... });
  builders.Add(endpointRouteBuilder.MapGet("/all", () => { ... });
  return new DelegateEndpointConventionBuilder(builders);
}

app.MapToDos().ExcludeFromDescription();
```

## Alternative Designs

One alternative is to have the extension methods target `IEndpointConventionBuilder` instead of `DelegateEndpointConventionBuilder` but this presents some problems because:

- The compiler will fail to resolve generic types correctly for extension methods that implement more than one generic `Produces<TResponse>(TBuilder)`
- We want to keep the high level of specificity for what builders this extension method targets

## Risks

- The `DelegateEndpointConventionBuilder` was introduced in .NET 6 so this is not a breaking change.
- Unlike other `IEndpointConventionBuilder`s the `DelegateEndpointConventionBuilder` has a requirement for this type of extensibility so it's the only one that follows the pattern of public class and public constructor.

