### PR TITLE
Fix UniqueJsonKeyClaimAction key comparison 

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/src/UniqueJsonKeyClaimAction.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/UniqueJsonKeyClaimAction.cs
@@ -36,8 +36,8 @@ public class UniqueJsonKeyClaimAction : JsonKeyClaimAction
             return;
         }
 
-        var claim = identity.FindFirst(c => string.Equals(c.Type, JsonKey, System.StringComparison.OrdinalIgnoreCase));
-        if (claim != null && string.Equals(claim.Value, value, System.StringComparison.Ordinal))
+        var claim = identity.FindFirst(c => string.Equals(c.Type, ClaimType, StringComparison.OrdinalIgnoreCase));
+        if (claim != null && string.Equals(claim.Value, value, StringComparison.Ordinal))
         {
             // Duplicate
             return;
@@ -47,9 +47,9 @@ public class UniqueJsonKeyClaimAction : JsonKeyClaimAction
         {
                 // If this claimType is mapped by the JwtSeurityTokenHandler, then this property will be set
                 return c.Properties.TryGetValue(JwtSecurityTokenHandler.ShortClaimTypeProperty, out var shortType)
-                && string.Equals(shortType, JsonKey, System.StringComparison.OrdinalIgnoreCase);
+                && string.Equals(shortType, ClaimType, StringComparison.OrdinalIgnoreCase);
         });
-        if (claim != null && string.Equals(claim.Value, value, System.StringComparison.Ordinal))
+        if (claim != null && string.Equals(claim.Value, value, StringComparison.Ordinal))
         {
             // Duplicate with an alternate name.
             return;

--- a/src/Security/Authentication/test/OpenIdConnect/UniqueJsonKeyClaimActionTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/UniqueJsonKeyClaimActionTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect.Claims;
+
+namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect;
+
+public class UniqueJsonKeyClaimActionTests
+{
+    [Fact]
+    public void AddsIfNoDuplicateExists()
+    {
+        var userData = JsonDocument.Parse("{ \"jsonKey\": \"value\" }");
+
+        var identity = new ClaimsIdentity();
+
+        var action = new UniqueJsonKeyClaimAction("claimType", "valueType", "jsonKey");
+        action.Run(userData.RootElement, identity, "iss");
+
+        var claim = identity.FindFirst("claimType");
+        Assert.NotNull(claim);
+        Assert.Equal("claimType", claim.Type);
+        Assert.Equal("value", claim.Value);
+    }
+
+    [Fact]
+    public void DoesNotAddIfDuplicateExists()
+    {
+        var userData = JsonDocument.Parse("{ \"jsonKey\": \"value\" }");
+
+        var identity = new ClaimsIdentity();
+        identity.AddClaim(new Claim("claimType", "value", "valueType"));
+
+        var action = new UniqueJsonKeyClaimAction("claimType", "valueType", "jsonKey");
+        action.Run(userData.RootElement, identity, "iss");
+
+        var claims = identity.FindAll("claimType");
+        Assert.Single(claims);
+        Assert.Equal("claimType", claims.First().Type);
+        Assert.Equal("value", claims.First().Value);
+    }
+}


### PR DESCRIPTION
Fixes #38572

UniqueJsonKeyClaimAction is designed to avoid adding duplicate claims when working with multiple sources. The claim type and the json key are commonly the same. However, when they're different the wrong value is used for the duplicate check. The JsonKey should only be used for the initial lookup in the JsonElement.

Not a regression, this bug was in the initial version.
https://github.com/Tratcher/aspnetcore/commit/ad425163b29b1e09a41e84423b0dcbac797c9164#diff-11a91e8c3fba5844a24e0ed32a5e41d1c7d0933ac192a0891308f9cd779ef3efR39