### PR TITLE
Specify the correct path for BlazorWASM project 

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -38,7 +38,7 @@
     },
     {
       "condition": "(!Hosted)",
-      "path": "ComponentsWebAssembly-CSharp.Client.csproj"
+      "path": "ComponentsWebAssembly-CSharp.csproj"
     },
     {
       "condition": "(Hosted && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/36463

## Description

The Blazor WASM project template re-uses contents for it's hosted and standalone projects. When deploying it's standalone project, it scopes it to the client project folder, and strips out the `.Client` suffix from the project name. However, it missed stripping out the suffix in one location - the "primary output"  property which is used to determine what project to launch in the IDE. This causes issues with VS4Mac.

Fixes https://github.com/dotnet/aspnetcore/issues/36463

## Customer Impact

n/a

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual - verified this with VS (for Windows) and dotnet CLI
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
