### PR TITLE
[SPA] Fix whitespace issues with the SpaProxy bash script

### DIFF
--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -251,7 +251,7 @@ catch
         {
             var fileName = Guid.NewGuid().ToString("N") + ".sh";
             var scriptPath = Path.Combine(AppContext.BaseDirectory, fileName);
-            var stopScript = @$"function list_child_processes(){{
+            var stopScript = @$"function list_child_processes() {{
     local ppid=$1;
     local current_children=$(pgrep -P $ppid);
     local local_child;
@@ -283,6 +283,9 @@ done;
 rm {scriptPath};
 ";
             File.WriteAllText(scriptPath, stopScript);
+
+            _logger.LogDebug($"ASP.NET process ID = {Environment.ProcessId}");
+            _logger.LogDebug($"SPA frontend process ID = {spaProcessId}");
 
             var stopScriptInfo = new ProcessStartInfo("/bin/bash", scriptPath)
             {


### PR DESCRIPTION
## Description

Fixes the script error described in https://github.com/aspnet/AspNetCore-ManualTests/issues/951#issuecomment-939722894

![image](https://user-images.githubusercontent.com/6995051/141324431-9db13513-250f-4a43-9005-105ccdd889b2.png)

Fixes a whitespace issue with the bash script that we create to stop the SPA proxy when the .NET process is terminated abruptly.

Adds a couple of debug messages to make troubleshooting issues easier.

## Customer Impact

When the .NET process is terminated abruptly, the NPM processes are kept running, which happens for example when you stop debugging or running the app from Visual Studio.
This fix addresses that issue so that the npm processes are also killed.

## Regression?

- [X] Yes
- [ ] No

This scenario regressed in 6.0, previous versions, as far as we know don't leave the npm processes running.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The issue was a whitespace issue with the bash script we created that was introduced as a CR feedback item. I've manually tested the fix to the script and we have error handling logic as part of launching the script so the worst thing that can happen is that the script continues to fail.

## Verification

- [X] Manual (required)
- [ ] Automated

![image](https://user-images.githubusercontent.com/6995051/141323163-bcc0397c-4099-47d4-9e96-74d4b4ee6796.png)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
