### PR TITLE
[release/5.0] Only dispose WindowsIdentity in LongPolling

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 Cancellation = null;
 
                 // Long Polling clones the windows identity if set
-                if (TransportType == HttpTransportType.LongPolling && User != null && User.Identity is WindowsIdentity)
+                if (TransportType == HttpTransportType.LongPolling && User?.Identity is WindowsIdentity)
                 {
                     foreach (var identity in User.Identities)
                     {

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -250,7 +250,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                 Cancellation = null;
 
-                if (User != null && User.Identity is WindowsIdentity)
+                // Long Polling clones the windows identity if set
+                if (TransportType == HttpTransportType.LongPolling && User != null && User.Identity is WindowsIdentity)
                 {
                     foreach (var identity in User.Identities)
                     {

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1775,10 +1775,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 if (transportType == HttpTransportType.LongPolling)
                 {
                     // first poll effectively noops
-                    await dispatcher.ExecuteAsync(context, options, app).DefaultTimeout();
+                    await dispatcher.ExecuteAsync(context, options, app).OrTimeout();
                 }
 
-                await dispatcher.ExecuteAsync(context, options, app).DefaultTimeout();
+                await dispatcher.ExecuteAsync(context, options, app).OrTimeout();
 
                 // Identity shouldn't be closed by the connections layer
                 Assert.False(windowsIdentity.AccessToken.IsClosed);


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/37781

# Only dispose WindowsIdentity in LongPolling

## Description

An `ObjectDisposedException` can occur when using SignalR and Windows Auth and the connection closes. This was caused by disposing the User identity incorrectly in SignalR.

Fixes #37521

## Customer Impact

Customer reported issue. When using SignalR + Windows Auth you can hit an `ObjectDisposedException` on a `SafeHandle` when accessing the Identity when the request is finished and the middleware is unwinding. In this instance this was hit when accessing the identity name in logging when the request completes.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Well understood fix, added a test to cover the missing scenario.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A