### PR TITLE
Run Sockets.BindTests in sequence

### DIFF
--- a/src/Servers/Kestrel/test/BindTests/Properties/AssemblyInfo.cs
+++ b/src/Servers/Kestrel/test/BindTests/Properties/AssemblyInfo.cs
@@ -7,3 +7,5 @@ using Microsoft.Extensions.Logging.Testing;
 
 [assembly: ShortClassName]
 [assembly: LogLevel(LogLevel.Trace)]
+// AddressRegistrationTests can cause issues with other tests so run all tests in sequence.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
AddressRegistrationTests are known to have issues when run with other tests, so let's keep them from running in parallel.