### PR TITLE
Ensure view caches are cleared when RazorHotReload.ClearCache is invoked

### DIFF
--- a/src/Mvc/Mvc.Razor/src/Compilation/DefaultViewCompiler.cs
+++ b/src/Mvc/Mvc.Razor/src/Compilation/DefaultViewCompiler.cs
@@ -74,6 +74,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
             _compiledViews = compiledViews;
         }
 
+        internal Dictionary<string, Task<CompiledViewDescriptor>>? CompiledViews => _compiledViews;
+
         // Invoked as part of a hot reload event.
         internal void ClearCache()
         {

--- a/src/Mvc/Mvc.Razor/src/Compilation/DefaultViewCompilerProvider.cs
+++ b/src/Mvc/Mvc.Razor/src/Compilation/DefaultViewCompilerProvider.cs
@@ -18,6 +18,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
             _compiler = new DefaultViewCompiler(applicationPartManager, loggerFactory.CreateLogger<DefaultViewCompiler>());
         }
 
+        internal DefaultViewCompiler Compiler => _compiler;
+
         public IViewCompiler GetCompiler() => _compiler;
     }
 }

--- a/src/Mvc/Mvc.Razor/src/RazorHotReload.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorHotReload.cs
@@ -28,9 +28,9 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             // For Razor view services, use the service locator pattern because they views not be registered by default.
             _razorCompiledItemFeatureProvider = applicationPartManager.FeatureProviders.OfType<RazorCompiledItemFeatureProvider>().FirstOrDefault();
 
-            if (viewCompilerProvider is DefaultViewCompiler defaultViewCompiler)
+            if (viewCompilerProvider is DefaultViewCompilerProvider defaultViewCompilerProvider)
             {
-                _defaultViewCompiler = defaultViewCompiler;
+                _defaultViewCompiler = defaultViewCompilerProvider.Compiler;
             }
 
             if (razorViewEngine.GetType() == typeof(RazorViewEngine))

--- a/src/Mvc/Mvc.Razor/src/RazorPageActivator.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPageActivator.cs
@@ -53,6 +53,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             _activationInfo.Clear();
         }
 
+        internal ConcurrentDictionary<CacheKey, RazorPagePropertyActivator> ActivationInfo => _activationInfo;
+
         /// <inheritdoc />
         public void Activate(IRazorPage page, ViewContext context)
         {
@@ -107,7 +109,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
             return propertyActivator;
         }
 
-        private readonly struct CacheKey : IEquatable<CacheKey>
+        internal readonly struct CacheKey : IEquatable<CacheKey>
         {
             public CacheKey(Type pageType, Type? providedModelType)
             {

--- a/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <summary>
         /// A cache for results of view lookups.
         /// </summary>
-        protected IMemoryCache ViewLookupCache { get; private set; }
+        protected internal IMemoryCache ViewLookupCache { get; private set; }
 
         /// <summary>
         /// Gets the case-normalized route value for the specified route <paramref name="key"/>.

--- a/src/Mvc/Mvc.Razor/test/Compilation/DefaultViewCompilerTest.cs
+++ b/src/Mvc/Mvc.Razor/test/Compilation/DefaultViewCompilerTest.cs
@@ -1,12 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.Logging.Abstractions;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Compilation
 {

--- a/src/Mvc/Mvc.Razor/test/RazorHotReloadTest.cs
+++ b/src/Mvc/Mvc.Razor/test/RazorHotReloadTest.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor.Compilation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Mvc.Razor;
+
+public class RazorHotReloadTest
+{
+    [Fact]
+    public void ClearCache_CanClearViewCompiler()
+    {
+        // Regression test for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1425693
+        // Arrange
+        var serviceProvider = GetServiceProvider();
+
+        var compilerProvider = Assert.IsType<DefaultViewCompilerProvider>(serviceProvider.GetRequiredService<IViewCompilerProvider>());
+        var hotReload = serviceProvider.GetRequiredService<RazorHotReload>();
+
+        // Act
+        hotReload.ClearCache(Type.EmptyTypes);
+
+        // Assert
+        Assert.Null(compilerProvider.Compiler.CompiledViews);
+    }
+
+    [Fact]
+    public void ClearCache_ResetsViewEngineLookupCache()
+    {
+        // Arrange
+        var serviceProvider = GetServiceProvider();
+
+        var viewEngine = Assert.IsType<RazorViewEngine>(serviceProvider.GetRequiredService<IRazorViewEngine>());
+        var hotReload = serviceProvider.GetRequiredService<RazorHotReload>();
+        var lookup = viewEngine.ViewLookupCache;
+
+        // Act
+        hotReload.ClearCache(Type.EmptyTypes);
+
+        // Assert
+        Assert.NotSame(lookup, viewEngine.ViewLookupCache);
+    }
+
+    [Fact]
+    public void ClearCache_ResetsRazorPageActivator()
+    {
+        // Arrange
+        var serviceProvider = GetServiceProvider();
+
+        var pageActivator = Assert.IsType<RazorPageActivator>(serviceProvider.GetRequiredService<IRazorPageActivator>());
+        var hotReload = serviceProvider.GetRequiredService<RazorHotReload>();
+        var cache = pageActivator.ActivationInfo;
+        cache[new RazorPageActivator.CacheKey()] = new RazorPagePropertyActivator(
+            typeof(string), typeof(object),
+            new EmptyModelMetadataProvider(),
+            new RazorPagePropertyActivator.PropertyValueAccessors());
+
+        // Act
+        Assert.Single(pageActivator.ActivationInfo);
+        hotReload.ClearCache(Type.EmptyTypes);
+
+        // Assert
+        Assert.Empty(pageActivator.ActivationInfo);
+    }
+
+    private static ServiceProvider GetServiceProvider()
+    {
+        var diagnosticListener = new DiagnosticListener("Microsoft.AspNetCore");
+
+        var serviceProvider = new ServiceCollection()
+            .AddControllersWithViews()
+            .Services
+            // Manually add RazorHotReload because it's only added if MetadataUpdateHandler.IsSupported = true 
+            .AddSingleton<RazorHotReload>()
+            .AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance)
+            .AddSingleton<DiagnosticSource>(diagnosticListener)
+            .AddSingleton(diagnosticListener)
+            .BuildServiceProvider();
+        return serviceProvider;
+    }
+}


### PR DESCRIPTION
# Ensure view caches are cleared when RazorHotReload.ClearCache is invoked

Summary of the changes (Less than 80 chars)

## Description

`RazorHotReload` looks up services in DI and clears caches on specific instances as part of a hot reload event. It matches by exact types and skips those that don't match or are missing since a user app could have changed / modified the service implementation. 

As part of https://github.com/dotnet/aspnetcore/pull/37037, we stopped injecting the `DefaultViewCompiler` in to the DI container, instead injecting a container for it - `DefaultViewCompilerProvider` for it. Unfortunately we missed updating the  reference to it inside `RazorHotReload`. As a result, while everything in the hot reload sequence of events works, the cache remains stale. This prevents the view from being updated.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1425693

## Customer Impact

Unable to perform hot reload for .cshtml file.

## Regression?

- [x] Yes
- [ ] No

6.0-RC2

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change is fairly localized to be within the hot reload code path which was tested as part of this change.

## Verification

- [x] Manual (required)
- [x] Automated (Added new unit tests to cover this code path)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props