### PR TITLE
Support "-" in authority hosts

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpCharacters.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpCharacters.cs
@@ -55,6 +55,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             Array.Copy(_alphaNumeric, authority, _tableSize);
             authority[':'] = true;
             authority['.'] = true;
+            authority['-'] = true;
             authority['['] = true;
             authority[']'] = true;
             authority['@'] = true;

--- a/src/Servers/Kestrel/Core/test/StartLineTests.cs
+++ b/src/Servers/Kestrel/Core/test/StartLineTests.cs
@@ -439,6 +439,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         [InlineData("localhost", "", "")]
         [InlineData("localhost:22", "", "")] // handles mismatched ports
         [InlineData("differenthost", "", "")] // handles mismatched hostname
+        [InlineData("different-host", "", "")]
         [InlineData("127.0.0.1", "", "")]
         [InlineData("[::1]", "", "")]
         [InlineData("[::1]:8080", "", "")]

--- a/src/Servers/Kestrel/shared/test/HttpParsingData.cs
+++ b/src/Servers/Kestrel/shared/test/HttpParsingData.cs
@@ -456,6 +456,7 @@ namespace Microsoft.AspNetCore.Testing
                     { "GET https://localhost:443/", "localhost:443" },
                     { "CONNECT asp.net:80", "asp.net:80" },
                     { "CONNECT asp.net:443", "asp.net:443" },
+                    { "CONNECT user-images.githubusercontent.com:443", "user-images.githubusercontent.com:443" },
                 };
 
         public static TheoryData<string, string> HostHeaderInvalidData


### PR DESCRIPTION
**PR Title**
Support `-` in authority hosts

**PR Description**
> Such a name consists of a sequence of domain labels separated by ".",
   each domain label starting and ending with an alphanumeric character
   and possibly also containing "-" characters.

https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2

Fixes #37421
