### PR TITLE
Remove stale link for `RZ9992` Diagnostic

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static readonly RazorDiagnosticDescriptor DisallowedScriptTag = new RazorDiagnosticDescriptor(
             $"{DiagnosticPrefix}9992",
-            () => "Script tags should not be placed inside components because they cannot be updated dynamically. To fix this, move the script tag to the 'index.html' file or another static location.",
+            () => "Script tags should not be placed inside components because they cannot be updated dynamically. To fix this, move the script tag to the 'index.html' file or another static location. For more information, see https://aka.ms/AAe3qu3",
             RazorDiagnosticSeverity.Error);
 
         // Reserved: BL9993 Component parameters should not be public

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Components
 
         public static readonly RazorDiagnosticDescriptor DisallowedScriptTag = new RazorDiagnosticDescriptor(
             $"{DiagnosticPrefix}9992",
-            () => "Script tags should not be placed inside components because they cannot be updated dynamically. To fix this, move the script tag to the 'index.html' file or another static location. For more information see https://go.microsoft.com/fwlink/?linkid=872131",
+            () => "Script tags should not be placed inside components because they cannot be updated dynamically. To fix this, move the script tag to the 'index.html' file or another static location.",
             RazorDiagnosticSeverity.Error);
 
         // Reserved: BL9993 Component parameters should not be public

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiagnosticRazorIntegrationTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiagnosticRazorIntegrationTest.cs
@@ -62,7 +62,7 @@ Goodbye");
                 item =>
                 {
                     Assert.Equal("RZ9992", item.Id);
-                    Assert.Equal("Script tags should not be placed inside components because they cannot be updated dynamically. To fix this, move the script tag to the 'index.html' file or another static location. For more information see https://go.microsoft.com/fwlink/?linkid=872131", item.GetMessage(CultureInfo.CurrentCulture));
+                    Assert.Equal("Script tags should not be placed inside components because they cannot be updated dynamically. To fix this, move the script tag to the 'index.html' file or another static location. For more information, see https://aka.ms/AAe3qu3", item.GetMessage(CultureInfo.CurrentCulture));
                     Assert.Equal(2, item.Span.LineIndex);
                     Assert.Equal(4, item.Span.CharacterIndex);
                 });


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/37669

This is a stale link, we also don't use `https://go.microsoft.com` links [elsewhere in the razor diagnostics](https://github.com/search?q=https%3A%2F%2Fgo.microsoft.com+repo%3Adotnet%2Faspnetcore+path%3Asrc%2FRazor%2FMicrosoft.AspNetCore.Razor.Language%2Fsrc%2F&type=Code&ref=advsearch&l=&l=).

Just removing the link as the diagnostic is pretty self-explanatory. If anyone has a way to reverse lookup the original link (`https://go.microsoft.com/fwlink/?linkid=872131`), please let me know!