### PR TITLE
Use a fake clock in the test

### DIFF
--- a/src/Identity/test/Identity.Test/SecurityStampValidatorTest.cs
+++ b/src/Identity/test/Identity.Test/SecurityStampValidatorTest.cs
@@ -285,7 +285,11 @@ namespace Microsoft.AspNetCore.Identity.Test
             var services = new ServiceCollection();
             services.AddSingleton(options.Object);
             services.AddSingleton(signInManager.Object);
-            var clock = new SystemClock();
+            var clock = new TestClock()
+            {
+                // Second precision
+                UtcNow = new DateTimeOffset(2013, 6, 11, 12, 34, 56, 0, TimeSpan.Zero)
+            };
             services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<PocoUser>(options.Object, signInManager.Object, clock, new LoggerFactory()));
             httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
             var id = new ClaimsIdentity(IdentityConstants.ApplicationScheme);

--- a/src/Identity/test/Shared/TestClock.cs
+++ b/src/Identity/test/Shared/TestClock.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.AspNetCore.Authentication;
 
-namespace Microsoft.AspNetCore.Identity.InMemory
+namespace Microsoft.AspNetCore.Identity.Test
 {
     public class TestClock : ISystemClock
     {


### PR DESCRIPTION
Addresses #36601. I forgot to use a fake clock so the seconds changed mid test.

Will backport to 6.0-rc2.