### PR TITLE
Set bootstrap5 for default static assets

### DIFF
--- a/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
+++ b/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
@@ -47,6 +47,7 @@
 
   <Target Name="GetIdentityUIAssets" Returns="@(ReferenceAsset)">
     <PropertyGroup>
+      <IdentityDefaultUIFramework Condition="'$(IdentityDefaultUIFramework)' == ''">Bootstrap5</IdentityDefaultUIFramework>
       <_ReferenceAssetContentRoot Condition="'$(IdentityDefaultUIFramework)' == 'Bootstrap5'">assets/V5</_ReferenceAssetContentRoot>
       <_ReferenceAssetContentRoot Condition="'$(IdentityDefaultUIFramework)' == 'Bootstrap4'">assets/V4</_ReferenceAssetContentRoot>
     </PropertyGroup>


### PR DESCRIPTION
Fixes issue where if no bootstrap attribute was specified, default would be to 4.

Fixes https://github.com/dotnet/aspnetcore/issues/36288