### PR TITLE
Remove continueOnBuildError for components E2E tests. Fixes #35565

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -27,7 +27,6 @@ variables:
 jobs:
 - template: jobs/default-build.yml
   parameters:
-    continueOnBuildError: true
     condition: ne(variables['SkipTests'], 'true')
     jobName: Components_E2E_Test
     jobDisplayName: "Test: Blazor E2E tests on Linux"


### PR DESCRIPTION
The components E2E tests have been very stable since I did a bunch of work to change how they run in CI (e.g., on Linux and without parallelism, and with retries). See the run history: https://dev.azure.com/dnceng/public/_build?definitionId=1026.

Since those changes, I haven't seen *any* cases where tests failed incorrectly. I haven't personally inspected every build, but all the failures I've seen have all been legit build issues, not test issues.

So it's now time to remove the "ignore failures" flag, and fix https://github.com/dotnet/aspnetcore/issues/35565