### PR TITLE
Use TryParse and BindAsync methods from interfaces

### DIFF
--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -660,6 +660,28 @@ namespace Microsoft.AspNetCore.Routing.Internal
             }
         }
 
+        private interface IBindAsync<T>
+        {
+            static ValueTask<T?> BindAsync(HttpContext context)
+            {
+                if (typeof(T) != typeof(MyBindAsyncFromInterfaceRecord))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                if (!Uri.TryCreate(context.Request.Headers.Referer, UriKind.Absolute, out var uri))
+                {
+                    return new(default(T));
+                }
+
+                return new(result: (T)(object)new MyBindAsyncFromInterfaceRecord(uri));
+            }
+        }
+
+        private record MyBindAsyncFromInterfaceRecord(Uri uri) : IBindAsync<MyBindAsyncFromInterfaceRecord>
+        {
+        }
+
         [Theory]
         [MemberData(nameof(TryParsableParameters))]
         public async Task RequestDelegatePopulatesUnattributedTryParsableParametersFromRouteValue(Delegate action, string? routeValue, object? expectedParameterValue)
@@ -830,6 +852,25 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
             Assert.Equal(new MyAwaitedBindAsyncRecord(new Uri("https://example.org")), httpContext.Items["myAwaitedBindAsyncRecord"]);
             Assert.Equal(new MyAwaitedBindAsyncStruct(new Uri("https://example.org")), httpContext.Items["myAwaitedBindAsyncStruct"]);
+        }
+
+        [Fact]
+        public async Task RequestDelegateUsesBindAsyncFromImplementedInterface()
+        {
+            var httpContext = CreateHttpContext();
+
+            httpContext.Request.Headers.Referer = "https://example.org";
+
+            var resultFactory = RequestDelegateFactory.Create((HttpContext httpContext, MyBindAsyncFromInterfaceRecord myBindAsyncRecord) =>
+            {
+                httpContext.Items["myBindAsyncFromInterfaceRecord"] = myBindAsyncRecord;
+            });
+
+            var requestDelegate = resultFactory.RequestDelegate;
+
+            await requestDelegate(httpContext);
+
+            Assert.Equal(new MyBindAsyncFromInterfaceRecord(new Uri("https://example.org")), httpContext.Items["myBindAsyncFromInterfaceRecord"]);
         }
 
         public static object[][] DelegatesWithAttributesOnNotTryParsableParameters


### PR DESCRIPTION
This PR searches the interfaces implemented by minimal route handler parameter types for TryParse and BindAsync if no methods are found directly on the type hierarchy first.

As mentioned in #36935, the motivation is to allow the bind logic to be easily shared between different type hierarchies meaning that DTOs can inherit from other classes unrelated to binding. Here's the sample from the issue:

``` c#
app.MapPost("/widget", (CreateWidgetDTO dto) =>
{
    // Use the dto
});

public interface ICompositeSourceBinder<T>
{
    // typeof(T) must equal ParameterInfo.Type otherwise we throw
    public static T BindAsync(HttpContext context, ParameterInfo parameter)
    {
        // Use reflection to bind the properties on T
    }
}

public class CreateWidgetDTO : MyBaseType, ICompositeSourceBinder<CreateWidgetDTO>
{
    [FromRoute]
    public string? Name { get; set; }

    [FromQuery]
    public int Id { get; set; }
}
```

Fixes #36935