### PR TITLE
Fix BoundAttributDescriptor.GetHashCode and add test (#36679)

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
@@ -60,6 +60,8 @@ namespace Microsoft.AspNetCore.Razor.Language
             hash.Add(descriptor.Kind, StringComparer.Ordinal);
             hash.Add(descriptor.Name, StringComparer.Ordinal);
             hash.Add(descriptor.IsEditorRequired);
+            hash.Add(descriptor.TypeName, StringComparer.Ordinal);
+            hash.Add(descriptor.Documentation, StringComparer.Ordinal);
 
             if (descriptor.BoundAttributeParameters != null)
             {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/BoundAttributeDescriptorTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/BoundAttributeDescriptorTest.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Test
+{
+    public class BoundAttributeDescriptorTest
+    {
+        [Fact]
+        public void BoundAttributeDescriptor_HashChangesWithType()
+        {
+            var expectedPropertyName = "PropertyName";
+
+            var tagHelperBuilder = new DefaultTagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
+            _ = tagHelperBuilder.TypeName("TestTagHelper");
+
+            var intBuilder = new DefaultBoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+            _ = intBuilder
+                .Name("test")
+                .PropertyName(expectedPropertyName)
+                .TypeName(typeof(int).FullName);
+
+            var intDescriptor = intBuilder.Build();
+
+            var stringBuilder = new DefaultBoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+            _ = stringBuilder
+                .Name("test")
+                .PropertyName(expectedPropertyName)
+                .TypeName(typeof(string).FullName);
+            var stringDescriptor = stringBuilder.Build();
+
+            Assert.NotEqual(intDescriptor.GetHashCode(), stringDescriptor.GetHashCode());
+        }
+    }
+}


### PR DESCRIPTION
## Description
BoundAttributeDescriptor wasn't accounting for the Type in it's Hash operation, which caused aspnetcore-tooling to have incorrect caching behavior.

## Customer Impact
This caused customers to see outdated TagHelper info after they changed the type of a parameter.

## Regression?
- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [x] Low

This change is low risk because we're only changing the way the Hash is calculated, which to our knowledge is only relied upon in aspnetcore-tooling.

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/34781
Which was merged into main instead of release/6.0-rc2 by mistake.