### PR TITLE
[release/5.0] Fixup feeds

### DIFF
--- a/src/Components/benchmarkapps/BlazingPizza.Server/NuGet.config
+++ b/src/Components/benchmarkapps/BlazingPizza.Server/NuGet.config
@@ -2,11 +2,6 @@
 <configuration>
     <packageSources>
         <clear />
-        <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-        <add key="extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
-        <add key="entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
-        <add key="aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
-        <add key="aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
-        <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+        <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>

--- a/src/Mvc/benchmarkapps/NuGet.config
+++ b/src/Mvc/benchmarkapps/NuGet.config
@@ -2,11 +2,6 @@
 <configuration>
     <packageSources>
         <clear />
-        <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-        <add key="extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
-        <add key="entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
-        <add key="aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
-        <add key="aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
-        <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+        <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
 </configuration>

--- a/src/Servers/Kestrel/NuGet.config
+++ b/src/Servers/Kestrel/NuGet.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <add key="general-testing" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
@mmitche I tried to do the same changes you did in 

https://github.com/dotnet/aspnetcore/commit/6a03ec2141cf0c50779c1ea08e330a35698ed284#diff-d762fdf991695cf086abf7a98538d5d1e5fff83b0e05d5be1f0942d245ab855d

The release/5.0 branch started failing with these errors:

```
Starting Multifeed Nuget Security Analysis: 
NuGet.config - Multiple internal feeds declared, but none with upstreams.
src/Components/benchmarkapps/BlazingPizza.Server/NuGet.config - Multiple feeds declared.
src/Mvc/benchmarkapps/NuGet.config - Multiple feeds declared.
src/Servers/Kestrel/NuGet.config - Missing <clear/> statement.
```