### PR TITLE
Switch to 1ES R&D Pools on main

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -107,24 +107,24 @@ jobs:
           vmImage: ubuntu-18.04
         ${{ if eq(parameters.useHostedUbuntu, false) }}:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Ubuntu.1804.Amd64.Open
+            name: NetCore1ESPool-Public
+            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Ubuntu.1804.Amd64
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
+          name: NetCore1ESPool-Public
           ${{ if ne(parameters.isTestingJob, true) }}:
             # Visual Studio Build Tools
-            queue: BuildPool.Server.Amd64.VS2019.BT.Open
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.BT.Open
           ${{ if eq(parameters.isTestingJob, true) }}:
             # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-            queue: BuildPool.Server.Amd64.VS2019.Open
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCoreInternal-Pool
+          name: NetCore1ESPool-Internal
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Server.Amd64.VS2019
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
     variables:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**Switch to 1ES R&D Pools on main**
We need to switch to the 1ES pools. This does that on main.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276
