### PR TITLE
Use SslApplicationProtocol.Http3

### DIFF
--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -1646,7 +1646,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             var email = await manager.GetUserNameAsync(user) + "@diddly.bop";
             IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, email));
             var token = await manager.GenerateEmailConfirmationTokenAsync(user);
-            await manager.ConfirmEmailAsync(user, token);
+            IdentityResultAssert.IsSuccess(await manager.ConfirmEmailAsync(user, token));
 
             var stamp = await manager.GetSecurityStampAsync(user);
             Assert.NotNull(stamp);
@@ -1823,7 +1823,7 @@ namespace Microsoft.AspNetCore.Identity.Test
             Assert.Equal("Phone", factors[0]);
             IdentityResultAssert.IsSuccess(await manager.SetEmailAsync(user, "test@test.com"));
             token = await manager.GenerateEmailConfirmationTokenAsync(user);
-            await manager.ConfirmEmailAsync(user, token);
+            IdentityResultAssert.IsSuccess(await manager.ConfirmEmailAsync(user, token));
             factors = await manager.GetValidTwoFactorProvidersAsync(user);
             Assert.NotNull(factors);
             Assert.Equal(2, factors.Count);

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -519,7 +519,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Https.Internal
             var sslServerAuthenticationOptions = new SslServerAuthenticationOptions
             {
                 ServerCertificate = httpsOptions.ServerCertificate,
-                ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol("h3"), new SslApplicationProtocol("h3-29") },
+                ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http3, new SslApplicationProtocol("h3-29") },
                 CertificateRevocationCheckMode = httpsOptions.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
             };
 

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
@@ -25,7 +25,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
     internal static class QuicTestHelpers
     {
-        public const string Alpn = "h3";
         private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");
 
         public static QuicTransportFactory CreateTransportFactory(ILoggerFactory loggerFactory = null, ISystemClock systemClock = null)
@@ -58,7 +57,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             var cert = TestResources.GetTestCertificate();
 
             var sslServerAuthenticationOptions = new SslServerAuthenticationOptions();
-            sslServerAuthenticationOptions.ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol(Alpn) };
+            sslServerAuthenticationOptions.ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http3 };
             sslServerAuthenticationOptions.ServerCertificate = cert;
             sslServerAuthenticationOptions.RemoteCertificateValidationCallback = RemoteCertificateValidationCallback;
             sslServerAuthenticationOptions.ClientCertificateRequired = clientCertificateRequired;
@@ -99,7 +98,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
                 {
                     ApplicationProtocols = new List<SslApplicationProtocol>
                     {
-                        new SslApplicationProtocol(Alpn)
+                        SslApplicationProtocol.Http3
                     },
                     RemoteCertificateValidationCallback = RemoteCertificateValidationCallback
                 }


### PR DESCRIPTION
**PR Title**

Use `SslApplicationProtocol.Http3`

**PR Description**

Use the new `SslApplicationProtocol.Http3` field where relevant.

Fixes #36668.
