### PR TITLE
[release/6.0] Fix AppHost pack prebuilt usage in source-build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -197,8 +197,18 @@
   <!-- The location of the local installation of the .NET Core shared framework. -->
   <PropertyGroup>
     <LocalDotNetRoot>$(RepoRoot).dotnet\</LocalDotNetRoot>
-    <!-- Override the SDK default and point to local .dotnet folder. -->
-    <NetCoreTargetingPackRoot>$(LocalDotNetRoot)packs\</NetCoreTargetingPackRoot>
+    <!--
+      Override the SDK default and point to local .dotnet folder. This is done to work around
+      limitations in the way the .NET SDK finds shared frameworks and targeting packs. It allows
+      tests to use the shared frameworks and targeting packs that were just built.
+
+      However, source-build needs this to not happen while building projects that rely on the
+      AppHost framework pack. Source-build installs an SDK in a custom location outside this
+      repository, and setting NetCoreTargetingPackRoot to a different location causes source-build
+      to restore the AppHost pack as a prebuilt rather than using the one that's present in the SDK.
+      Source-build doesn't run tests, so the property is simply conditioned out.
+    -->
+    <NetCoreTargetingPackRoot Condition="'$(DotNetBuildFromSource)' != 'true'">$(LocalDotNetRoot)packs\</NetCoreTargetingPackRoot>
   </PropertyGroup>
 
   <Import Project="eng\tools\RepoTasks\RepoTasks.tasks" Condition="'$(MSBuildProjectName)' != 'RepoTasks' AND '$(DesignTimeBuild)' != 'true'" />

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -214,6 +214,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <!-- Workaround https://github.com/dotnet/sdk/issues/2910 by copying targeting pack into local installation. -->
   <Target Name="_InstallTargetingPackIntoLocalDotNet"
           DependsOnTargets="_ResolveTargetingPackContent"
+          Condition="'$(DotNetBuildFromSource)' != 'true'"
           Inputs="@(RefPackContent)"
           Outputs="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')">
     <RemoveDir Directories="$(LocalInstallationOutputPath)" />


### PR DESCRIPTION
# [release/6.0] Fix AppHost pack prebuilt usage in source-build

Cherry picked from commit 2984e3bcd52999698abcba353b1a92f4fd2b2d65, PR https://github.com/dotnet/aspnetcore/pull/37672.

This change removes the `NetCoreTargetingPackRoot` override during source-build to avoid unnecessarily downloading the apphost pack as a prebuilt dependency. I also updated the comment on the override to be more descriptive and added details on why/when it needs to be disabled for source-build.

Added a non-source-build condition on `_InstallTargetingPackIntoLocalDotNet` to prevent it from attempting to install the targeting pack into the source-build-wide SDK that's in use. This matches the same condition already present on `_InstallFrameworkIntoLocalDotNet`.

* For https://github.com/dotnet/source-build/issues/2524
* PR that added this change as a patch into 6.0.1xx SDK: https://github.com/dotnet/installer/pull/12441

/cc @wtgodbe 