### PR TITLE
Stop running Components E2E Tests in Quarantined Test Pipelines

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -647,7 +647,6 @@ stages:
         cancelTimeoutInMinutes: 30
         buildArgs: -all -pack -test -binaryLog /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
                    /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
-                   /p:SkipComponentsE2ETests=true
                    $(_InternalRuntimeDownloadArgs)
         beforeBuild:
         - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
@@ -669,7 +668,7 @@ stages:
         agentOs: macOS
         timeoutInMinutes: 240
         isAzDOTestingJob: true
-        buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipComponentsE2ETests=true /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+        buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
         beforeBuild:
         - bash: "./eng/scripts/install-nginx-mac.sh"
           displayName: Installing Nginx
@@ -690,7 +689,7 @@ stages:
         agentOs: Linux
         isAzDOTestingJob: true
         useHostedUbuntu: false
-        buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipComponentsE2ETests=true /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+        buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
         beforeBuild:
         - bash: "./eng/scripts/install-nginx-linux.sh"
           displayName: Installing Nginx
@@ -722,7 +721,7 @@ stages:
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Restore interop projects
         - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
-                  /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:SkipComponentsE2ETests=true
+                  /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Run build.cmd helix target
           env:

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -21,6 +21,8 @@ pr:
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
+- name: EXECUTE_COMPONENTS_E2E_TESTS
+  value: true
 - name: _TeamName
   value:  AspNetCore
 

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -14,8 +14,8 @@
     <SkipTests Condition="'$(SeleniumE2ETestsSupported)' != 'true'">true</SkipTests>
     <SkipTests Condition="'$(SeleniumE2ETestsSupported)' == 'true'">false</SkipTests>
 
-    <!-- Until we resolve reliability issues, we're disabling these E2E tests in the main CI job -->
-    <SkipTests Condition="'$(SkipComponentsE2ETests)' == 'true'">true</SkipTests>
+    <!-- Skip the Components E2E tests in CI unless explicitly configured otherwise via EXECUTE_COMPONENTS_E2E_TESTS -->
+    <SkipTests Condition="'$(CI)' == 'true' and '$(EXECUTE_COMPONENTS_E2E_TESTS)' != 'true'">true</SkipTests>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
     <BaseOutputPath />

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -15,7 +15,7 @@
     <SkipTests Condition="'$(SeleniumE2ETestsSupported)' == 'true'">false</SkipTests>
 
     <!-- Skip the Components E2E tests in CI unless explicitly configured otherwise via EXECUTE_COMPONENTS_E2E_TESTS -->
-    <SkipTests Condition="'$(CI)' == 'true' and '$(EXECUTE_COMPONENTS_E2E_TESTS)' != 'true'">true</SkipTests>
+    <SkipTests Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(EXECUTE_COMPONENTS_E2E_TESTS)' != 'true'">true</SkipTests>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
     <BaseOutputPath />

--- a/src/Components/test/E2ETestMigration/Microsoft.AspNetCore.Components.Migration.E2ETests.csproj
+++ b/src/Components/test/E2ETestMigration/Microsoft.AspNetCore.Components.Migration.E2ETests.csproj
@@ -14,6 +14,7 @@
 
     <!-- Skip the Components E2ETestMigration in CI -->
     <SkipTests Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</SkipTests>
+    <BuildHelixPayload>false</BuildHelixPayload>
 
     <BuildInParallel>false</BuildInParallel>
   </PropertyGroup>

--- a/src/Components/test/E2ETestMigration/Microsoft.AspNetCore.Components.Migration.E2ETests.csproj
+++ b/src/Components/test/E2ETestMigration/Microsoft.AspNetCore.Components.Migration.E2ETests.csproj
@@ -11,7 +11,10 @@
 
     <TestTrimmedApps Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TestTrimmedApps>
     <TestTrimmedApps Condition="'$(Configuration)' == 'Release'">true</TestTrimmedApps>
-    
+
+    <!-- Skip the Components E2ETestMigration in CI -->
+    <SkipTests Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</SkipTests>
+
     <BuildInParallel>false</BuildInParallel>
   </PropertyGroup>
 


### PR DESCRIPTION
Stops running the components E2E tests for the [`aspnetcore-quarantined-tests`](https://dev.azure.com/dnceng/public/_test/analytics?definitionId=331&contextType=build) and [`aspnetcore-quarantined-pr`](https://dev.azure.com/dnceng/public/_test/analytics?definitionId=869&contextType=build) pipelines.

Also disables the E2EMigrationTests from the CI.

Fixes https://github.com/dotnet/aspnetcore/issues/37443