### PR TITLE
[release/6.0] Support struct IResults

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -487,6 +487,11 @@ namespace Microsoft.AspNetCore.Http
             }
             else if (typeof(IResult).IsAssignableFrom(returnType))
             {
+                if (returnType.IsValueType)
+                {
+                    var box = Expression.TypeAs(methodCall, typeof(IResult));
+                    return Expression.Call(ResultWriteResponseAsyncMethod, box, HttpContextExpr);
+                }
                 return Expression.Call(ResultWriteResponseAsyncMethod, methodCall, HttpContextExpr);
             }
             else if (returnType == typeof(string))

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2005,6 +2005,10 @@ namespace Microsoft.AspNetCore.Routing.Internal
                 static Task<object> StaticTaskOfIResultAsObject() => Task.FromResult<object>(new CustomResult("Still not enough tests!"));
                 static ValueTask<object> StaticValueTaskOfIResultAsObject() => ValueTask.FromResult<object>(new CustomResult("Still not enough tests!"));
 
+                StructResult TestStructAction() => new StructResult(resultString);
+                Task<StructResult> TaskTestStructAction() => Task.FromResult(new StructResult(resultString));
+                ValueTask<StructResult> ValueTaskTestStructAction() => ValueTask.FromResult(new StructResult(resultString));
+
                 return new List<object[]>
                 {
                     new object[] { (Func<CustomResult>)TestAction },
@@ -2023,6 +2027,10 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
                     new object[] { (Func<Task<object>>)StaticTaskOfIResultAsObject},
                     new object[] { (Func<ValueTask<object>>)StaticValueTaskOfIResultAsObject},
+
+                    new object[] { (Func<StructResult>)TestStructAction },
+                    new object[] { (Func<Task<StructResult>>)TaskTestStructAction },
+                    new object[] { (Func<ValueTask<StructResult>>)ValueTaskTestStructAction },
                 };
             }
         }
@@ -3239,6 +3247,21 @@ namespace Microsoft.AspNetCore.Routing.Internal
             private readonly string _resultString;
 
             public CustomResult(string resultString)
+            {
+                _resultString = resultString;
+            }
+
+            public Task ExecuteAsync(HttpContext httpContext)
+            {
+                return httpContext.Response.WriteAsync(_resultString);
+            }
+        }
+
+        private struct StructResult : IResult
+        {
+            private readonly string _resultString;
+
+            public StructResult(string resultString)
             {
                 _resultString = resultString;
             }


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/37344

## Customer Impact

If a customer defines a custom `IResult` as a struct instead of as a class they will get an error which doesn't really describe the problem:
```
Unhandled exception. System.ArgumentException: Expression of type 'CustomResult' cannot be used for parameter of type 'Microsoft.AspNetCore.Http.IResult' of method 'System.Threading.Tasks.Task ExecuteResultWriteResponse(Microsoft.AspNetCore.Http.IResult, Microsoft.AspNetCore.Http.HttpContext)' (Parameter 'arg0')
   at System.Dynamic.Utils.ExpressionUtils.ValidateOneArgument(MethodBase method, ExpressionType nodeKind, Expression arguments, ParameterInfo pi, String methodParamName, String argumentParamName, Int32 index)
   at System.Linq.Expressions.Expression.Call(MethodInfo method, Expression arg0, Expression arg1)
   at Microsoft.AspNetCore.Http.RequestDelegateFactory.AddResponseWritingToMethodCall(Expression methodCall, Type returnType)
   // removed for simplicity
   at Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapGet(IEndpointRouteBuilder endpoints, String pattern, Delegate handler)
   at Program.<Main>$(String[] args) in C:\Projects\WebApplication110\WebApplication110\Program.cs:line 4
```
This is a bug and structs should be allowed.

Example:
```csharp
app.MapGet("/endpoint", () => new CustomResult());

public struct CustomResult : IResult
{
    public Task ExecuteAsync(HttpContext httpContext)
    {
        httpContext.Response.StatusCode = StatusCodes.Status418ImATeapot;
        return Task.CompletedTask;
    }
}
```

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Very narrow scope, new code path should only be hit in `struct IResult` scenarios.

## Verification
- [x] Manual (required)
- [x] Automated