### PR TITLE
Fix IDE0059 suggestion

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpCharacters.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpCharacters.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
@@ -18,7 +17,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         internal static void Initialize()
         {
             // Access _alphaNumeric to initialize static fields
-            var initialize = _alphaNumeric;
+            var _ = _alphaNumeric;
         }
 
         private static bool[] InitializeAlphaNumeric()


### PR DESCRIPTION
**PR Title**

Fix IDE0059 suggestion

**PR Description**

Fix IDE0059 suggestion by using `_` for the variable name. Also trims a now-redundant using statement.

I was going to include this small refactor in a fix for #37421 but I was beaten to it, so here it is by itself.
