### PR TITLE
Enable TrackLinkedCacheEntries for cache tag helpers

### DIFF
--- a/src/Mvc/Mvc.TagHelpers/src/CacheTagHelperMemoryCacheFactory.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/CacheTagHelperMemoryCacheFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Caching.Memory;
@@ -20,7 +20,8 @@ public class CacheTagHelperMemoryCacheFactory
     {
         Cache = new MemoryCache(new MemoryCacheOptions
         {
-            SizeLimit = options.Value.SizeLimit
+            SizeLimit = options.Value.SizeLimit,
+            TrackLinkedCacheEntries = true,
         });
     }
 

--- a/src/Mvc/Mvc.TagHelpers/src/DependencyInjection/TagHelperExtensions.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/DependencyInjection/TagHelperExtensions.cs
@@ -84,6 +84,7 @@ public static class TagHelperServicesExtensions
 
         // Required default services for cache tag helpers
         services.AddDistributedMemoryCache();
+        services.AddMemoryCache(options => options.TrackLinkedCacheEntries = true);
         services.TryAddSingleton<CacheTagHelperMemoryCacheFactory>();
     }
 }

--- a/src/Mvc/Mvc.TagHelpers/src/DependencyInjection/TagHelperExtensions.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/DependencyInjection/TagHelperExtensions.cs
@@ -84,7 +84,6 @@ public static class TagHelperServicesExtensions
 
         // Required default services for cache tag helpers
         services.AddDistributedMemoryCache();
-        services.AddMemoryCache(options => options.TrackLinkedCacheEntries = true);
         services.TryAddSingleton<CacheTagHelperMemoryCacheFactory>();
     }
 }

--- a/src/Mvc/Mvc.TagHelpers/test/CacheTagHelperTest.cs
+++ b/src/Mvc/Mvc.TagHelpers/test/CacheTagHelperTest.cs
@@ -485,7 +485,6 @@ public class CacheTagHelperTest
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/36765")]
     public async Task ProcessAsync_FlowsEntryLinkThatAllowsAddingTriggersToAddedEntry()
     {
         // Arrange
@@ -493,7 +492,7 @@ public class CacheTagHelperTest
         var expectedContent = new DefaultTagHelperContent();
         expectedContent.SetContent("some-content");
         var tokenSource = new CancellationTokenSource();
-        var cache = new MemoryCache(new MemoryCacheOptions());
+        var cache = new MemoryCache(new MemoryCacheOptions() { TrackLinkedCacheEntries = true });
         var cacheEntryOptions = new MemoryCacheEntryOptions()
             .AddExpirationToken(new CancellationChangeToken(tokenSource.Token));
         var tagHelperContext = new TagHelperContext(

--- a/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/HtmlGenerationTest.cs
@@ -526,7 +526,6 @@ public class HtmlGenerationTest :
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/36765")]
     public async Task CacheTagHelper_BubblesExpirationOfNestedTagHelpers()
     {
         // Arrange & Act - 1

--- a/src/Mvc/test/WebSites/HtmlGenerationWebSite/Startup.cs
+++ b/src/Mvc/test/WebSites/HtmlGenerationWebSite/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace HtmlGenerationWebSite;
@@ -22,6 +23,7 @@ public class Startup
 
         services.AddSingleton(typeof(ISignalTokenProviderService<>), typeof(SignalTokenProviderService<>));
         services.AddSingleton<ProductsService>();
+        services.Configure<MemoryCacheOptions>(o => o.TrackLinkedCacheEntries = true);
     }
 
     public virtual void Configure(IApplicationBuilder app)


### PR DESCRIPTION
Fixes #36765 

The runtime disabled this feature by default in .NET 7, but cache tags depend on it so we need to opt-in in multiple places.

