### PR TITLE
Fix .NET Docker image used in Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] .NET version: 5.0, 3.1, 2.1
 ARG VARIANT="5.0"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,12 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0, 6.0, 7.0
-			"VARIANT": "7.0",
+			// The VARIANT here must align with a dotnet container image that
+			// is publicly available on https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list.
+			// We'll default to `latest` as the default. Generally, the .NET version that is baked
+			// into the image by default doesn't matter since we end up installing our own
+			// local version and using that by default in the container environment.
+			"VARIANT": "latest",
 			// Options
 			"INSTALL_NODE": "true",
 			"NODE_VERSION": "lts/*"


### PR DESCRIPTION
Codespaces are failing to start on `main` because it was updated to reference a non-existent 7.0 variant of the .NET Docker image. I've pinned this to latest and added a comment on why this setting makes sense for now.