### PR TITLE
Fixup OpenAPI displayed param type when using TryParse

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
         private ApiParameterDescription? CreateApiParameterDescription(ParameterInfo parameter, RoutePattern pattern)
         {
-            var (source, name, allowEmpty) = GetBindingSourceAndName(parameter, pattern);
+            var (source, name, allowEmpty, paramType) = GetBindingSourceAndName(parameter, pattern);
 
             // Services are ignored because they are not request parameters.
             // We ignore/skip body parameter because the value will be retrieved from the IAcceptsMetadata.
@@ -165,7 +165,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             return new ApiParameterDescription
             {
                 Name = name,
-                ModelMetadata = CreateModelMetadata(parameter.ParameterType),
+                ModelMetadata = CreateModelMetadata(paramType),
                 Source = source,
                 DefaultValue = parameter.DefaultValue,
                 Type = parameter.ParameterType,
@@ -184,25 +184,25 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 
         // TODO: Share more of this logic with RequestDelegateFactory.CreateArgument(...) using RequestDelegateFactoryUtilities
         // which is shared source.
-        private (BindingSource, string, bool) GetBindingSourceAndName(ParameterInfo parameter, RoutePattern pattern)
+        private (BindingSource, string, bool, Type) GetBindingSourceAndName(ParameterInfo parameter, RoutePattern pattern)
         {
             var attributes = parameter.GetCustomAttributes();
 
             if (attributes.OfType<IFromRouteMetadata>().FirstOrDefault() is { } routeAttribute)
             {
-                return (BindingSource.Path, routeAttribute.Name ?? parameter.Name ?? string.Empty, false);
+                return (BindingSource.Path, routeAttribute.Name ?? parameter.Name ?? string.Empty, false, parameter.ParameterType);
             }
             else if (attributes.OfType<IFromQueryMetadata>().FirstOrDefault() is { } queryAttribute)
             {
-                return (BindingSource.Query, queryAttribute.Name ?? parameter.Name ?? string.Empty, false);
+                return (BindingSource.Query, queryAttribute.Name ?? parameter.Name ?? string.Empty, false, parameter.ParameterType);
             }
             else if (attributes.OfType<IFromHeaderMetadata>().FirstOrDefault() is { } headerAttribute)
             {
-                return (BindingSource.Header, headerAttribute.Name ?? parameter.Name ?? string.Empty, false);
+                return (BindingSource.Header, headerAttribute.Name ?? parameter.Name ?? string.Empty, false, parameter.ParameterType);
             }
             else if (attributes.OfType<IFromBodyMetadata>().FirstOrDefault() is { } fromBodyAttribute)
             {
-                return (BindingSource.Body, parameter.Name ?? string.Empty, fromBodyAttribute.AllowEmpty);
+                return (BindingSource.Body, parameter.Name ?? string.Empty, fromBodyAttribute.AllowEmpty, parameter.ParameterType);
             }
             else if (parameter.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)) ||
                      parameter.ParameterType == typeof(HttpContext) ||
@@ -213,23 +213,25 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                      ParameterBindingMethodCache.HasBindAsyncMethod(parameter) ||
                      _serviceProviderIsService?.IsService(parameter.ParameterType) == true)
             {
-                return (BindingSource.Services, parameter.Name ?? string.Empty, false);
+                return (BindingSource.Services, parameter.Name ?? string.Empty, false, parameter.ParameterType);
             }
             else if (parameter.ParameterType == typeof(string) || ParameterBindingMethodCache.HasTryParseMethod(parameter))
             {
+                // complex types will display as strings since they use custom parsing via TryParse on a string
+                var displayType = !parameter.ParameterType.IsPrimitive ? typeof(string) : parameter.ParameterType;
                 // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
                 if (parameter.Name is { } name && pattern.GetParameter(name) is not null)
                 {
-                    return (BindingSource.Path, name, false);
+                    return (BindingSource.Path, name, false, displayType);
                 }
                 else
                 {
-                    return (BindingSource.Query, parameter.Name ?? string.Empty, false);
+                    return (BindingSource.Query, parameter.Name ?? string.Empty, false, displayType);
                 }
             }
             else
             {
-                return (BindingSource.Body, parameter.Name ?? string.Empty, false);
+                return (BindingSource.Body, parameter.Name ?? string.Empty, false, parameter.ParameterType);
             }
         }
 

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -218,7 +218,8 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             else if (parameter.ParameterType == typeof(string) || ParameterBindingMethodCache.HasTryParseMethod(parameter))
             {
                 // complex types will display as strings since they use custom parsing via TryParse on a string
-                var displayType = !parameter.ParameterType.IsPrimitive ? typeof(string) : parameter.ParameterType;
+                var displayType = !parameter.ParameterType.IsPrimitive && Nullable.GetUnderlyingType(parameter.ParameterType)?.IsPrimitive != true
+                    ? typeof(string) : parameter.ParameterType;
                 // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
                 if (parameter.Name is { } name && pattern.GetParameter(name) is not null)
                 {

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -280,7 +280,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         }
 
         [Fact]
-        public void AddsFromRouteParameterAsPathWithPrimitiveTypeWithTryParse()
+        public void AddsFromRouteParameterAsPathWithPrimitiveType()
         {
             static void AssertPathParameter(ApiDescription apiDescription)
             {
@@ -291,6 +291,20 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             }
 
             AssertPathParameter(GetApiDescription((int foo) => { }, "/{foo}"));
+        }
+
+        [Fact]
+        public void AddsFromRouteParameterAsPathWithNullablePrimitiveType()
+        {
+            static void AssertPathParameter(ApiDescription apiDescription)
+            {
+                var param = Assert.Single(apiDescription.ParameterDescriptions);
+                Assert.Equal(typeof(int?), param.Type);
+                Assert.Equal(typeof(int?), param.ModelMetadata.ModelType);
+                Assert.Equal(BindingSource.Path, param.Source);
+            }
+
+            AssertPathParameter(GetApiDescription((int? foo) => { }, "/{foo}"));
         }
 
         [Fact]

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -266,17 +266,45 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         }
 
         [Fact]
-        public void AddsFromRouteParameterAsPathWithCustomType()
+        public void AddsFromRouteParameterAsPathWithCustomClassWithTryParse()
         {
             static void AssertPathParameter(ApiDescription apiDescription)
             {
                 var param = Assert.Single(apiDescription.ParameterDescriptions);
                 Assert.Equal(typeof(TryParseStringRecord), param.Type);
-                Assert.Equal(typeof(TryParseStringRecord), param.ModelMetadata.ModelType);
+                Assert.Equal(typeof(string), param.ModelMetadata.ModelType);
                 Assert.Equal(BindingSource.Path, param.Source);
             }
 
             AssertPathParameter(GetApiDescription((TryParseStringRecord foo) => { }, "/{foo}"));
+        }
+
+        [Fact]
+        public void AddsFromRouteParameterAsPathWithCustomTypeWithTryParse()
+        {
+            static void AssertPathParameter(ApiDescription apiDescription)
+            {
+                var param = Assert.Single(apiDescription.ParameterDescriptions);
+                Assert.Equal(typeof(int), param.Type);
+                Assert.Equal(typeof(int), param.ModelMetadata.ModelType);
+                Assert.Equal(BindingSource.Path, param.Source);
+            }
+
+            AssertPathParameter(GetApiDescription((int foo) => { }, "/{foo}"));
+        }
+
+        [Fact]
+        public void AddsFromRouteParameterAsPathWithStructTypeWithTryParse()
+        {
+            static void AssertPathParameter(ApiDescription apiDescription)
+            {
+                var param = Assert.Single(apiDescription.ParameterDescriptions);
+                Assert.Equal(typeof(TryParseStringRecordStruct), param.Type);
+                Assert.Equal(typeof(string), param.ModelMetadata.ModelType);
+                Assert.Equal(BindingSource.Path, param.Source);
+            }
+
+            AssertPathParameter(GetApiDescription((TryParseStringRecordStruct foo) => { }, "/{foo}"));
         }
 
         [Fact]
@@ -915,6 +943,12 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         private record TryParseStringRecord(int Value)
         {
             public static bool TryParse(string value, out TryParseStringRecord result) =>
+                throw new NotImplementedException();
+        }
+
+        private record struct TryParseStringRecordStruct(int Value)
+        {
+            public static bool TryParse(string value, out TryParseStringRecordStruct result) =>
                 throw new NotImplementedException();
         }
 

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -280,7 +280,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         }
 
         [Fact]
-        public void AddsFromRouteParameterAsPathWithCustomTypeWithTryParse()
+        public void AddsFromRouteParameterAsPathWithPrimitiveTypeWithTryParse()
         {
             static void AssertPathParameter(ApiDescription apiDescription)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/36412

Before query and path would show object for complex types, now they display string and for primitives we keep them as the primitives name.