### PR TITLE
Set the `aria-invalid` attribute to "true" instead of true. 

### DIFF
--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -245,6 +245,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
                 // To make the `Input` components accessible by default
                 // we will automatically render the `aria-invalid` attribute when the validation fails
+                // value must be "true" see https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
                 additionalAttributes["aria-invalid"] = "true";
             }
             else if (hasAriaInvalidAttribute)

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -245,7 +245,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
                 // To make the `Input` components accessible by default
                 // we will automatically render the `aria-invalid` attribute when the validation fails
-                additionalAttributes["aria-invalid"] = true;
+                additionalAttributes["aria-invalid"] = "true";
             }
             else if (hasAriaInvalidAttribute)
             {

--- a/src/Components/Web/test/Forms/InputBaseTest.cs
+++ b/src/Components/Web/test/Forms/InputBaseTest.cs
@@ -430,7 +430,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             Assert.NotNull(component.AdditionalAttributes);
             Assert.Equal(1, component.AdditionalAttributes.Count);
             //Check for "true" see https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
-            Assert.True("true", (string)component.AdditionalAttributes["aria-invalid"]);
+            Assert.Equal("true", component.AdditionalAttributes["aria-invalid"]);
         }
 
         [Fact]

--- a/src/Components/Web/test/Forms/InputBaseTest.cs
+++ b/src/Components/Web/test/Forms/InputBaseTest.cs
@@ -429,7 +429,8 @@ namespace Microsoft.AspNetCore.Components.Forms
             Assert.Equal("invalid", component.CssClass);
             Assert.NotNull(component.AdditionalAttributes);
             Assert.Equal(1, component.AdditionalAttributes.Count);
-            Assert.True((bool)component.AdditionalAttributes["aria-invalid"]);
+            //Check for "true" see https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
+            Assert.True("true", (string)component.AdditionalAttributes["aria-invalid"]);
         }
 
         [Fact]


### PR DESCRIPTION
Setting the attribute to true will render it as ``aria-invalid``  (without a value). According to the specification, no value means  ``aria-invalid`` will have its default value, which is false. (So the element is NOT invalid, e.g. it's valid)

Setting the ``aria-invalid`` attribute to the string "true" will render it as ``aria-invalid="true"`` which has the intended behavior as marking the input element as not valid  

See: https://www.w3.org/TR/wai-aria-1.1/#aria-invalid

Fixes #37389