### PR TITLE
Added nullable overload for markupString

### DIFF
--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -29,6 +29,7 @@ Microsoft.AspNetCore.Components.NavigationOptions.NavigationOptions() -> void
 Microsoft.AspNetCore.Components.NavigationOptions.ReplaceHistoryEntry.get -> bool
 Microsoft.AspNetCore.Components.NavigationOptions.ReplaceHistoryEntry.init -> void
 Microsoft.AspNetCore.Components.RenderHandle.IsRenderingOnMetadataUpdate.get -> bool
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent(int sequence, Microsoft.AspNetCore.Components.MarkupString? markupContent) -> void
 Microsoft.AspNetCore.Components.RenderTree.Renderer.RemoveRootComponent(int componentId) -> void
 Microsoft.AspNetCore.Components.IPersistentComponentStateStore
 Microsoft.AspNetCore.Components.Infrastructure.ComponentStatePersistenceManager

--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -135,6 +135,14 @@ namespace Microsoft.AspNetCore.Components.Rendering
         /// Appends a frame representing markup content.
         /// </summary>
         /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
+        /// <param name="markupContent">nullable MarkupString object for the new markup frame.</param>
+        public void AddContent(int sequence, MarkupString? markupContent)
+            => AddMarkupContent(sequence, markupContent?.Value);
+
+        /// <summary>
+        /// Appends a frame representing markup content.
+        /// </summary>
+        /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
         /// <param name="markupContent">Content for the new markup frame.</param>
         public void AddContent(int sequence, MarkupString markupContent)
             => AddMarkupContent(sequence, markupContent.Value);

--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -135,7 +135,7 @@ namespace Microsoft.AspNetCore.Components.Rendering
         /// Appends a frame representing markup content.
         /// </summary>
         /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
-        /// <param name="markupContent">nullable MarkupString object for the new markup frame.</param>
+        /// <param name="markupContent">Content for the new text frame, or null.</param>
         public void AddContent(int sequence, MarkupString? markupContent)
             => AddMarkupContent(sequence, markupContent?.Value);
 

--- a/src/Components/Components/test/Rendering/RenderTreeBuilderTest.cs
+++ b/src/Components/Components/test/Rendering/RenderTreeBuilderTest.cs
@@ -88,6 +88,28 @@ namespace Microsoft.AspNetCore.Components.Rendering
         }
 
         [Fact]
+        public void CanAddNullableMarkupViaMarkupString()
+        {
+            // This represents putting @someMarkupString into the component,
+            // as opposed to calling builder.AddMarkupContent directly.
+
+            // Arrange
+            var builder = new RenderTreeBuilder();
+            MarkupString? nullableEmptyString = new MarkupString(null);
+            MarkupString? nullableString = new MarkupString("Test nullable Markup");
+
+            // Act - can use either constructor or cast
+            builder.AddContent(0, nullableString);
+            builder.AddContent(1, nullableEmptyString);
+
+            // Assert
+            var frames = builder.GetFrames();
+            Assert.Collection(frames.AsEnumerable(),
+                frame => AssertFrame.Markup(frame, "Test nullable Markup"),
+                frame => AssertFrame.Markup(frame, string.Empty));
+        }
+
+        [Fact]
         public void CanAddNullMarkup()
         {
             // Arrange


### PR DESCRIPTION
When the markupstring is declared as nullable, the HTML does not get rendered.

**PR Description**
Added the nullable markupstring overload in rendertreebuilder

Fixes #32099 