### PR TITLE
feat (Codespaces) - Added Commonly used tasks to `tasks.json` for VSCode users. 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,42 +1,42 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
 {
-    "name": "C# (.NET)",
-    "build": {
-        "dockerfile": "Dockerfile",
-        "args": {
-            // The VARIANT here must align with a dotnet container image that
-            // is publicly available on https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list.
-            // We'll default to `latest` as the default. Generally, the .NET version that is baked
-            // into the image by default doesn't matter since we end up installing our own
-            // local version and using that by default in the container environment.
-            "VARIANT": "latest",
-            // Options
-            "INSTALL_NODE": "true",
-            "NODE_VERSION": "lts/*"
-        }
-    },
-    // Add the IDs of extensions you want installed when the container is created.
-    "extensions": [
-        "ms-dotnettools.csharp",
-        "EditorConfig.EditorConfig",
-        "k--kato.docomment"
-    ],
-    "settings": {
-        // Loading projects on demand is better for larger codebases
-        "omnisharp.enableMsBuildLoadProjectsOnDemand": true,
-        "omnisharp.enableRoslynAnalyzers": true,
-        "omnisharp.enableEditorConfigSupport": true,
-    },
-    // Use 'postCreateCommand' to run commands after the container is created.
-    "onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",
-    // Add the locally installed dotnet to the path to ensure that it is activated
-    // This is needed so that things like the C# extension can resolve the correct SDK version
-    "remoteEnv": {
-        "PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
-        "DOTNET_MULTILEVEL_LOOKUP": "0",
-        "TARGET": "net7.0"
-    },
-    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-    "remoteUser": "vscode"
+	"name": "C# (.NET)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// The VARIANT here must align with a dotnet container image that
+			// is publicly available on https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list.
+			// We'll default to `latest` as the default. Generally, the .NET version that is baked
+			// into the image by default doesn't matter since we end up installing our own
+			// local version and using that by default in the container environment.
+			"VARIANT": "latest",
+			// Options
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*"
+		}
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-dotnettools.csharp",
+		"EditorConfig.EditorConfig",
+		"k--kato.docomment"
+	],
+	"settings": {
+		// Loading projects on demand is better for larger codebases
+		"omnisharp.enableMsBuildLoadProjectsOnDemand": true,
+		"omnisharp.enableRoslynAnalyzers": true,
+		"omnisharp.enableEditorConfigSupport": true,
+	},
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",
+	// Add the locally installed dotnet to the path to ensure that it is activated
+	// This is needed so that things like the C# extension can resolve the correct SDK version
+	"remoteEnv": {
+		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
+		"DOTNET_MULTILEVEL_LOOKUP": "0",
+		"TARGET": "net7.0"
+	},
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,47 +1,42 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
 {
-	"name": "C# (.NET)",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			// The VARIANT here must align with a dotnet container image that
-			// is publicly available on https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list.
-			// We'll default to `latest` as the default. Generally, the .NET version that is baked
-			// into the image by default doesn't matter since we end up installing our own
-			// local version and using that by default in the container environment.
-			"VARIANT": "latest",
-			// Options
-			"INSTALL_NODE": "true",
-			"NODE_VERSION": "lts/*"
-		}
-	},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-dotnettools.csharp",
-		"EditorConfig.EditorConfig",
+  "name": "C# (.NET)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // The VARIANT here must align with a dotnet container image that
+      // is publicly available on https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list.
+      // We'll default to `latest` as the default. Generally, the .NET version that is baked
+      // into the image by default doesn't matter since we end up installing our own
+      // local version and using that by default in the container environment.
+      "VARIANT": "latest",
+      // Options
+      "INSTALL_NODE": "true",
+      "NODE_VERSION": "lts/*"
+    }
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "ms-dotnettools.csharp",
+    "EditorConfig.EditorConfig",
     "k--kato.docomment"
-	],
-
-	"settings": {
-		// Loading projects on demand is better for larger codebases
-		"omnisharp.enableMsBuildLoadProjectsOnDemand": true,
+  ],
+  "settings": {
+    // Loading projects on demand is better for larger codebases
+    "omnisharp.enableMsBuildLoadProjectsOnDemand": true,
     "omnisharp.enableRoslynAnalyzers": true,
     "omnisharp.enableEditorConfigSupport": true,
-	},
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",
-
-	// Add the locally installed dotnet to the path to ensure that it is activated
-	// This is needed so that things like the C# extension can resolve the correct SDK version
-	"remoteEnv": {
-		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
-		"DOTNET_MULTILEVEL_LOOKUP": "0",
-		"TARGET": "net7.0"
-	},
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+  },
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",
+  // Add the locally installed dotnet to the path to ensure that it is activated
+  // This is needed so that things like the C# extension can resolve the correct SDK version
+  "remoteEnv": {
+    "PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
+    "DOTNET_MULTILEVEL_LOOKUP": "0",
+    "TARGET": "net7.0"
+  },
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-dotnettools.csharp"
+		"ms-dotnettools.csharp",
+		"EditorConfig.EditorConfig"
 	],
 
 	"settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,42 +1,42 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
 {
-  "name": "C# (.NET)",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": {
-      // The VARIANT here must align with a dotnet container image that
-      // is publicly available on https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list.
-      // We'll default to `latest` as the default. Generally, the .NET version that is baked
-      // into the image by default doesn't matter since we end up installing our own
-      // local version and using that by default in the container environment.
-      "VARIANT": "latest",
-      // Options
-      "INSTALL_NODE": "true",
-      "NODE_VERSION": "lts/*"
-    }
-  },
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "ms-dotnettools.csharp",
-    "EditorConfig.EditorConfig",
-    "k--kato.docomment"
-  ],
-  "settings": {
-    // Loading projects on demand is better for larger codebases
-    "omnisharp.enableMsBuildLoadProjectsOnDemand": true,
-    "omnisharp.enableRoslynAnalyzers": true,
-    "omnisharp.enableEditorConfigSupport": true,
-  },
-  // Use 'postCreateCommand' to run commands after the container is created.
-  "onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",
-  // Add the locally installed dotnet to the path to ensure that it is activated
-  // This is needed so that things like the C# extension can resolve the correct SDK version
-  "remoteEnv": {
-    "PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
-    "DOTNET_MULTILEVEL_LOOKUP": "0",
-    "TARGET": "net7.0"
-  },
-  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-  "remoteUser": "vscode"
+    "name": "C# (.NET)",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            // The VARIANT here must align with a dotnet container image that
+            // is publicly available on https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list.
+            // We'll default to `latest` as the default. Generally, the .NET version that is baked
+            // into the image by default doesn't matter since we end up installing our own
+            // local version and using that by default in the container environment.
+            "VARIANT": "latest",
+            // Options
+            "INSTALL_NODE": "true",
+            "NODE_VERSION": "lts/*"
+        }
+    },
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "ms-dotnettools.csharp",
+        "EditorConfig.EditorConfig",
+        "k--kato.docomment"
+    ],
+    "settings": {
+        // Loading projects on demand is better for larger codebases
+        "omnisharp.enableMsBuildLoadProjectsOnDemand": true,
+        "omnisharp.enableRoslynAnalyzers": true,
+        "omnisharp.enableEditorConfigSupport": true,
+    },
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "onCreateCommand": "bash -i ${containerWorkspaceFolder}/.devcontainer/scripts/container-creation.sh",
+    // Add the locally installed dotnet to the path to ensure that it is activated
+    // This is needed so that things like the C# extension can resolve the correct SDK version
+    "remoteEnv": {
+        "PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
+        "DOTNET_MULTILEVEL_LOOKUP": "0",
+        "TARGET": "net7.0"
+    },
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,12 +20,15 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-dotnettools.csharp",
-		"EditorConfig.EditorConfig"
+		"EditorConfig.EditorConfig",
+    "k--kato.docomment"
 	],
 
 	"settings": {
 		// Loading projects on demand is better for larger codebases
-		"omnisharp.enableMsBuildLoadProjectsOnDemand": true
+		"omnisharp.enableMsBuildLoadProjectsOnDemand": true,
+    "omnisharp.enableRoslynAnalyzers": true,
+    "omnisharp.enableEditorConfigSupport": true,
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,7 +38,7 @@
       }
     },
     {
-      "label": "Run tests",
+      "label": "Run all test projects",
       "type": "shell",
       "command": "./eng/build.sh -test",
       "windows": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,80 @@
+{
+  "version": "2.0.0",
+
+  "inputs": [
+    {
+      "type": "pickString",
+      "default": "Debug",
+      "options": ["Debug","Release"],
+      "id": "configurationType",
+      "description": "Select configuration type",
+    }
+  ],
+  "tasks": [
+    {
+      "label": "Restore projects",
+      "type": "shell",
+      "command": "./restore.sh",
+      "windows": {
+        "command": ".\\restore.cmd"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "Build entire repository (Debug/Release)",
+      "type": "shell",
+      "command": "./eng/build.sh -Configuration ${input:configurationType}",
+      "windows": {
+        "command": ".\\eng\\build.cmd -Configuration ${input:configurationType}"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "Run tests",
+      "type": "shell",
+      "command": "./eng/build.sh -test",
+      "windows": {
+        "command": ".\\eng\\build.cmd -test"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "Pack assets",
+      "type": "shell",
+      "command": "./eng/build.sh --pack",
+      "windows": {
+        "command": ".\\eng\\build.cmd -pack"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "Clean artifacts",
+      "type": "shell",
+      "command": "./clean.sh",
+      "windows": {
+        "command": ".\\clean.cmd"
+      },
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -271,6 +271,8 @@ code .
 > in `~/.vscode-server/server-env-setup`.
 > See <https://code.visualstudio.com/docs/remote/wsl#_advanced-environment-setup-script> for details.
 
+In Visual Studio Code, press `CTRL + SHIFT + P` (`CMD + SHIFT + P` on mac) to open command palette, then search and select for `Run Tasks` option. In task list, there are couple of most used tasks are already defined, in that you can select `Build entire repository` option from it to build the repository. Once you select that option, on next window you need to select configuration type from `Debug` OR `Release`. For development purpose one can go with `Debug` option and for actual testing one can choose `Release` mode as binaries will be optimized in this mode. 
+
 ### Building on command-line
 
 When developing in VS Code, you'll need to use the `build.cmd` or `build.sh` scripts in order to build the project. You can learn more about the command line options available, check out [the section below](#using-dotnet-on-command-line-in-this-repo).

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -142,6 +142,9 @@ The following extensions are recommended when developing in the ASP.NET Core rep
 
 - [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
 
+- [C# XML Documentation Comments](https://marketplace.visualstudio.com/items?itemName=k--kato.docomment)
+
+
 #### WiX (Optional)
 
 If you plan on working with the Windows installers defined in [src/Installers/Windows](../src/Installers/Windows), you will need to install the WiX toolkit from <https://wixtoolset.org/releases/>.

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -144,7 +144,6 @@ The following extensions are recommended when developing in the ASP.NET Core rep
 
 - [C# XML Documentation Comments](https://marketplace.visualstudio.com/items?itemName=k--kato.docomment)
 
-
 #### WiX (Optional)
 
 If you plan on working with the Windows installers defined in [src/Installers/Windows](../src/Installers/Windows), you will need to install the WiX toolkit from <https://wixtoolset.org/releases/>.


### PR DESCRIPTION
Further, improving codespaces/VScode experience for users.

1. Added EditorConfig as a preinstalled extension. 
2. Added commonly performed tasks to the `tasks.json` file. So that one can invoke that task through VSCode directly by pressing `CTRL + SHIFT + P` and then select option `Run Tasks` and then actual tasks. (We can add more tasks going forward.)

Press `CTRL + SHIFT + P` and search for Run Tasks. Select option like below. 

![image](https://user-images.githubusercontent.com/17148381/139052595-9156cba0-d7c1-4708-85af-9d1475941804.png)


Choose the task from list and hit enter to execute. 

![image](https://user-images.githubusercontent.com/17148381/139052925-3703f871-5a8b-4165-8e11-ae588d036bb8.png)

Some tasks may have more options to select, for example in the below case while building an entire repository, one can select different configurations like Debug OR Release. And based on the selection the command will run. 

![image](https://user-images.githubusercontent.com/17148381/139053193-552433a9-f8f7-4bcb-883e-22fce344e212.png)

And given task will start running in the terminal. 

![image](https://user-images.githubusercontent.com/17148381/139053363-8cd3911d-024f-456b-8d76-15d24636d567.png)
