### PR TITLE
Fix event name of RequestLog

### DIFF
--- a/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.HttpLogging
     {
         public static void RequestLog(this ILogger logger, HttpRequestLog requestLog) => logger.Log(
             LogLevel.Information,
-            new EventId(1, "RequestLogLog"),
+            new EventId(1, "RequestLog"),
             requestLog,
             exception: null,
             formatter: HttpRequestLog.Callback);


### PR DESCRIPTION
Fixing another event name in HttpLogging.