### PR TITLE
[release/6.0] Add more `crossgen2` dependencies

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -97,9 +97,15 @@ and are generated based on the last package release.
     <!-- Crossgen2 compiler -->
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.osx-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.osx-arm64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-arm" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-arm64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-musl-arm" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-musl-arm64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-musl-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.linux-x64" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-x64" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-x86" />
+    <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-arm" />
     <LatestPackageReference Include="Microsoft.NETCore.App.Crossgen2.win-arm64" />
   </ItemGroup>
 


### PR DESCRIPTION
- backport of #37374, `cherry-pick` of 64f0642371b5

Add more `crossgen2` dependencies (#37374)

  * Fix build on an arm64 machine
    * Building ASP.NET Core on an arm64 machine leads to a dependency error
      because `crossgen2` is not listed in eng/Dependencies.props.
  * Add all arm/arm64 variants
  * Add all win variants for `crossgen2`

  Co-authored-by: Doug Bunting <6431421+dougbu@users.noreply.github.com>