### PR TITLE
Update Test Failure Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/50_test_failure.md
+++ b/.github/ISSUE_TEMPLATE/50_test_failure.md
@@ -1,11 +1,15 @@
 ---
 name: Test failure
 about: Report a failing test that needs to be quarantined
-title: ''
+title: 'Quarantine <FAILING_TEST_NAME>'
 labels: test-failure
 assignees: ''
 
 ---
+
+<!--
+Note this issue template is specifically for failing tests within the dotnet/aspnetcore repo.
+-->
 
 ## Failing Test(s)
 


### PR DESCRIPTION
- Clarify instructions that this is specifically for dotnet/aspnetcore test failures
  - Avoids issues like https://github.com/dotnet/aspnetcore/issues/38248
  - Reasoning being, we want to avoid user issues being auto-tagged as `test-failure`s.
- Updates default title.
