### PR TITLE
[DO NOT MERGE] Get 6.0 non-crossgen'd assets

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -44,7 +44,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <!-- Optimize the framework using the crossgen2 tool. Crossgen2 is not currently supported on s390x. -->
     <CrossgenOutput Condition=" '$(TargetArchitecture)' == 's390x' ">false</CrossgenOutput>
-    <CrossgenOutput Condition=" '$(CrossgenOutput)' == '' AND '$(Configuration)' != 'Debug' ">true</CrossgenOutput>
+    <CrossgenOutput Condition=" '$(CrossgenOutput)' == '' AND '$(Configuration)' != 'Debug' ">false</CrossgenOutput>
 
     <!-- Produce crossgen2 profiling symbols (.ni.pdb or .r2rmap files). -->
     <GenerateCrossgenProfilingSymbols>true</GenerateCrossgenProfilingSymbols>


### PR DESCRIPTION
We actually need 6.0 stuff for APIScan, not 7.0