### PR TITLE
Health checks can use dependencies that implement IAsyncDisposable only

### DIFF
--- a/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
+++ b/src/HealthChecks/HealthChecks/src/DefaultHealthCheckService.cs
@@ -76,7 +76,8 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            using (var scope = _scopeFactory.CreateScope())
+            var scope = _scopeFactory.CreateAsyncScope();
+            await using (scope.ConfigureAwait(false))
             {
                 var healthCheck = registration.Factory(scope.ServiceProvider);
 

--- a/src/HealthChecks/HealthChecks/test/DefaultHealthCheckServiceTest.cs
+++ b/src/HealthChecks/HealthChecks/test/DefaultHealthCheckServiceTest.cs
@@ -434,6 +434,31 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
         }
 
         [Fact]
+        public async Task CheckHealthAsync_CheckCanHaveScopedDisposableDependencies()
+        {
+            // Arrange
+            var service = CreateHealthChecksService(b =>
+            {
+                b.Services.AddScoped<SynchronousDisposable>();
+                b.Services.AddScoped<AsyncOnlyDisposable>();
+                b.Services.AddScoped<SyncOrAsyncDisposable>();
+
+                b.AddCheck<DisposableDependeciesCheck>("TestDisposableDepenencies");
+            });
+
+            // Act
+            var results = await service.CheckHealthAsync();
+
+            // Assert
+            var healthCheck = (DisposableDependeciesCheck)results.Entries.Single().Value.Data.Single().Value;
+
+            Assert.True(healthCheck.SynchronousDisposable.IsDisposed);
+            Assert.True(healthCheck.AsyncOnlyDisposable.IsAsyncDisposed);
+            Assert.True(healthCheck.SyncOrAsyncDisposable.IsAsyncDisposed);
+            Assert.False(healthCheck.SyncOrAsyncDisposable.IsDisposed);
+        }
+
+        [Fact]
         public async Task CheckHealthAsync_CheckCanDependOnSingletonService()
         {
             // Arrange
@@ -682,6 +707,73 @@ namespace Microsoft.Extensions.Diagnostics.HealthChecks
             public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
             {
                 throw new Exception("check failed");
+            }
+        }
+
+        private class DisposableDependeciesCheck : IHealthCheck
+        {
+            public DisposableDependeciesCheck(
+                SynchronousDisposable disposable,
+                AsyncOnlyDisposable asyncOnlyDisposable,
+                SyncOrAsyncDisposable syncOrAsyncDisposable)
+            {
+                SynchronousDisposable = disposable;
+                AsyncOnlyDisposable = asyncOnlyDisposable;
+                SyncOrAsyncDisposable = syncOrAsyncDisposable;
+            }
+
+            public SynchronousDisposable SynchronousDisposable { get; }
+
+            public AsyncOnlyDisposable AsyncOnlyDisposable { get; }
+
+            public SyncOrAsyncDisposable SyncOrAsyncDisposable { get; }
+
+            public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(HealthCheckResult.Healthy(data: new Dictionary<string, object> { { "self", this } }));
+            }
+        }
+
+        private class SynchronousDisposable : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose()
+            {
+                if (IsDisposed) throw new InvalidOperationException("Dependency disposed multiple times.");
+                IsDisposed = true;
+            }
+        }
+
+        private class AsyncOnlyDisposable : IAsyncDisposable
+        {
+            public bool IsAsyncDisposed { get; private set; }
+
+            public ValueTask DisposeAsync()
+            {
+                if (IsAsyncDisposed) throw new InvalidOperationException("Dependency disposed multiple times.");
+                IsAsyncDisposed = true;
+                return default;
+            }
+        }
+
+        private class SyncOrAsyncDisposable : IDisposable, IAsyncDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public bool IsAsyncDisposed { get; private set; }
+
+            public void Dispose()
+            {
+                if (IsDisposed || IsAsyncDisposed) throw new InvalidOperationException("Dependency disposed multiple times.");
+                IsDisposed = true;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                if (IsDisposed || IsAsyncDisposed) throw new InvalidOperationException("Dependency disposed multiple times.");
+                IsAsyncDisposed = true;
+                return default;
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**Health checks can use dependencies that implement `IAsyncDisposable` only**
DefaultHealthCheckService uses CreateAsyncScope() and disposes asynchronously.

**PR Description**
Currently health checks with dependencies that implement only `IAsyncDisposable` (and not `IDisposable`) will fail: `System.InvalidOperationException : 'SomeDependency' type only implements IAsyncDisposable. Use DisposeAsync to dispose the container.` The PR updates `DefaultHealthCheckService` to use `IServiceScopeFactory.CreateAsyncScope()` instead of `IServiceScopeFactory.CreateScope()` and disposes the scope asynchronously.

Fixes #37296 
