### PR TITLE
Unquarantine shared tests

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -524,7 +524,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareDataName))]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/23043")]
         public async Task ConnectionClosedTokenFiresOnClientFIN(string listenOptionsName)
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -560,7 +559,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareDataName))]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/37750")]
         public async Task ConnectionClosedTokenFiresOnServerFIN(string listenOptionsName)
         {
             var testContext = new TestServiceContext(LoggerFactory);
@@ -597,7 +595,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareDataName))]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35686")]
         public async Task ConnectionClosedTokenFiresOnServerAbort(string listenOptionsName)
         {
             var testContext = new TestServiceContext(LoggerFactory);

--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -257,7 +257,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
 
         [Theory]
         [MemberData(nameof(ConnectionMiddlewareData))]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/33455")]
         public async Task WritingToConnectionAfterUnobservedCloseTriggersRequestAbortedToken(ListenOptions listenOptions)
         {
             const int connectionPausedEventId = 4;
@@ -825,8 +824,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
         }
 
         [Fact]
-        [CollectDump]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/26306")]
         public async Task ConnectionNotClosedWhenClientSatisfiesMinimumDataRateGivenLargeResponseHeaders()
         {
             var headerSize = 1024 * 1024; // 1 MB for each header value


### PR DESCRIPTION
These are tests that were quarantined for Libuv specific issues, but libuv is gone now.
Fixes #33455
Fixes #23043
Fixes #26306
Fixes #35686
Fixes #37750