### PR TITLE
Do not compare IPAddress by reference

### DIFF
--- a/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
+++ b/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
@@ -226,13 +226,13 @@ public class AddressBinderTests
             logger,
             endpoint =>
             {
-                if (endpoint.IPEndPoint.Address == IPAddress.IPv6Any)
+                if (endpoint.IPEndPoint.Address.Equals(IPAddress.IPv6Any))
                 {
                     ipV6Attempt = true;
                     throw new InvalidOperationException("EAFNOSUPPORT");
                 }
 
-                if (endpoint.IPEndPoint.Address == IPAddress.Any)
+                if (endpoint.IPEndPoint.Address.Equals(IPAddress.Any))
                 {
                     ipV4Attempt = true;
                 }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -42,17 +42,6 @@ internal class QuicConnectionListener : IMultiplexedConnectionListener, IAsyncDi
             throw new InvalidOperationException($"QUIC doesn't support listening on the configured endpoint type. Expected {nameof(IPEndPoint)} but got {endpoint.GetType().Name}.");
         }
 
-        // Workaround for issue in System.Net.Quic
-        // https://github.com/dotnet/runtime/issues/57241
-        if (listenEndPoint.Address.Equals(IPAddress.Any) && listenEndPoint.Address != IPAddress.Any)
-        {
-            listenEndPoint = new IPEndPoint(IPAddress.Any, listenEndPoint.Port);
-        }
-        if (listenEndPoint.Address.Equals(IPAddress.IPv6Any) && listenEndPoint.Address != IPAddress.IPv6Any)
-        {
-            listenEndPoint = new IPEndPoint(IPAddress.IPv6Any, listenEndPoint.Port);
-        }
-
         quicListenerOptions.ServerAuthenticationOptions = sslServerAuthenticationOptions;
         quicListenerOptions.ListenEndPoint = listenEndPoint;
         quicListenerOptions.IdleTimeout = options.IdleTimeout;

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -116,7 +116,7 @@ public class SocketTransportOptions
                 listenSocket = new Socket(ip.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
                 // Kestrel expects IPv6Any to bind to both IPv6 and IPv4
-                if (ip.Address == IPAddress.IPv6Any)
+                if (ip.Address.Equals(IPAddress.IPv6Any))
                 {
                     listenSocket.DualMode = true;
                 }


### PR DESCRIPTION
# Do not compare IPAddress by reference

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable. *-- I'm happy to add tests, if I get some guidance regarding this particular case.*
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue. *-- Opening a separate issue for this seemed to bring unnecessary overhead, but I can do it if asked.*

## Description

A user noticed in https://github.com/dotnet/runtime/issues/62072#issuecomment-983335568 that aspnetcore code uses reference equality for `IPAddress` which may result in bugs. One of the cases is a workaround for https://github.com/dotnet/runtime/issues/57241, which is no longer necessary since https://github.com/dotnet/runtime/pull/57250.
