### PR TITLE
Revert consolidating DefaultViewCompilerProvider + DefaultViewCompiler

### DIFF
--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var compilerProvider = services.FirstOrDefault(f =>
                 f.ServiceType == typeof(IViewCompilerProvider) &&
                 f.ImplementationType?.Assembly == typeof(IViewCompilerProvider).Assembly &&
-                f.ImplementationType.FullName == "Microsoft.AspNetCore.Mvc.Razor.Compilation.DefaultViewCompiler");
+                f.ImplementationType.FullName == "Microsoft.AspNetCore.Mvc.Razor.Compilation.DefaultViewCompilerProvider");
 
             if (compilerProvider != null)
             {

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/test/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensionsTest.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/test/DependencyInjection/RazorRuntimeCompilationMvcCoreBuilderExtensionsTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             // Arrange
             var services = new ServiceCollection()
-                .AddSingleton<IViewCompilerProvider, DefaultViewCompiler>();
+                .AddSingleton<IViewCompilerProvider, DefaultViewCompilerProvider>();
 
             // Act
             RazorRuntimeCompilationMvcCoreBuilderExtensions.AddServices(services);

--- a/src/Mvc/Mvc.Razor/src/Compilation/DefaultViewCompiler.cs
+++ b/src/Mvc/Mvc.Razor/src/Compilation/DefaultViewCompiler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
     /// Caches the result of runtime compilation of Razor files for the duration of the application lifetime.
     /// </summary>
     // This name is hardcoded in RazorRuntimeCompilationMvcCoreBuilderExtensions. Make sure it's updated if this is ever renamed.
-    internal class DefaultViewCompiler : IViewCompilerProvider, IViewCompiler
+    internal class DefaultViewCompiler : IViewCompiler
     {
         private readonly ApplicationPartManager _applicationPartManager;
         private readonly ConcurrentDictionary<string, string> _normalizedPathCache;
@@ -31,8 +31,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
 
             EnsureCompiledViews(logger);
         }
-
-        IViewCompiler IViewCompilerProvider.GetCompiler() => this;
 
         [MemberNotNull(nameof(_compiledViews))]
         private void EnsureCompiledViews(ILogger logger)

--- a/src/Mvc/Mvc.Razor/src/Compilation/DefaultViewCompilerProvider.cs
+++ b/src/Mvc/Mvc.Razor/src/Compilation/DefaultViewCompilerProvider.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
+{
+    // This type is referenced by name by the RuntimeCompilation package. Do not rename it
+    internal sealed class DefaultViewCompilerProvider : IViewCompilerProvider
+    {
+        private readonly DefaultViewCompiler _compiler;
+
+        public DefaultViewCompilerProvider(
+            ApplicationPartManager applicationPartManager,
+            ILoggerFactory loggerFactory)
+        {
+            _compiler = new DefaultViewCompiler(applicationPartManager, loggerFactory.CreateLogger<DefaultViewCompiler>());
+        }
+
+        public IViewCompiler GetCompiler() => _compiler;
+    }
+}

--- a/src/Mvc/Mvc.Razor/src/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Razor/src/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 ServiceDescriptor.Transient<IConfigureOptions<RazorViewEngineOptions>, RazorViewEngineOptionsSetup>());
 
             services.TryAddSingleton<IRazorViewEngine, RazorViewEngine>();
-            services.TryAddSingleton<IViewCompilerProvider, DefaultViewCompiler>();
+            services.TryAddSingleton<IViewCompilerProvider, DefaultViewCompilerProvider>();
 
             // In the default scenario the following services are singleton by virtue of being initialized as part of
             // creating the singleton RazorViewEngine instance.


### PR DESCRIPTION
As part of https://github.com/dotnet/aspnetcore/pull/35017, I had consolidated the DefaultViewCompiler and DefaultViewCompilerProvider types, largely as a clean up. The type DefaultViewCompilerProvider is looked up by the RuntimeCompilation package by name, and when making this change, this code was also updated.

However, we've had two reports so far of users trying to use an 5.0 or earlier version of the runtime compilation package with a 6.0 app. In this case, the lookup fails and the runtime compilation feature doesn't work as expected. This is a small change to preserve backwards compatibility.

Fixes https://github.com/dotnet/aspnetcore/issues/35267
