### PR TITLE
Remove remaining System.Net.Http 4.1.0 reference

### DIFF
--- a/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
@@ -63,6 +63,7 @@
 
     <Reference Include="Microsoft.NETCore.Windows.ApiSets" />
     <Reference Include="Microsoft.Web.Administration" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.ServiceProcess.ServiceController" />
   </ItemGroup>
 


### PR DESCRIPTION
Should resolve the last remaining Component Governance bug, which was about `System.Net.Http 4.1.0` being restored during build (I believe it was brought in via `Microsoft.Web.Administration`). Restoring the repo locally no longer restores that package.