### PR TITLE
Release JS Blob after BrowserFileStream is disposed. Fixes #35540

### DIFF
--- a/src/Components/Web/src/Forms/InputFile.cs
+++ b/src/Components/Web/src/Forms/InputFile.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Components.Forms
         private InputFileJsCallbacksRelay? _jsCallbacksRelay;
 
         [Inject]
-        private IJSRuntime JSRuntime { get; set; } = default!;
+        internal IJSRuntime JSRuntime { get; set; } = default!; // Internal for testing
 
         /// <summary>
         /// Gets or sets the event callback that will be invoked when the collection of selected files changes.

--- a/src/Components/Web/test/Forms/BrowserFileTest.cs
+++ b/src/Components/Web/test/Forms/BrowserFileTest.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using Microsoft.JSInterop;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Components.Forms
@@ -28,6 +30,49 @@ namespace Microsoft.AspNetCore.Components.Forms
             // Act & Assert
             var ex = Assert.Throws<IOException>(() => file.OpenReadStream(80));
             Assert.Equal("Supplied file with size 100 bytes exceeds the maximum of 80 bytes.", ex.Message);
+        }
+
+        [Fact]
+        public void OpenReadStream_ReturnsStreamWhoseDisposalReleasesTheJSObject()
+        {
+            // Arrange: JS runtime that always returns a specific mock IJSStreamReference
+            var jsRuntime = new Mock<IJSRuntime>(MockBehavior.Strict);
+            var jsStreamReference = new Mock<IJSStreamReference>();
+            jsRuntime.Setup(x => x.InvokeAsync<IJSStreamReference>(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
+                .Returns(ValueTask.FromResult(jsStreamReference.Object));
+
+            // Arrange: InputFile
+            var inputFile = new InputFile { JSRuntime = jsRuntime.Object };
+            var file = new BrowserFile { Owner = inputFile, Size = 5 };
+            var stream = file.OpenReadStream();
+
+            // Assert 1: IJSStreamReference isn't disposed yet
+            jsStreamReference.Verify(x => x.DisposeAsync(), Times.Never);
+
+            // Act
+            _ = stream.DisposeAsync();
+
+            // Assert: IJSStreamReference is disposed now
+            jsStreamReference.Verify(x => x.DisposeAsync());
+        }
+
+        [Fact]
+        public async Task OpenReadStream_ReturnsStreamWhoseDisposalReleasesTheJSObject_ToleratesDisposalException()
+        {
+            // Arrange: JS runtime that always returns a specific mock IJSStreamReference whose disposal throws
+            var jsRuntime = new Mock<IJSRuntime>(MockBehavior.Strict);
+            var jsStreamReference = new Mock<IJSStreamReference>();
+            jsRuntime.Setup(x => x.InvokeAsync<IJSStreamReference>(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<object[]>()))
+                .Returns(ValueTask.FromResult(jsStreamReference.Object));
+            jsStreamReference.Setup(x => x.DisposeAsync()).Throws(new InvalidTimeZoneException());
+
+            // Arrange: InputFile
+            var inputFile = new InputFile { JSRuntime = jsRuntime.Object };
+            var file = new BrowserFile { Owner = inputFile, Size = 5 };
+            var stream = file.OpenReadStream();
+
+            // Act/Assert. Not throwing is success here.
+            await stream.DisposeAsync();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35540, which was reported by several customers and ultimately could lead to the browser running out of memory if uploading a lot of large files.

The underlying issue here is that:

 * If you're working with `IJSStreamReference` directly through manual interop code, then as well as disposing any `Stream` instances you get by calling `jsStreamReference.OpenReadStreamAsync`, it's also your responsibility to dispose the `IJSStreamReference` itself. That's the point at which the JS-side `Blob` gets released, because until then, you could keep on calling `OpenReadStreamAsync` more times and continue to read the blob data.
 * However, if you're using an `InputFile` and you call `OpenReadStream` on one of the `IBrowserFile` instances it gives you, then you get a `Stream`, but you never get to see the underlying `IJSStreamReference` that we're using internally. In fact, our implementation `BrowserFileStream` doesn't even keep a reference to the `IJSStreamReference` - it just transiently calls the `OpenReadStreamAsync` method and discards the `IJSStreamReference`. As such, even when you manually dispose the `BrowserFileStream` it doesn't dispose the underlying `IJSStreamReference`, and hence the browser never releases the `Blob`.

The fix then is pretty simple. `BrowserFileStream` *should* keep track of the `IJSStreamReference` that it's using for transport, and it should dispose it when itself is disposed.

One further caveat is that with Blazor Server, there's no guarantee the connection to the browser still exists at this point. And we don't want the failure to dispose the `IJSStreamReference` to cause the .NET circuit disposal process itself to fail. So, when we dispose the JS stream reference we just do it on a "best effort, ignore failures" basis. Strictly speaking you could still leak memory if the disposal happens while the circuit is disconnected and then the circuit reconnects later, and this happens over and over. However that's extremely unlikely, and really is a broader underlying issue with `IJSObjectReference` - that if you try to dispose them while the circuit is disconnected, the disposal doesn't happen and nothing will automatically retry it later. If we're speaking super strictly, then we could say we're leaving the application developer to track and replay all JS interop calls that happen while disconnected if they really want to (since the semantics would always be scenario-specific), but it's incredibly rare for anyone to want to do that.

### Testing

It's not really sensible to try to E2E test this, because external systems have no visibility into the internal state of JS object reference caching. So what I have done is:

 * Manually verified using the JS debugger that it does in fact now release the `cachedJSObjectsById` entries when the `BrowserFileStream` is disposed
 * Added a unit test showing the .NET side code does ask for the JS object to be disposed. It's a bit unusual to unit test this, and I don't really like this kind of mocking much, but it's very localized to this one scenario so I don't think it's going to cause any real impact on long-term maintainability. I wouldn't do this if we have many more complex behaviors to test in this area.
