### PR TITLE
Add test for preload hosted services

### DIFF
--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -181,11 +181,45 @@ public static class Program
                     return 0;
                 }
 #endif
+            case "PreloadHostedService":
+                {
+                    var host = new HostBuilder().ConfigureWebHost((c) =>
+                    {
+                        c.ConfigureServices(services =>
+                        {
+                            services.AddSingleton<IHostedService, PreloadHostedService>();
+                        })
+                        .UseIIS()
+                        .UseStartup<Startup>();
+                    });
+                    host.Build().Run();
+                    return 0;
+                }
+
             default:
                 return StartServer();
 
         }
         return 12;
+    }
+
+    private class PreloadHostedService : IHostedService
+    {
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            File.WriteAllText("Preload_Started.txt", "");
+            Console.Error.WriteLine("Started preload hosted service...");
+            Console.Error.Flush();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            File.WriteAllText("Preload_Stopped.txt", "");
+            Console.Error.WriteLine("Stopped preload hosted service...");
+            Console.Error.Flush();
+            return Task.CompletedTask;
+        }
     }
 
     private static int StartServer()

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -184,16 +185,23 @@ public static class Program
 #endif
             case "PreloadHostedService":
                 {
-                    var host = new HostBuilder().ConfigureWebHost((c) =>
-                    {
-                        c.ConfigureServices(services =>
+                    var host = new WebHostBuilder()
+                        .ConfigureServices(services =>
                         {
                             services.AddSingleton<IHostedService, PreloadHostedService>();
                         })
+                        .ConfigureLogging((_, factory) =>
+                        {
+                            factory.AddConsole();
+                            factory.AddFilter("Console", level => level >= LogLevel.Information);
+                        })
+                        .UseKestrel()
                         .UseIIS()
-                        .UseStartup<Startup>();
-                    });
-                    host.Build().Run();
+                        .UseIISIntegration()
+                        .UseStartup<Startup>()
+                        .Build();
+
+                    host.Run();
                     return 0;
                 }
 


### PR DESCRIPTION
Test that demonstrates https://github.com/dotnet/aspnetcore/issues/28089

Stop is not called for preload hosted services, perhaps IIS just ungracefully kills things, @Tratcher any ideas for what we can do about this?