### PR TITLE
HTTP/3: Remove AsTask allocations

### DIFF
--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -79,16 +79,14 @@ internal sealed partial class WebHost : IWebHost, IAsyncDisposable
         _hostingServiceProvider = hostingServiceProvider;
         _applicationServiceCollection.AddSingleton<ApplicationLifetime>();
         // There's no way to to register multiple service types per definition. See https://github.com/aspnet/DependencyInjection/issues/360
-#pragma warning disable CS8634 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'class' constraint.
-        _applicationServiceCollection.AddSingleton(services
-            => services.GetService<ApplicationLifetime>() as IHostApplicationLifetime);
+        _applicationServiceCollection.AddSingleton<IHostApplicationLifetime>(services
+            => services.GetService<ApplicationLifetime>()!);
 #pragma warning disable CS0618 // Type or member is obsolete
-        _applicationServiceCollection.AddSingleton(services
-            => services.GetService<ApplicationLifetime>() as AspNetCore.Hosting.IApplicationLifetime);
-        _applicationServiceCollection.AddSingleton(services
-            => services.GetService<ApplicationLifetime>() as Extensions.Hosting.IApplicationLifetime);
+        _applicationServiceCollection.AddSingleton<AspNetCore.Hosting.IApplicationLifetime>(services
+            => services.GetService<ApplicationLifetime>()!);
+        _applicationServiceCollection.AddSingleton<Extensions.Hosting.IApplicationLifetime>(services
+            => services.GetService<ApplicationLifetime>()!);
 #pragma warning restore CS0618 // Type or member is obsolete
-#pragma warning restore CS8634 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'class' constraint.
         _applicationServiceCollection.AddSingleton<HostedServiceExecutor>();
     }
 

--- a/src/Http/Http.Abstractions/src/Extensions/HttpResponseWritingExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/HttpResponseWritingExtensions.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.Internal;
 
 namespace Microsoft.AspNetCore.Http;
 
@@ -78,15 +76,7 @@ public static class HttpResponseWritingExtensions
 
         Write(response, text, encoding);
 
-        var flushAsyncTask = response.BodyWriter.FlushAsync(cancellationToken);
-        if (flushAsyncTask.IsCompletedSuccessfully)
-        {
-            // Most implementations of ValueTask reset state in GetResult, so call it before returning a completed task.
-            flushAsyncTask.GetAwaiter().GetResult();
-            return Task.CompletedTask;
-        }
-
-        return flushAsyncTask.AsTask();
+        return response.BodyWriter.FlushAsync(cancellationToken).GetAsTask();
     }
 
     private static async Task StartAndWriteAsyncAwaited(this HttpResponse response, string text, Encoding encoding, CancellationToken cancellationToken, Task startAsyncTask)

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -25,6 +25,7 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
     <Compile Include="$(SharedSourceRoot)ParameterDefaultValue\*.cs" />
     <Compile Include="$(SharedSourceRoot)PropertyHelper\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)\UrlDecoder\UrlDecoder.cs" Link="UrlDecoder.cs" />
+    <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3FrameWriter.cs
@@ -1,19 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.Http;
 using System.Net.Http.QPack;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.PipeWriterHelpers;
@@ -129,7 +125,7 @@ internal class Http3FrameWriter
         _outgoingFrame.Length = totalLength;
         _outputWriter.Advance(totalLength);
 
-        return _outputWriter.FlushAsync().AsTask();
+        return _outputWriter.FlushAsync().GetAsTask();
     }
 
     internal static int CalculateSettingsSize(List<Http3PeerSetting> settings)
@@ -159,7 +155,7 @@ internal class Http3FrameWriter
     {
         var buffer = _outputWriter.GetSpan(8);
         _outputWriter.Advance(VariableLengthIntegerHelper.WriteInteger(buffer, id));
-        return _outputWriter.FlushAsync().AsTask();
+        return _outputWriter.FlushAsync().GetAsTask();
     }
 
     public ValueTask<FlushResult> WriteDataAsync(in ReadOnlySequence<byte> data)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
@@ -718,8 +719,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpH
             RequestBodyPipe.Writer.Write(segment.Span);
         }
 
-        // TODO this can be better.
-        return RequestBodyPipe.Writer.FlushAsync().AsTask();
+        return RequestBodyPipe.Writer.FlushAsync().GetAsTask();
     }
 
     protected override void OnReset()


### PR DESCRIPTION
`AsTask` always allocates. Use existing `GetAsTask` to avoid allocation if task is already complete.