### PR TITLE
Support Custom Classes for ValidationMessage

### DIFF
--- a/src/Components/Web/src/Forms/ValidationMessage.cs
+++ b/src/Components/Web/src/Forms/ValidationMessage.cs
@@ -73,8 +73,8 @@ public class ValidationMessage<TValue> : ComponentBase, IDisposable
         foreach (var message in CurrentEditContext.GetValidationMessages(_fieldIdentifier))
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(2, "class", "validation-message");
-            builder.AddMultipleAttributes(1, AdditionalAttributes);
+            builder.AddAttribute(1, "class", "validation-message");
+            builder.AddMultipleAttributes(2, AdditionalAttributes);
             builder.AddContent(3, message);
             builder.CloseElement();
         }

--- a/src/Components/Web/src/Forms/ValidationMessage.cs
+++ b/src/Components/Web/src/Forms/ValidationMessage.cs
@@ -73,8 +73,8 @@ public class ValidationMessage<TValue> : ComponentBase, IDisposable
         foreach (var message in CurrentEditContext.GetValidationMessages(_fieldIdentifier))
         {
             builder.OpenElement(0, "div");
-            builder.AddMultipleAttributes(1, AdditionalAttributes);
             builder.AddAttribute(2, "class", "validation-message");
+            builder.AddMultipleAttributes(1, AdditionalAttributes);
             builder.AddContent(3, message);
             builder.CloseElement();
         }

--- a/src/Components/Web/src/Forms/ValidationSummary.cs
+++ b/src/Components/Web/src/Forms/ValidationSummary.cs
@@ -75,8 +75,8 @@ public class ValidationSummary : ComponentBase, IDisposable
                 first = false;
 
                 builder.OpenElement(0, "ul");
-                builder.AddMultipleAttributes(1, AdditionalAttributes);
-                builder.AddAttribute(2, "class", "validation-errors");
+                builder.AddAttribute(1, "class", "validation-errors");
+                builder.AddMultipleAttributes(2, AdditionalAttributes);
             }
 
             builder.OpenElement(3, "li");


### PR DESCRIPTION
# Support Custom Classes for ValidationMessage

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Change the sequence of the attributes added to the ValidationMessage, so that the custom `class` attributes don't get overwritten by the default `class` attribute.


## Description

The ValidationMessage component does not allow to set custom `class` attributes. If a custom `class` attribute is set, it will get overridden by the default one.

This change permits custom `class` attributes to be set and take precedence over the default ones.

Fixes #38528 
