### PR TITLE
[release/6.0-rc2] Handle JsonExceptions in RequestDelegateFactory

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
@@ -504,7 +505,7 @@ namespace Microsoft.AspNetCore.Http
 
         private static Func<object?, HttpContext, Task> HandleRequestBodyAndCompileRequestDelegate(Expression responseWritingMethodCall, FactoryContext factoryContext)
         {
-            if (factoryContext.JsonRequestBodyType is null)
+            if (factoryContext.JsonRequestBodyParameter is null)
             {
                 if (factoryContext.ParameterBinders.Count > 0)
                 {
@@ -533,7 +534,12 @@ namespace Microsoft.AspNetCore.Http
                     responseWritingMethodCall, TargetExpr, HttpContextExpr).Compile();
             }
 
-            var bodyType = factoryContext.JsonRequestBodyType;
+            var bodyType = factoryContext.JsonRequestBodyParameter.ParameterType;
+            var parameterTypeName = TypeNameHelper.GetTypeDisplayName(factoryContext.JsonRequestBodyParameter.ParameterType, fullName: false);
+            var parameterName = factoryContext.JsonRequestBodyParameter.Name;
+
+            Debug.Assert(parameterName is not null, "CreateArgument() should throw if parameter.Name is null.");
+
             object? defaultBodyValue = null;
 
             if (factoryContext.AllowEmptyRequestBody && bodyType.IsValueType)
@@ -580,10 +586,10 @@ namespace Microsoft.AspNetCore.Http
                             Log.RequestBodyIOException(httpContext, ex);
                             return;
                         }
-                        catch (InvalidDataException ex)
+                        catch (Exception ex) when (ex is InvalidDataException || ex is JsonException)
                         {
-                            Log.RequestBodyInvalidDataException(httpContext, ex, factoryContext.ThrowOnBadRequest);
-                            httpContext.Response.StatusCode = 400;
+                            Log.InvalidJsonRequestBody(httpContext, parameterTypeName, parameterName, ex, factoryContext.ThrowOnBadRequest);
+                            httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
                             return;
                         }
                     }
@@ -618,10 +624,10 @@ namespace Microsoft.AspNetCore.Http
                             Log.RequestBodyIOException(httpContext, ex);
                             return;
                         }
-                        catch (InvalidDataException ex)
+                        catch (Exception ex) when (ex is InvalidDataException || ex is JsonException)
                         {
 
-                            Log.RequestBodyInvalidDataException(httpContext, ex, factoryContext.ThrowOnBadRequest);
+                            Log.InvalidJsonRequestBody(httpContext, parameterTypeName, parameterName, ex, factoryContext.ThrowOnBadRequest);
                             httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
                             return;
                         }
@@ -878,11 +884,14 @@ namespace Microsoft.AspNetCore.Http
 
         private static Expression BindParameterFromBody(ParameterInfo parameter, bool allowEmpty, FactoryContext factoryContext)
         {
-            if (factoryContext.JsonRequestBodyType is not null)
+            if (factoryContext.JsonRequestBodyParameter is not null)
             {
                 factoryContext.HasMultipleBodyParameters = true;
                 var parameterName = parameter.Name;
-                if (parameterName is not null && factoryContext.TrackedParameters.ContainsKey(parameterName))
+
+                Debug.Assert(parameterName is not null, "CreateArgument() should throw if parameter.Name is null.");
+
+                if (factoryContext.TrackedParameters.ContainsKey(parameterName))
                 {
                     factoryContext.TrackedParameters.Remove(parameterName);
                     factoryContext.TrackedParameters.Add(parameterName, "UNKNOWN");
@@ -891,7 +900,7 @@ namespace Microsoft.AspNetCore.Http
 
             var isOptional = IsOptionalParameter(parameter, factoryContext);
 
-            factoryContext.JsonRequestBodyType = parameter.ParameterType;
+            factoryContext.JsonRequestBodyParameter = parameter;
             factoryContext.AllowEmptyRequestBody = allowEmpty || isOptional;
             factoryContext.Metadata.Add(new AcceptsMetadata(parameter.ParameterType, factoryContext.AllowEmptyRequestBody, DefaultContentType));
 
@@ -1163,7 +1172,7 @@ namespace Microsoft.AspNetCore.Http
             public bool DisableInferredFromBody { get; init; }
 
             // Temporary State
-            public Type? JsonRequestBodyType { get; set; }
+            public ParameterInfo? JsonRequestBodyParameter { get; set; }
             public bool AllowEmptyRequestBody { get; set; }
 
             public bool UsingTempSourceString { get; set; }
@@ -1196,7 +1205,8 @@ namespace Microsoft.AspNetCore.Http
 
         private static partial class Log
         {
-            private const string RequestBodyInvalidDataExceptionMessage = "Reading the request body failed with an InvalidDataException.";
+            private const string InvalidJsonRequestBodyMessage = @"Failed to read parameter ""{ParameterType} {ParameterName}"" from the request body as JSON.";
+            private const string InvalidJsonRequestBodyExceptionMessage = @"Failed to read parameter ""{0} {1}"" from the request body as JSON.";
 
             private const string ParameterBindingFailedLogMessage = @"Failed to bind parameter ""{ParameterType} {ParameterName}"" from ""{SourceValue}"".";
             private const string ParameterBindingFailedExceptionMessage = @"Failed to bind parameter ""{0} {1}"" from ""{2}"".";
@@ -1206,6 +1216,7 @@ namespace Microsoft.AspNetCore.Http
 
             private const string UnexpectedContentTypeLogMessage = @"Expected a supported JSON media type but got ""{ContentType}"".";
             private const string UnexpectedContentTypeExceptionMessage = @"Expected a supported JSON media type but got ""{0}"".";
+
             private const string ImplicitBodyNotProvidedLogMessage = @"Implicit body inferred for parameter ""{ParameterName}"" but no body was provided. Did you mean to use a Service instead?";
             private const string ImplicitBodyNotProvidedExceptionMessage = @"Implicit body inferred for parameter ""{0}"" but no body was provided. Did you mean to use a Service instead?";
 
@@ -1217,18 +1228,19 @@ namespace Microsoft.AspNetCore.Http
             [LoggerMessage(1, LogLevel.Debug, "Reading the request body failed with an IOException.", EventName = "RequestBodyIOException")]
             private static partial void RequestBodyIOException(ILogger logger, IOException exception);
 
-            public static void RequestBodyInvalidDataException(HttpContext httpContext, InvalidDataException exception, bool shouldThrow)
+            public static void InvalidJsonRequestBody(HttpContext httpContext, string parameterTypeName, string parameterName, Exception exception, bool shouldThrow)
             {
                 if (shouldThrow)
                 {
-                    throw new BadHttpRequestException(RequestBodyInvalidDataExceptionMessage, exception);
+                    var message = string.Format(CultureInfo.InvariantCulture, InvalidJsonRequestBodyExceptionMessage, parameterTypeName, parameterName);
+                    throw new BadHttpRequestException(message, exception);
                 }
 
-                RequestBodyInvalidDataException(GetLogger(httpContext), exception);
+                InvalidJsonRequestBody(GetLogger(httpContext), parameterTypeName, parameterName, exception);
             }
 
-            [LoggerMessage(2, LogLevel.Debug, RequestBodyInvalidDataExceptionMessage, EventName = "RequestBodyInvalidDataException")]
-            private static partial void RequestBodyInvalidDataException(ILogger logger, InvalidDataException exception);
+            [LoggerMessage(2, LogLevel.Debug, InvalidJsonRequestBodyMessage, EventName = "InvalidJsonRequestBody")]
+            private static partial void InvalidJsonRequestBody(ILogger logger, string parameterType, string parameterName, Exception exception);
 
             public static void ParameterBindingFailed(HttpContext httpContext, string parameterTypeName, string parameterName, string sourceValue, bool shouldThrow)
             {

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -586,7 +586,7 @@ namespace Microsoft.AspNetCore.Http
                             Log.RequestBodyIOException(httpContext, ex);
                             return;
                         }
-                        catch (Exception ex) when (ex is InvalidDataException || ex is JsonException)
+                        catch (JsonException ex)
                         {
                             Log.InvalidJsonRequestBody(httpContext, parameterTypeName, parameterName, ex, factoryContext.ThrowOnBadRequest);
                             httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -624,7 +624,7 @@ namespace Microsoft.AspNetCore.Http
                             Log.RequestBodyIOException(httpContext, ex);
                             return;
                         }
-                        catch (Exception ex) when (ex is InvalidDataException || ex is JsonException)
+                        catch (JsonException ex)
                         {
 
                             Log.InvalidJsonRequestBody(httpContext, parameterTypeName, parameterName, ex, factoryContext.ThrowOnBadRequest);
@@ -1270,16 +1270,6 @@ namespace Microsoft.AspNetCore.Http
             [LoggerMessage(4, LogLevel.Debug, RequiredParameterNotProvidedLogMessage, EventName = "RequiredParameterNotProvided")]
             private static partial void RequiredParameterNotProvided(ILogger logger, string parameterType, string parameterName, string source);
 
-            public static void UnexpectedContentType(HttpContext httpContext, string? contentType, bool shouldThrow)
-            {
-                if (shouldThrow)
-                {
-                    var message = string.Format(CultureInfo.InvariantCulture, UnexpectedContentTypeExceptionMessage, contentType);
-                    throw new BadHttpRequestException(message, StatusCodes.Status415UnsupportedMediaType);
-                }
-
-                UnexpectedContentType(GetLogger(httpContext), contentType ?? "(none)");
-            }
             public static void ImplicitBodyNotProvided(HttpContext httpContext, string parameterName, bool shouldThrow)
             {
                 if (shouldThrow)
@@ -1294,8 +1284,16 @@ namespace Microsoft.AspNetCore.Http
             [LoggerMessage(5, LogLevel.Debug, ImplicitBodyNotProvidedLogMessage, EventName = "ImplicitBodyNotProvided")]
             private static partial void ImplicitBodyNotProvided(ILogger logger, string parameterName);
 
-            public static void UnexpectedContentType(HttpContext httpContext, string? contentType)
-                => UnexpectedContentType(GetLogger(httpContext), contentType ?? "(none)");
+            public static void UnexpectedContentType(HttpContext httpContext, string? contentType, bool shouldThrow)
+            {
+                if (shouldThrow)
+                {
+                    var message = string.Format(CultureInfo.InvariantCulture, UnexpectedContentTypeExceptionMessage, contentType);
+                    throw new BadHttpRequestException(message, StatusCodes.Status415UnsupportedMediaType);
+                }
+
+                UnexpectedContentType(GetLogger(httpContext), contentType ?? "(none)");
+            }
 
             [LoggerMessage(6, LogLevel.Debug, UnexpectedContentTypeLogMessage, EventName = "UnexpectedContentType")]
             private static partial void UnexpectedContentType(ILogger logger, string contentType);

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -956,7 +956,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = CreateHttpContext();
 
             var requestBodyBytes = JsonSerializer.SerializeToUtf8Bytes(originalTodo);
-            var stream = new MemoryStream(requestBodyBytes); ;
+            var stream = new MemoryStream(requestBodyBytes);
             httpContext.Request.Body = stream;
 
             httpContext.Request.Headers["Content-Type"] = "application/json";
@@ -1012,7 +1012,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = CreateHttpContext();
 
             var requestBodyBytes = JsonSerializer.SerializeToUtf8Bytes(originalTodo);
-            var stream = new MemoryStream(requestBodyBytes); ;
+            var stream = new MemoryStream(requestBodyBytes);
             httpContext.Request.Body = stream;
 
             httpContext.Request.Headers["Content-Type"] = "application/json";
@@ -1174,7 +1174,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var httpContext = CreateHttpContext();
 
             var requestBodyBytes = JsonSerializer.SerializeToUtf8Bytes(originalTodo);
-            var stream = new MemoryStream(requestBodyBytes); ;
+            var stream = new MemoryStream(requestBodyBytes);
             httpContext.Request.Body = stream;
 
             httpContext.Request.Headers["Content-Type"] = "application/json";
@@ -1354,10 +1354,43 @@ namespace Microsoft.AspNetCore.Routing.Internal
             Assert.False(httpContext.Response.HasStarted);
 
             var logMessage = Assert.Single(TestSink.Writes);
-            Assert.Equal(new EventId(2, "RequestBodyInvalidDataException"), logMessage.EventId);
+            Assert.Equal(new EventId(2, "InvalidJsonRequestBody"), logMessage.EventId);
             Assert.Equal(LogLevel.Debug, logMessage.LogLevel);
-            Assert.Equal("Reading the request body failed with an InvalidDataException.", logMessage.Message);
+            Assert.Equal(@"Failed to read parameter ""Todo todo"" from the request body as JSON.", logMessage.Message);
             Assert.Same(invalidDataException, logMessage.Exception);
+        }
+
+        [Fact]
+        public async Task RequestDelegateLogsFromBodyJsonExceptionAsDebugAndSets400Response()
+        {
+            var invoked = false;
+
+            void TestAction([FromBody] Todo todo)
+            {
+                invoked = true;
+            }
+
+            var httpContext = CreateHttpContext();
+            httpContext.Request.Headers["Content-Type"] = "application/json";
+            httpContext.Request.Headers["Content-Length"] = "1";
+            httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{"));
+            httpContext.Features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(true));
+
+            var factoryResult = RequestDelegateFactory.Create(TestAction);
+            var requestDelegate = factoryResult.RequestDelegate;
+
+            await requestDelegate(httpContext);
+
+            Assert.False(invoked);
+            Assert.False(httpContext.RequestAborted.IsCancellationRequested);
+            Assert.Equal(400, httpContext.Response.StatusCode);
+            Assert.False(httpContext.Response.HasStarted);
+
+            var logMessage = Assert.Single(TestSink.Writes);
+            Assert.Equal(new EventId(2, "InvalidJsonRequestBody"), logMessage.EventId);
+            Assert.Equal(LogLevel.Debug, logMessage.LogLevel);
+            Assert.Equal(@"Failed to read parameter ""Todo todo"" from the request body as JSON.", logMessage.Message);
+            Assert.IsType<JsonException>(logMessage.Exception);
         }
 
         [Fact]
@@ -1393,9 +1426,47 @@ namespace Microsoft.AspNetCore.Routing.Internal
             // We don't log bad requests when we throw.
             Assert.Empty(TestSink.Writes);
 
-            Assert.Equal("Reading the request body failed with an InvalidDataException.", badHttpRequestException.Message);
+            Assert.Equal(@"Failed to read parameter ""Todo todo"" from the request body as JSON.", badHttpRequestException.Message);
             Assert.Equal(400, badHttpRequestException.StatusCode);
             Assert.Same(invalidDataException, badHttpRequestException.InnerException);
+        }
+
+        [Fact]
+        public async Task RequestDelegateLogsFromBodyJsonExceptionsAsDebugAndThrowsIfThrowOnBadRequest()
+        {
+            var invoked = false;
+
+            void TestAction([FromBody] Todo todo)
+            {
+                invoked = true;
+            }
+
+            var invalidDataException = new InvalidDataException();
+
+            var httpContext = CreateHttpContext();
+            httpContext.Request.Headers["Content-Type"] = "application/json";
+            httpContext.Request.Headers["Content-Length"] = "1";
+            httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("{"));
+            httpContext.Features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(true));
+
+            var factoryResult = RequestDelegateFactory.Create(TestAction, new() { ThrowOnBadRequest = true });
+            var requestDelegate = factoryResult.RequestDelegate;
+
+            var badHttpRequestException = await Assert.ThrowsAsync<BadHttpRequestException>(() => requestDelegate(httpContext));
+
+            Assert.False(invoked);
+
+            // The httpContext should be untouched.
+            Assert.False(httpContext.RequestAborted.IsCancellationRequested);
+            Assert.Equal(200, httpContext.Response.StatusCode);
+            Assert.False(httpContext.Response.HasStarted);
+
+            // We don't log bad requests when we throw.
+            Assert.Empty(TestSink.Writes);
+
+            Assert.Equal(@"Failed to read parameter ""Todo todo"" from the request body as JSON.", badHttpRequestException.Message);
+            Assert.Equal(400, badHttpRequestException.StatusCode);
+            Assert.IsType<JsonException>(badHttpRequestException.InnerException);
         }
 
         [Fact]


### PR DESCRIPTION
Backport of #36589 to release/6.0-rc2

## Description

This change causes minimal API route handlers to respond with a "400 Bad Request" instead of "500 Internal Server Error" when given a request body with an `application/json` Content-Type but malformed JSON.

Before, we expected this to throw an `InvalidDataException` but malformed JSON results in a `JsonException` instead.

## Customer Impact

This more clearly distinguishes server side errors that should result in 500 responses from errors caused by a malformed JSON request body.

## Regression?
- [ ] Yes
- [X] No

## Risk
- [ ] High
- [ ] Medium
- [X] Low

This is a bug fix to handle JsonExceptions like we were handling InvalidDataExceptions before. ReadFromJsonAsync actually throws JsonExceptions but not InvalidDataExceptions.

## Verification
- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A

