### PR TITLE
Update helix queues that skip Playwright tests

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <!-- x64 Queues for public helix-matrix.yml and quarantine pipelines, except in windows-only cases -->
+  <!-- NOTICE: When updating these queues, also update SkipHelixQueues in Helix.targets -->
   <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
     <!-- Linux -->
-    <HelixAvailableTargetQueue Include="(Debian.11.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20210304164428-5a7c380" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
     <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
@@ -35,6 +35,7 @@
     <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
 
     <!-- Containers -->
+    <HelixAvailableTargetQueue Include="(Debian.11.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20210304164428-5a7c380" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Fedora.34.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210728124700-4f64125" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Alpine.312.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673" Platform="Linux" />
     <HelixAvailableTargetQueue Include="(Mariner)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620" Platform="Linux" />    

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -11,13 +11,11 @@
   <PropertyGroup Condition="'$(TestDependsOnPlaywright)' == 'true'">
     <SkipHelixQueues>
       (Alpine.312.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.12-helix-20200908125345-56c6673;
-      (Fedora.34.Amd64.Open)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210728124700-4f64125;
+      (Debian.11.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20210304164428-5a7c380;
+      (Fedora.34.Amd64.Open)ubuntu.1804.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210728124700-4f64125;
       (Mariner)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620;
-      Debian.9.Amd64.Open;
       Redhat.7.Amd64.Open;
       Ubuntu.2004.Amd64.Open;
-      Windows.7.Amd64.Open;
-      Windows.81.Amd64.Open;
     </SkipHelixQueues>
     <SkipHelixArm>true</SkipHelixArm>
   </PropertyGroup>

--- a/src/DefaultBuilder/samples/SampleApp/Properties/launchSettings.json
+++ b/src/DefaultBuilder/samples/SampleApp/Properties/launchSettings.json
@@ -10,11 +10,10 @@
   "profiles": {
     "DefaultBuilder.SampleApp": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      }
     },
     "IIS Express": {
       "commandName": "IISExpress",

--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -35,7 +35,7 @@ namespace Templates.Test
         }
 
         [ConditionalFact]
-        [SkipOnHelix("Not supported queues", Queues = "Windows.7.Amd64;Windows.7.Amd64.Open;Windows.81.Amd64.Open;All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+        [SkipOnHelix("Not supported queues", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [SkipOnAlpine("https://github.com/grpc/grpc/issues/18338")]
         public async Task GrpcTemplate()
         {


### PR DESCRIPTION
It looks like a recent update (#36845) to the helix test matrix caused helix queues that should have skipped Playwright tests to no longer skip them. However, this wasn't really noticeable until (the single?) running test that used Playwright (BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_Works) got unquarantined by (#37309). This has caused the [`main` aspnetcore-helix-matrix pipeline](https://dev.azure.com/dnceng/public/_build?definitionId=837&branchFilter=142985%2C142985%2C142985%2C142985%2C142985%2C142985%2C142985%2C142985%2C142985%2C142985%2C142985) to fail consistently since October 6th.

![image](https://user-images.githubusercontent.com/54385/137812006-3ae9328e-ee29-413a-93c0-8d27f26582d1.png)

@HaoK @TanayParikh Is it correct that `BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_Works` is the only test that uses Playwright? Are the other tests that use Playwright all quarantined or something?

[Sample failure log for Debian](
https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-aspnetcore-refs-heads-main-b2755079cb804ee482/BlazorTemplates.Tests--net7.0/1/console.1198c1d3.log?sv=2019-07-07&se=2021-11-04T00%3A46%3A17Z&sr=c&sp=rl&sig=PUyWDf8Jo9z86yglYmar11p%2Fp2e3QV4bM%2FbeTJR62zQ%3D)

```
Installing Playwright requirements...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libdbus-glib-1-2
...
```

[And Fedora](
https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-aspnetcore-refs-heads-main-e17ff9393adb4d5e8c/BlazorTemplates.Tests--net7.0/1/console.f180e2fb.log?sv=2019-07-07&se=2021-11-04T00%3A46%3A23Z&sr=c&sp=rl&sig=TkH1nJhC%2FRZqi0PEMDkGc12YRqk5%2FNoFQm6D3jeamoI%3D):

```
sudo: apt-get: command not found
sudo: apt-get: command not found
sudo: apt-get: command not found
...
```

The tests ran despite the apt-get failures, and failed with exceptions like the following:

```
[xUnit.net 00:06:02.13]       System.AggregateException : One or more errors occurred. (Host system is missing dependencies!
[xUnit.net 00:06:02.13]       
[xUnit.net 00:06:02.14]         Missing libraries are:
[xUnit.net 00:06:02.14]             libnss3.so
[xUnit.net 00:06:02.14]             libnssutil3.so
[xUnit.net 00:06:02.14]             libsmime3.so
...
```

I removed Windows 7 and Windows 8.1 from `SkipHelixQueues` since these are no longer used.