### PR TITLE
Add additional types to SuppressChildValidationMetadataProvider  (#37150)

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -134,6 +135,11 @@ namespace Microsoft.AspNetCore.Mvc
 
             // Add types to be excluded from Validation
             modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Type)));
+            modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Delegate)));
+            modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(MethodInfo)));
+            modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(MemberInfo)));
+            modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(ParameterInfo)));
+            modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Assembly)));
             modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Uri)));
             modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(CancellationToken)));
             modelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(IFormFile)));

--- a/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
+++ b/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
@@ -213,6 +213,31 @@ namespace Microsoft.AspNetCore.Mvc
                 provider =>
                 {
                     var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
+                    Assert.Equal(typeof(Delegate), excludeFilter.Type);
+                },
+                provider =>
+                {
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
+                    Assert.Equal(typeof(MethodInfo), excludeFilter.Type);
+                },
+                provider =>
+                {
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
+                    Assert.Equal(typeof(MemberInfo), excludeFilter.Type);
+                },
+                provider =>
+                {
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
+                    Assert.Equal(typeof(ParameterInfo), excludeFilter.Type);
+                },
+                provider =>
+                {
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
+                    Assert.Equal(typeof(Assembly), excludeFilter.Type);
+                },
+                provider =>
+                {
+                    var excludeFilter = Assert.IsType<SuppressChildValidationMetadataProvider>(provider);
                     Assert.Equal(typeof(Uri), excludeFilter.Type);
                 },
                 provider =>

--- a/src/Mvc/test/Mvc.IntegrationTests/ModelBindingTestHelper.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ModelBindingTestHelper.cs
@@ -87,7 +87,8 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
         public static ParameterBinder GetParameterBinder(
             IModelMetadataProvider metadataProvider,
             IModelBinderProvider binderProvider = null,
-            MvcOptions mvcOptions = null)
+            MvcOptions mvcOptions = null,
+            ObjectModelValidator validator = null)
         {
             var services = GetServices(metadataProvider, mvcOptions: mvcOptions);
             var options = services.GetRequiredService<IOptions<MvcOptions>>();
@@ -97,13 +98,15 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
                 options.Value.ModelBinderProviders.Insert(0, binderProvider);
             }
 
+            validator ??= new DefaultObjectValidator(
+                metadataProvider,
+                new[] { new CompositeModelValidatorProvider(GetModelValidatorProviders(options)) },
+                options.Value);
+
             return new ParameterBinder(
                 metadataProvider,
                 new ModelBinderFactory(metadataProvider, options, services),
-                new DefaultObjectValidator(
-                    metadataProvider,
-                    new[] { new CompositeModelValidatorProvider(GetModelValidatorProviders(options)) },
-                    options.Value),
+                validator,
                 options,
                 NullLoggerFactory.Instance);
         }

--- a/src/Mvc/test/Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -18,6 +18,8 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -2437,10 +2439,105 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
 
         private static void Validation_InifnitelyRecursiveModel_ValidationOnTopLevelParameterMethod([Required] RecursiveModel model) { }
 
+        [Fact]
+        public async Task Validation_ModelWithNonNullableReferenceTypes_DoesNotValidateNonNullablePropertiesOnFrameworkTypes()
+        {
+            // Arrange
+            var parameterInfo = GetType().GetMethod(nameof(Validation_ModelWithNonNullableReferenceTypes_DoesNotValidateNonNullablePropertiesOnFrameworkTypesAction), BindingFlags.NonPublic | BindingFlags.Static)
+                .GetParameters()
+                .First();
+
+            var modelMetadataProvider = TestModelMetadataProvider.CreateDefaultProvider();
+            var services = ModelBindingTestHelper.GetServices(modelMetadataProvider);
+            var modelMetadata = modelMetadataProvider.GetMetadataForParameter(parameterInfo);
+            var options = services.GetRequiredService<IOptions<MvcOptions>>().Value;
+            var validator = new RecordingObjectValidator(
+                modelMetadataProvider,
+                 TestModelValidatorProvider.CreateDefaultProvider().ValidatorProviders,
+                 options);
+            var parameterBinder = ModelBindingTestHelper.GetParameterBinder(modelMetadataProvider, mvcOptions: options, validator: validator);
+
+            var parameter = new ParameterDescriptor()
+            {
+                Name = parameterInfo.Name,
+                ParameterType = parameterInfo.ParameterType,
+            };
+
+            var testContext = ModelBindingTestHelper.GetTestContext(request =>
+            {
+                request.QueryString = new QueryString("?Name=CoolName");
+            });
+            var modelState = testContext.ModelState;
+
+            // Act
+            var modelBindingResult = await parameterBinder.BindModelAsync(parameter, testContext, modelMetadataProvider, modelMetadata);
+
+            // Assert
+            Assert.True(modelBindingResult.IsModelSet);
+
+            var model = Assert.IsType<ModelWithNonNullableReferenceTypeProperties>(modelBindingResult.Model);
+            Assert.Equal("CoolName", model.Name);
+
+            Assert.True(modelState.IsValid);
+            Assert.Equal(ModelValidationState.Valid, modelState.ValidationState);
+
+            var visited = validator.ValidationVisitor.Visited;
+            Assert.Collection(
+                visited,
+                v => Assert.Equal(typeof(ModelWithNonNullableReferenceTypeProperties), v.ModelType),
+                v => Assert.Equal(typeof(string), v.ModelType),
+                v => Assert.Equal(typeof(Delegate), v.ModelType));
+        }
+
+#nullable enable
+        private static void Validation_ModelWithNonNullableReferenceTypes_DoesNotValidateNonNullablePropertiesOnFrameworkTypesAction(ModelWithNonNullableReferenceTypeProperties model) { }
+
+        public class ModelWithNonNullableReferenceTypeProperties
+        {
+            public string Name { get; set; } = default!;
+
+            public Delegate Delegate { get; set; } = typeof(ModelWithNonNullableReferenceTypeProperties).GetMethod(nameof(SomeMethod))!.CreateDelegate<Action>();
+
+            public static void SomeMethod() { }
+        }
+#nullable restore
+
         private static void AssertRequiredError(string key, ModelError error)
         {
             Assert.Equal(ValidationAttributeUtil.GetRequiredErrorMessage(key), error.ErrorMessage);
             Assert.Null(error.Exception);
+        }
+
+        private class RecordingObjectValidator : DefaultObjectValidator
+        {
+            public RecordingObjectValidator(IModelMetadataProvider modelMetadataProvider, IList<IModelValidatorProvider> validatorProviders, MvcOptions mvcOptions)
+                : base(modelMetadataProvider, validatorProviders, mvcOptions)
+            {
+            }
+
+            public RecordingValidationVisitor ValidationVisitor { get; private set; }
+
+            public override ValidationVisitor GetValidationVisitor(ActionContext actionContext, IModelValidatorProvider validatorProvider, ValidatorCache validatorCache, IModelMetadataProvider metadataProvider, ValidationStateDictionary validationState)
+            {
+                ValidationVisitor = new RecordingValidationVisitor(actionContext, validatorProvider, validatorCache, metadataProvider, validationState);
+                return ValidationVisitor;
+            }
+        }
+
+        private class RecordingValidationVisitor : ValidationVisitor
+        {
+            public RecordingValidationVisitor(ActionContext actionContext, IModelValidatorProvider validatorProvider, ValidatorCache validatorCache, IModelMetadataProvider metadataProvider, ValidationStateDictionary validationState)
+                : base(actionContext, validatorProvider, validatorCache, metadataProvider, validationState)
+            {
+            }
+
+            public List<ModelMetadata> Visited = new();
+
+            protected override bool Visit(ModelMetadata metadata, string key, object model)
+            {
+                Visited.Add(metadata);
+                return base.Visit(metadata, key, model);
+            }
         }
     }
 }


### PR DESCRIPTION
Prevent 'System.Delegate' and some reflection types from being validated.

Fixes https://github.com/dotnet/aspnetcore/issues/36919

### Description

MVC has where it will attempt to ensure that properties of a model being bound, that are marked as non-nullable, and indeed not null during validation. Validation will also recurse over the entire object graph. In the user reported issue, the user had a `System.Delegate` type appear in their model. Since the BCL is annotated for nullability, MVC's validation ends up at `Assembly.ExportedTypes` via `Delegate.MethodInfo` and ends up visiting every `Type` instance on it.

While we think we need a better fix for this in 7.0, we'd like to consider a much more limited fix for 6.0 by preventing properties on `Delegate` and some reflection types from being validated. MVC already excludes some types including `System.Type` from being validated, so this is an expansion of the list to include `Delegate` and a few reflection types such as `MethodInfo`, `ParameterInfo`, that would not warrant validation.

### Regression
No

### Testing
[x] Manual
[x] Automated

### Risk

It's possible that someone's actually trying to model bind a custom instance of `MethodInfo` that does need to be validated for nullability. This is an incredibly contrived scenario and we don't have any evidence anyone is actually doing so. Users should be able to workaround this by configuring `MvcOptions` to allow these types to be validated.