### PR TITLE
[Static web assets] Fixes an issue where patterns at the root were not being considered

### DIFF
--- a/src/Hosting/Hosting/test/StaticWebAssets/ManifestStaticWebAssetsFileProviderTests.cs
+++ b/src/Hosting/Hosting/test/StaticWebAssets/ManifestStaticWebAssetsFileProviderTests.cs
@@ -321,7 +321,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests.StaticWebAssets
             var fileProvider = new ManifestStaticWebAssetFileProvider(manifest, factory);
 
             // Act
-            var file = fileProvider.GetFileInfo("other.html");
+            var file = fileProvider.GetFileInfo("/other.html");
 
             // Assert
             Assert.NotNull(file);

--- a/src/Shared/StaticWebAssets/ManifestStaticWebAssetFileProvider.cs
+++ b/src/Shared/StaticWebAssets/ManifestStaticWebAssetFileProvider.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets
             // The list of patterns is ordered by pattern depth, so we compute the string to check for patterns only
             // once per level. We don't aim to solve conflicts here where multiple files could match a given path,
             // we have a build check that takes care of that.
-            var currentDepth = 0;
+            var currentDepth = -1;
             var candidatePath = subpath;
 
             if (patterns != null)


### PR DESCRIPTION
The issue was that we were using the subpath as the initial value for candidatePath and not trimming the leading "/" on the first iteration.

By setting the currentDepth=-1 the candidatePath gets normalized on the first iteration too.

Fixes #37508