### PR TITLE
Fix a tiny typo

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/VirtualFileResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/VirtualFileResultExecutor.cs
@@ -25,7 +25,7 @@ public class VirtualFileResultExecutor : FileResultExecutorBase, IActionResultEx
     /// Initializes a new instance of <see cref="VirtualFileResultExecutor"/>.
     /// </summary>
     /// <param name="loggerFactory">The factory used to create loggers.</param>
-    /// <param name="hostingEnvironment">The hosting enviornment</param>
+    /// <param name="hostingEnvironment">The hosting environment</param>
     public VirtualFileResultExecutor(ILoggerFactory loggerFactory, IWebHostEnvironment hostingEnvironment)
         : base(CreateLogger<VirtualFileResultExecutor>(loggerFactory))
     {


### PR DESCRIPTION
I assume this will cascade to the docs site properly:

https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.infrastructure.virtualfileresultexecutor.-ctor?view=aspnetcore-6.0#Microsoft_AspNetCore_Mvc_Infrastructure_VirtualFileResultExecutor__ctor_Microsoft_Extensions_Logging_ILoggerFactory_Microsoft_AspNetCore_Hosting_IWebHostEnvironment_
