### PR TITLE
[main] Special case X.Y.1 in Directory.Build.targets.in

### DIFF
--- a/eng/tools/GenerateFiles/Directory.Build.targets.in
+++ b/eng/tools/GenerateFiles/Directory.Build.targets.in
@@ -64,8 +64,9 @@
           Condition=" '%(TargetFramework)' == '${DefaultNetCoreTargetFramework}' ">${MicrosoftAspNetCoreAppRuntimeVersion}</LatestRuntimeFrameworkVersion>
       <RuntimePackRuntimeIdentifiers
           Condition=" '%(TargetFramework)' == '${DefaultNetCoreTargetFramework}' ">${SupportedRuntimeIdentifiers}</RuntimePackRuntimeIdentifiers>
+      <!-- Do not update %(TargetingPackVersion) until X.Y.0 versions have been released. -->
       <TargetingPackVersion
-          Condition=" '%(TargetFramework)' == '${DefaultNetCoreTargetFramework}' ">${MicrosoftAspNetCoreAppRefVersion}</TargetingPackVersion>
+          Condition=" '%(TargetFramework)' == '${DefaultNetCoreTargetFramework}' AND '${AspNetCorePatchVersion}' != '1' ">${MicrosoftAspNetCoreAppRefVersion}</TargetingPackVersion>
       <DefaultRuntimeFrameworkVersion Condition=" '$(IsServicingBuild)' != 'true' AND
           '%(TargetFramework)' == '${DefaultNetCoreTargetFramework}' ">${MicrosoftAspNetCoreAppRuntimeVersion}</DefaultRuntimeFrameworkVersion>
     </KnownFrameworkReference>

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -13,6 +13,7 @@
   <Target Name="GenerateDirectoryBuildFiles">
     <PropertyGroup>
       <_TemplateProperties>
+        AspNetCorePatchVersion=$(AspNetCorePatchVersion);
         DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
         MicrosoftAspNetCoreAppRefVersion=$(TargetingPackVersion);
         MicrosoftAspNetCoreAppRuntimeVersion=$(SharedFxVersion);


### PR DESCRIPTION
- cherry-pick <https://github.com/dotnet/aspnetcore/pull/38027/commits/711d9dca8ac86f801fa2647a57dfb52138d32a48>
- see #38027
  - avoid problems in 7.0.1 between rebranding and 7.0.0 release
- do not update `%(TargetingPackVersion)` until X.Y.0 versions have been released
  - address an odd timing issue I missed in #36718 and #37120
  - fine to stick w/ SDK's bundled targeting pack for one release