### PR TITLE
DisplayFor doc: what if template file is not found

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelperOfT.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelperOfT.cs
@@ -47,8 +47,9 @@ public interface IHtmlHelper<TModel> : IHtmlHelper
 
     /// <summary>
     /// Returns HTML markup for the <paramref name="expression"/>, using a display template, specified HTML field
-    /// name, and additional view data. The template is found using the <paramref name="templateName"/> or the
-    /// <paramref name="expression"/>'s <see cref="ModelBinding.ModelMetadata"/>.
+    /// name, and additional view data. The template name is taken from the <paramref name="templateName"/> or the
+    /// <paramref name="expression"/>’s <see cref="ModelBinding.ModelMetadata"/>.
+    /// If the template file is not found, a default template will be used.
     /// </summary>
     /// <param name="expression">An expression to be evaluated against the current model.</param>
     /// <param name="templateName">The name of the template used to create the HTML markup.</param>


### PR DESCRIPTION
# DisplayFor doc: what if template file is not found

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

What happens if a template file corresponding to a template name is not found.

## Description

Explain that a default template will be used if a template file corresponding to a template name is not found.

Not worth a bug.
