### PR TITLE
Re-quarantine IHttpActivityFeatureIsPopulated

### DIFF
--- a/src/Hosting/Hosting/test/HostingApplicationTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationTests.cs
@@ -93,6 +93,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35142")]
         public void IHttpActivityFeatureIsPopulated()
         {
             var testSource = new ActivitySource(Path.GetRandomFileName());


### PR DESCRIPTION
Fix mistake in https://github.com/dotnet/aspnetcore/pull/37821