### PR TITLE
Accessibility fixes in templates

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/_Layout.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/_Layout.cshtml
@@ -3,7 +3,7 @@
 @inject IWebHostEnvironment Environment
 @inject ICompositeViewEngine Engine
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml
@@ -17,7 +17,7 @@
 <div class="row">
     <div class="col-md-4">
         <form asp-page-handler="Confirmation" asp-route-returnUrl="@Model.ReturnUrl" method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Input.Email" class="form-control" autocomplete="email" />
                 <label asp-for="Input.Email" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ForgotPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ForgotPassword.cshtml
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-md-4">
         <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
                 <label asp-for="Input.Email" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Login.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Login.cshtml
@@ -12,7 +12,7 @@
             <form id="account" method="post">
                 <h2>Use a local account to log in.</h2>
                 <hr />
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
                 <div class="form-floating">
                     <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
                     <label asp-for="Input.Email" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWith2fa.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWith2fa.cshtml
@@ -11,7 +11,7 @@
     <div class="col-md-4">
         <form method="post" asp-route-returnUrl="@Model.ReturnUrl">
             <input asp-for="RememberMe" type="hidden" />
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Input.TwoFactorCode" class="form-control" autocomplete="off" />
                 <label asp-for="Input.TwoFactorCode" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWithRecoveryCode.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWithRecoveryCode.cshtml
@@ -13,7 +13,7 @@
 <div class="row">
     <div class="col-md-4">
         <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Input.RecoveryCode" class="form-control" autocomplete="off" />
                 <label asp-for="Input.RecoveryCode" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/ChangePassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/ChangePassword.cshtml
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-md-6">
         <form id="change-password-form" method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" aria-required="true" />
                 <label asp-for="Input.OldPassword" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/DeletePersonalData.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/DeletePersonalData.cshtml
@@ -15,7 +15,7 @@
 
 <div>
     <form id="delete-user" method="post">
-        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
         @if (Model.RequirePassword)
         {
             <div class="form-floating">

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Email.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Email.cshtml
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-md-6">
         <form id="email-form" method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All" class="text-danger" role="alert"></div>
             @if (Model.IsEmailConfirmed)
             {
                 <div class="form-floating input-group">

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/EnableAuthenticator.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/EnableAuthenticator.cshtml
@@ -40,7 +40,7 @@
                             <span asp-validation-for="Input.Code" class="text-danger"></span>
                         </div>
                         <button type="submit" class="w-100 btn btn-lg btn-primary">Verify</button>
-                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
                     </form>
                 </div>
             </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Index.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Index.cshtml
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-md-6">
         <form id="profile-form" method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Username" class="form-control" disabled />
                 <label asp-for="Username" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/SetPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/SetPassword.cshtml
@@ -14,7 +14,7 @@
 <div class="row">
     <div class="col-md-6">
         <form id="set-password-form" method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" />
                 <label asp-for="Input.NewPassword" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Register.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Register.cshtml
@@ -11,7 +11,7 @@
         <form id="registerForm" asp-route-returnUrl="@Model.ReturnUrl" method="post">
             <h2>Create a new account.</h2>
             <hr />
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />
                 <label asp-for="Input.Email"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResendEmailConfirmation.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResendEmailConfirmation.cshtml
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-md-4">
         <form method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
+            <div asp-validation-summary="All" class="text-danger" role="alert"></div>
             <div class="form-floating">
                 <input asp-for="Input.Email" class="form-control" aria-required="true" />
                 <label asp-for="Input.Email" class="form-label"></label>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResetPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResetPassword.cshtml
@@ -10,7 +10,7 @@
 <div class="row">
     <div class="col-md-4">
         <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
             <input asp-for="Input.Code" type="hidden" />
             <div class="form-floating">
                 <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" />

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/_Layout.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/_Layout.cshtml
@@ -3,7 +3,7 @@
 @inject IWebHostEnvironment Environment
 @inject ICompositeViewEngine Engine
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/Error.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/Error.cshtml
@@ -2,7 +2,7 @@
 @model BlazorServerWeb_CSharp.Pages.ErrorModel
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/SurveyPrompt.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/SurveyPrompt.razor
@@ -4,7 +4,7 @@
 
     <span class="text-nowrap">
         Please take our
-        <a target="_blank" class="font-weight-bold" href="https://go.microsoft.com/fwlink/?linkid=2149017">brief survey</a>
+        <a target="_blank" class="font-weight-bold link-dark" href="https://go.microsoft.com/fwlink/?linkid=2149017">brief survey</a>
     </span>
     and tell us what you think.
 </div>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/site.css
@@ -9,7 +9,7 @@ h1:focus {
 }
 
 a, .btn-link {
-    color: #0077cc;
+    color: #0071c1;
 }
 
 .btn-primary {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Shared/SurveyPrompt.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Shared/SurveyPrompt.razor
@@ -4,7 +4,7 @@
 
     <span class="text-nowrap">
         Please take our
-        <a target="_blank" class="font-weight-bold" href="https://go.microsoft.com/fwlink/?linkid=2148851">brief survey</a>
+        <a target="_blank" class="font-weight-bold link-dark" href="https://go.microsoft.com/fwlink/?linkid=2148851">brief survey</a>
     </span>
     and tell us what you think.
 </div>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
@@ -9,7 +9,7 @@ h1:focus {
 }
 
 a, .btn-link {
-    color: #0077cc;
+    color: #0071c1;
 }
 
 .btn-primary {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Pages/Error.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Pages/Error.cshtml
@@ -2,7 +2,7 @@
 @model ComponentsWebAssembly_CSharp.Server.Pages.ErrorModel
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Views/Shared/_Layout.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Views/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Description

* Increases color contrast on links in Blazor templates
* Adds `lang` attribute to `<html>` elements across all templates
* Improves accessibility of server-side validation errors produced in Identity UI

## Customer Impact

Resolves reported accessibility issues.

**Notes:**

The color contrast and `lang` issues are definitely, objectively fixed here.

However the issue about "screen reader does not read out server-side validation errors" is more ambiguous because we don't have 100% control over that. The truth is it *did* already read them out, just not with high priority, so the message could get lost among all the rest of the page content.

The change here adds `role="alert"` which is the standards-compliant way to indicate it's an error message and should have priority to be read out. But screen readers vary in their behavior, and may choose to read out the message before other content, or after other content. We don't get to choose that. There was a proposal for [a new standard ARIA role meaning "definitely read this first"](https://github.com/w3c/aria/issues/1360), but that was eventually closed because people said `role="alert"` should already take top priority and if it doesn't, that's a screen reader bug. Until all screen readers start behaving consistently with `role="alert"`, our options are:

1. To add the `role="alert"` and let screen readers make their own choice about how highly to prioritize that in reading order
2. To change from server-side validation to client-side validation, which works much more consistently. However that's way out of scope for this PR and involves substantial functional changes.
3. To introduce further custom JS that tries to coerce the screen reader into reading things in a particular order by dynamically setting focus after the page loads. However that's also outside the scope of this PR because it needs design to work out how this would interact with customization and should go through public previews to mitigate the risk that it breaks something else. Plus it can leader to weirder interactions if the script doesn't run until the reader has already started introducing some earlier content.

So for 6.0 GA I think the most reasonable option is (1), which is what this PR does.

## Regression?
- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Low as long as we don't try to solve this in a more complicated way, since it's just a few declarative changes to HTML/CSS.

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

Addresses 1412465, 1411915, 1411027