### PR TITLE
Fix build on arm64 machines

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -98,6 +98,7 @@ and are generated based on the last package release.
     <!-- Crossgen2 compiler -->
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.osx-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.osx-arm64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-musl-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-x64" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -98,7 +98,10 @@ and are generated based on the last package release.
     <!-- Crossgen2 compiler -->
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.osx-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.osx-arm64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-arm64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-musl-arm" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-musl-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-musl-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-x64" />

--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -105,6 +105,8 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-musl-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-x64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-x86" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.freebsd-x64" />
   </ItemGroup>


### PR DESCRIPTION
Building ASP.NET Core on an arm64 machine using `./build.sh -arch arm64` leads to a dependency error because crossgen2 is not listed in eng/Dependencies.props.
