### PR TITLE
Get dotnet cores on Linux / macOS

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -138,8 +138,6 @@ jobs:
       - BuildDirectory: $(System.DefaultWorkingDirectory)
     - ${{ if ne(parameters.buildDirectory, '') }}:
       - BuildDirectory: ${{ parameters.buildDirectory }}
-    - COMPlus_DbgEnableMiniDump: 1
-    - COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
     - DOTNET_CLI_HOME: $(System.DefaultWorkingDirectory)
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - TeamName: AspNetCore
@@ -218,21 +216,38 @@ jobs:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
     - ${{ if ne(parameters.steps, '')}}:
-      - ${{ parameters.steps }}
+      - ${{ each step in parameters.steps }}:
+          - ${{ each pair in step }}:
+              ${{ if ne(pair.key, 'env') }}:
+                ${{ pair.key }}: ${{ pair.value }}
+            env:
+              COMPlus_DbgEnableMiniDump: 1
+              COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
+              ${{ if step.env }}:
+                ${{ step.env }}
     - ${{ if eq(parameters.steps, '')}}:
       - ${{ if eq(parameters.buildScript, '') }}:
         - ${{ if eq(parameters.agentOs, 'Windows') }}:
           - script: $(BuildDirectory)\build.cmd -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs) /p:DotNetSignType=$(_SignType)
             displayName: Run build.cmd
             continueOnError: ${{ parameters.continueOnBuildError }}
+            env:
+              COMPlus_DbgEnableMiniDump: 1
+              COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
         - ${{ if ne(parameters.agentOs, 'Windows') }}:
           - script: $(BuildDirectory)/build.sh --ci --nobl --configuration $(BuildConfiguration) $(BuildScriptArgs)
             displayName: Run build.sh
             continueOnError: ${{ parameters.continueOnBuildError }}
+            env:
+              COMPlus_DbgEnableMiniDump: 1
+              COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
       - ${{ if ne(parameters.buildScript, '') }}:
         - script: $(BuildScript) -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs)
           displayName: run $(BuildScript)
           continueOnError: ${{ parameters.continueOnBuildError }}
+          env:
+            COMPlus_DbgEnableMiniDump: 1
+            COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
 
     - ${{ parameters.afterBuild }}
 
@@ -266,26 +281,6 @@ jobs:
       - script:  echo "##vso[task.setvariable variable=CG_RAN]true"
         displayName: 'Skip Component Detection'
 
-    - task: CopyFiles@2
-      displayName: Create dump directory
-      condition: always()
-      continueOnError: true
-      inputs:
-        contents: |
-          '*.core'
-          restore.sh
-        sourceFolder: $(System.DefaultWorkingDirectory)
-        targetFolder: artifacts/dumps/
-    - task: PublishBuildArtifacts@1
-      displayName: Upload dump files
-      condition: always()
-      continueOnError: true
-      inputs:
-        artifactName: ${{ coalesce(parameters.jobName, parameters.agentOs) }}_Dumps
-        artifactType: Container
-        parallel: true
-        pathtoPublish: artifacts/dumps/
-
     - ${{ each artifact in parameters.artifacts }}:
       - task: PublishBuildArtifacts@1
         displayName: Upload artifacts from ${{ artifact.path }}
@@ -299,6 +294,15 @@ jobs:
             artifactName: ${{ artifact.name }}
           artifactType: Container
           parallel: true
+
+    - ${{ if eq(parameters.agentOs, 'Windows') }}:
+      - powershell: $(Build.SourcesDirectory)/eng/scripts/UploadCores.ps1 -ProcDumpOutputPath artifacts/dumps/
+        condition: failed()
+        displayName: Upload cores
+    - ${{ if ne(parameters.agentOs, 'Windows') }}:
+      - script: $(Build.SourcesDirectory)/eng/scripts/upload-cores.sh
+        condition: failed()
+        displayName: Upload cores
 
     - ${{ if and(eq(parameters.isTestingJob, true), ne(parameters.jobName, 'Windows_Templates_Test')) }}:
       - task: PublishTestResults@2

--- a/eng/scripts/UploadCores.ps1
+++ b/eng/scripts/UploadCores.ps1
@@ -1,0 +1,47 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string]$ProcDumpOutputPath
+)
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+function Warn {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Message
+  )
+
+  Write-Warning "$Message"
+  if ((Test-Path env:TF_BUILD) -and $env:TF_BUILD) {
+    Write-Host "##vso[task.logissue type=warning]$Message"
+  }
+}
+
+$repoRoot = Resolve-Path "$PSScriptRoot\..\.."
+$procDumpOutputPath = Join-Path $repoRoot $ProcDumpOutputPath
+
+if ((Test-Path env:SYSTEM_DEFAULTWORKINGDIRECTORY) -and $env:SYSTEM_DEFAULTWORKINGDIRECTORY) {
+  if (Test-Path env:SYSTEM_PHASENAME) { $jobName = "$env:SYSTEM_PHASENAME" } else { $jobName = "$env:AGENT_OS" }
+  $artifactName = "${jobName}_Dumps"
+  $wd = $env:SYSTEM_DEFAULTWORKINGDIRECTORY
+} else {
+  $artifactName = "Artifacts_Dumps"
+  $wd = "$PWD"
+}
+
+[string[]]$files = Get-ChildItem "$wd\dotnet-*.core"
+if (Test-Path "$procDumpOutputPath") {
+  $files += Get-ChildItem "${procDumpOutputPath}*.dmp"
+}
+
+if ($null -eq $files -or 0 -eq $files.Count) {
+  Warn "No core files found."
+} else {
+  foreach ($file in $files) {
+    Write-Host "##vso[artifact.upload containerfolder=$artifactName;artifactname=$artifactName]$file"
+  }
+}

--- a/eng/scripts/upload-cores.sh
+++ b/eng/scripts/upload-cores.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+RESET="\033[0m"
+YELLOW="\033[0;33m"
+
+__warn() {
+  echo -e "${YELLOW}warning: $*${RESET}"
+  if [ -n "${TF_BUILD:-}" ]; then
+    echo "##vso[task.logissue type=warning]$*"
+  fi
+}
+
+if [ -n "${SYSTEM_DEFAULTWORKINGDIRECTORY:-}" ]; then
+  jobName="${SYSTEM_PHASENAME:-$AGENT_OS}"
+  artifactName="${jobName}_Dumps"
+  wd=$SYSTEM_DEFAULTWORKINGDIRECTORY
+else
+  artifactName=Artifacts_Dumps
+  wd=$(pwd -P)
+fi
+
+save_nullglob=$(shopt -p nullglob || true)
+shopt -s nullglob
+files=(
+  $wd/core*
+  $wd/dotnet-*.core
+)
+$save_nullglob
+
+if [ -z "${files:-}" ] || (( ${#files[@]} == 0 )); then
+  __warn "No core files found."
+else
+  for file in ${files[@]}; do
+    echo "##vso[artifact.upload containerfolder=$artifactName;artifactname=$artifactName]$file"
+  done
+fi


### PR DESCRIPTION
- follow up to 0d0103b
- `COMPlus*` variables were uppercased and `dotnet` ignored them on Linux / macOS
- only upload dumps in `failed()` jobs
  - use scripts to avoid more YAML complications and avoid empty artifacts