### PR TITLE
[Release/6.0] Fix uncompressed scenarios with DisableBuffering

### DIFF
--- a/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
         }
 
-        private void InitializeCompressionHeaders()
+        private ICompressionProvider? InitializeCompressionHeaders()
         {
             if (_provider.ShouldCompressResponse(_context))
             {
@@ -235,7 +235,11 @@ namespace Microsoft.AspNetCore.ResponseCompression
                     headers.ContentMD5 = default; // Reset the MD5 because the content changed.
                     headers.ContentLength = default;
                 }
+
+                return compressionProvider;
             }
+
+            return null;
         }
 
         private void OnWrite()
@@ -244,11 +248,11 @@ namespace Microsoft.AspNetCore.ResponseCompression
             {
                 _compressionChecked = true;
 
-                InitializeCompressionHeaders();
+                var compressionProvider = InitializeCompressionHeaders();
 
-                if (_compressionProvider != null)
+                if (compressionProvider != null)
                 {
-                    _compressionStream = _compressionProvider.CreateStream(_innerStream);
+                    _compressionStream = compressionProvider.CreateStream(_innerStream);
                 }
             }
         }

--- a/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionBody.cs
@@ -201,6 +201,10 @@ namespace Microsoft.AspNetCore.ResponseCompression
             }
         }
 
+        /// <summary>
+        /// Checks if the response should be compressed and sets the response headers.
+        /// </summary>
+        /// <returns>The compression provider to use if compression is enabled, otherwise null.</returns>
         private ICompressionProvider? InitializeCompressionHeaders()
         {
             if (_provider.ShouldCompressResponse(_context))

--- a/src/Middleware/ResponseCompression/test/ResponseCompressionMiddlewareTest.cs
+++ b/src/Middleware/ResponseCompression/test/ResponseCompressionMiddlewareTest.cs
@@ -960,6 +960,73 @@ namespace Microsoft.AspNetCore.ResponseCompression.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(SupportedEncodings))]
+        public async Task UncompressedTrickleWriteAndFlushAsync_FlushesEachWrite(string encoding)
+        {
+            var responseReceived = new[]
+            {
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+            };
+
+            using var host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddResponseCompression();
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseResponseCompression();
+                        app.Run(async context =>
+                        {
+                            context.Response.Headers.ContentMD5 = "MD5";
+                            context.Response.ContentType = "Un/compressed";
+                            context.Features.Get<IHttpResponseBodyFeature>().DisableBuffering();
+
+                            foreach (var signal in responseReceived)
+                            {
+                                await context.Response.WriteAsync("a");
+                                await context.Response.Body.FlushAsync();
+                                await signal.Task.TimeoutAfter(TimeSpan.FromSeconds(3));
+                            }
+                        });
+                    });
+                }).Build();
+
+            await host.StartAsync();
+
+            var server = host.GetTestServer();
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "");
+            request.Headers.AcceptEncoding.ParseAdd(encoding);
+
+            var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            Assert.True(response.Content.Headers.TryGetValues(HeaderNames.ContentMD5, out var md5));
+            Assert.Equal("MD5", md5.SingleOrDefault());
+            Assert.Empty(response.Content.Headers.ContentEncoding);
+
+            var body = await response.Content.ReadAsStreamAsync();
+
+            var data = new byte[100];
+            foreach (var signal in responseReceived)
+            {
+                var read = await body.ReadAsync(data, 0, data.Length);
+                Assert.Equal(1, read);
+                Assert.Equal('a', (char)data[0]);
+
+                signal.SetResult(0);
+            }
+        }
+
         [Fact]
         public async Task SendFileAsync_DifferentContentType_NotBypassed()
         {


### PR DESCRIPTION
Fixes #36960
Backport of https://github.com/dotnet/aspnetcore/pull/37022

## Description

Applications that add the response compression middleware and call the DisableBuffering API are seeing responses compressed that should not have been, and in a way that the client is not able to decompress them (missing headers, appears as data corruption).

## Customer Impact

dotnet-monitor is blocked from upgrading to 6.0 due to these responses that appear corrupted.

## Regression?
- [x] Yes
- [ ] No

From 5.0

## Risk
- [ ] High
- [ ] Medium
- [x] Low

This middleware is opt-in, and the DisableBuffering API is uncommon. Unit test coverage has been added for this negative case.

## Verification
- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A