### PR TITLE
[release/6.0] Don't clear NuGet caches at all

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -175,14 +175,6 @@ jobs:
         displayName: Install Node 14.x
         inputs:
           versionSpec: 14.x
-    - ${{ if eq(parameters.agentOs, 'Windows') }}:
-      - task: NuGetToolInstaller@1
-      - task: NuGetCommand@2
-        displayName: 'Clear NuGet caches'
-        condition: succeeded()
-        inputs:
-          command: custom
-          arguments: 'locals all -clear'
     - ${{ if and(eq(parameters.installJdk, 'true'), eq(parameters.agentOs, 'Windows')) }}:
       - powershell: ./eng/scripts/InstallJdk.ps1
         displayName: Install JDK 11


### PR DESCRIPTION
- backport of #36898

Don't clear NuGet caches at all (#36898)

  - `$use_global_nuget_cache` and `$useGlobalNuGetCache` have default values in our pipelines
  - therefore, cache is always within `$(System.DefaultWorkingDirectory)` and should not exist at job start