### PR TITLE
Add support for BindAsync without ParameterInfo

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -840,7 +840,7 @@ namespace Microsoft.AspNetCore.Http
             var isOptional = IsOptionalParameter(parameter, factoryContext);
 
             // Get the BindAsync method for the type.
-            var bindAsyncExpression = ParameterBindingMethodCache.FindBindAsyncMethod(parameter);
+            var (bindAsyncExpression, paramCount) = ParameterBindingMethodCache.FindBindAsyncMethod(parameter);
             // We know BindAsync exists because there's no way to opt-in without defining the method on the type.
             Debug.Assert(bindAsyncExpression is not null);
 
@@ -854,6 +854,7 @@ namespace Microsoft.AspNetCore.Http
             if (!isOptional)
             {
                 var typeName = TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false);
+                var message = paramCount == 2 ? $"{typeName}.BindAsync(HttpContext, ParameterInfo)" : $"{typeName}.BindAsync(HttpContext)";
                 var checkRequiredBodyBlock = Expression.Block(
                         Expression.IfThen(
                         Expression.Equal(boundValueExpr, Expression.Constant(null)),
@@ -863,7 +864,7 @@ namespace Microsoft.AspNetCore.Http
                                         HttpContextExpr,
                                         Expression.Constant(typeName),
                                         Expression.Constant(parameter.Name),
-                                        Expression.Constant($"{typeName}.BindAsync(HttpContext, ParameterInfo)"),
+                                        Expression.Constant(message),
                                         Expression.Constant(factoryContext.ThrowOnBadRequest))
                             )
                         )

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -173,12 +173,13 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
             var parameter = new MockParameterInfo(type, "bindAsyncRecord");
             var methodFound = cache.FindBindAsyncMethod(parameter);
 
-            Assert.NotNull(methodFound);
+            Assert.NotNull(methodFound.Item1);
+            Assert.Equal(2, methodFound.Item2);
 
             var parsedValue = Expression.Variable(type, "parsedValue");
 
             var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object>>>(
-                Expression.Block(new[] { parsedValue }, methodFound!),
+                Expression.Block(new[] { parsedValue }, methodFound.Item1!),
                 ParameterBindingMethodCache.HttpContextExpr).Compile();
 
             var httpContext = new DefaultHttpContext
@@ -195,6 +196,37 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
             Assert.Equal(new BindAsyncRecord(42), await parseHttpContext(httpContext));
         }
 
+        [Fact]
+        public async Task FindBindAsyncMethod_FindsSingleArgBindAsync()
+        {
+            var type = typeof(BindAsyncSingleArgStruct);
+            var cache = new ParameterBindingMethodCache();
+            var parameter = new MockParameterInfo(type, "bindAsyncSingleArgStruct");
+            var methodFound = cache.FindBindAsyncMethod(parameter);
+
+            Assert.NotNull(methodFound.Item1);
+            Assert.Equal(1, methodFound.Item2);
+
+            var parsedValue = Expression.Variable(type, "parsedValue");
+
+            var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object>>>(
+                Expression.Block(new[] { parsedValue }, methodFound.Item1!),
+                ParameterBindingMethodCache.HttpContextExpr).Compile();
+
+            var httpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Headers =
+                    {
+                        ["ETag"] = "42",
+                    },
+                },
+            };
+
+            Assert.Equal(new BindAsyncSingleArgStruct(42), await parseHttpContext(httpContext));
+        }
+
         public static IEnumerable<object[]> BindAsyncParameterInfoData
         {
             get
@@ -209,6 +241,14 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
                     {
                         GetFirstParameter((BindAsyncStruct arg) => BindAsyncStructMethod(arg)),
                     },
+                    new[]
+                    {
+                        GetFirstParameter((BindAsyncSingleArgRecord arg) => BindAsyncSingleArgRecordMethod(arg)),
+                    },
+                    new[]
+                    {
+                        GetFirstParameter((BindAsyncSingleArgStruct arg) => BindAsyncSingleArgStructMethod(arg)),
+                    }
                 };
             }
         }
@@ -249,6 +289,11 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         private static void BindAsyncStructMethod(BindAsyncStruct arg) { }
         private static void BindAsyncNullableStructMethod(BindAsyncStruct? arg) { }
         private static void NullableReturningBindAsyncStructMethod(NullableReturningBindAsyncStruct arg) { }
+
+        private static void BindAsyncSingleArgRecordMethod(BindAsyncSingleArgRecord arg) { }
+        private static void BindAsyncSingleArgStructMethod(BindAsyncSingleArgStruct arg) { }
+        private static void BindAsyncNullableSingleArgStructMethod(BindAsyncSingleArgStruct? arg) { }
+        private static void NullableReturningBindAsyncSingleArgStructMethod(NullableReturningBindAsyncSingleArgStruct arg) { }
 
         private static ParameterInfo GetFirstParameter<T>(Expression<Action<T>> expr)
         {
@@ -319,6 +364,38 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         }
 
         private record struct NullableReturningBindAsyncStruct(int Value)
+        {
+            public static ValueTask<NullableReturningBindAsyncStruct?> BindAsync(HttpContext context, ParameterInfo parameter) =>
+                throw new NotImplementedException();
+        }
+
+        private record BindAsyncSingleArgRecord(int Value)
+        {
+            public static ValueTask<BindAsyncSingleArgRecord?> BindAsync(HttpContext context)
+            {
+                if (!int.TryParse(context.Request.Headers.ETag, out var val))
+                {
+                    return new(result: null);
+                }
+
+                return new(result: new(val));
+            }
+        }
+
+        private record struct BindAsyncSingleArgStruct(int Value)
+        {
+            public static ValueTask<BindAsyncSingleArgStruct> BindAsync(HttpContext context)
+            {
+                if (!int.TryParse(context.Request.Headers.ETag, out var val))
+                {
+                    throw new BadHttpRequestException("The request is missing the required ETag header.");
+                }
+
+                return new(result: new(val));
+            }
+        }
+
+        private record struct NullableReturningBindAsyncSingleArgStruct(int Value)
         {
             public static ValueTask<NullableReturningBindAsyncStruct?> BindAsync(HttpContext context, ParameterInfo parameter) =>
                 throw new NotImplementedException();

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -173,13 +173,13 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
             var parameter = new MockParameterInfo(type, "bindAsyncRecord");
             var methodFound = cache.FindBindAsyncMethod(parameter);
 
-            Assert.NotNull(methodFound.Item1);
-            Assert.Equal(2, methodFound.Item2);
+            Assert.NotNull(methodFound.Expression);
+            Assert.Equal(2, methodFound.ParamCount);
 
             var parsedValue = Expression.Variable(type, "parsedValue");
 
             var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object>>>(
-                Expression.Block(new[] { parsedValue }, methodFound.Item1!),
+                Expression.Block(new[] { parsedValue }, methodFound.Expression!),
                 ParameterBindingMethodCache.HttpContextExpr).Compile();
 
             var httpContext = new DefaultHttpContext
@@ -204,13 +204,13 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
             var parameter = new MockParameterInfo(type, "bindAsyncSingleArgStruct");
             var methodFound = cache.FindBindAsyncMethod(parameter);
 
-            Assert.NotNull(methodFound.Item1);
-            Assert.Equal(1, methodFound.Item2);
+            Assert.NotNull(methodFound.Expression);
+            Assert.Equal(1, methodFound.ParamCount);
 
             var parsedValue = Expression.Variable(type, "parsedValue");
 
             var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object>>>(
-                Expression.Block(new[] { parsedValue }, methodFound.Item1!),
+                Expression.Block(new[] { parsedValue }, methodFound.Expression!),
                 ParameterBindingMethodCache.HttpContextExpr).Compile();
 
             var httpContext = new DefaultHttpContext

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -46,11 +46,8 @@ namespace Microsoft.AspNetCore.Http
             return FindTryParseMethod(nonNullableParameterType) is not null;
         }
 
-        public bool HasBindAsyncMethod(ParameterInfo parameter)
-        {
-            var (expression, _) = FindBindAsyncMethod(parameter);
-            return expression is not null;
-        }
+        public bool HasBindAsyncMethod(ParameterInfo parameter) =>
+            FindBindAsyncMethod(parameter).Expression is not null;
 
         public Func<ParameterExpression, Expression>? FindTryParseMethod(Type type)
         {
@@ -131,7 +128,7 @@ namespace Microsoft.AspNetCore.Http
             return _stringMethodCallCache.GetOrAdd(type, Finder);
         }
 
-        public (Expression?, int) FindBindAsyncMethod(ParameterInfo parameter)
+        public (Expression? Expression, int ParamCount) FindBindAsyncMethod(ParameterInfo parameter)
         {
             static (Func<ParameterInfo, Expression>?, int) Finder(Type nonNullableParameterType)
             {

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -46,9 +46,11 @@ namespace Microsoft.AspNetCore.Http
             return FindTryParseMethod(nonNullableParameterType) is not null;
         }
 
-        public bool HasBindAsyncMethod(ParameterInfo parameter) =>
+        public bool HasBindAsyncMethod(ParameterInfo parameter)
+        {
             var (expression, _) = FindBindAsyncMethod(parameter);
             return expression is not null;
+        }
 
         public Func<ParameterExpression, Expression>? FindTryParseMethod(Type type)
         {

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -47,7 +47,8 @@ namespace Microsoft.AspNetCore.Http
         }
 
         public bool HasBindAsyncMethod(ParameterInfo parameter) =>
-            FindBindAsyncMethod(parameter).Item1 is not null;
+            var (expression, _) = FindBindAsyncMethod(parameter);
+            return expression is not null;
 
         public Func<ParameterExpression, Expression>? FindTryParseMethod(Type type)
         {

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Http
 
         // Since this is shared source, the cache won't be shared between RequestDelegateFactory and the ApiDescriptionProvider sadly :(
         private readonly ConcurrentDictionary<Type, Func<ParameterExpression, Expression>?> _stringMethodCallCache = new();
-        private readonly ConcurrentDictionary<Type, Func<ParameterInfo, Expression>?> _bindAsyncMethodCallCache = new();
+        private readonly ConcurrentDictionary<Type, (Func<ParameterInfo, Expression>?, int)> _bindAsyncMethodCallCache = new();
 
         // If IsDynamicCodeSupported is false, we can't use the static Enum.TryParse<T> since there's no easy way for
         // this code to generate the specific instantiation for any enums used
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Http
         }
 
         public bool HasBindAsyncMethod(ParameterInfo parameter) =>
-            FindBindAsyncMethod(parameter) is not null;
+            FindBindAsyncMethod(parameter).Item1 is not null;
 
         public Func<ParameterExpression, Expression>? FindTryParseMethod(Type type)
         {
@@ -128,12 +128,18 @@ namespace Microsoft.AspNetCore.Http
             return _stringMethodCallCache.GetOrAdd(type, Finder);
         }
 
-        public Expression? FindBindAsyncMethod(ParameterInfo parameter)
+        public (Expression?, int) FindBindAsyncMethod(ParameterInfo parameter)
         {
-            static Func<ParameterInfo, Expression>? Finder(Type nonNullableParameterType)
+            static (Func<ParameterInfo, Expression>?, int) Finder(Type nonNullableParameterType)
             {
+                var hasParameterInfo = true;
                 // There should only be one BindAsync method with these parameters since C# does not allow overloading on return type.
                 var methodInfo = nonNullableParameterType.GetMethod("BindAsync", BindingFlags.Public | BindingFlags.Static, new[] { typeof(HttpContext), typeof(ParameterInfo) });
+                if (methodInfo is null)
+                {
+                    hasParameterInfo = false;
+                    methodInfo = nonNullableParameterType.GetMethod("BindAsync", BindingFlags.Public | BindingFlags.Static, new[] { typeof(HttpContext) });
+                }
 
                 // We're looking for a method with the following signatures:
                 // public static ValueTask<{type}> BindAsync(HttpContext context, ParameterInfo parameter)
@@ -147,34 +153,51 @@ namespace Microsoft.AspNetCore.Http
                     // ValueTask<{type}>?
                     if (valueTaskResultType == nonNullableParameterType)
                     {
-                        return (parameter) =>
+                        return ((parameter) =>
                         {
-                            // parameter is being intentionally shadowed. We never want to use the outer ParameterInfo inside
-                            // this Func because the ParameterInfo varies after it's been cached for a given parameter type.
-                            var typedCall = Expression.Call(methodInfo, HttpContextExpr, Expression.Constant(parameter));
+                            MethodCallExpression typedCall;
+                            if (hasParameterInfo)
+                            {
+                                // parameter is being intentionally shadowed. We never want to use the outer ParameterInfo inside
+                                // this Func because the ParameterInfo varies after it's been cached for a given parameter type.
+                                typedCall = Expression.Call(methodInfo, HttpContextExpr, Expression.Constant(parameter));
+                            }
+                            else
+                            {
+                                typedCall = Expression.Call(methodInfo, HttpContextExpr);
+                            }
                             return Expression.Call(ConvertValueTaskMethod.MakeGenericMethod(nonNullableParameterType), typedCall);
-                        };
+                        }, hasParameterInfo ? 2 : 1);
                     }
                     // ValueTask<Nullable<{type}>>?
                     else if (valueTaskResultType.IsGenericType &&
                              valueTaskResultType.GetGenericTypeDefinition() == typeof(Nullable<>) &&
                              valueTaskResultType.GetGenericArguments()[0] == nonNullableParameterType)
                     {
-                        return (parameter) =>
+                        return ((parameter) =>
                         {
-                            // parameter is being intentionally shadowed. We never want to use the outer ParameterInfo inside
-                            // this Func because the ParameterInfo varies after it's been cached for a given parameter type.
-                            var typedCall = Expression.Call(methodInfo, HttpContextExpr, Expression.Constant(parameter));
+                            MethodCallExpression typedCall;
+                            if (hasParameterInfo)
+                            {
+                                // parameter is being intentionally shadowed. We never want to use the outer ParameterInfo inside
+                                // this Func because the ParameterInfo varies after it's been cached for a given parameter type.
+                                typedCall = Expression.Call(methodInfo, HttpContextExpr, Expression.Constant(parameter));
+                            }
+                            else
+                            {
+                                typedCall = Expression.Call(methodInfo, HttpContextExpr);
+                            }
                             return Expression.Call(ConvertValueTaskOfNullableResultMethod.MakeGenericMethod(nonNullableParameterType), typedCall);
-                        };
+                        }, hasParameterInfo ? 2 : 1);
                     }
                 }
 
-                return null;
+                return (null, 0);
             }
 
             var nonNullableParameterType = Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType;
-            return _bindAsyncMethodCallCache.GetOrAdd(nonNullableParameterType, Finder)?.Invoke(parameter);
+            var (method, paramCount) = _bindAsyncMethodCallCache.GetOrAdd(nonNullableParameterType, Finder);
+            return (method?.Invoke(parameter), paramCount);
         }
 
         private static MethodInfo GetEnumTryParseMethod(bool preferNonGenericEnumParseOverload)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/36415

Prefers `BindAsync(HttpContext, ParameterInfo)` over `BindAsync(HttpContext)`.