### PR TITLE
Add test for BoundAttributDescriptor HashCode

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
@@ -60,6 +60,8 @@ namespace Microsoft.AspNetCore.Razor.Language
             hash.Add(descriptor.Kind, StringComparer.Ordinal);
             hash.Add(descriptor.Name, StringComparer.Ordinal);
             hash.Add(descriptor.IsEditorRequired);
+            hash.Add(descriptor.TypeName, StringComparer.Ordinal);
+            hash.Add(descriptor.Documentation, StringComparer.Ordinal);
 
             if (descriptor.BoundAttributeParameters != null)
             {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/BoundAttributeDescriptorTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/BoundAttributeDescriptorTest.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Test
+{
+    public class BoundAttributeDescriptorTest
+    {
+        [Fact]
+        public void BoundAttributeDescriptor_HashChangesWithType()
+        {
+            var expectedPropertyName = "PropertyName";
+
+            var tagHelperBuilder = new DefaultTagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
+            _ = tagHelperBuilder.TypeName("TestTagHelper");
+
+            var intBuilder = new DefaultBoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+            _ = intBuilder
+                .Name("test")
+                .PropertyName(expectedPropertyName)
+                .TypeName(typeof(int).FullName);
+
+            var intDescriptor = intBuilder.Build();
+
+            var stringBuilder = new DefaultBoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+            _ = stringBuilder
+                .Name("test")
+                .PropertyName(expectedPropertyName)
+                .TypeName(typeof(string).FullName);
+            var stringDescriptor = stringBuilder.Build();
+
+            Assert.NotEqual(intDescriptor.GetHashCode(), stringDescriptor.GetHashCode());
+        }
+    }
+}


### PR DESCRIPTION
- When changing the type of a Component property it's possible to get a "stale" result from things like Hover.
- This happens because [we cache these results](https://github.com/dotnet/aspnetcore-tooling/blob/main/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/TagHelperDescriptorJsonConverter.cs#L36-L42).
- That cache incorrectly thinks it has nothing to update because `GetHashCode` for `BoundAttributeDescriptor` does not consider the TypeName when calculating it.
- Also added a test for this scenario.

Fixes https://github.com/dotnet/aspnetcore/issues/34781
