### PR TITLE
Avoid using invalid content type for ValidationProblemDetails

### DIFF
--- a/src/Http/Routing/src/Builder/OpenApiDelegateEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/OpenApiDelegateEndpointConventionBuilderExtensions.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Http
         /// </summary>
         /// <param name="builder">The <see cref="DelegateEndpointConventionBuilder"/>.</param>
         /// <param name="statusCode">The response status code. Defaults to StatusCodes.Status400BadRequest.</param>
-        /// <param name="contentType">The response content type. Defaults to "application/validationproblem+json".</param>
+        /// <param name="contentType">The response content type. Defaults to "application/problem+json".</param>
         /// <returns>A <see cref="DelegateEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
         public static DelegateEndpointConventionBuilder ProducesValidationProblem(this DelegateEndpointConventionBuilder builder,
             int statusCode = StatusCodes.Status400BadRequest,
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Http
         {
             if (string.IsNullOrEmpty(contentType))
             {
-                contentType = "application/validationproblem+json";
+                contentType = "application/problem+json";
             }
 
             return Produces<HttpValidationProblemDetails>(builder, statusCode, contentType);

--- a/src/Mvc/Mvc.ApiExplorer/test/ApiResponseTypeProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/ApiResponseTypeProviderTest.cs
@@ -715,7 +715,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
             // Arrange
             var actionDescriptor = GetControllerActionDescriptor(typeof(TestController), nameof(TestController.GetUser));
             actionDescriptor.FilterDescriptors.Add(new FilterDescriptor(new ProducesAttribute("text/xml") { Type = typeof(BaseModel) }, FilterScope.Action));
-            actionDescriptor.FilterDescriptors.Add(new FilterDescriptor(new ProducesResponseTypeAttribute(typeof(ValidationProblemDetails), 400, "application/validationproblem+json"), FilterScope.Action));
+            actionDescriptor.FilterDescriptors.Add(new FilterDescriptor(new ProducesResponseTypeAttribute(typeof(ValidationProblemDetails), 400, "application/problem+json"), FilterScope.Action));
             actionDescriptor.FilterDescriptors.Add(new FilterDescriptor(new ProducesResponseTypeAttribute(typeof(ProblemDetails), 404, "application/problem+json"), FilterScope.Action));
             actionDescriptor.FilterDescriptors.Add(new FilterDescriptor(new ProducesResponseTypeAttribute(409), FilterScope.Action));
 
@@ -738,7 +738,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 {
                     Assert.Equal(typeof(ValidationProblemDetails), responseType.Type);
                     Assert.Equal(400, responseType.StatusCode);
-                    Assert.Equal(new[] { "application/validationproblem+json" }, GetSortedMediaTypes(responseType));
+                    Assert.Equal(new[] { "application/problem+json" }, GetSortedMediaTypes(responseType));
                 },
                 responseType =>
                 {

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -598,7 +598,7 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
                 {
                     Assert.Equal(typeof(HttpValidationProblemDetails), responseType.Type);
                     Assert.Equal(400, responseType.StatusCode);
-                    Assert.Equal(new[] { "application/validationproblem+json" }, GetSortedMediaTypes(responseType));
+                    Assert.Equal(new[] { "application/problem+json" }, GetSortedMediaTypes(responseType));
                 },
                 responseType =>
                 {


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/36560 
Closes https://github.com/dotnet/aspnetcore/issues/36557.

The OpenAPI extension methods assume an `application/validationproblem+json` content type but the results object represnet a different result.