### PR TITLE
Fix AppHost pack prebuilt usage in source-build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -198,8 +198,18 @@
   <!-- The location of the local installation of the .NET Core shared framework. -->
   <PropertyGroup>
     <LocalDotNetRoot>$(RepoRoot).dotnet\</LocalDotNetRoot>
-    <!-- Override the SDK default and point to local .dotnet folder. -->
-    <NetCoreTargetingPackRoot>$(LocalDotNetRoot)packs\</NetCoreTargetingPackRoot>
+    <!--
+      Override the SDK default and point to local .dotnet folder. This is done to work around
+      limitations in the way the .NET SDK finds shared frameworks and targeting packs. It allows
+      tests to use the shared frameworks and targeting packs that were just built.
+
+      However, source-build needs this to not happen while building projects that rely on the
+      AppHost framework pack. Source-build installs an SDK in a custom location outside this
+      repository, and setting NetCoreTargetingPackRoot to a different location causes source-build
+      to restore the AppHost pack as a prebuilt rather than using the one that's present in the SDK.
+      Source-build doesn't run tests, so the property is simply conditioned out.
+    -->
+    <NetCoreTargetingPackRoot Condition="'$(DotNetBuildFromSource)' != 'true'">$(LocalDotNetRoot)packs\</NetCoreTargetingPackRoot>
   </PropertyGroup>
 
   <Import Project="eng\tools\RepoTasks\RepoTasks.tasks" Condition="'$(MSBuildProjectName)' != 'RepoTasks' AND '$(DesignTimeBuild)' != 'true'" />

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -211,6 +211,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <!-- Workaround https://github.com/dotnet/sdk/issues/2910 by copying targeting pack into local installation. -->
   <Target Name="_InstallTargetingPackIntoLocalDotNet"
           DependsOnTargets="_ResolveTargetingPackContent"
+          Condition="'$(DotNetBuildFromSource)' != 'true'"
           Inputs="@(RefPackContent)"
           Outputs="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')">
     <RemoveDir Directories="$(LocalInstallationOutputPath)" />


### PR DESCRIPTION
# Fix AppHost pack prebuilt usage in source-build

This change removes the `NetCoreTargetingPackRoot` override in some cases during source-build to avoid unnecessarily downloading the apphost pack as a prebuilt dependency. I also updated the comment on the override to be more descriptive (based on `git blame`) and added details on why/when it needs to be disabled for source-build.

* For https://github.com/dotnet/source-build/issues/2524
* PR to add this change to 6.0.1xx SDK: https://github.com/dotnet/installer/pull/12441

/cc @dougbu 