### PR TITLE
Add Components E2E Test Execution Instructions

### DIFF
--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -39,7 +39,7 @@ To build this specific project from source, follow the instructions [on building
 
 This project contains a collection of unit tests implemented with XUnit and E2E tests implemented using Selenium. In order to run the E2E tests, you will need to have Node installed on your machine.
 
-The E2E tests are located in the `tests/E2ETest` folder. The E2E test assets are located in the `test/testassets` directory, and they consists of a top-level `TestServer` which instantiates different app servers for specific scenarios:
+The E2E tests are located in the `tests/E2ETest` folder. The E2E test assets are located in the `test/testassets` directory, and it contains a top-level `TestServer` which instantiates different app servers for specific scenarios:
 
 - Standalone Blazor WASM
 - Hosted Blazor WASM

--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -37,18 +37,42 @@ To build this specific project from source, follow the instructions [on building
 
 ### Test
 
-This project contains a collection of unit tests implemented with XUnit and E2E tests implemented using Selenium. In order to run the E2E tests, you will need to have Selenium installed on your machine.
+This project contains a collection of unit tests implemented with XUnit and E2E tests implemented using Selenium. In order to run the E2E tests, you will need to have Node installed on your machine.
 
-The E2E tests are located in the top-level `tests` folder in this directory. The E2E tests consists of a top-level `TestServer` which instantiates different app servers for specific scenarios:
+The E2E tests are located in the `tests/E2ETest` folder. The E2E test assets are located in the `test/testassets` directory, and they consists of a top-level `TestServer` which instantiates different app servers for specific scenarios:
 
 - Standalone Blazor WASM
 - Hosted Blazor WASM
 - Blazor Server
 - Blazor Server with pre-rendering
 
-Each app server mounts the same `BasicTestApp` application under each scenario.
+Each app server mounts the same `BasicTestApp` application under each scenario (located at `tests/testassets/BasicTestApp`).
 
-To run the tests for this project, [run the tests on the command line](../../docs/BuildFromSource.md#running-tests-on-command-line) in this directory.
+#### How to run the E2E Tests
+
+To run the tests for this project, follow these steps (from the root directory):
+
+##### Windows
+
+```powershell
+./restore.cmd
+npm install --prefix ./src/Components/test/E2ETest
+. .\activate.ps1
+dotnet test ./src/Components/test/E2ETest
+```
+
+##### Linux / MacOS
+
+```shell
+./restore.sh
+npm install --prefix ./src/Components/test/E2ETest
+source ./activate.sh
+dotnet test ./src/Components/test/E2ETest
+```
+
+Please see the [`Build From Source`](https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md) docs for more information on building and testing from source.
+
+#### WebAssembly Trimming
 
 By default, WebAssembly E2E tests that run as part of the CI or when run in Release builds run with trimming enabled. It's possible that tests that successfully run locally might fail as part of the CI run due to errors introduced due to trimming. To test this scenario locally, either run the E2E tests in release build or with the `TestTrimmedApps` property set. For e.g.
 

--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -37,7 +37,7 @@ To build this specific project from source, follow the instructions [on building
 
 ### Test
 
-This project contains a collection of unit tests implemented with XUnit and E2E tests implemented using Selenium. In order to run the E2E tests, you will need to have Node installed on your machine.
+This project contains a collection of unit tests implemented with XUnit and E2E tests implemented using Selenium. In order to run the E2E tests, you will need to have [Node v16](https://nodejs.org/en/) installed on your machine.
 
 The E2E tests are located in the `tests/E2ETest` folder. The E2E test assets are located in the `test/testassets` directory, and it contains a top-level `TestServer` which instantiates different app servers for specific scenarios:
 
@@ -76,7 +76,7 @@ Note, you may wish to filter tests using the `--filter` command (ie. `dotnet tes
 
 Please see the [`Build From Source`](https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md) docs for more information on building and testing from source.
 
-#### WebAssembly Trimming
+##### WebAssembly Trimming
 
 By default, WebAssembly E2E tests that run as part of the CI or when run in Release builds run with trimming enabled. It's possible that tests that successfully run locally might fail as part of the CI run due to errors introduced due to trimming. To test this scenario locally, either run the E2E tests in release build or with the `TestTrimmedApps` property set. For e.g.
 

--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -48,6 +48,8 @@ The E2E tests are located in the `tests/E2ETest` folder. The E2E test assets are
 
 Each app server mounts the same `BasicTestApp` application under each scenario (located at `tests/testassets/BasicTestApp`).
 
+These tests are run in the CI as part of the [`aspnetcore-components-e2e`](https://dev.azure.com/dnceng/public/_build?definitionId=1026) pipeline.
+
 #### How to run the E2E Tests
 
 To run the tests for this project, follow these steps (from the root directory):

--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -70,6 +70,8 @@ source ./activate.sh
 dotnet test ./src/Components/test/E2ETest
 ```
 
+Note, you may wish to filter tests using the `--filter` command (ie. `dotnet test --filter <TEST_NAME> ./src/Components/test/E2ETest`).
+
 Please see the [`Build From Source`](https://github.com/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md) docs for more information on building and testing from source.
 
 #### WebAssembly Trimming


### PR DESCRIPTION
Fixes: https://github.com/dotnet/aspnetcore/issues/37654

Updated E2E test execution instructions based on what we're currently doing in the CI:

https://github.com/dotnet/aspnetcore/blob/372de32302eecce686fa40cf5cc02d293434ddc7/.azure/pipelines/components-e2e-tests.yml#L38-L56

Note, `./src/Components/build.cmd -test` isn't sufficient in this case as it leads to build errors (it's wanting stuff from `src/Identity` and so on). Doing a root level `./build.cmd` first may resolve it, but would want to avoid that whenever possible as that can be an intensive process.
