### PR TITLE
Don't clear NuGet caches at all

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -178,11 +178,6 @@ jobs:
         displayName: Install Node 14.x
         inputs:
           versionSpec: 14.x
-    - task: NuGetCommand@2
-      displayName: 'Clear NuGet caches'
-      inputs:
-        command: custom
-        arguments: 'locals all -clear'
     - ${{ if and(eq(parameters.installJdk, 'true'), eq(parameters.agentOs, 'Windows')) }}:
       - powershell: ./eng/scripts/InstallJdk.ps1
         displayName: Install JDK 11

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -178,14 +178,11 @@ jobs:
         displayName: Install Node 14.x
         inputs:
           versionSpec: 14.x
-    - ${{ if eq(parameters.agentOs, 'Windows') }}:
-      - task: NuGetToolInstaller@1
-      - task: NuGetCommand@2
-        displayName: 'Clear NuGet caches'
-        condition: succeeded()
-        inputs:
-          command: custom
-          arguments: 'locals all -clear'
+    - task: NuGetCommand@2
+      displayName: 'Clear NuGet caches'
+      inputs:
+        command: custom
+        arguments: 'locals all -clear'
     - ${{ if and(eq(parameters.installJdk, 'true'), eq(parameters.agentOs, 'Windows')) }}:
       - powershell: ./eng/scripts/InstallJdk.ps1
         displayName: Install JDK 11


### PR DESCRIPTION
- `$use_global_nuget_cache` and `$useGlobalNuGetCache` have default values in our pipelines
- therefore, cache is always within `$(System.DefaultWorkingDirectory)` and should not exist at job start