### PR TITLE
34411 HTTP/2 and HTTP/3: Response trailers collection not reset

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -121,6 +121,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
         {
             _keepAlive = true;
             _connectionAborted = false;
+            _userTrailers = null;
 
             // Reset Http2 Features
             _currentIHttpMinRequestBodyDataRateFeature = this;
@@ -128,7 +129,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             _currentIHttpResponseTrailersFeature = this;
             _currentIHttpResetFeature = this;
             _currentIPersistentStateFeature = this;
-            _userTrailers = null;
         }
 
         protected override void OnRequestProcessingEnded()

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -128,6 +128,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2
             _currentIHttpResponseTrailersFeature = this;
             _currentIHttpResetFeature = this;
             _currentIPersistentStateFeature = this;
+            _userTrailers = null;
         }
 
         protected override void OnRequestProcessingEnded()

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -726,12 +726,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         {
             _keepAlive = true;
             _connectionAborted = false;
+            _userTrailers = null;
 
             // Reset Http3 Features
             _currentIHttpMinRequestBodyDataRateFeature = this;
             _currentIHttpResponseTrailersFeature = this;
             _currentIHttpResetFeature = this;
-            _userTrailers = null;
         }
 
         protected override void ApplicationAbort() => ApplicationAbort(new ConnectionAbortedException(CoreStrings.ConnectionAbortedByApplication), Http3ErrorCode.InternalError);

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -731,6 +731,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             _currentIHttpMinRequestBodyDataRateFeature = this;
             _currentIHttpResponseTrailersFeature = this;
             _currentIHttpResetFeature = this;
+            _userTrailers = null;
         }
 
         protected override void ApplicationAbort() => ApplicationAbort(new ConnectionAbortedException(CoreStrings.ConnectionAbortedByApplication), Http3ErrorCode.InternalError);

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -687,6 +687,17 @@ namespace Microsoft.AspNetCore.Testing
             return http3WithPayload.Payload;
         }
 
+        internal async ValueTask<Dictionary<string, string>> ExpectTrailersAsync()
+        {
+            var http3WithPayload = await ReceiveFrameAsync(false, true);
+            Http3InMemory.AssertFrameType(http3WithPayload.Type, Http3FrameType.Headers);
+
+            _headerHandler.DecodedHeaders.Clear();
+            _headerHandler.QpackDecoder.Decode(http3WithPayload.PayloadSequence, this);
+            _headerHandler.QpackDecoder.Reset();
+            return _headerHandler.DecodedHeaders.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, _headerHandler.DecodedHeaders.Comparer);
+        }
+
         internal async Task ExpectReceiveEndOfStream()
         {
             var result = await ReadApplicationInputAsync();


### PR DESCRIPTION
# 34411 HTTP/2 and HTTP/3: Response trailers collection not reset

This is a follow up on [discussion](https://github.com/dotnet/aspnetcore/pull/34360#discussion_r670867499): "would the trailers field get reset between requests"

## Description

- Resetting user set Trailers on H2 and H3 Stream's OnReset() methods
- Adding a unit tests that covers if the stream is reset or not

Fixes #34411
