### PR TITLE
Bump .NET SDK again

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -185,11 +185,6 @@
     <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildUtilitiesCoreVersion>16.9.0</MicrosoftBuildUtilitiesCoreVersion>
     <!--
-      Temporarily override the Microsoft.NET.Test.Sdk version Arcade defaults to. That's incompatible w/ test
-      framework in current .NET SDKs.
-    -->
-    <MicrosoftNETTestSdkVersion>17.1.0-preview-20211109-03</MicrosoftNETTestSdkVersion>
-    <!--
       Versions of Microsoft.CodeAnalysis packages referenced by analyzers shipped in the SDK.
       This need to be pinned since they're used in 3.1 apps and need to be loadable in VS 2019.
     -->

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "7.0.100-alpha.1.21568.2"
+    "version": "7.0.100-alpha.1.21606.3"
   },
   "tools": {
-    "dotnet": "7.0.100-alpha.1.21568.2",
+    "dotnet": "7.0.100-alpha.1.21606.3",
     "runtimes": {
       "dotnet/x64": [
         "2.1.30",

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "7.0.100-alpha.1.21574.8"
+    "version": "7.0.100-alpha.1.21568.2"
   },
   "tools": {
-    "dotnet": "7.0.100-alpha.1.21574.8",
+    "dotnet": "7.0.100-alpha.1.21568.2",
     "runtimes": {
       "dotnet/x64": [
         "2.1.30",

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "7.0.100-alpha.1.21558.2"
+    "version": "7.0.100-alpha.1.21574.8"
   },
   "tools": {
-    "dotnet": "7.0.100-alpha.1.21558.2",
+    "dotnet": "7.0.100-alpha.1.21574.8",
     "runtimes": {
       "dotnet/x64": [
         "2.1.30",


### PR DESCRIPTION
- remove Microsoft.NET.Test.Sdk version override
- new vstest.console.dll in the .NET SDK is again compatible w/ older testhost.dll in the Test SDK