### PR TITLE
HTTP/3: Remove TCS allocation with resettable value source

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -402,7 +402,6 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpH
 
         // Stream will be pooled after app completed.
         // Wait to signal app completed after any potential aborts on the stream.
-        Debug.Assert(_appCompletedTaskSource != null);
         _appCompletedTaskSource.SetResult(null);
     }
 


### PR DESCRIPTION
Replace TCS allocation per stream with `ManualResetValueTaskSource`. It is allocated once and then reused.