### PR TITLE
Avoid null args when RazorDiagnostic does not have a message

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorDiagnosticDescriptor.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorDiagnosticDescriptor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public string GetMessageFormat()
         {
-            var message = _messageFormat.Invoke();
+            var message = _messageFormat();
             if (string.IsNullOrEmpty(message))
             {
                 return Resources.FormatRazorDiagnosticDescriptor_DefaultError(Id);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorDiagnosticDescriptor.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorDiagnosticDescriptor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -35,7 +35,16 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public RazorDiagnosticSeverity Severity { get; }
 
-        public string GetMessageFormat() => _messageFormat();
+        public string GetMessageFormat()
+        {
+            var message = _messageFormat.Invoke();
+            if (string.IsNullOrEmpty(message))
+            {
+                return Resources.FormatRazorDiagnosticDescriptor_DefaultError(Id);
+            }
+
+            return message;
+        }
 
         public override bool Equals(object obj)
         {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Resources.resx
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Resources.resx
@@ -574,4 +574,7 @@
   <data name="Component_EditorRequiredParameterNotSpecified" xml:space="preserve">
     <value>Component '{0}' expects a value for the parameter '{1}', but a value may not have been provided.</value>
   </data>
+  <data name="RazorDiagnosticDescriptor_DefaultError" xml:space="preserve">
+    <value>Encountered diagnostic '{0}'.</value>
+  </data>
 </root>

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/RazorDiagnosticDescriptorTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/RazorDiagnosticDescriptorTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
@@ -73,6 +73,18 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Assert
             Assert.False(result);
+        }
+
+        [Fact]
+        public void RazorDiagnosticDescriptor_NullMessage()
+        {
+            // Arrange & Act
+            var descriptor = new RazorDiagnosticDescriptor("RZ0001", () => null, RazorDiagnosticSeverity.Error);
+
+            // Assert
+            Assert.Equal("RZ0001", descriptor.Id);
+            Assert.Equal(RazorDiagnosticSeverity.Error, descriptor.Severity);
+            Assert.Equal("Encountered diagnostic 'RZ0001'.", descriptor.GetMessageFormat());
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/RazorDiagnosticTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/RazorDiagnosticTest.cs
@@ -1,6 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Xunit;
 
@@ -40,6 +41,21 @@ namespace Microsoft.AspNetCore.Razor.Language
             Assert.Equal("RZ0001", defaultDiagnostic.Id);
             Assert.Equal(RazorDiagnosticSeverity.Error, defaultDiagnostic.Severity);
             Assert.Equal(span, diagnostic.Span);
+        }
+
+        [Fact]
+        public void GetMessage_WithNullDescriptorFormat_ReturnsDefaultErrorString()
+        {
+            // Arrange
+            var descriptor = new RazorDiagnosticDescriptor("RZ0001", () => null, RazorDiagnosticSeverity.Error);
+            var span = new SourceSpan("test.cs", 15, 1, 8, 5);
+
+            // Act
+            var diagnostic = RazorDiagnostic.Create(descriptor, span, "Hello", "World");
+            var message = diagnostic.GetMessage(CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.Equal("Encountered diagnostic 'RZ0001'.", message);
         }
     }
 }


### PR DESCRIPTION
We've received tooling reports of the Razor compiler failing with a argument null exception
when trying to format a diagnostic message. Unfortunately dumps don't have enough details to indicate
what code path causes the badly formatted argument to be used and we haven't reproduced the error locally. 

Inspecting the code and turning on nullability in this code path does not suggest any obvious candidates in Razor's codebase. Tooling is working around this by try-catching the exception, but this results in squiggles / error items that do not
disappear. This PR introduces a temporary workaround that prints a generic error message so that it does not crash VS
/ require tooling workarounds while we try and figure out the root cause.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1405849

Port of https://github.com/dotnet/aspnetcore/pull/37648

======================

### Description

We've received tooling reports of the Razor compiler failing with a argument null exception
when trying to format a diagnostic message. Unfortunately dumps don't have enough details to indicate
what code path causes the badly formatted argument to be used and we haven't reproduced the error locally. 

Inspecting the code and turning on nullability in this code path does not suggest any obvious candidates in Razor's codebase. Tooling is working around this by try-catching the exception, but this results in squiggles / error items that do not
disappear. This PR introduces a temporary workaround that prints a generic error message so that it does not crash VS
/ require tooling workarounds while we try and figure out the root cause.

### Customer impact

Exceptions in VS and errors that cannot be dismissed once they appear.

### Regression

No

### Testing

Added automated unit tests

### Risk
Low

### Packaging changes 
n/a
