### PR TITLE
Fix `components-e2e` Pipeline

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -60,8 +60,8 @@ jobs:
     - task: PublishTestResults@2
       displayName: Publish Quarantined E2E Test Results
       inputs:
-        testResultsFormat: 'xUnit'
-        testResultsFiles: '*.xml'
+        testResultsFormat: 'VSTest'
+        testResultsFiles: '*.trx'
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
         testRunTitle: Quarantine-$(AgentOsName)-$(BuildConfiguration)-xunit
         mergeTestResults: true

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -47,12 +47,12 @@ jobs:
     - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined!=true|Quarantined=false'
                  --logger:"trx%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.trx"
                  --logger:"html%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.html"
-                 "--ResultsDirectory:$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)"
+                 --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Unquarantined
       displayName: Run E2E tests
     - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined=true' -p:RunQuarantinedTests=true
                  --logger:"trx%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.trx"
                  --logger:"html%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.html"
-                 "--ResultsDirectory:$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Quarantined"
+                 --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Quarantined
       displayName: Run Quarantined E2E tests
       continueOnError: true
     - task: PublishTestResults@2
@@ -60,7 +60,7 @@ jobs:
       inputs:
         testResultsFormat: 'VSTest'
         testResultsFiles: '*.trx'
-        searchFolder: '$(Build.SourcesDirectory)/src/Components/test/E2ETest/TestResults'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Unquarantined'
         testRunTitle: ComponentsE2E-$(AgentOsName)-$(BuildConfiguration)-xunit
       condition: always()
     - task: PublishTestResults@2

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -44,9 +44,9 @@ jobs:
       displayName: NPM install
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter Quarantined\!=true --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined!=true|Quarantined=false' --logger trx
       displayName: Run E2E tests
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter Quarantined=true -p:RunQuarantinedTests=true --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined=true' -p:RunQuarantinedTests=true --logger trx --logger:"trx%3BLogFileName=$(_TestResultTrxFileName)" --logger:"html%3BLogFileName=$(_TestResultHtmlFileName)" "--ResultsDirectory:$(_TestResultDirectory)"`
       displayName: Run Quarantined E2E tests
       continueOnError: true
     - task: PublishTestResults@2

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -44,9 +44,15 @@ jobs:
       displayName: NPM install
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined!=true|Quarantined=false' --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined!=true|Quarantined=false'
+                 --logger:"trx%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.trx"
+                 --logger:"html%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.html"
+                 "--ResultsDirectory:$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)"
       displayName: Run E2E tests
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined=true' -p:RunQuarantinedTests=true --logger trx --logger:"trx%3BLogFileName=$(_TestResultTrxFileName)" --logger:"html%3BLogFileName=$(_TestResultHtmlFileName)" "--ResultsDirectory:$(_TestResultDirectory)"`
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined=true' -p:RunQuarantinedTests=true
+                 --logger:"trx%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.trx"
+                 --logger:"html%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.html"
+                 "--ResultsDirectory:$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Quarantined"
       displayName: Run Quarantined E2E tests
       continueOnError: true
     - task: PublishTestResults@2
@@ -62,7 +68,7 @@ jobs:
       inputs:
         testResultsFormat: 'VSTest'
         testResultsFiles: '*.trx'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Quarantined'
         testRunTitle: Quarantine-$(AgentOsName)-$(BuildConfiguration)-xunit
         mergeTestResults: true
       condition: always()

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -44,9 +44,9 @@ jobs:
       displayName: NPM install
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter Quarantined\!~github --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter Quarantined\!=true --logger trx
       displayName: Run E2E tests
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter Quarantined~github -p:RunQuarantinedTests=true --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter Quarantined=true -p:RunQuarantinedTests=true --logger trx
       displayName: Run Quarantined E2E tests
       continueOnError: true
     - task: PublishTestResults@2

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -75,5 +75,5 @@ jobs:
 
     artifacts:
     - name: Components_E2E_Test_Logs
-      path: ./src/Components/test/E2ETest/TestResults
+      path: '$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)'
       publishOnError: true

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -44,9 +44,9 @@ jobs:
       displayName: NPM install
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter QuarantinedTest\!~github --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter Quarantined\!~github --logger trx
       displayName: Run E2E tests
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter QuarantinedTest~github -p:RunQuarantinedTests=true --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter Quarantined~github -p:RunQuarantinedTests=true --logger trx
       displayName: Run Quarantined E2E tests
       continueOnError: true
     - task: PublishTestResults@2


### PR DESCRIPTION
Support for the `QuarantinedTest` attribute.

Using the `Quarantined` trait defined here:
https://github.com/dotnet/aspnetcore/blob/ba18614ec220c1209a3976f66aacc2c761568931/src/Testing/src/xunit/QuarantinedTestTraitDiscoverer.cs#L18

Extension of https://github.com/dotnet/aspnetcore/pull/38693 which got auto-merged.
