### PR TITLE
Remove Arm64-specific jobs in matrix pipelines

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -720,7 +720,8 @@ stages:
         - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Restore interop projects
-        - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
+        - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative
+                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true
                   /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Run build.cmd helix target

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -721,7 +721,7 @@ stages:
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Restore interop projects
         - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
-                  /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
+                  /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Run build.cmd helix target
           env:

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -40,7 +40,7 @@ jobs:
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Restore interop projects
     - script: .\eng\build.cmd -ci -nobl -noBuildRepoTasks -NoRestore -test -all -noBuildNative -projects eng\helix\helix.proj
-              /p:IsHelixDaily=true /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true
+              /p:IsHelixDaily=true /p:IsHelixJob=true /p:BuildInteropProjects=true
               /p:RunTemplateTests=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
@@ -50,29 +50,3 @@ jobs:
     - name: Helix_logs
       path: artifacts/log/
       publishOnError: true
-
-# Helix ARM64
-- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Helix_matrix_arm64
-      jobDisplayName: "Tests: Helix ARM64 matrix"
-      agentOs: Linux
-      timeoutInMinutes: 480
-      useHostedUbuntu: false
-      steps:
-      - script: ./eng/build.sh --ci --nobl --pack --arch arm64
-                /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-        displayName: Build shared Fx
-      - script: ./eng/build.sh --ci --nobl --arch arm64 --noBuildRepoTasks --no-build-nodejs --no-restore --test --all
-                --projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
-                /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-        displayName: Run build.sh helix arm64 target
-        env:
-          HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-      artifacts:
-      - name: Helix_arm64_logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -39,9 +39,10 @@ jobs:
     - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Restore interop projects
-    - script: .\eng\build.cmd -ci -nobl -noBuildRepoTasks -NoRestore -test -all -noBuildNative -projects eng\helix\helix.proj
-              /p:IsHelixDaily=true /p:IsHelixJob=true /p:BuildInteropProjects=true
-              /p:RunTemplateTests=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
+    - script: .\eng\build.cmd -ci -nobl -noBuildRepoTasks -NoRestore -test -all -noBuildNative
+              -projects eng\helix\helix.proj
+              /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
+              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -64,7 +64,7 @@ jobs:
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Restore interop projects
     - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
-              -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsRequiredCheck=true /p:IsHelixJob=true
+              -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:BuildInteropProjects=true /p:RunTemplateTests=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -64,8 +64,8 @@ jobs:
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Restore interop projects
     - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
-              -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
-              /p:BuildInteropProjects=true /p:RunTemplateTests=true
+              -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:RunQuarantinedTests=true
+              /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       continueOnError: true

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -35,7 +35,7 @@ jobs:
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Restore interop projects
     - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
-              -projects eng\helix\helix.proj /p:IsHelixDaily=true /p:RunQuarantinedTests=true
+              -projects eng\helix\helix.proj /p:RunQuarantinedTests=true
               /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -35,7 +35,7 @@ jobs:
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Restore interop projects
     - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
-              -projects eng\helix\helix.proj /p:IsHelixDaily=true /p:RunQuarantinedTests=true /p:IsRequiredCheck=true
+              -projects eng\helix\helix.proj /p:IsHelixDaily=true /p:RunQuarantinedTests=true
               /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
@@ -47,29 +47,3 @@ jobs:
     - name: Helix_logs
       path: artifacts/log/
       publishOnError: true
-
-# Helix ARM64
-- template: jobs/default-build.yml
-  parameters:
-    jobName: Helix_quarantined_arm64
-    jobDisplayName: "Tests: Helix ARM64"
-    agentOs: Linux
-    timeoutInMinutes: 480
-    steps:
-    - script: ./eng/build.sh --ci --nobl --pack --arch arm64
-              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-      displayName: Build shared Fx
-    - script: ./eng/build.sh --ci --nobl  --arch arm64 --noBuildRepoTasks --no-build-nodejs --no-restore --test --all
-              --projects $(Build.SourcesDirectory)/eng/helix/helix.proj /p:IsHelixJob=true /p:IsHelixDaily=true
-              /p:RunQuarantinedTests=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-      displayName: Run build.sh helix arm64 target
-      continueOnError: true
-      env:
-        HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-    installNodeJs: false
-    artifacts:
-    - name: Helix_arm64_logs
-      path: artifacts/log/
-      publishOnError: true
-      includeForks: true

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -48,7 +48,7 @@
     <HelixType>ci</HelixType>
     <!-- Creator is not valid for internal queues -->
     <Creator Condition="'$(_UseHelixOpenQueues)' == 'true'">aspnetcore</Creator>
-    <HelixBuild>$(BUILD_BUILDNUMBER).$(TargetArchitecture).$(SYSTEM_JOBATTEMPT)</HelixBuild>
+    <HelixBuild>$(BUILD_BUILDNUMBER).$(SYSTEM_JOBATTEMPT)</HelixBuild>
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
     <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
     <EnableXUnitReporter>true</EnableXUnitReporter>
@@ -78,7 +78,7 @@
   <ItemGroup Condition="Exists('$(HelixTestConfigurationFilePath)')">
     <HelixCorrelationPayload Include="$(HelixTestConfigurationFilePath)" AsArchive="false" />
   </ItemGroup>
-  
+
   <Target Name="IncludeAspNetRuntime" BeforeTargets="Gather"
     Condition="'$(DoNotRequireSharedFxHelix)' != 'true' OR
     EXISTS('$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Runtime.$(TargetRuntimeIdentifier).$(SharedFxVersion).nupkg')">

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -56,6 +56,6 @@ Write-Host -ForegroundColor Yellow "And if packing for a different platform, add
 
 $HelixQueues = $HelixQueues -replace ";", "%3B"
 dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" `
-    /p:IsHelixDaily=true /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests `
+    /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests `
     /p:_UseHelixOpenQueues=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log `
     /p:DoNotRequireSharedFxHelix=true @MSBuildArguments

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -55,7 +55,7 @@ Write-Host -ForegroundColor Yellow "If running tests that need the shared Fx, ru
 Write-Host -ForegroundColor Yellow "And if packing for a different platform, add '/p:CrossgenOutput=false'."
 
 $HelixQueues = $HelixQueues -replace ";", "%3B"
-dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" /p:IsRequiredCheck=true `
+dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" `
     /p:IsHelixDaily=true /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests `
     /p:_UseHelixOpenQueues=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log `
     /p:DoNotRequireSharedFxHelix=true @MSBuildArguments

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -24,7 +24,7 @@
     at the moment. And, most Windows-specific checks are handled using @(HelixAvailablePlatform) in Helix.props.
   -->
   <Choose>
-    <When Condition=" '$(IsHelixDaily)' != 'true' ">
+    <When Condition=" '$(IsHelixPRCheck)' == 'true' ">
       <!-- aspnetcore-ci[-official] (ci.yml) -->
       <!-- aspnetcore-quarantined-pr (quarantined-pr.yml) -->
       <ItemGroup>

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -1,5 +1,5 @@
 <Project>
-  <!-- this file is shared between Helix.proj and .csproj files -->
+  <!-- This file is shared between Helix.proj and .csproj files. -->
   <PropertyGroup>
     <HelixQueueAlpine314>(Alpine.314.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-helix-amd64-20210910135833-1848e19</HelixQueueAlpine314>
     <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20211001171307-0ece9b3</HelixQueueDebian11>
@@ -8,57 +8,57 @@
     <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20211001171229-97d8652</HelixQueueArmDebian11>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true'">
+  <!-- Don't use <Choose/> for $(IsWindowsOnlyTest) checks. <When/> Condition is evaluated before project load. -->
+  <ItemGroup Condition=" '$(IsWindowsOnlyTest)' != 'true' ">
     <HelixAvailablePlatform Include="Windows" />
     <HelixAvailablePlatform Include="OSX" />
     <HelixAvailablePlatform Include="Linux" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(IsWindowsOnlyTest)' == 'true'">
+  <ItemGroup Condition=" '$(IsWindowsOnlyTest)' == 'true' ">
     <HelixAvailablePlatform Include="Windows" />
   </ItemGroup>
 
-  <!-- x64 PR(ci.yaml) required queues for internal and public cases -->
-  <ItemGroup Condition="'$(IsRequiredCheck)' == 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' != 'true'">
-    <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="Windows.11.Amd64.ClientPre.Open" Platform="Windows" />
-    <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
-  </ItemGroup>
+  <!--
+    Usually do not need to check $(_UseHelixOpenQueues), $(RunQuarantinedTests) or $(IsWindowsOnlyTest).
+    $(_UseHelixOpenQueues) handling in helix.proj and Helix.targets is sufficient. We have no quarantined queues
+    at the moment. And, most Windows-specific checks are handled using @(HelixAvailablePlatform) in Helix.props.
+  -->
+  <Choose>
+    <When Condition=" '$(IsHelixDaily)' != 'true' ">
+      <!-- aspnetcore-ci[-official] (ci.yml) -->
+      <!-- aspnetcore-quarantined-pr (quarantined-pr.yml) -->
+      <ItemGroup>
+        <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
+        <HelixAvailableTargetQueue Include="Windows.11.Amd64.ClientPre.Open" Platform="Windows" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <!-- aspnetcore-helix-matrix[-internal] (helix-matrix.yml) and RunHelix.ps1 -->
+      <!-- aspnetcore-quarantined-tests (quarantined-tests.yml) and RunHelix.ps1 -RunQuarantinedTests -->
+      <ItemGroup>
+        <!-- Linux -->
+        <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
 
-  <!-- x64 Queues for public helix-matrix.yml and quarantine pipelines, except in windows-only cases -->
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
-    <!-- Linux -->
-    <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
+        <!-- Containers -->
+        <HelixAvailableTargetQueue Include="$(HelixQueueAlpine314)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueDebian11)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueFedora34)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueMariner)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian11)" Platform="Linux" />
 
-    <!-- Mac -->
-    <HelixAvailableTargetQueue Include="OSX.1015.Amd64.Open" Platform="OSX" />
+        <!-- Mac -->
+        <HelixAvailableTargetQueue Include="OSX.1015.Amd64.Open" Platform="OSX" />
 
-    <!-- Containers -->
-    <HelixAvailableTargetQueue Include="$(HelixQueueAlpine314)" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="$(HelixQueueDebian11)" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="$(HelixQueueFedora34)" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="$(HelixQueueMariner)" Platform="Linux" />
-  </ItemGroup>
+        <!-- Windows -->
+        <HelixAvailableTargetQueue Include="Windows.10.Amd64.Server20H2.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
 
-  <!-- x64 Queues for public helix-matrix.yml and quarantine pipelines, Windows cases-->
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true'">
-    <HelixAvailableTargetQueue Include="Windows.10.Amd64.Server20H2.Open" Platform="Windows" />
-    <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
-  </ItemGroup>
-
-  <!-- x64 Queues for internal helix-matrix.yml and quarantine pipelines -->
-  <!-- The preview queue is only available internally, and should only be run on a daily basis -->
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' != 'true'">
-  </ItemGroup>
-
-  <!-- arm64 queues for helix-matrix.yml and quarantine pipeline -->
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
-    <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian11)" Platform="Linux" />
-  </ItemGroup>
-
-  <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on it's setup scripts. -->
-  <ItemGroup Condition="'$(TargetArchitecture)' == 'arm64' AND '$(IsHelixDaily)' == 'true' AND '$(_UseHelixOpenQueues)' == 'true' AND '$(IsWindowsOnlyTest)' != 'true'">
-    <HelixAvailableTargetQueue Include="Windows.10.Arm64v8.Open" Platform="Windows" />
-  </ItemGroup>
+        <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on its setup scripts. -->
+        <HelixAvailableTargetQueue Include="Windows.10.Arm64v8.Open" Platform="Windows"
+            Condition=" '$(IsWindowsOnlyTest)' != 'true' "/>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -1,5 +1,4 @@
 <Project>
-
   <Import Project="Helix.Common.props" />
 
   <ItemDefinitionGroup>
@@ -10,20 +9,28 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
-    <CreateHelixPayload>true</CreateHelixPayload>
     <HelixTimeout>00:30:00</HelixTimeout>
     <HelixTimeout Condition="$(HelixTargetQueue.StartsWith('Windows.10.Amd64'))">00:40:00</HelixTimeout>
     <RunQuarantinedTests>false</RunQuarantinedTests>
+
+    <IsArm64HelixQueue>false</IsArm64HelixQueue>
     <IsWindowsHelixQueue>false</IsWindowsHelixQueue>
-    <IsWindowsHelixQueue Condition="$(HelixTargetQueue.Contains('Windows')) or $(HelixTargetQueue.Contains('windows'))">true</IsWindowsHelixQueue>
     <IsMacHelixQueue>false</IsMacHelixQueue>
-    <IsMacHelixQueue Condition="$(HelixTargetQueue.Contains('OSX')) or $(HelixTargetQueue.Contains('macOs'))">true</IsMacHelixQueue>
+
     <HelixTestName>$(MSBuildProjectName)--$(TargetFramework)</HelixTestName>
     <LoggingTestingDisableFileLogging Condition="'$(IsHelixJob)' == 'true'">false</LoggingTestingDisableFileLogging>
     <NodeVersion>16.11.0</NodeVersion>
     <!-- Have all tests depend on the latest runtimes until we get a net7.0 SDK -->
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
+  </PropertyGroup>
+
+  <!-- Override a few properties in innermost (Publish) build for Helix submission. -->
+  <PropertyGroup Condition=" '$(HelixTargetQueue)' != '' ">
+    <HelixTimeout Condition="$(HelixTargetQueue.StartsWith('Windows.10.Amd64'))">00:40:00</HelixTimeout>
+    <IsArm64HelixQueue Condition="$(HelixTargetQueue.Contains('Arm64'))">true</IsArm64HelixQueue>
+    <IsWindowsHelixQueue Condition="$(HelixTargetQueue.Contains('Windows'))">true</IsWindowsHelixQueue>
+    <IsMacHelixQueue Condition="$(HelixTargetQueue.Contains('OSX'))">true</IsMacHelixQueue>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
@@ -37,5 +44,4 @@
   <ItemGroup>
     <HelixContent Include="$(RepoRoot)eng\helix\content\**\*" Exclude="$(RepoRoot)eng\helix\content\*.in" />
   </ItemGroup>
-
 </Project>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -4,9 +4,14 @@
     <HelixPreCommand Condition="'$(IsWindowsHelixQueue)' != 'true' AND '$(IsMacHelixQueue)' != 'true'" Include="./installjdk.sh 10.0.2 x64 &amp;&amp; if [ &quot;%24JAVA_HOME&quot; = &quot;&quot; ]%3B then export JAVA_HOME=%24PWD/java%3B fi" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TestDependsOnMssql)' == 'true' AND '$(IsWindowsHelixQueue)' == 'true' AND '$(TargetArchitecture)' != 'arm64'">
+  <ItemGroup Condition="'$(TestDependsOnMssql)' == 'true' AND '$(IsWindowsHelixQueue)' == 'true' AND '$(IsArm64HelixQueue)' != 'true'">
     <HelixPreCommand Include="call RunPowershell.cmd mssql\InstallSqlServerLocalDB.ps1 || exit /b 1" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <_TestingArchitecture>x64</_TestingArchitecture>
+    <_TestingArchitecture Condition=" '$(IsArm64HelixQueue)' == 'true' ">arm64</_TestingArchitecture>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestDependsOnPlaywright)' == 'true'">
     <SkipHelixQueues>
@@ -35,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestDependsOnNode)' == 'true' AND '$(IsWindowsHelixQueue)' == 'false'">
-    <HelixPreCommand Include="./installnode.sh $(NodeVersion) $(TargetArchitecture)" />
+    <HelixPreCommand Include="./installnode.sh $(NodeVersion) $(_TestingArchitecture)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestDependsOnNode)' == 'true' AND '$(IsWindowsHelixQueue)' == 'true'">
@@ -123,7 +128,7 @@
 
     <PropertyGroup>
       <BuildHelixPayload Condition="'@(_HelixApplicableTargetQueue->Count())' == '0'">false</BuildHelixPayload>
-      <BuildHelixPayload Condition="'$(TargetArchitecture)' == 'arm64' AND '$(SkipHelixArm)' == 'true'">false</BuildHelixPayload>
+      <BuildHelixPayload Condition="'$(IsArm64HelixQueue)' == 'true' AND '$(SkipHelixArm)' == 'true'">false</BuildHelixPayload>
       <BuildHelixPayload Condition="$(HelixTargetQueue.StartsWith('%28Alpine.')) AND '$(SkipHelixAlpine)' == 'true'">false</BuildHelixPayload>
       <BuildHelixPayload Condition="$(SkipHelixQueues.Contains('$(HelixTargetQueue)'))">false</BuildHelixPayload>
     </PropertyGroup>
@@ -188,8 +193,8 @@
           When the targeting pack builds, it has exactly the same version as the shared framework. Passing
           SharedFxVersion because that's needed even when the targeting pack isn't building.
         -->
-        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfVersion) $(HelixTimeout) $(TestDependsOnPlaywright)</Command>
-        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(TargetArchitecture) $(RunQuarantinedTests) $(DotnetEfVersion) $(HelixTimeout) $(TestDependsOnPlaywright)</Command>
+        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(_TestingArchitecture) $(RunQuarantinedTests) $(DotnetEfVersion) $(HelixTimeout) $(TestDependsOnPlaywright)</Command>
+        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(_TestingArchitecture) $(RunQuarantinedTests) $(DotnetEfVersion) $(HelixTimeout) $(TestDependsOnPlaywright)</Command>
         <Command Condition="$(HelixCommand) != ''">$(HelixCommand)</Command>
         <Timeout>$(HelixTimeout)</Timeout>
       </HelixWorkItem>


### PR DESCRIPTION
- stop using `$(TargetArchitecture)` in Helix.Common.props and Helix.targets
  - add `$(IsArm64HelixQueue)`
- make Helix queue choices more readable
  - use `<Choose/>
  - remove excess `Condition` clauses

nit: remove unused `$(IsRequiredCheck)` and `$(CreateHelixPayload)` properties