### PR TITLE
Always download blazor-hotreload.js from app root

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
 
             // Attempt to read previously applied hot reload deltas. dotnet-watch and VS will serve the script that can provide results from local-storage and
             // the injected middleware if present.
-            var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "./_framework/blazor-hotreload.js"));
+            var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "/_framework/blazor-hotreload.js"));
             await jsObjectReference.InvokeUnmarshalled<Task<int>>("receiveHotReload");
         }
 


### PR DESCRIPTION
Port https://github.com/dotnet/aspnetcore/pull/35737 to release/6.0-rc2

## Description

Hot reload for WebAssembly attempts to download a JS script as part of booting up the app which is served from the root of the app (e.g. `/_framework/blazor-hotreload.js`). Blazor constructs a URL for the script and downloads it. Currently this URL is relative to where Blazor is hosted. Blazor also allows a way to configure it to be served from a subdirectory of the app root. In this case, the URL for the script is incorrectly constructed (e.g. `/mycustomsubdir/_framework/blazor-hotreload.js`) which causes the app to fail loading.

## Regression

No. 

## Testing
The change was manually tested. 

## Risk

There's a very uncommon scenario where the user does additional work to host the entire app of a virtual subdirectory which this change regresses. However, other scripts scripts that VS injects in to the app (browser-link for css updates) are already broken in this case so we're not making things significantly worse.

## Issues
Fixes https://github.com/dotnet/aspnetcore/issues/35555
Fixes https://github.com/dotnet/aspnetcore/issues/35967

