### PR TITLE
Spot check on E2E tests

### DIFF
--- a/src/Components/Authorization/src/AttributeAuthorizeDataCache.cs
+++ b/src/Components/Authorization/src/AttributeAuthorizeDataCache.cs
@@ -30,10 +30,13 @@ namespace Microsoft.AspNetCore.Components.Authorization
             List<IAuthorizeData>? authorizeDatas = null;
             for (var i = 0; i < allAttributes.Length; i++)
             {
+                /*
+                Disabling this functionality to check that E2E tests catch the bug
                 if (allAttributes[i] is IAllowAnonymous)
                 {
                     return null;
                 }
+                */
 
                 if (allAttributes[i] is IAuthorizeData authorizeData)
                 {


### PR DESCRIPTION
Since all the work to improve E2E test reliability, we've had a phenomenal 100% pass rate every single time. It's now so disturbingly reliable that people have questioned if the E2E tests are even reporting failures if they happen.

To find out, this draft PR breaks some functionality on purpose. It won't be merged!