### PR TITLE
Backport #37532 (Pass IJSVoidResult instead of object to Invoke to indicate void result)

### DIFF
--- a/src/Components/test/E2ETest/Tests/InteropTest.cs
+++ b/src/Components/test/E2ETest/Tests/InteropTest.cs
@@ -130,6 +130,8 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
                 ["instanceMethodIncomingByRef"] = "123",
                 ["instanceMethodOutgoingByRef"] = "1234",
                 ["jsInProcessObjectReference.identity"] = "Invoked from JSInProcessObjectReference",
+                ["invokeVoidReturnsWithoutSerializingIJSInProcessRuntime"] = "Success",
+                ["invokeVoidReturnsWithoutSerializingInIJSInProcessObjectReference"] = "Success",
                 ["jsUnmarshalledObjectReference.unmarshalledFunction"] = "True",
                 ["jsToDotNetStreamReturnValueUnmarshalled"] = "Success",
                 ["jsCastedUnmarshalledObjectReference.unmarshalledFunction"] = "False",

--- a/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/InteropComponent.razor
@@ -284,8 +284,32 @@
     {
         var inProcRuntime = ((IJSInProcessRuntime)JSRuntime);
 
+         try
+        {
+            // Fetch a non-serializable Window (https://developer.mozilla.org/en-US/docs/Web/API/Window)
+            // InvokeVoid shouldn't serialize return values, and thus there shouldn't be any exception thrown.
+            inProcRuntime.InvokeVoid("eval", "window");
+            ReturnValues["invokeVoidReturnsWithoutSerializingIJSInProcessRuntime"] = "Success";
+        }
+        catch (Exception ex)
+        {
+            ReturnValues["invokeVoidReturnsWithoutSerializingIJSInProcessRuntime"] = $"Failure: {ex.Message}";
+        }
+
         var jsInProcObjectReference = inProcRuntime.Invoke<IJSInProcessObjectReference>("returnJSObjectReference");
         ReturnValues["jsInProcessObjectReference.identity"] = jsInProcObjectReference.Invoke<string>("identity", "Invoked from JSInProcessObjectReference");
+
+        try
+        {
+            // Fetch a non-serializable Window (https://developer.mozilla.org/en-US/docs/Web/API/Window)
+            // InvokeVoid shouldn't serialize return values, and thus there shouldn't be any exception thrown.
+            jsInProcObjectReference.InvokeVoid("getWindow");
+            ReturnValues["invokeVoidReturnsWithoutSerializingInIJSInProcessObjectReference"] = "Success";
+        }
+        catch (Exception ex)
+        {
+            ReturnValues["invokeVoidReturnsWithoutSerializingInIJSInProcessObjectReference"] = $"Failure: {ex.Message}";
+        }
 
         // we should be able to downcast a IJSInProcessObjectReference as a IJSUnmarshalledObjectReference
         var unmarshalledCast = (IJSUnmarshalledObjectReference)jsInProcObjectReference;

--- a/src/JSInterop/Microsoft.JSInterop/src/JSInProcessObjectReferenceExtensions.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSInProcessObjectReferenceExtensions.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop
 {
@@ -25,7 +25,7 @@ namespace Microsoft.JSInterop
                 throw new ArgumentNullException(nameof(jsObjectReference));
             }
 
-            jsObjectReference.Invoke<object>(identifier, args);
+            jsObjectReference.Invoke<IJSVoidResult>(identifier, args);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/JSInProcessRuntimeExtensions.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSInProcessRuntimeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop
 {
@@ -25,7 +26,7 @@ namespace Microsoft.JSInterop
                 throw new ArgumentNullException(nameof(jsRuntime));
             }
 
-            jsRuntime.Invoke<object>(identifier, args);
+            jsRuntime.Invoke<IJSVoidResult>(identifier, args);
         }
     }
 }

--- a/src/JSInterop/Microsoft.JSInterop/test/JSInProcessObjectReferenceExtensionsTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSInProcessObjectReferenceExtensionsTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.JSInterop
 {
-    public class JSInProcessRuntimeExtensionsTest
+    public class JSInProcessObjectReferenceExtensionsTest
     {
         [Fact]
         public void InvokeVoid_Works()
@@ -16,13 +16,13 @@ namespace Microsoft.JSInterop
             // Arrange
             var method = "someMethod";
             var args = new[] { "a", "b" };
-            var jsRuntime = new Mock<IJSInProcessRuntime>(MockBehavior.Strict);
-            jsRuntime.Setup(s => s.Invoke<IJSVoidResult>(method, args)).Returns(Mock.Of<IJSVoidResult>());
+            var jsInProcessObjectReference = new Mock<IJSInProcessObjectReference>(MockBehavior.Strict);
+            jsInProcessObjectReference.Setup(s => s.Invoke<IJSVoidResult>(method, args)).Returns(Mock.Of<IJSVoidResult>());
 
             // Act
-            jsRuntime.Object.InvokeVoid(method, args);
+            jsInProcessObjectReference.Object.InvokeVoid(method, args);
 
-            jsRuntime.Verify();
+            jsInProcessObjectReference.Verify();
         }
     }
 }


### PR DESCRIPTION
# Pass `IJSVoidResult` instead of `object` to `InvokeVoid` to indicate void result

Change `InvokeVoid` in `JSInProcessObjectReferenceExtensions` & `JSInProcessRuntimeExtensions` to have a generic return value of `IJSVoidResult` instead of `object` to indicate void result.

## Description

As part of https://github.com/dotnet/aspnetcore/issues/35929, we moved from `InvokeVoidAsync<object>` to `InvokeVoidAsync<IJSVoidResult>`. However, this change is missing for `InvokeVoid`. This PR updates the `InvokeVoid` APIs to be in line with `InvokeVoidAsync`, to ensure operational consistency and decrease interop overhead. 

Fixes #37528

## Customer Impact

Without this change, `InvokeVoid` and `InvokeVoidAsync` behave differently, which may lead to user confusion. This also [causes issues](https://github.com/dotnet/aspnetcore/issues/37528) with testability in external testing frameworks like [`bunit`](https://bunit.dev/). 

Additionally, without this change if users attempt to return non-serializable values like a JavaScript `window`, then they will see an error with `InvokeVoid` but not with `InvokeVoidAsync`.

Currently, we're serializing the return value of `InvokeVoid`, and then discarding it. With this change, we do not serialize the return value at all. Consequently, this change has performance benefits as well.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

We discard the return value of `InvokeVoid` regardless, by setting the generic return value to `IJSVoidResult` instead of `object`, we ensure the return value isn't serialized in the first place. 

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A