### PR TITLE
Harden test to accept either shutdown message

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/ShadowCopyTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/ShadowCopyTests.cs
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
             // Depending on timing, this could result in a shutdown failure, but sometimes it succeeds, handle both situations
             if (!response.IsSuccessStatusCode)
             {
-                Assert.Equal("Application Shutting Down", response.ReasonPhrase);
+                Assert.True(response.ReasonPhrase == "Application Shutting Down" || response.ReasonPhrase == "Server has been shutdown");
             }
 
             // This shutdown should trigger a copy to the next highest directory, which will be 11


### PR DESCRIPTION
Make the test more resilient as the app could either be running still, shutting down, or already shutdown

Fixes https://github.com/dotnet/aspnetcore/issues/36887