### PR TITLE
[Components] Unquarantine CanCacheRouteTable

### DIFF
--- a/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
+++ b/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Components.Routing
     public class RouteTableFactoryTests
     {
         [Fact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/36888")]
         public void CanCacheRouteTable()
         {
             // Arrange


### PR DESCRIPTION
This test failed a single time and hasn't failed since.

There's nothing on the test that can induce flakiness and there's not enough data to try and reproduce the issue.

This was most likely caused by a "transient" bug on the runtime/clr that got fixed in subsequent releases, but its impossible to trace this down to the root.
