### PR TITLE
Fix Missing `RZ10012` diagnostic for components written in certain cultures

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             bool suppressPrimaryMethodBody,
             bool suppressNullabilityEnforcement,
             bool omitMinimizedComponentAttributeValues,
+            bool supportLocalizedComponentNames,
             bool useEnhancedLinePragma)
         {
             IndentWithTabs = indentWithTabs;
@@ -26,6 +27,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             SuppressPrimaryMethodBody = suppressPrimaryMethodBody;
             SuppressNullabilityEnforcement = suppressNullabilityEnforcement;
             OmitMinimizedComponentAttributeValues = omitMinimizedComponentAttributeValues;
+            SupportLocalizedComponentNames = supportLocalizedComponentNames;
             UseEnhancedLinePragma = useEnhancedLinePragma;
         }
 
@@ -42,6 +44,8 @@ namespace Microsoft.AspNetCore.Razor.Language
         public override bool SuppressNullabilityEnforcement { get; }
 
         public override bool OmitMinimizedComponentAttributeValues { get; }
+
+        public override bool SupportLocalizedComponentNames { get; }
 
         public override bool UseEnhancedLinePragma { get; }
     }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptions.cs
@@ -45,8 +45,6 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override bool OmitMinimizedComponentAttributeValues { get; }
 
-        public override bool SupportLocalizedComponentNames { get; }
-
         public override bool UseEnhancedLinePragma { get; }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptionsBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptionsBuilder.cs
@@ -41,6 +41,8 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override bool OmitMinimizedComponentAttributeValues { get; set; }
 
+        public override bool SupportLocalizedComponentNames { get; set; }
+
         public override bool UseEnhancedLinePragma { get; set; }
 
         public override RazorCodeGenerationOptions Build()
@@ -55,6 +57,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 SuppressPrimaryMethodBody,
                 SuppressNullabilityEnforcement,
                 OmitMinimizedComponentAttributeValues,
+                SupportLocalizedComponentNames,
                 UseEnhancedLinePragma)
             {
                 SuppressMetadataSourceChecksumAttributes = SuppressMetadataSourceChecksumAttributes,

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1223,10 +1223,10 @@ namespace Microsoft.AspNetCore.Razor.Language
                     // In certain cultures, characters are not explicitly Uppercase/Lowercase, hence we must check
                     // the specific UnicodeCategory to see if we may still be able to treat it as a component.
                     //
-                    //    The goal here is to avoid clashing with any future standard-HTML elements.
+                    // The goal here is to avoid clashing with any future standard-HTML elements.
                     //
-                    //    To avoid a breaking change, the support of localized component names (without explicit
-                    //    Uppercase classification) is behind a `SupportLocalizedComponentNames` feature flag.
+                    // To avoid a breaking change, the support of localized component names (without explicit
+                    // Uppercase classification) is behind a `SupportLocalizedComponentNames` feature flag.
                     return category is UnicodeCategory.UppercaseLetter ||
                         (document.Options.SupportLocalizedComponentNames &&
                             (category is UnicodeCategory.TitlecaseLetter || category is UnicodeCategory.OtherLetter));

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1216,7 +1216,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
                 static bool LooksLikeAComponentName(DocumentIntermediateNode document, string startTagName)
                 {
-                    var category = CharUnicodeInfo.GetUnicodeCategory(startTagName, 0);
+                    var category = char.GetUnicodeCategory(startTagName, 0);
 
                     // A markup element which starts with an uppercase character is likely a component.
                     //

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -33,3 +33,6 @@ Microsoft.AspNetCore.Razor.Language.SourceSpan.EndCharacterIndex.get -> int
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.UseEnhancedLinePragma.get -> bool
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.UseEnhancedLinePragma.set -> void
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.UseEnhancedLinePragma.get -> bool
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.get -> bool
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.set -> void
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.get -> bool

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -33,5 +33,7 @@ Microsoft.AspNetCore.Razor.Language.SourceSpan.EndCharacterIndex.get -> int
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.UseEnhancedLinePragma.get -> bool
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.UseEnhancedLinePragma.set -> void
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.UseEnhancedLinePragma.get -> bool
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.get -> bool
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.set -> void
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.get -> bool
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.set -> void

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -37,3 +37,4 @@ virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.Su
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.set -> void
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.get -> bool
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.set -> void
+~static Microsoft.AspNetCore.Razor.Language.RazorProjectEngineBuilderExtensions.SetSupportLocalizedComponentNames(this Microsoft.AspNetCore.Razor.Language.RazorProjectEngineBuilder builder) -> Microsoft.AspNetCore.Razor.Language.RazorProjectEngineBuilder

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -33,6 +33,5 @@ Microsoft.AspNetCore.Razor.Language.SourceSpan.EndCharacterIndex.get -> int
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.UseEnhancedLinePragma.get -> bool
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.UseEnhancedLinePragma.set -> void
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.UseEnhancedLinePragma.get -> bool
-virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.get -> bool
-virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.set -> void
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.get -> bool
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.set -> void

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 suppressPrimaryMethodBody: false,
                 suppressNullabilityEnforcement: false,
                 omitMinimizedComponentAttributeValues: false,
+                supportLocalizedComponentNames: false,
                 useEnhancedLinePragma: true);
         }
 
@@ -34,6 +35,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 suppressPrimaryMethodBody: false,
                 suppressNullabilityEnforcement: false,
                 omitMinimizedComponentAttributeValues: false,
+                supportLocalizedComponentNames: false,
                 useEnhancedLinePragma: true);
         }
 
@@ -133,6 +135,14 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// </summary>
         public virtual bool OmitMinimizedComponentAttributeValues { get; }
 
+        /// <summary>
+        /// Gets a value that determines if localized component names are to be supported.
+        /// </summary>
+        public virtual bool SupportLocalizedComponentNames { get; }
+
+        /// <summary>
+        /// Gets a value that determines if enhanced line pragmas are to be utilized.
+        /// </summary>
         public virtual bool UseEnhancedLinePragma { get; }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// <summary>
         /// Gets a value that determines if localized component names are to be supported.
         /// </summary>
-        public virtual bool SupportLocalizedComponentNames { get; }
+        public virtual bool SupportLocalizedComponentNames { get; set; }
 
         /// <summary>
         /// Gets a value that determines if enhanced line pragmas are to be utilized.

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
@@ -73,6 +73,14 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// </summary>
         public virtual bool OmitMinimizedComponentAttributeValues { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value that determines if localized component names are to be supported.
+        /// </summary>
+        public virtual bool SupportLocalizedComponentNames { get; set; }
+
+        /// <summary>
+        /// Gets a value that determines if enhanced line pragmas are to be utilized.
+        /// </summary>
         public virtual bool UseEnhancedLinePragma { get; set; }
 
         public abstract RazorCodeGenerationOptions Build();

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngineBuilderExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngineBuilderExtensions.cs
@@ -92,6 +92,22 @@ namespace Microsoft.AspNetCore.Razor.Language
             return builder;
         }
 
+        /// <summary>
+        /// Sets the SupportLocalizedComponentNames property to make localized component name diagnostics available.
+        /// </summary>
+        /// <param name="builder">The <see cref="RazorProjectEngineBuilder"/>.</param>
+        /// <returns>The <see cref="RazorProjectEngineBuilder"/>.</returns>
+        public static RazorProjectEngineBuilder SetSupportLocalizedComponentNames(this RazorProjectEngineBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Features.Add(new SetSupportLocalizedComponentNamesFeature());
+            return builder;
+        }
+
         public static void SetImportFeature(this RazorProjectEngineBuilder builder, IImportProjectFeature feature)
         {
             if (builder == null)
@@ -299,6 +315,21 @@ namespace Microsoft.AspNetCore.Razor.Language
                 public override bool Exists => true;
 
                 public override Stream Read() => new MemoryStream(_importBytes);
+            }
+        }
+
+        private class SetSupportLocalizedComponentNamesFeature : RazorEngineFeatureBase, IConfigureRazorCodeGenerationOptionsFeature
+        {
+            public int Order { get; set; }
+
+            public void Configure(RazorCodeGenerationOptionsBuilder options)
+            {
+                if (options == null)
+                {
+                    throw new ArgumentNullException(nameof(options));
+                }
+
+                options.SupportLocalizedComponentNames = true;
             }
         }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentChildContentIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentChildContentIntegrationTest.cs
@@ -115,18 +115,20 @@ Some Content
                 diagnostic.GetMessage(CultureInfo.CurrentCulture));
         }
 
-        [Fact]
-        public void ChildContent_ExplicitChildContent_UnrecogizedElement_ProducesDiagnostic()
+        [Theory]
+        [InlineData("UnrecognizedChildContent")]
+        [InlineData("繁体字")]
+        public void ChildContent_ExplicitChildContent_UnrecogizedElement_ProducesDiagnostic(string unrecognizedComponentName)
         {
             // Arrange
             AdditionalSyntaxTrees.Add(RenderChildContentComponent);
 
             // Act
-            var generated = CompileToCSharp(@"
+            var generated = CompileToCSharp(@$"
 <RenderChildContent>
 <ChildContent>
 </ChildContent>
-<UnrecognizedChildContent></UnrecognizedChildContent>
+<{unrecognizedComponentName}></{unrecognizedComponentName}>
 </RenderChildContent>");
 
             // Assert

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentChildContentIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentChildContentIntegrationTest.cs
@@ -116,9 +116,11 @@ Some Content
         }
 
         [Theory]
-        [InlineData("UnrecognizedChildContent")]
-        [InlineData("繁体字")]
-        public void ChildContent_ExplicitChildContent_UnrecogizedElement_ProducesDiagnostic(string unrecognizedComponentName)
+        [InlineData("UnrecognizedChildContent", true, true)]
+        [InlineData("UnrecognizedChildContent", false, true)]
+        [InlineData("繁体字", true, true)]
+        [InlineData("繁体字", false, false)]
+        public void ChildContent_ExplicitChildContent_UnrecogizedElement_ProducesDiagnostic(string unrecognizedComponentName, bool supportLocalizedComponentNames, bool diagnosticExpected)
         {
             // Arrange
             AdditionalSyntaxTrees.Add(RenderChildContentComponent);
@@ -129,13 +131,22 @@ Some Content
 <ChildContent>
 </ChildContent>
 <{unrecognizedComponentName}></{unrecognizedComponentName}>
-</RenderChildContent>");
+</RenderChildContent>", supportLocalizedComponentNames: supportLocalizedComponentNames);
 
             // Assert
-            Assert.Collection(
-                generated.Diagnostics,
-                d => Assert.Equal("RZ10012", d.Id),
-                d => Assert.Equal("RZ9996", d.Id));
+            if (diagnosticExpected)
+            {
+                Assert.Collection(
+                    generated.Diagnostics,
+                    d => Assert.Equal("RZ10012", d.Id),
+                    d => Assert.Equal("RZ9996", d.Id));
+            }
+            else
+            {
+                Assert.Collection(
+                    generated.Diagnostics,
+                    d => Assert.Equal("RZ9996", d.Id));
+            }
         }
 
         [Fact]

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiagnosticRazorIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiagnosticRazorIntegrationTest.cs
@@ -147,9 +147,11 @@ namespace Test
         }
 
         [Theory]
-        [InlineData("PossibleComponent")]
-        [InlineData("繁体字")]
-        public void Component_NotFound_ReportsWarning(string componentName)
+        [InlineData("PossibleComponent", true, true)]
+        [InlineData("PossibleComponent", false, true)]
+        [InlineData("繁体字", true, true)]
+        [InlineData("繁体字", false, false)]
+        public void Component_NotFound_ReportsWarning(string componentName, bool supportLocalizedComponentNames, bool diagnosticExpected)
         {
             // Arrange & Act
             var generated = CompileToCSharp(@$"
@@ -157,15 +159,22 @@ namespace Test
 
 @functions {{
     public string Text {{ get; set; }} = ""text"";
-}}");
+}}", supportLocalizedComponentNames: supportLocalizedComponentNames);
 
             // Assert
-            var diagnostic = Assert.Single(generated.Diagnostics);
-            Assert.Equal("RZ10012", diagnostic.Id);
-            Assert.Equal(RazorDiagnosticSeverity.Warning, diagnostic.Severity);
-            Assert.Equal(
-                $"Found markup element with unexpected name '{componentName}'. If this is intended to be a component, add a @using directive for its namespace.",
-                diagnostic.GetMessage(CultureInfo.CurrentCulture));
+            if (diagnosticExpected)
+            {
+                var diagnostic = Assert.Single(generated.Diagnostics);
+                Assert.Equal("RZ10012", diagnostic.Id);
+                Assert.Equal(RazorDiagnosticSeverity.Warning, diagnostic.Severity);
+                Assert.Equal(
+                    $"Found markup element with unexpected name '{componentName}'. If this is intended to be a component, add a @using directive for its namespace.",
+                    diagnostic.GetMessage(CultureInfo.CurrentCulture));
+            }
+            else
+            {
+                Assert.Empty(generated.Diagnostics);
+            }
         }
 
         [Fact]

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiagnosticRazorIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiagnosticRazorIntegrationTest.cs
@@ -43,7 +43,6 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             var diagnostic = Assert.Single(generated.Diagnostics);
             Assert.Equal("RZ9979", diagnostic.Id);
             Assert.NotNull(diagnostic.GetMessage(CultureInfo.CurrentCulture));
-
         }
 
         [Fact]
@@ -147,23 +146,25 @@ namespace Test
                 diagnostic.GetMessage(CultureInfo.CurrentCulture));
         }
 
-        [Fact]
-        public void Element_DoesNotStartWithLowerCase_ReportsWarning()
+        [Theory]
+        [InlineData("PossibleComponent")]
+        [InlineData("繁体字")]
+        public void Component_NotFound_ReportsWarning(string componentName)
         {
             // Arrange & Act
-            var generated = CompileToCSharp(@"
-<PossibleComponent></PossibleComponent>
+            var generated = CompileToCSharp(@$"
+<{componentName}></{componentName}>
 
-@functions {
-    public string Text { get; set; } = ""text"";
-}");
+@functions {{
+    public string Text {{ get; set; }} = ""text"";
+}}");
 
             // Assert
             var diagnostic = Assert.Single(generated.Diagnostics);
             Assert.Equal("RZ10012", diagnostic.Id);
             Assert.Equal(RazorDiagnosticSeverity.Warning, diagnostic.Severity);
             Assert.Equal(
-                "Found markup element with unexpected name 'PossibleComponent'. If this is intended to be a component, add a @using directive for its namespace.",
+                $"Found markup element with unexpected name '{componentName}'. If this is intended to be a component, add a @using directive for its namespace.",
                 diagnostic.GetMessage(CultureInfo.CurrentCulture));
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
         internal virtual string WorkingDirectory { get; }
 
         // intentionally private - we don't want individual tests messing with the project engine
-        private RazorProjectEngine CreateProjectEngine(RazorConfiguration configuration, MetadataReference[] references)
+        private RazorProjectEngine CreateProjectEngine(RazorConfiguration configuration, MetadataReference[] references, bool supportLocalizedComponentNames)
         {
             return RazorProjectEngine.Create(configuration, FileSystem, b =>
             {
@@ -121,7 +121,10 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                 // Turn off checksums, we're testing code generation.
                 b.Features.Add(new SuppressChecksum());
 
-                b.Features.Add(new SupportLocalizedComponentNames());
+                if (supportLocalizedComponentNames)
+                {
+                    b.Features.Add(new SupportLocalizedComponentNames());
+                }
 
                 b.Features.Add(new TestImportProjectFeature(ImportItems));
 
@@ -170,12 +173,12 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             };
         }
 
-        protected CompileToCSharpResult CompileToCSharp(string cshtmlContent, bool throwOnFailure=true, string cssScope = null)
+        protected CompileToCSharpResult CompileToCSharp(string cshtmlContent, bool throwOnFailure=true, string cssScope = null, bool supportLocalizedComponentNames = false)
         {
-            return CompileToCSharp(DefaultFileName, cshtmlContent, throwOnFailure, cssScope: cssScope);
+            return CompileToCSharp(DefaultFileName, cshtmlContent, throwOnFailure, cssScope: cssScope, supportLocalizedComponentNames: supportLocalizedComponentNames);
         }
 
-        protected CompileToCSharpResult CompileToCSharp(string cshtmlRelativePath, string cshtmlContent, bool throwOnFailure = true, string fileKind = null, string cssScope = null)
+        protected CompileToCSharpResult CompileToCSharp(string cshtmlRelativePath, string cshtmlContent, bool throwOnFailure = true, string fileKind = null, string cssScope = null, bool supportLocalizedComponentNames = false)
         {
             if (DeclarationOnly && DesignTime)
             {
@@ -191,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             {
                 // The first phase won't include any metadata references for component discovery. This mirrors
                 // what the build does.
-                var projectEngine = CreateProjectEngine(Configuration, Array.Empty<MetadataReference>());
+                var projectEngine = CreateProjectEngine(Configuration, Array.Empty<MetadataReference>(), supportLocalizedComponentNames);
 
                 RazorCodeDocument codeDocument;
                 foreach (var item in AdditionalRazorItems)
@@ -220,7 +223,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
 
                 // Add the 'temp' compilation as a metadata reference
                 var references = BaseCompilation.References.Concat(new[] { tempAssembly.Compilation.ToMetadataReference() }).ToArray();
-                projectEngine = CreateProjectEngine(Configuration, references);
+                projectEngine = CreateProjectEngine(Configuration, references, supportLocalizedComponentNames);
 
                 // Now update the any additional files
                 foreach (var item in AdditionalRazorItems)
@@ -249,7 +252,7 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             {
                 // For single phase compilation tests just use the base compilation's references.
                 // This will include the built-in components.
-                var projectEngine = CreateProjectEngine(Configuration, BaseCompilation.References.ToArray());
+                var projectEngine = CreateProjectEngine(Configuration, BaseCompilation.References.ToArray(), supportLocalizedComponentNames);
 
                 var projectItem = CreateProjectItem(cshtmlRelativePath, cshtmlContent, fileKind, cssScope);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorIntegrationTestBase.cs
@@ -121,6 +121,8 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
                 // Turn off checksums, we're testing code generation.
                 b.Features.Add(new SuppressChecksum());
 
+                b.Features.Add(new SupportLocalizedComponentNames());
+
                 b.Features.Add(new TestImportProjectFeature(ImportItems));
 
                 if (LineEnding != null)
@@ -443,6 +445,18 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
             public void Configure(RazorCodeGenerationOptionsBuilder options)
             {
                 options.SuppressChecksum = true;
+            }
+        }
+
+        private class SupportLocalizedComponentNames : IConfigureRazorCodeGenerationOptionsFeature
+        {
+            public int Order => 0;
+
+            public RazorEngine Engine { get; set; }
+
+            public void Configure(RazorCodeGenerationOptionsBuilder options)
+            {
+                options.SupportLocalizedComponentNames = true;
             }
         }
 


### PR DESCRIPTION
## Description

Blazor expects components to begin with an uppercase letter. Certain cultures do not differentiate between upper/lowercase characters. As such, components named in those cultures were not getting the `RZ10012` diagnostic. Due to the missing diagnostic, some VS code actions were also unavailable. 

Note: There is a companion PR to this (internal SDK) which will need to consume the changes of this PR for the final solution to work. This will be done after this PR is merged, and we trigger a "dependency update" between the base `release/6.0-rc2` branch we're targeting here, and the `release/6.0.1xx-rc2` in the `dotnet/sdk` repo.

## Customer Impact

Ensure components named using characters from cultures which do not differentiate between upper/lowercase still get diagnostics and code actions (ex. GB18030 `繁体字`).

For an unrecognized component `繁体字`, Blazor will silently output `<繁体字></繁体字>` as markup instead of providing a warning message indicating this may have been intended to be a component. As a result of the missing warning message, Visual Studio code actions (lightbulbs) for creating a component of name `繁体字`, or adding a missing using statement will not appear.

## Regression?
- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1408782


