### PR TITLE
Don't allow modifying WebRootPath after initialization

### DIFF
--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -111,6 +111,11 @@ namespace Microsoft.AspNetCore.Hosting
             };
 
             hostingEnvironment.ContentRootFileProvider = new PhysicalFileProvider(hostingEnvironment.ContentRootPath);
+            if (hostConfiguration[WebHostDefaults.WebRootKey] is string webRootPath)
+            {
+                hostingEnvironment.WebRootPath = ContentRootResolver.ResolvePath(hostingEnvironment.ContentRootPath, webRootPath);
+                hostingEnvironment.WebRootFileProvider = new PhysicalFileProvider(hostingEnvironment.WebRootPath);
+            }
 
             // Normalize the content root setting for the path in configuration
             hostConfiguration[HostDefaults.ContentRootKey] = hostingEnvironment.ContentRootPath;
@@ -157,7 +162,9 @@ namespace Microsoft.AspNetCore.Hosting
             public string EnvironmentName { get; set; } = default!;
             public string ApplicationName { get; set; } = default!;
             public string ContentRootPath { get; set; } = default!;
+            public string WebRootPath { get; set; } = default!;
             public IFileProvider ContentRootFileProvider { get; set; } = default!;
+            public IFileProvider WebRootFileProvider { get; set; } = default!;
         }
     }
 }

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -107,7 +107,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 ApplicationName = hostConfiguration[HostDefaults.ApplicationKey],
                 EnvironmentName = hostConfiguration[HostDefaults.EnvironmentKey] ?? Environments.Production,
-                ContentRootPath = ContentRootResolver.ResolvePath(hostConfiguration[HostDefaults.ContentRootKey]),
+                ContentRootPath = HostingPathResolver.ResolvePath(hostConfiguration[HostDefaults.ContentRootKey]),
             };
 
             hostingEnvironment.ContentRootFileProvider = new PhysicalFileProvider(hostingEnvironment.ContentRootPath);

--- a/src/DefaultBuilder/src/BootstrapHostBuilder.cs
+++ b/src/DefaultBuilder/src/BootstrapHostBuilder.cs
@@ -111,11 +111,6 @@ namespace Microsoft.AspNetCore.Hosting
             };
 
             hostingEnvironment.ContentRootFileProvider = new PhysicalFileProvider(hostingEnvironment.ContentRootPath);
-            if (hostConfiguration[WebHostDefaults.WebRootKey] is string webRootPath)
-            {
-                hostingEnvironment.WebRootPath = ContentRootResolver.ResolvePath(hostingEnvironment.ContentRootPath, webRootPath);
-                hostingEnvironment.WebRootFileProvider = new PhysicalFileProvider(hostingEnvironment.WebRootPath);
-            }
 
             // Normalize the content root setting for the path in configuration
             hostConfiguration[HostDefaults.ContentRootKey] = hostingEnvironment.ContentRootPath;
@@ -162,9 +157,7 @@ namespace Microsoft.AspNetCore.Hosting
             public string EnvironmentName { get; set; } = default!;
             public string ApplicationName { get; set; } = default!;
             public string ContentRootPath { get; set; } = default!;
-            public string WebRootPath { get; set; } = default!;
             public IFileProvider ContentRootFileProvider { get; set; } = default!;
-            public IFileProvider WebRootFileProvider { get; set; } = default!;
         }
     }
 }

--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -74,9 +74,9 @@ namespace Microsoft.AspNetCore.Builder
                 throw new NotSupportedException($"The application name changed from \"{previousApplicationName}\" to \"{_configuration[HostDefaults.ApplicationKey]}\". Changing the host configuration using WebApplicationBuilder.Host is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
 
-            if (!string.Equals(previousContentRoot, ContentRootResolver.ResolvePath(_configuration[HostDefaults.ContentRootKey]), StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(previousContentRoot, HostingPathResolver.ResolvePath(_configuration[HostDefaults.ContentRootKey]), StringComparison.OrdinalIgnoreCase))
             {
-                throw new NotSupportedException($"The content root changed from \"{previousContentRoot}\" to \"{ContentRootResolver.ResolvePath(_configuration[HostDefaults.ContentRootKey])}\". Changing the host configuration using WebApplicationBuilder.Host is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
+                throw new NotSupportedException($"The content root changed from \"{previousContentRoot}\" to \"{HostingPathResolver.ResolvePath(_configuration[HostDefaults.ContentRootKey])}\". Changing the host configuration using WebApplicationBuilder.Host is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
 
             if (!string.Equals(previousEnvironment, _configuration[HostDefaults.EnvironmentKey], StringComparison.OrdinalIgnoreCase))

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Builder
         public IWebHostBuilder ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate)
         {
             var previousContentRoot = _context.HostingEnvironment.ContentRootPath;
-            var previousWebRoot = _configuration[WebHostDefaults.ContentRootKey];
+            var previousWebRoot = _configuration[WebHostDefaults.WebRootKey];
             var previousApplication = _configuration[WebHostDefaults.ApplicationKey];
             var previousEnvironment = _configuration[WebHostDefaults.EnvironmentKey];
             var previousHostingStartupAssemblies = _configuration[WebHostDefaults.HostingStartupAssembliesKey];
@@ -50,9 +50,8 @@ namespace Microsoft.AspNetCore.Builder
 
             if (_configuration[WebHostDefaults.WebRootKey] is string value && !string.Equals(previousWebRoot, value, StringComparison.OrdinalIgnoreCase))
             {
-                // We allow changing the web root since it's based off the content root and typically
-                // read after the host is built.
-                _environment.WebRootPath = Path.Combine(_environment.ContentRootPath, value);
+                // Diasllow changing the web root for consistency with other types.
+                throw new NotSupportedException($"The web root changed from \"{previousWebRoot}\" to \"{_configuration[WebHostDefaults.WebRootKey]}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
             else if (!string.Equals(previousApplication, _configuration[WebHostDefaults.ApplicationKey], StringComparison.OrdinalIgnoreCase))
             {
@@ -113,16 +112,18 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             var previousContentRoot = _context.HostingEnvironment.ContentRootPath;
+            var previousWebRoot = _configuration[WebHostDefaults.WebRootKey];
             var previousApplication = _configuration[WebHostDefaults.ApplicationKey];
             var previousEnvironment = _configuration[WebHostDefaults.EnvironmentKey];
             var previousHostingStartupAssemblies = _configuration[WebHostDefaults.HostingStartupAssembliesKey];
             var previousHostingStartupAssembliesExclude = _configuration[WebHostDefaults.HostingStartupExcludeAssembliesKey];
 
-            if (string.Equals(key, WebHostDefaults.WebRootKey, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(key, WebHostDefaults.WebRootKey, StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(previousWebRoot, value, StringComparison.OrdinalIgnoreCase))
             {
-                // We allow changing the web root since it's based off the content root and typically
-                // read after the host is built.
-                _environment.WebRootPath = Path.Combine(_environment.ContentRootPath, value);
+                 // Disallow changing any host configuration
+                throw new NotSupportedException($"The web root changed from \"{previousWebRoot}\" to \"{value}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
+
             }
             else if (string.Equals(key, WebHostDefaults.ApplicationKey, StringComparison.OrdinalIgnoreCase) &&
                     !string.Equals(previousApplication, value, StringComparison.OrdinalIgnoreCase))

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Builder
         public IWebHostBuilder ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate)
         {
             var previousContentRoot = _context.HostingEnvironment.ContentRootPath;
-            var previousWebRoot = _configuration[WebHostDefaults.WebRootKey];
+            var previousWebRoot = _context.HostingEnvironment.WebRootPath;
             var previousApplication = _configuration[WebHostDefaults.ApplicationKey];
             var previousEnvironment = _configuration[WebHostDefaults.EnvironmentKey];
             var previousHostingStartupAssemblies = _configuration[WebHostDefaults.HostingStartupAssembliesKey];
@@ -48,20 +48,20 @@ namespace Microsoft.AspNetCore.Builder
             // Run these immediately so that they are observable by the imperative code
             configureDelegate(_context, _configuration);
 
-            if (_configuration[WebHostDefaults.WebRootKey] is string value && !string.Equals(previousWebRoot, value, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(HostingPathResolver.ResolvePath(previousWebRoot, previousContentRoot), HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.WebRootKey], previousContentRoot), StringComparison.OrdinalIgnoreCase))
             {
                 // Diasllow changing the web root for consistency with other types.
-                throw new NotSupportedException($"The web root changed from \"{previousWebRoot}\" to \"{_configuration[WebHostDefaults.WebRootKey]}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
+                throw new NotSupportedException($"The web root changed from \"{HostingPathResolver.ResolvePath(previousWebRoot, previousContentRoot)}\" to \"{HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.WebRootKey], previousContentRoot)}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
             else if (!string.Equals(previousApplication, _configuration[WebHostDefaults.ApplicationKey], StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow changing any host configuration
                 throw new NotSupportedException($"The application name changed from \"{previousApplication}\" to \"{_configuration[WebHostDefaults.ApplicationKey]}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
-            else if (!string.Equals(previousContentRoot, ContentRootResolver.ResolvePath(_configuration[WebHostDefaults.ContentRootKey]), StringComparison.OrdinalIgnoreCase))
+            else if (!string.Equals(previousContentRoot, HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.ContentRootKey]), StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow changing any host configuration
-                throw new NotSupportedException($"The content root changed from \"{previousContentRoot}\" to \"{ContentRootResolver.ResolvePath(_configuration[WebHostDefaults.ContentRootKey])}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
+                throw new NotSupportedException($"The content root changed from \"{previousContentRoot}\" to \"{HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.ContentRootKey])}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
             else if (!string.Equals(previousEnvironment, _configuration[WebHostDefaults.EnvironmentKey], StringComparison.OrdinalIgnoreCase))
             {
@@ -112,17 +112,17 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             var previousContentRoot = _context.HostingEnvironment.ContentRootPath;
-            var previousWebRoot = _configuration[WebHostDefaults.WebRootKey];
+            var previousWebRoot = _context.HostingEnvironment.WebRootPath;
             var previousApplication = _configuration[WebHostDefaults.ApplicationKey];
             var previousEnvironment = _configuration[WebHostDefaults.EnvironmentKey];
             var previousHostingStartupAssemblies = _configuration[WebHostDefaults.HostingStartupAssembliesKey];
             var previousHostingStartupAssembliesExclude = _configuration[WebHostDefaults.HostingStartupExcludeAssembliesKey];
 
             if (string.Equals(key, WebHostDefaults.WebRootKey, StringComparison.OrdinalIgnoreCase) &&
-                    !string.Equals(previousWebRoot, value, StringComparison.OrdinalIgnoreCase))
+                    !string.Equals(HostingPathResolver.ResolvePath(previousWebRoot, previousContentRoot), HostingPathResolver.ResolvePath(value, previousContentRoot), StringComparison.OrdinalIgnoreCase))
             {
-                 // Disallow changing any host configuration
-                throw new NotSupportedException($"The web root changed from \"{previousWebRoot}\" to \"{value}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
+                // Disallow changing any host configuration
+                throw new NotSupportedException($"The web root changed from \"{HostingPathResolver.ResolvePath(previousWebRoot, previousContentRoot)}\" to \"{HostingPathResolver.ResolvePath(value, previousContentRoot)}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
 
             }
             else if (string.Equals(key, WebHostDefaults.ApplicationKey, StringComparison.OrdinalIgnoreCase) &&
@@ -132,10 +132,10 @@ namespace Microsoft.AspNetCore.Builder
                 throw new NotSupportedException($"The application name changed from \"{previousApplication}\" to \"{value}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
             else if (string.Equals(key, WebHostDefaults.ContentRootKey, StringComparison.OrdinalIgnoreCase) &&
-                    !string.Equals(previousContentRoot, ContentRootResolver.ResolvePath(value), StringComparison.OrdinalIgnoreCase))
+                    !string.Equals(previousContentRoot, HostingPathResolver.ResolvePath(value), StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow changing any host configuration
-                throw new NotSupportedException($"The content root changed from \"{previousContentRoot}\" to \"{ContentRootResolver.ResolvePath(value)}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
+                throw new NotSupportedException($"The content root changed from \"{previousContentRoot}\" to \"{HostingPathResolver.ResolvePath(value)}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
             else if (string.Equals(key, WebHostDefaults.EnvironmentKey, StringComparison.OrdinalIgnoreCase) &&
                     !string.Equals(previousEnvironment, value, StringComparison.OrdinalIgnoreCase))

--- a/src/DefaultBuilder/src/ContentRootResolver.cs
+++ b/src/DefaultBuilder/src/ContentRootResolver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore
             return Path.EndsInDirectorySeparator(canonicalPath) ? canonicalPath : canonicalPath + Path.DirectorySeparatorChar;
         }
 
-        public static string ResolvePath(string contentRootPath, string basePath)
+        private static string ResolvePath(string contentRootPath, string basePath)
         {
             if (string.IsNullOrEmpty(contentRootPath))
             {

--- a/src/DefaultBuilder/src/ContentRootResolver.cs
+++ b/src/DefaultBuilder/src/ContentRootResolver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore
             return Path.EndsInDirectorySeparator(canonicalPath) ? canonicalPath : canonicalPath + Path.DirectorySeparatorChar;
         }
 
-        private static string ResolvePath(string contentRootPath, string basePath)
+        public static string ResolvePath(string contentRootPath, string basePath)
         {
             if (string.IsNullOrEmpty(contentRootPath))
             {

--- a/src/DefaultBuilder/src/HostingPathResolver.cs
+++ b/src/DefaultBuilder/src/HostingPathResolver.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore
 {
-    internal static class ContentRootResolver
+    internal static class HostingPathResolver
     {
         public static string ResolvePath(string contentRootPath)
         {
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore
             return Path.EndsInDirectorySeparator(canonicalPath) ? canonicalPath : canonicalPath + Path.DirectorySeparatorChar;
         }
 
-        private static string ResolvePath(string contentRootPath, string basePath)
+        public static string ResolvePath(string contentRootPath, string basePath)
         {
             if (string.IsNullOrEmpty(contentRootPath))
             {

--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -42,6 +42,8 @@ Microsoft.AspNetCore.Builder.WebApplicationOptions.ContentRootPath.get -> string
 Microsoft.AspNetCore.Builder.WebApplicationOptions.ContentRootPath.init -> void
 Microsoft.AspNetCore.Builder.WebApplicationOptions.EnvironmentName.get -> string?
 Microsoft.AspNetCore.Builder.WebApplicationOptions.EnvironmentName.init -> void
+Microsoft.AspNetCore.Builder.WebApplicationOptions.WebRootPath.get -> string?
+Microsoft.AspNetCore.Builder.WebApplicationOptions.WebRootPath.init -> void
 Microsoft.AspNetCore.Builder.WebApplicationOptions.WebApplicationOptions() -> void
 static Microsoft.AspNetCore.Builder.WebApplication.Create(string![]? args = null) -> Microsoft.AspNetCore.Builder.WebApplication!
 static Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder() -> Microsoft.AspNetCore.Builder.WebApplicationBuilder!

--- a/src/DefaultBuilder/src/WebApplicationOptions.cs
+++ b/src/DefaultBuilder/src/WebApplicationOptions.cs
@@ -38,6 +38,11 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         public string? ContentRootPath { get; init; }
 
+        /// <summary>
+        /// The web root path.
+        /// </summary>
+        public string? WebRootPath { get; init; }
+
         internal void ApplyHostConfiguration(IConfigurationBuilder builder)
         {
             Dictionary<string, string>? config = null;
@@ -58,6 +63,12 @@ namespace Microsoft.AspNetCore.Builder
             {
                 config ??= new();
                 config[HostDefaults.ContentRootKey] = ContentRootPath;
+            }
+
+            if (WebRootPath is not null)
+            {
+                config ??= new();
+                config[WebHostDefaults.WebRootKey] = WebRootPath;
             }
 
             if (config is not null)

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -330,6 +330,100 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Theory]
+        [InlineData("wwwroot2")]
+        [InlineData("./wwwroot2")]
+        [InlineData("./bar/../wwwroot2")]
+        [InlineData("foo/../wwwroot2")]
+        [InlineData("wwwroot2/.")]
+        public void WebApplicationBuilder_CanHandleVariousWebRootPaths(string webRoot)
+        {
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRoot);
+            var fullWebRootPath = Path.Combine(contentRoot, "wwwroot2");
+
+            try
+            {
+                var options = new WebApplicationOptions
+                {
+                    ContentRootPath = contentRoot,
+                    WebRootPath = "wwwroot2"
+                };
+
+                var builder = new WebApplicationBuilder(options);
+
+                Assert.Equal(contentRoot + Path.DirectorySeparatorChar, builder.Environment.ContentRootPath);
+                Assert.Equal(fullWebRootPath, builder.Environment.WebRootPath);
+
+                builder.WebHost.UseWebRoot(webRoot);
+            }
+            finally
+            {
+                Directory.Delete(contentRoot, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void WebApplicationBuilder_CanOverrideWithFullWebRootPaths()
+        {
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRoot);
+            var fullWebRootPath = Path.Combine(contentRoot, "wwwroot");
+            Directory.CreateDirectory(fullWebRootPath);
+
+            try
+            {
+                var options = new WebApplicationOptions
+                {
+                    ContentRootPath = contentRoot,
+                };
+
+                var builder = new WebApplicationBuilder(options);
+
+                Assert.Equal(contentRoot + Path.DirectorySeparatorChar, builder.Environment.ContentRootPath);
+                Assert.Equal(fullWebRootPath, builder.Environment.WebRootPath);
+
+                builder.WebHost.UseWebRoot(fullWebRootPath);
+            }
+            finally
+            {
+                Directory.Delete(contentRoot, recursive: true);
+            }
+        }
+
+        [Theory]
+        [InlineData("wwwroot")]
+        [InlineData("./wwwroot")]
+        [InlineData("./bar/../wwwroot")]
+        [InlineData("foo/../wwwroot")]
+        [InlineData("wwwroot/.")]
+        public void WebApplicationBuilder_CanHandleVariousWebRootPaths_OverrideDefaultPath(string webRoot)
+        {
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRoot);
+            var fullWebRootPath = Path.Combine(contentRoot, "wwwroot");
+            Directory.CreateDirectory(fullWebRootPath);
+
+            try
+            {
+                var options = new WebApplicationOptions
+                {
+                    ContentRootPath = contentRoot
+                };
+
+                var builder = new WebApplicationBuilder(options);
+
+                Assert.Equal(contentRoot + Path.DirectorySeparatorChar, builder.Environment.ContentRootPath);
+                Assert.Equal(fullWebRootPath, builder.Environment.WebRootPath);
+
+                builder.WebHost.UseWebRoot(webRoot);
+            }
+            finally
+            {
+                Directory.Delete(contentRoot, recursive: true);
+            }
+        }
+
+        [Theory]
         [InlineData("")]  // Empty behaves differently to null
         [InlineData(".")]
         public void SettingContentRootToRelativePathUsesAppContextBaseDirectoryAsPathBase(string path)

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.Tests
         {
             var builder = WebApplication.CreateBuilder();
 
-            var contentRoot = Path.GetTempPath();
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var webRoot = Path.Combine(contentRoot, "wwwroot");
             var envName = $"{nameof(WebApplicationTests)}_ENV";
 
@@ -256,7 +256,7 @@ namespace Microsoft.AspNetCore.Tests
         {
             var builder = WebApplication.CreateBuilder();
 
-            var contentRoot = Path.GetTempPath();
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var webRoot = Path.Combine(contentRoot, "wwwroot");
             var envName = $"{nameof(WebApplicationTests)}_ENV";
 
@@ -315,25 +315,18 @@ namespace Microsoft.AspNetCore.Tests
             var contentRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(contentRoot);
 
-            try
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
             {
-                var builder = WebApplication.CreateBuilder(new WebApplicationOptions
-                {
-                    ContentRootPath = contentRoot
-                });
+                ContentRootPath = contentRoot
+            });
 
-                builder.Host.UseContentRoot(contentRoot + Path.DirectorySeparatorChar);
-                builder.Host.UseContentRoot(contentRoot.ToUpperInvariant());
-                builder.Host.UseContentRoot(contentRoot.ToLowerInvariant());
+            builder.Host.UseContentRoot(contentRoot + Path.DirectorySeparatorChar);
+            builder.Host.UseContentRoot(contentRoot.ToUpperInvariant());
+            builder.Host.UseContentRoot(contentRoot.ToLowerInvariant());
 
-                builder.WebHost.UseContentRoot(contentRoot + Path.DirectorySeparatorChar);
-                builder.WebHost.UseContentRoot(contentRoot.ToUpperInvariant());
-                builder.WebHost.UseContentRoot(contentRoot.ToLowerInvariant());
-            }
-            finally
-            {
-                Directory.Delete(contentRoot);
-            }
+            builder.WebHost.UseContentRoot(contentRoot + Path.DirectorySeparatorChar);
+            builder.WebHost.UseContentRoot(contentRoot.ToUpperInvariant());
+            builder.WebHost.UseContentRoot(contentRoot.ToLowerInvariant());
         }
 
         [Theory]
@@ -373,10 +366,10 @@ namespace Microsoft.AspNetCore.Tests
         [Fact]
         public void WebApplicationBuilderCanConfigureHostSettingsUsingWebApplicationOptions()
         {
-            var contentRoot = Path.GetTempPath();
-            var webRoot = "wwwroot";
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRoot);
+            var webRoot = "wwwroot2";
             var fullWebRootPath = Path.Combine(contentRoot, webRoot);
-            Directory.CreateDirectory(fullWebRootPath);
             var envName = $"{nameof(WebApplicationTests)}_ENV";
 
             try
@@ -397,28 +390,28 @@ namespace Microsoft.AspNetCore.Tests
                         {
                             Assert.Equal(nameof(WebApplicationTests), context.HostingEnvironment.ApplicationName);
                             Assert.Equal(envName, context.HostingEnvironment.EnvironmentName);
-                            Assert.Equal(contentRoot, context.HostingEnvironment.ContentRootPath);
+                            Assert.Equal(contentRoot + Path.DirectorySeparatorChar, context.HostingEnvironment.ContentRootPath);
                         });
                     });
 
                 Assert.Equal(nameof(WebApplicationTests), builder.Environment.ApplicationName);
                 Assert.Equal(envName, builder.Environment.EnvironmentName);
-                Assert.Equal(contentRoot, builder.Environment.ContentRootPath);
+                Assert.Equal(contentRoot + Path.DirectorySeparatorChar, builder.Environment.ContentRootPath);
                 Assert.Equal(fullWebRootPath, builder.Environment.WebRootPath);
             }
             finally
             {
-                Directory.Delete(fullWebRootPath);
+                Directory.Delete(contentRoot, recursive: true);
             }
         }
 
         [Fact]
         public void WebApplicationBuilderWebApplicationOptionsPropertiesOverridesArgs()
         {
-            var contentRoot = Path.GetTempPath();
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRoot);
             var webRoot = "wwwroot2";
             var fullWebRootPath = Path.Combine(contentRoot, webRoot);
-            Directory.CreateDirectory(fullWebRootPath);
             var envName = $"{nameof(WebApplicationTests)}_ENV";
 
             try
@@ -426,11 +419,11 @@ namespace Microsoft.AspNetCore.Tests
                 var options = new WebApplicationOptions
                 {
                     Args = new[] {
-                    $"--{WebHostDefaults.ApplicationKey}=testhost",
-                    $"--{WebHostDefaults.ContentRootKey}={contentRoot}",
-                    $"--{WebHostDefaults.WebRootKey}=wwwroot2",
-                    $"--{WebHostDefaults.EnvironmentKey}=Test"
-                },
+                        $"--{WebHostDefaults.ApplicationKey}=testhost",
+                        $"--{WebHostDefaults.ContentRootKey}={contentRoot}",
+                        $"--{WebHostDefaults.WebRootKey}=wwwroot2",
+                        $"--{WebHostDefaults.EnvironmentKey}=Test"
+                    },
                     ApplicationName = nameof(WebApplicationTests),
                     ContentRootPath = contentRoot,
                     EnvironmentName = envName,
@@ -445,40 +438,41 @@ namespace Microsoft.AspNetCore.Tests
                         {
                             Assert.Equal(nameof(WebApplicationTests), context.HostingEnvironment.ApplicationName);
                             Assert.Equal(envName, context.HostingEnvironment.EnvironmentName);
-                            Assert.Equal(contentRoot, context.HostingEnvironment.ContentRootPath);
+                            Assert.Equal(contentRoot + Path.DirectorySeparatorChar, context.HostingEnvironment.ContentRootPath);
                         });
                     });
 
                 Assert.Equal(nameof(WebApplicationTests), builder.Environment.ApplicationName);
                 Assert.Equal(envName, builder.Environment.EnvironmentName);
-                Assert.Equal(contentRoot, builder.Environment.ContentRootPath);
+                Assert.Equal(contentRoot + Path.DirectorySeparatorChar, builder.Environment.ContentRootPath);
                 Assert.Equal(fullWebRootPath, builder.Environment.WebRootPath);
             }
             finally
             {
-                Directory.Delete(fullWebRootPath);
+                Directory.Delete(contentRoot, recursive: true);
             }
         }
 
         [Fact]
         public void WebApplicationBuilderCanConfigureHostSettingsUsingWebApplicationOptionsArgs()
         {
-            var contentRoot = Path.GetTempPath();
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(contentRoot);
             var webRoot = "wwwroot";
             var fullWebRootPath = Path.Combine(contentRoot, webRoot);
-            Directory.CreateDirectory(fullWebRootPath);
             var envName = $"{nameof(WebApplicationTests)}_ENV";
 
             try
             {
+
                 var options = new WebApplicationOptions
                 {
                     Args = new[] {
-                    $"--{WebHostDefaults.ApplicationKey}={nameof(WebApplicationTests)}",
-                    $"--{WebHostDefaults.ContentRootKey}={contentRoot}",
-                    $"--{WebHostDefaults.EnvironmentKey}={envName}",
-                    $"--{WebHostDefaults.WebRootKey}={webRoot}",
-                }
+                        $"--{WebHostDefaults.ApplicationKey}={nameof(WebApplicationTests)}",
+                        $"--{WebHostDefaults.ContentRootKey}={contentRoot}",
+                        $"--{WebHostDefaults.EnvironmentKey}={envName}",
+                        $"--{WebHostDefaults.WebRootKey}={webRoot}",
+                    }
                 };
 
                 var builder = new WebApplicationBuilder(
@@ -489,18 +483,18 @@ namespace Microsoft.AspNetCore.Tests
                         {
                             Assert.Equal(nameof(WebApplicationTests), context.HostingEnvironment.ApplicationName);
                             Assert.Equal(envName, context.HostingEnvironment.EnvironmentName);
-                            Assert.Equal(contentRoot, context.HostingEnvironment.ContentRootPath);
+                            Assert.Equal(contentRoot + Path.DirectorySeparatorChar, context.HostingEnvironment.ContentRootPath);
                         });
                     });
 
                 Assert.Equal(nameof(WebApplicationTests), builder.Environment.ApplicationName);
                 Assert.Equal(envName, builder.Environment.EnvironmentName);
-                Assert.Equal(contentRoot, builder.Environment.ContentRootPath);
+                Assert.Equal(contentRoot + Path.DirectorySeparatorChar, builder.Environment.ContentRootPath);
                 Assert.Equal(fullWebRootPath, builder.Environment.WebRootPath);
             }
             finally
             {
-                Directory.Delete(fullWebRootPath);
+                Directory.Delete(contentRoot, recursive: true);
             }
         }
 
@@ -1435,8 +1429,7 @@ namespace Microsoft.AspNetCore.Tests
         {
             var builder = WebApplication.CreateBuilder();
 
-            var contentRoot = Path.GetTempPath();
-            var webRoot = Path.Combine(contentRoot, "wwwroot");
+            var contentRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var envName = $"{nameof(WebApplicationTests)}_ENV";
 
             builder.Configuration[WebHostDefaults.ApplicationKey] = nameof(WebApplicationTests);

--- a/src/Mvc/test/Mvc.FunctionalTests/SimpleWithWebApplicationBuilderTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/SimpleWithWebApplicationBuilderTests.cs
@@ -192,6 +192,27 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
         }
 
         [Fact]
+        public async Task WebRoot_Can_Be_Overriden()
+        {
+            var webRoot = "foo";
+            var expectedWebRoot = "";
+            // Arrange
+            var fixture = _fixture.WithWebHostBuilder(builder =>
+            {
+                expectedWebRoot = Path.GetFullPath(Path.Combine(builder.GetSetting(WebHostDefaults.ContentRootKey), webRoot));
+                builder.UseSetting(WebHostDefaults.WebRootKey, webRoot);
+            });
+
+            using var client = fixture.CreateDefaultClient();
+
+            // Act
+            var content = await client.GetStringAsync("http://localhost/webroot");
+
+            // Assert
+            Assert.Equal(expectedWebRoot, content);
+        }
+
+        [Fact]
         public async Task Accepts_Json_WhenBindingAComplexType()
         {
             // Act

--- a/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/Program.cs
+++ b/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/Program.cs
@@ -34,6 +34,7 @@ app.MapGet("/many-results", (int id) =>
 app.MapGet("/problem", () => Results.Problem("Some problem"));
 
 app.MapGet("/environment", (IHostEnvironment environment) => environment.EnvironmentName);
+app.MapGet("/webroot", (IWebHostEnvironment environment) => environment.WebRootPath);
 
 app.MapGet("/greeting", (IConfiguration config) => config["Greeting"]);
 


### PR DESCRIPTION
## Description

This PR resolves an issue where the `WebRootFileProvider` was not set correctly when users would modify the web root for their application. The `FileProvider` is used to resolve paths to assets in middlewares across the stack. The PR also updates `WebRootPath` to be unmodifiable after construction to match the other objects in the host configuration.

## Customer Impact

Without this change, customers are unable to leverage middlewares that dependent on the web root file provider in their applications. This means that features, like serving static files, will not work in minimal apps.

## Regression?
- [X] Yes
- [ ] No

Yes, this PR fixes a regression from an earlier .NET 6 preview.

## Risk
- [ ] High
- [ ] Medium
- [X] Low

This change is low-risk because it brings back pre-existing logic that was removed after a code refactor.

## Verification
- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A


Addresses https://github.com/dotnet/aspnetcore/issues/36999