### PR TITLE
IHtmlHelper doc: what goes into SelectListItem

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
@@ -375,7 +375,9 @@ public interface IHtmlHelper
     /// <typeparam name="TEnum">Type to generate a select list for.</typeparam>
     /// <returns>
     /// An <see cref="IEnumerable{SelectListItem}"/> containing the select list for the given
-    /// <typeparamref name="TEnum"/>.
+    /// <typeparamref name="TEnum"/>,
+    /// with a decimal representation of the ordinal as <see cref="SelectListItem#Value" />
+    /// and the display name as <see cref="SelectListItem#Text" >.
     /// </returns>
     /// <exception cref="ArgumentException">
     /// Thrown if <typeparamref name="TEnum"/> is not an <see cref="Enum"/> or if it has a

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
@@ -376,7 +376,7 @@ public interface IHtmlHelper
     /// <returns>
     /// An <see cref="IEnumerable{SelectListItem}"/> containing the select list for the given
     /// <typeparamref name="TEnum"/>,
-    /// with a decimal representation of the ordinal as <see cref="SelectListItem#Value" />
+    /// with a decimal representation of the ordinal as <see cref="SelectListItem.Value" />
     /// and the display name as <see cref="SelectListItem#Text" >.
     /// </returns>
     /// <exception cref="ArgumentException">

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
@@ -376,8 +376,8 @@ public interface IHtmlHelper
     /// <returns>
     /// An <see cref="IEnumerable{SelectListItem}"/> containing the select list for the given
     /// <typeparamref name="TEnum"/>,
-    /// with a decimal representation of the ordinal as <see cref="SelectListItem.Value" />
-    /// and the display name as <see cref="SelectListItem.Text" >.
+    /// with a decimal representation of the ordinal as <see cref="SelectListItem.Value"/>
+    /// and the display name as <see cref="SelectListItem.Text"/>.
     /// </returns>
     /// <exception cref="ArgumentException">
     /// Thrown if <typeparamref name="TEnum"/> is not an <see cref="Enum"/> or if it has a

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
@@ -377,7 +377,7 @@ public interface IHtmlHelper
     /// An <see cref="IEnumerable{SelectListItem}"/> containing the select list for the given
     /// <typeparamref name="TEnum"/>,
     /// with a decimal representation of the ordinal as <see cref="SelectListItem.Value" />
-    /// and the display name as <see cref="SelectListItem#Text" >.
+    /// and the display name as <see cref="SelectListItem.Text" >.
     /// </returns>
     /// <exception cref="ArgumentException">
     /// Thrown if <typeparamref name="TEnum"/> is not an <see cref="Enum"/> or if it has a


### PR DESCRIPTION
# IHtmlHelper doc: what goes into SelectListItem

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

[SelectListItem](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.rendering.selectlistitem) of an enum: `Value` = ordinal, `Text` = display name

## Description

[GetEnumSelectList](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.rendering.ihtmlhelper.getenumselectlist) sets the following values of each [SelectListItem](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.rendering.selectlistitem):
<DL ><DT >Value<DD >a decimal representation of the ordinal of the item
<DT >Text<DD >a display name for the item</DL >

I did not explain that the display name is the name or comes from the [Display attribute](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.displayattribute).  I think that would be excessive.

Not worth reporting a bug.  Note that `Value` is not obvious, a priori it could contain the code name of the item.
