### PR TITLE
Remove extra aspnetcore-components-e2e build tasks

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -723,6 +723,7 @@ stages:
         jobDisplayName: 'Tests: Helix x64'
         agentOs: Windows
         timeoutInMinutes: 240
+        # While isTestingJob is technically true, this job needs none of the normal installations nor test results.
         steps:
         # Build the shared framework
         - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -33,7 +33,7 @@ jobs:
     agentOs: Linux
     installNodeJs: true
     installJdk: true
-    isTestingJob: true
+    # While isTestingJob is technically true, this job needs none of the normal installations nor test results.
     steps:
     - script: git submodule update --init
       displayName: Update submodules

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -31,6 +31,7 @@ jobs:
     jobDisplayName: 'Tests: Helix full matrix x64'
     agentOs: Windows
     timeoutInMinutes: 480
+    # While isTestingJob is technically true, this job needs none of the normal installations nor test results.
     steps:
     # Build the shared framework
     - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
@@ -60,6 +61,7 @@ jobs:
       agentOs: Linux
       timeoutInMinutes: 480
       useHostedUbuntu: false
+      # While isTestingJob is technically true, this job needs none of the normal installations nor test results.
       steps:
       - script: ./eng/build.sh --ci --nobl --pack --arch arm64
                 /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -300,12 +300,12 @@ jobs:
           artifactType: Container
           parallel: true
 
-    - ${{ if and(eq(parameters.isTestingJob, true), ne(parameters.jobName, 'Windows_Templates_Test')) }}:
+    - ${{ if eq(parameters.isTestingJob, true) }}:
       - task: PublishTestResults@2
         displayName: Publish js test results
         condition: always()
         inputs:
-          testRunner: junit
+          testResultsFormat: JUnit
           testResultsFiles: '**/artifacts/log/**/*.junit.xml'
           testRunTitle: $(AgentOsName)-$(BuildConfiguration)-js
           mergeTestResults: true

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -55,6 +55,7 @@ jobs:
     jobDisplayName: 'Tests: Helix'
     agentOs: Windows
     timeoutInMinutes: 120
+    # While isTestingJob is technically true, this job needs none of the normal installations nor test results.
     steps:
     # Build the shared framework
     - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64


### PR DESCRIPTION
- remove `isTestingJob` parameters in YAML
  - normal `PublishTestResults@2` tasks all fail
- add comments in components-e2e and Helix jobs about missing `isTestingJob` parameters

nits:
- remove mention of non-existent `Windows_Templates_Test` job
- use `testResultsFormat` input name for consistency (alias of `testRunner`)