### PR TITLE
Fix IHost being disposed of twice

### DIFF
--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -24,6 +24,8 @@ namespace Microsoft.AspNetCore.Builder
         private readonly IHost _host;
         private readonly List<EndpointDataSource> _dataSources = new();
 
+        private bool _disposed;
+
         internal WebApplication(IHost host)
         {
             _host = host;
@@ -162,12 +164,26 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Disposes the application.
         /// </summary>
-        void IDisposable.Dispose() => _host.Dispose();
+        void IDisposable.Dispose()
+        {
+            if (!_disposed)
+            {
+                _host.Dispose();
+                _disposed = true;
+            }
+        }
 
         /// <summary>
         /// Disposes the application.
         /// </summary>
-        public ValueTask DisposeAsync() => ((IAsyncDisposable)_host).DisposeAsync();
+        public async ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                await ((IAsyncDisposable)_host).DisposeAsync();
+                _disposed = true;
+            }
+        }
 
         internal RequestDelegate BuildRequestDelegate() => ApplicationBuilder.Build();
         RequestDelegate IApplicationBuilder.Build() => BuildRequestDelegate();

--- a/src/Mvc/Mvc.Testing/src/DeferredHostBuilder.cs
+++ b/src/Mvc/Mvc.Testing/src/DeferredHostBuilder.cs
@@ -141,7 +141,10 @@ namespace Microsoft.AspNetCore.Mvc.Testing
                     await disposable.DisposeAsync().ConfigureAwait(false);
                     return;
                 }
-                Dispose();
+                else
+                {
+                    _host.Dispose();
+                }
             }
 
             public async Task StartAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
# Fix IHost being disposed of twice

Fix the `IHost` wrapped by `DeferredHost` being disposed of twice.

## Description

Fix the `IHost` wrapped by `DeferredHost` being disposed of twice if the implementation implements `IAsyncDisposable`, as it would first call `IHost.DisposeAsync()`, and then `Dispose()` which would call `IHost.Dispose()` immediately afterwards.

Now only one of the two dispose methods is called.

This surfaced in the integration tests using `Microsoft.AspNetCore.Mvc.Testing` in an application I updated from `6.0.0-rc.1.21451.13` to `6.0.100-rc.2.21505.57` where the application uses the Azure Key Vault configuration provider, which throws an `ObjectDisposedException` if it is disposed of twice:

```
CancellationTokenSource.Cancel()
AzureKeyVaultConfigurationProvider.Dispose(Boolean disposing)
AzureKeyVaultConfigurationProvider.Dispose()
ConfigurationRoot.Dispose()
ServiceProviderEngineScope.DisposeAsync()
--- End of stack trace from previous location ---
Host.<DisposeAsync>g__DisposeAsync|16_0(Object o)
Host.DisposeAsync()
Host.Dispose()
DeferredHost.Dispose()
HttpServerFixture.Dispose(Boolean disposing) line 160
WebApplicationFactory`1.DisposeAsync()
WebApplicationFactory`1.Dispose(Boolean disposing)
HttpServerFixture.Dispose(Boolean disposing) line 154
WebApplicationFactory`1.Dispose()
```

I'm not sure what change specifically has precipitated this issue being surfaced by RC2, as `DeferredHostBuilder` doesn't appear to have been changed for several months - possibly #36832 introduced it by the configuration being added to the service collection.

Happy to add any required tests for this, but I've gotten pushback on adding unit tests for `WebApplicationFactory<T>` before as they sort of need to be integration tests by design to validate it works (_Who tests the tests?_).