### PR TITLE
Fix UI issues for org auth login nav

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Shared/_LoginPartial.OrgAuth.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Shared/_LoginPartial.OrgAuth.cshtml
@@ -19,16 +19,12 @@
         @if (!string.IsNullOrEmpty(options.EditProfilePolicyId))
         {
             <li class="nav-item">
-                <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="EditProfile">
-                    <span class="text-dark">Hello @User.Identity?.Name!</span>
-                </a>
+                <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="EditProfile">Hello @User.Identity?.Name!</a>
             </li>
         }
         else
         {
-            <li class="nav-item">
-                <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
-            </li>
+            <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
         }
         <li class="nav-item">
             <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignOut">Sign out</a>
@@ -36,16 +32,12 @@
 }
 else
 {
-        <li class="nav-item">
-            <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignIn">Sign in</a>
-        </li>
+        <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
 }
 #else
 @if (User.Identity?.IsAuthenticated == true)
 {
-        <li class="nav-item">
-            <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
-        </li>
+        <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
         <li class="nav-item">
             <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignOut">Sign out</a>
         </li>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Views/Shared/_LoginPartial.OrgAuth.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Views/Shared/_LoginPartial.OrgAuth.cshtml
@@ -19,16 +19,12 @@
         @if (!string.IsNullOrEmpty(options.EditProfilePolicyId))
         {
             <li class="nav-item">
-                <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="EditProfile">
-                    <span class="text-dark">Hello @User.Identity?.Name!</span>
-                </a>
+                <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="EditProfile">Hello @User.Identity?.Name!</a>
             </li>
         }
         else
         {
-            <li class="nav-item">
-                <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
-            </li>
+            <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
         }
         <li class="nav-item">
             <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignOut">Sign out</a>
@@ -43,9 +39,7 @@ else
 #else
 @if (User.Identity?.IsAuthenticated == true)
 {
-        <li class="nav-item">
-            <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
-        </li>
+        <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
         <li class="nav-item">
             <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignOut">Sign out</a>
         </li>


### PR DESCRIPTION
Found by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1389765/

Fixes issue where bootstrap 5 renders spans inside of nav items misaligned, this pattern seems to only be in org auth so it only affects starterweb/razor pages:

Before:
![image](https://user-images.githubusercontent.com/6537861/135042048-a29a2de6-76e4-4421-8c15-cbe2e62e6b95.png)

After:
![image](https://user-images.githubusercontent.com/6537861/135041824-6aa3e544-b2dc-4a71-a19b-dfe12a037294.png)
