### PR TITLE
[release/3.1] Backport x64 on ARM64 installer changes

### DIFF
--- a/eng/targets/Wix.Common.props
+++ b/eng/targets/Wix.Common.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
     <ProductVersion>3.14</ProductVersion>
-    <WixVersion>1.0.0-v3.14.0.4118</WixVersion>
+    <WixVersion>1.0.0-v3.14.0.5722</WixVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/targets/Wix.Common.props
+++ b/eng/targets/Wix.Common.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
     <ProductVersion>3.14</ProductVersion>
-    <WixVersion>3.14.0-dotnet</WixVersion>
+    <WixVersion>1.0.0-v3.14.0.4118</WixVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,7 +20,7 @@
   <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.props" Condition="'$(_ProjectExtensionsWereImported)' != 'true'" />
 
   <ItemGroup>
-    <PackageReference Include="Wix" Version="$(WixVersion)" />
+    <PackageReference Include="Microsoft.Signed.Wix" Version="$(WixVersion)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="Microsoft.Signed.Wix" Version="1.0.0-v3.14.0.4118" />
+    <PackageReference Include="Microsoft.Signed.Wix" Version="1.0.0-v3.14.0.5722" />
 
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Framework" />

--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="Wix" Version="3.11.1" />
+    <PackageReference Include="Microsoft.Signed.Wix" Version="1.0.0-v3.14.0.4118" />
 
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Framework" />

--- a/src/Installers/Windows/Common/dotnethome_x64.wxs
+++ b/src/Installers/Windows/Common/dotnethome_x64.wxs
@@ -5,23 +5,28 @@
     <?define Platform = "$(sys.BUILDARCH)"?>
   <?endif?>
 
-  <!-- InstallerArchitecture matches the expected values for PROCESSOR_ARCHITECTURE
-       https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details  -->
+  <!-- InstallerNativeMachine matches the expected values for image file machine constants
+       https://docs.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants -->
   <?if $(var.Platform)~=x86?>
-    <?define InstallerArchitecture="X86"?>
+    <?define InstallerNativeMachine=332?>
   <?elseif $(var.Platform)~=x64?>
-    <?define InstallerArchitecture="AMD64"?>
+    <?define InstallerNativeMachine=34404?>
   <?elseif $(var.Platform)~=arm64?>
-    <?define InstallerArchitecture="ARM64"?>
+    <?define InstallerNativeMachine=43620?>
   <?else?>
-    <?error Unknown platform, $(var.Platform) ?>?
+    <?error Unknown platform, $(var.Platform) ?>
   <?endif?>
 
   <Fragment>
-    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE does not match the installer architecture
-          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <!-- Identify when installing in emulation as when WIX_NATIVE_MACHINE does not match the installer
+         native machine (where supported).  Also detect running under WOW on x86 using VersionNT64,
+         since WIX_NATIVE_MACHINE cannot be retrieved on older Windows builds. -->
+    <PropertyRef Id="WIX_NATIVE_MACHINE" />
     <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize">
-      NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
+     <?if $(var.Platform)~=x86?>
+      VersionNT64 OR
+     <?endif?>
+      WIX_NATIVE_MACHINE AND NOT WIX_NATIVE_MACHINE="$(var.InstallerNativeMachine)"
     </SetProperty>
   </Fragment>
 

--- a/src/Installers/Windows/Common/dotnethome_x64.wxs
+++ b/src/Installers/Windows/Common/dotnethome_x64.wxs
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?ifndef Platform?>
+    <?define Platform = "$(sys.BUILDARCH)"?>
+  <?endif?>
+
+  <!-- InstallerArchitecture matches the expected values for PROCESSOR_ARCHITECTURE
+       https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details  -->
+  <?if $(var.Platform)~=x86?>
+    <?define InstallerArchitecture="X86"?>
+  <?elseif $(var.Platform)~=x64?>
+    <?define InstallerArchitecture="AMD64"?>
+  <?elseif $(var.Platform)~=arm64?>
+    <?define InstallerArchitecture="ARM64"?>
+  <?else?>
+    <?error Unknown platform, $(var.Platform) ?>?
+  <?endif?>
+
+  <Fragment>
+    <!-- Identify when installing in emulation as when PROCESSOR_ARCHITECTURE does not match the installer architecture
+          https://docs.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details -->
+    <SetProperty Action="Set_NON_NATIVE_ARCHITECTURE" Id="NON_NATIVE_ARCHITECTURE" Value="true" Before="CostFinalize">
+      NOT %PROCESSOR_ARCHITECTURE="$(var.InstallerArchitecture)"
+    </SetProperty>
+  </Fragment>
+
+  <?if $(var.Platform)~=x64?>
+  <Fragment>
+    <!-- When running in a non-native architecture and user hasn't specified install directory,
+         install to an x64 subdirectory.
+         This is only define for x64, since x86 has redirection and no other native architecture can install ARM64 today -->
+    <SetProperty Action="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" Id="DOTNETHOME" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE">
+      NON_NATIVE_ARCHITECTURE AND NOT DOTNETHOME
+    </SetProperty>
+  </Fragment>
+  <?endif?>
+</Wix>

--- a/src/Installers/Windows/SharedFramework/Product.wxs
+++ b/src/Installers/Windows/SharedFramework/Product.wxs
@@ -35,6 +35,10 @@
                 </Directory>
             </Directory>
         </Directory>
+
+        <?if $(var.Platform)=x64?>
+        <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+        <?endif?>
     </Fragment>
 
     <Fragment>
@@ -52,6 +56,10 @@
             <ComponentRef Id="C_eula.rtf" />
             <ComponentRef Id="C_ProductVersion"/>
             <ComponentRef Id="C_ProductInstallDir"/>
+            <?if $(var.Platform)=x64 ?>
+            <ComponentRef Id="C_ProductVersion_NonNative" />
+            <ComponentRef Id="C_ProductInstallDir_NonNative" />
+            <?endif?>
         </ComponentGroup>
 
         <DirectoryRef Id="SharedFolder">
@@ -66,16 +74,41 @@
             <?define ProductVersionKey=SOFTWARE\Microsoft\ASP.NET Core\Shared Framework\v$(var.MajorVersion).$(var.MinorVersion)\$(var.PackageVersion)?>
 
             <Component Id="C_ProductVersion">
+                <?if $(var.Platform)=x64 ?>
+                <!-- Only install when actually on native architecture -->
+                <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+                <?endif?>
                 <RegistryKey Key="$(var.ProductVersionKey)" Root="HKLM">
                     <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
                 </RegistryKey>
             </Component>
 
             <Component Id="C_ProductInstallDir">
+                <?if $(var.Platform)=x64 ?>
+                <!-- Only install when actually on native architecture -->
+                <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+                <?endif?>
                 <RegistryKey Key="SOFTWARE\Microsoft\ASP.NET Core\Shared Framework" Root="HKLM">
                     <RegistryValue Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
                 </RegistryKey>
             </Component>
+
+            <?if $(var.Platform)=x64 ?>
+            <!-- Install keys to a different path when not native architecture -->
+            <Component Id="C_ProductVersion_NonNative">
+                <Condition>NON_NATIVE_ARCHITECTURE</Condition>
+                <RegistryKey Key="$(var.ProductVersionKey)\$(var.Platform)" Root="HKLM">
+                    <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
+                </RegistryKey>
+            </Component>
+
+            <Component Id="C_ProductInstallDir_NonNative">
+                <Condition>NON_NATIVE_ARCHITECTURE</Condition>
+                <RegistryKey Key="SOFTWARE\Microsoft\ASP.NET Core\Shared Framework\$(var.Platform)" Root="HKLM">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
+                </RegistryKey>
+            </Component>
+            <?endif?>
         </DirectoryRef>
     </Fragment>
 </Wix>

--- a/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
+++ b/src/Installers/Windows/SharedFramework/SharedFramework.wixproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="DependencyProvider.wxs" />
     <Compile Include="Product.wxs" />
+    <Compile Include="..\Common\dotnethome_x64.wxs" Link="dotnethome_x64.wxs" />
     <EmbeddedResource Include="Strings.wxl" />
   </ItemGroup>
 

--- a/src/Installers/Windows/TargetingPack/Product.wxs
+++ b/src/Installers/Windows/TargetingPack/Product.wxs
@@ -33,6 +33,10 @@
                 <Directory Id="DOTNETHOME" Name="dotnet" />
             </Directory>
         </Directory>
+
+        <?if $(var.Platform)=x64?>
+        <CustomActionRef Id="Set_DOTNETHOME_NON_NATIVE_ARCHITECTURE" />
+        <?endif?>
     </Fragment>
 
     <Fragment>
@@ -49,6 +53,10 @@
         <ComponentGroup Id="CG_ProductInfo">
             <ComponentRef Id="C_ProductVersion"/>
             <ComponentRef Id="C_ProductInstallDir"/>
+            <?if $(var.Platform)=x64 ?>
+            <ComponentRef Id="C_ProductVersion_NonNative"/>
+            <ComponentRef Id="C_ProductInstallDir_NonNative"/>
+            <?endif?>
         </ComponentGroup>
 
         <DirectoryRef Id="DOTNETHOME">
@@ -59,16 +67,41 @@
             <?define ProductVersionKey=SOFTWARE\Microsoft\ASP.NET Core\Targeting Pack\v$(var.MajorVersion).$(var.MinorVersion)\$(var.PackageVersion)?>
 
             <Component Id="C_ProductVersion">
+                <?if $(var.Platform)=x64 ?>
+                <!-- Only install when actually on native architecture -->
+                <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+                <?endif?>
                 <RegistryKey Key="$(var.ProductVersionKey)" Root="HKLM">
                     <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
                 </RegistryKey>
             </Component>
 
             <Component Id="C_ProductInstallDir">
+                <?if $(var.Platform)=x64 ?>
+                <!-- Only install when actually on native architecture -->
+                <Condition>NOT NON_NATIVE_ARCHITECTURE</Condition>
+                <?endif?>
                 <RegistryKey Key="SOFTWARE\Microsoft\ASP.NET Core\Targeting Pack" Root="HKLM">
                     <RegistryValue Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
                 </RegistryKey>
             </Component>
+
+
+            <?if $(var.Platform)=x64 ?>
+            <!-- Install keys to a different path when not native architecture -->
+            <Component Id="C_ProductVersion_NonNative">
+                <Condition>NON_NATIVE_ARCHITECTURE</Condition>
+                <RegistryKey Key="$(var.ProductVersionKey)\$(var.Platform)" Root="HKLM">
+                    <RegistryValue Name="Version" Type="string" Value="$(var.Version)" />
+                </RegistryKey>
+            </Component>
+            <Component Id="C_ProductInstallDir_NonNative">
+                <Condition>NON_NATIVE_ARCHITECTURE</Condition>
+                <RegistryKey Key="SOFTWARE\Microsoft\ASP.NET Core\Targeting Pack\$(var.Platform)" Root="HKLM">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
+                </RegistryKey>
+            </Component>
+            <?endif?>
         </DirectoryRef>
     </Fragment>
 </Wix>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="DependencyProvider.wxs" />
     <Compile Include="Product.wxs" />
+    <Compile Include="..\Common\dotnethome_x64.wxs" Link="dotnethome_x64.wxs" />
     <EmbeddedResource Include="Strings.wxl" />
   </ItemGroup>
 


### PR DESCRIPTION
Port of all the x64 on ARM64 changes made in 6.0 for 3.1 servicing.  Only changes made were merge conflicts on wix PackageReference changes.

6.0 changes:
- https://github.com/dotnet/aspnetcore/commit/38452c0fe18eed3a452b8fae9e95efec612f41e1
- https://github.com/dotnet/aspnetcore/commit/a96feda78a3970c440a160c7024ae975b84e7f2c
- https://github.com/dotnet/aspnetcore/commit/5d636458808d9f04b39296d84c89b34218effe33
- https://github.com/dotnet/aspnetcore/commit/2fddf6851540d8243d9d9aad5b291802ca4b3bf9