### PR TITLE
Remove quarantine attributes from Blazor e2e tests

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -79,7 +79,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23015")]
         public async Task ClosingTheBrowserWindow_GracefullyDisconnects_WhenNavigatingAwayFromThePage()
         {
             // Arrange & Act

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerEventTest.cs
@@ -19,7 +19,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public override void EventDuringBatchRendering_CanTriggerDOMEvents()
         {
             base.EventDuringBatchRendering_CanTriggerDOMEvents();

--- a/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/src/Components/test/E2ETest/Tests/BinaryHttpClientTest.cs
@@ -46,7 +46,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         public override Task InitializeAsync() => base.InitializeAsync(Guid.NewGuid().ToString());
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33454")]
         public void CanSendAndReceiveBytes()
         {
             IssueRequest("/subdir/api/data");

--- a/src/Components/test/E2ETest/Tests/BindTest.cs
+++ b/src/Components/test/E2ETest/Tests/BindTest.cs
@@ -611,7 +611,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         // This tests what happens you put invalid (unconvertable) input in. This is separate from the
         // other tests because it requires type="text" - the other tests use type="number"
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34183")]
         public void CanBindTextbox_Decimal_InvalidInput()
         {
             var target = Browser.Exists(By.Id("textbox-decimal-invalid"));

--- a/src/Components/test/E2ETest/Tests/CascadingValueTest.cs
+++ b/src/Components/test/E2ETest/Tests/CascadingValueTest.cs
@@ -30,7 +30,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33715")]
         public void CanUpdateValuesMatchedByType()
         {
             var currentCount = Browser.Exists(By.Id("current-count"));
@@ -50,7 +49,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33530")]
         public void CanUpdateValuesMatchedByName()
         {
             var currentFlag1Value = Browser.Exists(By.Id("flag-1"));
@@ -72,7 +70,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34867")]
         public void CanUpdateFixedValuesMatchedByInterface()
         {
             var currentCount = Browser.Exists(By.Id("current-count"));

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -467,7 +467,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Theory]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/32907")]
         [InlineData("focus-button-onafterrender-invoke")]
         [InlineData("focus-button-onafterrender-await")]
         public void CanFocusDuringOnAfterRenderAsyncWithFocusInEvent(string triggerButton)

--- a/src/Components/test/E2ETest/Tests/ErrorBoundaryTest.cs
+++ b/src/Components/test/E2ETest/Tests/ErrorBoundaryTest.cs
@@ -147,7 +147,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33528")]
         public void CanHandleMultipleAsyncErrorsFromDescendants()
         {
             var container = Browser.Exists(By.Id("multiple-child-errors-test"));

--- a/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventBubblingTest.cs
@@ -48,7 +48,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void BubblingStandardEvent_FiredOnElementWithoutHandler()
         {
             Browser.Exists(By.Id("button-without-onclick")).Click();

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -203,7 +203,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void PreventDefault_DotNotApplyByDefault()
         {
             var appElement = Browser.MountTestComponent<EventPreventDefaultComponent>();
@@ -212,7 +211,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void InputEvent_RespondsOnKeystrokes()
         {
             Browser.MountTestComponent<InputEventComponent>();
@@ -230,7 +228,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void InputEvent_RespondsOnKeystrokes_EvenIfUpdatesAreLaggy()
         {
             // This test doesn't mean much on WebAssembly - it just shows that even if the CPU is locked

--- a/src/Components/test/E2ETest/Tests/GlobalizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/GlobalizationTest.cs
@@ -97,7 +97,6 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests
         [Theory]
         [InlineData("en-US")]
         [InlineData("fr-FR")]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33297")]
         public void CanSetCultureAndParseCultureInvariantNumbersAndDatesWithInputFields(string culture)
         {
             var cultureInfo = CultureInfo.GetCultureInfo(culture);

--- a/src/Components/test/E2ETest/Tests/MultipleHostedAppTest.cs
+++ b/src/Components/test/E2ETest/Tests/MultipleHostedAppTest.cs
@@ -31,7 +31,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34395")]
         public void CanLoadBlazorAppFromSubPath()
         {
             Navigate("/app/");
@@ -41,14 +40,12 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34395")]
         public void HasTitle()
         {
             Assert.Equal("Sample Blazor app", Browser.Title);
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34395")]
         public void ServesStaticAssetsFromClientAppWebRoot()
         {
             var javascriptExecutor = (IJavaScriptExecutor)Browser;

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -610,12 +610,10 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void PreventDefault_CanBlockNavigation_ForInternalNavigation_PreventDefaultTarget()
             => PreventDefault_CanBlockNavigation("internal", "target");
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31195")]
         public void PreventDefault_CanBlockNavigation_ForExternalNavigation_PreventDefaultAncestor()
             => PreventDefault_CanBlockNavigation("external", "ancestor");
 

--- a/src/Components/test/E2ETest/Tests/WebAssemblyAuthenticationTests.cs
+++ b/src/Components/test/E2ETest/Tests/WebAssemblyAuthenticationTests.cs
@@ -67,7 +67,6 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34886")]
         public void WasmAuthentication_Loads()
         {
             Browser.Equal("Wasm.Authentication.Client", () => Browser.Title);


### PR DESCRIPTION
Removing quarantine attribute from tests in the aspnetcore-components-e2e pipeline with 100% success rates
over the lifetime of the pipeline.

This is primarily a cleanup activity as these tests are not run as part of the regular test pipeline and
unquarantining does not change the outcome of the build.

Fixes https://github.com/dotnet/aspnetcore/issues/23015
Fixes https://github.com/dotnet/aspnetcore/issues/31195
Fixes https://github.com/dotnet/aspnetcore/issues/34886
Fixes https://github.com/dotnet/aspnetcore/issues/34395
Fixes https://github.com/dotnet/aspnetcore/issues/33297
Fixes https://github.com/dotnet/aspnetcore/issues/33528
Fixes https://github.com/dotnet/aspnetcore/issues/32907
Fixes https://github.com/dotnet/aspnetcore/issues/34867
Fixes https://github.com/dotnet/aspnetcore/issues/33530
Fixes https://github.com/dotnet/aspnetcore/issues/33715
Fixes https://github.com/dotnet/aspnetcore/issues/34183
Fixes https://github.com/dotnet/aspnetcore/issues/33454
