### PR TITLE
Bump Swashbuckle.AspNetCore version in templates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -257,7 +257,7 @@
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.2.4</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>3.1.1</SystemReactiveLinqVersion>
-    <SwashbuckleAspNetCoreVersion>6.1.5</SwashbuckleAspNetCoreVersion>
+    <SwashbuckleAspNetCoreVersion>6.2.3</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
     <XunitAnalyzersVersion>0.10.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.1</XunitVersion>


### PR DESCRIPTION
## Description

This PR updates the version of the `Swashbuckle.AspNetCore` dependency used in the templates from `6.1.5` to `6.2.3`.

## Customer Impact

This change brings in some bug fixes that were made in the `Swashbuckle.AspNetCore` library to bring in bug fixes associated with the new hosting model and allow users to leverage new OpenAPI features end-to-end with Swashbuckle.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Low risk because:
- The package update has been verified independently in an E2E app with Swagger configured.
- The change is limited to templates that come with OpenAPI enabled by default.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A