### PR TITLE
Don't start the .NET webassembly app inside the auth iframe. Fixes #37355

### DIFF
--- a/src/Components/Web.JS/src/Boot.WebAssembly.ts
+++ b/src/Components/Web.JS/src/Boot.WebAssembly.ts
@@ -27,7 +27,7 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
   started = true;
 
   if (inAuthRedirectIframe()) {
-    await new Promise(() => {}); // See pauseBecauseInAuthRedirectIframe for explanation
+    await new Promise(() => {}); // See inAuthRedirectIframe for explanation
   }
 
   setDispatchEventMiddleware((browserRendererId, eventHandlerId, continuation) => {

--- a/src/Components/Web.JS/src/Boot.WebAssembly.ts
+++ b/src/Components/Web.JS/src/Boot.WebAssembly.ts
@@ -26,6 +26,10 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
   }
   started = true;
 
+  if (inAuthRedirectIframe()) {
+    await new Promise(() => {}); // See pauseBecauseInAuthRedirectIframe for explanation
+  }
+
   setDispatchEventMiddleware((browserRendererId, eventHandlerId, continuation) => {
     // It's extremely unusual, but an event can be raised while we're in the middle of synchronously applying a
     // renderbatch. For example, a renderbatch might mutate the DOM in such a way as to cause an <input> to lose
@@ -192,6 +196,22 @@ function retrieveByteArray(): System_Object {
 
   const typedArray = BINDING.js_typed_array_to_array(byteArrayBeingTransferred);
   return typedArray;
+}
+
+function inAuthRedirectIframe(): boolean {
+  // We don't want the .NET runtime to start up a second time inside the AuthenticationService.ts iframe. It uses resources
+  // unnecessarily and can lead to errors (#37355), plus the behavior is not well defined as the frame will be terminated shortly.
+  // So, if we're in that situation, block the startup process indefinitely so that anything chained to Blazor.start never happens.
+  // The detection logic here is based on the equivalent check in AuthenticationService.ts.
+  // TODO: Later we want AuthenticationService.ts to become responsible for doing this via a JS initializer. Doing it here is a
+  //       tactical fix for .NET 6 so we don't have to change how authentication is initialized.
+  if (window.parent !== window && !window.opener && window.frameElement) {
+    const settingsJson = window.sessionStorage && window.sessionStorage['Microsoft.AspNetCore.Components.WebAssembly.Authentication.CachedAuthSettings'];
+    const settings = settingsJson && JSON.parse(settingsJson);
+    return settings && settings.redirect_uri && location.href.startsWith(settings.redirect_uri);
+  }
+
+  return false;
 }
 
 Blazor.start = boot;


### PR DESCRIPTION
As described in https://github.com/dotnet/aspnetcore/issues/37355, we're getting errors by default in the auth-enabled WebAssembly template. When the child iframe tries to start up the Blazor WebAssembly app, it tries to request `blazor.boot.json`, and this request was failing.

 * On Chromium, it's reported as "Failed to fetch"
 * On Firefox, it's reported as NS_BINDING_ABORTED

To fix it, this PR causes the Blazor WebAssembly app *not* to start up a second copy inside the iframe. This has the additional benefit that we no longer have the unnecessary second copy of the app using resources and triggering a lot of unwanted noise inside devtools.

**The specific approach used in this PR is tactical.** Longer term, as discussed with @javiercn, we'd like to change how AuthenticationService.js is added to the page, and make it a JS initializer. This will have the dual benefit of (1) developer no longer needs to add the `<script>` tag to their host page, and (2) the initializer can take over the responsibility of blocking the app from starting when it detects it's inside the iframe (by never completing the initialization). However it's too late in 6.0 to make a substantial structural change like that (and it would be breaking to people who're running on RC2) so this PR just inlines the small amount of logic needed to detect the scenario into `Boot.WebAssembly.ts`.

We also considered an alternate fix of removing the `credential: 'include'` flag from the `fetch` request for `blazor.boot.json`. However that doesn't work because this flag is not the problem. The actual problem is a matter of timing - the child iframe gets removed while the HTTP request is in flight. These kinds of nasty timing-based interactions are a characteristic problem of starting a second copy of the app in an iframe for an indeterminately small period, so I'm glad that with this PR we can just avoid that whole pattern.