### PR TITLE
Improve building ASP.NET Core directly on arm64 machines

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -172,6 +172,10 @@
       freebsd-x64
     </SupportedRuntimeIdentifiers>
 
+    <!-- Playwright provides binaries for Windows (x86 and x64), macOS (x64) and Linux (x64, non musl). We can't use it on other architectures. -->
+    <IsPlaywrightAvailable Condition="'$(TargetOsName)' == 'linux-musl' OR ('$(TargetArchitecture)' != 'x86' AND '$(TargetArchitecture)' != 'x64')">false</IsPlaywrightAvailable>
+    <IsPlaywrightAvailable Condition="'$(IsPlaywrightAvailable)' == ''">true</IsPlaywrightAvailable>
+
     <!-- Make error messages clickable in VS Code's console -->
     <GenerateFullPaths Condition="'$(VSCODE_CWD)' != '' OR '$(TERM_PROGRAM)' == 'vscode'">true</GenerateFullPaths>
 

--- a/global.json
+++ b/global.json
@@ -5,12 +5,11 @@
   "tools": {
     "dotnet": "7.0.100-alpha.1.21558.2",
     "runtimes": {
-      "dotnet/x64": [
-        "2.1.30",
+      "dotnet": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ],
-      "dotnet/x86": [
-        "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
+      "dotnet/x64": [
+        "2.1.30"
       ],
       "aspnetcore/x64": [
         "3.1.21"

--- a/global.json
+++ b/global.json
@@ -6,12 +6,13 @@
     "dotnet": "7.0.100-alpha.1.21558.2",
     "runtimes": {
       "dotnet": [
+        "2.1.30",
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ],
-      "dotnet/x64": [
-        "2.1.30"
+      "dotnet/x86": [
+        "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ],
-      "aspnetcore/x64": [
+      "aspnetcore": [
         "3.1.21"
       ]
     },

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
@@ -212,7 +212,7 @@ public class WebHostFunctionalTests : LoggedTest
         bool setTestEnvVars = false,
         string environment = "Development")
     {
-        var deploymentParameters = new DeploymentParameters(Path.Combine(GetTestSitesPath(), applicationName), ServerType.Kestrel, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64)
+        var deploymentParameters = new DeploymentParameters(Path.Combine(GetTestSitesPath(), applicationName), ServerType.Kestrel, RuntimeFlavor.CoreClr, RuntimeArchitectures.Current)
         {
             TargetFramework = "net7.0",
         };

--- a/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentParameters.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentParameters.cs
@@ -105,7 +105,7 @@ public class DeploymentParameters
 
     public RuntimeFlavor RuntimeFlavor { get; set; }
 
-    public RuntimeArchitecture RuntimeArchitecture { get; set; } = RuntimeArchitecture.x64;
+    public RuntimeArchitecture RuntimeArchitecture { get; set; } = RuntimeArchitectures.Current;
 
     /// <summary>
     /// Suggested base url for the deployed application. The final deployed url could be

--- a/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitecture.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitecture.cs
@@ -5,6 +5,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting;
 
 public enum RuntimeArchitecture
 {
+    arm64,
     x64,
     x86
 }

--- a/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitectures.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitectures.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Server.IntegrationTesting;
+
+public class RuntimeArchitectures
+{
+    public static RuntimeArchitecture Current
+    {
+        get
+        {
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.Arm64 => RuntimeArchitecture.arm64,
+                Architecture.X64 => RuntimeArchitecture.x64,
+                Architecture.X86 => RuntimeArchitecture.x86,
+                _ => throw new NotImplementedException($"Unknown RuntimeInformation.OSArchitecture: {RuntimeInformation.OSArchitecture.ToString()}"),
+            };
+        }
+    }
+}

--- a/src/Hosting/Server.IntegrationTesting/src/TestMatrix.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/TestMatrix.cs
@@ -53,10 +53,17 @@ public class TestMatrix : IEnumerable<object[]>
         return this;
     }
 
+    /// <summary>
+    /// With all architectures that are compatible with the currently running architecture
+    /// </summary>
+    /// <returns></returns>
     public TestMatrix WithAllArchitectures()
     {
-        Architectures.Add(RuntimeArchitecture.x64);
-        Architectures.Add(RuntimeArchitecture.x86);
+        Architectures.Add(RuntimeArchitectures.Current);
+        if (RuntimeInformation.OSArchitecture == Architecture.X64)
+        {
+            Architectures.Add(RuntimeArchitecture.x86);
+        }
         return this;
     }
 
@@ -122,19 +129,7 @@ public class TestMatrix : IEnumerable<object[]>
     {
         if (!Architectures.Any())
         {
-            switch (RuntimeInformation.OSArchitecture)
-            {
-                case Architecture.Arm:
-                case Architecture.X86:
-                    Architectures.Add(RuntimeArchitecture.x86);
-                    break;
-                case Architecture.Arm64:
-                case Architecture.X64:
-                    Architectures.Add(RuntimeArchitecture.x64);
-                    break;
-                default:
-                    throw new ArgumentException(RuntimeInformation.OSArchitecture.ToString());
-            }
+            Architectures.Add(RuntimeArchitectures.Current);
         }
     }
 

--- a/src/Hosting/test/FunctionalTests/LinkedApplicationTests.cs
+++ b/src/Hosting/test/FunctionalTests/LinkedApplicationTests.cs
@@ -33,10 +33,9 @@ public class LinkedApplicationTests : LoggedTest
                 applicationPath,
                 ServerType.Kestrel,
                 RuntimeFlavor.CoreClr,
-                RuntimeArchitecture.x64)
+                RuntimeArchitectures.Current)
             {
                 TargetFramework = Tfm.Default,
-                RuntimeArchitecture = RuntimeArchitecture.x64,
                 ApplicationType = ApplicationType.Standalone,
                 PublishApplicationBeforeDeployment = true,
                 RestoreDependencies = true,

--- a/src/Hosting/test/FunctionalTests/ShutdownTests.cs
+++ b/src/Hosting/test/FunctionalTests/ShutdownTests.cs
@@ -58,7 +58,7 @@ public class ShutdownTests : LoggedTest
                 applicationPath,
                 ServerType.Kestrel,
                 RuntimeFlavor.CoreClr,
-                RuntimeArchitecture.x64)
+                RuntimeArchitectures.Current)
             {
                 EnvironmentName = "Shutdown",
                 TargetFramework = Tfm.Default,

--- a/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnTester.cs
+++ b/src/Middleware/WebSockets/test/ConformanceTests/Autobahn/AutobahnTester.cs
@@ -138,7 +138,7 @@ public class AutobahnTester : IDisposable
 
         var appPath = Helpers.GetApplicationPath("AutobahnTestApp");
         var configPath = Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "Http.config");
-        var parameters = new DeploymentParameters(appPath, server, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64)
+        var parameters = new DeploymentParameters(appPath, server, RuntimeFlavor.CoreClr, RuntimeArchitectures.Current)
         {
             Scheme = (ssl ? Uri.UriSchemeHttps : Uri.UriSchemeHttp),
             ApplicationType = ApplicationType.Portable,

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
@@ -44,8 +44,8 @@
     <Reference Include="Microsoft.Extensions.Configuration.Json" />
     <Reference Include="AngleSharp" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="PlaywrightSharp" Condition="'$(TargetOsName)' != 'linux-musl'" />
-    <Reference Include="PlaywrightSharp" ExcludeAssets="build" Condition="'$(TargetOsName)' == 'linux-musl'" />
+    <Reference Include="PlaywrightSharp" Condition="'$(IsPlaywrightAvailable)' == 'true'" />
+    <Reference Include="PlaywrightSharp" ExcludeAssets="build" Condition="'$(IsPlaywrightAvailable)' != 'true'" />
     <ProjectReference Include="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
       Private="false"
       ReferenceOutputAssembly="false"

--- a/src/Servers/HttpSys/test/NonHelixTests/DelegateOutOfProcTests.cs
+++ b/src/Servers/HttpSys/test/NonHelixTests/DelegateOutOfProcTests.cs
@@ -30,7 +30,7 @@ public class DelegateOutOfProcTests : LoggedTest
             applicationPath,
             ServerType.HttpSys,
             RuntimeFlavor.CoreClr,
-            RuntimeArchitecture.x64)
+            RuntimeArchitectures.Current)
         {
             EnvironmentName = "Testing",
             TargetFramework = Tfm.Default,

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecCommands.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecCommands.cs
@@ -50,7 +50,7 @@ public static class H2SpecCommands
         {
             return Path.Combine(root, "windows", "h2spec.exe");
         }
-        else if (OperatingSystem.IsLinux())
+        else if (OperatingSystem.IsLinux() && (RuntimeInformation.OSArchitecture == Architecture.X64))
         {
             var toolPath = Path.Combine(root, "linux", "h2spec");
             chmod755(toolPath);

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -20,6 +21,8 @@ namespace Interop.FunctionalTests;
 
 public class H2SpecTests : LoggedTest
 {
+
+    [SkipOnArchitecture(Architecture.Arm64, Architecture.X86)] // The h2spec executable is an x64-binary
     [ConditionalTheory]
     [MemberData(nameof(H2SpecTestCases))]
     public async Task RunIndividualTestCase(H2SpecTestCase testCase)

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -6,7 +6,6 @@
     <TestGroupName>Interop.FunctionalTests</TestGroupName>
     <!-- WebDriver is not strong named, so this test assembly cannot be strong-named either. -->
     <SignAssembly>false</SignAssembly>
-    <SkipHelixArm>true</SkipHelixArm>
     <SkipHelixAlpine>true</SkipHelixAlpine>
   </PropertyGroup>
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/SkipOnArchitectureAttribute.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/SkipOnArchitectureAttribute.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Testing;
+
+namespace Interop.FunctionalTests;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+public class SkipOnArchitectureAttribute : Attribute, ITestCondition
+{
+    private readonly Architecture[] _excludedArchitectures;
+
+    public SkipOnArchitectureAttribute(params Architecture[] excludedArchitectures)
+    {
+        _excludedArchitectures = excludedArchitectures;
+    }
+
+    public bool IsMet => (Array.IndexOf(_excludedArchitectures, RuntimeInformation.OSArchitecture) == -1);
+
+    public string SkipReason => $"This test is running on {RuntimeInformation.OSArchitecture} which is marked as to be skipped.";
+}

--- a/src/Servers/test/FunctionalTests/HelloWorldTest.cs
+++ b/src/Servers/test/FunctionalTests/HelloWorldTest.cs
@@ -60,14 +60,9 @@ public class HelloWorldTests : LoggedTest
                 var responseText = await response.Content.ReadAsStringAsync();
                 try
                 {
-                    if (variant.Architecture == RuntimeArchitecture.x64)
-                    {
-                        Assert.Equal("Hello World X64", responseText);
-                    }
-                    else
-                    {
-                        Assert.Equal("Hello World X86", responseText);
-                    }
+                    string expectedName = Enum.GetName(typeof(RuntimeArchitecture), variant.Architecture);
+                    expectedName = char.ToUpperInvariant(expectedName[0]) + expectedName.Substring(1);
+                    Assert.Equal($"Hello World {expectedName}", responseText);
                 }
                 catch (XunitException)
                 {

--- a/src/Shared/BrowserTesting/src/Microsoft.AspNetCore.BrowserTesting.csproj
+++ b/src/Shared/BrowserTesting/src/Microsoft.AspNetCore.BrowserTesting.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="PlaywrightSharp" Condition="'$(TargetOsName)' != 'linux-musl'" />
-    <Reference Include="PlaywrightSharp" ExcludeAssets="build" Condition="'$(TargetOsName)' == 'linux-musl'" />
+    <Reference Include="PlaywrightSharp" Condition="'$(IsPlaywrightAvailable)' == 'true'" />
+    <Reference Include="PlaywrightSharp" ExcludeAssets="build" Condition="'$(IsPlaywrightAvailable)' != 'true'" />
     <Reference Include="Microsoft.AspNetCore.Testing" />
   </ItemGroup>
 


### PR DESCRIPTION
[This is still a work in progress]

This PR tries to get ASP.NET Core repo to build more easily and tests to pass on Arm64. I am only testing on Linux, though. Please note that unlike the CI environments which build and test Arm64 while running on (and cross-compiling on) x64, my goal here is to get this to work on Arm64 machines themselves.

My goal is to get `eng/build.sh --arch arm64 --test` to fully pass on arm64. Failing that, I would like to get to the same set of test failures that I see on x64.