### PR TITLE
[release/6.0] Use 1ES pools again

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -101,24 +101,24 @@ jobs:
           vmImage: ubuntu-18.04
         ${{ if eq(parameters.useHostedUbuntu, false) }}:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Ubuntu.1804.Amd64.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Ubuntu.1804.Amd64
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
+          name: NetCore1ESPool-Svc-Public
           ${{ if ne(parameters.isTestingJob, true) }}:
             # Visual Studio Build Tools
-            queue: BuildPool.Server.Amd64.VS2019.BT.Open
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.BT.Open
           ${{ if eq(parameters.isTestingJob, true) }}:
             # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-            queue: BuildPool.Server.Amd64.VS2019.Open
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCoreInternal-Pool
+          name: NetCore1ESPool-Svc-Internal
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Server.Amd64.VS2019
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
     variables:


### PR DESCRIPTION
- revert "Revert "Use new Hosted build pools (#36110)" (#36613)"
- this reverts commit eb6705fc3b58aa5b17e90049458dac50c94a1511