### PR TITLE
Update test matrix

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -25,7 +25,7 @@
   <!-- x64 Queues for public helix-matrix.yml and quarantine pipelines, except in windows-only cases -->
   <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
     <!-- Linux -->
-    <HelixAvailableTargetQueue Include="Debian.9.Amd64.Open" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="(Debian.11.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20210304164428-5a7c380" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
@@ -36,7 +36,7 @@
 
     <!-- Containers -->
     <HelixAvailableTargetQueue Include="(Fedora.34.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210728124700-4f64125" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="(Alpine.312.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673" Platform="Linux" />
+    <HelixAvailableTargetQueue Include="(Alpine.314.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-20210910135833-8a6f4f3" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Mariner)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620" Platform="Linux" />    
   </ItemGroup>
 


### PR DESCRIPTION
Fixes part of https://github.com/dotnet/aspnetcore/issues/36032. Open questions/TODOs (copied from issue):

- RHEL8 - we could use Fedora28, or spin up a docker image using https://hub.docker.com/r/redhat/ubi8
- Fedora35 - not out yet
- MacOs 12 - OSX.1200.Arm64.Open is the only queue, safe to use? 
- Server 2022 - Don't think we have a pool yet

CC @MattGal for the last 2 bullet points