### PR TITLE
Add listener for QUIC logs to HTTP/3 sample

### DIFF
--- a/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(KestrelSharedSourceRoot)test\HttpEventSourceListener.cs" LinkBase="shared" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="Microsoft.Extensions.Hosting" />

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Microsoft.AspNetCore.Testing;
 
 namespace Http3SampleApp
 {
@@ -17,7 +18,7 @@ namespace Http3SampleApp
                 .ConfigureLogging((_, factory) =>
                 {
                     factory.SetMinimumLevel(LogLevel.Trace);
-                    factory.AddConsole();
+                    factory.AddSimpleConsole(o => o.TimestampFormat = "[HH:mm:ss.fff] ");
                 })
                 .ConfigureWebHost(webHost =>
                 {
@@ -111,7 +112,12 @@ namespace Http3SampleApp
                     .UseStartup<Startup>();
                 });
 
-            hostBuilder.Build().Run();
+            var host = hostBuilder.Build();
+
+            // Listener needs to be configured before host (and HTTP/3 endpoints) start up.
+            using var httpEventSource = new HttpEventSourceListener(host.Services.GetRequiredService<ILoggerFactory>());
+
+            host.Run();
         }
     }
 }

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Startup.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Testing;
+
 namespace Http3SampleApp
 {
     public class Startup

--- a/src/Servers/Kestrel/shared/test/HttpEventSourceListener.cs
+++ b/src/Servers/Kestrel/shared/test/HttpEventSourceListener.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Tracing;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace Interop.FunctionalTests.Http3
+namespace Microsoft.AspNetCore.Testing
 {
     public sealed class HttpEventSourceListener : EventListener
     {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -19,6 +19,7 @@
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\IWebHostPortExtensions.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestConstants.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" LinkBase="shared" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\HttpEventSourceListener.cs" LinkBase="shared" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\MsQuicSupportedAttribute.cs" LinkBase="shared\TransportTestHelpers\MsQuicSupportedAttribute.cs" />
   </ItemGroup>


### PR DESCRIPTION
I've needed this to give logs to networking teams a couple of times so lets just set it up by default.