### PR TITLE
SignOut 2fa remember me cookie when validation fails

### DIFF
--- a/src/Identity/Core/src/IdentityCookiesBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityCookiesBuilderExtensions.cs
@@ -81,7 +81,14 @@ public static class IdentityCookieAuthenticationBuilderExtensions
     /// <returns>The <see cref="OptionsBuilder{TOptions}"/> which can be used to configure the cookie authentication.</returns>
     public static OptionsBuilder<CookieAuthenticationOptions> AddTwoFactorRememberMeCookie(this AuthenticationBuilder builder)
     {
-        builder.AddCookie(IdentityConstants.TwoFactorRememberMeScheme, o => o.Cookie.Name = IdentityConstants.TwoFactorRememberMeScheme);
+        builder.AddCookie(IdentityConstants.TwoFactorRememberMeScheme, o =>
+        {
+            o.Cookie.Name = IdentityConstants.TwoFactorRememberMeScheme;
+            o.Events = new CookieAuthenticationEvents
+            {
+                OnValidatePrincipal = SecurityStampValidator.ValidateAsync<ITwoFactorSecurityStampValidator>
+            };
+        });
         return new OptionsBuilder<CookieAuthenticationOptions>(builder.Services, IdentityConstants.TwoFactorRememberMeScheme);
     }
 

--- a/src/Identity/Core/src/SecurityStampValidator.cs
+++ b/src/Identity/Core/src/SecurityStampValidator.cs
@@ -142,6 +142,7 @@ public class SecurityStampValidator<TUser> : ISecurityStampValidator where TUser
                 Logger.LogDebug(EventIds.SecurityStampValidationFailed, "Security stamp validation failed, rejecting cookie.");
                 context.RejectPrincipal();
                 await SignInManager.SignOutAsync();
+                await SignInManager.Context.SignOutAsync(IdentityConstants.TwoFactorRememberMeScheme);
             }
         }
     }

--- a/src/Identity/test/Identity.Test/SecurityStampValidatorTest.cs
+++ b/src/Identity/test/Identity.Test/SecurityStampValidatorTest.cs
@@ -115,10 +115,13 @@ public class SecurityStampTest
             signInManager.Setup(s => s.CreateUserPrincipalAsync(user)).ReturnsAsync(principal).Verifiable();
         }
 
+        var authService = new Mock<IAuthenticationService>();
+        authService.Setup(c => c.SignOutAsync(httpContext.Object, IdentityConstants.TwoFactorRememberMeScheme, /*properties*/null)).Returns(Task.CompletedTask).Verifiable();
         var services = new ServiceCollection();
         services.AddSingleton(options.Object);
         services.AddSingleton(signInManager.Object);
         services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<PocoUser>(options.Object, signInManager.Object, new SystemClock(), new LoggerFactory()));
+        services.AddSingleton(authService.Object);
         httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
 
         await testCode.Invoke();
@@ -153,7 +156,6 @@ public class SecurityStampTest
     {
         var user = new PocoUser("test");
         var httpContext = new Mock<HttpContext>();
-
 
         var userManager = MockHelpers.MockUserManager<PocoUser>();
 
@@ -208,10 +210,13 @@ public class SecurityStampTest
         var signInManager = new Mock<SignInManager<PocoUser>>(userManager.Object,
             contextAccessor.Object, claimsManager.Object, identityOptions.Object, null, new Mock<IAuthenticationSchemeProvider>().Object, new DefaultUserConfirmation<PocoUser>());
         signInManager.Setup(s => s.ValidateSecurityStampAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(default(PocoUser)).Verifiable();
+        var authService = new Mock<IAuthenticationService>();
+        authService.Setup(c => c.SignOutAsync(httpContext.Object, IdentityConstants.TwoFactorRememberMeScheme, /*properties*/null)).Returns(Task.CompletedTask).Verifiable();
         var services = new ServiceCollection();
         services.AddSingleton(options.Object);
         services.AddSingleton(signInManager.Object);
         services.AddSingleton<ISecurityStampValidator>(new SecurityStampValidator<PocoUser>(options.Object, signInManager.Object, new SystemClock(), new LoggerFactory()));
+        services.AddSingleton(authService.Object);
         httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
         var id = new ClaimsIdentity(IdentityConstants.ApplicationScheme);
         id.AddClaim(new Claim(ClaimTypes.NameIdentifier, user.Id));
@@ -332,10 +337,13 @@ public class SecurityStampTest
             contextAccessor.Object, claimsManager.Object, identityOptions.Object, null, new Mock<IAuthenticationSchemeProvider>().Object, new DefaultUserConfirmation<PocoUser>());
         signInManager.Setup(s => s.ValidateTwoFactorSecurityStampAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(shouldStampValidate ? user : default).Verifiable();
 
+        var authService = new Mock<IAuthenticationService>();
+        authService.Setup(c => c.SignOutAsync(httpContext.Object, IdentityConstants.TwoFactorRememberMeScheme, /*properties*/null)).Returns(Task.CompletedTask).Verifiable();
         var services = new ServiceCollection();
         services.AddSingleton(options.Object);
         services.AddSingleton(signInManager.Object);
         services.AddSingleton<ITwoFactorSecurityStampValidator>(new TwoFactorSecurityStampValidator<PocoUser>(options.Object, signInManager.Object, new SystemClock(), new LoggerFactory()));
+        services.AddSingleton(authService.Object);
         httpContext.Setup(c => c.RequestServices).Returns(services.BuildServiceProvider());
 
         var principal = await signInManager.Object.StoreRememberClient(user);


### PR DESCRIPTION
Fix for https://github.com/dotnet/aspnetcore/issues/37963

We now properly configure the 2fa remember me cookie via AddIdentityCore, and we clear the remember me cookie whenever the security stamp validation fails