### PR TITLE
Avoid null ref in TagHelperMatchingConvention when attribute name is null

### DIFF
--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/src/StringSegment.cs
@@ -110,7 +110,6 @@ namespace Microsoft.AspNetCore.Razor
             return Equals(other, StringComparison.Ordinal);
         }
 
-
         /// <summary>
         /// Indicates whether the current object is equal to another object of the same type.
         /// </summary>
@@ -160,15 +159,7 @@ namespace Microsoft.AspNetCore.Razor
         /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
         /// <returns><code>true</code> if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
         public bool Equals(string text, StringComparison comparisonType)
-        {
-            var textLength = text.Length;
-            if (!HasValue || Length != textLength)
-            {
-                return false;
-            }
-
-            return string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
-        }
+            => Equals(new StringSegment(text), comparisonType);
 
         /// <inheritdoc />
         public override int GetHashCode()
@@ -225,10 +216,7 @@ namespace Microsoft.AspNetCore.Razor
         /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
         /// <returns><code>true</code> if <paramref name="text"/> matches the beginning of this <see cref="StringSegment"/>; otherwise, <code>false</code>.</returns>
         public bool StartsWith(string text, StringComparison comparisonType)
-        {
-            var textLength = text.Length;
-            return string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
-        }
+            => StartsWith(new StringSegment(text), comparisonType);
 
         public bool StartsWith(StringSegment text, StringComparison comparisonType)
         {

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringSegmentTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/StringSegmentTest.cs
@@ -249,6 +249,48 @@ namespace Microsoft.AspNetCore.Razor.Language
         }
 
         [Fact]
+        public void StringSegment_Equals_NullString()
+        {
+            // Arrange
+            var stringSegment = new StringSegment("text");
+            var @string = (string)null;
+
+            // Act
+            var result = stringSegment.Equals(@string, StringComparison.Ordinal);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void StringSegment_DefaultValue_Equals_NullString()
+        {
+            // Arrange
+            var stringSegment = StringSegment.Empty;
+            var @string = (string)null;
+
+            // Act
+            var result = stringSegment.Equals(@string, StringComparison.Ordinal);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void StringSegment_DefaultValue_Equals_EmptyString()
+        {
+            // Arrange
+            var stringSegment = StringSegment.Empty;
+            var @string = string.Empty;
+
+            // Act
+            var result = stringSegment.Equals(@string, StringComparison.Ordinal);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
         public void StringSegment_StaticEquals_Valid()
         {
             var segment1 = new StringSegment("My Car Is Cool", 3, 3);

--- a/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
+++ b/src/Razor/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
@@ -1,7 +1,8 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language
@@ -153,6 +154,40 @@ namespace Microsoft.AspNetCore.Razor.Language
 
             // Assert
             Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void CanSatisfyBoundAttribute_IndexerAttribute_ReturnsFalseIsNotMatching()
+        {
+            // Arrange
+            var tagHelperBuilder = new DefaultTagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
+            var builder = new DefaultBoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+            builder.AsDictionary("asp-", typeof(Dictionary<string, string>).FullName);
+
+            var boundAttribute = builder.Build();
+
+            // Act
+            var result = TagHelperMatchingConventions.CanSatisfyBoundAttribute("style", boundAttribute);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void CanSatisfyBoundAttribute_IndexerAttribute_ReturnsTrueIfMatching()
+        {
+            // Arrange
+            var tagHelperBuilder = new DefaultTagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TestTagHelper", "Test");
+            var builder = new DefaultBoundAttributeDescriptorBuilder(tagHelperBuilder, TagHelperConventions.DefaultKind);
+            builder.AsDictionary("asp-", typeof(Dictionary<string, string>).FullName);
+
+            var boundAttribute = builder.Build();
+
+            // Act
+            var result = TagHelperMatchingConventions.CanSatisfyBoundAttribute("asp-route-controller", boundAttribute);
+
+            // Assert
+            Assert.True(result);
         }
     }
 }


### PR DESCRIPTION
As part of .NET 6, we made some  tweaks to the razor parser to avoid string allocations. This change
results in a null-ref for bound properties without public setters. The parser change affects building
apps going back all the way to .NET 2.1, so we'd like to fix this.

Fixes https://github.com/dotnet/aspnetcore/issues/38194

----------------------------------

### Description / Customer Impact

Attempting to build an app that references certain kinds of tag helpers<sup>[1]</sup> in cshtml files results in a null reference exception in the Razor parser.  With the 6.0 SDK installed, this causes the build to fail in < 6.0 apps and for the source generator to not add files in 6.0.

[1] - TagHelpers with IDictionary properties that do not have setters.

### Regression
[x] Yes
[ ] No

Regression introduced in .NET 6 preview6

### Testing
[x] Automated (added additional unit tests for this)
[x] Manual testing (patched the SDK and verified the fix)

### Risk
* [ ] High
* [ ] Medium
* [x] Low

The change is primarily limited to build, not part of the shared fx. The null-ref happens with somewhat uncommon inputs so we have confidence this change addresses it.

