### PR TITLE
Use Swagger defaults in web API controllers template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -41,6 +41,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 #if (EnableOpenAPI)
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
@@ -2,6 +2,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 #if (EnableOpenAPI)
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
@@ -44,10 +44,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddControllers();
 #if (EnableOpenAPI)
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
-{
-    c.SwaggerDoc("v1", new() { Title = "Company.WebApplication1", Version = "v1" });
-});
+builder.Services.AddSwaggerGen();
 #endif
 
 var app = builder.Build();
@@ -57,7 +54,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Company.WebApplication1 v1"));
+    app.UseSwaggerUI();
 }
 #endif
 #if (RequiresHttps)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 builder.Services.AddControllers();
 #if (EnableOpenAPI)
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 #endif


### PR DESCRIPTION
Fixes #36819

## Description
This makes it so both flavors of the web API template (controllers & minimal) use the Swashbuckle defaults for OpenAPI/Swagger configuration, i.e.:

``` diff
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
-{
-    c.SwaggerDoc("v1", new() { Title = "Company.WebApplication1", Version = "v1" });
-});
+builder.Services.AddSwaggerGen();

var app = builder.Build();

if (app.Environment.IsDevelopment())
{
    app.UseSwagger();
-    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Company.WebApplication1 v1"));
+    app.UseSwaggerUI();
}
```

Current Swagger UI generated for controllers flavor of template with relevant details highlighted:
![image](https://user-images.githubusercontent.com/249088/134258551-e4a049dd-f351-4528-9a1d-2bf38bb51f02.png)

Current Swagger UI generated for minimal flavor of template with same details highlighted:
![image](https://user-images.githubusercontent.com/249088/134258659-1b4c01ee-b7d6-40d7-833f-a5ac064d87e5.png)

## Customer Impact
With the current configuration code in the controllers flavor of the webapi template, there can be [issues caused when the app is deployed in certain configurations](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/commit/a2893063ab98a088810c96457a1d61a4a35829e3#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R293) (e.g. behind proxies). This update changes the project templates so that the library defaults are used. The change also ensures both flavors of the template are consistent with each other.

## Testing
Manually tested locally to ensure the produced Swagger UI matches the intent.

## Risk
Low. We're actually removing custom code that is more likely to cause issues than the defaults from the library itself.
