### PR TITLE
Avoid null ref in TagHelperMatchingConvention when attribute name is null

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
@@ -110,7 +110,6 @@ internal readonly struct StringSegment : IEquatable<StringSegment>, IEquatable<s
         return Equals(other, StringComparison.Ordinal);
     }
 
-
     /// <summary>
     /// Indicates whether the current object is equal to another object of the same type.
     /// </summary>
@@ -160,15 +159,7 @@ internal readonly struct StringSegment : IEquatable<StringSegment>, IEquatable<s
     /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
     /// <returns><code>true</code> if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
     public bool Equals(string text, StringComparison comparisonType)
-    {
-        var textLength = text.Length;
-        if (!HasValue || Length != textLength)
-        {
-            return false;
-        }
-
-        return string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
-    }
+        => Equals(new StringSegment(text), comparisonType);
 
     /// <inheritdoc />
     public override int GetHashCode()
@@ -225,10 +216,7 @@ internal readonly struct StringSegment : IEquatable<StringSegment>, IEquatable<s
     /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
     /// <returns><code>true</code> if <paramref name="text"/> matches the beginning of this <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
     public bool StartsWith(string text, StringComparison comparisonType)
-    {
-        var textLength = text.Length;
-        return string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
-    }
+        => StartsWith(new StringSegment(text), comparisonType);
 
     public bool StartsWith(StringSegment text, StringComparison comparisonType)
     {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringSegmentTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringSegmentTest.cs
@@ -249,6 +249,48 @@ public class StringSegmentTest
     }
 
     [Fact]
+    public void StringSegment_Equals_NullString()
+    {
+        // Arrange
+        var stringSegment = new StringSegment("text");
+        var @string = (string)null;
+
+        // Act
+        var result = stringSegment.Equals(@string, StringComparison.Ordinal);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void StringSegment_DefaultValue_Equals_NullString()
+    {
+        // Arrange
+        var stringSegment = StringSegment.Empty;
+        var @string = (string)null;
+
+        // Act
+        var result = stringSegment.Equals(@string, StringComparison.Ordinal);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void StringSegment_DefaultValue_Equals_EmptyString()
+    {
+        // Arrange
+        var stringSegment = StringSegment.Empty;
+        var @string = string.Empty;
+
+        // Act
+        var result = stringSegment.Equals(@string, StringComparison.Ordinal);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
     public void StringSegment_StaticEquals_Valid()
     {
         var segment1 = new StringSegment("My Car Is Cool", 3, 3);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
@@ -1,7 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -153,5 +154,39 @@ public class TagHelperMatchingConventionsTest
 
         // Assert
         Assert.Equal(expectedResult, result);
+    }
+
+    [Fact]
+    public void CanSatisfyBoundAttribute_IndexerAttribute_ReturnsFalseIsNotMatching()
+    {
+        // Arrange
+        var tagHelperBuilder = new DefaultTagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
+        var builder = new DefaultBoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        builder.AsDictionary("asp-", typeof(Dictionary<string, string>).FullName);
+
+        var boundAttribute = builder.Build();
+
+        // Act
+        var result = TagHelperMatchingConventions.CanSatisfyBoundAttribute("style", boundAttribute);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CanSatisfyBoundAttribute_IndexerAttribute_ReturnsTrueIfMatching()
+    {
+        // Arrange
+        var tagHelperBuilder = new DefaultTagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
+        var builder = new DefaultBoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+        builder.AsDictionary("asp-", typeof(Dictionary<string, string>).FullName);
+
+        var boundAttribute = builder.Build();
+
+        // Act
+        var result = TagHelperMatchingConventions.CanSatisfyBoundAttribute("asp-route-controller", boundAttribute);
+
+        // Assert
+        Assert.True(result);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/38194
