### PR TITLE
Report the RawConnectionId for HttpSys

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -45,7 +45,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             _contentBoundaryType = BoundaryType.None;
 
             RequestId = requestContext.RequestId;
+            // For HTTP/2 Http.Sys assigns each request a unique connection id for use with API calls, but the RawConnectionId represents the real connection.
             UConnectionId = requestContext.ConnectionId;
+            RawConnectionId = requestContext.RawConnectionId;
             SslStatus = requestContext.SslStatus;
 
             KnownMethod = requestContext.VerbId;
@@ -115,8 +117,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal ulong UConnectionId { get; }
 
+        internal ulong RawConnectionId { get; }
+
         // No ulongs in public APIs...
-        public long ConnectionId => (long)UConnectionId;
+        public long ConnectionId => (long)RawConnectionId;
 
         internal ulong RequestId { get; }
 

--- a/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
+++ b/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
@@ -99,6 +99,8 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         internal ulong ConnectionId => NativeRequest->ConnectionId;
 
+        internal ulong RawConnectionId => NativeRequest->RawConnectionId;
+
         internal HttpApiTypes.HTTP_VERB VerbId => NativeRequest->Verb;
 
         internal ulong UrlContext => NativeRequest->UrlContext;


### PR DESCRIPTION
Http.Sys uses the ConnectionId as a field in many APIs. To make those APIs work well with HTTP/2 they assigned each request a fake unique connection id, however the RawConnectionId still reports the underlying connection id. This is the value we want to report from HttpContext.Connection.Id.

https://github.com/dotnet/aspnetcore/issues/37946