### PR TITLE
Fix multiple dictionary add in polly

### DIFF
--- a/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.Http
 
             var result = await base.SendAsync(request, cancellationToken);
 
-            request.Properties.Add(PriorResponseKey, result);
+            request.Properties[PriorResponseKey] = result;
 
             return result;
         }

--- a/src/HttpClientFactory/Polly/test/PolicyHttpMessageHandlerTest.cs
+++ b/src/HttpClientFactory/Polly/test/PolicyHttpMessageHandlerTest.cs
@@ -148,6 +148,58 @@ namespace Microsoft.Extensions.Http
         }
 
         [Fact]
+        public async Task SendAsync_MultipleHandlers_StaticPolicy_PolicyTriggers_CanReexecuteSendAsync_FirstResponseDisposed()
+        {
+            // Arrange
+            var policy1 = HttpPolicyExtensions.HandleTransientHttpError()
+                .RetryAsync(retryCount: 1);
+            var policy2 = HttpPolicyExtensions.HandleTransientHttpError()
+                .CircuitBreakerAsync(handledEventsAllowedBeforeBreaking: 2, durationOfBreak: TimeSpan.FromSeconds(10));
+
+            var callCount = 0;
+            var fakeContent = new FakeContent();
+            var firstResponse = new HttpResponseMessage()
+            {
+                StatusCode = System.Net.HttpStatusCode.InternalServerError,
+                Content = fakeContent,
+            };
+            var expected = new HttpResponseMessage();
+
+            var handler1 = new PolicyHttpMessageHandler(policy1);
+            var handler2 = new PolicyHttpMessageHandler(policy2);
+            handler1.InnerHandler = handler2;
+            handler2.InnerHandler = new TestHandler()
+            {
+                OnSendAsync = (req, ct) =>
+                {
+                    if (callCount == 0)
+                    {
+                        callCount++;
+                        return Task.FromResult(firstResponse);
+                    }
+                    else if (callCount == 1)
+                    {
+                        callCount++;
+                        return Task.FromResult(expected);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException();
+                    }
+                }
+            };
+            var invoke = new HttpMessageInvoker(handler1);
+
+            // Act
+            var response = await invoke.SendAsync(new HttpRequestMessage(), CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, callCount);
+            Assert.Same(expected, response);
+            Assert.True(fakeContent.Disposed);
+        }
+
+        [Fact]
         public async Task SendAsync_DynamicPolicy_PolicySelectorReturnsNull_ThrowsException()
         {
             // Arrange

--- a/src/HttpClientFactory/Polly/test/PolicyHttpMessageHandlerTest.cs
+++ b/src/HttpClientFactory/Polly/test/PolicyHttpMessageHandlerTest.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.Http
         }
 
         [Fact]
-        public async Task SendAsync_MultipleHandlers_StaticPolicy_PolicyTriggers_CanReexecuteSendAsync_FirstResponseDisposed()
+        public async Task MultipleHandlers_CanReexecuteSendAsync_FirstResponseDisposed()
         {
             // Arrange
             var policy1 = HttpPolicyExtensions.HandleTransientHttpError()


### PR DESCRIPTION
Fixes 6.0-rc2 customer feedback https://github.com/dotnet/aspnetcore/commit/8d5212dbb252e25647d98309fd5c583a23732860#r57959949

#36162 previously fixed an issue with undisposed responses when retrying requests. Unfortunately, it introduced a regression if you have multiple policies, throwing a duplicate dictionary key exception for the second policy.

The fix is to use the dictionary indexer instead of Add. The disposal logic is idempotent, it doesn't matter if it runs multiple times.

This needs to be backported to 6.0.
