### PR TITLE
Unquarantine (most) HTTP3 tests

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class QuicConnectionContextTests : TestApplicationErrorLoggerLoggedTest
     {
         private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
     {
         private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicStreamContextTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class QuicStreamContextTests : TestApplicationErrorLoggerLoggedTest
     {
         private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTransportFactoryTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTransportFactoryTests.cs
@@ -16,7 +16,6 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class QuicTransportFactoryTests : TestApplicationErrorLoggerLoggedTest
     {
         [ConditionalFact]

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests
 {
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class WebHostTests : LoggedTest
     {
         [ConditionalFact]

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -22,7 +22,6 @@ using Xunit;
 
 namespace Interop.FunctionalTests.Http3
 {
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class Http3RequestTests : LoggedTest
     {
         private class StreamingHttpContent : HttpContent
@@ -394,6 +393,7 @@ namespace Interop.FunctionalTests.Http3
         [MsQuicSupported]
         [InlineData(HttpProtocols.Http3)]
         [InlineData(HttpProtocols.Http2)]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
         public async Task POST_ServerAbort_ClientReceivesAbort(HttpProtocols protocol)
         {
             // Arrange
@@ -1472,6 +1472,7 @@ namespace Interop.FunctionalTests.Http3
         [MsQuicSupported]
         [InlineData(HttpProtocols.Http3)]
         [InlineData(HttpProtocols.Http2)]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
         public async Task GET_GracefulServerShutdown_AbortRequestsAfterHostTimeout(HttpProtocols protocol)
         {
             // Arrange

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -15,7 +15,6 @@ using Xunit;
 
 namespace Interop.FunctionalTests.Http3
 {
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public class Http3TlsTests : LoggedTest
     {
         [ConditionalFact]
@@ -156,6 +155,7 @@ namespace Interop.FunctionalTests.Http3
         [InlineData(ClientCertificateMode.AllowCertificate, true)]
         [MsQuicSupported]
         [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "https://github.com/dotnet/aspnetcore/issues/35800")]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
         public async Task ClientCertificate_AllowOrRequire_Available_Invalid_Refused(ClientCertificateMode mode, bool serverAllowInvalid)
         {
             var builder = CreateHostBuilder(async context =>
@@ -212,6 +212,7 @@ namespace Interop.FunctionalTests.Http3
         [ConditionalFact]
         [MsQuicSupported]
         [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux, SkipReason = "https://github.com/dotnet/aspnetcore/issues/35800")]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
         public async Task ClientCertificate_Allow_NotAvailable_Optional()
         {
             var builder = CreateHostBuilder(async context =>


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/35070. These have been running for 30+ days without incident, except the 4 mentioned here: https://github.com/dotnet/aspnetcore/issues/35070#issuecomment-948809856. `ClientCertificate_AllowOrRequire_Available_Invalid_Refused` and `ClientCertificate_Allow_NotAvailable_Optional` were recently fixed but do not yet have 30 days of green runs, so they're still quarantined.