### PR TITLE
HTTP/3: Improve static table compression to include values

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -102,6 +102,179 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         WWWAuthenticate,
     }
 
+    internal static class HttpHeadersCompression
+    {
+        internal static (int index, bool matchedValue) MatchKnownHeaderQPack(KnownHeaderType knownHeader, string value)
+        {
+            switch (knownHeader)
+            {
+                case KnownHeaderType.Age:
+                    switch (value)
+                    {
+                        case "0":
+                            return (2, true);
+                        default:
+                            return (2, false);
+                    }
+                case KnownHeaderType.ContentLength:
+                    switch (value)
+                    {
+                        case "0":
+                            return (4, true);
+                        default:
+                            return (4, false);
+                    }
+                case KnownHeaderType.Date:
+                    return (6, false);
+                case KnownHeaderType.ETag:
+                    return (7, false);
+                case KnownHeaderType.LastModified:
+                    return (10, false);
+                case KnownHeaderType.Location:
+                    return (12, false);
+                case KnownHeaderType.SetCookie:
+                    return (14, false);
+                case KnownHeaderType.AcceptRanges:
+                    switch (value)
+                    {
+                        case "bytes":
+                            return (32, true);
+                        default:
+                            return (32, false);
+                    }
+                case KnownHeaderType.AccessControlAllowHeaders:
+                    switch (value)
+                    {
+                        case "cache-control":
+                            return (33, true);
+                        case "content-type":
+                            return (34, true);
+                        case "*":
+                            return (75, true);
+                        default:
+                            return (33, false);
+                    }
+                case KnownHeaderType.AccessControlAllowOrigin:
+                    switch (value)
+                    {
+                        case "*":
+                            return (35, true);
+                        default:
+                            return (35, false);
+                    }
+                case KnownHeaderType.CacheControl:
+                    switch (value)
+                    {
+                        case "max-age=0":
+                            return (36, true);
+                        case "max-age=2592000":
+                            return (37, true);
+                        case "max-age=604800":
+                            return (38, true);
+                        case "no-cache":
+                            return (39, true);
+                        case "no-store":
+                            return (40, true);
+                        case "public, max-age=31536000":
+                            return (41, true);
+                        default:
+                            return (36, false);
+                    }
+                case KnownHeaderType.ContentEncoding:
+                    switch (value)
+                    {
+                        case "br":
+                            return (42, true);
+                        case "gzip":
+                            return (43, true);
+                        default:
+                            return (42, false);
+                    }
+                case KnownHeaderType.ContentType:
+                    switch (value)
+                    {
+                        case "application/dns-message":
+                            return (44, true);
+                        case "application/javascript":
+                            return (45, true);
+                        case "application/json":
+                            return (46, true);
+                        case "application/x-www-form-urlencoded":
+                            return (47, true);
+                        case "image/gif":
+                            return (48, true);
+                        case "image/jpeg":
+                            return (49, true);
+                        case "image/png":
+                            return (50, true);
+                        case "text/css":
+                            return (51, true);
+                        case "text/html; charset=utf-8":
+                            return (52, true);
+                        case "text/plain":
+                            return (53, true);
+                        case "text/plain;charset=utf-8":
+                            return (54, true);
+                        default:
+                            return (44, false);
+                    }
+                case KnownHeaderType.Vary:
+                    switch (value)
+                    {
+                        case "accept-encoding":
+                            return (59, true);
+                        case "origin":
+                            return (60, true);
+                        default:
+                            return (59, false);
+                    }
+                case KnownHeaderType.AccessControlAllowCredentials:
+                    switch (value)
+                    {
+                        case "FALSE":
+                            return (73, true);
+                        case "TRUE":
+                            return (74, true);
+                        default:
+                            return (73, false);
+                    }
+                case KnownHeaderType.AccessControlAllowMethods:
+                    switch (value)
+                    {
+                        case "get":
+                            return (76, true);
+                        case "get, post, options":
+                            return (77, true);
+                        case "options":
+                            return (78, true);
+                        default:
+                            return (76, false);
+                    }
+                case KnownHeaderType.AccessControlExposeHeaders:
+                    switch (value)
+                    {
+                        case "content-length":
+                            return (79, true);
+                        default:
+                            return (79, false);
+                    }
+                case KnownHeaderType.AltSvc:
+                    switch (value)
+                    {
+                        case "clear":
+                            return (83, true);
+                        default:
+                            return (83, false);
+                    }
+                case KnownHeaderType.Server:
+                    return (92, false);
+                
+                default:
+                    return (-1, false);
+            }
+        }
+    }
+
     internal partial class HttpHeaders
     {
         private readonly static HashSet<string> _internedHeaderNames = new HashSet<string>(96, StringComparer.OrdinalIgnoreCase)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3HeadersEnumerator.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3HeadersEnumerator.cs
@@ -29,7 +29,7 @@ internal sealed class Http3HeadersEnumerator : IEnumerator<KeyValuePair<string, 
 
     public Func<string, Encoding?> EncodingSelector { get; set; } = KestrelServerOptions.DefaultHeaderEncodingSelector;
 
-    public int QPackStaticTableId => GetResponseHeaderStaticTableId(_knownHeaderType);
+    public (int index, bool matchedValue) GetQPackStaticTableId() => HttpHeadersCompression.MatchKnownHeaderQPack(_knownHeaderType, Current.Value);
     public KeyValuePair<string, string> Current { get; private set; }
     object IEnumerator.Current => Current;
 
@@ -144,67 +144,5 @@ internal sealed class Http3HeadersEnumerator : IEnumerator<KeyValuePair<string, 
 
     public void Dispose()
     {
-    }
-
-    internal static int GetResponseHeaderStaticTableId(KnownHeaderType responseHeaderType)
-    {
-        // Removed from this test are request-only headers, e.g. cookie.
-        //
-        // Not every header in the QPACK static table is known.
-        // These are missing from this test and the full header name is written.
-        // Missing:
-        // - link
-        // - location
-        // - strict-transport-security
-        // - x-content-type-options
-        // - x-xss-protection
-        // - content-security-policy
-        // - early-data
-        // - expect-ct
-        // - purpose
-        // - timing-allow-origin
-        // - x-forwarded-for
-        // - x-frame-options
-        switch (responseHeaderType)
-        {
-            case KnownHeaderType.Age:
-                return H3StaticTable.Age0;
-            case KnownHeaderType.ContentLength:
-                return H3StaticTable.ContentLength0;
-            case KnownHeaderType.Date:
-                return H3StaticTable.Date;
-            case KnownHeaderType.ETag:
-                return H3StaticTable.ETag;
-            case KnownHeaderType.LastModified:
-                return H3StaticTable.LastModified;
-            case KnownHeaderType.Location:
-                return H3StaticTable.Location;
-            case KnownHeaderType.SetCookie:
-                return H3StaticTable.SetCookie;
-            case KnownHeaderType.AcceptRanges:
-                return H3StaticTable.AcceptRangesBytes;
-            case KnownHeaderType.AccessControlAllowHeaders:
-                return H3StaticTable.AccessControlAllowHeadersCacheControl;
-            case KnownHeaderType.AccessControlAllowOrigin:
-                return H3StaticTable.AccessControlAllowOriginAny;
-            case KnownHeaderType.CacheControl:
-                return H3StaticTable.CacheControlMaxAge0;
-            case KnownHeaderType.ContentEncoding:
-                return H3StaticTable.ContentEncodingBr;
-            case KnownHeaderType.ContentType:
-                return H3StaticTable.ContentTypeApplicationDnsMessage;
-            case KnownHeaderType.Vary:
-                return H3StaticTable.VaryAcceptEncoding;
-            case KnownHeaderType.AccessControlAllowCredentials:
-                return H3StaticTable.AccessControlAllowCredentials;
-            case KnownHeaderType.AccessControlAllowMethods:
-                return H3StaticTable.AccessControlAllowMethodsGet;
-            case KnownHeaderType.AltSvc:
-                return H3StaticTable.AltSvcClear;
-            case KnownHeaderType.Server:
-                return H3StaticTable.Server;
-            default:
-                return -1;
-        }
     }
 }

--- a/src/Servers/Kestrel/Core/test/Http3/Http3HeadersEnumeratorTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3/Http3HeadersEnumeratorTests.cs
@@ -93,17 +93,20 @@ public class Http3HeadersEnumeratorTests
         Assert.True(e.MoveNext());
         Assert.Equal("Name1", e.Current.Key);
         Assert.Equal("Value1", e.Current.Value);
-        Assert.Equal(-1, e.QPackStaticTableId);
+        var (index, matchedValue) = e.GetQPackStaticTableId();
+        Assert.Equal(-1, index);
 
         Assert.True(e.MoveNext());
         Assert.Equal("Name2", e.Current.Key);
         Assert.Equal("Value2-1", e.Current.Value);
-        Assert.Equal(-1, e.QPackStaticTableId);
+        (index, matchedValue) = e.GetQPackStaticTableId();
+        Assert.Equal(-1, index);
 
         Assert.True(e.MoveNext());
         Assert.Equal("Name2", e.Current.Key);
         Assert.Equal("Value2-2", e.Current.Value);
-        Assert.Equal(-1, e.QPackStaticTableId);
+        (index, matchedValue) = e.GetQPackStaticTableId();
+        Assert.Equal(-1, index);
 
         var responseTrailers = (IHeaderDictionary)new HttpResponseTrailers();
 
@@ -118,22 +121,26 @@ public class Http3HeadersEnumeratorTests
         Assert.True(e.MoveNext());
         Assert.Equal("Grpc-Status", e.Current.Key);
         Assert.Equal("1", e.Current.Value);
-        Assert.Equal(-1, e.QPackStaticTableId);
+        (index, matchedValue) = e.GetQPackStaticTableId();
+        Assert.Equal(-1, index);
 
         Assert.True(e.MoveNext());
         Assert.Equal("Name1", e.Current.Key);
         Assert.Equal("Value1", e.Current.Value);
-        Assert.Equal(-1, e.QPackStaticTableId);
+        (index, matchedValue) = e.GetQPackStaticTableId();
+        Assert.Equal(-1, index);
 
         Assert.True(e.MoveNext());
         Assert.Equal("Name2", e.Current.Key);
         Assert.Equal("Value2-1", e.Current.Value);
-        Assert.Equal(-1, e.QPackStaticTableId);
+        (index, matchedValue) = e.GetQPackStaticTableId();
+        Assert.Equal(-1, index);
 
         Assert.True(e.MoveNext());
         Assert.Equal("Name2", e.Current.Key);
         Assert.Equal("Value2-2", e.Current.Value);
-        Assert.Equal(-1, e.QPackStaticTableId);
+        (index, matchedValue) = e.GetQPackStaticTableId();
+        Assert.Equal(-1, index);
 
         Assert.False(e.MoveNext());
     }
@@ -143,7 +150,7 @@ public class Http3HeadersEnumeratorTests
         var headers = new List<(int HPackStaticTableId, string Name, string Value)>();
         while (enumerator.MoveNext())
         {
-            headers.Add(CreateHeaderResult(enumerator.QPackStaticTableId, enumerator.Current.Key, enumerator.Current.Value));
+            headers.Add(CreateHeaderResult(enumerator.GetQPackStaticTableId().index, enumerator.Current.Key, enumerator.Current.Value));
         }
         return headers.ToArray();
     }

--- a/src/Servers/Kestrel/Core/test/Http3/Http3QPackEncoderTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3/Http3QPackEncoderTests.cs
@@ -74,6 +74,25 @@ public class Http3QPackEncoderTests
     }
 
     [Fact]
+    public void BeginEncodeHeaders_StaticKeyAndValue_WriteIndex()
+    {
+        Span<byte> buffer = new byte[1024 * 16];
+
+        var headers = (IHeaderDictionary)new HttpResponseHeaders();
+        headers.ContentType = "application/json";
+
+        var totalHeaderSize = 0;
+        var enumerator = new Http3HeadersEnumerator();
+        enumerator.Initialize(headers);
+
+        Assert.True(QPackHeaderWriter.BeginEncodeHeaders(enumerator, buffer, ref totalHeaderSize, out var length));
+
+        var result = buffer.Slice(2, length - 2).ToArray(); // trim prefix
+        var hex = BitConverter.ToString(result);
+        Assert.Equal("EE", hex);
+    }
+
+    [Fact]
     public void BeginEncodeHeaders_NonStaticKey_WriteFullNameAndFullValue()
     {
         Span<byte> buffer = new byte[1024 * 16];

--- a/src/Servers/Kestrel/Core/test/Http3/Http3QPackEncoderTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3/Http3QPackEncoderTests.cs
@@ -136,7 +136,7 @@ public class Http3QPackEncoderTests
         Span<byte> buffer = new byte[1024 * 16];
 
         var headers = (IHeaderDictionary)new HttpResponseHeaders();
-        headers.ContentType = "application/json";
+        headers.ContentType = "application/custom";
 
         var totalHeaderSize = 0;
         var enumerator = new Http3HeadersEnumerator();
@@ -146,6 +146,6 @@ public class Http3QPackEncoderTests
 
         var result = buffer.Slice(2, length - 2).ToArray();
         var hex = BitConverter.ToString(result);
-        Assert.Equal("5F-1D-10-61-70-70-6C-69-63-61-74-69-6F-6E-2F-6A-73-6F-6E", hex);
+        Assert.Equal("5F-1D-12-61-70-70-6C-69-63-61-74-69-6F-6E-2F-63-75-73-74-6F-6D", hex);
     }
 }

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1431,7 +1431,7 @@ $@"        private void Clear(long bitsToClear)
         var staticHeaders = new (int Index, System.Net.Http.QPack.HeaderField HeaderField)[H3StaticTable.Count];
         for (var i = 0; i < H3StaticTable.Count; i++)
         {
-            staticHeaders[i] = (i, H3StaticTable.GetHeaderFieldAt(i));
+            staticHeaders[i] = (i, H3StaticTable.Get(i));
         }
 
         var groupedHeaders = staticHeaders.GroupBy(h => Encoding.ASCII.GetString(h.HeaderField.Name)).Select(g =>

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http.HPack;
+using System.Net.Http.QPack;
 using System.Reflection;
 using System.Text;
 using Microsoft.Net.Http.Headers;
@@ -20,33 +21,33 @@ public class KnownHeaders
     public static readonly KnownHeader[] ResponseTrailers;
     public static readonly string[] InternalHeaderAccessors = new[]
     {
-            HeaderNames.Allow,
-            HeaderNames.AltSvc,
-            HeaderNames.TransferEncoding,
-            HeaderNames.ContentLength,
-            HeaderNames.Connection,
-            HeaderNames.Scheme,
-            HeaderNames.Path,
-            HeaderNames.Method,
-            HeaderNames.Authority,
-            HeaderNames.Host,
-        };
+        HeaderNames.Allow,
+        HeaderNames.AltSvc,
+        HeaderNames.TransferEncoding,
+        HeaderNames.ContentLength,
+        HeaderNames.Connection,
+        HeaderNames.Scheme,
+        HeaderNames.Path,
+        HeaderNames.Method,
+        HeaderNames.Authority,
+        HeaderNames.Host,
+    };
 
     public static readonly string[] DefinedHeaderNames = typeof(HeaderNames).GetFields(BindingFlags.Static | BindingFlags.Public).Select(h => h.Name).ToArray();
 
     public static readonly string[] ObsoleteHeaderNames = new[]
     {
-            HeaderNames.DNT,
-        };
+        HeaderNames.DNT,
+    };
 
     public static readonly string[] PseudoHeaderNames = new[]
     {
-            "Authority", // :authority
-            "Method", // :method
-            "Path", // :path
-            "Scheme", // :scheme
-            "Status" // :status
-        };
+        "Authority", // :authority
+        "Method", // :method
+        "Path", // :path
+        "Scheme", // :scheme
+        "Status" // :status
+    };
 
     public static readonly string[] NonApiHeaders =
         ObsoleteHeaderNames
@@ -65,85 +66,85 @@ public class KnownHeaders
     {
         var requestPrimaryHeaders = new[]
         {
-                HeaderNames.Accept,
-                HeaderNames.Connection,
-                HeaderNames.Host,
-                HeaderNames.UserAgent
-            };
+            HeaderNames.Accept,
+            HeaderNames.Connection,
+            HeaderNames.Host,
+            HeaderNames.UserAgent
+        };
         var responsePrimaryHeaders = new[]
         {
-                HeaderNames.Connection,
-                HeaderNames.Date,
-                HeaderNames.ContentType,
-                HeaderNames.Server,
-                HeaderNames.ContentLength,
-            };
+            HeaderNames.Connection,
+            HeaderNames.Date,
+            HeaderNames.ContentType,
+            HeaderNames.Server,
+            HeaderNames.ContentLength,
+        };
         var commonHeaders = new[]
         {
-                HeaderNames.CacheControl,
-                HeaderNames.Connection,
-                HeaderNames.Date,
-                HeaderNames.GrpcEncoding,
-                HeaderNames.KeepAlive,
-                HeaderNames.Pragma,
-                HeaderNames.TransferEncoding,
-                HeaderNames.Upgrade,
-                HeaderNames.Via,
-                HeaderNames.Warning,
-                HeaderNames.ContentType,
-            };
+            HeaderNames.CacheControl,
+            HeaderNames.Connection,
+            HeaderNames.Date,
+            HeaderNames.GrpcEncoding,
+            HeaderNames.KeepAlive,
+            HeaderNames.Pragma,
+            HeaderNames.TransferEncoding,
+            HeaderNames.Upgrade,
+            HeaderNames.Via,
+            HeaderNames.Warning,
+            HeaderNames.ContentType,
+        };
         // http://www.w3.org/TR/cors/#syntax
         var corsRequestHeaders = new[]
         {
-                HeaderNames.Origin,
-                HeaderNames.AccessControlRequestMethod,
-                HeaderNames.AccessControlRequestHeaders,
-            };
+            HeaderNames.Origin,
+            HeaderNames.AccessControlRequestMethod,
+            HeaderNames.AccessControlRequestHeaders,
+        };
         var requestHeadersExistence = new[]
         {
-                HeaderNames.Connection,
-                HeaderNames.TransferEncoding,
-            };
+            HeaderNames.Connection,
+            HeaderNames.TransferEncoding,
+        };
         var requestHeadersCount = new[]
         {
-                HeaderNames.Host
-            };
+            HeaderNames.Host
+        };
         RequestHeaders = commonHeaders.Concat(new[]
         {
-                HeaderNames.Authority,
-                HeaderNames.Method,
-                HeaderNames.Path,
-                HeaderNames.Scheme,
-                HeaderNames.Accept,
-                HeaderNames.AcceptCharset,
-                HeaderNames.AcceptEncoding,
-                HeaderNames.AcceptLanguage,
-                HeaderNames.Authorization,
-                HeaderNames.Cookie,
-                HeaderNames.Expect,
-                HeaderNames.From,
-                HeaderNames.GrpcAcceptEncoding,
-                HeaderNames.GrpcTimeout,
-                HeaderNames.Host,
-                HeaderNames.IfMatch,
-                HeaderNames.IfModifiedSince,
-                HeaderNames.IfNoneMatch,
-                HeaderNames.IfRange,
-                HeaderNames.IfUnmodifiedSince,
-                HeaderNames.MaxForwards,
-                HeaderNames.ProxyAuthorization,
-                HeaderNames.Referer,
-                HeaderNames.Range,
-                HeaderNames.TE,
-                HeaderNames.Translate,
-                HeaderNames.UserAgent,
-                HeaderNames.UpgradeInsecureRequests,
-                HeaderNames.RequestId,
-                HeaderNames.CorrelationContext,
-                HeaderNames.TraceParent,
-                HeaderNames.TraceState,
-                HeaderNames.Baggage,
-            })
+            HeaderNames.Authority,
+            HeaderNames.Method,
+            HeaderNames.Path,
+            HeaderNames.Scheme,
+            HeaderNames.Accept,
+            HeaderNames.AcceptCharset,
+            HeaderNames.AcceptEncoding,
+            HeaderNames.AcceptLanguage,
+            HeaderNames.Authorization,
+            HeaderNames.Cookie,
+            HeaderNames.Expect,
+            HeaderNames.From,
+            HeaderNames.GrpcAcceptEncoding,
+            HeaderNames.GrpcTimeout,
+            HeaderNames.Host,
+            HeaderNames.IfMatch,
+            HeaderNames.IfModifiedSince,
+            HeaderNames.IfNoneMatch,
+            HeaderNames.IfRange,
+            HeaderNames.IfUnmodifiedSince,
+            HeaderNames.MaxForwards,
+            HeaderNames.ProxyAuthorization,
+            HeaderNames.Referer,
+            HeaderNames.Range,
+            HeaderNames.TE,
+            HeaderNames.Translate,
+            HeaderNames.UserAgent,
+            HeaderNames.UpgradeInsecureRequests,
+            HeaderNames.RequestId,
+            HeaderNames.CorrelationContext,
+            HeaderNames.TraceParent,
+            HeaderNames.TraceState,
+            HeaderNames.Baggage,
+        })
         .Concat(corsRequestHeaders)
         .OrderBy(header => header)
         .OrderBy(header => !requestPrimaryHeaders.Contains(header))
@@ -165,54 +166,54 @@ public class KnownHeaders
 
         var responseHeadersExistence = new[]
         {
-                HeaderNames.Connection,
-                HeaderNames.Server,
-                HeaderNames.Date,
-                HeaderNames.TransferEncoding,
-                HeaderNames.AltSvc
-            };
+            HeaderNames.Connection,
+            HeaderNames.Server,
+            HeaderNames.Date,
+            HeaderNames.TransferEncoding,
+            HeaderNames.AltSvc
+        };
         var enhancedHeaders = new[]
         {
-                HeaderNames.Connection,
-                HeaderNames.Server,
-                HeaderNames.Date,
-                HeaderNames.TransferEncoding,
-                HeaderNames.AltSvc
-            };
+            HeaderNames.Connection,
+            HeaderNames.Server,
+            HeaderNames.Date,
+            HeaderNames.TransferEncoding,
+            HeaderNames.AltSvc
+        };
         // http://www.w3.org/TR/cors/#syntax
         var corsResponseHeaders = new[]
         {
-                HeaderNames.AccessControlAllowCredentials,
-                HeaderNames.AccessControlAllowHeaders,
-                HeaderNames.AccessControlAllowMethods,
-                HeaderNames.AccessControlAllowOrigin,
-                HeaderNames.AccessControlExposeHeaders,
-                HeaderNames.AccessControlMaxAge,
-            };
+            HeaderNames.AccessControlAllowCredentials,
+            HeaderNames.AccessControlAllowHeaders,
+            HeaderNames.AccessControlAllowMethods,
+            HeaderNames.AccessControlAllowOrigin,
+            HeaderNames.AccessControlExposeHeaders,
+            HeaderNames.AccessControlMaxAge,
+        };
         ResponseHeaders = commonHeaders.Concat(new[]
         {
-                HeaderNames.AcceptRanges,
-                HeaderNames.Age,
-                HeaderNames.Allow,
-                HeaderNames.AltSvc,
-                HeaderNames.ETag,
-                HeaderNames.Location,
-                HeaderNames.ProxyAuthenticate,
-                HeaderNames.ProxyConnection,
-                HeaderNames.RetryAfter,
-                HeaderNames.Server,
-                HeaderNames.SetCookie,
-                HeaderNames.Vary,
-                HeaderNames.Expires,
-                HeaderNames.WWWAuthenticate,
-                HeaderNames.ContentRange,
-                HeaderNames.ContentEncoding,
-                HeaderNames.ContentLanguage,
-                HeaderNames.ContentLocation,
-                HeaderNames.ContentMD5,
-                HeaderNames.LastModified,
-                HeaderNames.Trailer,
-            })
+            HeaderNames.AcceptRanges,
+            HeaderNames.Age,
+            HeaderNames.Allow,
+            HeaderNames.AltSvc,
+            HeaderNames.ETag,
+            HeaderNames.Location,
+            HeaderNames.ProxyAuthenticate,
+            HeaderNames.ProxyConnection,
+            HeaderNames.RetryAfter,
+            HeaderNames.Server,
+            HeaderNames.SetCookie,
+            HeaderNames.Vary,
+            HeaderNames.Expires,
+            HeaderNames.WWWAuthenticate,
+            HeaderNames.ContentRange,
+            HeaderNames.ContentEncoding,
+            HeaderNames.ContentLanguage,
+            HeaderNames.ContentLocation,
+            HeaderNames.ContentMD5,
+            HeaderNames.LastModified,
+            HeaderNames.Trailer,
+        })
         .Concat(corsResponseHeaders)
         .OrderBy(header => header)
         .OrderBy(header => !responsePrimaryHeaders.Contains(header))
@@ -235,10 +236,10 @@ public class KnownHeaders
 
         ResponseTrailers = new[]
         {
-                HeaderNames.ETag,
-                HeaderNames.GrpcMessage,
-                HeaderNames.GrpcStatus
-            }
+            HeaderNames.ETag,
+            HeaderNames.GrpcMessage,
+            HeaderNames.GrpcStatus
+        }
         .OrderBy(header => header)
         .OrderBy(header => !responsePrimaryHeaders.Contains(header))
         .Select((header, index) => new KnownHeader
@@ -253,12 +254,12 @@ public class KnownHeaders
 
         var invalidH2H3ResponseHeaders = new[]
         {
-                HeaderNames.Connection,
-                HeaderNames.TransferEncoding,
-                HeaderNames.KeepAlive,
-                HeaderNames.Upgrade,
-                HeaderNames.ProxyConnection
-            };
+            HeaderNames.Connection,
+            HeaderNames.TransferEncoding,
+            HeaderNames.KeepAlive,
+            HeaderNames.Upgrade,
+            HeaderNames.ProxyConnection
+        };
 
         InvalidH2H3ResponseHeadersBits = ResponseHeaders
             .Where(header => invalidH2H3ResponseHeaders.Contains(header.Name))
@@ -728,7 +729,6 @@ public class KnownHeaders
 
     public static string GeneratedFile()
     {
-
         var requestHeaders = RequestHeaders;
         Debug.Assert(requestHeaders.Length <= 64);
         Debug.Assert(requestHeaders.Max(x => x.Index) <= 62);
@@ -803,6 +803,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     {{
         Unknown,{Each(allHeaderNames, n => @"
         " + n + ",")}
+    }}
+
+    internal static class HttpHeadersCompression
+    {{
+        {GetQPackStaticTableMatch()}
     }}
 
     internal partial class HttpHeaders
@@ -1383,9 +1388,68 @@ $@"        private void Clear(long bitsToClear)
         }};";
     }
 
+    private static string GetQPackStaticTableMatch()
+    {
+        var group = GroupQPack(ResponseHeaders);
+
+        return @$"internal static (int index, bool matchedValue) MatchKnownHeaderQPack(KnownHeaderType knownHeader, string value)
+        {{
+            switch (knownHeader)
+            {{
+                {Each(group, (h) => @$"case KnownHeaderType.{h.Header.Identifier}:
+                    {AppendQPackSwitch(h.QPackStaticTableFields.OrderBy(t => t.Index).ToList())}
+                ")}
+                default:
+                    return (-1, false);
+            }}
+        }}";
+    }
+
+    private static string AppendQPackSwitch(IList<(int Index, System.Net.Http.QPack.HeaderField Field)> values)
+    {
+        if (values.Count == 1 && values[0].Field.Value.Length == 0)
+        {
+            // Skip check if the only value is empty string. Empty string wasn't chosen because it is common.
+            // Instead it is the default value when there isn't a common value for the header.
+            return $"return ({values[0].Index}, false);";
+        }
+        else
+        {
+            // Use smallest index if there is no match. Smaller number is more likely to fit into a single byte.
+            return $@"switch (value)
+                    {{{Each(values, value => $@"
+                        case ""{Encoding.ASCII.GetString(value.Field.Value)}"":
+                            return ({value.Index}, true);")}
+                        default:
+                            return ({values.Min(v => v.Index)}, false);
+                    }}";
+        }
+    }
+
+    private static IEnumerable<QPackGroup> GroupQPack(KnownHeader[] headers)
+    {
+        var staticHeaders = new (int Index, System.Net.Http.QPack.HeaderField HeaderField)[H3StaticTable.Count];
+        for (var i = 0; i < H3StaticTable.Count; i++)
+        {
+            staticHeaders[i] = (i, H3StaticTable.GetHeaderFieldAt(i));
+        }
+
+        var groupedHeaders = staticHeaders.GroupBy(h => Encoding.ASCII.GetString(h.HeaderField.Name)).Select(g =>
+        {
+            return new QPackGroup
+            {
+                Name = g.Key,
+                Header = headers.SingleOrDefault(knownHeader => string.Equals(knownHeader.Name, g.Key, StringComparison.OrdinalIgnoreCase)),
+                QPackStaticTableFields = g.ToArray()
+            };
+        }).Where(g => g.Header != null).ToList();
+
+        return groupedHeaders;
+    }
+
     private static IEnumerable<HPackGroup> GroupHPack(KnownHeader[] headers)
     {
-        var staticHeaders = new (int Index, HeaderField HeaderField)[H2StaticTable.Count];
+        var staticHeaders = new (int Index, System.Net.Http.HPack.HeaderField HeaderField)[H2StaticTable.Count];
         for (var i = 0; i < H2StaticTable.Count; i++)
         {
             staticHeaders[i] = (i + 1, H2StaticTable.Get(i));
@@ -1402,6 +1466,13 @@ $@"        private void Clear(long bitsToClear)
         }).Where(g => g.Header != null).ToList();
 
         return groupedHeaders;
+    }
+
+    private class QPackGroup
+    {
+        public (int Index, System.Net.Http.QPack.HeaderField Field)[] QPackStaticTableFields { get; set; }
+        public KnownHeader Header { get; set; }
+        public string Name { get; set; }
     }
 
     private class HPackGroup

--- a/src/Servers/Kestrel/tools/CodeGenerator/CodeGenerator.csproj
+++ b/src/Servers/Kestrel/tools/CodeGenerator/CodeGenerator.csproj
@@ -12,9 +12,9 @@
     <Compile Include="$(SharedSourceRoot)runtime\Http2\Hpack\H2StaticTable.Http2.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\Hpack\H2StaticTable.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\Hpack\HeaderField.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />
-    <Compile Include="$(SharedSourceRoot)runtime\Http3\Qpack\H3StaticTable.Http3.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
-    <Compile Include="$(SharedSourceRoot)runtime\Http3\Qpack\H3StaticTable.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
-    <Compile Include="$(SharedSourceRoot)runtime\Http3\Qpack\HeaderField.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http3\QPack\H3StaticTable.Http3.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http3\QPack\H3StaticTable.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http3\QPack\HeaderField.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/tools/CodeGenerator/CodeGenerator.csproj
+++ b/src/Servers/Kestrel/tools/CodeGenerator/CodeGenerator.csproj
@@ -12,6 +12,9 @@
     <Compile Include="$(SharedSourceRoot)runtime\Http2\Hpack\H2StaticTable.Http2.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\Hpack\H2StaticTable.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\Hpack\HeaderField.cs" Link="Shared\runtime\Http2\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http3\Qpack\H3StaticTable.Http3.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http3\Qpack\H3StaticTable.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
+    <Compile Include="$(SharedSourceRoot)runtime\Http3\Qpack\HeaderField.cs" Link="Shared\runtime\Http3\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/33980

Improves on https://github.com/dotnet/aspnetcore/pull/38565

When writing known headers, check if the value also matches a static table entry. If it matches then write just an index for name and value.