### PR TITLE
AzureB2C - Fix missing sign in button

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Shared/_LoginPartial.OrgAuth.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Shared/_LoginPartial.OrgAuth.cshtml
@@ -32,7 +32,9 @@
 }
 else
 {
-        <span class="navbar-text text-dark">Hello @User.Identity?.Name!</span>
+        <li class="nav-item">
+            <a class="nav-link text-dark" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignIn">Sign in</a>
+        </li>
 }
 #else
 @if (User.Identity?.IsAuthenticated == true)


### PR DESCRIPTION
# AzureB2C - Fix missing sign in button

Fixes issue with the azure b2c variant of the razor pages template which resulting in a missing sign in button

## Description

Fix a copy paste error in the razor pages variant of the template where the sign in button was removed, this just puts the sign in button back.

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/974

## Customer Impact

There's no way to login without the button

## Regression?

- [X] Yes
- [ ] No

All versions, since the template isn't useable without the button

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Just reverts the copy paste error in https://github.com/dotnet/aspnetcore/commit/3456cb1ad2581406f5d987be33923a503bfc541e#diff-02f44f66d659128b602ced02bb37a1b548f20ec948055803bc09791cdc0bbb99R35

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

----
