### PR TITLE
Add MapPatch API to endpointRouteBuilderExtensions

### DIFF
--- a/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Builder
         private static readonly string[] PostVerb = new[] { "POST" };
         private static readonly string[] PutVerb = new[] { "PUT" };
         private static readonly string[] DeleteVerb = new[] { "DELETE" };
-
+        private static readonly string[] PatchVerb = new[] { "PATCH" };
         /// <summary>
         /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP GET requests
         /// for the specified pattern.
@@ -86,6 +86,22 @@ namespace Microsoft.AspNetCore.Builder
             RequestDelegate requestDelegate)
         {
             return MapMethods(endpoints, pattern, DeleteVerb, requestDelegate);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP PATCH requests
+        /// for the specified pattern.
+        /// </summary>
+        /// <param name="endpoints"></param>
+        /// <param name="pattern"></param>
+        /// <param name="requestDelegate"></param>
+        /// <returns></returns>
+        public static IEndpointConventionBuilder MapPatch(
+            this IEndpointRouteBuilder endpoints,
+            string pattern,
+            RequestDelegate requestDelegate)
+        {
+            return MapMethods(endpoints, pattern, PatchVerb, requestDelegate);
         }
 
         /// <summary>
@@ -253,6 +269,23 @@ namespace Microsoft.AspNetCore.Builder
             Delegate handler)
         {
             return MapMethods(endpoints, pattern, DeleteVerb, handler);
+        }
+
+
+        /// <summary>
+        /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP PATCH requests
+        /// for the specified pattern.
+        /// </summary>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
+        /// <param name="handler">The delegate executed when the endpoint is matched.</param>
+        /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the endpoint.</returns>
+        public static RouteHandlerBuilder MapPatch(
+            this IEndpointRouteBuilder endpoints,
+            string pattern,
+            Delegate handler)
+        {
+            return MapMethods(endpoints, pattern, PatchVerb, handler);
         }
 
         /// <summary>

--- a/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
@@ -92,10 +92,10 @@ namespace Microsoft.AspNetCore.Builder
         /// Adds a <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that matches HTTP PATCH requests
         /// for the specified pattern.
         /// </summary>
-        /// <param name="endpoints"></param>
-        /// <param name="pattern"></param>
-        /// <param name="requestDelegate"></param>
-        /// <returns></returns>
+        /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+        /// <param name="pattern">The route pattern.</param>
+        /// <param name="requestDelegate">The delegate executed when the endpoint is matched.</param>
+        /// <returns>A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
         public static IEndpointConventionBuilder MapPatch(
             this IEndpointRouteBuilder endpoints,
             string pattern,
@@ -278,7 +278,7 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
         /// <param name="pattern">The route pattern.</param>
-        /// <param name="handler">The delegate executed when the endpoint is matched.</param>
+        /// <param name="handler">The <see cref="Delegate" /> executed when the endpoint is matched.</param>
         /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the endpoint.</returns>
         public static RouteHandlerBuilder MapPatch(
             this IEndpointRouteBuilder endpoints,

--- a/src/Http/Routing/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing/src/PublicAPI.Unshipped.txt
@@ -38,6 +38,8 @@ static Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapGet(this M
 static Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapMethods(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Collections.Generic.IEnumerable<string!>! httpMethods, System.Delegate! handler) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder!
 static Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapPost(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! handler) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder!
 static Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapPut(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! handler) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder!
+static Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapPatch(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, System.Delegate! handler) -> Microsoft.AspNetCore.Builder.RouteHandlerBuilder!
+static Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapPatch(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, string! pattern, Microsoft.AspNetCore.Http.RequestDelegate! requestDelegate) -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!
 static Microsoft.AspNetCore.Builder.RoutingEndpointConventionBuilderExtensions.WithName<TBuilder>(this TBuilder builder, string! endpointName) -> TBuilder
 static Microsoft.AspNetCore.Builder.RoutingEndpointConventionBuilderExtensions.WithGroupName<TBuilder>(this TBuilder builder, string! endpointGroupName) -> TBuilder
 Microsoft.AspNetCore.Routing.IExcludeFromDescriptionMetadata

--- a/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
@@ -40,6 +40,9 @@ namespace Microsoft.AspNetCore.Builder
                 IEndpointConventionBuilder MapDelete(IEndpointRouteBuilder routes, string template, Delegate action) =>
                     routes.MapDelete(template, action);
 
+                IEndpointConventionBuilder MapPatch(IEndpointRouteBuilder routes, string template, Delegate action) =>
+                    routes.MapPatch(template, action);
+
                 IEndpointConventionBuilder Map(IEndpointRouteBuilder routes, string template, Delegate action) =>
                     routes.Map(template, action);
 
@@ -49,6 +52,7 @@ namespace Microsoft.AspNetCore.Builder
                     new object?[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)MapPost, "POST" },
                     new object?[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)MapPut, "PUT" },
                     new object?[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)MapDelete, "DELETE" },
+                    new object?[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)MapPatch, "PATCH" },
                     new object?[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)Map, null },
                 };
             }
@@ -99,6 +103,26 @@ namespace Microsoft.AspNetCore.Builder
 
             var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
             Assert.Equal("HTTP: GET /", routeEndpointBuilder.DisplayName);
+            Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
+        }
+
+        [Fact]
+        public void MapPatch_BuildsEndpointWithCorrectMethod()
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
+            _ = builder.MapPatch("/", () => { });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            var methodMetadata = endpoint.Metadata.GetMetadata<IHttpMethodMetadata>();
+            Assert.NotNull(methodMetadata);
+            var method = Assert.Single(methodMetadata!.HttpMethods);
+            Assert.Equal("PATCH", method);
+
+            var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
+            Assert.Equal("HTTP: PATCH /", routeEndpointBuilder.DisplayName);
             Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
         }
 
@@ -264,6 +288,26 @@ namespace Microsoft.AspNetCore.Builder
             Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
         }
 
+        [Fact]
+        public void MapPatch_ImplicitFromService()
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<TodoService>().BuildServiceProvider()));
+            _ = builder.MapPatch("/", (TodoService todo) => { });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            var methodMetadata = endpoint.Metadata.GetMetadata<IHttpMethodMetadata>();
+            Assert.NotNull(methodMetadata);
+            var method = Assert.Single(methodMetadata!.HttpMethods);
+            Assert.Equal("PATCH", method);
+
+            var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
+            Assert.Equal("HTTP: PATCH /", routeEndpointBuilder.DisplayName);
+            Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
+        }
+
         [AttributeUsage(AttributeTargets.Parameter)]
         private class TestFromServiceAttribute : Attribute, IFromServiceMetadata
         { }
@@ -308,6 +352,26 @@ namespace Microsoft.AspNetCore.Builder
             Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
         }
 
+        [Fact]
+        public void MapPatch_ExplicitFromService()
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new ServiceCollection().AddSingleton<TodoService>().BuildServiceProvider()));
+            _ = builder.MapPatch("/", ([TestFromServiceAttribute] TodoService todo) => { });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            var methodMetadata = endpoint.Metadata.GetMetadata<IHttpMethodMetadata>();
+            Assert.NotNull(methodMetadata);
+            var method = Assert.Single(methodMetadata!.HttpMethods);
+            Assert.Equal("PATCH", method);
+
+            var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
+            Assert.Equal("HTTP: PATCH /", routeEndpointBuilder.DisplayName);
+            Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
+        }
+
         [AttributeUsage(AttributeTargets.Parameter)]
         private class TestFromBodyAttribute : Attribute, IFromBodyMetadata
         { }
@@ -349,6 +413,26 @@ namespace Microsoft.AspNetCore.Builder
 
             var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
             Assert.Equal("HTTP: DELETE /", routeEndpointBuilder.DisplayName);
+            Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
+        }
+
+        [Fact]
+        public void MapPatch_ExplicitFromBody_BuildsEndpointWithCorrectMethod()
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
+            _ = builder.MapPatch("/", ([TestFromBody] Todo todo) => { });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            var methodMetadata = endpoint.Metadata.GetMetadata<IHttpMethodMetadata>();
+            Assert.NotNull(methodMetadata);
+            var method = Assert.Single(methodMetadata!.HttpMethods);
+            Assert.Equal("PATCH", method);
+
+            var routeEndpointBuilder = GetRouteEndpointBuilder(builder);
+            Assert.Equal("HTTP: PATCH /", routeEndpointBuilder.DisplayName);
             Assert.Equal("/", routeEndpointBuilder.RoutePattern.RawText);
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ x] You've included unit or integration tests for your change, where applicable.
- [x ] You've included inline docs for your change, where applicable.
- [ x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**Add MapPatch API to endpointRouteBuilderExtensions**
just add the patch verb with the same behavior as other verbs in this file

**PR Description**
As written above
Still have some issues building this project, not sure that i find `DelegateEndpointConventionBuilder` as in the original suggestion


Fixes #36198 (in this specific format)
