### PR TITLE
Override base implementations of WriteLineAsync in HttpResponseStreamWriter

### DIFF
--- a/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
+++ b/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
@@ -445,7 +445,7 @@ public class HttpResponseStreamWriter : TextWriter
         }
         else
         {
-            return WriteAsyncAwaited(values, index, count);
+            return WriteLineAsyncAwaited(values, index, count);
         }
     }
 

--- a/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
+++ b/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
@@ -382,6 +382,7 @@ public class HttpResponseStreamWriter : TextWriter
     }
 
     /// <inheritdoc/>
+    [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads.", Justification = "Required to maintain compatibility")]
     public override Task WriteLineAsync(ReadOnlyMemory<char> value, CancellationToken cancellationToken = default)
     {
         if (_disposed)

--- a/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
+++ b/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
@@ -450,8 +450,8 @@ public class HttpResponseStreamWriter : TextWriter
 
     private async Task WriteLineAsyncAwaited(char[] values, int index, int count)
     {
-        await WriteLineAsync(values, index, count);
-        await WriteLineAsync(NewLine);
+        await WriteAsync(values, index, count);
+        await WriteAsync(NewLine);
     }
 
     /// <inheritdoc/>

--- a/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
+++ b/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
@@ -382,6 +382,7 @@ public class HttpResponseStreamWriter : TextWriter
     }
 
     /// <inheritdoc/>
+    [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads.", Justification = "Required to maintain compatibility")] 
     public override Task WriteLineAsync(ReadOnlyMemory<char> value, CancellationToken cancellationToken = default)
     {
         if (_disposed)

--- a/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
+++ b/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(char value) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(char[]! values, int index, int count) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(string? value) -> System.Threading.Tasks.Task!

--- a/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
+++ b/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(string? value) -> System.Threading.Tasks.Task!

--- a/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
+++ b/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
+override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(char[]! values, int index, int count) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(string? value) -> System.Threading.Tasks.Task!

--- a/src/Http/WebUtilities/test/HttpResponseStreamWriterTest.cs
+++ b/src/Http/WebUtilities/test/HttpResponseStreamWriterTest.cs
@@ -517,6 +517,30 @@ public class HttpResponseStreamWriterTest
     }
 
     [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(HttpResponseStreamWriter.DefaultBufferSize - 1)]
+    [InlineData(HttpResponseStreamWriter.DefaultBufferSize)]
+    public async Task WriteLineAsyncChar_WritesToStream(int newLineLength)
+    {
+        // Arrange
+        var content = 'a';
+        var stream = new TestMemoryStream();
+        var writer = new HttpResponseStreamWriter(stream, Encoding.UTF8);
+        writer.NewLine = new string('\n', newLineLength);
+
+        // Act
+        using (writer)
+        {
+            await writer.WriteLineAsync(content);
+        }
+
+        // Assert
+        Assert.Equal(newLineLength + 1, stream.Length);
+    }
+
+    [Theory]
     [InlineData(0, 1)]
     [InlineData(1022, 1)]
     [InlineData(1023, 1)]

--- a/src/Http/WebUtilities/test/HttpResponseStreamWriterTest.cs
+++ b/src/Http/WebUtilities/test/HttpResponseStreamWriterTest.cs
@@ -457,6 +457,66 @@ public class HttpResponseStreamWriterTest
     }
 
     [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1022, 1)]
+    [InlineData(1023, 1)]
+    [InlineData(1024, 1)]
+    [InlineData(1050, 1)]
+    [InlineData(2047, 1)]
+    [InlineData(2048, 1)]
+    [InlineData(1021, 2)]
+    [InlineData(1022, 2)]
+    [InlineData(1023, 2)]
+    [InlineData(1024, 2)]
+    [InlineData(1024, 1023)]
+    [InlineData(1024, 1024)]
+    [InlineData(1024, 1050)]
+    [InlineData(1050, 2)]
+    [InlineData(2046, 2)]
+    [InlineData(2048, 2)]
+    [InlineData(HttpResponseStreamWriter.DefaultBufferSize + 1, 1)]
+    [InlineData(HttpResponseStreamWriter.DefaultBufferSize + 1, 2)]
+    [InlineData(HttpResponseStreamWriter.DefaultBufferSize + 1, HttpResponseStreamWriter.DefaultBufferSize)]
+    public async Task WriteLineStringAsync_WritesToStream(int charCount, int newLineLength)
+    {
+        // Arrange
+        var content = new string('a', charCount);
+        var stream = new TestMemoryStream();
+        var writer = new HttpResponseStreamWriter(stream, Encoding.UTF8);
+        writer.NewLine = new string('\n', newLineLength);
+
+        // Act
+        using (writer)
+        {
+            await writer.WriteLineAsync(content);
+        }
+
+        // Assert
+        Assert.Equal(charCount + newLineLength, stream.Length);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task WriteLineAsyncString_OnlyWritesNewLineToStream_ForNullArgument(int newLineLength)
+    {
+        // Arrange
+        string? content = null;
+        var stream = new TestMemoryStream();
+        var writer = new HttpResponseStreamWriter(stream, Encoding.UTF8);
+        writer.NewLine = new string('\n', newLineLength);
+
+        // Act
+        using (writer)
+        {
+            await writer.WriteLineAsync(content);
+        }
+
+        // Assert
+        Assert.Equal(newLineLength, stream.Length);
+    }
+
+    [Theory]
     [InlineData("你好世界", "utf-16")]
     [InlineData("హలో ప్రపంచ", "iso-8859-1")]
     [InlineData("வணக்கம் உலக", "utf-32")]
@@ -736,6 +796,10 @@ public class HttpResponseStreamWriterTest
         yield return new object[] { new Func<HttpResponseStreamWriter, Task>(async (httpResponseStreamWriter) =>
             {
                 await httpResponseStreamWriter.WriteLineAsync(new ReadOnlyMemory<char>(new char[] { 'a', 'b' }));
+            })};
+        yield return new object[] { new Func<HttpResponseStreamWriter, Task>(async (httpResponseStreamWriter) =>
+            {
+                await httpResponseStreamWriter.WriteLineAsync("hello");
             })};
 
         yield return new object[] { new Func<HttpResponseStreamWriter, Task>(async (httpResponseStreamWriter) =>

--- a/src/Http/WebUtilities/test/HttpResponseStreamWriterTest.cs
+++ b/src/Http/WebUtilities/test/HttpResponseStreamWriterTest.cs
@@ -488,7 +488,7 @@ public class HttpResponseStreamWriterTest
         // Act
         using (writer)
         {
-            await writer.WriteLineAsync(content);
+            await writer.WriteLineAsync(content, 0, charCount);
         }
 
         // Assert
@@ -498,6 +498,7 @@ public class HttpResponseStreamWriterTest
     [Theory]
     [InlineData(1)]
     [InlineData(2)]
+    [InlineData(HttpResponseStreamWriter.DefaultBufferSize + 1)]
     public async Task WriteLineAsyncCharArray_OnlyWritesNewLineToStream_ForNullArgument(int newLineLength)
     {
         // Arrange
@@ -509,7 +510,7 @@ public class HttpResponseStreamWriterTest
         // Act
         using (writer)
         {
-            await writer.WriteLineAsync(content);
+            await writer.WriteLineAsync(content!, 0, 0);
         }
 
         // Assert
@@ -582,6 +583,7 @@ public class HttpResponseStreamWriterTest
     [Theory]
     [InlineData(1)]
     [InlineData(2)]
+    [InlineData(HttpResponseStreamWriter.DefaultBufferSize + 1)]
     public async Task WriteLineAsyncString_OnlyWritesNewLineToStream_ForNullArgument(int newLineLength)
     {
         // Arrange

--- a/src/Http/WebUtilities/test/HttpResponseStreamWriterTest.cs
+++ b/src/Http/WebUtilities/test/HttpResponseStreamWriterTest.cs
@@ -518,6 +518,28 @@ public class HttpResponseStreamWriterTest
     }
 
     [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(HttpResponseStreamWriter.DefaultBufferSize + 1)]
+    public async Task WriteLineAsyncCharArray_OnlyWritesNewLineToStream_ForZeroCount(int newLineLength)
+    {
+        // Arrange
+        var content = new char[1];
+        var stream = new TestMemoryStream();
+        var writer = new HttpResponseStreamWriter(stream, Encoding.UTF8);
+        writer.NewLine = new string('\n', newLineLength);
+
+        // Act
+        using (writer)
+        {
+            await writer.WriteLineAsync(content, 0, 0);
+        }
+
+        // Assert
+        Assert.Equal(newLineLength, stream.Length);
+    }
+
+    [Theory]
     [InlineData(0)]
     [InlineData(1)]
     [InlineData(2)]


### PR DESCRIPTION
## Description

Currently, `HttpResponseStreamWriter` uses the base implementation for `WriteLineAsync(string)` inherited from `TextWriter`. However, this base implementation apparently makes use of some synchronous operations. 

As a result, when attempting to write a long string (~20,000+ characters) to an `HttpResponse` body with `HttpResponseStreamWriter.WriteLineAsync(string)`, a `System.InvalidOperationException` will be thrown unexpectedly due to the synchronous operations used in the base implementation. This PR adds a fully asynchronous override for `WriteLineAsync(string)` to address this issue.

Fixes #38210