### PR TITLE
Add the ConfigurationManager to the IServiceCollection (#36832)

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -99,6 +99,8 @@ namespace Microsoft.AspNetCore.Builder
             Logging = new LoggingBuilder(Services);
             Host = new ConfigureHostBuilder(hostContext, Configuration, Services);
             WebHost = new ConfigureWebHostBuilder(webHostContext, Configuration, Services);
+
+            Services.AddSingleton<IConfiguration>(Configuration);
         }
 
         /// <summary>
@@ -171,6 +173,17 @@ namespace Microsoft.AspNetCore.Builder
                 // we called ConfigureWebHostDefaults on both the _deferredHostBuilder and _hostBuilder.
                 foreach (var s in _services)
                 {
+                    // Skip the configuration manager instance we added earlier
+                    // we're already going to wire it up to this new configuration source
+                    // after we've built the application. There's a chance the user manually added
+                    // this as well but we still need to remove it from the final configuration
+                    // to avoid cycles in the configuration graph
+                    if (s.ServiceType == typeof(IConfiguration) &&
+                        s.ImplementationInstance == Configuration)
+                    {
+                        continue;
+                    }
+
                     services.Add(s);
                 }
 

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -694,6 +694,39 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
+        public void CanResolveIConfigurationBeforeBuildingApplication()
+        {
+            var builder = WebApplication.CreateBuilder();
+            var sp = builder.Services.BuildServiceProvider();
+
+            var config = sp.GetService<IConfiguration>();
+            Assert.NotNull(config);
+            Assert.Same(config, builder.Configuration);
+
+            var app = builder.Build();
+
+            // These are different
+            Assert.NotSame(app.Configuration, builder.Configuration);
+        }
+
+        [Fact]
+        public void ManuallyAddingConfigurationAsServiceWorks()
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
+            var sp = builder.Services.BuildServiceProvider();
+
+            var config = sp.GetService<IConfiguration>();
+            Assert.NotNull(config);
+            Assert.Same(config, builder.Configuration);
+
+            var app = builder.Build();
+
+            // These are different
+            Assert.NotSame(app.Configuration, builder.Configuration);
+        }
+
+        [Fact]
         public async Task WebApplicationConfiguration_EnablesForwardedHeadersFromConfig()
         {
             var builder = WebApplication.CreateBuilder();


### PR DESCRIPTION
- Add an IConfiguration to the service collection for scenarios where uses end up prematurely building the service provider or sniffing the IServiceCollection for it. We then remove the ConfigurationManager reference it from the final IServiceCollection to avoid cycles in the configuration graph that result in stack overflows (we link the configuration manager to the final configuration that has been built).
- Added tests

Backport of ce733508a53a35119e98c35827d7a4c19e077bad