### PR TITLE
Pass IJSVoidResult instead of object to Invoke to indicate void result

### DIFF
--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -130,6 +130,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 ["instanceMethodIncomingByRef"] = "123",
                 ["instanceMethodOutgoingByRef"] = "1234",
                 ["jsInProcessObjectReference.identity"] = "Invoked from JSInProcessObjectReference",
+                ["invokeVoidReturnsWithoutSerializingIJSInProcessRuntime"] = "Success",
                 ["invokeVoidReturnsWithoutSerializingInIJSInProcessObjectReference"] = "Success",
                 ["jsUnmarshalledObjectReference.unmarshalledFunction"] = "True",
                 ["jsToDotNetStreamReturnValueUnmarshalled"] = "Success",

--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -130,6 +130,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 ["instanceMethodIncomingByRef"] = "123",
                 ["instanceMethodOutgoingByRef"] = "1234",
                 ["jsInProcessObjectReference.identity"] = "Invoked from JSInProcessObjectReference",
+                ["invokeVoidReturnsWithoutSerializingInIJSInProcessObjectReference"] = "Success",
                 ["jsUnmarshalledObjectReference.unmarshalledFunction"] = "True",
                 ["jsToDotNetStreamReturnValueUnmarshalled"] = "Success",
                 ["jsCastedUnmarshalledObjectReference.unmarshalledFunction"] = "False",

--- a/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
@@ -284,7 +284,7 @@
     {
         var inProcRuntime = ((IJSInProcessRuntime)JSRuntime);
 
-		try
+         try
         {
             // Fetch a non-serializable Window (https://developer.mozilla.org/en-US/docs/Web/API/Window)
             // InvokeVoid shouldn't serialize return values, and thus there shouldn't be any exception thrown.

--- a/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
@@ -287,6 +287,18 @@
         var jsInProcObjectReference = inProcRuntime.Invoke<IJSInProcessObjectReference>("returnJSObjectReference");
         ReturnValues["jsInProcessObjectReference.identity"] = jsInProcObjectReference.Invoke<string>("identity", "Invoked from JSInProcessObjectReference");
 
+        try
+        {
+            // Fetch a non-serializable Window (https://developer.mozilla.org/en-US/docs/Web/API/Window)
+            // InvokeVoid shouldn't serialize return values, and thus there shouldn't be any exception thrown.
+            jsInProcObjectReference.InvokeVoid("getWindow");
+            ReturnValues["invokeVoidReturnsWithoutSerializingInIJSInProcessObjectReference"] = "Success";
+        }
+        catch (Exception ex)
+        {
+            ReturnValues["invokeVoidReturnsWithoutSerializingInIJSInProcessObjectReference"] = $"Failure: {ex.Message}";
+        }
+
         // we should be able to downcast a IJSInProcessObjectReference as a IJSUnmarshalledObjectReference
         var unmarshalledCast = (IJSUnmarshalledObjectReference)jsInProcObjectReference;
         ReturnValues["jsCastedUnmarshalledObjectReference.unmarshalledFunction"] = unmarshalledCast.InvokeUnmarshalled<InteropStruct, bool>("unmarshalledFunction", new InteropStruct

--- a/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
@@ -284,6 +284,18 @@
     {
         var inProcRuntime = ((IJSInProcessRuntime)JSRuntime);
 
+		try
+        {
+            // Fetch a non-serializable Window (https://developer.mozilla.org/en-US/docs/Web/API/Window)
+            // InvokeVoid shouldn't serialize return values, and thus there shouldn't be any exception thrown.
+            inProcRuntime.InvokeVoid("eval", "window");
+            ReturnValues["invokeVoidReturnsWithoutSerializingIJSInProcessRuntime"] = "Success";
+        }
+        catch (Exception ex)
+        {
+            ReturnValues["invokeVoidReturnsWithoutSerializingIJSInProcessRuntime"] = $"Failure: {ex.Message}";
+        }
+
         var jsInProcObjectReference = inProcRuntime.Invoke<IJSInProcessObjectReference>("returnJSObjectReference");
         ReturnValues["jsInProcessObjectReference.identity"] = jsInProcObjectReference.Invoke<string>("identity", "Invoked from JSInProcessObjectReference");
 

--- a/src/JSInterop/Microsoft.JSInterop/src/JSInProcessObjectReferenceExtensions.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSInProcessObjectReferenceExtensions.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop
 {
@@ -25,7 +25,7 @@ namespace Microsoft.JSInterop
                 throw new ArgumentNullException(nameof(jsObjectReference));
             }
 
-            jsObjectReference.Invoke<object>(identifier, args);
+            jsObjectReference.Invoke<IJSVoidResult>(identifier, args);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/JSInProcessRuntimeExtensions.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSInProcessRuntimeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop
 {
@@ -25,7 +26,7 @@ namespace Microsoft.JSInterop
                 throw new ArgumentNullException(nameof(jsRuntime));
             }
 
-            jsRuntime.Invoke<object>(identifier, args);
+            jsRuntime.Invoke<IJSVoidResult>(identifier, args);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/test/JSInProcessObjectReferenceExtensionsTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSInProcessObjectReferenceExtensionsTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.JSInterop
             var method = "someMethod";
             var args = new[] { "a", "b" };
             var jsInProcessObjectReference = new Mock<IJSInProcessObjectReference>(MockBehavior.Strict);
-            jsRuntime.Setup(s => s.Invoke<IJSVoidResult>(method, args)).Returns(Mock.Of<IJSVoidResult>());
+            jsInProcessObjectReference.Setup(s => s.Invoke<IJSVoidResult>(method, args)).Returns(Mock.Of<IJSVoidResult>());
 
             // Act
             jsInProcessObjectReference.Object.InvokeVoid(method, args);

--- a/src/JSInterop/Microsoft.JSInterop/test/JSInProcessObjectReferenceExtensionsTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSInProcessObjectReferenceExtensionsTest.cs
@@ -16,13 +16,13 @@ namespace Microsoft.JSInterop
             // Arrange
             var method = "someMethod";
             var args = new[] { "a", "b" };
-            var jsRuntime = new Mock<IJSInProcessObjectReference>(MockBehavior.Strict);
+            var jsInProcessObjectReference = new Mock<IJSInProcessObjectReference>(MockBehavior.Strict);
             jsRuntime.Setup(s => s.Invoke<IJSVoidResult>(method, args)).Returns(Mock.Of<IJSVoidResult>());
 
             // Act
-            jsRuntime.Object.InvokeVoid(method, args);
+            jsInProcessObjectReference.Object.InvokeVoid(method, args);
 
-            jsRuntime.Verify();
+            jsInProcessObjectReference.Verify();
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/test/JSInProcessObjectReferenceExtensionsTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSInProcessObjectReferenceExtensionsTest.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.JSInterop.Infrastructure;
+using Moq;
+using Xunit;
+
+namespace Microsoft.JSInterop
+{
+    public class JSInProcessObjectReferenceExtensionsTest
+    {
+        [Fact]
+        public void InvokeVoid_Works()
+        {
+            // Arrange
+            var method = "someMethod";
+            var args = new[] { "a", "b" };
+            var jsRuntime = new Mock<IJSInProcessObjectReference>(MockBehavior.Strict);
+            jsRuntime.Setup(s => s.Invoke<IJSVoidResult>(method, args)).Returns(Mock.Of<IJSVoidResult>());
+
+            // Act
+            jsRuntime.Object.InvokeVoid(method, args);
+
+            jsRuntime.Verify();
+        }
+    }
+}

--- a/src/JSInterop/Microsoft.JSInterop/test/JSInProcessRuntimeExtensionsTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSInProcessRuntimeExtensionsTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
+using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using Xunit;
 
@@ -16,7 +17,7 @@ namespace Microsoft.JSInterop
             var method = "someMethod";
             var args = new[] { "a", "b" };
             var jsRuntime = new Mock<IJSInProcessRuntime>(MockBehavior.Strict);
-            jsRuntime.Setup(s => s.Invoke<object>(method, args)).Returns(new ValueTask<object>(new object()));
+            jsRuntime.Setup(s => s.Invoke<IJSVoidResult>(method, args)).Returns(Mock.Of<IJSVoidResult>());
 
             // Act
             jsRuntime.Object.InvokeVoid(method, args);


### PR DESCRIPTION
# Pass IJSVoidResult instead of object to Invoke

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Change `InvokeVoid` in `JSInProcessObjectReferenceExtensions` to pass `IJSVoidResult` instead of `object` to `Invoke` to indicate void result.

Fixes #37528
