### PR TITLE
Bump helix timeout for iis functionals

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
@@ -450,7 +450,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalFact]
         [RequiresNewHandler]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/37915")]
         public async Task StartupTimeoutIsApplied()
         {
             // From what we can tell, this failure is due to ungraceful shutdown.

--- a/src/Servers/IIS/IIS/test/FunctionalTest.props
+++ b/src/Servers/IIS/IIS/test/FunctionalTest.props
@@ -1,8 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <HelixTimeout>00:45:00</HelixTimeout>
-    <HelixTimeout Condition="$(HelixTargetQueue.StartsWith('Windows.10.Amd64'))">01:00:00</HelixTimeout>
+    <HelixTimeout>01:15:00</HelixTimeout>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Unquarantine innocent test, we lost the 1 hour time customization since we changed helix queues to win11, bumping the test timeout up 15 minutes to be safe as well