### PR TITLE
Use Authorization header in WebSockets on Node

### DIFF
--- a/src/SignalR/clients/ts/signalr/tests/WebSocketTransport.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/WebSocketTransport.test.ts
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+import { HeaderNames } from "../src/HeaderNames";
 import { MessageHeaders } from "../src/IHubProtocol";
 import { ILogger } from "../src/ILogger";
 import { TransferFormat } from "../src/ITransport";
@@ -97,15 +98,20 @@ describe("WebSocketTransport", () => {
         });
     });
 
-    [["http://example.com", "ws://example.com?access_token=secretToken"],
-    ["http://example.com?value=null", "ws://example.com?value=null&access_token=secretToken"],
-    ["https://example.com?value=null", "wss://example.com?value=null&access_token=secretToken"]]
+    [[undefined as any, undefined],
+    ["secretToken", "Bearer secretToken"],
+    ["", undefined]]
         .forEach(([input, expected]) => {
-            it(`generates correct WebSocket URL for  ${input} with access_token`, async () => {
+            it(`sets Authorization header with ${input} correctly`, async () => {
                 await VerifyLogger.run(async (logger) => {
-                    await createAndStartWebSocket(logger, input, () => "secretToken");
+                    await createAndStartWebSocket(logger, "http://example.com", () => input);
 
-                    expect(TestWebSocket.webSocket.url).toBe(expected);
+                    expect(TestWebSocket.webSocket.url).toBe("ws://example.com");
+                    if (expected) {
+                        expect(TestWebSocket.webSocket.options.headers[HeaderNames.Authorization]).toBe(expected);
+                    } else {
+                        expect(TestWebSocket.webSocket.options.headers[HeaderNames.Authorization]).toBeUndefined();
+                    }
                 });
             });
         });


### PR DESCRIPTION
We can set headers in WebSockets on Node, so we should set the Authorization header in that case instead of using the query string.

Saw something on stackoverflow a few months ago that was related to this and forgot to file an issue, so now I'm just fixing it 😃 