### PR TITLE
Fix uncompressed scenarios with DisableBuffering 

### DIFF
--- a/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
         }
 
-        private void InitializeCompressionHeaders()
+        private ICompressionProvider? InitializeCompressionHeaders()
         {
             if (_provider.ShouldCompressResponse(_context))
             {
@@ -235,7 +235,11 @@ namespace Microsoft.AspNetCore.ResponseCompression
                     headers.ContentMD5 = default; // Reset the MD5 because the content changed.
                     headers.ContentLength = default;
                 }
+
+                return compressionProvider;
             }
+
+            return null;
         }
 
         private void OnWrite()
@@ -244,11 +248,11 @@ namespace Microsoft.AspNetCore.ResponseCompression
             {
                 _compressionChecked = true;
 
-                InitializeCompressionHeaders();
+                var compressionProvider = InitializeCompressionHeaders();
 
-                if (_compressionProvider != null)
+                if (compressionProvider != null)
                 {
-                    _compressionStream = _compressionProvider.CreateStream(_innerStream);
+                    _compressionStream = compressionProvider.CreateStream(_innerStream);
                 }
             }
         }

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
@@ -201,6 +201,10 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
         }
 
+        /// <summary>
+        /// Checks if the response should be compressed and sets the response headers.
+        /// </summary>
+        /// <returns>The compression provider to use if compression is enabled, otherwise null.</returns>
         private ICompressionProvider? InitializeCompressionHeaders()
         {
             if (_provider.ShouldCompressResponse(_context))

--- a/src/Middleware/ResponseCompression/test/ResponseCompressionMiddlewareTest.cs
+++ b/src/Middleware/ResponseCompression/test/ResponseCompressionMiddlewareTest.cs
@@ -960,6 +960,73 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(SupportedEncodings))]
+        public async Task UncompressedTrickleWriteAndFlushAsync_FlushesEachWrite(string encoding)
+        {
+            var responseReceived = new[]
+            {
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+            };
+
+            using var host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddResponseCompression();
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseResponseCompression();
+                        app.Run(async context =>
+                        {
+                            context.Response.Headers.ContentMD5 = "MD5";
+                            context.Response.ContentType = "Un/compressed";
+                            context.Features.Get<IHttpResponseBodyFeature>().DisableBuffering();
+
+                            foreach (var signal in responseReceived)
+                            {
+                                await context.Response.WriteAsync("a");
+                                await context.Response.Body.FlushAsync();
+                                await signal.Task.TimeoutAfter(TimeSpan.FromSeconds(3));
+                            }
+                        });
+                    });
+                }).Build();
+
+            await host.StartAsync();
+
+            var server = host.GetTestServer();
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "");
+            request.Headers.AcceptEncoding.ParseAdd(encoding);
+
+            var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            Assert.True(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out var md5));
+            Assert.Equal("MD5", md5.SingleOrDefault());
+            Assert.Empty(response.Content.Headers.ContentEncoding);
+
+            var body = await response.Content.ReadAsStreamAsync();
+
+            var data = new byte[100];
+            foreach (var signal in responseReceived)
+            {
+                var read = await body.ReadAsync(data, 0, data.Length);
+                Assert.Equal(1, read);
+                Assert.Equal('a', (char)data[0]);
+
+                signal.SetResult(0);
+            }
+        }
+
         [Fact]
         public async Task SendFileAsync_DifferentContentType_NotBypassed()
         {


### PR DESCRIPTION
Contributes to #36960

The compression provider is created so long as the client's request allows compression.  The compression stream should only be created if the response content-type is compressible. 

DisableBuffering for uncompressed responses was regressed by https://github.com/dotnet/aspnetcore/pull/28464/. If you called DisableBuffering then the compression stream would still get created but none of the compression headers would be set so the client wouldn't decompress.

The fix is to only create the compression stream if ShouldCompressResponse is true.

This should be backported to 6.0.