### PR TITLE
Revert "New Hosted build pools"

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -104,24 +104,24 @@ jobs:
           vmImage: ubuntu-18.04
         ${{ if eq(parameters.useHostedUbuntu, false) }}:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore1ESPool-Svc-Public
-            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+            name: NetCorePublic-Pool
+            queue: BuildPool.Ubuntu.1804.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Ubuntu.1804.Amd64
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Svc-Public
+          name: NetCorePublic-Pool
           ${{ if ne(parameters.isTestingJob, true) }}:
             # Visual Studio Build Tools
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019.BT.Open
+            queue: BuildPool.Server.Amd64.VS2019.BT.Open
           ${{ if eq(parameters.isTestingJob, true) }}:
             # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+            queue: BuildPool.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Svc-Internal
+          name: NetCoreInternal-Pool
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          queue: BuildPool.Server.Amd64.VS2019
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
     variables:


### PR DESCRIPTION
Reverts dotnet/aspnetcore#36110

1ES pools don't handle the current load.