### PR TITLE
Cleanup YAML parameters and settings

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -358,7 +358,6 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       installNodeJs: false
-      installJdk: false
       artifacts:
       - name: MacOS_arm64_Logs
         path: artifacts/log/
@@ -389,7 +388,6 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       installNodeJs: false
-      installJdk: false
       artifacts:
       - name: MacOS_x64_Logs
         path: artifacts/log/
@@ -456,7 +454,6 @@ stages:
             $(_InternalRuntimeDownloadArgs)
         displayName: Build RPM installers
       installNodeJs: false
-      installJdk: false
       artifacts:
       - name: Linux_x64_Logs
         path: artifacts/log/
@@ -488,7 +485,6 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       installNodeJs: false
-      installJdk: false
       artifacts:
       - name: Linux_arm_Logs
         path: artifacts/log/
@@ -520,7 +516,6 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       installNodeJs: false
-      installJdk: false
       artifacts:
       - name: Linux_arm64_Logs
         path: artifacts/log/
@@ -554,7 +549,6 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       installNodeJs: false
-      installJdk: false
       skipComponentGovernanceDetection: true
       artifacts:
       - name: Linux_musl_x64_Logs
@@ -590,7 +584,6 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       installNodeJs: false
-      installJdk: false
       artifacts:
       - name: Linux_musl_arm_Logs
         path: artifacts/log/
@@ -625,7 +618,6 @@ stages:
         $(_PublishArgs)
         $(_InternalRuntimeDownloadArgs)
       installNodeJs: false
-      installJdk: false
       artifacts:
       - name: Linux_musl_arm64_Logs
         path: artifacts/log/

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -27,12 +27,9 @@ variables:
 jobs:
 - template: jobs/default-build.yml
   parameters:
-    condition: ne(variables['SkipTests'], 'true')
     jobName: Components_E2E_Test
     jobDisplayName: "Test: Blazor E2E tests on Linux"
     agentOs: Linux
-    installNodeJs: true
-    installJdk: true
     isTestingJob: true
     steps:
     - script: git submodule update --init

--- a/.azure/pipelines/devBuilds.yml
+++ b/.azure/pipelines/devBuilds.yml
@@ -15,7 +15,6 @@ stages:
   # Build components on Windows (x64)
   - template: jobs/default-build.yml
     parameters:
-      codeSign: false
       jobName: Windows_build
       jobDisplayName: "Build: Components"
       agentOs: Windows
@@ -38,7 +37,6 @@ stages:
   # Build servers on Windows (x64)
   - template: jobs/default-build.yml
     parameters:
-      codeSign: false
       jobName: Windows_build
       jobDisplayName: "Build: Servers"
       agentOs: Windows
@@ -61,7 +59,6 @@ stages:
   # Build servers on Windows (x64)
   - template: jobs/default-build.yml
     parameters:
-      codeSign: false
       jobName: Windows_build
       jobDisplayName: "Build: Project Templates"
       agentOs: Windows
@@ -84,7 +81,6 @@ stages:
   # Build servers on Windows (x64)
   - template: jobs/default-build.yml
     parameters:
-      codeSign: false
       jobName: Windows_build
       jobDisplayName: "Build: Everything"
       agentOs: Windows

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -71,7 +71,6 @@ jobs:
         env:
           HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
           SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-      installNodeJs: true
       artifacts:
       - name: Helix_arm64_logs
         path: artifacts/log/

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -35,34 +35,34 @@
 #       Specifies what directory to run build.sh/cmd
 #   skipComponentGovernanceDetection: boolean
 #       Determines if component governance detection can be skipped
-#   continueOnBuildError: boolean
-#       Specifies whether continueOnError is set for the build step
 #
 # See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details
 #
 
 parameters:
+  # jobName: '' - use agentOs by default.
+  # jobDisplayName: '' - use agentOs by default.
   agentOs: 'Windows'
   buildArgs: ''
-  configuration: 'Release'
   beforeBuild: []
   # steps: []  don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.steps)"
   afterBuild: []
-  codeSign: false
+  artifacts: []
   dependsOn: ''
   condition: ''
-  # jobName: '' - use agentOs by default.
-  # jobDisplayName: '' - use agentOs by default.
-  artifacts: []
+  codeSign: false
   buildDirectory: $(System.DefaultWorkingDirectory)/eng/
-  installTar: true
+  skipComponentGovernanceDetection: false
+
+  configuration: 'Release'
+  container: ''
+  enableRichCodeNavigation: ''
   installNodeJs: true
-  installJdk: true
+  installJdk: true # Ignored unless agentOs == Windows.
+  isTestingJob: false
   timeoutInMinutes: 180
   testRunTitle: $(AgentOsName)-$(BuildConfiguration)
   useHostedUbuntu: true
-  skipComponentGovernanceDetection: false
-  continueOnBuildError: false
 
   # We need longer than the default amount of 5 minutes to upload our logs/artifacts. (We currently take around 5 mins in the best case).
   # This makes sure we have time to upload everything in the case of a build timeout - really important for investigating a build
@@ -180,10 +180,9 @@ jobs:
             Write-Host "##vso[task.setvariable variable=SeleniumProcessTrackingFolder]$(Build.SourcesDirectory)\artifacts\tmp\selenium\"
             ./eng/scripts/InstallGoogleChrome.ps1
           displayName: Install Chrome
-    - ${{ if and(eq(parameters.installTar, 'true'), eq(parameters.agentOs, 'Windows')) }}:
+    - ${{ if eq(parameters.agentOs, 'Windows') }}:
       - powershell: ./eng/scripts/InstallTar.ps1
         displayName: Find or install Tar
-    - ${{ if eq(parameters.agentOs, 'Windows') }}:
       - powershell: Write-Host "##vso[task.prependpath]$(DOTNET_CLI_HOME)\.dotnet\tools"
         displayName: Add dotnet tools to path
     - ${{ if ne(parameters.agentOs, 'Windows') }}:
@@ -230,14 +229,12 @@ jobs:
       - ${{ if eq(parameters.agentOs, 'Windows') }}:
         - script: $(BuildDirectory)\build.cmd -ci -nobl -Configuration $(BuildConfiguration) $(BuildScriptArgs) /p:DotNetSignType=$(_SignType)
           displayName: Run build.cmd
-          continueOnError: ${{ parameters.continueOnBuildError }}
           env:
             COMPlus_DbgEnableMiniDump: 1
             COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
       - ${{ if ne(parameters.agentOs, 'Windows') }}:
         - script: $(BuildDirectory)/build.sh --ci --nobl --configuration $(BuildConfiguration) $(BuildScriptArgs)
           displayName: Run build.sh
-          continueOnError: ${{ parameters.continueOnBuildError }}
           env:
             COMPlus_DbgEnableMiniDump: 1
             COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"

--- a/.azure/pipelines/richnav.yml
+++ b/.azure/pipelines/richnav.yml
@@ -24,7 +24,6 @@ stages:
   # Build Windows (x64/x86)
   - template: jobs/default-build.yml
     parameters:
-      codeSign: false
       jobName: Windows_build
       jobDisplayName: "Build: Windows x64/x86"
       enableRichCodeNavigation: true

--- a/.azure/pipelines/stress.yml
+++ b/.azure/pipelines/stress.yml
@@ -19,7 +19,6 @@ variables:
 jobs:
 - template: jobs/default-build.yml
   parameters:
-    condition: ne(variables['SkipTests'], 'true')
     jobName: Windows_Stress_Test
     jobDisplayName: "Windows Stress test"
     agentOs: Windows


### PR DESCRIPTION
- do not set parameters to their default values
  - do not set `installJdk` except in Windows jobs (ignored otherwise)
- remove unused `continueOnBuildError` and `installTar` parameters
  - components-e2e-tests.yml no longer needs `continueOnBuildError`
- remove confusing `SkipTests` conditions in test-only pipelines

nits:
- sort parameters to align with documentation
- provide defaults for undocumented parameters (reduce searching)