### PR TITLE
Revert "[release/5.0] Disable OSX10.14 Helix jobs for now"

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -22,8 +22,7 @@
   <ItemGroup Condition="'$(IsRequiredCheck)' == 'true' AND '$(TargetArchitecture)' == 'x64'">
     <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Windows.10.Amd64.Open" Platform="Windows" />
-    <!-- Re-enable once https://github.com/dotnet/core-eng/issues/14346 is resolved -->
-    <!-- <HelixAvailableTargetQueue Include="OSX.1014.Amd64.Open" Platform="OSX" /> -->
+    <HelixAvailableTargetQueue Include="OSX.1014.Amd64.Open" Platform="OSX" />
   </ItemGroup>
 
   <!-- queues for helix-matrix.yml pipeline -->


### PR DESCRIPTION
dotnet/core-eng#14346 is resolved. Hold for November servicing