### PR TITLE
Only attempt to import blazor-hotreload.js is AspNetCore Browser tool…

### DIFF
--- a/src/Components/Web.JS/src/Platform/BootConfig.ts
+++ b/src/Components/Web.JS/src/Platform/BootConfig.ts
@@ -21,6 +21,7 @@ export class BootConfigResult {
     const applicationEnvironment = environment || bootConfigResponse.headers.get('Blazor-Environment') || 'Production';
     const bootConfig: BootJsonData = await bootConfigResponse.json();
     bootConfig.modifiableAssemblies = bootConfigResponse.headers.get('DOTNET-MODIFIABLE-ASSEMBLIES');
+    bootConfig.aspnetCoreBrowserTools = bootConfigResponse.headers.get('ASPNETCORE-BROWSER-TOOLS');
 
     return new BootConfigResult(bootConfig, applicationEnvironment);
 
@@ -48,6 +49,7 @@ export interface BootJsonData {
 
   // These properties are tacked on, and not found in the boot.json file
   modifiableAssemblies: string | null;
+  aspnetCoreBrowserTools: string | null;
 }
 
 export type BootJsonDataExtension = { [extensionName: string]: ResourceList };

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -440,6 +440,11 @@ function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourceLoade
       MONO.mono_wasm_setenv('DOTNET_MODIFIABLE_ASSEMBLIES', resourceLoader.bootConfig.modifiableAssemblies);
     }
 
+    if (resourceLoader.bootConfig.aspnetCoreBrowserTools) {
+      // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
+      MONO.mono_wasm_setenv('__ASPNETCORE_BROWSER_TOOLS', resourceLoader.bootConfig.aspnetCoreBrowserTools);
+    }
+
     const load_runtime = cwrap('mono_wasm_load_runtime', null, ['string', 'number']);
     // -1 enables debugging with logging disabled. 0 disables debugging entirely.
     load_runtime(appBinDirName, hasDebuggingEnabled() ? -1 : 0);

--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -47,13 +47,23 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     context.Response.Headers.Append("Blazor-Environment", webHostEnvironment.EnvironmentName);
 
-                    // DOTNET_MODIFIABLE_ASSEMBLIES is used by the runtime to initialize hot-reload specific environment variables and is configured
-                    // by the launching process (dotnet-watch / Visual Studio).
-                    // In Development, we'll transmit the environment variable to WebAssembly as a HTTP header. The bootstrapping code will read the header
-                    // and configure it as env variable for the wasm app.
-                    if (webHostEnvironment.IsDevelopment() &&  Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES") is not null)
+                    if (webHostEnvironment.IsDevelopment())
                     {
-                        context.Response.Headers.Append("DOTNET-MODIFIABLE-ASSEMBLIES", Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES"));
+                        // DOTNET_MODIFIABLE_ASSEMBLIES is used by the runtime to initialize hot-reload specific environment variables and is configured
+                        // by the launching process (dotnet-watch / Visual Studio).
+                        // In Development, we'll transmit the environment variable to WebAssembly as a HTTP header. The bootstrapping code will read the header
+                        // and configure it as env variable for the wasm app.
+                        if (Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES") is string dotnetModifiableAssemblies)
+                        {
+                            context.Response.Headers.Append("DOTNET-MODIFIABLE-ASSEMBLIES", dotnetModifiableAssemblies);
+                        }
+
+                        // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
+                        // Translate the _ASPNETCORE_BROWSER_TOOLS environment configured by the browser tools agent in to a HTTP response header.
+                        if (Environment.GetEnvironmentVariable("__ASPNETCORE_BROWSER_TOOLS") is string blazorWasmHotReload)
+                        {
+                            context.Response.Headers.Append("ASPNETCORE-BROWSER-TOOLS", blazorWasmHotReload);
+                        }
                     }
 
                     await next(context);

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -27,10 +27,15 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
         {
             _hotReloadAgent = new HotReloadAgent(m => Debug.WriteLine(m));
 
-            // Attempt to read previously applied hot reload deltas. dotnet-watch and VS will serve the script that can provide results from local-storage and
-            // the injected middleware if present.
-            var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "/_framework/blazor-hotreload.js"));
-            await jsObjectReference.InvokeUnmarshalled<Task<int>>("receiveHotReload");
+            if (Environment.GetEnvironmentVariable("__ASPNETCORE_BROWSER_TOOLS") == "true")
+            {
+                // Attempt to read previously applied hot reload deltas if the ASP.NET Core browser tools are available (indicated by the presence of the Environment variable).
+                // The agent is injected in to the hosted app and can serve this script that can provide results from local-storage .
+                // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
+
+                var jsObjectReference = (IJSUnmarshalledObjectReference)(await DefaultWebAssemblyJSRuntime.Instance.InvokeAsync<IJSObjectReference>("import", "/_framework/blazor-hotreload.js"));
+                await jsObjectReference.InvokeUnmarshalled<Task<int>>("receiveHotReload");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
…s middleware is present

Contributes to https://github.com/dotnet/aspnetcore/issues/37357

Port https://github.com/dotnet/aspnetcore/pull/3753 to 6.0

--------------------------
Issue: https://github.com/dotnet/aspnetcore/issues/37357


SDK PR: https://github.com/dotnet/sdk/pull/22023
Blazor PR: https://github.com/dotnet/aspnetcore/pull/37536


### Description

Blazor WebAssembly has a special code path to handle a user refreshing the browser (essentially re-initializing the app) after hot reload has been applied. As part of it's initialization, Blazor WebAssembly calls out to the hot-reload endpoint to get any deltas that are cached as part of the browser's local-storage. Unfortunately the current check relies on if HotReload "can" be allowed, but not necessarily if it's actually enabled.

In the user reported issue, the user turned off hot reload while under the debugger. The endpoint to fetch previously applied deltas becomes unavailable and causes blazor wasm to fail to initialize. The two part fix we have here is by configuring an ambient environment variable when the hot-reload endpoint is actually available and making this value available to the WASM app in the browser via a game of telephones.

### Customer impact
Unable to start a blazor wasm app under debugger with hot reload disabled in VS.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This affects a very narrow code path involving refreshing a browser after hot reload which was verified.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A