### PR TITLE
Add warning when targeting release/* branches

### DIFF
--- a/.azuredevops/pull_request_template/branches/release.md
+++ b/.azuredevops/pull_request_template/branches/release.md
@@ -1,5 +1,11 @@
 # {PR title}
 
+<!--
+  In almost all cases, targeting this branch is incorrect. Did you mean to target an internal/release/* branch?
+  If yes, please retarget your PR. If not, please justify updating a branch that should be an exact mirror of
+  our GitHub content.
+-->
+
 Summary of the changes (Less than 80 chars)
 
 ## Description


### PR DESCRIPTION
- internal PRs should never or almost never target release/* branches