### PR TITLE
Avoiding Inferred required attribute when default value is defined

### DIFF
--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -386,7 +386,7 @@ internal class DataAnnotationsMetadataProvider :
             else if (context.Key.MetadataKind == ModelMetadataKind.Parameter)
             {
                 // If the default value is assigned we don't need to check the nullabilty
-                // since the parameter will be optional
+                // since the parameter will be optional.
                 if (!context.Key.ParameterInfo!.HasDefaultValue)
                 {
                     addInferredRequiredAttribute = IsNullableReferenceType(

--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -346,8 +346,7 @@ internal class DataAnnotationsMetadataProvider :
         // must have a non-null value on the model during validation.
         var requiredAttribute = attributes.OfType<RequiredAttribute>().FirstOrDefault();
 
-        // For non-nullable reference types without a default value define,
-        // treat them as-if they had an implicit [Required].
+        // For non-nullable reference types, treat them as-if they had an implicit [Required].
         // This allows the developer to specify [Required] to customize the error message, so
         // if they already have [Required] then there's no need for us to do this check.
         if (!_options.SuppressImplicitRequiredAttributeForNonNullableReferenceTypes &&
@@ -386,6 +385,8 @@ internal class DataAnnotationsMetadataProvider :
             }
             else if (context.Key.MetadataKind == ModelMetadataKind.Parameter)
             {
+                // If the default value is assigned we don't need to check the nullabilty
+                // since the parameter will be optional
                 if (!context.Key.ParameterInfo!.HasDefaultValue)
                 {
                     addInferredRequiredAttribute = IsNullableReferenceType(

--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -346,7 +346,8 @@ internal class DataAnnotationsMetadataProvider :
         // must have a non-null value on the model during validation.
         var requiredAttribute = attributes.OfType<RequiredAttribute>().FirstOrDefault();
 
-        // For non-nullable reference types, treat them as-if they had an implicit [Required].
+        // For non-nullable reference types without a default value define,
+        // treat them as-if they had an implicit [Required].
         // This allows the developer to specify [Required] to customize the error message, so
         // if they already have [Required] then there's no need for us to do this check.
         if (!_options.SuppressImplicitRequiredAttributeForNonNullableReferenceTypes &&
@@ -376,7 +377,7 @@ internal class DataAnnotationsMetadataProvider :
                     }
                 }
                 else
-                {
+                { 
                     addInferredRequiredAttribute = IsNullableReferenceType(
                         property.DeclaringType!,
                         member: null,
@@ -385,10 +386,13 @@ internal class DataAnnotationsMetadataProvider :
             }
             else if (context.Key.MetadataKind == ModelMetadataKind.Parameter)
             {
-                addInferredRequiredAttribute = IsNullableReferenceType(
-                    context.Key.ParameterInfo!.Member.ReflectedType,
-                    context.Key.ParameterInfo.Member,
-                    context.ParameterAttributes!);
+                if (!context.Key.ParameterInfo!.HasDefaultValue)
+                {
+                    addInferredRequiredAttribute = IsNullableReferenceType(
+                        context.Key.ParameterInfo!.Member.ReflectedType,
+                        context.Key.ParameterInfo.Member,
+                        context.ParameterAttributes!);
+                }
             }
             else
             {

--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -376,7 +376,7 @@ internal class DataAnnotationsMetadataProvider :
                     }
                 }
                 else
-                { 
+                {
                     addInferredRequiredAttribute = IsNullableReferenceType(
                         property.DeclaringType!,
                         member: null,

--- a/src/Mvc/test/Mvc.FunctionalTests/NonNullableReferenceTypesTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/NonNullableReferenceTypesTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -105,5 +105,19 @@ public class NonNullableReferenceTypesTest : IClassFixture<MvcTestFixture<BasicW
         //
         // Redirect means there were no validation errors.
         await response.AssertStatusCodeAsync(HttpStatusCode.Redirect);
+    }
+
+    [Fact]
+    public async Task CanUseNonNullableReferenceType_WithController_DefaultValueParameter_NoError()
+    {
+        // Act 1
+        var response = await Client.GetAsync("http://localhost/api/NonNullable");
+
+        // Assert 1
+        _ = await response.AssertStatusCodeAsync(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert 2
+        Assert.NotNull(content);
     }
 }

--- a/src/Mvc/test/Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -614,7 +614,7 @@ public class ValidationIntegrationTests
         {
         }
 
-        public static ParameterInfo NoAttributesParameterInfo
+        public static ParameterInfo NonNullableParameterInfo
             = typeof(ParameterInfos)!
                 .GetMethod(nameof(ParameterInfos.Method))!
                 .GetParameters()[0];
@@ -659,7 +659,7 @@ public class ValidationIntegrationTests
         {
             Name = "parameter",
             ParameterType = typeof(string),
-            ParameterInfo = ParameterInfos.NoAttributesParameterInfo
+            ParameterInfo = ParameterInfos.NonNullableParameterInfo
         };
 
         var testContext = ModelBindingTestHelper.GetTestContext();

--- a/src/Mvc/test/Mvc.IntegrationTests/ValidationIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/ValidationIntegrationTests.cs
@@ -605,6 +605,78 @@ public class ValidationIntegrationTests
         AssertRequiredError("ProductId", error);
     }
 
+#nullable enable
+    private class ParameterInfos
+    {
+        public void Method(
+            string param1,
+            string param2 = "sample_data")
+        {
+        }
+
+        public static ParameterInfo NoAttributesParameterInfo
+            = typeof(ParameterInfos)!
+                .GetMethod(nameof(ParameterInfos.Method))!
+                .GetParameters()[0];
+
+        public static ParameterInfo DefaultValueParameterInfo
+            = typeof(ParameterInfos)!
+                .GetMethod(nameof(ParameterInfos.Method))!
+                .GetParameters()[1];
+    }
+#nullable restore
+
+    [Fact]
+    public async Task Validation_RequiredAttribute_OnActionParameter_WithDefaultValue()
+    {
+        // Arrange
+        var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+        var parameter = new ControllerParameterDescriptor()
+        {
+            Name = "parameter",
+            ParameterType = typeof(string),
+            ParameterInfo = ParameterInfos.DefaultValueParameterInfo
+        };
+
+        var testContext = ModelBindingTestHelper.GetTestContext();
+
+        var modelState = testContext.ModelState;
+
+        // Act
+        _ = await parameterBinder.BindModelAsync(parameter, testContext);
+
+        // Assert
+        Assert.True(modelState.IsValid);
+        Assert.Equal(0, modelState.ErrorCount);
+    }
+
+    [Fact]
+    public async Task Validation_RequiredAttribute_OnActionParameter_Invalid()
+    {
+        // Arrange
+        var parameterBinder = ModelBindingTestHelper.GetParameterBinder();
+        var parameter = new ControllerParameterDescriptor()
+        {
+            Name = "parameter",
+            ParameterType = typeof(string),
+            ParameterInfo = ParameterInfos.NoAttributesParameterInfo
+        };
+
+        var testContext = ModelBindingTestHelper.GetTestContext();
+
+        var modelState = testContext.ModelState;
+
+        // Act
+        _ = await parameterBinder.BindModelAsync(parameter, testContext);
+
+        // Assert
+        Assert.False(modelState.IsValid);
+        Assert.Equal(1, modelState.ErrorCount);
+
+        var entry = Assert.Single(modelState, e => e.Key == "parameter").Value;
+        Assert.Equal(ModelValidationState.Invalid, entry.ValidationState);
+    }
+
     private class Order6
     {
         [StringLength(5, ErrorMessage = "Too Long.")]

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/NonNullableApiController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/NonNullableApiController.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using Microsoft.AspNetCore.Mvc;
+
+namespace BasicWebSite.Controllers;
+
+#nullable enable
+
+[ApiController]
+[Route("api/NonNullable")]
+public class NonNullableApiController : ControllerBase
+{
+    // GET: api/<controller>
+    [HttpGet]
+    public ActionResult<string> Get(string language = "pt-br")
+    {
+        return language;
+    }
+}
+
+#nullable restore

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/NonNullableApiController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/NonNullableApiController.cs
@@ -6,8 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace BasicWebSite.Controllers;
 
-#nullable enable
-
 [ApiController]
 [Route("api/NonNullable")]
 public class NonNullableApiController : ControllerBase
@@ -19,5 +17,3 @@ public class NonNullableApiController : ControllerBase
         return language;
     }
 }
-
-#nullable restore


### PR DESCRIPTION
# Avoiding Inferred required attribute when default value is defined

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Adding `if (!context.Key.ParameterInfo!.HasDefaultValue)`

## Description

The current mechanism to infer required attribute based on the nullable attribute is not able to mark the parameter as optional when the default value is defined. 

This change includes a small validation to not infer anymore.
 ``` 
**if (!context.Key.ParameterInfo!.HasDefaultValue)**
{
    addInferredRequiredAttribute = IsNullableReferenceType(
                        context.Key.ParameterInfo!.Member.ReflectedType,
                        context.Key.ParameterInfo.Member,
                        context.ParameterAttributes!);
}
```

Fixes #18403
