### PR TITLE
Load IConfigurationProviders once in WebApplicationBuilder

### DIFF
--- a/src/DefaultBuilder/src/ConfigurationProviderSource.cs
+++ b/src/DefaultBuilder/src/ConfigurationProviderSource.cs
@@ -66,9 +66,9 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             // Provide access to the original IConfigurationProvider via a single-element IEnumerable to code that goes out of its way to look for it.
-            public IEnumerator<IConfigurationProvider> GetEnumerator() => new List<IConfigurationProvider> { _provider }.GetEnumerator();
+            public IEnumerator<IConfigurationProvider> GetEnumerator() => GetUnwrappedEnumerable().GetEnumerator();
 
-            IEnumerator IEnumerable.GetEnumerator() => new List<IConfigurationProvider> { _provider }.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetUnwrappedEnumerable().GetEnumerator();
 
             public override bool Equals(object? obj)
             {
@@ -88,6 +88,11 @@ namespace Microsoft.AspNetCore.Builder
             public void Dispose()
             {
                 (_provider as IDisposable)?.Dispose();
+            }
+
+            private IEnumerable<IConfigurationProvider> GetUnwrappedEnumerable()
+            {
+                yield return _provider;
             }
         }
     }

--- a/src/DefaultBuilder/src/ConfigurationProviderSource.cs
+++ b/src/DefaultBuilder/src/ConfigurationProviderSource.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    internal sealed class ConfigurationProviderSource : IConfigurationSource
+    {
+        private readonly IConfigurationProvider _configurationProvider;
+
+        public ConfigurationProviderSource(IConfigurationProvider configurationProvider)
+        {
+            _configurationProvider = configurationProvider;
+        }
+
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return new IgnoreFirstLoadConfigurationProvider(_configurationProvider);
+        }
+
+        // These providers have already been loaded, so no need to reload initially.
+        // Otherwise, providers that cannot be reloaded like StreamConfigurationProviders will fail.
+        private sealed class IgnoreFirstLoadConfigurationProvider : IConfigurationProvider
+        {
+            private readonly IConfigurationProvider _provider;
+
+            private bool _hasIgnoredFirstLoad;
+
+            public IgnoreFirstLoadConfigurationProvider(IConfigurationProvider provider)
+            {
+                _provider = provider;
+            }
+
+            public IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string parentPath)
+            {
+                return _provider.GetChildKeys(earlierKeys, parentPath);
+            }
+
+            public IChangeToken GetReloadToken()
+            {
+                return _provider.GetReloadToken();
+            }
+
+            public void Load()
+            {
+                if (!_hasIgnoredFirstLoad)
+                {
+                    _hasIgnoredFirstLoad = true;
+                    return;
+                }
+
+                _provider.Load();
+            }
+
+            public void Set(string key, string value)
+            {
+                _provider.Set(key, value);
+            }
+
+            public bool TryGet(string key, out string value)
+            {
+                return _provider.TryGet(key, out value);
+            }
+
+            public override bool Equals(object? obj)
+            {
+                return _provider.Equals(obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return _provider.GetHashCode();
+            }
+
+            public override string? ToString()
+            {
+                return _provider.ToString();
+            }
+        }
+    }
+}

--- a/src/DefaultBuilder/src/ConfigurationProviderSource.cs
+++ b/src/DefaultBuilder/src/ConfigurationProviderSource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 
@@ -22,7 +23,7 @@ namespace Microsoft.AspNetCore.Builder
 
         // These providers have already been loaded, so no need to reload initially.
         // Otherwise, providers that cannot be reloaded like StreamConfigurationProviders will fail.
-        private sealed class IgnoreFirstLoadConfigurationProvider : IConfigurationProvider, IDisposable
+        private sealed class IgnoreFirstLoadConfigurationProvider : IConfigurationProvider, IEnumerable<IConfigurationProvider>, IDisposable
         {
             private readonly IConfigurationProvider _provider;
 
@@ -63,6 +64,11 @@ namespace Microsoft.AspNetCore.Builder
             {
                 return _provider.TryGet(key, out value);
             }
+
+            // Provide access to the original IConfigurationProvider via a single-element IEnumerable to code that goes out of its way to look for it.
+            public IEnumerator<IConfigurationProvider> GetEnumerator() => new List<IConfigurationProvider> { _provider }.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => new List<IConfigurationProvider> { _provider }.GetEnumerator();
 
             public override bool Equals(object? obj)
             {

--- a/src/DefaultBuilder/src/ConfigurationProviderSource.cs
+++ b/src/DefaultBuilder/src/ConfigurationProviderSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Builder
 
         // These providers have already been loaded, so no need to reload initially.
         // Otherwise, providers that cannot be reloaded like StreamConfigurationProviders will fail.
-        private sealed class IgnoreFirstLoadConfigurationProvider : IConfigurationProvider
+        private sealed class IgnoreFirstLoadConfigurationProvider : IConfigurationProvider, IDisposable
         {
             private readonly IConfigurationProvider _provider;
 
@@ -77,6 +77,11 @@ namespace Microsoft.AspNetCore.Builder
             public override string? ToString()
             {
                 return _provider.ToString();
+            }
+
+            public void Dispose()
+            {
+                (_provider as IDisposable)?.Dispose();
             }
         }
     }

--- a/src/DefaultBuilder/src/TrackingChainedConfigurationSource.cs
+++ b/src/DefaultBuilder/src/TrackingChainedConfigurationSource.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    internal sealed class TrackingChainedConfigurationSource : IConfigurationSource
+    {
+        private readonly ChainedConfigurationSource _chainedConfigurationSource = new();
+
+        public TrackingChainedConfigurationSource(ConfigurationManager configManager)
+        {
+            _chainedConfigurationSource.Configuration = configManager;
+        }
+
+        public IConfigurationProvider? BuiltProvider { get; set; }
+
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            BuiltProvider = _chainedConfigurationSource.Build(builder);
+            return BuiltProvider;
+        }
+    }
+}

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -20,10 +19,10 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteBuilder, IAsyncDisposable
     {
+        internal const string GlobalEndpointRouteBuilderKey = "__GlobalEndpointRouteBuilder";
+
         private readonly IHost _host;
         private readonly List<EndpointDataSource> _dataSources = new();
-
-        internal static string GlobalEndpointRouteBuilderKey = "__GlobalEndpointRouteBuilder";
 
         internal WebApplication(IHost host)
         {

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -222,6 +222,10 @@ namespace Microsoft.AspNetCore.Builder
             // Mark the service collection as read-only to prevent future modifications
             _services.IsReadOnly = true;
 
+            // Resolve both the _hostBuilder's Configuration and builder.Configuration to mark both as resolved within the
+            // service provider ensuring both will be properly disposed with the provider.
+            _ = _builtApplication.Services.GetService<IEnumerable<IConfiguration>>();
+
             return _builtApplication;
         }
 

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -198,9 +198,8 @@ namespace Microsoft.AspNetCore.Builder
 
                 if (!hostBuilderProviders.Contains(chainedConfigSource.BuiltProvider))
                 {
-                    // Something removed the TrackingChainedConfigurationSource pointing back to the ConfigurationManager.
-                    // This is likely a test using WebApplicationFactory<TEntryPoint>.
-                    // We replicate the effect by clearing the ConfingurationManager sources.
+                    // Something removed the _hostBuilder's TrackingChainedConfigurationSource pointing back to the ConfigurationManager.
+                    // This is likely a test using WebApplicationFactory. Replicate the effect by clearing the ConfingurationManager sources.
                     ((IConfigurationBuilder)Configuration).Sources.Clear();
                 }
 
@@ -302,39 +301,6 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             public IServiceCollection Services { get; }
-        }
-
-        private sealed class TrackingChainedConfigurationSource : IConfigurationSource
-        {
-            private readonly ChainedConfigurationSource _chainedConfigurationSource = new();
-
-            public TrackingChainedConfigurationSource(ConfigurationManager configManager)
-            {
-                _chainedConfigurationSource.Configuration = configManager;
-            }
-
-            public IConfigurationProvider? BuiltProvider { get; set; }
-
-            public IConfigurationProvider Build(IConfigurationBuilder builder)
-            {
-                BuiltProvider = _chainedConfigurationSource.Build(builder);
-                return BuiltProvider;
-            }
-        }
-
-        private sealed class ConfigurationProviderSource : IConfigurationSource
-        {
-            private readonly IConfigurationProvider _configurationProvider;
-
-            public ConfigurationProviderSource(IConfigurationProvider configurationProvider)
-            {
-                _configurationProvider = configurationProvider;
-            }
-
-            public IConfigurationProvider Build(IConfigurationBuilder builder)
-            {
-                return _configurationProvider;
-            }
         }
     }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebApplicationFunctionalTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebApplicationFunctionalTests.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
-using Xunit;
+using Microsoft.Extensions.Logging.EventLog;
 
 namespace Microsoft.AspNetCore.Tests
 {
@@ -15,9 +13,12 @@ namespace Microsoft.AspNetCore.Tests
         [Fact]
         public async Task LoggingConfigurationSectionPassedToLoggerByDefault()
         {
+            var contentRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRootPath);
+
             try
             {
-                await File.WriteAllTextAsync("appsettings.json", @"
+                await File.WriteAllTextAsync(Path.Combine(contentRootPath, "appsettings.json"), @"
 {
     ""Logging"": {
         ""LogLevel"": {
@@ -26,7 +27,7 @@ namespace Microsoft.AspNetCore.Tests
     }
 }");
 
-                await using var app = WebApplication.Create();
+                await using var app = WebApplication.Create(new[] { "--contentRoot", contentRootPath });
 
                 var factory = (ILoggerFactory)app.Services.GetService(typeof(ILoggerFactory));
                 var logger = factory.CreateLogger("Test");
@@ -48,16 +49,19 @@ namespace Microsoft.AspNetCore.Tests
             }
             finally
             {
-                File.Delete("appsettings.json");
+                Directory.Delete(contentRootPath, recursive: true);
             }
         }
 
         [Fact]
         public async Task EnvironmentSpecificLoggingConfigurationSectionPassedToLoggerByDefault()
         {
+            var contentRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRootPath);
+
             try
             {
-                await File.WriteAllTextAsync("appsettings.Development.json", @"
+                await File.WriteAllTextAsync(Path.Combine(contentRootPath, "appsettings.Development.json"), @"
 {
     ""Logging"": {
         ""LogLevel"": {
@@ -66,13 +70,7 @@ namespace Microsoft.AspNetCore.Tests
     }
 }");
 
-                var app = WebApplication.Create(new[] { "--environment", "Development" });
-
-                // TODO: Make this work! I think it should be possible if we register our Configuration
-                // as a ChainedConfigurationSource instead of copying over the bootstrapped IConfigurationSources.
-                //var builder = WebApplication.CreateBuilder();
-                //builder.Environment.EnvironmentName = "Development";
-                //await using var app = builder.Build();
+                var app = WebApplication.Create(new[] { "--environment", "Development", "--contentRoot", contentRootPath });
 
                 var factory = (ILoggerFactory)app.Services.GetService(typeof(ILoggerFactory));
                 var logger = factory.CreateLogger("Test");
@@ -94,9 +92,86 @@ namespace Microsoft.AspNetCore.Tests
             }
             finally
             {
-                File.Delete("appsettings.json");
+                Directory.Delete(contentRootPath, recursive: true);
             }
         }
 
+        [Fact]
+        public async Task LoggingConfigurationReactsToRuntimeChanges()
+        {
+            var contentRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRootPath);
+
+            try
+            {
+                await File.WriteAllTextAsync(Path.Combine(contentRootPath, "appsettings.json"), @"
+{
+    ""Logging"": {
+        ""LogLevel"": {
+            ""Default"": ""Error""
+        }
+    }
+}");
+
+                var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+                {
+                    ContentRootPath = contentRootPath,
+                });
+
+                // Disable the EventLogLoggerProvider because HostBuilder.ConfigureDefaults() configures it to log everything warning and higher which overrides non-provider-specific config.
+                // https://github.com/dotnet/runtime/blob/8048fe613933a1cd91e3fad6d571c74f726143ef/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs#L238
+                builder.Logging.AddFilter<EventLogLoggerProvider>(_ => false);
+
+                await using var app = builder.Build();
+
+                var factory = (ILoggerFactory)app.Services.GetService(typeof(ILoggerFactory));
+                var logger = factory.CreateLogger("Test");
+
+                Assert.False(logger.IsEnabled(LogLevel.Warning));
+
+                logger.Log(LogLevel.Warning, 0, "Message", null, (s, e) =>
+                {
+                    Assert.True(false);
+                    return string.Empty;
+                });
+
+                // Lower log level from Error to Warning and wait for logging to react to the config changes.
+                var configChangedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                using var registration = app.Configuration.GetReloadToken().RegisterChangeCallback(
+                    tcs => ((TaskCompletionSource)tcs).SetResult(), configChangedTcs);
+
+                await File.WriteAllTextAsync(Path.Combine(contentRootPath, "appsettings.json"), @"
+{
+    ""Logging"": {
+        ""LogLevel"": {
+            ""Default"": ""Warning""
+        }
+    }
+}");
+
+                // Wait for a config change notification because logging will not react until this is fired. Even then, it won't react immediately
+                // so we loop until success or a timeout.
+                await configChangedTcs.Task.DefaultTimeout();
+
+                var timeoutTicks = Environment.TickCount64 + Testing.TaskExtensions.DefaultTimeoutDuration;
+                var logWritten = false;
+
+                while (!logWritten && Environment.TickCount < timeoutTicks)
+                {
+                    logger.Log(LogLevel.Warning, 0, "Message", null, (s, e) =>
+                    {
+                        logWritten = true;
+                        return string.Empty;
+                    });
+                }
+
+                Assert.True(logWritten);
+                Assert.True(logger.IsEnabled(LogLevel.Warning));
+            }
+            finally
+            {
+                Directory.Delete(contentRootPath, recursive: true);
+            }
+        }
     }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -770,6 +770,41 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task WebApplicationDisposesConfigurationProvidersAddedInBuild()
+        {
+            var hostConfigSource = new RandomConfigurationSource();
+            var appConfigSource = new RandomConfigurationSource();
+
+            // This mimics what WebApplicationFactory<T> does and runs configure
+            // services callbacks
+            using var listener = new HostingListener(hostBuilder =>
+            {
+                hostBuilder.ConfigureHostConfiguration(config => config.Add(hostConfigSource));
+                hostBuilder.ConfigureAppConfiguration(config => config.Add(appConfigSource));
+            });
+
+            var builder = WebApplication.CreateBuilder();
+
+            {
+                await using var app = builder.Build();
+
+                Assert.Equal(1, hostConfigSource.ProvidersBuilt);
+                Assert.Equal(1, appConfigSource.ProvidersBuilt);
+                Assert.Equal(1, hostConfigSource.ProvidersLoaded);
+                Assert.Equal(1, appConfigSource.ProvidersLoaded);
+                Assert.Equal(0, hostConfigSource.ProvidersDisposed);
+                Assert.Equal(0, appConfigSource.ProvidersDisposed);
+            }
+
+            Assert.Equal(1, hostConfigSource.ProvidersBuilt);
+            Assert.Equal(1, appConfigSource.ProvidersBuilt);
+            Assert.Equal(1, hostConfigSource.ProvidersLoaded);
+            Assert.Equal(1, appConfigSource.ProvidersLoaded);
+            Assert.Equal(1, hostConfigSource.ProvidersDisposed);
+            Assert.Equal(1, appConfigSource.ProvidersDisposed);
+        }
+
+        [Fact]
         public void WebApplicationBuilderHostProperties_IsCaseSensitive()
         {
             var builder = WebApplication.CreateBuilder();

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -800,8 +800,8 @@ namespace Microsoft.AspNetCore.Tests
             Assert.Equal(1, appConfigSource.ProvidersBuilt);
             Assert.Equal(1, hostConfigSource.ProvidersLoaded);
             Assert.Equal(1, appConfigSource.ProvidersLoaded);
-            Assert.Equal(1, hostConfigSource.ProvidersDisposed);
-            Assert.Equal(1, appConfigSource.ProvidersDisposed);
+            Assert.True(hostConfigSource.ProvidersDisposed > 0);
+            Assert.True(appConfigSource.ProvidersDisposed > 0);
         }
 
         [Fact]

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -805,6 +805,24 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task WebApplicationMakesOriginalConfigurationProvidersAddedInBuildAccessable()
+        {
+            // This mimics what WebApplicationFactory<T> does and runs configure
+            // services callbacks
+            using var listener = new HostingListener(hostBuilder =>
+            {
+                hostBuilder.ConfigureAppConfiguration(config => config.Add(new RandomConfigurationSource()));
+            });
+
+            var builder = WebApplication.CreateBuilder();
+            await using var app = builder.Build();
+
+            var wrappedProviders = ((IConfigurationRoot)app.Configuration).Providers.OfType<IEnumerable<IConfigurationProvider>>();
+            var unwrappedProviders = wrappedProviders.Select(p => Assert.Single(p));
+            Assert.Single(unwrappedProviders.OfType<RandomConfigurationProvider>());
+        }
+
+        [Fact]
         public void WebApplicationBuilderHostProperties_IsCaseSensitive()
         {
             var builder = WebApplication.CreateBuilder();

--- a/src/Shared/TaskExtensions.cs
+++ b/src/Shared/TaskExtensions.cs
@@ -25,9 +25,9 @@ namespace System.Threading.Tasks.Extensions
 #if DEBUG
         // Shorter duration when running tests with debug.
         // Less time waiting for hang unit tests to fail in aspnetcore solution.
-        private const int DefaultTimeoutDuration = 5 * 1000;
+        public const int DefaultTimeoutDuration = 5 * 1000;
 #else
-        private const int DefaultTimeoutDuration = 30 * 1000;
+        public const int DefaultTimeoutDuration = 30 * 1000;
 #endif
 
         public static TimeSpan DefaultTimeoutTimeSpan { get; } = TimeSpan.FromMilliseconds(DefaultTimeoutDuration);


### PR DESCRIPTION
This updates `WebApplicationBuilder` to only load `IConfigurationProvider`s once. Before this change, they would be loaded twice. Once by `Configurationmanager` and then again by the inner generic host's `ConfigurationBuilder`.

This causes problems with `StreamConfigurationSource`s like the one used by `builder.Configuration.AddJsonStream(jsonStream)` throwing errors similar to the following:

```
System.Text.Json.JsonReaderException
  HResult=0x80131500
  Message=The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.
  Source=System.Text.Json
  StackTrace:
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException(Utf8JsonReader& json, ExceptionResource resource, Byte nextByte, ReadOnlySpan`1 bytes)
   at System.Text.Json.Utf8JsonReader.Read()
   at System.Text.Json.JsonDocument.Parse(ReadOnlySpan`1 utf8JsonSpan, JsonReaderOptions readerOptions, MetadataDb& database, StackRowStack& stack)
   at System.Text.Json.JsonDocument.Parse(ReadOnlyMemory`1 utf8Json, JsonReaderOptions readerOptions, Byte[] extraRentedArrayPoolBytes, PooledByteBufferWriter extraPooledByteBufferWriter)
   at System.Text.Json.JsonDocument.Parse(ReadOnlyMemory`1 json, JsonDocumentOptions options)
   at System.Text.Json.JsonDocument.Parse(String json, JsonDocumentOptions options)
   at Microsoft.Extensions.Configuration.Json.JsonConfigurationFileParser.ParseStream(Stream input)
   at Microsoft.Extensions.Configuration.Json.JsonStreamConfigurationProvider.Load(Stream stream)
   at Microsoft.Extensions.Configuration.StreamConfigurationProvider.Load()
   at Microsoft.Extensions.Configuration.ConfigurationRoot..ctor(IList`1 providers)
   at Microsoft.Extensions.Configuration.ConfigurationBuilder.Build()
   at Microsoft.Extensions.Hosting.HostBuilder.BuildAppConfiguration()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at Microsoft.AspNetCore.Builder.WebApplicationBuilder.Build()
```

Fixes #37030
Fixes #37046