### PR TITLE
Remove `SkipNonexistentProjects` settings

### DIFF
--- a/eng/CodeGen.proj
+++ b/eng/CodeGen.proj
@@ -15,8 +15,7 @@
     <MSBuild Projects="@(ProjectToBuild)"
              Targets="GetReferencesProvided"
              BuildInParallel="true"
-             SkipNonexistentTargets="true"
-             SkipNonexistentProjects="true">
+             SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceProvider" />
     </MSBuild>
 

--- a/eng/CodeGen.proj
+++ b/eng/CodeGen.proj
@@ -15,7 +15,8 @@
     <MSBuild Projects="@(ProjectToBuild)"
              Targets="GetReferencesProvided"
              BuildInParallel="true"
-             SkipNonexistentTargets="true">
+             SkipNonexistentTargets="true"
+             SkipNonexistentProjects="true">
       <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceProvider" />
     </MSBuild>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -46,8 +46,7 @@
     -->
     <MSBuild Projects="$(RepoRoot)src\SignalR\clients\ts\FunctionalTests\SignalR.Npm.FunctionalTests.npmproj"
         Properties="DisableYarnCheck=true;ExcludeFromBuild=false"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
+        Targets="_GetPackageVersionInfo">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
     </MSBuild>
 
@@ -94,8 +93,7 @@
     -->
     <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
         Properties="DisableYarnCheck=true;ExcludeFromBuild=false"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
+        Targets="_GetPackageVersionInfo">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedProductVersionInfo" />
     </MSBuild>
 

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -79,8 +79,7 @@
     EXISTS('$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Runtime.$(TargetRuntimeIdentifier).$(SharedFxVersion).nupkg')">
     <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
         Properties="DisableYarnCheck=true;ExcludeFromBuild=false"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
+        Targets="_GetPackageVersionInfo">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedProductVersionInfo" />
     </MSBuild>
 

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -86,8 +86,7 @@
   <Target Name="GenerateTestData" BeforeTargets="GetAssemblyAttributes" DependsOnTargets="InitializeSourceControlInformation">
     <!-- Use the ref pack logic to compute the list of expected targeting pack content -->
     <MSBuild Projects="$(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-        Targets="_ResolveTargetingPackContent"
-        SkipNonexistentProjects="false">
+        Targets="_ResolveTargetingPackContent">
       <Output TaskParameter="TargetOutputs" ItemName="_TargetingPackDependencies" />
     </MSBuild>
 

--- a/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -69,8 +69,7 @@
       Condition=" '$(IsShipping)' == 'true' ">
     <!-- This target is defined in eng/targets/Packaging.targets and included in every C# and F# project. -->
     <MSBuild Projects="$(RepoRoot)src\SiteExtensions\LoggingBranch\LB.csproj"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
+        Targets="_GetPackageVersionInfo">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
     </MSBuild>
 

--- a/src/SiteExtensions/LoggingBranch/LB.csproj
+++ b/src/SiteExtensions/LoggingBranch/LB.csproj
@@ -40,8 +40,7 @@
   <Target Name="_GetHostingStartupPackageReference" BeforeTargets="GenerateHostingStartupDeps">
     <!-- This target is defined in eng/targets/Packaging.targets and included in every C# and F# project. -->
     <MSBuild Projects="$(RepoRoot)src\Azure\AzureAppServices.HostingStartup\src\Microsoft.AspNetCore.AzureAppServices.HostingStartup.csproj"
-        Targets="_GetPackageVersionInfo"
-        SkipNonexistentProjects="false">
+        Targets="_GetPackageVersionInfo">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
     </MSBuild>
 


### PR DESCRIPTION
- ~~stop covering up authoring errors w/ `SkipNonexistentTargets="true"`~~
  (our few `SkipNonexistentTargets="true"` uses are fine because some targets are not defined everywhere)
- `SkipNonexistentTargets="false"` is the default and not worth mentioning