### PR TITLE
Unquarantine ClientTimesoutWhenHandshakeResponseTakesTooLong

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.ConnectionLifecycle.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.ConnectionLifecycle.cs
@@ -486,7 +486,6 @@ namespace Microsoft.AspNetCore.SignalR.Client.Tests
             }
 
             [Fact]
-            [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35728")]
             public async Task ClientTimesoutWhenHandshakeResponseTakesTooLong()
             {
                 var handshakeTimeoutLogged = false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/35728

100% pass rate over the last 30 days.

![image](https://user-images.githubusercontent.com/303201/138757392-be88952d-ffec-4b51-a5af-2cd0e49c5230.png)
