### PR TITLE
[release/3.1] Use new Hosted build pools

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -94,17 +94,17 @@ jobs:
         vmImage: ubuntu-18.04
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
+          name: NetCore1ESPool-Svc-Public
           ${{ if ne(parameters.isTestingJob, true) }}:
             # Visual Studio Build Tools
-            queue: BuildPool.Server.Amd64.VS2019.BT.Open
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.BT.Open
           ${{ if eq(parameters.isTestingJob, true) }}:
             # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-            queue: BuildPool.Server.Amd64.VS2019.Open
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCoreInternal-Pool
+          name: NetCore1ESPool-Svc-Internal
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          queue: BuildPool.Server.Amd64.VS2019
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
     variables:
     - AgentOsName: ${{ parameters.agentOs }}
     - ASPNETCORE_TEST_LOG_MAXPATH: "200" # Keep test log file name length low enough for artifact zipping


### PR DESCRIPTION
- `cherry-pick` of f4cc3c003222658b92753af55fbd66dbfa59251b