### PR TITLE
Update spa-templates submodule to reference 6.0 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "src/submodules/spa-templates"]
 	path = src/submodules/spa-templates
 	url = https://github.com/dotnet/spa-templates.git
-	branch = main
+	branch = release/6.0


### PR DESCRIPTION
spa-templates' main branch is going to `net7.0`, so we've created a `release/6.0` branch which our 6.0 branches need to reference. Doing this in rc2 so subsequent builds of that branch don't break (there are still incoming changes). Commit isn't changing for the submodule because it's currently the same commit as in `main`. CC @Pilchie since this goes into rc2