### PR TITLE
HTTP/3: Fix tests failing because of new error code

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
             using var clientConnection = new QuicConnection(options);
 
             var qex = await Assert.ThrowsAsync<QuicException>(async () => await clientConnection.ConnectAsync().DefaultTimeout());
-            Assert.Equal("Connection has been shutdown by transport. Error Code: 0x80410100", qex.Message);
+            Assert.StartsWith("Connection has been shutdown by transport.", qex.Message);
         }
     }
 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -226,7 +226,7 @@ namespace Interop.FunctionalTests.Http3
 
             // https://github.com/dotnet/runtime/issues/57308, optional client certs aren't supported.
             var ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request, CancellationToken.None).DefaultTimeout());
-            Assert.StartsWith("Connection has been shutdown by transport. Error Code: 0x80410100", ex.Message);
+            Assert.StartsWith("Connection has been shutdown by transport.", ex.Message);
 
             await host.StopAsync().DefaultTimeout();
         }


### PR DESCRIPTION
Two quarantined tests have been consistently failing because the error code in asserts has changed.

PR removes error code from asserts.