### PR TITLE
Only attempt to import blazor-hotreload.js is AspNetCore Browser tools middleware is present

### DIFF
--- a/src/Components/Web.JS/src/Platform/BootConfig.ts
+++ b/src/Components/Web.JS/src/Platform/BootConfig.ts
@@ -20,6 +20,7 @@ export class BootConfigResult {
     const applicationEnvironment = environment || bootConfigResponse.headers.get('Blazor-Environment') || 'Production';
     const bootConfig: BootJsonData = await bootConfigResponse.json();
     bootConfig.modifiableAssemblies = bootConfigResponse.headers.get('DOTNET-MODIFIABLE-ASSEMBLIES');
+    bootConfig.aspnetCoreBrowserTools = bootConfigResponse.headers.get('ASPNETCORE-BROWSER-TOOLS');
 
     return new BootConfigResult(bootConfig, applicationEnvironment);
 
@@ -46,6 +47,7 @@ export interface BootJsonData {
 
   // These properties are tacked on, and not found in the boot.json file
   modifiableAssemblies: string | null;
+  aspnetCoreBrowserTools: string | null;
 }
 
 export type BootJsonDataExtension = { [extensionName: string]: ResourceList };

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -453,6 +453,11 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
       MONO.mono_wasm_setenv('DOTNET_MODIFIABLE_ASSEMBLIES', resourceLoader.bootConfig.modifiableAssemblies);
     }
 
+    if (resourceLoader.bootConfig.aspnetCoreBrowserTools) {
+      // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
+      MONO.mono_wasm_setenv('_ASPNETCORE_BROWSER_TOOLS', resourceLoader.bootConfig.aspnetCoreBrowserTools);
+    }
+
     const load_runtime = cwrap('mono_wasm_load_runtime', null, ['string', 'number']);
     // -1 enables debugging with logging disabled. 0 disables debugging entirely.
     load_runtime(appBinDirName, hasDebuggingEnabled() ? -1 : 0);

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -455,7 +455,7 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
 
     if (resourceLoader.bootConfig.aspnetCoreBrowserTools) {
       // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
-      MONO.mono_wasm_setenv('_ASPNETCORE_BROWSER_TOOLS', resourceLoader.bootConfig.aspnetCoreBrowserTools);
+      MONO.mono_wasm_setenv('__ASPNETCORE_BROWSER_TOOLS', resourceLoader.bootConfig.aspnetCoreBrowserTools);
     }
 
     const load_runtime = cwrap('mono_wasm_load_runtime', null, ['string', 'number']);

--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Builder
 
                         // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
                         // Translate the _ASPNETCORE_BROWSER_TOOLS environment configured by the browser tools agent in to a HTTP response header.
-                        if (Environment.GetEnvironmentVariable("_ASPNETCORE_BROWSER_TOOLS") is string blazorWasmHotReload)
+                        if (Environment.GetEnvironmentVariable("__ASPNETCORE_BROWSER_TOOLS") is string blazorWasmHotReload)
                         {
                             context.Response.Headers.Append("ASPNETCORE-BROWSER-TOOLS", blazorWasmHotReload);
                         }

--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -47,13 +47,23 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     context.Response.Headers.Append("Blazor-Environment", webHostEnvironment.EnvironmentName);
 
-                    // DOTNET_MODIFIABLE_ASSEMBLIES is used by the runtime to initialize hot-reload specific environment variables and is configured
-                    // by the launching process (dotnet-watch / Visual Studio).
-                    // In Development, we'll transmit the environment variable to WebAssembly as a HTTP header. The bootstrapping code will read the header
-                    // and configure it as env variable for the wasm app.
-                    if (webHostEnvironment.IsDevelopment() &&  Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES") is not null)
+                    if (webHostEnvironment.IsDevelopment())
                     {
-                        context.Response.Headers.Append("DOTNET-MODIFIABLE-ASSEMBLIES", Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES"));
+                        // DOTNET_MODIFIABLE_ASSEMBLIES is used by the runtime to initialize hot-reload specific environment variables and is configured
+                        // by the launching process (dotnet-watch / Visual Studio).
+                        // In Development, we'll transmit the environment variable to WebAssembly as a HTTP header. The bootstrapping code will read the header
+                        // and configure it as env variable for the wasm app.
+                        if (Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES") is string dotnetModifiableAssemblies)
+                        {
+                            context.Response.Headers.Append("DOTNET-MODIFIABLE-ASSEMBLIES", dotnetModifiableAssemblies);
+                        }
+
+                        // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
+                        // Translate the _ASPNETCORE_BROWSER_TOOLS environment configured by the browser tools agent in to a HTTP response header.
+                        if (Environment.GetEnvironmentVariable("_ASPNETCORE_BROWSER_TOOLS") is string blazorWasmHotReload)
+                        {
+                            context.Response.Headers.Append("ASPNETCORE-BROWSER-TOOLS", blazorWasmHotReload);
+                        }
                     }
 
                     await next(context);

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
         {
             _hotReloadAgent = new HotReloadAgent(m => Debug.WriteLine(m));
 
-            if (Environment.GetEnvironmentVariable("_ASPNETCORE_BROWSER_TOOLS") == "true")
+            if (Environment.GetEnvironmentVariable("__ASPNETCORE_BROWSER_TOOLS") == "true")
             {
                 // Attempt to read previously applied hot reload deltas if the ASP.NET Core browser tools are available (indicated by the presence of the Environment variable).
                 // The agent is injected in to the hosted app and can serve this script that can provide results from local-storage .

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -27,10 +27,15 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
         {
             _hotReloadAgent = new HotReloadAgent(m => Debug.WriteLine(m));
 
-            // Attempt to read previously applied hot reload deltas. dotnet-watch and VS will serve the script that can provide results from local-storage and
-            // the injected middleware if present.
-            var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "/_framework/blazor-hotreload.js"));
-            await jsObjectReference.InvokeUnmarshalled<Task<int>>("receiveHotReload");
+            if (Environment.GetEnvironmentVariable("_ASPNETCORE_BROWSER_TOOLS") == "true")
+            {
+                // Attempt to read previously applied hot reload deltas if the ASP.NET Core browser tools are available (indicated by the presence of the Environment variable).
+                // The agent is injected in to the hosted app and can serve this script that can provide results from local-storage .
+                // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
+
+                var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "/_framework/blazor-hotreload.js"));
+                await jsObjectReference.InvokeUnmarshalled<Task<int>>("receiveHotReload");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/37357
Corresponding SDK PR: https://github.com/dotnet/sdk/pull/22023

Gist of what's happening is listed here:  https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000

Repasting the content for ease of discovery:

Implementation notes self since this has a few moving parts:

On startup, Blazor WASM attempts to re-apply any deltas from a before the browser was refreshed by invoking a JS module. Currently this is gated on `MetadataUpdater.IsSupported` which is true when debugger is attached. While we wire up other things in the framework based on this condition, this is the first incidence of doing something pro-active when the feature switch is present. This poses a problem since `IsSupported` does not indicate `IsEnabled` which is what's happening in the user's case.

For this particular case, we can infer the presence of the `blazor-hotreload` endpoint as a proxy to hot reload being enabled. To do this,

a) The browser refresh middleware binary will configure an environment variable that says it is indeed injected.
b) Components.WebAssembly.Server will read this env variable and configure an additional HTTP response header when sending blazor.boot.json
c) The client script will configure a env variable in WASM based on the presence of this HTTP header.
d) WebAssemblyHost will only attempt to download the module if both `MetadataUpdater.IsSupported` and this environment variable are present.

