### PR TITLE
Use the RawConnectionId for HttpSys

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -45,7 +45,9 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             _contentBoundaryType = BoundaryType.None;
 
             RequestId = requestContext.RequestId;
+            // For HTTP/2 Http.Sys assigns each request a unique connection id for use with API calls, but the RawConnectionId represents the real connection.
             UConnectionId = requestContext.ConnectionId;
+            RawConnectionId = requestContext.RawConnectionId;
             SslStatus = requestContext.SslStatus;
 
             KnownMethod = requestContext.VerbId;
@@ -115,8 +117,10 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal ulong UConnectionId { get; }
 
+        internal ulong RawConnectionId { get; }
+
         // No ulongs in public APIs...
-        public long ConnectionId => (long)UConnectionId;
+        public long ConnectionId => (long)RawConnectionId;
 
         internal ulong RequestId { get; }
 

--- a/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
+++ b/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
@@ -99,6 +99,8 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         internal ulong ConnectionId => NativeRequest->ConnectionId;
 
+        internal ulong RawConnectionId => NativeRequest->RawConnectionId;
+
         internal HttpApiTypes.HTTP_VERB VerbId => NativeRequest->Verb;
 
         internal ulong UrlContext => NativeRequest->UrlContext;


### PR DESCRIPTION
# Use the RawConnectionId for HttpSys

Change HttpSys to report the RawConnectionId instead of the ConnectionId

## Description

Http.Sys uses the ConnectionId as a field in many APIs. To make those APIs work well with HTTP/2 they assigned each request a fake unique connection id, however the RawConnectionId still reports the underlying connection id. This is the value we want to report from HttpContext.Connection.Id for more consistent behavior with HTTP/1.

Fixes #37946

Backport of #37945 to 6.0.x

## Customer Impact

Customers want to know the real connection id so they can generate per-connection stats.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The value is informational.

## Verification

- [x] Manual (required)
- [ ] Automated
- [x] Fix confirmed working by requestor

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A