### PR TITLE
Include SharedFx bundle in Hosting Bundle, instead of SharedFx .msi

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
-    <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)"
-            dep:ProviderKey="$(var.BundleProviderKey)">
+    <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)">
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://go.microsoft.com/fwlink/?LinkId=329770"
                                                     LogoFile="DotNetLogo.bmp"

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -76,8 +76,7 @@
             <PackageGroupRef Id="PG_ANCM" />
             <PackageGroupRef Id="PG_DOTNET_REDIST_LTS_BUNDLE" />
             <!--<PackageGroupRef Id="PG_DOTNET_REDIST_FTS_BUNDLE" />-->
-            <PackageGroupRef Id="PG_AspNetCoreSharedFramework_x86" />
-            <PackageGroupRef Id="PG_AspNetCoreSharedFramework_x64" />
+            <PackageGroupRef Id="PG_SHAREDFX_REDIST_BUNDLE" />
         </Chain>
     </Bundle>
 </Wix>

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -122,10 +122,10 @@
     </ItemGroup>
 
     <!-- Read MSI properties -->
-    <GetMsiProperty InstallPackage="%(DotNetPayload.Identity)" Property="ProductVersion">
+    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductVersion">
       <Output TaskParameter="Value" PropertyName="%(ProductVersionProperty)" />
     </GetMsiProperty>
-    <GetMsiProperty InstallPackage="%(DotNetPayload.Identity)" Property="ProductCode">
+    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductCode">
       <Output TaskParameter="Value" PropertyName="%(ProductCodeProperty)" />
     </GetMsiProperty>
 

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -3,6 +3,10 @@
     <DotNetDarkOutputPath>$(IntermediateOutputPath)d\</DotNetDarkOutputPath>
     <DepsPath>$(BaseIntermediateOutputPath)</DepsPath>
     <DefineConstants>$(DefineConstants);DepsPath=$(DepsPath)</DefineConstants>
+    <DefineConstants>$(DefineConstants);InstallersOutputPath=$(InstallersOutputPath)</DefineConstants>
+    <SharedFxPackageVersion>$(PackageVersion)</SharedFxPackageVersion>
+    <SharedFxPackageVersion
+        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</SharedFxPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +21,17 @@
       <BundleNameProperty>DotNetRedistLtsInstallerx86</BundleNameProperty>
       <Version>$(MicrosoftNETCoreAppRuntimeVersion)</Version>
     </RuntimeInstallers>
+
+    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.exe">
+      <TargetPlatform>x64</TargetPlatform>
+      <BundleNameProperty>SharedFxRedistInstallerx64</BundleNameProperty>
+      <Version>$(SharedFxPackageVersion)</Version>
+    </SharedFxInstallers>
+    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.exe">
+      <TargetPlatform>x86</TargetPlatform>
+      <BundleNameProperty>SharedFxRedistInstallerx86</BundleNameProperty>
+      <Version>$(SharedFxPackageVersion)</Version>
+    </SharedFxInstallers>
   </ItemGroup>
 
   <Target Name="FetchDependencies" BeforeTargets="Restore;CollectPackageReferences">
@@ -85,6 +100,42 @@
       <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerProductVersionx86=$(DotNetRedistLtsInstallerProductVersionx86)</DefineConstants>
       <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerProductCodex86=$(DotNetRedistLtsInstallerProductCodex86)</DefineConstants>
       <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerUpgradeCodex86=$(DotNetRedistLtsInstallerUpgradeCodex86)</DefineConstants>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="ExtractPropertiesFromSharedFxMsi" DependsOnTargets="FetchDependencies" BeforeTargets="BeforeBuild">
+    <!-- Create properties that holds the executable name. These are passed to the bundles so we can reference them as variables
+             from inside the ExePackage authoring. -->
+    <CreateProperty Value="%(SharedFxInstallers.Filename)%(Extension)">
+      <Output TaskParameter="Value" PropertyName="%(SharedFxInstallers.BundleNameProperty)"/>
+    </CreateProperty>
+
+    <ItemGroup>
+      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.msi">
+        <ProductVersionProperty>SharedFxInstallerProductVersionx64</ProductVersionProperty>
+        <ProductCodeProperty>SharedFxInstallerProductCodex64</ProductCodeProperty>
+      </SharedFxPayload>
+      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.msi">
+        <ProductVersionProperty>SharedFxInstallerProductVersionx86</ProductVersionProperty>
+        <ProductCodeProperty>SharedFxInstallerProductCodex86</ProductCodeProperty>
+      </SharedFxPayload>
+    </ItemGroup>
+
+    <!-- Read MSI properties -->
+    <GetMsiProperty InstallPackage="%(DotNetPayload.Identity)" Property="ProductVersion">
+      <Output TaskParameter="Value" PropertyName="%(ProductVersionProperty)" />
+    </GetMsiProperty>
+    <GetMsiProperty InstallPackage="%(DotNetPayload.Identity)" Property="ProductCode">
+      <Output TaskParameter="Value" PropertyName="%(ProductCodeProperty)" />
+    </GetMsiProperty>
+
+    <PropertyGroup>
+      <DefineConstants>$(DefineConstants);SharedFxRedistInstallerx64=$(SharedFxRedistInstallerx64)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxInstallerProductVersionx64=$(SharedFxInstallerProductVersionx64)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxInstallerProductCodex64=$(SharedFxInstallerProductCodex64)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxRedistInstallerx86=$(SharedFxRedistInstallerx86)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxInstallerProductVersionx86=$(SharedFxInstallerProductVersionx86)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxInstallerProductCodex86=$(SharedFxInstallerProductCodex86)</DefineConstants>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/Installers/Windows/WindowsHostingBundle/Product.targets
+++ b/src/Installers/Windows/WindowsHostingBundle/Product.targets
@@ -4,9 +4,6 @@
     <DepsPath>$(BaseIntermediateOutputPath)</DepsPath>
     <DefineConstants>$(DefineConstants);DepsPath=$(DepsPath)</DefineConstants>
     <DefineConstants>$(DefineConstants);InstallersOutputPath=$(InstallersOutputPath)</DefineConstants>
-    <SharedFxPackageVersion>$(PackageVersion)</SharedFxPackageVersion>
-    <SharedFxPackageVersion
-        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</SharedFxPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,17 +18,6 @@
       <BundleNameProperty>DotNetRedistLtsInstallerx86</BundleNameProperty>
       <Version>$(MicrosoftNETCoreAppRuntimeVersion)</Version>
     </RuntimeInstallers>
-
-    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.exe">
-      <TargetPlatform>x64</TargetPlatform>
-      <BundleNameProperty>SharedFxRedistInstallerx64</BundleNameProperty>
-      <Version>$(SharedFxPackageVersion)</Version>
-    </SharedFxInstallers>
-    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.exe">
-      <TargetPlatform>x86</TargetPlatform>
-      <BundleNameProperty>SharedFxRedistInstallerx86</BundleNameProperty>
-      <Version>$(SharedFxPackageVersion)</Version>
-    </SharedFxInstallers>
   </ItemGroup>
 
   <Target Name="FetchDependencies" BeforeTargets="Restore;CollectPackageReferences">
@@ -100,42 +86,6 @@
       <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerProductVersionx86=$(DotNetRedistLtsInstallerProductVersionx86)</DefineConstants>
       <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerProductCodex86=$(DotNetRedistLtsInstallerProductCodex86)</DefineConstants>
       <DefineConstants>$(DefineConstants);DotNetRedistLtsInstallerUpgradeCodex86=$(DotNetRedistLtsInstallerUpgradeCodex86)</DefineConstants>
-    </PropertyGroup>
-  </Target>
-
-  <Target Name="ExtractPropertiesFromSharedFxMsi" DependsOnTargets="FetchDependencies" BeforeTargets="BeforeBuild">
-    <!-- Create properties that holds the executable name. These are passed to the bundles so we can reference them as variables
-             from inside the ExePackage authoring. -->
-    <CreateProperty Value="%(SharedFxInstallers.Filename)%(Extension)">
-      <Output TaskParameter="Value" PropertyName="%(SharedFxInstallers.BundleNameProperty)"/>
-    </CreateProperty>
-
-    <ItemGroup>
-      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.msi">
-        <ProductVersionProperty>SharedFxInstallerProductVersionx64</ProductVersionProperty>
-        <ProductCodeProperty>SharedFxInstallerProductCodex64</ProductCodeProperty>
-      </SharedFxPayload>
-      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.msi">
-        <ProductVersionProperty>SharedFxInstallerProductVersionx86</ProductVersionProperty>
-        <ProductCodeProperty>SharedFxInstallerProductCodex86</ProductCodeProperty>
-      </SharedFxPayload>
-    </ItemGroup>
-
-    <!-- Read MSI properties -->
-    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductVersion">
-      <Output TaskParameter="Value" PropertyName="%(ProductVersionProperty)" />
-    </GetMsiProperty>
-    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductCode">
-      <Output TaskParameter="Value" PropertyName="%(ProductCodeProperty)" />
-    </GetMsiProperty>
-
-    <PropertyGroup>
-      <DefineConstants>$(DefineConstants);SharedFxRedistInstallerx64=$(SharedFxRedistInstallerx64)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxInstallerProductVersionx64=$(SharedFxInstallerProductVersionx64)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxInstallerProductCodex64=$(SharedFxInstallerProductCodex64)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxRedistInstallerx86=$(SharedFxRedistInstallerx86)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxInstallerProductVersionx86=$(SharedFxInstallerProductVersionx86)</DefineConstants>
-      <DefineConstants>$(DefineConstants);SharedFxInstallerProductCodex86=$(SharedFxInstallerProductCodex86)</DefineConstants>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+    <Fragment>
+        <PackageGroup Id="PG_SHAREDFX_REDIST_BUNDLE">
+            <RollbackBoundary Id="RB_SHAREDFX_REDIST_BUNDLE" />
+
+            <ExePackage Id="SharedFxRedist_x64" SourceFile="$(var.InstallersOutputPath)\$(var.SharedFxRedistInstallerx64)"
+                        Name="$(var.SharedFxRedistInstallerx64)"
+                        Compressed="yes"
+                        Vital="yes"
+                        InstallCondition="VersionNT64 AND (NOT OPT_NO_SHAREDFX)"
+                        InstallCommand="/quiet /norestart"
+                        RepairCommand="/quiet /repair"
+                        Permanent="yes"
+                        DetectCondition="SharedFxRedistProductVersion_x64 = v$(var.SharedFxInstallerProductVersionx64)">
+            </ExePackage>
+
+            <ExePackage Id="SharedFxRedist_x86" SourceFile="$(var.DepsPath)\$(var.SharedFxRedistInstallerx86)"
+                        Name="$(var.SharedFxRedistInstallerx86)"
+                        Compressed="yes"
+                        Vital="yes"
+                        InstallCondition="(NOT OPT_NO_SHAREDFX) AND (NOT OPT_NO_X86)"
+                        InstallCommand="/quiet /norestart"
+                        RepairCommand="/quiet /repair"
+                        Permanent="yes"
+                        DetectCondition="SharedFxRedistProductVersion_x86 = v$(var.SharedFxInstallerProductVersionx86)">
+            </ExePackage>
+        </PackageGroup>
+    </Fragment>
+
+    <Fragment>
+        <util:ProductSearch Id="SharedFxRedistProductSearch_x86"
+                            Condition="NOT VersionNT64"
+                            ProductCode="$(var.SharedFxInstallerProductCodex86)"
+                            Result="version"
+                            Variable="SharedFxRedistProductVersion_x86" />
+
+        <util:ProductSearch Id="SharedFxRedistProductSearch_x64"
+                            Condition="VersionNT64"
+                            ProductCode="$(var.SharedFxInstallerProductCodex64)"
+                            Result="version"
+                            Variable="SharedFxRedistProductVersion_x64" />
+    </Fragment>
+</Wix>

--- a/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
@@ -15,7 +15,7 @@
                         DetectCondition="SharedFxRedistProductVersion_x64 = v$(var.SharedFxInstallerProductVersionx64)">
             </ExePackage>
 
-            <ExePackage Id="SharedFxRedist_x86" SourceFile="$(var.DepsPath)\$(var.SharedFxRedistInstallerx86)"
+            <ExePackage Id="SharedFxRedist_x86" SourceFile="$(var.InstallersOutputPath)\$(var.SharedFxRedistInstallerx86)"
                         Name="$(var.SharedFxRedistInstallerx86)"
                         Compressed="yes"
                         Vital="yes"

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -66,8 +66,9 @@
 
     <BundleNameShort>Microsoft .NET $(PackageBrandingVersion)</BundleNameShort>
     <SharedFxPackageVersion>$(PackageVersion)</SharedFxPackageVersion>
-    <SharedFxPackageVersion
-        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</SharedFxPackageVersion>
+    <SharedFxMsiVersion>$(PackageVersion)</SharedFxMsiVersion>
+    <SharedFxMsiVersion
+        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</SharedFxMsiVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -117,11 +118,11 @@
     </CreateProperty>
 
     <ItemGroup>
-      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.msi">
+      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x64.msi">
         <ProductVersionProperty>SharedFxInstallerProductVersionx64</ProductVersionProperty>
         <ProductCodeProperty>SharedFxInstallerProductCodex64</ProductCodeProperty>
       </SharedFxPayload>
-      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.msi">
+      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxMsiVersion)-win-x86.msi">
         <ProductVersionProperty>SharedFxInstallerProductVersionx86</ProductVersionProperty>
         <ProductCodeProperty>SharedFxInstallerProductCodex86</ProductCodeProperty>
       </SharedFxPayload>

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -54,20 +54,7 @@
       <Private>True</Private>
       <DoNotHarvest>true</DoNotHarvest>
     </ProjectReference>
-    <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj">
-      <SetPlatform>Platform=x86</SetPlatform>
-      <Name>SharedFrameworkLib_x86</Name>
-      <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
-      <Private>True</Private>
-      <DoNotHarvest>true</DoNotHarvest>
-    </ProjectReference>
-    <ProjectReference Include="..\SharedFrameworkLib\SharedFrameworkLib.wixproj">
-      <SetPlatform>Platform=x64</SetPlatform>
-      <Name>SharedFrameworkLib_x64</Name>
-      <Project>{5244BC49-2568-4701-80A6-EAB8950AB5FA}</Project>
-      <Private>True</Private>
-      <DoNotHarvest>true</DoNotHarvest>
-    </ProjectReference>
+    <ProjectReference Include="..\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" />
   </ItemGroup>
 
   <Import Project="Product.targets" />
@@ -133,22 +120,18 @@
       <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.msi">
         <ProductVersionProperty>SharedFxInstallerProductVersionx64</ProductVersionProperty>
         <ProductCodeProperty>SharedFxInstallerProductCodex64</ProductCodeProperty>
-        <CopyDir>$(InstallersOutputPath)temp/$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.msi</CopyDir>
       </SharedFxPayload>
       <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.msi">
         <ProductVersionProperty>SharedFxInstallerProductVersionx86</ProductVersionProperty>
         <ProductCodeProperty>SharedFxInstallerProductCodex86</ProductCodeProperty>
-        <CopyDir>$(InstallersOutputPath)temp/$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.msi</CopyDir>
       </SharedFxPayload>
     </ItemGroup>
 
-    <Copy SourceFiles="@(SharedFxPayload)" DestinationFiles="$(InstallersOutputPath)temp/$%(Filename)" />
-
     <!-- Read MSI properties -->
-    <GetMsiProperty InstallPackage="%(SharedFxPayload.CopyDir)" Property="ProductVersion">
+    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductVersion">
       <Output TaskParameter="Value" PropertyName="%(ProductVersionProperty)" />
     </GetMsiProperty>
-    <GetMsiProperty InstallPackage="%(SharedFxPayload.CopyDir)" Property="ProductCode">
+    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductCode">
       <Output TaskParameter="Value" PropertyName="%(ProductCodeProperty)" />
     </GetMsiProperty>
 

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -54,7 +54,10 @@
       <Private>True</Private>
       <DoNotHarvest>true</DoNotHarvest>
     </ProjectReference>
-    <ProjectReference Include="..\SharedFrameworkBundle\SharedFrameworkBundle.wixproj" />
+    <ProjectReference Include="..\SharedFrameworkBundle\SharedFrameworkBundle.wixproj">
+      <Private>True</Private>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
   <Import Project="Product.targets" />

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -133,18 +133,22 @@
       <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.msi">
         <ProductVersionProperty>SharedFxInstallerProductVersionx64</ProductVersionProperty>
         <ProductCodeProperty>SharedFxInstallerProductCodex64</ProductCodeProperty>
+        <CopyDir>$(InstallersOutputPath)temp/$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.msi</CopyDir>
       </SharedFxPayload>
       <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.msi">
         <ProductVersionProperty>SharedFxInstallerProductVersionx86</ProductVersionProperty>
         <ProductCodeProperty>SharedFxInstallerProductCodex86</ProductCodeProperty>
+        <CopyDir>$(InstallersOutputPath)temp/$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.msi</CopyDir>
       </SharedFxPayload>
     </ItemGroup>
 
+    <Copy SourceFiles="@(SharedFxPayload)" DestinationFiles="$(InstallersOutputPath)temp/$%(Filename)" />
+
     <!-- Read MSI properties -->
-    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductVersion">
+    <GetMsiProperty InstallPackage="%(SharedFxPayload.CopyDir)" Property="ProductVersion">
       <Output TaskParameter="Value" PropertyName="%(ProductVersionProperty)" />
     </GetMsiProperty>
-    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductCode">
+    <GetMsiProperty InstallPackage="%(SharedFxPayload.CopyDir)" Property="ProductCode">
       <Output TaskParameter="Value" PropertyName="%(ProductCodeProperty)" />
     </GetMsiProperty>
 

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -35,6 +35,7 @@
     <Compile Include="ANCM.wxs" />
     <Compile Include="Bundle.wxs" />
     <Compile Include="DotNetCore.wxs" />
+    <Compile Include="SharedFramework.wxs" />
     <EmbeddedResource Include="thm.wxl" />
   </ItemGroup>
 

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -78,6 +78,9 @@
     <PackageFileName>dotnet-hosting-$(PackageVersion)-win$(TargetExt)</PackageFileName>
 
     <BundleNameShort>Microsoft .NET $(PackageBrandingVersion)</BundleNameShort>
+    <SharedFxPackageVersion>$(PackageVersion)</SharedFxPackageVersion>
+    <SharedFxPackageVersion
+        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</SharedFxPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -94,6 +97,19 @@
     <BundleRegName>$(BundleNameFull)</BundleRegName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.exe">
+      <TargetPlatform>x64</TargetPlatform>
+      <BundleNameProperty>SharedFxRedistInstallerx64</BundleNameProperty>
+      <Version>$(SharedFxPackageVersion)</Version>
+    </SharedFxInstallers>
+    <SharedFxInstallers Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.exe">
+      <TargetPlatform>x86</TargetPlatform>
+      <BundleNameProperty>SharedFxRedistInstallerx86</BundleNameProperty>
+      <Version>$(SharedFxPackageVersion)</Version>
+    </SharedFxInstallers>
+  </ItemGroup>
+
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);BundleName=$(BundleName)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleNameFull=$(BundleNameFull)</DefineConstants>
@@ -105,4 +121,40 @@
     <DefineConstants>$(DefineConstants);BundleRegFamily=$(BundleRegFamily)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleRegName=$(BundleRegName)</DefineConstants>
   </PropertyGroup>
+
+  <Target Name="ExtractPropertiesFromSharedFxMsi" DependsOnTargets="FetchDependencies" BeforeTargets="BeforeBuild">
+    <!-- Create properties that holds the executable name. These are passed to the bundles so we can reference them as variables
+             from inside the ExePackage authoring. -->
+    <CreateProperty Value="%(SharedFxInstallers.Filename)%(Extension)">
+      <Output TaskParameter="Value" PropertyName="%(SharedFxInstallers.BundleNameProperty)"/>
+    </CreateProperty>
+
+    <ItemGroup>
+      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x64.msi">
+        <ProductVersionProperty>SharedFxInstallerProductVersionx64</ProductVersionProperty>
+        <ProductCodeProperty>SharedFxInstallerProductCodex64</ProductCodeProperty>
+      </SharedFxPayload>
+      <SharedFxPayload Include="$(InstallersOutputPath)$(RuntimeInstallerBaseName)-$(SharedFxPackageVersion)-win-x86.msi">
+        <ProductVersionProperty>SharedFxInstallerProductVersionx86</ProductVersionProperty>
+        <ProductCodeProperty>SharedFxInstallerProductCodex86</ProductCodeProperty>
+      </SharedFxPayload>
+    </ItemGroup>
+
+    <!-- Read MSI properties -->
+    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductVersion">
+      <Output TaskParameter="Value" PropertyName="%(ProductVersionProperty)" />
+    </GetMsiProperty>
+    <GetMsiProperty InstallPackage="%(SharedFxPayload.Identity)" Property="ProductCode">
+      <Output TaskParameter="Value" PropertyName="%(ProductCodeProperty)" />
+    </GetMsiProperty>
+
+    <PropertyGroup>
+      <DefineConstants>$(DefineConstants);SharedFxRedistInstallerx64=$(SharedFxRedistInstallerx64)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxInstallerProductVersionx64=$(SharedFxInstallerProductVersionx64)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxInstallerProductCodex64=$(SharedFxInstallerProductCodex64)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxRedistInstallerx86=$(SharedFxRedistInstallerx86)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxInstallerProductVersionx86=$(SharedFxInstallerProductVersionx86)</DefineConstants>
+      <DefineConstants>$(DefineConstants);SharedFxInstallerProductCodex86=$(SharedFxInstallerProductCodex86)</DefineConstants>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -109,7 +109,7 @@
     <DefineConstants>$(DefineConstants);BundleRegName=$(BundleRegName)</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="ExtractPropertiesFromSharedFxMsi" DependsOnTargets="FetchDependencies" BeforeTargets="BeforeBuild">
+  <Target Name="ExtractPropertiesFromSharedFxMsi" DependsOnTargets="FetchDependencies" AfterTargets="ResolveProjectReferences">
     <!-- Create properties that holds the executable name. These are passed to the bundles so we can reference them as variables
              from inside the ExePackage authoring. -->
     <CreateProperty Value="%(SharedFxInstallers.Filename)%(Extension)">


### PR DESCRIPTION
Short-term fix for https://github.com/dotnet/aspnetcore/issues/36382. Add a wix project for the SharedFx bundles and reference that from the Hosting bundle, instead of the SharedFx .msi's. Also change the Hosting Bundle to ProjectReference SharedFrameworkBundle instead of having 2 ProjectReferences to SharedFrameworkLib - this ensures that by the time `ResolveProjectReferences` is done, the SharedFx .msi's are available so we can extract the Product Code from them & pass it along to the new wix project. Will need to backport this to servicing after I confirm it works with test builds.

I also removed `BundleProviderKey` from the SharedFx bundle after conversation with @joeloff to confirm it wasn't necessary.

CC @jamshedd 