### PR TITLE
Update gRPC template reference to Grpc.AspNetCore

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -230,11 +230,11 @@
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>4.2.1</FSharpCoreVersion>
-    <GoogleProtobufVersion>3.13.0</GoogleProtobufVersion>
-    <GrpcAspNetCoreVersion>2.32.0</GrpcAspNetCoreVersion>
-    <GrpcAuthVersion>2.32.0</GrpcAuthVersion>
-    <GrpcNetClientVersion>2.32.0</GrpcNetClientVersion>
-    <GrpcToolsVersion>2.32.0</GrpcToolsVersion>
+    <GoogleProtobufVersion>3.18.0</GoogleProtobufVersion>
+    <GrpcAspNetCoreVersion>2.39.0</GrpcAspNetCoreVersion>
+    <GrpcAuthVersion>2.39.0</GrpcAuthVersion>
+    <GrpcNetClientVersion>2.39.0</GrpcNetClientVersion>
+    <GrpcToolsVersion>2.39.0</GrpcToolsVersion>
     <DuendeIdentityServerAspNetIdentityVersion>5.2.0</DuendeIdentityServerAspNetIdentityVersion>
     <DuendeIdentityServerEntityFrameworkVersion>5.2.0</DuendeIdentityServerEntityFrameworkVersion>
     <DuendeIdentityServerVersion>5.2.0</DuendeIdentityServerVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -231,10 +231,10 @@
     <CommandLineParserVersion>2.3.0</CommandLineParserVersion>
     <FSharpCoreVersion>4.2.1</FSharpCoreVersion>
     <GoogleProtobufVersion>3.18.0</GoogleProtobufVersion>
-    <GrpcAspNetCoreVersion>2.39.0</GrpcAspNetCoreVersion>
-    <GrpcAuthVersion>2.39.0</GrpcAuthVersion>
-    <GrpcNetClientVersion>2.39.0</GrpcNetClientVersion>
-    <GrpcToolsVersion>2.39.0</GrpcToolsVersion>
+    <GrpcAspNetCoreVersion>2.40.0</GrpcAspNetCoreVersion>
+    <GrpcAuthVersion>2.40.0</GrpcAuthVersion>
+    <GrpcNetClientVersion>2.40.0</GrpcNetClientVersion>
+    <GrpcToolsVersion>2.40.0</GrpcToolsVersion>
     <DuendeIdentityServerAspNetIdentityVersion>5.2.0</DuendeIdentityServerAspNetIdentityVersion>
     <DuendeIdentityServerEntityFrameworkVersion>5.2.0</DuendeIdentityServerEntityFrameworkVersion>
     <DuendeIdentityServerVersion>5.2.0</DuendeIdentityServerVersion>


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/37060

**Notes:**
* [x] I'm organizing 2.40.0 to be published. I will update package reference to 2.40.0 when available, hopefully tomorrow.
* [x] Will port to 6.0

### Description

There is a [bug in Grpc.Tools for MacOS Big Sur](https://github.com/grpc/grpc/issues/24529) that prevents gRPC tooling working. This is fixed in an update of Grpc.Tools. This PR updates the templates to use a fixed gRPC version.

### Customer impact

gRPC template is broken on MacOS Big Sur. Customers can update their NuGet package versions to fix.

### Regression

No.

### Risk

Low. Only updates package versions in templates.