### PR TITLE
Enable text/javascript response compression

### DIFF
--- a/src/Middleware/ResponseCompression/src/ResponseCompressionDefaults.cs
+++ b/src/Middleware/ResponseCompression/src/ResponseCompressionDefaults.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.ResponseCompression
             // Static files
             "text/css",
             "application/javascript",
+            "text/javascript",
             // MVC
             "text/html",
             "application/xml",


### PR DESCRIPTION
[ECMAScript Media Types Updates](https://datatracker.ietf.org/doc/draft-ietf-dispatch-javascript-mjs/) obsoletes mime-types other than text/javascript:

> This document defines equivalent processing requirements for the
   types text/javascript, text/ecmascript, and application/javascript.
   The most widely supported media type in use is text/javascript; all
   others are considered historical and obsolete compared to text/
   javascript.

While this is still a draft, adding text/javascript next to application/javascript seems like a better default for "the 90% case". text/javascript has been in use for a long time. In fact even ASP.NET MVC has been using text/javascript.