### PR TITLE
Add `timeoutInMinutes` for `components-e2e-tests` Pipeline

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -32,6 +32,7 @@ jobs:
     agentOs: Linux
     isAzDOTestingJob: true
     enablePublishTestResults: false
+    timeoutInMinutes: 75
     steps:
     - script: git submodule update --init
       displayName: Update submodules


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14852843/139164753-a89a765c-ea5d-4811-9294-03e76d5850ff.png)

Based on analytics 75 minute timeout seems appropriate.

![image](https://user-images.githubusercontent.com/14852843/139165049-0ff7615b-ecf3-45be-9581-0d12743167d6.png)
