### PR TITLE
[release/6.0] Enable targeting pack build during source-build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -142,7 +142,6 @@
     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>
 
     <!-- This is used to produce targeting pack installers/packages once per major.minor. -->
-    <IsTargetingPackBuilding Condition=" '$(DotNetBuildFromSource)' == 'true' ">false</IsTargetingPackBuilding>
     <IsTargetingPackBuilding
         Condition=" '$(IsTargetingPackBuilding)' == '' AND '$(AspNetCorePatchVersion)' != '0' ">false</IsTargetingPackBuilding>
     <IsTargetingPackBuilding Condition=" '$(IsTargetingPackBuilding)' == '' ">true</IsTargetingPackBuilding>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,10 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <!-- Only build Microsoft.AspNetCore.App and ref/ assemblies in source build. -->
+    <!-- Only build Microsoft.AspNetCore.App, Microsoft.AspNetCore.App.Ref, and ref/ assemblies in source build. -->
     <!-- Analyzer package are needed in source build for WebSDK -->
     <ExcludeFromSourceBuild
-        Condition="'$(ExcludeFromSourceBuild)' == '' and '$(DotNetBuildFromSource)' == 'true' and '$(IsAspNetCoreApp)' != 'true' and '$(IsAnalyzersProject)' != 'true'">true</ExcludeFromSourceBuild>
+        Condition="'$(ExcludeFromSourceBuild)' == '' and '$(DotNetBuildFromSource)' == 'true' and '$(IsAspNetCoreApp)' != 'true' and '$(MSBuildProjectName)' != '$(TargetingPackName)' and '$(IsAnalyzersProject)' != 'true'">true</ExcludeFromSourceBuild>
 
     <!-- If the user has specified that they want to skip building any test related projects with SkipTestBuild,
      suppress all targets for TestProjects using ExcludeFromBuild. -->

--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Microsoft.AspNetCore.App.CodeFixes.csproj
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Microsoft.AspNetCore.App.CodeFixes.csproj
@@ -2,6 +2,13 @@
   <PropertyGroup>
     <Description>CSharp CodeFixes for ASP.NET Core.</Description>
     <IsShippingPackage>false</IsShippingPackage>
+    <!--
+      This project is fed into the targeting pack build, so it needs to be built during
+      source-build. One way to build it is to mark it as an analyzers project. If this project's
+      name ended in '.Analyzers', it would automatically be marked as an analyzers project, but it
+      doesn't in this case. Mark it manually, instead.
+    -->
+    <IsAnalyzersProject>true</IsAnalyzersProject>
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
# [release/6.0] Enable targeting pack build during source-build

Cherry picked cleanly from commit 4ff8165fb16ca824bb529dc3c6ecdb30a60a90b9, PR https://github.com/dotnet/aspnetcore/pull/37652. This PR is for patch removal in .NET SDK 6.0.1xx.

> Enable building `Microsoft.AspNetCore.App.Ref` during source-build. In past releases, this package could be produced by https://github.com/dotnet/source-build-reference-packages for use in source-build because targeting packs contained only reference assemblies. This is no longer an option in 6.0+ because the targeting packs contain executable binaries. (The analyzers and source generators.)
>
> * See https://github.com/dotnet/source-build/issues/2506

/cc @wtgodbe @Pilchie 