### PR TITLE
Unquarantine tests / skip mslocaldb helix tests

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -8,6 +8,7 @@
     {"testName": {"contains": "CheckStdoutWithLargeWrites"}},
     {"testName": {"contains": "ServerShutsDownWhenMainExitsStress" }},
     {"testName": {"contains": "AddressRegistrationTests" }},
+    {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
     {"failureMessage": "network disconnected" }
   ],
   "failOnRules": [

--- a/src/Middleware/Diagnostics/test/FunctionalTests/Diagnostics.FunctionalTests.csproj
+++ b/src/Middleware/Diagnostics/test/FunctionalTests/Diagnostics.FunctionalTests.csproj
@@ -5,6 +5,9 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyName>Diagnostics.FunctionalTests</AssemblyName>
     <TestDependsOnMssql>true</TestDependsOnMssql>
+    
+    <!-- https://github.com/dotnet/aspnetcore/issues/38819 LocalDb sometimes hangs on win11 helix queue -->
+    <BuildHelixPayload>false</BuildHelixPayload>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
+++ b/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
@@ -115,7 +115,6 @@ public class FileLoggerProcessorTests
         }
     }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/34284")]
     [Fact]
     public async Task RollsTextFilesBasedOnSize()
     {

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
@@ -9,6 +9,9 @@
     <BaseOutputPath />
     <OutputPath />
 
+    <!-- https://github.com/dotnet/aspnetcore/issues/38818 -->
+    <BuildHelixPayload>false</BuildHelixPayload>
+    
     <!-- Properties that affect test runs -->
     <!-- TestTemplateCreationFolder is the folder where the templates will be created. Will point out to $(OutputDir)$(TestTemplateCreationFolder) -->
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>

--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -38,7 +38,6 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
     [InlineData("SingleOrg", null)]
     [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
     public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish(string auth, string[] args)
         => CreateBuildPublishAsync("blazorserveridweb" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), auth, args);
 

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -232,7 +232,6 @@ public class RazorPagesTemplateTest : LoggedTest
 
     [ConditionalTheory]
     [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31729")]
     public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes_WithSingleOrg(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
     private async Task<Project> BuildAndPublishRazorPagesTemplate(string auth, string[] args)

--- a/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/MaxRequestBufferSizeTests.cs
@@ -115,7 +115,7 @@ public class MaxRequestBufferSizeTests : LoggedTest
     }
     [Theory]
     [MemberData(nameof(LargeUploadData))]
-    [QuarantinedTest("This is inherently flaky and should never be unquarantined.")]
+    // This is inherently flaky and is relying on helix retry to pass consistently
     public async Task LargeUpload(long? maxRequestBufferSize, bool connectionAdapter, bool expectPause)
     {
         // Parameters

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -235,7 +235,6 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/37930")]
     public async Task ResponseTrailers_MultipleStreams_Reset()
     {
         IEnumerable<KeyValuePair<string, string>> requestHeaders = new[]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/37930
Fixes https://github.com/dotnet/aspnetcore/issues/34284
Fixes https://github.com/dotnet/aspnetcore/issues/31729
Fixes https://github.com/dotnet/aspnetcore/issues/37930

Parole for:
- 2 non playwright blazor template tests that were grouped in the playwright template test issue, these are fairly reliable and have been clean for 30 days
- FileLoggerProcessor test was improved by community PRs
- Http2ConnectionTest that was missing a test-fixed label that has been 30 days clean
- Switch to retry instead of perma quarantine for MaxRequestBufferSizeTests.LargeUpload as its been 30 days clean

![image](https://user-images.githubusercontent.com/6537861/144653070-9548c934-0432-420b-906b-2391901db15a.png)