### PR TITLE
Update Chrome and Selenium Versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -255,9 +255,9 @@
     <PlaywrightSharpVersion>0.192.0</PlaywrightSharpVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.2</PollyVersion>
-    <SeleniumSupportVersion>4.0.0</SeleniumSupportVersion>
-    <SeleniumWebDriverChromeDriverVersion>95.0.4638.1700</SeleniumWebDriverChromeDriverVersion>
-    <SeleniumWebDriverVersion>4.0.0</SeleniumWebDriverVersion>
+    <SeleniumSupportVersion>4.0.1</SeleniumSupportVersion>
+    <SeleniumWebDriverChromeDriverVersion>95.0.4638.5400</SeleniumWebDriverChromeDriverVersion>
+    <SeleniumWebDriverVersion>4.0.1</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.2.4</StackExchangeRedisVersion>

--- a/src/Shared/E2ETesting/selenium-config.json
+++ b/src/Shared/E2ETesting/selenium-config.json
@@ -1,7 +1,7 @@
 {
   "drivers": {
     "chrome": {
-      "version" : "95.0.4638.17"
+      "version" : "95.0.4638.54"
     }
   },
   "ignoreExtraDrivers": true


### PR DESCRIPTION
- some Chrome 96 drivers are available but browser remains at Chrome 95