### PR TITLE
Un-skip SetSecrets

### DIFF
--- a/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
+++ b/src/Tools/dotnet-user-secrets/test/SecretManagerTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Extensions.SecretManager.Tools.Tests
             Assert.Contains(Resources.FormatMessage_Project_File_Path(Path.Combine(cwd, "..", "TestProject.csproj")), _console.GetOutput());
         }
 
-        [ConditionalTheory(Skip = "https://github.com/dotnet/aspnetcore/issues/25109")]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public void SetSecrets(bool fromCurrentDirectory)


### PR DESCRIPTION
Test was skipped due to a bug in Runtime, should have been unskipped a year ago 😆 https://github.com/dotnet/aspnetcore/issues/25109
Also one of the oldest `test-failure` issues is pointing at this test https://github.com/dotnet/aspnetcore/issues/21413, I think we should close it, add the test to the normal runs again and see if it fails anymore.