### PR TITLE
[ANCM] Add disableRotatationOnConfig flag to handler settings

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -169,6 +169,8 @@ HandlerResolver::GetApplicationFactory(const IHttpApplication& pApplication, con
 
     m_loadedApplicationHostingModel = options.QueryHostingModel();
     m_loadedApplicationId = pApplication.GetApplicationId();
+    m_loadedDisallowRotationOnConfigChange = options.QueryDisallowRotationOnConfigChange();
+
     RETURN_IF_FAILED(LoadRequestHandlerAssembly(pApplication, shadowCopyPath, options, pApplicationFactory, errorContext));
 
     return S_OK;
@@ -187,6 +189,13 @@ APP_HOSTING_MODEL HandlerResolver::GetHostingModel()
     SRWExclusiveLock lock(m_requestHandlerLoadLock);
 
     return m_loadedApplicationHostingModel;
+}
+
+bool HandlerResolver::GetDisallowRotationOnConfigChange()
+{
+    SRWExclusiveLock lock(m_requestHandlerLoadLock);
+
+    return m_loadedDisallowRotationOnConfigChange;
 }
 
 HRESULT

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -24,6 +24,7 @@ HandlerResolver::HandlerResolver(HMODULE hModule, const IHttpServer &pServer)
       m_pServer(pServer),
       m_loadedApplicationHostingModel(HOSTING_UNKNOWN)
 {
+    m_loadedDisallowRotationOnConfigChange = false;
     InitializeSRWLock(&m_requestHandlerLoadLock);
 }
 
@@ -193,8 +194,6 @@ APP_HOSTING_MODEL HandlerResolver::GetHostingModel()
 
 bool HandlerResolver::GetDisallowRotationOnConfigChange()
 {
-    SRWExclusiveLock lock(m_requestHandlerLoadLock);
-
     return m_loadedDisallowRotationOnConfigChange;
 }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -24,7 +24,7 @@ HandlerResolver::HandlerResolver(HMODULE hModule, const IHttpServer &pServer)
       m_pServer(pServer),
       m_loadedApplicationHostingModel(HOSTING_UNKNOWN)
 {
-    m_loadedDisallowRotationOnConfigChange = false;
+    m_disallowRotationOnConfigChange = false;
     InitializeSRWLock(&m_requestHandlerLoadLock);
 }
 
@@ -170,7 +170,7 @@ HandlerResolver::GetApplicationFactory(const IHttpApplication& pApplication, con
 
     m_loadedApplicationHostingModel = options.QueryHostingModel();
     m_loadedApplicationId = pApplication.GetApplicationId();
-    m_loadedDisallowRotationOnConfigChange = options.QueryDisallowRotationOnConfigChange();
+    m_disallowRotationOnConfigChange = options.QueryDisallowRotationOnConfigChange();
 
     RETURN_IF_FAILED(LoadRequestHandlerAssembly(pApplication, shadowCopyPath, options, pApplicationFactory, errorContext));
 
@@ -194,7 +194,7 @@ APP_HOSTING_MODEL HandlerResolver::GetHostingModel()
 
 bool HandlerResolver::GetDisallowRotationOnConfigChange()
 {
-    return m_loadedDisallowRotationOnConfigChange;
+    return m_disallowRotationOnConfigChange;
 }
 
 HRESULT

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.h
@@ -18,6 +18,7 @@ public:
     HRESULT GetApplicationFactory(const IHttpApplication &pApplication, const std::filesystem::path& shadowCopyPath, std::unique_ptr<ApplicationFactory>& pApplicationFactory, const ShimOptions& options, ErrorContext& errorContext);
     void ResetHostingModel();
     APP_HOSTING_MODEL GetHostingModel();
+    bool GetDisallowRotationOnConfigChange();
 
 private:
     HRESULT LoadRequestHandlerAssembly(const IHttpApplication &pApplication, const std::filesystem::path& shadowCopyPath, const ShimOptions& pConfiguration, std::unique_ptr<ApplicationFactory>& pApplicationFactory, ErrorContext& errorContext);
@@ -38,6 +39,7 @@ private:
     std::wstring m_loadedApplicationId;
     APP_HOSTING_MODEL m_loadedApplicationHostingModel;
     HostFxr m_hHostFxrDll;
+    bool m_loadedDisallowRotationOnConfigChange;
 
     static const PCWSTR          s_pwzAspnetcoreInProcessRequestHandlerName;
     static const PCWSTR          s_pwzAspnetcoreOutOfProcessRequestHandlerName;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.h
@@ -39,7 +39,7 @@ private:
     std::wstring m_loadedApplicationId;
     APP_HOSTING_MODEL m_loadedApplicationHostingModel;
     HostFxr m_hHostFxrDll;
-    bool m_loadedDisallowRotationOnConfigChange;
+    bool m_disallowRotationOnConfigChange;
 
     static const PCWSTR          s_pwzAspnetcoreInProcessRequestHandlerName;
     static const PCWSTR          s_pwzAspnetcoreOutOfProcessRequestHandlerName;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
@@ -11,6 +11,7 @@
 #define CS_ASPNETCORE_SHADOW_COPY                        L"experimentalEnableShadowCopy"
 #define CS_ASPNETCORE_SHADOW_COPY_DIRECTORY              L"shadowCopyDirectory"
 #define CS_ASPNETCORE_CLEAN_SHADOW_DIRECTORY_CONTENT     L"cleanShadowCopyDirectory"
+#define CS_ASPNETCORE_DISALLOW_ROTATE_CONFIG             L"disallowRotationOnConfigChange"
 
 ShimOptions::ShimOptions(const ConfigurationSource &configurationSource) :
         m_hostingModel(HOSTING_UNKNOWN),
@@ -50,6 +51,9 @@ ShimOptions::ShimOptions(const ConfigurationSource &configurationSource) :
     m_strShadowCopyingDirectory = find_element(handlerSettings, CS_ASPNETCORE_SHADOW_COPY_DIRECTORY)
         .value_or(m_fexperimentalEnableShadowCopying ? L"ShadowCopyDirectory" : std::wstring());
 
+    auto disallowRotationOnConfigChange = find_element(handlerSettings, CS_ASPNETCORE_DISALLOW_ROTATE_CONFIG).value_or(std::wstring());
+    m_fDisallowRotationOnConfigChange = equals_ignore_case(L"true", disallowRotationOnConfigChange);
+                
     m_strProcessPath = section->GetRequiredString(CS_ASPNETCORE_PROCESS_EXE_PATH);
     m_strArguments = section->GetString(CS_ASPNETCORE_PROCESS_ARGUMENTS).value_or(CS_ASPNETCORE_PROCESS_ARGUMENTS_DEFAULT);
     m_fStdoutLogEnabled = section->GetRequiredBool(CS_ASPNETCORE_STDOUT_LOG_ENABLED);

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
@@ -83,6 +83,12 @@ public:
         return m_strShadowCopyingDirectory;
     }
 
+    const std::wstring&
+    QueryDisallowRotationOnConfigChange() const noexcept
+    {
+        return m_fDisallowRotationOnConfigChange;
+    }
+
     ShimOptions(const ConfigurationSource &configurationSource);
 
 private:
@@ -96,5 +102,6 @@ private:
     bool                           m_fShowDetailedErrors;
     bool                           m_fexperimentalEnableShadowCopying;
     bool                           m_fCleanShadowCopyDirectory;
+    bool                           m_fDisallowRotationOnConfigChange;
     std::wstring                   m_strShadowCopyingDirectory;
 };

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
@@ -83,7 +83,7 @@ public:
         return m_strShadowCopyingDirectory;
     }
 
-    const std::wstring&
+    bool
     QueryDisallowRotationOnConfigChange() const noexcept
     {
         return m_fDisallowRotationOnConfigChange;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.h
@@ -41,6 +41,12 @@ public:
         InitializeSRWLock(&m_srwLock);
     }
 
+    bool
+    ShouldRecycleOnConfigChange()
+    {
+        return !m_handlerResolver.GetDisallowRotationOnConfigChange();
+    }
+
 private:
 
     std::unordered_map<std::wstring, std::shared_ptr<APPLICATION_INFO>>      m_pApplicationInfoHash;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
@@ -59,6 +59,8 @@ ASPNET_CORE_GLOBAL_MODULE::OnGlobalConfigurationChange(
         _wcsicmp(pwszChangePath, L"MACHINE") != 0 &&
         _wcsicmp(pwszChangePath, L"MACHINE/WEBROOT") != 0)
     {
+        // Configuration change recycling behavior can be turned off via setting disallowRotationOnConfigChange=true on the handler settings section.
+        // We need this duplicate setting because the global module is unable to read the app settings disallowRotationOnConfigChange value.
         if (m_pApplicationManager && m_pApplicationManager->ShouldRecycleOnConfigChange())
         {
             m_pApplicationManager->RecycleApplicationFromManager(pwszChangePath);   

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
@@ -59,7 +59,7 @@ ASPNET_CORE_GLOBAL_MODULE::OnGlobalConfigurationChange(
         _wcsicmp(pwszChangePath, L"MACHINE") != 0 &&
         _wcsicmp(pwszChangePath, L"MACHINE/WEBROOT") != 0)
     {
-        if (m_pApplicationManager)
+        if (m_pApplicationManager && m_pApplicationManager->ShouldRecycleOnConfigChange())
         {
             m_pApplicationManager->RecycleApplicationFromManager(pwszChangePath);   
         }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
@@ -425,7 +425,7 @@ public class ShutdownTests : IISFunctionalTestBase
         deploymentResult.ModifyWebConfig(element => { });
 
         // Have to retry here to allow ANCM to receive notification and react to it
-        // Verify that worker process does not restarted with new process id
+        // Verify that worker process does not get restarted with new process id
         await deploymentResult.HttpClient.RetryRequestAsync("/ProcessId", async r => await r.Content.ReadAsStringAsync() == processBefore);
     }
 
@@ -444,7 +444,7 @@ public class ShutdownTests : IISFunctionalTestBase
         deploymentResult.ModifyWebConfig(element => { });
 
         // Have to retry here to allow ANCM to receive notification and react to it
-        // Verify that worker process does not restarted with new process id
+        // Verify that worker process does not get restarted with new process id
         await deploymentResult.HttpClient.RetryRequestAsync("/ProcessId", async r => await r.Content.ReadAsStringAsync() == processBefore);
     }
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
@@ -430,6 +430,26 @@ public class ShutdownTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
+    public async Task AppHostConfigurationChangeIsIgnoredInProcess()
+    {
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.InProcess);
+        deploymentParameters.HandlerSettings["disallowRotationOnConfigChange"] = "true";
+
+        var deploymentResult = await DeployAsync(deploymentParameters);
+
+        var processBefore = await deploymentResult.HttpClient.GetStringAsync("/ProcessId");
+
+        await deploymentResult.AssertStarts();
+
+        // Just "touching" applicationHost.config should be enough
+        _deployer.ModifyApplicationHostConfig(element => { });
+
+        // Have to retry here to allow ANCM to receive notification and react to it
+        // Verify that worker process does not get restarted with new process id
+        await deploymentResult.HttpClient.RetryRequestAsync("/ProcessId", async r => await r.Content.ReadAsStringAsync() == processBefore);
+    }
+
+    [ConditionalFact]
     [RequiresNewShim]
     public async Task ConfigurationChangeCanBeIgnoredOutOfProcess()
     {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/ShutdownTests.cs
@@ -410,6 +410,45 @@ public class ShutdownTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
+    public async Task ConfigurationChangeCanBeIgnoredInProcess()
+    {
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.InProcess);
+        deploymentParameters.HandlerSettings["disallowRotationOnConfigChange"] = "true";
+
+        var deploymentResult = await DeployAsync(deploymentParameters);
+
+        var processBefore = await deploymentResult.HttpClient.GetStringAsync("/ProcessId");
+
+        await deploymentResult.AssertStarts();
+
+        // Just "touching" web.config should be enough
+        deploymentResult.ModifyWebConfig(element => { });
+
+        // Have to retry here to allow ANCM to receive notification and react to it
+        // Verify that worker process does not restarted with new process id
+        await deploymentResult.HttpClient.RetryRequestAsync("/ProcessId", async r => await r.Content.ReadAsStringAsync() == processBefore);
+    }
+
+    [ConditionalFact]
+    [RequiresNewShim]
+    public async Task ConfigurationChangeCanBeIgnoredOutOfProcess()
+    {
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
+        deploymentParameters.HandlerSettings["disallowRotationOnConfigChange"] = "true";
+
+        var deploymentResult = await DeployAsync(deploymentParameters);
+
+        var processBefore = await deploymentResult.HttpClient.GetStringAsync("/ProcessId");
+
+        // Just "touching" web.config should be enough
+        deploymentResult.ModifyWebConfig(element => { });
+
+        // Have to retry here to allow ANCM to receive notification and react to it
+        // Verify that worker process does not restarted with new process id
+        await deploymentResult.HttpClient.RetryRequestAsync("/ProcessId", async r => await r.Content.ReadAsStringAsync() == processBefore);
+    }
+
+    [ConditionalFact]
     public async Task OutOfProcessToInProcessHostingModelSwitchWorks()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -29,10 +29,13 @@ public class IISDeployer : IISDeployerBase
     private readonly CancellationTokenSource _hostShutdownToken = new CancellationTokenSource();
 
     private string _configPath;
+    private string _applicationHostConfig;
     private string _debugLogFile;
     private bool _disposed;
 
     public Process HostProcess { get; set; }
+
+    protected override string ApplicationHostConfigPath => _applicationHostConfig;
 
     public IISDeployer(DeploymentParameters deploymentParameters, ILoggerFactory loggerFactory)
         : base(new IISDeploymentParameters(deploymentParameters), loggerFactory)
@@ -286,13 +289,13 @@ public class IISDeployer : IISDeployerBase
     private void AddTemporaryAppHostConfig(string contentRoot, int port)
     {
         _configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"));
-        var appHostConfigPath = Path.Combine(_configPath, "applicationHost.config");
+        _applicationHostConfig = Path.Combine(_configPath, "applicationHost.config");
         Directory.CreateDirectory(_configPath);
         var config = XDocument.Parse(DeploymentParameters.ServerConfigTemplateContent ?? File.ReadAllText("IIS.config"));
 
         ConfigureAppHostConfig(config.Root, contentRoot, port);
 
-        config.Save(appHostConfigPath);
+        config.Save(_applicationHostConfig);
 
         RetryServerManagerAction(serverManager =>
         {

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployerBase.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployerBase.cs
@@ -1,12 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 
@@ -22,6 +16,15 @@ public abstract class IISDeployerBase : ApplicationDeployer
         : base(deploymentParameters, loggerFactory)
     {
         IISDeploymentParameters = deploymentParameters;
+    }
+
+    protected abstract string ApplicationHostConfigPath { get; }
+
+    public void ModifyApplicationHostConfig(Action<XElement> action)
+    {
+        var document = XDocument.Load(ApplicationHostConfigPath);
+        action(document.Root);
+        document.Save(ApplicationHostConfigPath);
     }
 
     protected void RunWebConfigActions(string contentRoot)

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -44,6 +44,8 @@ public class IISExpressDeployer : IISDeployerBase
     {
     }
 
+    protected override string ApplicationHostConfigPath => DeploymentParameters.ServerConfigLocation;
+
     public override async Task<DeploymentResult> DeployAsync()
     {
         using (Logger.BeginScope("Deployment"))


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/37463

Adds a flag which allows opt out of global application recycles due to config changes