### PR TITLE
Continue using HashCodeCombiner in Razor.Language

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport/Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport.csproj
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport/Microsoft.AspNetCore.Razor.Internal.SourceGenerator.Transport.csproj
@@ -30,7 +30,6 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis.Common" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp" />
-    <Reference Include="Microsoft.Bcl.HashCode" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptorComparer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -41,10 +42,10 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// <inheritdoc />
         public virtual int GetHashCode(AllowedChildTagDescriptor descriptor)
         {
-            var hash = new HashCode();
-            hash.Add(descriptor.Name ?? string.Empty, StringComparer.Ordinal);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(descriptor.Name, StringComparer.Ordinal);
 
-            return hash.ToHashCode();
+            return hash.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -55,12 +56,12 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var hash = new HashCode();
-            hash.Add(descriptor.Kind ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(descriptor.Name ?? string.Empty, StringComparer.Ordinal);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(descriptor.Kind, StringComparer.Ordinal);
+            hash.Add(descriptor.Name, StringComparer.Ordinal);
             hash.Add(descriptor.IsEditorRequired);
-            hash.Add(descriptor.TypeName ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(descriptor.Documentation ?? string.Empty, StringComparer.Ordinal);
+            hash.Add(descriptor.TypeName, StringComparer.Ordinal);
+            hash.Add(descriptor.Documentation, StringComparer.Ordinal);
 
             if (descriptor.BoundAttributeParameters != null)
             {
@@ -88,7 +89,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 }
             }
 
-            return hash.ToHashCode();
+            return hash.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -49,13 +50,13 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var hash = new HashCode();
-            hash.Add(descriptor.Kind ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(descriptor.Name ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(descriptor.TypeName ?? string.Empty, StringComparer.Ordinal);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(descriptor.Kind, StringComparer.Ordinal);
+            hash.Add(descriptor.Name, StringComparer.Ordinal);
+            hash.Add(descriptor.TypeName, StringComparer.Ordinal);
             hash.Add(descriptor.Metadata?.Count);
 
-            return hash.ToHashCode();
+            return hash.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/LinePragma.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/LinePragma.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
 {
@@ -61,7 +62,11 @@ namespace Microsoft.AspNetCore.Razor.Language.CodeGeneration
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(StartLineIndex, LineCount, FilePath);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(StartLineIndex);
+            hash.Add(LineCount);
+            hash.Add(FilePath);
+            return hash;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorDiagnostic.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorDiagnostic.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -68,7 +69,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            var hash = new HashCode();
+            var hash = new HashCodeCombiner();
             hash.Add(Descriptor.GetHashCode());
             hash.Add(Span.GetHashCode());
 
@@ -77,7 +78,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 hash.Add(Args[i]);
             }
 
-            return hash.ToHashCode();
+            return hash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorDiagnostic.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorDiagnostic.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            var hash = new HashCodeCombiner();
+            var hash = HashCodeCombiner.Start();
             hash.Add(Descriptor.GetHashCode());
             hash.Add(Span.GetHashCode());
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DirectiveDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DirectiveDescriptorComparer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -38,8 +39,8 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var hash = new HashCode();
-            hash.Add(descriptor.Directive ?? string.Empty, StringComparer.Ordinal);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(descriptor.Directive, StringComparer.Ordinal);
             hash.Add(descriptor.Kind);
 
             if (descriptor.Tokens != null)
@@ -50,7 +51,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 }
             }
 
-            return hash.ToHashCode();
+            return hash.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DirectiveTokenDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/DirectiveTokenDescriptorComparer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -33,7 +34,11 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            return HashCode.Combine(descriptor.Kind, descriptor.Optional ? 1 : 0);
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(descriptor.Kind);
+            hashCodeCombiner.Add(descriptor.Optional ? 1 : 0);
+
+            return hashCodeCombiner.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/HashCodeCombiner.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/HashCodeCombiner.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Extensions.Internal
+{
+    internal struct HashCodeCombiner
+    {
+        private long _combinedHash64;
+
+        public int CombinedHash
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return _combinedHash64.GetHashCode(); }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private HashCodeCombiner(long seed)
+        {
+            _combinedHash64 = seed;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator int(HashCodeCombiner self)
+        {
+            return self.CombinedHash;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add(int i)
+        {
+            _combinedHash64 = ((_combinedHash64 << 5) + _combinedHash64) ^ i;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add<T>(T? o)
+        {
+            Add(o?.GetHashCode() ?? 0);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add<TValue>(TValue value, IEqualityComparer<TValue> comparer)
+        {
+            var hashCode = value != null ? comparer.GetHashCode(value) : 0;
+            Add(hashCode);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static HashCodeCombiner Start()
+        {
+            return new HashCodeCombiner(0x1505L);
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/AddTagHelperChunkGenerator.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/AddTagHelperChunkGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -49,14 +50,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            var combiner = new HashCode();
+            var combiner = HashCodeCombiner.Start();
             combiner.Add(base.GetHashCode());
-            combiner.Add(LookupText ?? string.Empty, StringComparer.Ordinal);
-            combiner.Add(DirectiveText ?? string.Empty, StringComparer.Ordinal);
-            combiner.Add(TypePattern ?? string.Empty, StringComparer.Ordinal);
-            combiner.Add(AssemblyName ?? string.Empty, StringComparer.Ordinal);
+            combiner.Add(LookupText, StringComparer.Ordinal);
+            combiner.Add(DirectiveText, StringComparer.Ordinal);
+            combiner.Add(TypePattern, StringComparer.Ordinal);
+            combiner.Add(AssemblyName, StringComparer.Ordinal);
 
-            return combiner.ToHashCode();
+            return combiner.CombinedHash;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/AutoCompleteEditHandler.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/AutoCompleteEditHandler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -59,7 +60,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         public override int GetHashCode()
         {
             // Hash code should include only immutable properties but Equals also checks the type.
-            return HashCode.Combine(TypeHashCode, AutoCompleteAtEndOfSpan);
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(TypeHashCode);
+            hashCodeCombiner.Add(AutoCompleteAtEndOfSpan);
+
+            return hashCodeCombiner.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/DirectiveTokenChunkGenerator.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/DirectiveTokenChunkGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -26,7 +27,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(base.GetHashCode(), Type);
+            var combiner = HashCodeCombiner.Start();
+            combiner.Add(base.GetHashCode());
+            combiner.Add(Type);
+
+            return combiner.CombinedHash;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/ImplicitExpressionEditHandler.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/ImplicitExpressionEditHandler.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -53,7 +54,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         public override int GetHashCode()
         {
             // Hash code should include only immutable properties and base has none.
-            return HashCode.Combine(AcceptTrailingDot);
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(AcceptTrailingDot);
+
+            return hashCodeCombiner;
         }
 
         protected override PartialParseResultInternal CanAcceptChange(SyntaxNode target, SourceChange change)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/LiteralAttributeChunkGenerator.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/LiteralAttributeChunkGenerator.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Globalization;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -33,7 +33,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Prefix, Value);
+            var hashCodeCombiner = HashCodeCombiner.Start();
+
+            hashCodeCombiner.Add(Prefix);
+            hashCodeCombiner.Add(Value);
+
+            return hashCodeCombiner;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/LocationTagged.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/LocationTagged.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -44,7 +45,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Location, Value);
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(Location);
+            hashCodeCombiner.Add(Value);
+
+            return hashCodeCombiner.CombinedHash;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/RemoveTagHelperChunkGenerator.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/RemoveTagHelperChunkGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -49,14 +50,14 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            var combiner = new HashCode();
+            var combiner = HashCodeCombiner.Start();
             combiner.Add(base.GetHashCode());
-            combiner.Add(LookupText ?? string.Empty, StringComparer.Ordinal);
-            combiner.Add(DirectiveText ?? string.Empty, StringComparer.Ordinal);
-            combiner.Add(TypePattern ?? string.Empty, StringComparer.Ordinal);
-            combiner.Add(AssemblyName ?? string.Empty, StringComparer.Ordinal);
+            combiner.Add(LookupText, StringComparer.Ordinal);
+            combiner.Add(DirectiveText, StringComparer.Ordinal);
+            combiner.Add(TypePattern, StringComparer.Ordinal);
+            combiner.Add(AssemblyName, StringComparer.Ordinal);
 
-            return combiner.ToHashCode();
+            return combiner.CombinedHash;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperPrefixDirectiveChunkGenerator.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperPrefixDirectiveChunkGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy
 {
@@ -36,12 +37,12 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            var combiner = new HashCode();
+            var combiner = HashCodeCombiner.Start();
             combiner.Add(base.GetHashCode());
-            combiner.Add(Prefix ?? string.Empty, StringComparer.Ordinal);
-            combiner.Add(DirectiveText ?? string.Empty, StringComparer.Ordinal);
+            combiner.Add(Prefix, StringComparer.Ordinal);
+            combiner.Add(DirectiveText, StringComparer.Ordinal);
 
-            return combiner.ToHashCode();
+            return combiner.CombinedHash;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Microsoft.AspNetCore.Razor.Language.csproj
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Microsoft.AspNetCore.Razor.Language.csproj
@@ -8,8 +8,4 @@
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Reference Include="Microsoft.Bcl.HashCode" />
-  </ItemGroup>
-
 </Project>

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorConfiguration.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorConfiguration.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            var hash = new HashCodeCombiner();
+            var hash = HashCodeCombiner.Start();
             hash.Add(LanguageVersion);
             hash.Add(ConfigurationName);
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorConfiguration.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorConfiguration.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -93,7 +94,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            var hash = new HashCode();
+            var hash = new HashCodeCombiner();
             hash.Add(LanguageVersion);
             hash.Add(ConfigurationName);
 
@@ -102,7 +103,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 hash.Add(Extensions[i].ExtensionName);
             }
 
-            return hash.ToHashCode();
+            return hash;
         }
 
         private class DefaultRazorConfiguration : RazorConfiguration

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RequiredAttributeDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RequiredAttributeDescriptorComparer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -54,11 +55,11 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var hash = new HashCode();
-            hash.Add(descriptor.Name ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(descriptor.Value ?? string.Empty, StringComparer.Ordinal);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(descriptor.Name, StringComparer.Ordinal);
+            hash.Add(descriptor.Value, StringComparer.Ordinal);
 
-            return hash.ToHashCode();
+            return hash.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceChange.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceChange.cs
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            var hash = new HashCodeCombiner();
+            var hash = HashCodeCombiner.Start();
             hash.Add(Span);
             hash.Add(NewText, StringComparer.Ordinal);
             return hash;

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceChange.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceChange.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -124,10 +125,10 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            var hash = new HashCode();
+            var hash = new HashCodeCombiner();
             hash.Add(Span);
-            hash.Add(NewText ?? string.Empty, StringComparer.Ordinal);
-            return hash.ToHashCode();
+            hash.Add(NewText, StringComparer.Ordinal);
+            return hash;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceLocation.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceLocation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -105,11 +106,11 @@ namespace Microsoft.AspNetCore.Razor.Language
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            var hashCode = new HashCode();
-            hashCode.Add(FilePath ?? string.Empty, StringComparer.Ordinal);
-            hashCode.Add(AbsoluteIndex);
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(FilePath, StringComparer.Ordinal);
+            hashCodeCombiner.Add(AbsoluteIndex);
 
-            return hashCode.ToHashCode();
+            return hashCodeCombiner;
         }
 
         /// <inheritdoc />

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceMapping.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceMapping.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -37,7 +38,11 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(OriginalSpan, GeneratedSpan);
+            var hashCodeCombiner = HashCodeCombiner.Start();
+            hashCodeCombiner.Add(OriginalSpan);
+            hashCodeCombiner.Add(GeneratedSpan);
+
+            return hashCodeCombiner;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceSpan.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/SourceSpan.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -72,14 +73,14 @@ namespace Microsoft.AspNetCore.Razor.Language
 
         public override int GetHashCode()
         {
-            var hash = new HashCode();
-            hash.Add(FilePath ?? string.Empty, StringComparer.Ordinal);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(FilePath, StringComparer.Ordinal);
             hash.Add(AbsoluteIndex);
             hash.Add(LineIndex);
             hash.Add(CharacterIndex);
             hash.Add(Length);
 
-            return hash.ToHashCode();
+            return hash;
         }
 
         public override string ToString()

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor
 {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/ChildSyntaxList.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/ChildSyntaxList.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax
 {
@@ -570,7 +571,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
                     return 0;
                 }
 
-                return HashCode.Combine(_node.GetHashCode(), _count);
+                var hash = HashCodeCombiner.Start();
+                hash.Add(_node.GetHashCode());
+                hash.Add(_count);
+                return hash.CombinedHash;
             }
 
             public override bool Equals(object obj)

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxTriviaList.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxTriviaList.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax
 {
@@ -448,7 +449,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Node, Index);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(Node);
+            hash.Add(Index);
+            return hash.CombinedHash;
         }
 
         /// <summary>

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/TextSpan.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/TextSpan.cs
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
         /// </summary>
         public override int GetHashCode()
         {
-            var combiner = new HashCodeCombiner();
+            var combiner = HashCodeCombiner.Start();
             combiner.Add(Start);
             combiner.Add(Length);
 

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/TextSpan.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Syntax/TextSpan.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax
 {
@@ -228,7 +229,11 @@ namespace Microsoft.AspNetCore.Razor.Language.Syntax
         /// </summary>
         public override int GetHashCode()
         {
-            return HashCode.Combine(Start, Length);
+            var combiner = new HashCodeCombiner();
+            combiner.Add(Start);
+            combiner.Add(Length);
+
+            return combiner.CombinedHash;
         }
 
         /// <summary>

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -115,11 +116,11 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var hash = new HashCode();
-            hash.Add(descriptor.Kind ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(descriptor.AssemblyName ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(descriptor.Name ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(descriptor.DisplayName ?? string.Empty, StringComparer.Ordinal);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(descriptor.Kind, StringComparer.Ordinal);
+            hash.Add(descriptor.AssemblyName, StringComparer.Ordinal);
+            hash.Add(descriptor.Name, StringComparer.Ordinal);
+            hash.Add(descriptor.DisplayName, StringComparer.Ordinal);
             hash.Add(descriptor.CaseSensitive ? 1 : 0);
 
             if (descriptor.BoundAttributes != null)
@@ -161,21 +162,21 @@ namespace Microsoft.AspNetCore.Razor.Language
                 {
                     foreach (var kvp in metadata)
                     {
-                        hash.Add(kvp.Key ?? string.Empty, StringComparer.Ordinal);
-                        hash.Add(kvp.Value ?? string.Empty, StringComparer.Ordinal);
+                        hash.Add(kvp.Key, StringComparer.Ordinal);
+                        hash.Add(kvp.Value, StringComparer.Ordinal);
                     }
                 }
                 else
                 {
                     foreach (var kvp in descriptor.Metadata)
                     {
-                        hash.Add(kvp.Key ?? string.Empty, StringComparer.Ordinal);
-                        hash.Add(kvp.Value ?? string.Empty, StringComparer.Ordinal);
+                        hash.Add(kvp.Key, StringComparer.Ordinal);
+                        hash.Add(kvp.Value, StringComparer.Ordinal);
                     }
                 }
             }
 
-            return hash.ToHashCode();
+            return hash.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptorComparer.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptorComparer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language
 {
@@ -45,9 +46,9 @@ namespace Microsoft.AspNetCore.Razor.Language
                 throw new ArgumentNullException(nameof(rule));
             }
 
-            var hash = new HashCode();
-            hash.Add(rule.TagName ?? string.Empty, StringComparer.Ordinal);
-            hash.Add(rule.ParentTag ?? string.Empty, StringComparer.Ordinal);
+            var hash = HashCodeCombiner.Start();
+            hash.Add(rule.TagName, StringComparer.Ordinal);
+            hash.Add(rule.ParentTag, StringComparer.Ordinal);
 
             if (rule.Attributes != null)
             {
@@ -57,7 +58,7 @@ namespace Microsoft.AspNetCore.Razor.Language
                 }
             }
 
-            return hash.ToHashCode();
+            return hash.CombinedHash;
         }
     }
 }

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/HashCodeCombinerTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/HashCodeCombinerTest.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.Extensions.Internal
+{
+    public class HashCodeCombinerTest
+    {
+        [Fact]
+        public void GivenTheSameInputs_ItProducesTheSameOutput()
+        {
+            var hashCode1 = new HashCodeCombiner();
+            var hashCode2 = new HashCodeCombiner();
+
+            hashCode1.Add(42);
+            hashCode1.Add("foo");
+            hashCode2.Add(42);
+            hashCode2.Add("foo");
+
+            Assert.Equal(hashCode1.CombinedHash, hashCode2.CombinedHash);
+        }
+
+        [Fact]
+        public void HashCode_Is_OrderSensitive()
+        {
+            var hashCode1 = HashCodeCombiner.Start();
+            var hashCode2 = HashCodeCombiner.Start();
+
+            hashCode1.Add(42);
+            hashCode1.Add("foo");
+
+            hashCode2.Add("foo");
+            hashCode2.Add(42);
+
+            Assert.NotEqual(hashCode1.CombinedHash, hashCode2.CombinedHash);
+        }
+    }
+}

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/HashCodeCombinerTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/HashCodeCombinerTest.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Extensions.Internal
         [Fact]
         public void GivenTheSameInputs_ItProducesTheSameOutput()
         {
-            var hashCode1 = new HashCodeCombiner();
-            var hashCode2 = new HashCodeCombiner();
+            var hashCode1 = HashCodeCombiner.Start();
+            var hashCode2 = HashCodeCombiner.Start();
 
             hashCode1.Add(42);
             hashCode1.Add("foo");

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/AssemblyIdentityEqualityComparer.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/AssemblyIdentityEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Razor
                     return 0;
                 }
 
-                var hash = new HashCodeCombiner();
+                var hash = HashCodeCombiner.Start();
                 hash.Add(obj.Name, StringComparer.OrdinalIgnoreCase);
                 hash.Add(obj.Version);
                 return hash;

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/AssemblyIdentityEqualityComparer.cs
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/AssemblyIdentityEqualityComparer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.CodeAnalysis.Razor
 {
@@ -39,10 +40,10 @@ namespace Microsoft.CodeAnalysis.Razor
                     return 0;
                 }
 
-                var hash = new HashCode();
-                hash.Add(obj.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+                var hash = new HashCodeCombiner();
+                hash.Add(obj.Name, StringComparer.OrdinalIgnoreCase);
                 hash.Add(obj.Version);
-                return hash.ToHashCode();
+                return hash;
             }
         }
     }

--- a/src/Razor/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
+++ b/src/Razor/Microsoft.CodeAnalysis.Razor/src/Microsoft.CodeAnalysis.Razor.csproj
@@ -12,6 +12,5 @@
     <Reference Include="Microsoft.AspNetCore.Razor.Language" />
     <Reference Include="Microsoft.CodeAnalysis.Common" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp" />
-    <Reference Include="Microsoft.Bcl.HashCode" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
References by Razor.Language end up getting loaded in VS and the source generator. I'd like to avoid Razor to load a general purpose assembly unless we absolutely need to.
