### PR TITLE
Fix test typos

### DIFF
--- a/src/Mvc/Mvc.DataAnnotations/test/RequiredAttributeAdapterTest.cs
+++ b/src/Mvc/Mvc.DataAnnotations/test/RequiredAttributeAdapterTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Mvc.DataAnnotations
             var attribute = new RequiredAttribute();
 
             var expectedProperties = new object[] { "Length" };
-            var message = "This paramter is required.";
+            var message = "This parameter is required.";
             var expectedMessage = "FR This parameter is required.";
             attribute.ErrorMessage = message;
 

--- a/src/Mvc/test/Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ActionParametersIntegrationTest.cs
@@ -991,7 +991,7 @@ namespace Microsoft.AspNetCore.Mvc.IntegrationTests
             private static MethodInfo MyActionMethodInfo
                 => typeof(ParameterWithValidateNever).GetMethod(nameof(MyAction));
 
-            public static ParameterInfo NameParamterInfo
+            public static ParameterInfo NameParameterInfo
                 => MyActionMethodInfo.GetParameters()[0];
 
             public static ParameterInfo ValidateNeverParameterInfo


### PR DESCRIPTION
# Fix test typos

Fix two typos of "paramter"

## Description

Did a GitHub search for "paramter" and found these two remaining typos in some tests.
