### PR TITLE
Backport `components-e2e` CI Pipeline Fixes to release/6.0

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -43,8 +43,11 @@ jobs:
       displayName: NPM install
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter QuarantinedTest\!~github --logger trx
       displayName: Run E2E tests
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter QuarantinedTest~github -p:RunQuarantinedTests=true --logger trx
+      displayName: Run Quarantined E2E tests
+      continueOnError: true
     - task: PublishTestResults@2
       displayName: Publish E2E Test Results
       inputs:
@@ -53,6 +56,16 @@ jobs:
         searchFolder: '$(Build.SourcesDirectory)/src/Components/test/E2ETest/TestResults'
         testRunTitle: ComponentsE2E-$(AgentOsName)-$(BuildConfiguration)-xunit
       condition: always()
+    - task: PublishTestResults@2
+      displayName: Publish Quarantined E2E Test Results
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '*.xml'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
+        testRunTitle: Quarantine-$(AgentOsName)-$(BuildConfiguration)-xunit
+        mergeTestResults: true
+      condition: always()
+
     artifacts:
     - name: Components_E2E_Test_Logs
       path: ./src/Components/test/E2ETest/TestResults

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -43,9 +43,15 @@ jobs:
       displayName: NPM install
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter QuarantinedTest\!~github --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined!=true|Quarantined=false'
+                 --logger:"trx%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.trx"
+                 --logger:"html%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.html"
+                 --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Unquarantined
       displayName: Run E2E tests
-    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter QuarantinedTest~github -p:RunQuarantinedTests=true --logger trx
+    - script: .dotnet/dotnet test ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-build --filter 'Quarantined=true' -p:RunQuarantinedTests=true
+                 --logger:"trx%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.trx"
+                 --logger:"html%3BLogFileName=Microsoft.AspNetCore.Components.E2ETests.html"
+                 --results-directory $(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Quarantined
       displayName: Run Quarantined E2E tests
       continueOnError: true
     - task: PublishTestResults@2
@@ -53,20 +59,20 @@ jobs:
       inputs:
         testResultsFormat: 'VSTest'
         testResultsFiles: '*.trx'
-        searchFolder: '$(Build.SourcesDirectory)/src/Components/test/E2ETest/TestResults'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Unquarantined'
         testRunTitle: ComponentsE2E-$(AgentOsName)-$(BuildConfiguration)-xunit
       condition: always()
     - task: PublishTestResults@2
       displayName: Publish Quarantined E2E Test Results
       inputs:
-        testResultsFormat: 'xUnit'
-        testResultsFiles: '*.xml'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
+        testResultsFormat: 'VSTest'
+        testResultsFiles: '*.trx'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)/Quarantined'
         testRunTitle: Quarantine-$(AgentOsName)-$(BuildConfiguration)-xunit
         mergeTestResults: true
       condition: always()
 
     artifacts:
     - name: Components_E2E_Test_Logs
-      path: ./src/Components/test/E2ETest/TestResults
+      path: '$(Build.SourcesDirectory)/artifacts/TestResults/$(BuildConfiguration)'
       publishOnError: true

--- a/src/Components/test/E2ETest/Tests/JSRootComponentsTest.cs
+++ b/src/Components/test/E2ETest/Tests/JSRootComponentsTest.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/38613")]
         public void CanAddAndDisposeRootComponents(bool intoBlazorUi, bool attachShadowRoot)
         {
             var message = app.FindElement(By.Id("message"));


### PR DESCRIPTION
Backports fixes from https://github.com/dotnet/aspnetcore/pull/38693 and https://github.com/dotnet/aspnetcore/pull/38704 to release/6.0. This is needed to resolve the CI issues seen in https://github.com/dotnet/aspnetcore/pull/38811, specifically https://dev.azure.com/dnceng/public/_build/results?buildId=1495836&view=results.

@dotnet/aspnet-build would this be `tell-mode`?