### PR TITLE
[6.0-rc2] Fix DatabaseDeveloperPageExceptionFilter to handle wrapped DbExceptions

### DIFF
--- a/src/Middleware/Diagnostics.EntityFrameworkCore/src/DatabaseDeveloperPageExceptionFilter.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/src/DatabaseDeveloperPageExceptionFilter.cs
@@ -45,7 +45,10 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
         /// <inheritdoc />
         public async Task HandleExceptionAsync(ErrorContext errorContext, Func<ErrorContext, Task> next)
         {
-            if (!(errorContext.Exception is DbException))
+            var dbException = errorContext.Exception as DbException
+                  ?? errorContext.Exception?.InnerException as DbException;
+
+            if (dbException == null)
             {
                 await next(errorContext);
                 return;
@@ -76,7 +79,7 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
                     {
                         var page = new DatabaseErrorPage
                         {
-                            Model = new DatabaseErrorPageModel(errorContext.Exception, contextDetails, _options, errorContext.HttpContext.Request.PathBase)
+                            Model = new DatabaseErrorPageModel(dbException, contextDetails, _options, errorContext.HttpContext.Request.PathBase)
                         };
 
                         await page.ExecuteAsync(errorContext.HttpContext);

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/test/UnitTests/DatabaseDeveloperPageExceptionFilterTests.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/test/UnitTests/DatabaseDeveloperPageExceptionFilterTests.cs
@@ -43,6 +43,33 @@ namespace Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore.Tests
         }
 
         [Fact]
+        public async Task Wrapped_DbExceptions_HandlingFails_InvokesNextFilter()
+        {
+            var sink = new TestSink();
+            var filter = new DatabaseDeveloperPageExceptionFilter(
+                new TestLogger<DatabaseDeveloperPageExceptionFilter>(new TestLoggerFactory(sink, true)),
+                Options.Create(new DatabaseErrorPageOptions()));
+            var context = new DefaultHttpContext();
+            var exception = new InvalidOperationException("Bang!", new Mock<DbException>().Object);
+            var nextFilterInvoked = false;
+
+            await filter.HandleExceptionAsync(
+                new ErrorContext(context, exception),
+                context =>
+                {
+                    nextFilterInvoked = true;
+                    return Task.CompletedTask;
+                });
+
+            Assert.True(nextFilterInvoked);
+            Assert.Equal(1, sink.Writes.Count);
+            var message = sink.Writes.Single();
+            Assert.Equal(LogLevel.Error, message.LogLevel);
+            Assert.Contains("An exception occurred while calculating the database error page content.", message.Message);
+        }
+		
+
+        [Fact]
         public async Task DbExceptions_HandlingFails_InvokesNextFilter()
         {
             var sink = new TestSink();


### PR DESCRIPTION
## Description

Sometimes EF (or other libraries) wrap database errors. The exception filter should account for this, but was not doing. This was revealed by https://github.com/dotnet/efcore/issues/25050 where we started treating more error numbers as transient and hence wrapping their exceptions.

Note that the original Diagnostics.EFCore.FunctionalTests have a test for this, but it appears that these tests were never updated when the mechanism was changed in .NET 5.

## Customer Impact

When first creating a site and the DB doesn't exist, you get an error message rather than the custom database page that allows you to create it.

## Regression?
- [X] Yes
- [ ] No

Regressed since RC1, as EF started wrapping more exceptions in https://github.com/dotnet/efcore/issues/25050

## Risk
- [ ] High
- [ ] Medium
- [X] Low

Just falls back to `InnerException` if the exception isn't `DBException`.

## Verification
- [X] Manual (required) - @javiercn did some e2e testing on the scenario
- [X] Automated - added in this PR.

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A


Addresses AzDO#1399210