### PR TITLE
Verify DI trimming in unit tests

### DIFF
--- a/eng/targets/CSharp.Common.targets
+++ b/eng/targets/CSharp.Common.targets
@@ -37,6 +37,8 @@
     <!-- See https://github.com/dotnet/roslyn/issues/54867 for more info. -->
     <EnforceCodeStyleInBuild Condition="'$(BuildingInsideVisualStudio)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '17.0'))">false</EnforceCodeStyleInBuild>
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>
+
+    <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(IsTestProject)' == 'true'">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
   </PropertyGroup>
 
   <!-- Enable implicit usings for projects that target the default TFM -->

--- a/eng/targets/CSharp.Common.targets
+++ b/eng/targets/CSharp.Common.targets
@@ -38,6 +38,7 @@
     <EnforceCodeStyleInBuild Condition="'$(BuildingInsideVisualStudio)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '17.0'))">false</EnforceCodeStyleInBuild>
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>
 
+    <!-- Enable trimming annotation validation in DI. See https://github.com/dotnet/runtime/blob/main/docs/workflow/trimming/feature-switches.md -->
     <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(IsTestProject)' == 'true'">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
   </PropertyGroup>
 


### PR DESCRIPTION
Set `VerifyDependencyInjectionOpenGenericServiceTrimmability` on test projects. This sets `Microsoft.Extensions.DependencyInjection.VerifyOpenGenericServiceTrimmability` switch so unit tests with DI will validate trimming attributes are correct.

Enabling trimming on an app sets the validation flag automatically. Explicitly setting the flag means we get validation all the time. We will catch these errors immediately rather than waiting until apps are trimmed.

Details about switch: https://github.com/dotnet/runtime/blob/main/docs/workflow/trimming/feature-switches.md

Executed code: https://github.com/dotnet/runtime/blob/4bac6ed6430e3848f2a5146ad9abe560dd65a6f5/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs#L90-L128