### PR TITLE
[release/6.0] Honor FromRoute parameter name when specified

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -215,13 +215,14 @@ namespace Microsoft.AspNetCore.Http
 
             if (parameterCustomAttributes.OfType<IFromRouteMetadata>().FirstOrDefault() is { } routeAttribute)
             {
-                factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.RouteAttribue);
-                if (factoryContext.RouteParameters is { } routeParams && !routeParams.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase))
+                var routeName = routeAttribute.Name ?? parameter.Name;
+                factoryContext.TrackedParameters.Add(routeName, RequestDelegateFactoryConstants.RouteAttribute);
+                if (factoryContext.RouteParameters is { } routeParams && !routeParams.Contains(routeName, StringComparer.OrdinalIgnoreCase))
                 {
-                    throw new InvalidOperationException($"{parameter.Name} is not a route paramter.");
+                    throw new InvalidOperationException($"'{routeName}' is not a route parameter.");
                 }
 
-                return BindParameterFromProperty(parameter, RouteValuesExpr, routeAttribute.Name ?? parameter.Name, factoryContext, "route");
+                return BindParameterFromProperty(parameter, RouteValuesExpr, routeName, factoryContext, "route");
             }
             else if (parameterCustomAttributes.OfType<IFromQueryMetadata>().FirstOrDefault() is { } queryAttribute)
             {

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Http
             if (parameterCustomAttributes.OfType<IFromRouteMetadata>().FirstOrDefault() is { } routeAttribute)
             {
                 var routeName = routeAttribute.Name ?? parameter.Name;
-                factoryContext.TrackedParameters.Add(routeName, RequestDelegateFactoryConstants.RouteAttribute);
+                factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.RouteAttribue);
                 if (factoryContext.RouteParameters is { } routeParams && !routeParams.Contains(routeName, StringComparer.OrdinalIgnoreCase))
                 {
                     throw new InvalidOperationException($"'{routeName}' is not a route parameter.");

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -880,7 +880,7 @@ namespace Microsoft.AspNetCore.Http
                 factoryContext.ParamCheckExpressions.Add(checkRequiredBodyBlock);
             }
 
-            // (ParamterType)boundValues[i]
+            // (ParameterType)boundValues[i]
             return Expression.Convert(boundValueExpr, parameter.ParameterType);
         }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -340,7 +340,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 RequestDelegateFactory.Create(([FromRoute] int id) => { }, new() { RouteParameterNames = Array.Empty<string>() }));
 
-            Assert.Equal("id is not a route paramter.", ex.Message);
+            Assert.Equal("'id' is not a route parameter.", ex.Message);
         }
 
         [Fact]

--- a/src/Http/Routing/src/Template/TemplatePart.cs
+++ b/src/Http/Routing/src/Template/TemplatePart.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Routing.Template
         }
 
         /// <summary>
-        /// Creates a <see cref="TemplatePart"/> representing a paramter part.
+        /// Creates a <see cref="TemplatePart"/> representing a parameter part.
         /// </summary>
         /// <param name="name">The name of the parameter.</param>
         /// <param name="isCatchAll"><see langword="true"/> if the parameter is a catch-all parameter.</param>
@@ -128,15 +128,15 @@ namespace Microsoft.AspNetCore.Routing.Template
         /// </summary>
         public string? Name { get; private set; }
         /// <summary>
-        /// The textual representation of the route paramter. Can be null. Used to represent route seperators and literal parts.
+        /// The textual representation of the route parameter. Can be null. Used to represent route seperators and literal parts.
         /// </summary>
         public string? Text { get; private set; }
         /// <summary>
-        /// The default value for route paramters. Can be null.
+        /// The default value for route parameters. Can be null.
         /// </summary>
         public object? DefaultValue { get; private set; }
         /// <summary>
-        /// The constraints associates with a route paramter.
+        /// The constraints associates with a route parameter.
         /// </summary>
         public IEnumerable<InlineConstraint> InlineConstraints { get; private set; } = Enumerable.Empty<InlineConstraint>();
 

--- a/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
@@ -498,7 +498,63 @@ namespace Microsoft.AspNetCore.Builder
         {
             var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
             var ex = Assert.Throws<InvalidOperationException>(() => builder.MapGet("/", ([FromRoute] int id) => { }));
-            Assert.Equal("id is not a route paramter.", ex.Message);
+            Assert.Equal("'id' is not a route parameter.", ex.Message);
+        }
+
+        [Fact]
+        public async Task MapGetWithNamedFromRouteParameter_UsesFromRouteName()
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
+            _ = builder.MapGet("/{value}", ([FromRoute(Name = "value")] int id, HttpContext httpContext) =>
+            {
+                httpContext.Items["value"] = id;
+            });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            // Assert that we don't fallback to the query string
+            var httpContext = new DefaultHttpContext();
+
+            httpContext.Request.RouteValues["value"] = "42";
+
+            await endpoint.RequestDelegate!(httpContext);
+
+            Assert.Equal(42, httpContext.Items["value"]);
+        }
+
+        [Fact]
+        public async Task MapGetWithNamedFromRouteParameter_FailsForParameterName()
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
+            _ = builder.MapGet("/{value}", ([FromRoute(Name = "value")] int id, HttpContext httpContext) =>
+            {
+                httpContext.Items["value"] = id;
+            });
+
+            var dataSource = GetBuilderEndpointDataSource(builder);
+            // Trigger Endpoint build by calling getter.
+            var endpoint = Assert.Single(dataSource.Endpoints);
+
+            // Assert that we don't fallback to the query string
+            var httpContext = new DefaultHttpContext();
+            httpContext.RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider();
+
+            httpContext.Request.RouteValues["id"] = "42";
+
+            await endpoint.RequestDelegate!(httpContext);
+
+            Assert.Null(httpContext.Items["value"]);
+            Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+        }
+
+        [Fact]
+        public void MapGetWithNamedFromRouteParameter_ThrowsForMismatchedPattern()
+        {
+            var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(new EmptyServiceProvider()));
+            var ex = Assert.Throws<InvalidOperationException>(() =>builder.MapGet("/{id}", ([FromRoute(Name = "value")] int id, HttpContext httpContext) => { }));
+            Assert.Equal("'value' is not a route parameter.", ex.Message);
         }
 
         [Fact]

--- a/src/Http/Routing/test/UnitTests/DefaultLinkGeneratorProcessTemplateTest.cs
+++ b/src/Http/Routing/test/UnitTests/DefaultLinkGeneratorProcessTemplateTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -856,7 +856,7 @@ namespace Microsoft.AspNetCore.Routing
 
         // Default values are visible to the constraint when they are used to fill a parameter.
         [Fact]
-        public void TryProcessTemplate_ConstraintsSeesDefault_WhenThereItsAParamter()
+        public void TryProcessTemplate_ConstraintsSeesDefault_WhenThereItsAParameter()
         {
             // Arrange
             var constraint = new CapturingConstraint();

--- a/src/Http/Routing/test/UnitTests/RouteTest.cs
+++ b/src/Http/Routing/test/UnitTests/RouteTest.cs
@@ -1050,7 +1050,7 @@ namespace Microsoft.AspNetCore.Routing
 
         // Default values are visible to the constraint when they are used to fill a parameter.
         [Fact]
-        public void GetVirtualPath_ConstraintsSeesDefault_WhenThereItsAParamter()
+        public void GetVirtualPath_ConstraintsSeesDefault_WhenThereItsAParameter()
         {
             // Arrange
             var constraint = new CapturingConstraint();


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/37271

## Customer Impact

A scenario just flat out does not work. If a `[FromRoute(Name = "someName")]` attribute is applied to a parameter then the name isn't used and we instead look at the parameter name, so if it doesn't match (which is more likely when you specified a name in the attribute) then we will throw, which is incorrect.

Example:
```
app.MapGet("/hello/{name}", ([FromRoute(Name = "name")] string doesNotMatter) =>
    $"Hello, {doesNotMatter}!");
```
This throws instead of working.

## Regression?
- [x] Yes
- [ ] No

This regressed in 6.0-preview7

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Very scoped change that doesn't affect a large area, we were just missing some simple tests and we added an exception code path that broke the scenario.

## Verification
- [x] Manual (required)
- [x] Automated