### PR TITLE
Normalize startup test expected error codes

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
@@ -445,18 +445,11 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
             File.Delete(Path.Combine(deploymentResult.ContentRoot, "aspnetcorev2_inprocess.dll"));
 
-            if (DeployerSelector.HasNewShim && DeployerSelector.HasNewHandler)
+            if (DeployerSelector.HasNewShim)
             {
                 await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.33");
 
                 EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
-            }
-            else if (DeployerSelector.HasNewShim)
-            {
-                // Forwards compat tests fail earlier due to a error with the M.AspNetCore.Server.IIS package.
-                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.31");
-
-                EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
             }
             else
             {


### PR DESCRIPTION
For https://github.com/dotnet/aspnetcore/issues/31893

After a SDK update last year, https://github.com/dotnet/aspnetcore/blob/cede6c4fbb3ab6d7c42cc3e9a0fcf5b802a36af2/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs#L435-L447

The Forwards compat tests no longer fail earlier so we always get 500.33

This is due to https://github.com/dotnet/aspnetcore/blob/main/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp#L285
```
            const auto intHostFxrExitCode = m_hHostFxrDll.GetNativeSearchDirectories(
                hostfxrArgc,
                hostfxrArgv.get(),
                struNativeSearchPaths.data(),
                dwBufferSize,
                &dwRequiredBufferSize
            );

            if (intHostFxrExitCode == 0)
            {
                break;
            }
```

GetNativeSearchDirectories (which is just calling into hostfxr) is no longer failing (exit code is now 0 verified in the debugger) which this test expects to get 500.31, so its behaving similar to the above case with the HasNewHandler and failing with 500.33 instead of 500.31 which is the next error case below

