### PR TITLE
Improve Results.Problem and Results.ValidationProblem APIs

### DIFF
--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -20,7 +20,8 @@ static Microsoft.AspNetCore.Http.Results.LocalRedirect(string! localUrl, bool pe
 static Microsoft.AspNetCore.Http.Results.NoContent() -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.NotFound(object? value = null) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Ok(object? value = null) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.Problem(string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Problem(string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null, System.Collections.Generic.IDictionary<string!, object?>? extensions = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Problem(Microsoft.AspNetCore.Mvc.ProblemDetails! problemDetails) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Redirect(string! url, bool permanent = false, bool preserveMethod = false) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.RedirectToRoute(string? routeName = null, object? routeValues = null, bool permanent = false, bool preserveMethod = false, string? fragment = null) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.SignIn(System.Security.Claims.ClaimsPrincipal! principal, Microsoft.AspNetCore.Authentication.AuthenticationProperties? properties = null, string? authenticationScheme = null) -> Microsoft.AspNetCore.Http.IResult!
@@ -30,6 +31,7 @@ static Microsoft.AspNetCore.Http.Results.Stream(System.IO.Stream! stream, string
 static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Unauthorized() -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.UnprocessableEntity(object? error = null) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.ValidationProblem(System.Collections.Generic.IDictionary<string!, string![]!>! errors, string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.ValidationProblem(System.Collections.Generic.IDictionary<string!, string![]!>! errors, string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null, System.Collections.Generic.IDictionary<string!, object?>? extensions = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.ValidationProblem(Microsoft.AspNetCore.Http.HttpValidationProblemDetails! problemDetails) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Extensions.get -> Microsoft.AspNetCore.Http.IResultExtensions!
 Microsoft.AspNetCore.Http.IResultExtensions

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -32,6 +32,5 @@ static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentTy
 static Microsoft.AspNetCore.Http.Results.Unauthorized() -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.UnprocessableEntity(object? error = null) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.ValidationProblem(System.Collections.Generic.IDictionary<string!, string![]!>! errors, string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null, System.Collections.Generic.IDictionary<string!, object?>? extensions = null) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.ValidationProblem(Microsoft.AspNetCore.Http.HttpValidationProblemDetails! problemDetails) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Extensions.get -> Microsoft.AspNetCore.Http.IResultExtensions!
 Microsoft.AspNetCore.Http.IResultExtensions

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -487,7 +487,7 @@ namespace Microsoft.AspNetCore.Http
                 Instance = instance,
                 Status = statusCode,
                 Title = title,
-                Type = type
+                Type = type,
             };
 
             if (extensions is not null)
@@ -544,7 +544,7 @@ namespace Microsoft.AspNetCore.Http
                 Instance = instance,
                 Title = title,
                 Type = type,
-                Status = statusCode
+                Status = statusCode,
             };
 
             if (extensions is not null)
@@ -555,19 +555,6 @@ namespace Microsoft.AspNetCore.Http
                 }
             }
 
-            return new ObjectResult(problemDetails)
-            {
-                ContentType = "application/problem+json",
-            };
-        }
-
-        /// <summary>
-        /// Produces a <see cref="HttpValidationProblemDetails"/> response.
-        /// </summary>
-        /// <param name="problemDetails">The <see cref="HttpValidationProblemDetails"/>  object to produce a response from.</param>
-        /// <returns>The created <see cref="IResult"/> for the response.</returns>
-        public static IResult ValidationProblem(HttpValidationProblemDetails problemDetails)
-        {
             return new ObjectResult(problemDetails)
             {
                 ContentType = "application/problem+json",

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -471,13 +471,15 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="instance">The value for <see cref="ProblemDetails.Instance" />.</param>
         /// <param name="title">The value for <see cref="ProblemDetails.Title" />.</param>
         /// <param name="type">The value for <see cref="ProblemDetails.Type" />.</param>
+        /// <param name="extensions">The value for <see cref="ProblemDetails.Extensions" />.</param>
         /// <returns>The created <see cref="IResult"/> for the response.</returns>
         public static IResult Problem(
             string? detail = null,
             string? instance = null,
             int? statusCode = null,
             string? title = null,
-            string? type = null)
+            string? type = null,
+            IDictionary<string, object?>? extensions = null)
         {
             var problemDetails = new ProblemDetails
             {
@@ -488,6 +490,27 @@ namespace Microsoft.AspNetCore.Http
                 Type = type
             };
 
+            if (extensions is not null)
+            {
+                foreach (var extension in extensions)
+                {
+                    problemDetails.Extensions.Add(extension);
+                }
+            }
+
+            return new ObjectResult(problemDetails)
+            {
+                ContentType = "application/problem+json",
+            };
+        }
+
+        /// <summary>
+        /// Produces a <see cref="ProblemDetails"/> response.
+        /// </summary>
+        /// <param name="problemDetails">The <see cref="ProblemDetails"/>  object to produce a response from.</param>
+        /// <returns>The created <see cref="IResult"/> for the response.</returns>
+        public static IResult Problem(ProblemDetails problemDetails)
+        {
             return new ObjectResult(problemDetails)
             {
                 ContentType = "application/problem+json",
@@ -504,6 +527,7 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="statusCode">The status code.</param>
         /// <param name="title">The value for <see cref="ProblemDetails.Title" />.</param>
         /// <param name="type">The value for <see cref="ProblemDetails.Type" />.</param>
+        /// <param name="extensions">The value for <see cref="ProblemDetails.Extensions" />.</param>
         /// <returns>The created <see cref="IResult"/> for the response.</returns>
         public static IResult ValidationProblem(
             IDictionary<string, string[]> errors,
@@ -511,7 +535,8 @@ namespace Microsoft.AspNetCore.Http
             string? instance = null,
             int? statusCode = null,
             string? title = null,
-            string? type = null)
+            string? type = null,
+            IDictionary<string, object?>? extensions = null)
         {
             var problemDetails = new HttpValidationProblemDetails(errors)
             {
@@ -519,9 +544,30 @@ namespace Microsoft.AspNetCore.Http
                 Instance = instance,
                 Title = title,
                 Type = type,
-                Status = statusCode,
+                Status = statusCode
             };
 
+            if (extensions is not null)
+            {
+                foreach (var extension in extensions)
+                {
+                    problemDetails.Extensions.Add(extension);
+                }
+            }
+
+            return new ObjectResult(problemDetails)
+            {
+                ContentType = "application/problem+json",
+            };
+        }
+
+        /// <summary>
+        /// Produces a <see cref="HttpValidationProblemDetails"/> response.
+        /// </summary>
+        /// <param name="problemDetails">The <see cref="HttpValidationProblemDetails"/>  object to produce a response from.</param>
+        /// <returns>The created <see cref="IResult"/> for the response.</returns>
+        public static IResult ValidationProblem(HttpValidationProblemDetails problemDetails)
+        {
             return new ObjectResult(problemDetails)
             {
                 ContentType = "application/problem+json",

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -542,10 +542,11 @@ namespace Microsoft.AspNetCore.Http
             {
                 Detail = detail,
                 Instance = instance,
-                Title = title ?? "One or more validation errors occurred.",
                 Type = type,
                 Status = statusCode,
             };
+            
+            problemDetails.Title = title ?? problemDetails.Title;
 
             if (extensions is not null)
             {

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -525,7 +525,7 @@ namespace Microsoft.AspNetCore.Http
         /// <param name="detail">The value for <see cref="ProblemDetails.Detail" />.</param>
         /// <param name="instance">The value for <see cref="ProblemDetails.Instance" />.</param>
         /// <param name="statusCode">The status code.</param>
-        /// <param name="title">The value for <see cref="ProblemDetails.Title" />.</param>
+        /// <param name="title">The value for <see cref="ProblemDetails.Title" />. Defaults to "One or more validation errors occurred."</param>
         /// <param name="type">The value for <see cref="ProblemDetails.Type" />.</param>
         /// <param name="extensions">The value for <see cref="ProblemDetails.Extensions" />.</param>
         /// <returns>The created <see cref="IResult"/> for the response.</returns>
@@ -542,7 +542,7 @@ namespace Microsoft.AspNetCore.Http
             {
                 Detail = detail,
                 Instance = instance,
-                Title = title,
+                Title = title ?? "One or more validation errors occurred.",
                 Type = type,
                 Status = statusCode,
             };

--- a/src/Http/samples/MinimalSample/MinimalSample.csproj
+++ b/src/Http/samples/MinimalSample/MinimalSample.csproj
@@ -8,6 +8,8 @@
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Diagnostics" />
     <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Http" />
+    <Reference Include="Microsoft.AspNetCore.Http.Results" />
     <!-- Mvc.Core is referenced only for its attributes -->
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />

--- a/src/Http/samples/MinimalSample/Program.cs
+++ b/src/Http/samples/MinimalSample/Program.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Mvc;
 
 var app = WebApplication.Create(args);
 
@@ -13,12 +11,29 @@ if (app.Environment.IsDevelopment())
 }
 
 string Plaintext() => "Hello, World!";
-app.MapGet("/plaintext", (Func<string>)Plaintext);
+app.MapGet("/plaintext", Plaintext);
+
 
 object Json() => new { message = "Hello, World!" };
-app.MapGet("/json", (Func<object>)Json);
+app.MapGet("/json", Json);
 
 string SayHello(string name) => $"Hello, {name}!";
-app.MapGet("/hello/{name}", (Func<string, string>)SayHello);
+app.MapGet("/hello/{name}", SayHello);
+
+var extensions = new Dictionary<string, object>() { { "traceId", "traceId123" } };
+
+app.MapGet("/problem", () =>
+    Results.Problem(statusCode: 500, extensions: extensions));
+
+app.MapGet("/problem-object", () =>
+    Results.Problem(new ProblemDetails() { Status = 500, Extensions = { { "traceId", "traceId123"} } }));
+
+var errors = new Dictionary<string, string[]>();
+
+app.MapGet("/validation-problem", () =>
+    Results.ValidationProblem(errors, statusCode: 400, extensions: extensions));
+
+app.MapGet("/validation-problem-object", () =>
+    Results.ValidationProblem(new HttpValidationProblemDetails(errors) { Status = 400, Extensions = { { "traceId", "traceId123"}}}));
 
 app.Run();

--- a/src/Http/samples/MinimalSample/Program.cs
+++ b/src/Http/samples/MinimalSample/Program.cs
@@ -34,6 +34,6 @@ app.MapGet("/validation-problem", () =>
     Results.ValidationProblem(errors, statusCode: 400, extensions: extensions));
 
 app.MapGet("/validation-problem-object", () =>
-    Results.ValidationProblem(new HttpValidationProblemDetails(errors) { Status = 400, Extensions = { { "traceId", "traceId123"}}}));
+    Results.Problem(new HttpValidationProblemDetails(errors) { Status = 400, Extensions = { { "traceId", "traceId123"}}}));
 
 app.Run();


### PR DESCRIPTION
## Description

In .NET 6, we introduced new extension methods as shorthands for creating Results types from endpoint. However, due to an error, we missed adding a parameter to the `Results.Problem` and `Results.ValidationProblem` to align with the `Extensions` property available in those types.

As a result of this, customers are not able to return `ProblemDetails` or `HttpValidationProblemDetails` with a configured `Extensions` type from their APIs.

## Customer Impact

Without this fix, customers are not able to return to return `ProblemDetails` objects 

There are no desirable workarounds for this issue since the `Results.Problem` and `Results.ValidationProblem` provide a public abstraction over a lot of currently internal functionality, like setting sensible defaults for the title and type of ProblemDetails.

## Regression?
- [ ] Yes
- [X] No

## Risk
- [ ] High
- [ ] Medium
- [X] Low

*Low* risk because:
- This change resolves an existing gap in the in the `Results` extension methods API.

## Verification
- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A

<hr/>


## Background and Motivation

The `Results.Problem` and `Results.Validation` extension methods do not provide a way for users to customize the `Extensions` property on the resulting `ProblemDetails` payload.

To support these scenarios, we are adding the `extensions` parameter to the existing methods and adding new overloads that takes a `ProblemDetails` or `HttpValidationProblemDetails` object to provide further customizability for users.

## Proposed API

```diff
namespace Microsoft.AspNetCore.Http
{
    public static class Results
    {
        public static IResult Problem(
            string? detail = null,
            string? instance = null,
            int? statusCode = null,
            string? title = null,
            string? type = null,
+           IDictionary<string, object?>? extensions = null)
        {
            ...
        }

+       public static IResult Problem(ProblemDetails problemDetails) { ... }

        public static IResult ValidationProblem(
            IDictionary<string, string[]> errors,
            string? detail = null,
            string? instance = null,
            int? statusCode = null,
            string? title = null,
            string? type = null,
+           IDictionary<string, object?>? extensions = null)
        {
            ...
        }
    }
}
```


## Usage Examples

```csharp
// {
//   "type": "https://tools.ietf.org/html/rfc7231#section-6.6.1",
//   "title": "An error occurred while processing your request.",
//   "status": 500,
//   "green": "foo"
// }
app.MapGet("/sample1", () => 
    Results.Problem(statusCode: 500, extensions: new Dictionary<string, object?>() { { "green", "foo" } }));
// {
//   "type": "https://tools.ietf.org/html/rfc7231#section-6.6.1",
//   "title": "An error occurred while processing your request.",
//   "status": 500,
//   "green": "foo"
// }
app.MapGet("/sample2", () => 
    Results.Problem(new ProblemDetails() { Status = 500, Extensions = { { "green", "foo"}}}));
var errors = new Dictionary<string, string[]>();
// {
//   "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
//   "title": "Bad Request",
//   "status": 400,
//   "green": "foo",
//   "errors": {
    
//   }
// }
app.MapGet("/sample3", () =>
    Results.ValidationProblem(errors, statusCode: 400, extensions: new Dictionary<string, object?>() { { "green", "foo" } }));
// {
//     "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
//     "title": "One or more validation errors occurred.",
//     "status": 400,
//     "green": "foo",
//     "errors": {
        
//     }
// }
app.MapGet("/sample4", () => 
    Results.Problem(new HttpValidationProblemDetails(errors) { Status = 400, Extensions = { { "green", "foo"}}}));
```

Fixes https://github.com/dotnet/aspnetcore/issues/36848