### PR TITLE
Fix groupIdentity in protobuf template

### DIFF
--- a/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
@@ -12,9 +12,9 @@
     "language": "",
     "type": "item"
   },
-  "groupIdentity": "Microsoft.Web.Grpc.Protobuf.6.0",
+  "groupIdentity": "Microsoft.Web.Grpc.Protobuf",
   "precedence": "600",
-  "identity": "Microsoft.Web.Grpc.Protobuf",
+  "identity": "Microsoft.Web.Grpc.Protobuf.6.0",
   "shortname": "proto",
   "sourceName": "protobuf",
   "primaryOutputs": [


### PR DESCRIPTION
## Description

This PR fixes a typo in the template definitions for gRPC that resulted in errors when customers would try to add a new protobuf file via the "New Item" experience in VS.

## Customer Impact

Without this fix, customers are not able to create new templates 

## Regression?

- [X] Yes
- [ ] No

This is a regression from .NET 5.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This PR fixes a typo in the templates to align with the expected values.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

----

Closes https://github.com/dotnet/aspnetcore/issues/37815.