### PR TITLE
[Accessiblity] Set aria-current for manage nav

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/ManageNavPages.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/ManageNavPages.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
@@ -115,8 +114,67 @@ namespace Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal
         public static string PageNavClass(ViewContext viewContext, string page)
         {
             var activePage = viewContext.ViewData["ActivePage"] as string
-                ?? System.IO.Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
+                ?? Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
             return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "active" : null;
+        }
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string IndexAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, Index);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string EmailAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, Email);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ChangePasswordAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, ChangePassword);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DownloadPersonalDataAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, DownloadPersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DeletePersonalDataAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, DeletePersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ExternalLoginsAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, ExternalLogins);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string PersonalDataAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, PersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string TwoFactorAuthenticationAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, TwoFactorAuthentication);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string AriaCurrent(ViewContext viewContext, string page)
+        {
+            var activePage = viewContext.ViewData["ActivePage"] as string
+                ?? Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
+            return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "page" : null;
         }
     }
 }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/_ManageNav.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Manage/_ManageNav.cshtml
@@ -1,11 +1,11 @@
 ﻿<ul class="nav nav-pills flex-column">
-    <li class="nav-item"><a class="nav-link @ManageNavPages.IndexNavClass(ViewContext)" id="profile" asp-page="./Index">Profile</a></li>
-    <li class="nav-item"><a class="nav-link @ManageNavPages.EmailNavClass(ViewContext)" id="email" asp-page="./Email">Email</a></li>
-    <li class="nav-item"><a class="nav-link @ManageNavPages.ChangePasswordNavClass(ViewContext)" id="change-password" asp-page="./ChangePassword">Password</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.IndexNavClass(ViewContext)" id="profile" asp-page="./Index" aria-current="@ManageNavPages.IndexAriaCurrent(ViewContext)">Profile</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.EmailNavClass(ViewContext)" id="email" asp-page="./Email" aria-current="@ManageNavPages.EmailAriaCurrent(ViewContext)">Email</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.ChangePasswordNavClass(ViewContext)" id="change-password" asp-page="./ChangePassword" aria-current="@ManageNavPages.ChangePasswordAriaCurrent(ViewContext)">Password</a></li>
     @if ((bool)ViewData["ManageNav.HasExternalLogins"])
     {
-        <li id="external-logins" class="nav-item"><a id="external-login" class="nav-link @ManageNavPages.ExternalLoginsNavClass(ViewContext)" asp-page="./ExternalLogins">External logins</a></li>
+        <li id="external-logins" class="nav-item"><a id="external-login" class="nav-link @ManageNavPages.ExternalLoginsNavClass(ViewContext)" asp-page="./ExternalLogins" aria-current="@ManageNavPages.ExternalLoginsAriaCurrent(ViewContext)">External logins</a></li>
     }
-    <li class="nav-item"><a class="nav-link @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)" id="two-factor" asp-page="./TwoFactorAuthentication">Two-factor authentication</a></li>
-    <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="./PersonalData">Personal data</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)" id="two-factor" asp-page="./TwoFactorAuthentication" aria-current="@ManageNavPages.TwoFactorAuthenticationAriaCurrent(ViewContext)">Two-factor authentication</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="./PersonalData" aria-current="@ManageNavPages.PersonalDataAriaCurrent(ViewContext)">Personal data</a></li>
 </ul>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/ManageNavPages.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/ManageNavPages.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal
@@ -115,8 +114,67 @@ namespace Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal
         public static string PageNavClass(ViewContext viewContext, string page)
         {
             var activePage = viewContext.ViewData["ActivePage"] as string
-                ?? System.IO.Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
+                ?? Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
             return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "active" : null;
+        }
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string IndexAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, Index);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string EmailAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, Email);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ChangePasswordAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, ChangePassword);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DownloadPersonalDataAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, DownloadPersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string DeletePersonalDataAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, DeletePersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ExternalLoginsAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, ExternalLogins);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string PersonalDataAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, PersonalData);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string TwoFactorAuthenticationAriaCurrent(ViewContext viewContext) => AriaCurrent(viewContext, TwoFactorAuthentication);
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string AriaCurrent(ViewContext viewContext, string page)
+        {
+            var activePage = viewContext.ViewData["ActivePage"] as string
+                ?? Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
+            return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "page" : null;
         }
     }
 }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/_ManageNav.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/_ManageNav.cshtml
@@ -1,11 +1,11 @@
 ﻿<ul class="nav nav-pills flex-column">
-    <li class="nav-item"><a class="nav-link @ManageNavPages.IndexNavClass(ViewContext)" id="profile" asp-page="./Index">Profile</a></li>
-    <li class="nav-item"><a class="nav-link @ManageNavPages.EmailNavClass(ViewContext)" id="email" asp-page="./Email">Email</a></li>
-    <li class="nav-item"><a class="nav-link @ManageNavPages.ChangePasswordNavClass(ViewContext)" id="change-password" asp-page="./ChangePassword">Password</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.IndexNavClass(ViewContext)" id="profile" asp-page="./Index" aria-current="@ManageNavPages.IndexAriaCurrent(ViewContext)">Profile</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.EmailNavClass(ViewContext)" id="email" asp-page="./Email" aria-current="@ManageNavPages.EmailAriaCurrent(ViewContext)">Email</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.ChangePasswordNavClass(ViewContext)" id="change-password" asp-page="./ChangePassword" aria-current="@ManageNavPages.ChangePasswordAriaCurrent(ViewContext)">Password</a></li>
     @if ((bool)ViewData["ManageNav.HasExternalLogins"])
     {
-        <li id="external-logins" class="nav-item"><a id="external-login" class="nav-link @ManageNavPages.ExternalLoginsNavClass(ViewContext)" asp-page="./ExternalLogins">External logins</a></li>
+        <li id="external-logins" class="nav-item"><a id="external-login" class="nav-link @ManageNavPages.ExternalLoginsNavClass(ViewContext)" asp-page="./ExternalLogins" aria-current="@ManageNavPages.ExternalLoginsAriaCurrent(ViewContext)">External logins</a></li>
     }
-    <li class="nav-item"><a class="nav-link @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)" id="two-factor" asp-page="./TwoFactorAuthentication">Two-factor authentication</a></li>
-    <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="./PersonalData">Personal data</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)" id="two-factor" asp-page="./TwoFactorAuthentication" aria-current="@ManageNavPages.TwoFactorAuthenticationAriaCurrent(ViewContext)">Two-factor authentication</a></li>
+    <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="./PersonalData" aria-current="@ManageNavPages.PersonalDataAriaCurrent(ViewContext)">Personal data</a></li>
 </ul>

--- a/src/Identity/UI/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/UI/src/PublicAPI.Unshipped.txt
@@ -283,22 +283,40 @@ virtual Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Internal.ResendEmailCo
 ~Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.TwoFactorAuthenticationModel.StatusMessage.set -> void
 ~Microsoft.AspNetCore.Identity.UI.V5.Pages.Internal.ErrorModel.RequestId.get -> string
 ~Microsoft.AspNetCore.Identity.UI.V5.Pages.Internal.ErrorModel.RequestId.set -> void
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.AriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext, string page) -> string
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.ChangePasswordAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.DeletePersonalDataAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.DownloadPersonalDataAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.EmailAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.ExternalLoginsAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.IndexAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.PersonalDataAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
+~static Microsoft.AspNetCore.Identity.UI.V4.Pages.Account.Manage.Internal.ManageNavPages.TwoFactorAuthenticationAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.AriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext, string page) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.ChangePassword.get -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.ChangePasswordAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.ChangePasswordNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.DeletePersonalData.get -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.DeletePersonalDataAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.DeletePersonalDataNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.DownloadPersonalData.get -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.DownloadPersonalDataAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.DownloadPersonalDataNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.Email.get -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.EmailAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.EmailNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.ExternalLogins.get -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.ExternalLoginsAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.ExternalLoginsNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.Index.get -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.IndexAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.IndexNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.PageNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext, string page) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.PersonalData.get -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.PersonalDataAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.PersonalDataNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.TwoFactorAuthentication.get -> string
+~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.TwoFactorAuthenticationAriaCurrent(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~static Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Manage.Internal.ManageNavPages.TwoFactorAuthenticationNavClass(Microsoft.AspNetCore.Mvc.Rendering.ViewContext viewContext) -> string
 ~virtual Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Internal.ConfirmEmailChangeModel.OnGetAsync(string userId, string email, string code) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult>
 ~virtual Microsoft.AspNetCore.Identity.UI.V5.Pages.Account.Internal.ConfirmEmailModel.OnGetAsync(string userId, string code) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult>


### PR DESCRIPTION
Fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1411043/

Adds `area-current="page"` on the currently selected nav item for the manage nav bar

Example html of when the change password is selected, null attributes are not rendered so its safe to attempt to set it on each item
```html

<li class="nav-item"><a class="nav-link" id="profile" href="/Identity/Account/Manage">Profile</a></li>
 <li class="nav-item"><a class="nav-link" id="email" href="/Identity/Account/Manage/Email">Email</a></li>
 <li class="nav-item"><a class="nav-link active" id="change-password" aria-current="page" href="/Identity/Account/Manage/ChangePassword">Password</a></li>
  <li class="nav-item"><a class="nav-link" id="two-factor" href="/Identity/Account/Manage/TwoFactorAuthentication">Two-factor authentication</a></li>
  <li class="nav-item"><a class="nav-link" id="personal-data" href="/Identity/Account/Manage/PersonalData">Personal data</a></li>

```