### PR TITLE
Fix virtualization handling of large dataset length changes. Fixes #37245

### DIFF
--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -308,6 +308,14 @@ namespace Microsoft.AspNetCore.Components.Web.Virtualization
 
         private void UpdateItemDistribution(int itemsBefore, int visibleItemCapacity)
         {
+            // If the itemcount just changed to a lower number, and we're already scrolled past the end of the new
+            // reduced set of items, clamp the scroll position to the new maximum
+            if (itemsBefore + visibleItemCapacity > _itemCount)
+            {
+                itemsBefore = Math.Max(0, _itemCount - visibleItemCapacity);
+            }
+
+            // If anything about the offset changed, re-render
             if (itemsBefore != _itemsBefore || visibleItemCapacity != _visibleItemCapacity)
             {
                 _itemsBefore = itemsBefore;

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationDataChanges.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationDataChanges.razor
@@ -38,10 +38,33 @@
     </Virtualize>
 </div>
 
+<h4>Large data set with size changes</h4>
+<p>
+    Data set length:
+    <select id="large-dataset-length" value="@largeDataSetLength" @onchange="@(e => SetLargeDataSetLengthAsync(int.Parse((string)e.Value)))">
+        <option>25</option>
+        <option>1000</option>
+        <option>100000</option>
+    </select>
+    Last rendered:
+    <span id="large-dataset-length-lastrendered">@largeDataSetLengthLastRendered</span>
+</p>
+<div id="removing-many" style="overflow-y: auto; height: 200px; border: 1px dashed gray;">
+    <Virtualize @ref="removeManyVirtualize" ItemsProvider="GetLargeDataSetAsync">
+        <div @key="@context.Name" class="person" style="border-bottom: 1px solid silver; padding: 4px;">
+            <span>@context.Name</span>
+        </div>
+    </Virtualize>
+</div>
+
 @code {
     Virtualize<Person> asyncVirtualize;
+    Virtualize<Person> removeManyVirtualize;
     List<Person> fixedPeople = Enumerable.Range(1, 3).Select(GeneratePerson).ToList();
     int numPeopleInItemsProvider = 3;
+
+    int largeDataSetLength = 25;
+    int? largeDataSetLengthLastRendered;
 
     void AddPersonToFixedList()
     {
@@ -67,6 +90,27 @@
         return new ItemsProviderResult<Person>(
             Enumerable.Range(1 + request.StartIndex, lastIndexExcl - request.StartIndex).Select(GeneratePerson).ToList(),
             numPeopleInItemsProvider);
+    }
+
+    async Task SetLargeDataSetLengthAsync(int length)
+    {
+        largeDataSetLength = length;
+        await removeManyVirtualize.RefreshDataAsync();
+    }
+
+    async ValueTask<ItemsProviderResult<Person>> GetLargeDataSetAsync(ItemsProviderRequest request)
+    {
+        await Task.Delay(500);
+        largeDataSetLengthLastRendered = largeDataSetLength;
+
+        // Behave like a .Skip(startIndex).Take(count), so that if you ask for data beyond the end of the
+        // set, you get back nothing
+        var lastIndexExcl = Math.Min(request.StartIndex + request.Count, largeDataSetLength);
+        var effectiveCount = lastIndexExcl - request.StartIndex;
+        var resultItems = effectiveCount <= 0
+            ? Enumerable.Empty<Person>()
+            : Enumerable.Range(1 + request.StartIndex, effectiveCount).Select(GeneratePerson).ToList();
+        return new ItemsProviderResult<Person>(resultItems, largeDataSetLength);
     }
 
     class Person


### PR DESCRIPTION
Fix for https://github.com/dotnet/aspnetcore/issues/37245

This is a really small and simple change to `Virtualize.cs`. We just detect the invalid offset and clamp it back to the valid range. It shouldn't affect any case where the offset is valid.

Most of this PR is just the E2E test coverage.