### PR TITLE
Revert "Update SDK to 7.0.100-alpha.1.21555.1 (#38179)"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "7.0.100-alpha.1.21555.1"
+    "version": "7.0.100-alpha.1.21551.3"
   },
   "tools": {
-    "dotnet": "7.0.100-alpha.1.21555.1",
+    "dotnet": "7.0.100-alpha.1.21551.3",
     "runtimes": {
       "dotnet/x64": [
         "2.1.30",


### PR DESCRIPTION
This reverts commit 087d27c3cd933b100431870a2bb9b7503d0cecd8.

SDK update is causing failures in the Arm64 leg. Reverting this until we can identify the root cause.