### PR TITLE
Backport Fix Missing `RZ10012` diagnostic for components written in certain cultures

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             bool suppressPrimaryMethodBody,
             bool suppressNullabilityEnforcement,
             bool omitMinimizedComponentAttributeValues,
+            bool supportLocalizedComponentNames,
             bool useEnhancedLinePragma)
         {
             IndentWithTabs = indentWithTabs;
@@ -26,6 +27,7 @@ namespace Microsoft.AspNetCore.Razor.Language
             SuppressPrimaryMethodBody = suppressPrimaryMethodBody;
             SuppressNullabilityEnforcement = suppressNullabilityEnforcement;
             OmitMinimizedComponentAttributeValues = omitMinimizedComponentAttributeValues;
+            SupportLocalizedComponentNames = supportLocalizedComponentNames;
             UseEnhancedLinePragma = useEnhancedLinePragma;
         }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptionsBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorCodeGenerationOptionsBuilder.cs
@@ -41,6 +41,8 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override bool OmitMinimizedComponentAttributeValues { get; set; }
 
+        public override bool SupportLocalizedComponentNames { get; set; }
+
         public override bool UseEnhancedLinePragma { get; set; }
 
         public override RazorCodeGenerationOptions Build()
@@ -55,6 +57,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 SuppressPrimaryMethodBody,
                 SuppressNullabilityEnforcement,
                 OmitMinimizedComponentAttributeValues,
+                SupportLocalizedComponentNames,
                 UseEnhancedLinePragma)
             {
                 SuppressMetadataSourceChecksumAttributes = SuppressMetadataSourceChecksumAttributes,

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1229,7 +1229,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                     // Uppercase classification) is behind a `SupportLocalizedComponentNames` feature flag.
                     return category is UnicodeCategory.UppercaseLetter ||
                         (document.Options.SupportLocalizedComponentNames &&
-                            (category is UnicodeCategory.TitlecaseLetter || category is UnicodeCategory.OtherLetter));
+                            (category is UnicodeCategory.TitlecaseLetter or UnicodeCategory.OtherLetter));
                 }
             }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
@@ -1200,10 +1201,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     // We only want this error during the second phase of the two phase compilation.
                     var startTagName = node.StartTag.GetTagNameWithOptionalBang();
-                    if (startTagName != null && startTagName.Length > 0 && char.IsUpper(startTagName, 0))
+                    if (!string.IsNullOrEmpty(startTagName) && LooksLikeAComponentName(_document, startTagName))
                     {
-                        // A markup element that starts with an uppercase character.
-                        // It is most likely intended to be a component. Add a warning.
                         element.Diagnostics.Add(
                             ComponentDiagnosticFactory.Create_UnexpectedMarkupElement(startTagName, BuildSourceSpanFromNode(node.StartTag)));
                     }
@@ -1214,6 +1213,24 @@ namespace Microsoft.AspNetCore.Razor.Language
                 base.VisitMarkupElement(node);
 
                 _builder.Pop();
+
+                static bool LooksLikeAComponentName(DocumentIntermediateNode document, string startTagName)
+                {
+                    var category = char.GetUnicodeCategory(startTagName, 0);
+
+                    // A markup element which starts with an uppercase character is likely a component.
+                    //
+                    // In certain cultures, characters are not explicitly Uppercase/Lowercase, hence we must check
+                    // the specific UnicodeCategory to see if we may still be able to treat it as a component.
+                    //
+                    // The goal here is to avoid clashing with any future standard-HTML elements.
+                    //
+                    // To avoid a breaking change, the support of localized component names (without explicit
+                    // Uppercase classification) is behind a `SupportLocalizedComponentNames` feature flag.
+                    return category is UnicodeCategory.UppercaseLetter ||
+                        (document.Options.SupportLocalizedComponentNames &&
+                            (category is UnicodeCategory.TitlecaseLetter || category is UnicodeCategory.OtherLetter));
+                }
             }
 
             public override void VisitMarkupStartTag(MarkupStartTagSyntax node)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -33,3 +33,8 @@ Microsoft.AspNetCore.Razor.Language.SourceSpan.EndCharacterIndex.get -> int
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.UseEnhancedLinePragma.get -> bool
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.UseEnhancedLinePragma.set -> void
 virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.UseEnhancedLinePragma.get -> bool
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.get -> bool
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder.SupportLocalizedComponentNames.set -> void
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.get -> bool
+virtual Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.SupportLocalizedComponentNames.set -> void
+~static Microsoft.AspNetCore.Razor.Language.RazorProjectEngineBuilderExtensions.SetSupportLocalizedComponentNames(this Microsoft.AspNetCore.Razor.Language.RazorProjectEngineBuilder builder) -> Microsoft.AspNetCore.Razor.Language.RazorProjectEngineBuilder

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 suppressPrimaryMethodBody: false,
                 suppressNullabilityEnforcement: false,
                 omitMinimizedComponentAttributeValues: false,
+                supportLocalizedComponentNames: false,
                 useEnhancedLinePragma: true);
         }
 
@@ -34,6 +35,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 suppressPrimaryMethodBody: false,
                 suppressNullabilityEnforcement: false,
                 omitMinimizedComponentAttributeValues: false,
+                supportLocalizedComponentNames: false,
                 useEnhancedLinePragma: true);
         }
 
@@ -133,6 +135,14 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// </summary>
         public virtual bool OmitMinimizedComponentAttributeValues { get; }
 
+        /// <summary>
+        /// Gets a value that determines if localized component names are to be supported.
+        /// </summary>
+        public virtual bool SupportLocalizedComponentNames { get; set; }
+
+        /// <summary>
+        /// Gets a value that determines if enhanced line pragmas are to be utilized.
+        /// </summary>
         public virtual bool UseEnhancedLinePragma { get; }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
@@ -73,6 +73,14 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// </summary>
         public virtual bool OmitMinimizedComponentAttributeValues { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value that determines if localized component names are to be supported.
+        /// </summary>
+        public virtual bool SupportLocalizedComponentNames { get; set; }
+
+        /// <summary>
+        /// Gets a value that determines if enhanced line pragmas are to be utilized.
+        /// </summary>
         public virtual bool UseEnhancedLinePragma { get; set; }
 
         public abstract RazorCodeGenerationOptions Build();

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorCodeGenerationOptionsBuilder.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Razor.Language
         public virtual bool SupportLocalizedComponentNames { get; set; }
 
         /// <summary>
-        /// Gets a value that determines if enhanced line pragmas are to be utilized.
+        /// Gets or sets a value that determines if enhanced line pragmas are to be utilized.
         /// </summary>
         public virtual bool UseEnhancedLinePragma { get; set; }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngineBuilderExtensions.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngineBuilderExtensions.cs
@@ -92,6 +92,22 @@ namespace Microsoft.AspNetCore.Razor.Language
             return builder;
         }
 
+        /// <summary>
+        /// Sets the SupportLocalizedComponentNames property to make localized component name diagnostics available.
+        /// </summary>
+        /// <param name="builder">The <see cref="RazorProjectEngineBuilder"/>.</param>
+        /// <returns>The <see cref="RazorProjectEngineBuilder"/>.</returns>
+        public static RazorProjectEngineBuilder SetSupportLocalizedComponentNames(this RazorProjectEngineBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Features.Add(new SetSupportLocalizedComponentNamesFeature());
+            return builder;
+        }
+
         public static void SetImportFeature(this RazorProjectEngineBuilder builder, IImportProjectFeature feature)
         {
             if (builder == null)
@@ -299,6 +315,21 @@ namespace Microsoft.AspNetCore.Razor.Language
                 public override bool Exists => true;
 
                 public override Stream Read() => new MemoryStream(_importBytes);
+            }
+        }
+
+        private class SetSupportLocalizedComponentNamesFeature : RazorEngineFeatureBase, IConfigureRazorCodeGenerationOptionsFeature
+        {
+            public int Order { get; set; }
+
+            public void Configure(RazorCodeGenerationOptionsBuilder options)
+            {
+                if (options == null)
+                {
+                    throw new ArgumentNullException(nameof(options));
+                }
+
+                options.SupportLocalizedComponentNames = true;
             }
         }
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentChildContentIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentChildContentIntegrationTest.cs
@@ -115,8 +115,10 @@ Some Content
                 diagnostic.GetMessage(CultureInfo.CurrentCulture));
         }
 
-        [Fact]
-        public void ChildContent_ExplicitChildContent_UnrecogizedElement_ProducesDiagnostic()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ChildContent_ExplicitChildContent_UnrecogizedElement_ProducesDiagnostic(bool supportLocalizedComponentNames)
         {
             // Arrange
             AdditionalSyntaxTrees.Add(RenderChildContentComponent);
@@ -127,12 +129,53 @@ Some Content
 <ChildContent>
 </ChildContent>
 <UnrecognizedChildContent></UnrecognizedChildContent>
-</RenderChildContent>");
+</RenderChildContent>", supportLocalizedComponentNames: supportLocalizedComponentNames);
 
             // Assert
             Assert.Collection(
                 generated.Diagnostics,
                 d => Assert.Equal("RZ10012", d.Id),
+                d => Assert.Equal("RZ9996", d.Id));
+        }
+
+        [Fact]
+        public void ChildContent_ExplicitChildContent_StartsWithCharThatIsOtherLetterCategory_WhenLocalizedComponentNamesIsAllowed()
+        {
+            // Arrange
+            AdditionalSyntaxTrees.Add(RenderChildContentComponent);
+
+            // Act
+            var generated = CompileToCSharp(@$"
+<RenderChildContent>
+<ChildContent>
+</ChildContent>
+<繁体字></繁体字>
+</RenderChildContent>", supportLocalizedComponentNames: true);
+
+            // Assert
+            Assert.Collection(
+                generated.Diagnostics,
+                d => Assert.Equal("RZ10012", d.Id),
+                d => Assert.Equal("RZ9996", d.Id));
+        }
+
+        [Fact]
+        public void ChildContent_ExplicitChildContent_StartsWithCharThatIsOtherLetterCategory_WhenLocalizedComponentNamesIsDisallowed()
+        {
+            // Arrange
+            AdditionalSyntaxTrees.Add(RenderChildContentComponent);
+
+            // Act
+            var generated = CompileToCSharp(@$"
+<RenderChildContent>
+<ChildContent>
+</ChildContent>
+<繁体字></繁体字>
+</RenderChildContent>", supportLocalizedComponentNames: false);
+
+            // Assert
+            Assert.Collection(
+                generated.Diagnostics,
                 d => Assert.Equal("RZ9996", d.Id));
         }
 


### PR DESCRIPTION
Backports changes from https://github.com/dotnet/aspnetcore/pull/36907 to main