### PR TITLE
[release/3.1] Only dispose WindowsIdentity in LongPolling

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -237,7 +237,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
                 Cancellation = null;
 
                 // Long Polling clones the windows identity if set
-                if (TransportType == HttpTransportType.LongPolling && User != null && User.Identity is WindowsIdentity)
+                if (TransportType == HttpTransportType.LongPolling && User?.Identity is WindowsIdentity)
                 {
                     foreach (var identity in User.Identities)
                     {

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -236,7 +236,8 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal
 
                 Cancellation = null;
 
-                if (User != null && User.Identity is WindowsIdentity)
+                // Long Polling clones the windows identity if set
+                if (TransportType == HttpTransportType.LongPolling && User != null && User.Identity is WindowsIdentity)
                 {
                     foreach (var identity in User.Identities)
                     {

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1691,7 +1691,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 services.AddSingleton<TestConnectionHandler>();
                 services.AddLogging();
 
-                var context = MakeRequest("/foo", connection, services);
+                var context = MakeRequest("/foo", connection);
                 SetTransport(context, transportType);
                 var builder = new ConnectionBuilder(services.BuildServiceProvider());
                 builder.UseConnectionHandler<ImmediatelyCompleteConnectionHandler>();
@@ -1706,10 +1706,10 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
                 if (transportType == HttpTransportType.LongPolling)
                 {
                     // first poll effectively noops
-                    await dispatcher.ExecuteAsync(context, options, app).DefaultTimeout();
+                    await dispatcher.ExecuteAsync(context, options, app).OrTimeout();
                 }
 
-                await dispatcher.ExecuteAsync(context, options, app).DefaultTimeout();
+                await dispatcher.ExecuteAsync(context, options, app).OrTimeout();
 
                 // Identity shouldn't be closed by the connections layer
                 Assert.False(windowsIdentity.AccessToken.IsClosed);

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1673,6 +1673,55 @@ namespace Microsoft.AspNetCore.Http.Connections.Tests
             }
         }
 
+        [ConditionalTheory]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        [InlineData(HttpTransportType.LongPolling)]
+        [InlineData(HttpTransportType.ServerSentEvents)]
+        [InlineData(HttpTransportType.WebSockets)]
+        public async Task WindowsIdentityNotClosed(HttpTransportType transportType)
+        {
+            using (StartVerifiableLog())
+            {
+                var manager = CreateConnectionManager(LoggerFactory);
+                var connection = manager.CreateConnection();
+                connection.TransportType = transportType;
+                var dispatcher = new HttpConnectionDispatcher(manager, LoggerFactory);
+                var services = new ServiceCollection();
+                services.AddOptions();
+                services.AddSingleton<TestConnectionHandler>();
+                services.AddLogging();
+
+                var context = MakeRequest("/foo", connection, services);
+                SetTransport(context, transportType);
+                var builder = new ConnectionBuilder(services.BuildServiceProvider());
+                builder.UseConnectionHandler<ImmediatelyCompleteConnectionHandler>();
+                var app = builder.Build();
+                var options = new HttpConnectionDispatcherOptions();
+                options.WebSockets.CloseTimeout = TimeSpan.FromSeconds(0);
+
+                var windowsIdentity = WindowsIdentity.GetAnonymous();
+                context.User = new WindowsPrincipal(windowsIdentity);
+                context.User.AddIdentity(new ClaimsIdentity());
+
+                if (transportType == HttpTransportType.LongPolling)
+                {
+                    // first poll effectively noops
+                    await dispatcher.ExecuteAsync(context, options, app).DefaultTimeout();
+                }
+
+                await dispatcher.ExecuteAsync(context, options, app).DefaultTimeout();
+
+                // Identity shouldn't be closed by the connections layer
+                Assert.False(windowsIdentity.AccessToken.IsClosed);
+
+                if (transportType == HttpTransportType.LongPolling)
+                {
+                    // Long polling clones the user, make sure it disposes it too
+                    Assert.True(((WindowsIdentity)connection.User.Identity).AccessToken.IsClosed);
+                }
+            }
+        }
+
         [Fact]
         public async Task SetsInherentKeepAliveFeatureOnFirstLongPollingRequest()
         {


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/37781

# Only dispose WindowsIdentity in LongPolling

## Description

An `ObjectDisposedException` can occur when using SignalR and Windows Auth and the connection closes. This was caused by disposing the User identity incorrectly in SignalR.

Fixes #37521

## Customer Impact

Customer reported issue. When using SignalR + Windows Auth you can hit an `ObjectDisposedException` on a `SafeHandle` when accessing the Identity when the request is finished and the middleware is unwinding. In this instance this was hit when accessing the identity name in logging when the request completes.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Well understood fix, added a test to cover the missing scenario.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A