### PR TITLE
[Static web assets] Fixes an issue where patterns at the root were not being considered (#37560)

### DIFF
--- a/src/Hosting/Hosting/test/StaticWebAssets/ManifestStaticWebAssetsFileProviderTests.cs
+++ b/src/Hosting/Hosting/test/StaticWebAssets/ManifestStaticWebAssetsFileProviderTests.cs
@@ -314,6 +314,42 @@ namespace Microsoft.AspNetCore.Hosting.Tests.StaticWebAssets
         }
 
         [Fact]
+        public void GetFileInfoHandlesRootPatternCorrectly()
+        {
+            var (manifest, factory) = CreateTestManifestWithPattern();
+
+            var fileProvider = new ManifestStaticWebAssetFileProvider(manifest, factory);
+
+            // Act
+            var file = fileProvider.GetFileInfo("/other.html");
+
+            // Assert
+            Assert.NotNull(file);
+            Assert.True(file.Exists);
+            Assert.False(file.IsDirectory);
+            Assert.Equal("other.html", file.Name);
+        }
+
+        [Fact]
+        public void GetDirectoryContentsHandlesRootPatternCorrectly()
+        {
+            var (manifest, factory) = CreateTestManifestWithPattern();
+
+            var fileProvider = new ManifestStaticWebAssetFileProvider(manifest, factory);
+
+            // Act
+            var contents = fileProvider.GetDirectoryContents("");
+
+            // Assert
+            Assert.NotNull(contents);
+            Assert.True(contents.Exists);
+            var file = contents.Single();
+            Assert.True(file.Exists);
+            Assert.False(file.IsDirectory);
+            Assert.Equal("other.html", file.Name);
+        }
+
+        [Fact]
         public void CanFindFileMatchingPattern()
         {
             var (manifest, factory) = CreateTestManifest();
@@ -695,6 +731,46 @@ namespace Microsoft.AspNetCore.Hosting.Tests.StaticWebAssets
                                 Patterns = new ManifestStaticWebAssetFileProvider.StaticWebAssetPattern[] { new() { ContentRoot = 1, Depth = 2, Pattern = "**" } }
                             }
                         }
+                    }
+                }
+            };
+
+            return (manifest, factory);
+        }
+
+        private static (ManifestStaticWebAssetFileProvider.StaticWebAssetManifest manifest, Func<string, IFileProvider> factory) CreateTestManifestWithPattern()
+        {
+            // Arrange
+            var otherHtml = new TestFileInfo { Exists = true, IsDirectory = false, Name = "other.html" };
+
+            var manifest = new ManifestStaticWebAssetFileProvider.StaticWebAssetManifest();
+            manifest.ContentRoots = new [] { "Cero" };
+            Func<string, IFileProvider> factory = (string contentRoot) =>
+            {
+                if (contentRoot == "Cero")
+                {
+                    var providerMock = new Mock<IFileProvider>();
+                    providerMock.Setup(p => p.GetFileInfo("other.html")).Returns(otherHtml);
+                    providerMock.Setup(p => p.GetDirectoryContents("")).Returns(new TestDirectoryContents(new[] { otherHtml })
+                    {
+                        Exists = true
+                    });
+
+                    return providerMock.Object;
+                }
+
+                throw new InvalidOperationException("Invalid content root");
+            };
+            manifest.Root = new()
+            {
+                Children = new Dictionary<string, ManifestStaticWebAssetFileProvider.StaticWebAssetNode>(),
+                Patterns = new[]
+                {
+                    new ManifestStaticWebAssetFileProvider.StaticWebAssetPattern
+                    {
+                        ContentRoot = 0,
+                        Depth = 0,
+                        Pattern = "**"
                     }
                 }
             };

--- a/src/Shared/StaticWebAssets/ManifestStaticWebAssetFileProvider.cs
+++ b/src/Shared/StaticWebAssets/ManifestStaticWebAssetFileProvider.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.StaticWebAssets
             // The list of patterns is ordered by pattern depth, so we compute the string to check for patterns only
             // once per level. We don't aim to solve conflicts here where multiple files could match a given path,
             // we have a build check that takes care of that.
-            var currentDepth = 0;
+            var currentDepth = -1;
             var candidatePath = subpath;
 
             if (patterns != null)


### PR DESCRIPTION
## Description

Static web assets falls back to check on a set of defined folders when it can't find a file in its manifest at runtime. This allows us to map new and renamed files while the app without having to restart the app, in the same way it works when you are dealing with a web project and content in the wwwroot folder.

Blazor Webassembly leverages this capability to allow the user to add and rename files to the client wwwroot folder and automatically serve them on a page refresh without having to restart the application.

Static web assets contains a list of all the potential locations for content in its manifest (simplified) as a triplet of (base path, pattern, folder).

The issue is that Blazor Webassembly applications typically serve these files from the root of the url space "/" and when we fail to find a file on the manifest and need to check the pattern ("/", "**", <<folder>>) added by the Blazor webassembly app, we don't process the path correctly to remove the initial "/' from the path, and that causes the pattern matching to not match.

The fix initializes the depth to "-1" instead of "0" which forces the algorithm to go through the same steps that it follows for other pattern and normalize the path before the evaluation against the pattern. This way, a request like "/other.html" is preprocessed to "other.html" which matches the pattern "**" and causes the file to be returned if present.

Fixes #37508

## Customer Impact

Customers can't add or rename a file in their blazor webassembly app project wwwroot and have it served without stopping and rebuilding the app. This puts a dent on the inner loop performance

## Regression?

- [X] Yes
- [ ] No

5.0

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Its a bug in the initialization conditions of the algorithm, we added a specific test to cover this case.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A