### PR TITLE
open DI in F# webapi project template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Program.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Program.fs
@@ -12,6 +12,7 @@ open Microsoft.AspNetCore.Hosting
 open Microsoft.AspNetCore.HttpsPolicy
 #endif
 open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
 


### PR DESCRIPTION
This is a follow up to https://github.com/dotnet/aspnetcore/pull/35833. Without `open Microsoft.Extensions.DependencyInjection`, the `AddControllers()` extension method cannot be found in the F# project template. I thought we tested if our project templates compiled, but maybe that was just C#.

I've also added this commit to the 6.0-rc2 backport of the F# project template changes (https://github.com/dotnet/aspnetcore/pull/36660).

Screenshot without the change:

![image](https://user-images.githubusercontent.com/54385/133857622-b2fa186a-8316-4d10-830c-d943c6cee260.png)
