### PR TITLE
Throw for invalid TryParse and BindAsync

### DIFF
--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -289,9 +289,9 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         {
             var ex = Assert.Throws<InvalidOperationException>(
                 () => new ParameterBindingMethodCache().FindTryParseMethod(type));
-            Assert.StartsWith($"TryParse method found on {TypeNameHelper.GetTypeDisplayName(type)} with incorrect format. Must be a static method with format", ex.Message);
-            Assert.Contains($"bool TryParse(string, IFormatProvider, out {TypeNameHelper.GetTypeDisplayName(type)})", ex.Message);
-            Assert.Contains($"bool TryParse(string, out {TypeNameHelper.GetTypeDisplayName(type)})", ex.Message);
+            Assert.StartsWith($"TryParse method found on {TypeNameHelper.GetTypeDisplayName(type, fullName: false)} with incorrect format. Must be a static method with format", ex.Message);
+            Assert.Contains($"bool TryParse(string, IFormatProvider, out {TypeNameHelper.GetTypeDisplayName(type, fullName: false)})", ex.Message);
+            Assert.Contains($"bool TryParse(string, out {TypeNameHelper.GetTypeDisplayName(type, fullName: false)})", ex.Message);
         }
 
         [Theory]
@@ -314,11 +314,11 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
             var parameter = new MockParameterInfo(type, "anything");
             var ex = Assert.Throws<InvalidOperationException>(
                 () => cache.FindBindAsyncMethod(parameter));
-            Assert.StartsWith($"BindAsync method found on {TypeNameHelper.GetTypeDisplayName(type)} with incorrect format. Must be a static method with format", ex.Message);
-            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type)}> BindAsync(HttpContext context, ParameterInfo parameter)", ex.Message);
-            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type)}> BindAsync(HttpContext context)", ex.Message);
-            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type)}?> BindAsync(HttpContext context, ParameterInfo parameter)", ex.Message);
-            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type)}?> BindAsync(HttpContext context)", ex.Message);
+            Assert.StartsWith($"BindAsync method found on {TypeNameHelper.GetTypeDisplayName(type, fullName: false)} with incorrect format. Must be a static method with format", ex.Message);
+            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type, fullName: false)}> BindAsync(HttpContext context, ParameterInfo parameter)", ex.Message);
+            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type, fullName: false)}> BindAsync(HttpContext context)", ex.Message);
+            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type, fullName: false)}?> BindAsync(HttpContext context, ParameterInfo parameter)", ex.Message);
+            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type, fullName: false)}?> BindAsync(HttpContext context)", ex.Message);
         }
 
         [Theory]

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Http.Extensions.Tests
 {
@@ -288,9 +289,9 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
         {
             var ex = Assert.Throws<InvalidOperationException>(
                 () => new ParameterBindingMethodCache().FindTryParseMethod(type));
-            Assert.StartsWith($"TryParse method found on {type.Name} with incorrect format. Must be a static method with format", ex.Message);
-            Assert.Contains($"bool TryParse(string, IFormatProvider, out {type.Name})", ex.Message);
-            Assert.Contains($"bool TryParse(string, out {type.Name})", ex.Message);
+            Assert.StartsWith($"TryParse method found on {TypeNameHelper.GetTypeDisplayName(type)} with incorrect format. Must be a static method with format", ex.Message);
+            Assert.Contains($"bool TryParse(string, IFormatProvider, out {TypeNameHelper.GetTypeDisplayName(type)})", ex.Message);
+            Assert.Contains($"bool TryParse(string, out {TypeNameHelper.GetTypeDisplayName(type)})", ex.Message);
         }
 
         [Theory]
@@ -313,11 +314,11 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
             var parameter = new MockParameterInfo(type, "anything");
             var ex = Assert.Throws<InvalidOperationException>(
                 () => cache.FindBindAsyncMethod(parameter));
-            Assert.StartsWith($"BindAsync method found on {type.Name} with incorrect format. Must be a static method with format", ex.Message);
-            Assert.Contains($"ValueTask<{type.Name}> BindAsync(HttpContext context, ParameterInfo parameter)", ex.Message);
-            Assert.Contains($"ValueTask<{type.Name}> BindAsync(HttpContext context)", ex.Message);
-            Assert.Contains($"ValueTask<{type.Name}?> BindAsync(HttpContext context, ParameterInfo parameter)", ex.Message);
-            Assert.Contains($"ValueTask<{type.Name}?> BindAsync(HttpContext context)", ex.Message);
+            Assert.StartsWith($"BindAsync method found on {TypeNameHelper.GetTypeDisplayName(type)} with incorrect format. Must be a static method with format", ex.Message);
+            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type)}> BindAsync(HttpContext context, ParameterInfo parameter)", ex.Message);
+            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type)}> BindAsync(HttpContext context)", ex.Message);
+            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type)}?> BindAsync(HttpContext context, ParameterInfo parameter)", ex.Message);
+            Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type)}?> BindAsync(HttpContext context)", ex.Message);
         }
 
         [Theory]
@@ -601,12 +602,6 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
             }
         }
 
-        private record struct NullableReturningBindAsyncSingleArgStruct(int Value)
-        {
-            public static ValueTask<NullableReturningBindAsyncStruct?> BindAsync(HttpContext context, ParameterInfo parameter) =>
-                throw new NotImplementedException();
-        }
-
         private record struct InvalidWrongReturnBindAsyncStruct(int Value)
         {
             public static Task<InvalidWrongReturnBindAsyncStruct> BindAsync(HttpContext context, ParameterInfo parameter) =>
@@ -621,13 +616,13 @@ namespace Microsoft.AspNetCore.Http.Extensions.Tests
 
         private record struct InvalidWrongParamBindAsyncStruct(int Value)
         {
-            public static ValueTask<InvalidWrongReturnBindAsyncStruct> BindAsync(ParameterInfo parameter) =>
+            public static ValueTask<InvalidWrongParamBindAsyncStruct> BindAsync(ParameterInfo parameter) =>
                 throw new NotImplementedException();
         }
 
         private class InvalidWrongParamBindAsyncClass
         {
-            public static Task<InvalidWrongReturnBindAsyncClass> BindAsync(ParameterInfo parameter) =>
+            public static Task<InvalidWrongParamBindAsyncClass> BindAsync(ParameterInfo parameter) =>
                 throw new NotImplementedException();
         }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1538,6 +1538,51 @@ namespace Microsoft.AspNetCore.Routing.Internal
             Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(TestBothInvalidAction));
         }
 
+        [Fact]
+        public void BuildRequestDelegateThrowsInvalidOperationExceptionForInvalidTryParse()
+        {
+            void TestTryParseStruct(BadTryParseStruct value1) { }
+            void TestTryParseClass(BadTryParseClass value1) { }
+
+            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(TestTryParseStruct));
+            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(TestTryParseClass));
+        }
+
+        private struct BadTryParseStruct
+        {
+            public static void TryParse(string? value, out BadTryParseStruct result) { }
+        }
+
+        private class BadTryParseClass
+        {
+            public static void TryParse(string? value, out BadTryParseClass result)
+            {
+                result = new();
+            }
+        }
+
+        [Fact]
+        public void BuildRequestDelegateThrowsInvalidOperationExceptionForInvalidBindAsync()
+        {
+            void TestBindAsyncStruct(BadBindAsyncStruct value1) { }
+            void TestBindAsyncClass(BadBindAsyncClass value1) { }
+
+            var ex = Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(TestBindAsyncStruct));
+            Assert.Throws<InvalidOperationException>(() => RequestDelegateFactory.Create(TestBindAsyncClass));
+        }
+
+        private struct BadBindAsyncStruct
+        {
+            public static Task<BadBindAsyncStruct> BindAsync(HttpContext context, ParameterInfo parameter) =>
+                throw new NotImplementedException();
+        }
+
+        private class BadBindAsyncClass
+        {
+            public static Task<BadBindAsyncClass> BindAsync(HttpContext context, ParameterInfo parameter) =>
+                throw new NotImplementedException();
+        }
+
         public static object[][] ExplicitFromServiceActions
         {
             get

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -128,7 +128,6 @@ namespace Microsoft.AspNetCore.Http
                     var stringBuilder = new StringBuilder();
                     stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"TryParse method found on {type.Name} with incorrect format. Must be a static method with format");
                     stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, IFormatProvider, out {type.Name})");
-                    stringBuilder.AppendLine("or");
                     stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, out {type.Name})");
                     stringBuilder.AppendLine("but found");
                     stringBuilder.Append(invalidMethod.IsStatic ? "static " : "not-static ");

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -127,9 +127,9 @@ namespace Microsoft.AspNetCore.Http
                 if (type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance) is MethodInfo invalidMethod)
                 {
                     var stringBuilder = new StringBuilder();
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"TryParse method found on {TypeNameHelper.GetTypeDisplayName(type)} with incorrect format. Must be a static method with format");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, IFormatProvider, out {TypeNameHelper.GetTypeDisplayName(type)})");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, out {TypeNameHelper.GetTypeDisplayName(type)})");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"TryParse method found on {TypeNameHelper.GetTypeDisplayName(type, fullName: false)} with incorrect format. Must be a static method with format");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, IFormatProvider, out {TypeNameHelper.GetTypeDisplayName(type, fullName: false)})");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, out {TypeNameHelper.GetTypeDisplayName(type, fullName: false)})");
                     stringBuilder.AppendLine("but found");
                     stringBuilder.Append(invalidMethod.IsStatic ? "static " : "not-static ");
                     stringBuilder.Append(invalidMethod.ToString());
@@ -210,11 +210,11 @@ namespace Microsoft.AspNetCore.Http
                 if (nonNullableParameterType.GetMethod("BindAsync", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance) is MethodInfo invalidBindMethod)
                 {
                     var stringBuilder = new StringBuilder();
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"BindAsync method found on {TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)} with incorrect format. Must be a static method with format");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)}> BindAsync(HttpContext context, ParameterInfo parameter)");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)}> BindAsync(HttpContext context)");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)}?> BindAsync(HttpContext context, ParameterInfo parameter)");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)}?> BindAsync(HttpContext context)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"BindAsync method found on {TypeNameHelper.GetTypeDisplayName(nonNullableParameterType, fullName: false)} with incorrect format. Must be a static method with format");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType, fullName: false)}> BindAsync(HttpContext context, ParameterInfo parameter)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType, fullName: false)}> BindAsync(HttpContext context)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType, fullName: false)}?> BindAsync(HttpContext context, ParameterInfo parameter)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType, fullName: false)}?> BindAsync(HttpContext context)");
                     stringBuilder.AppendLine("but found");
                     stringBuilder.Append(invalidBindMethod.IsStatic ? "static " : "not-static");
                     stringBuilder.Append(invalidBindMethod.ToString());

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -10,6 +10,7 @@ using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.Extensions.Internal;
 
 #nullable enable
 
@@ -126,9 +127,9 @@ namespace Microsoft.AspNetCore.Http
                 if (type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance) is MethodInfo invalidMethod)
                 {
                     var stringBuilder = new StringBuilder();
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"TryParse method found on {type.Name} with incorrect format. Must be a static method with format");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, IFormatProvider, out {type.Name})");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, out {type.Name})");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"TryParse method found on {TypeNameHelper.GetTypeDisplayName(type)} with incorrect format. Must be a static method with format");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, IFormatProvider, out {TypeNameHelper.GetTypeDisplayName(type)})");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, out {TypeNameHelper.GetTypeDisplayName(type)})");
                     stringBuilder.AppendLine("but found");
                     stringBuilder.Append(invalidMethod.IsStatic ? "static " : "not-static ");
                     stringBuilder.Append(invalidMethod.ToString());
@@ -209,11 +210,11 @@ namespace Microsoft.AspNetCore.Http
                 if (nonNullableParameterType.GetMethod("BindAsync", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance) is MethodInfo invalidBindMethod)
                 {
                     var stringBuilder = new StringBuilder();
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"BindAsync method found on {nonNullableParameterType.Name} with incorrect format. Must be a static method with format");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{nonNullableParameterType.Name}> BindAsync(HttpContext context, ParameterInfo parameter)");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{nonNullableParameterType.Name}> BindAsync(HttpContext context)");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{nonNullableParameterType.Name}?> BindAsync(HttpContext context, ParameterInfo parameter)");
-                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{nonNullableParameterType.Name}?> BindAsync(HttpContext context)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"BindAsync method found on {TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)} with incorrect format. Must be a static method with format");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)}> BindAsync(HttpContext context, ParameterInfo parameter)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)}> BindAsync(HttpContext context)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)}?> BindAsync(HttpContext context, ParameterInfo parameter)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{TypeNameHelper.GetTypeDisplayName(nonNullableParameterType)}?> BindAsync(HttpContext context)");
                     stringBuilder.AppendLine("but found");
                     stringBuilder.Append(invalidBindMethod.IsStatic ? "static " : "not-static");
                     stringBuilder.Append(invalidBindMethod.ToString());

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 #nullable enable
 
@@ -106,7 +107,7 @@ namespace Microsoft.AspNetCore.Http
 
                 methodInfo = type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static, new[] { typeof(string), typeof(IFormatProvider), type.MakeByRefType() });
 
-                if (methodInfo != null)
+                if (methodInfo is not null && methodInfo.ReturnType == typeof(bool))
                 {
                     return (expression) => Expression.Call(
                         methodInfo,
@@ -117,9 +118,23 @@ namespace Microsoft.AspNetCore.Http
 
                 methodInfo = type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static, new[] { typeof(string), type.MakeByRefType() });
 
-                if (methodInfo != null)
+                if (methodInfo is not null && methodInfo.ReturnType == typeof(bool))
                 {
                     return (expression) => Expression.Call(methodInfo, TempSourceStringExpr, expression);
+                }
+
+                if (type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance) is MethodInfo invalidMethod)
+                {
+                    var stringBuilder = new StringBuilder();
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"TryParse method found on {type.Name} with incorrect format. Must be a static method with format");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, IFormatProvider, out {type.Name})");
+                    stringBuilder.AppendLine("or");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"bool TryParse(string, out {type.Name})");
+                    stringBuilder.AppendLine("but found");
+                    stringBuilder.Append(invalidMethod.IsStatic ? "static " : "not-static ");
+                    stringBuilder.Append(invalidMethod.ToString());
+
+                    throw new InvalidOperationException(stringBuilder.ToString());
                 }
 
                 return null;
@@ -190,6 +205,21 @@ namespace Microsoft.AspNetCore.Http
                             return Expression.Call(ConvertValueTaskOfNullableResultMethod.MakeGenericMethod(nonNullableParameterType), typedCall);
                         }, hasParameterInfo ? 2 : 1);
                     }
+                }
+
+                if (nonNullableParameterType.GetMethod("BindAsync", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance) is MethodInfo invalidBindMethod)
+                {
+                    var stringBuilder = new StringBuilder();
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"BindAsync method found on {nonNullableParameterType.Name} with incorrect format. Must be a static method with format");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{nonNullableParameterType.Name}> BindAsync(HttpContext context, ParameterInfo parameter)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{nonNullableParameterType.Name}> BindAsync(HttpContext context)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{nonNullableParameterType.Name}?> BindAsync(HttpContext context, ParameterInfo parameter)");
+                    stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"ValueTask<{nonNullableParameterType.Name}?> BindAsync(HttpContext context)");
+                    stringBuilder.AppendLine("but found");
+                    stringBuilder.Append(invalidBindMethod.IsStatic ? "static " : "not-static");
+                    stringBuilder.Append(invalidBindMethod.ToString());
+
+                    throw new InvalidOperationException(stringBuilder.ToString());
                 }
 
                 return (null, 0);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/36523

Tried to make the error semi-nice, there is room for improvement if we're willing to loop over the args and format them

**BindAsync**
```
BindAsync method found on InvalidWrongReturnBindAsyncStruct with incorrect format. Must be a static method with format
ValueTask<InvalidWrongReturnBindAsyncStruct> BindAsync(HttpContext context, ParameterInfo parameter)
ValueTask<InvalidWrongReturnBindAsyncStruct> BindAsync(HttpContext context)
ValueTask<Nullable<InvalidWrongReturnBindAsyncStruct>> BindAsync(HttpContext context, ParameterInfo parameter)
ValueTask<Nullable<InvalidWrongReturnBindAsyncStruct>> BindAsync(HttpContext context)
but found
static System.Threading.Tasks.Task`1[Microsoft.AspNetCore.Http.Extensions.Tests.ParameterBindingMethodCacheTests+InvalidWrongReturnBindAsyncStruct] BindAsync(Microsoft.AspNetCore.Http.HttpContext, System.Reflection.ParameterInfo)
```
**TryParse**
```
TryParse method found on InvalidNonStaticTryParseClass with incorrect format. Must be a static method with format
bool TryParse(string, IFormatProvider, out InvalidNonStaticTryParseClass)
bool TryParse(string, out InvalidNonStaticTryParseClass)
but found
not-static Boolean TryParse(System.String, System.IFormatProvider, InvalidNonStaticTryParseClass ByRef)
```