### PR TITLE
Avoid building the configuration sources twice

### DIFF
--- a/src/DefaultBuilder/DefaultBuilder.slnf
+++ b/src/DefaultBuilder/DefaultBuilder.slnf
@@ -11,6 +11,7 @@
       "src\\Hosting\\Hosting\\src\\Microsoft.AspNetCore.Hosting.csproj",
       "src\\Hosting\\Server.Abstractions\\src\\Microsoft.AspNetCore.Hosting.Server.Abstractions.csproj",
       "src\\Hosting\\Server.IntegrationTesting\\src\\Microsoft.AspNetCore.Server.IntegrationTesting.csproj",
+      "src\\Hosting\\TestHost\\src\\Microsoft.AspNetCore.TestHost.csproj",
       "src\\Http\\Authentication.Abstractions\\src\\Microsoft.AspNetCore.Authentication.Abstractions.csproj",
       "src\\Http\\Authentication.Core\\src\\Microsoft.AspNetCore.Authentication.Core.csproj",
       "src\\Http\\Headers\\src\\Microsoft.Net.Http.Headers.csproj",
@@ -35,7 +36,8 @@
       "src\\Servers\\Kestrel\\Core\\src\\Microsoft.AspNetCore.Server.Kestrel.Core.csproj",
       "src\\Servers\\Kestrel\\Kestrel\\src\\Microsoft.AspNetCore.Server.Kestrel.csproj",
       "src\\Servers\\Kestrel\\Transport.Quic\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.csproj",
-      "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj"
+      "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj",
+      "src\\Testing\\src\\Microsoft.AspNetCore.Testing.csproj"
     ]
   }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1478,10 +1478,26 @@ namespace Microsoft.AspNetCore.Tests
             Assert.NotEqual(value0, value1);
         }
 
+        [Fact]
+        public void ConfigurationSourcesAreBuiltOnce()
+        {
+            var builder = WebApplication.CreateBuilder();
+
+            var configSource = new RandomConfigurationSource();
+            ((IConfigurationBuilder)builder.Configuration).Sources.Add(configSource);
+
+            var app = builder.Build();
+
+            Assert.Equal(1, configSource.ProvidersBuilt);
+        }
+
         public class RandomConfigurationSource : IConfigurationSource
         {
+            public int ProvidersBuilt { get; set; }
+
             public IConfigurationProvider Build(IConfigurationBuilder builder)
             {
+                ProvidersBuilt++;
                 return new RandomConfigurationProvider();
             }
         }


### PR DESCRIPTION
- When making the internal host builder, we copy the sources from the ConfigurationManager to the internal IConfigurationBuilder and the HostBuilder creates. This results in building configuration twice which can be problematic for performance reasons. Instead, we copy over the already built configuration providers in a custom IConfigurationSource implementation. This change does means the looking at the list of sources will not match the original list of sources though.
- Added a test


Fixes #36452