### PR TITLE
[release/6.0] Publish Windows x64/x86 checksums

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -213,25 +213,13 @@ stages:
                 -buildInstallers
                 -noBuildNative
                 /p:DotNetSignType=$(_SignType)
+                /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
                 $(_BuildArgs)
+                $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
+                /p:PublishInstallerBaseVersion=true
                 $(WindowsInstallersLogArgs)
         displayName: Build Installers
-
-      - script: ./eng/build.cmd
-               -ci
-               -noBuildRepoTasks
-               -noBuildNative
-               -noBuild
-               -noRestore
-               -projects eng/empty.proj
-               $(_BuildArgs)
-               $(_InternalRuntimeDownloadArgs)
-               $(_PublishArgs)
-               /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
-               /p:PublishInstallerBaseVersion=true
-               /bl:artifacts/log/Release/Build.Publish.binlog
-        displayName: Publish
 
       # A few files must also go to the VS package feed.
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:


### PR DESCRIPTION
- were missing because AfterSigning.proj executes only when main build does something
  - i.e. must combine checksum generation w/ `Build`, `Test`, `Pack`, or similar targets
- recombine Installers and Publish build steps, matching what we have in release/5.0
- cherry-pick from #37557