### PR TITLE
Set the aria-invalid attribute to "true" instead of true (v2)

### DIFF
--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -245,6 +245,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
                 // To make the `Input` components accessible by default
                 // we will automatically render the `aria-invalid` attribute when the validation fails
+                // value must be "true" see https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
                 additionalAttributes["aria-invalid"] = "true";
             }
             else if (hasAriaInvalidAttribute)

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -245,7 +245,7 @@ namespace Microsoft.AspNetCore.Components.Forms
 
                 // To make the `Input` components accessible by default
                 // we will automatically render the `aria-invalid` attribute when the validation fails
-                additionalAttributes["aria-invalid"] = true;
+                additionalAttributes["aria-invalid"] = "true";
             }
             else if (hasAriaInvalidAttribute)
             {

--- a/src/Components/Web/test/Forms/InputBaseTest.cs
+++ b/src/Components/Web/test/Forms/InputBaseTest.cs
@@ -430,7 +430,7 @@ namespace Microsoft.AspNetCore.Components.Forms
             Assert.NotNull(component.AdditionalAttributes);
             Assert.Equal(1, component.AdditionalAttributes.Count);
             //Check for "true" see https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
-            Assert.True("true", (string)component.AdditionalAttributes["aria-invalid"]);
+            Assert.Equal("true", component.AdditionalAttributes["aria-invalid"]);
         }
 
         [Fact]

--- a/src/Components/Web/test/Forms/InputBaseTest.cs
+++ b/src/Components/Web/test/Forms/InputBaseTest.cs
@@ -429,7 +429,8 @@ namespace Microsoft.AspNetCore.Components.Forms
             Assert.Equal("invalid", component.CssClass);
             Assert.NotNull(component.AdditionalAttributes);
             Assert.Equal(1, component.AdditionalAttributes.Count);
-            Assert.True((bool)component.AdditionalAttributes["aria-invalid"]);
+            //Check for "true" see https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
+            Assert.True("true", (string)component.AdditionalAttributes["aria-invalid"]);
         }
 
         [Fact]

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -95,19 +95,19 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
             Browser.Equal("valid", () => nameInput.GetAttribute("class"));
             nameInput.SendKeys("Bert\t");
             Browser.Equal("modified valid", () => nameInput.GetAttribute("class"));
-            EnsureAttributeRendering(nameInput, "aria-invalid", false);
+            EnsureAttributeNotRendered(nameInput, "aria-invalid");
 
             // Can become invalid
             nameInput.SendKeys("01234567890123456789\t");
             Browser.Equal("modified invalid", () => nameInput.GetAttribute("class"));
-            EnsureAttributeRendering(nameInput, "aria-invalid");
+            EnsureAttributeValue(nameInput, "aria-invalid", "true");
             Browser.Equal(new[] { "That name is too long" }, messagesAccessor);
 
             // Can become valid
             nameInput.Clear();
             nameInput.SendKeys("Bert\t");
             Browser.Equal("modified valid", () => nameInput.GetAttribute("class"));
-            EnsureAttributeRendering(nameInput, "aria-invalid", false);
+            EnsureAttributeNotRendered(nameInput, "aria-invalid");
             Browser.Empty(messagesAccessor);
         }
 
@@ -978,9 +978,14 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 .ToArray();
         }
 
-        private void EnsureAttributeRendering(IWebElement element, string attributeName, bool shouldBeRendered = true)
+        private void EnsureAttributeValue(IWebElement element, string attributeName, string value)
         {
-            Browser.Equal(shouldBeRendered, () => element.GetAttribute(attributeName) != null);
+            Browser.Equal(value, () => element.GetAttribute(attributeName));
+        }
+
+        private void EnsureAttributeNotRendered(IWebElement element, string attributeName)
+        {
+            Browser.True(() => element.GetAttribute(attributeName) == null);
         }
 
         private bool ElementHasAttribute(IWebElement webElement, string attribute)


### PR DESCRIPTION
Continuation of https://github.com/dotnet/aspnetcore/pull/37423, but with E2E test coverage. I had to make a new PR because the original one didn't let me push any further commits to its fork.