### PR TITLE
[release/6.0-rc2] Parse date types into UTC by default

### DIFF
--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2889,6 +2889,49 @@ namespace Microsoft.AspNetCore.Routing.Internal
             }
         }
 
+        public static IEnumerable<object?[]> DateTimeDelegates
+        {
+            get
+            {
+                string dateTimeParsing(DateTime time) => $"Time: {time.ToString("O")}, Kind: {time.Kind}";
+                string dateTimeOffsetParsing(DateTimeOffset time) => $"Time: {time.ToString("O")}";
+                string dateOnlyParsing(DateOnly time) => $"Time: {time.ToString("O")}";
+                string timeOnlyParsing(TimeOnly time) => $"Time: {time.ToString("O")}";
+
+                return new List<object?[]>
+                {
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "09/20/2021 16:34:09", "Time: 2021-09-20T16:34:09.0000000Z, Kind: Utc" },
+                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:34:09 +00:00", "Time: 2021-09-20T16:34:09.0000000+00:00" },
+                    new object?[] { (Func<DateOnly, string>)dateOnlyParsing, "9/20/2021", "Time: 2021-09-20" },
+                    new object?[] { (Func<TimeOnly, string>)timeOnlyParsing, "4:34 PM", "Time: 16:34:00.0000000" },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DateTimeDelegates))]
+        public async Task RequestDelegateCanProcessDateTimeValues(Delegate @delegate, string inputTime, string expectedResponse)
+        {
+            var httpContext = CreateHttpContext();
+            var responseBodyStream = new MemoryStream();
+            httpContext.Response.Body = responseBodyStream;
+
+            httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+            {
+                ["time"] = inputTime
+            });
+
+            var factoryResult = RequestDelegateFactory.Create(@delegate);
+            var requestDelegate = factoryResult.RequestDelegate;
+
+            await requestDelegate(httpContext);
+
+            Assert.Equal(200, httpContext.Response.StatusCode);
+            Assert.False(httpContext.RequestAborted.IsCancellationRequested);
+            var decodedResponseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+            Assert.Equal(expectedResponse, decodedResponseBody);
+        }
+
         private DefaultHttpContext CreateHttpContext()
         {
             var responseFeature = new TestHttpResponseFeature();

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2937,13 +2937,13 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             get
             {
-                string dateTimeOffsetParsing(DateTimeOffset time) => $"Offset: {time.Offset}";
+                string dateTimeOffsetParsing(DateTimeOffset time) => $"Time: {time.ToString("O", CultureInfo.InvariantCulture)}, Offset: {time.Offset}";
 
                 return new List<object?[]>
                 {
-                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12 +00:00", "Offset: 00:00:00" },
-                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12", "Offset: 00:00:00" },
-                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "    09/20/2021    16:35:12   ", "Offset: 00:00:00" },
+                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12 +00:00", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
+                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
+                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, " 09/20/2021 16:35:12 ", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
                 };
             }
         }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2942,6 +2942,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 return new List<object?[]>
                 {
                     new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12 +00:00", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
+                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 11:35:12 +07:00", "Time: 2021-09-20T11:35:12.0000000+07:00, Offset: 07:00:00" },
                     new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
                     new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, " 09/20/2021 16:35:12 ", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
                 };

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -476,7 +476,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
                     new object[] { (Action<HttpContext, float>)Store, "0.5", 0.5f },
                     new object[] { (Action<HttpContext, Half>)Store, "0.5", (Half)0.5f },
                     new object[] { (Action<HttpContext, decimal>)Store, "0.5", 0.5m },
-                    new object[] { (Action<HttpContext, DateTime>)Store, now.ToString("o"), now },
+                    new object[] { (Action<HttpContext, DateTime>)Store, now.ToString("o"), now.ToUniversalTime() },
                     new object[] { (Action<HttpContext, DateTimeOffset>)Store, "1970-01-01T00:00:00.0000000+00:00", DateTimeOffset.UnixEpoch },
                     new object[] { (Action<HttpContext, TimeSpan>)Store, "00:00:42", TimeSpan.FromSeconds(42) },
                     new object[] { (Action<HttpContext, Guid>)Store, "00000000-0000-0000-0000-000000000000", Guid.Empty },
@@ -2937,13 +2937,13 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             get
             {
-                string dateTimeOffsetParsing(DateTimeOffset time) => $"Time: {time.ToString("O", CultureInfo.InvariantCulture)}, Offset: {time.Offset}";
+                string dateTimeOffsetParsing(DateTimeOffset time) => $"Offset: {time.Offset}";
 
                 return new List<object?[]>
                 {
-                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12 +00:00", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
-                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
-                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "    09/20/2021    16:35:12   ", "Time: 2021-09-20T16:35:12.0000000+00:00, Offset: 00:00:00" },
+                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12 +00:00", "Offset: 00:00:00" },
+                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:35:12", "Offset: 00:00:00" },
+                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "    09/20/2021    16:35:12   ", "Offset: 00:00:00" },
                 };
             }
         }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2893,13 +2893,18 @@ namespace Microsoft.AspNetCore.Routing.Internal
         {
             get
             {
-                string dateTimeParsing(DateTime time) => $"Time: {time.ToString("O", CultureInfo.InvariantCulture)}";
-                string dateTimeOffsetParsing(DateTimeOffset time) => $"Time: {time.ToString("O", CultureInfo.InvariantCulture)}";
+                string dateTimeParsing(DateTime time) => $"Time: {time.ToString("O", CultureInfo.InvariantCulture)}, Kind: {time.Kind}";
 
                 return new List<object?[]>
                 {
-                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "09/20/2021 16:34:09", "Time: 2021-09-20T16:34:09.0000000Z" },
-                    new object?[] { (Func<DateTimeOffset, string>)dateTimeOffsetParsing, "09/20/2021 16:34:09 +00:00", "Time: 2021-09-20T16:34:09.0000000+00:00" }
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "9/20/2021 4:18:44 PM", "Time: 2021-09-20T16:18:44.0000000, Kind: Unspecified" },
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "2021-09-20 4:18:44", "Time: 2021-09-20T04:18:44.0000000, Kind: Unspecified" },
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "   9/20/2021    4:18:44 PM  ", "Time: 2021-09-20T16:18:44.0000000, Kind: Unspecified" },
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "2021-09-20T16:28:02.000-07:00", "Time: 2021-09-20T23:28:02.0000000Z, Kind: Utc" },
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "  2021-09-20T 16:28:02.000-07:00  ", "Time: 2021-09-20T23:28:02.0000000Z, Kind: Utc" },
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "2021-09-20T23:30:02.000+00:00", "Time: 2021-09-20T23:30:02.0000000Z, Kind: Utc" },
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "     2021-09-20T23:30: 02.000+00:00 ", "Time: 2021-09-20T23:30:02.0000000Z, Kind: Utc" },
+                    new object?[] { (Func<DateTime, string>)dateTimeParsing, "2021-09-20 16:48:02-07:00", "Time: 2021-09-20T23:48:02.0000000Z, Kind: Utc" },
                 };
             }
         }
@@ -2938,7 +2943,9 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 return new List<object?[]>
                 {
                     new object?[] { (Func<DateOnly, string>)dateOnlyParsing, "9/20/2021", "Time: 2021-09-20" },
+                    new object?[] { (Func<DateOnly, string>)dateOnlyParsing, "9 /20 /2021", "Time: 2021-09-20" },
                     new object?[] { (Func<TimeOnly, string>)timeOnlyParsing, "4:34 PM", "Time: 16:34:00.0000000" },
+                    new object?[] { (Func<TimeOnly, string>)timeOnlyParsing, "    4:34 PM   ", "Time: 16:34:00.0000000" },
                 };
             }
         }

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -88,11 +88,18 @@ namespace Microsoft.AspNetCore.Http
 
                 if (TryGetDateTimeTryParseMethod(type, out methodInfo))
                 {
+                    // We generate `DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeLocal ` to
+                    // support parsing types into the UTC timezone for DateTime and DateTimeOffset.
+                    // DateOnly and TimeOnly types do not support conversion to Utc so we
+                    // default to `DateTimeStyles.None`.
+                    var supportsParseToUtc = type == typeof(DateTime) || type == typeof(DateTimeOffset);
+                    var dateTimeStyles = supportsParseToUtc ? DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeLocal : DateTimeStyles.None;
+
                     return (expression) => Expression.Call(
                         methodInfo!,
                         TempSourceStringExpr,
                         Expression.Constant(CultureInfo.InvariantCulture),
-                        Expression.Constant(DateTimeStyles.None),
+                        Expression.Constant(dateTimeStyles),
                         expression);
                 }
 

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -95,13 +95,15 @@ namespace Microsoft.AspNetCore.Http
                     //
                     // `DateTimeOffset`s are always in UTC and don't allow specifying an `Unspecific` kind.
                     // For this, we always assume that the original value is already in UTC to avoid resolving
-                    // the offset incorrectly dependening on the timezone of the machine.
+                    // the offset incorrectly dependening on the timezone of the machine. We don't bother mapping
+                    // it to UTC in this case. In the event that the original timestamp is not in UTC, it's offset
+                    // value will be maintained.
                     //
                     // DateOnly and TimeOnly types do not support conversion to Utc so we
                     // default to `DateTimeStyles.AllowWhiteSpaces`.
                     var dateTimeStyles = type switch {
                         Type t when t == typeof(DateTime) => DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces,
-                        Type t when t == typeof(DateTimeOffset) => DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowWhiteSpaces,
+                        Type t when t == typeof(DateTimeOffset) => DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowWhiteSpaces,
                         _ => DateTimeStyles.AllowWhiteSpaces
                     };
 

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -88,12 +88,12 @@ namespace Microsoft.AspNetCore.Http
 
                 if (TryGetDateTimeTryParseMethod(type, out methodInfo))
                 {
-                    // We generate `DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeLocal ` to
+                    // We generate `DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces ` to
                     // support parsing types into the UTC timezone for DateTime and DateTimeOffset.
                     // DateOnly and TimeOnly types do not support conversion to Utc so we
-                    // default to `DateTimeStyles.None`.
+                    // default to `DateTimeStyles.AllowWhiteSpaces`.
                     var supportsParseToUtc = type == typeof(DateTime) || type == typeof(DateTimeOffset);
-                    var dateTimeStyles = supportsParseToUtc ? DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeLocal : DateTimeStyles.None;
+                    var dateTimeStyles = supportsParseToUtc ? DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces : DateTimeStyles.AllowWhiteSpaces;
 
                     return (expression) => Expression.Call(
                         methodInfo!,


### PR DESCRIPTION
## Description

This PR resolves an issue where `DateTime` and `DateTimeOffset` types were deserialized into the local timezone instead of UTC, resulting in confusing behavior for customers building apps with minimal APIs.

## Customer Impact

Without this change, date-type parameters passed as route or parameter queries in minimal apps would be deserialized into the local timezone on the server by default. This can result in confusing behavior where APIs will report different date time values depending on the timezone of the server the API is running in.

To ensure that minimal apps can handle dates predictably we deserialize dates into UTC by default.
## Regression?
- [ ] Yes
- [X] No

## Risk
- [ ] High
- [ ] Medium
- [X] Low

This change has a low surface area, it will only apply to:
- Minimal apps
- Apps that use `DateTime` and `DateTimeOffset` parameters

The change was validated on unit tests and manually.

Behaviorally, this change is not risky since it mimics what is already done in MVC.

## Verification
- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/36725