### PR TITLE
Fix typo in Web API template option description (#37780)

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -291,7 +291,7 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Whether to use mininmal APIs instead of controllers."
+      "description": "Whether to use minimal APIs instead of controllers."
     },
     "Framework": {
       "type": "parameter",


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/37780

Fixes https://github.com/dotnet/aspnetcore/issues/37788

## Description

Typo found in templates, it was too late to take for 6.0 GA.

## Customer Impact

Shows up in VS when making a new project.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Fixing a typo, no code changes