### PR TITLE
Add source-index build job to pipeline

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -278,14 +278,6 @@ stages:
         $(_BuildArgs)
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
-      afterBuild:
-      - task: CopyFiles@2
-        inputs:
-          sourceFolder: '$(Build.SourcesDirectory)'
-          cleanTargetFolder: true
-          contents: '**/obj/**/*.cs'
-          targetFolder: '$(Build.ArtifactStagingDirectory)'
-        displayName: Copy generated sources
       installNodeJs: false
       installJdk: false
       artifacts:
@@ -295,8 +287,6 @@ stages:
         includeForks: true
       - name: Windows_arm_Packages
         path: artifacts/packages/
-      - name: Windows_arm_csharp
-        path: '$(Build.ArtifactStagingDirectory)'
 
   # Build Windows ARM64
   - template: jobs/default-build.yml
@@ -356,6 +346,7 @@ stages:
             packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
             nuGetFeedType: external
             publishFeedCredentials: 'DevDiv - VS package feed'
+
 
   # Build MacOS arm64
   - template: jobs/default-build.yml
@@ -830,15 +821,8 @@ stages:
               artifactName: Windows_arm_Logs
               cleanDestinationFolder: true
               itemPattern: '**/Build.binlog'
-          - task: DownloadBuildArtifacts@0
-            inputs:
-              artifactName: Windows_arm_csharp
-          - task: CopyFiles@2
-            inputs:
-              sourceFolder: '$(System.ArtifactsDirectory)/Windows_arm_csharp/'
-              targetFolder: '$(Build.SourcesDirectory)'
-        # Should not need further actions with binary log and C# files in place.
-        sourceIndexBuildCommand: dir /b $(Build.SourcesDirectory)
+        # Should not need further actions with binary log in place.
+        sourceIndexBuildCommand: dir /b /s $(System.ArtifactsDirectory)
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -278,6 +278,14 @@ stages:
         $(_BuildArgs)
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
+      afterBuild:
+      - task: CopyFiles@2
+        inputs:
+          sourceFolder: '$(Build.SourcesDirectory)'
+          cleanTargetFolder: true
+          contents: '**/obj/**/*.cs'
+          targetFolder: '$(Build.ArtifactStagingDirectory)'
+        displayName: Copy generated sources
       installNodeJs: false
       installJdk: false
       artifacts:
@@ -287,6 +295,8 @@ stages:
         includeForks: true
       - name: Windows_arm_Packages
         path: artifacts/packages/
+      - name: Windows_arm_csharp
+        path: '$(Build.ArtifactStagingDirectory)'
 
   # Build Windows ARM64
   - template: jobs/default-build.yml
@@ -346,7 +356,6 @@ stages:
             packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
             nuGetFeedType: external
             publishFeedCredentials: 'DevDiv - VS package feed'
-
 
   # Build MacOS arm64
   - template: jobs/default-build.yml
@@ -821,8 +830,15 @@ stages:
               artifactName: Windows_arm_Logs
               cleanDestinationFolder: true
               itemPattern: '**/Build.binlog'
-        # Should not need further actions with binary log in place.
-        sourceIndexBuildCommand: dir /b /s $(System.ArtifactsDirectory)
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              artifactName: Windows_arm_csharp
+          - task: CopyFiles@2
+            inputs:
+              sourceFolder: '$(System.ArtifactsDirectory)/Windows_arm_csharp/'
+              targetFolder: '$(Build.SourcesDirectory)'
+        # Should not need further actions with binary log and C# files in place.
+        sourceIndexBuildCommand: dir /b $(Build.SourcesDirectory)
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -72,6 +72,12 @@ variables:
     value: -ExcludeCIBinaryLog
   - name: WindowsArm64InstallersLogArgs
     value: -ExcludeCIBinaryLog
+  # Variables for source indexing afterBuild step and job.
+  - name: sourceIndexPackageVersion
+    value: 1.0.1-20210614.1
+  - name: sourceIndexPackageSource
+    value: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+  - group: source-dot-net stage1 variables
 - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
     value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
@@ -278,6 +284,19 @@ stages:
         $(_BuildArgs)
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        afterBuild:
+        - powershell: . $(Build.SourcesDirectory)/activate.ps1;
+            dotnet tool install BinLogToSln
+            --version $(SourceIndexPackageVersion)
+            --add-source $(SourceIndexPackageSource)
+            --tool-path $(Build.SourcesDirectory)/.tools;
+            $(Build.SourcesDirectory)/.tools/BinLogToSln
+            -i $(Build.SourcesDirectory)/artifacts/log/Release/Build.binlog
+            -r $(Build.SourcesDirectory)
+            -n $(Build.Repository.Name)
+            -o $(Build.ArtifactStagingDirectory)/sourceIndex/
+          displayName: Process binary log into indexable sln
       installNodeJs: false
       installJdk: false
       artifacts:
@@ -287,6 +306,9 @@ stages:
         includeForks: true
       - name: Windows_arm_Packages
         path: artifacts/packages/
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - name: Windows_arm_SourceIndex
+          path: $(Build.ArtifactStagingDirectory)/sourceIndex/
 
   # Build Windows ARM64
   - template: jobs/default-build.yml
@@ -777,52 +799,67 @@ stages:
           vmImage: vs2017-win2016
         publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
         enablePublishBuildArtifacts: true # publish artifacts/log files
-    - template: /eng/common/templates/job/source-index-stage1.yml
-      parameters:
-        binlogPath: $(System.ArtifactsDirectory)/Windows_arm_Logs/Release/Build.binlog
-        dependsOn:
-          - Windows_arm_build
-          # In addition to the dependency above that provides assets, ensure the build was successful overall.
-          - Windows_build
-          - Windows_arm64_build
-          - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-            - CodeSign_Xplat_MacOS_arm64
-            - CodeSign_Xplat_MacOS_x64
-            - CodeSign_Xplat_Linux_x64
-            - CodeSign_Xplat_Linux_arm
-            - CodeSign_Xplat_Linux_arm64
-            - CodeSign_Xplat_Linux_musl_x64
-            - CodeSign_Xplat_Linux_musl_arm
-            - CodeSign_Xplat_Linux_musl_arm64
-          - ${{ if eq(variables['PostBuildSign'], 'true') }}:
-            - MacOs_arm64_build
-            - MacOs_x64_build
-            - Linux_x64_build
-            - Linux_arm_build
-            - Linux_arm64_build
-            - Linux_musl_x64_build
-            - Linux_musl_arm_build
-            - Linux_musl_arm64_build
-          - ${{ if in(variables['Build.Reason'], 'Manual') }}:
-            - Code_check
-            - ${{ if ne(parameters.skipTests, 'true') }}:
-              - Windows_Test
-              - MacOS_Test
-              - Linux_Test
-              - Helix_x64
-          - Source_Build_Managed
-        pool:
-          name: NetCore1ESPool-Internal
-          # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019
-        preSteps:
+    - job: SourceIndexUpload
+      displayName: Upload indexable solution
+      dependsOn:
+        - Windows_arm_build
+        # In addition to the dependency above that provides assets, ensure the build was successful overall.
+        - Windows_build
+        - Windows_arm64_build
+        - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+          - CodeSign_Xplat_MacOS_arm64
+          - CodeSign_Xplat_MacOS_x64
+          - CodeSign_Xplat_Linux_x64
+          - CodeSign_Xplat_Linux_arm
+          - CodeSign_Xplat_Linux_arm64
+          - CodeSign_Xplat_Linux_musl_x64
+          - CodeSign_Xplat_Linux_musl_arm
+          - CodeSign_Xplat_Linux_musl_arm64
+        - ${{ if eq(variables['PostBuildSign'], 'true') }}:
+          - MacOs_arm64_build
+          - MacOs_x64_build
+          - Linux_x64_build
+          - Linux_arm_build
+          - Linux_arm64_build
+          - Linux_musl_x64_build
+          - Linux_musl_arm_build
+          - Linux_musl_arm64_build
+        - ${{ if in(variables['Build.Reason'], 'Manual') }}:
+          - Code_check
+          - ${{ if ne(parameters.skipTests, 'true') }}:
+            - Windows_Test
+            - MacOS_Test
+            - Linux_Test
+            - Helix_x64
+        - Source_Build_Managed
+      pool:
+        name: NetCore1ESPool-Internal
+        # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        steps:
           - task: DownloadBuildArtifacts@0
             inputs:
-              artifactName: Windows_arm_Logs
+              artifactName: Windows_arm_SourceIndex
               cleanDestinationFolder: true
-              itemPattern: '**/Build.binlog'
-        # Should not need further actions with binary log in place.
-        sourceIndexBuildCommand: dir /b /s $(System.ArtifactsDirectory)
+          # Ignore repository's global.json and any existing .NET SDK.
+          - task: UseDotNet@2
+            displayName: Use .NET Core sdk 3.1
+            inputs:
+              packageType: sdk
+              version: 3.1.x
+              installationPath: $(Agent.TempDirectory)/.dotnet
+              workingDirectory: $(Agent.TempDirectory)
+          - script: $(Agent.TempDirectory)/.dotnet/dotnet tool install UploadIndexStage1
+              --version $(SourceIndexPackageVersion)
+              --add-source $(SourceIndexPackageSource)
+              --tool-path $(Agent.TempDirectory)/.tools;
+              $(Agent.TempDirectory)/.tools/UploadIndexStage1
+              -i $(System.ArtifactsDirectory)/Windows_arm_SourceIndex/
+              -n $(Build.Repository.Name)
+            displayName: Upload indexable solution
+            workingDirectory: $(Agent.TempDirectory)
+            env:
+              BLOB_CONTAINER_URL: $(source-dot-net-stage1-blob-container-url)
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -283,9 +283,16 @@ stages:
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)'
           cleanTargetFolder: true
-          contents: '**/obj/**/*.cs'
+          # Make generated C# files and incoming ref/ assemblies available.
+          # Special-case a project that ignores its build output.
+          contents: |
+            **/obj/**/*.cs
+            .packages/microsoft.internal.runtime.aspnetcore.transport/**
+            !.packages/microsoft.internal.runtime.aspnetcore.transport/**/lib/**
+            .packages/microsoft.netcore.app.ref/**
+            artifacts/obj/Microsoft.AspNetCore.App.Ref.Internal/**/Microsoft.AspNetCore.App.Ref.Internal.dll
           targetFolder: '$(Build.ArtifactStagingDirectory)'
-        displayName: Copy generated sources
+        displayName: Copy for source indexing
       installNodeJs: false
       installJdk: false
       artifacts:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -283,16 +283,9 @@ stages:
         inputs:
           sourceFolder: '$(Build.SourcesDirectory)'
           cleanTargetFolder: true
-          # Make generated C# files and incoming ref/ assemblies available.
-          # Special-case a project that ignores its build output.
-          contents: |
-            **/obj/**/*.cs
-            .packages/microsoft.internal.runtime.aspnetcore.transport/**
-            !.packages/microsoft.internal.runtime.aspnetcore.transport/**/lib/**
-            .packages/microsoft.netcore.app.ref/**
-            artifacts/obj/Microsoft.AspNetCore.App.Ref.Internal/**/Microsoft.AspNetCore.App.Ref.Internal.dll
+          contents: '**/obj/**/*.cs'
           targetFolder: '$(Build.ArtifactStagingDirectory)'
-        displayName: Copy for source indexing
+        displayName: Copy generated sources
       installNodeJs: false
       installJdk: false
       artifacts:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -18,11 +18,17 @@ pr:
     include:
     - '*'
 
-# Choose whether to skip tests when running pipeline manually.
 parameters:
+# Choose whether to skip tests when running pipeline manually.
 - name: skipTests
   default: false
   displayName: Skip tests?
+  type: boolean
+# Choose whether to test source indexing. Ignored in public builds.
+# Will cause inaccessible links on https://source.dot.net/ unless commits are also available in GitHub.
+- name: testSourceIndexing
+  default: false
+  displayName: Test source indexing? !Danger! see comments in YAML.
   type: boolean
 
 variables:
@@ -156,10 +162,10 @@ stages:
       agentOs: Windows
       steps:
       - script: "echo ##vso[build.addbuildtag]daily-build"
-        condition: and(notin(variables['Build.Reason'], 'PullRequest'), notin(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
+        condition: and(notin(variables['Build.Reason'], 'PullRequest'), notin(variables.DotNetFinalVersionKind, 'release', 'prerelease'))
         displayName: 'Set CI tags'
       - script: "echo ##vso[build.addbuildtag]release-candidate"
-        condition: and(notin(variables['Build.Reason'], 'PullRequest'), in(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
+        condition: and(notin(variables['Build.Reason'], 'PullRequest'), in(variables.DotNetFinalVersionKind, 'release', 'prerelease'))
         displayName: 'Set CI tags'
 
       # !!! NOTE !!! Some of these steps have disabled code signing.
@@ -247,7 +253,7 @@ stages:
         displayName: Publish
 
       # A few files must also go to the VS package feed.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables.PostBuildSign, 'true')) }}:
         - task: NuGetCommand@2
           displayName: Push Visual Studio packages
           inputs:
@@ -284,7 +290,7 @@ stages:
         $(_BuildArgs)
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
         afterBuild:
         - powershell: . $(Build.SourcesDirectory)/activate.ps1;
             dotnet tool install BinLogToSln
@@ -306,9 +312,9 @@ stages:
         includeForks: true
       - name: Windows_arm_Packages
         path: artifacts/packages/
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: Windows_arm_SourceIndex
-          path: $(Build.ArtifactStagingDirectory)/sourceIndex/
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+          - name: Windows_arm_SourceIndex
+            path: $(Build.ArtifactStagingDirectory)/sourceIndex/
 
   # Build Windows ARM64
   - template: jobs/default-build.yml
@@ -360,7 +366,7 @@ stages:
         displayName: Build Arm64 Installers
 
       # A few files must also go to the VS package feed.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables.PostBuildSign, 'true')) }}:
         - task: NuGetCommand@2
           displayName: Push Visual Studio packages
           inputs:
@@ -397,7 +403,7 @@ stages:
       - name: MacOS_arm64_Packages
         path: artifacts/packages/
 
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+  - ${{ if ne(variables.PostBuildSign, 'true') }}:
     - template: jobs/codesign-xplat.yml
       parameters:
         inputName: MacOS_arm64
@@ -428,7 +434,7 @@ stages:
       - name: MacOS_x64_Packages
         path: artifacts/packages/
 
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+  - ${{ if ne(variables.PostBuildSign, 'true') }}:
     - template: jobs/codesign-xplat.yml
       parameters:
         inputName: MacOS_x64
@@ -477,7 +483,7 @@ stages:
       - name: Linux_x64_Packages
         path: artifacts/packages/
 
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+  - ${{ if ne(variables.PostBuildSign, 'true') }}:
     - template: jobs/codesign-xplat.yml
       parameters:
         inputName: Linux_x64
@@ -509,7 +515,7 @@ stages:
       - name: Linux_arm_Packages
         path: artifacts/packages/
 
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+  - ${{ if ne(variables.PostBuildSign, 'true') }}:
     - template: jobs/codesign-xplat.yml
       parameters:
         inputName: Linux_arm
@@ -541,7 +547,7 @@ stages:
       - name: Linux_arm64_Packages
         path: artifacts/packages/
 
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+  - ${{ if ne(variables.PostBuildSign, 'true') }}:
     - template: jobs/codesign-xplat.yml
       parameters:
         inputName: Linux_arm64
@@ -576,7 +582,7 @@ stages:
       - name: Linux_musl_x64_Packages
         path: artifacts/packages/
 
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+  - ${{ if ne(variables.PostBuildSign, 'true') }}:
     - template: jobs/codesign-xplat.yml
       parameters:
         inputName: Linux_musl_x64
@@ -611,7 +617,7 @@ stages:
       - name: Linux_musl_arm_Packages
         path: artifacts/packages/
 
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+  - ${{ if ne(variables.PostBuildSign, 'true') }}:
     - template: jobs/codesign-xplat.yml
       parameters:
         inputName: Linux_musl_arm
@@ -646,7 +652,7 @@ stages:
       - name: Linux_musl_arm64_Packages
         path: artifacts/packages/
 
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+  - ${{ if ne(variables.PostBuildSign, 'true') }}:
     - template: jobs/codesign-xplat.yml
       parameters:
         inputName: Linux_musl_arm64
@@ -768,7 +774,7 @@ stages:
           - Windows_build
           - Windows_arm_build
           - Windows_arm64_build
-          - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+          - ${{ if ne(variables.PostBuildSign, 'true') }}:
             - CodeSign_Xplat_MacOS_arm64
             - CodeSign_Xplat_MacOS_x64
             - CodeSign_Xplat_Linux_x64
@@ -777,7 +783,7 @@ stages:
             - CodeSign_Xplat_Linux_musl_x64
             - CodeSign_Xplat_Linux_musl_arm
             - CodeSign_Xplat_Linux_musl_arm64
-          - ${{ if eq(variables['PostBuildSign'], 'true') }}:
+          - ${{ if eq(variables.PostBuildSign, 'true') }}:
             - MacOs_arm64_build
             - MacOs_x64_build
             - Linux_x64_build
@@ -799,43 +805,44 @@ stages:
           vmImage: vs2017-win2016
         publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
         enablePublishBuildArtifacts: true # publish artifacts/log files
-    - job: SourceIndexUpload
-      displayName: Upload indexable solution
-      dependsOn:
-        - Windows_arm_build
-        # In addition to the dependency above that provides assets, ensure the build was successful overall.
-        - Windows_build
-        - Windows_arm64_build
-        - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-          - CodeSign_Xplat_MacOS_arm64
-          - CodeSign_Xplat_MacOS_x64
-          - CodeSign_Xplat_Linux_x64
-          - CodeSign_Xplat_Linux_arm
-          - CodeSign_Xplat_Linux_arm64
-          - CodeSign_Xplat_Linux_musl_x64
-          - CodeSign_Xplat_Linux_musl_arm
-          - CodeSign_Xplat_Linux_musl_arm64
-        - ${{ if eq(variables['PostBuildSign'], 'true') }}:
-          - MacOs_arm64_build
-          - MacOs_x64_build
-          - Linux_x64_build
-          - Linux_arm_build
-          - Linux_arm64_build
-          - Linux_musl_x64_build
-          - Linux_musl_arm_build
-          - Linux_musl_arm64_build
-        - ${{ if in(variables['Build.Reason'], 'Manual') }}:
-          - Code_check
-          - ${{ if ne(parameters.skipTests, 'true') }}:
-            - Windows_Test
-            - MacOS_Test
-            - Linux_Test
-            - Helix_x64
-        - Source_Build_Managed
-      pool:
-        name: NetCore1ESPool-Internal
-        # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+      - job: SourceIndexUpload
+        displayName: Upload indexable solution
+        dependsOn:
+          - Windows_arm_build
+          # In addition to the dependency above that provides assets, ensure the build was successful overall.
+          - Windows_build
+          - Windows_arm64_build
+          - ${{ if ne(variables.PostBuildSign, 'true') }}:
+            - CodeSign_Xplat_MacOS_arm64
+            - CodeSign_Xplat_MacOS_x64
+            - CodeSign_Xplat_Linux_x64
+            - CodeSign_Xplat_Linux_arm
+            - CodeSign_Xplat_Linux_arm64
+            - CodeSign_Xplat_Linux_musl_x64
+            - CodeSign_Xplat_Linux_musl_arm
+            - CodeSign_Xplat_Linux_musl_arm64
+          - ${{ if eq(variables.PostBuildSign, 'true') }}:
+            - MacOs_arm64_build
+            - MacOs_x64_build
+            - Linux_x64_build
+            - Linux_arm_build
+            - Linux_arm64_build
+            - Linux_musl_x64_build
+            - Linux_musl_arm_build
+            - Linux_musl_arm64_build
+          - ${{ if in(variables['Build.Reason'], 'Manual') }}:
+            - Code_check
+            - ${{ if ne(parameters.skipTests, 'true') }}:
+              - Windows_Test
+              - MacOS_Test
+              - Linux_Test
+              - Helix_x64
+          - Source_Build_Managed
+        pool:
+          name: NetCore1ESPool-Internal
+          # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
         steps:
           - task: DownloadBuildArtifacts@0
             inputs:
@@ -852,7 +859,7 @@ stages:
           - script: $(Agent.TempDirectory)/.dotnet/dotnet tool install UploadIndexStage1
               --version $(SourceIndexPackageVersion)
               --add-source $(SourceIndexPackageSource)
-              --tool-path $(Agent.TempDirectory)/.tools;
+              --tool-path $(Agent.TempDirectory)/.tools &&
               $(Agent.TempDirectory)/.tools/UploadIndexStage1
               -i $(System.ArtifactsDirectory)/Windows_arm_SourceIndex/
               -n $(Build.Repository.Name)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -126,7 +126,7 @@ stages:
   displayName: Build
   jobs:
   # Code check
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
+  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual')) }}:
     - template: jobs/default-build.yml
       parameters:
         jobName: Code_check
@@ -271,6 +271,7 @@ stages:
         -pack
         -noBuildNodeJS
         -noBuildJava
+        -binaryLog
         /p:DotNetSignType=$(_SignType)
         /p:OnlyPackPlatformSpecificPackages=true
         /p:AssetManifestFileName=aspnetcore-win-arm.xml
@@ -430,37 +431,19 @@ stages:
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
         displayName: Run build.sh
-      - script: |
-          git clean -xfd src/**/obj/
-          ./dockerbuild.sh bionic \
-            --ci \
-            --nobl \
-            --arch x64 \
-            --build-installers \
-            --no-build-deps \
-            --no-build-nodejs \
-            -p:OnlyPackPlatformSpecificPackages=true \
-            -p:BuildRuntimeArchive=false \
-            -p:LinuxInstallerType=deb \
-            $(_BuildArgs) \
-            $(_InternalRuntimeDownloadArgs)
+      - script: git clean -xfd src/**/obj/;
+          ./dockerbuild.sh bionic --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs
+          -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=deb
+          $(_BuildArgs)
+          $(_InternalRuntimeDownloadArgs)
         displayName: Build Debian installers
-      - script: |
-          git clean -xfd src/**/obj/
-          ./dockerbuild.sh rhel \
-            --ci \
-            --nobl \
-            --arch x64 \
-            --build-installers \
-            --no-build-deps \
-            --no-build-nodejs \
-            -p:OnlyPackPlatformSpecificPackages=true \
-            -p:BuildRuntimeArchive=false \
-            -p:LinuxInstallerType=rpm \
-            -p:AssetManifestFileName=aspnetcore-Linux_x64.xml \
-            $(_BuildArgs) \
-            $(_PublishArgs) \
-            $(_InternalRuntimeDownloadArgs)
+      - script: git clean -xfd src/**/obj/;
+          ./dockerbuild.sh rhel --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs
+          -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
+          -p:AssetManifestFileName=aspnetcore-Linux_x64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
         displayName: Build RPM installers
       installNodeJs: false
       installJdk: false
@@ -646,7 +629,7 @@ stages:
       parameters:
         inputName: Linux_musl_arm64
 
-  - ${{ if and(ne(parameters.skipTests, 'true'), or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual'))) }}:
+  - ${{ if and(ne(parameters.skipTests, 'true'), or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual'))) }}:
     # Test jobs
     - template: jobs/default-build.yml
       parameters:
@@ -755,7 +738,7 @@ stages:
         buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
         skipPublishValidation: true
 
-  # Publish to the BAR
+  # Publish to the BAR and perform source indexing. Wait until everything else is done.
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/job/publish-build-assets.yml
       parameters:
@@ -781,12 +764,65 @@ stages:
             - Linux_musl_x64_build
             - Linux_musl_arm_build
             - Linux_musl_arm64_build
-          # In addition to the dependencies above, ensure the build was successful overall.
+          # In addition to the dependencies above that provide assets, ensure the build was successful overall.
+          - ${{ if in(variables['Build.Reason'], 'Manual') }}:
+            - Code_check
+            - ${{ if ne(parameters.skipTests, 'true') }}:
+              - Windows_Test
+              - MacOS_Test
+              - Linux_Test
+              - Helix_x64
           - Source_Build_Managed
         pool:
           vmImage: vs2017-win2016
         publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
         enablePublishBuildArtifacts: true # publish artifacts/log files
+    - template: /eng/common/templates/job/source-index-stage1.yml
+      parameters:
+        binlogPath: $(System.ArtifactsDirectory)/Windows_arm_Logs/Release/Build.binlog
+        dependsOn:
+          - Windows_arm_build
+          # In addition to the dependency above that provides assets, ensure the build was successful overall.
+          - Windows_build
+          - Windows_arm64_build
+          - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+            - CodeSign_Xplat_MacOS_arm64
+            - CodeSign_Xplat_MacOS_x64
+            - CodeSign_Xplat_Linux_x64
+            - CodeSign_Xplat_Linux_arm
+            - CodeSign_Xplat_Linux_arm64
+            - CodeSign_Xplat_Linux_musl_x64
+            - CodeSign_Xplat_Linux_musl_arm
+            - CodeSign_Xplat_Linux_musl_arm64
+          - ${{ if eq(variables['PostBuildSign'], 'true') }}:
+            - MacOs_arm64_build
+            - MacOs_x64_build
+            - Linux_x64_build
+            - Linux_arm_build
+            - Linux_arm64_build
+            - Linux_musl_x64_build
+            - Linux_musl_arm_build
+            - Linux_musl_arm64_build
+          - ${{ if in(variables['Build.Reason'], 'Manual') }}:
+            - Code_check
+            - ${{ if ne(parameters.skipTests, 'true') }}:
+              - Windows_Test
+              - MacOS_Test
+              - Linux_Test
+              - Helix_x64
+          - Source_Build_Managed
+        pool:
+          name: NetCore1ESPool-Internal
+          # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        preSteps:
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              artifactName: Windows_arm_Logs
+              cleanDestinationFolder: true
+              itemPattern: '**/Build.binlog'
+        # Should not need further actions with binary log in place.
+        sourceIndexBuildCommand: dir /b /s $(System.ArtifactsDirectory)
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -280,7 +280,11 @@ jobs:
         condition: and(or(succeeded(), eq('${{ artifact.publishOnError }}', 'true')), or(eq(variables['system.pullrequest.isfork'], false), eq('${{ artifact.includeForks }}', 'true')))
         continueOnError: true
         inputs:
-          pathtoPublish: $(Build.SourcesDirectory)/${{ artifact.path }}
+          # Assume runtime variable values are absolute paths already.
+          ${{ if startsWith(artifact.path, '$(') }}:
+            pathToPublish: ${{ artifact.path }}
+          ${{ if not(startsWith(artifact.path, '$(')) }}:
+            pathToPublish: $(Build.SourcesDirectory)/${{ artifact.path }}
           ${{ if eq(artifact.name, '') }}:
             artifactName: artifacts-$(AgentOsName)-$(BuildConfiguration)
           ${{ if ne(artifact.name, '') }}:

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -280,11 +280,7 @@ jobs:
         condition: and(or(succeeded(), eq('${{ artifact.publishOnError }}', 'true')), or(eq(variables['system.pullrequest.isfork'], false), eq('${{ artifact.includeForks }}', 'true')))
         continueOnError: true
         inputs:
-          # Assume runtime variable values are absolute paths already.
-          ${{ if startsWith(artifact.path, '$(') }}:
-            pathToPublish: ${{ artifact.path }}
-          ${{ if not(startsWith(artifact.path, '$(')) }}:
-            pathToPublish: $(Build.SourcesDirectory)/${{ artifact.path }}
+          pathtoPublish: $(Build.SourcesDirectory)/${{ artifact.path }}
           ${{ if eq(artifact.name, '') }}:
             artifactName: artifacts-$(AgentOsName)-$(BuildConfiguration)
           ${{ if ne(artifact.name, '') }}:


### PR DESCRIPTION
- #33534
- use 1ES agents because default VS is incompatible with our .NET SDK version
  - `windows-latest` might work but prefer to protect binary log
- wait to source-index for other jobs
- use binary log from Linux_x64 build
  - we're waiting for that build anyhow
- only source index the 'main' branch
  - anything else would be redundant 

nits:
- remove unnecessary backslashes in the Linux_x64_build job's `script`s
   - instead separate commands with a semicolon
 - confirm test build success before BAR updates in manual builds