### PR TITLE
LdapAdapter: Keep track of already processed groups to account for circular references

### DIFF
--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -68,7 +68,7 @@ internal static class LdapAdapter
 
                 if (!settings.IgnoreNestedGroups)
                 {
-                    GetNestedGroups(settings.LdapConnection, identity, distinguishedName, groupCN, logger, retrievedClaims);
+                    GetNestedGroups(settings.LdapConnection, identity, distinguishedName, groupCN, logger, retrievedClaims, new HashSet<string>());
                 }
                 else
                 {
@@ -96,8 +96,10 @@ internal static class LdapAdapter
         }
     }
 
-    private static void GetNestedGroups(LdapConnection connection, ClaimsIdentity principal, string distinguishedName, string groupCN, ILogger logger, IList<string> retrievedClaims)
+    private static void GetNestedGroups(LdapConnection connection, ClaimsIdentity principal, string distinguishedName, string groupCN, ILogger logger, IList<string> retrievedClaims, HashSet<string> processedGroups)
     {
+        retrievedClaims.Add(groupCN);
+
         var filter = $"(&(objectClass=group)(sAMAccountName={groupCN}))"; // This is using ldap search query language, it is looking on the server for someUser
         var searchRequest = new SearchRequest(distinguishedName, filter, SearchScope.Subtree);
         var searchResponse = (SearchResponse)connection.SendRequest(searchRequest);
@@ -109,18 +111,26 @@ internal static class LdapAdapter
                 logger.LogWarning($"More than one response received for query: {filter} with distinguished name: {distinguishedName}");
             }
 
-            var group = searchResponse.Entries[0]; //Get the object that was found on ldap
-            string name = group.DistinguishedName;
-            retrievedClaims.Add(name);
+            var group = searchResponse.Entries[0]; // Get the object that was found on ldap
+            var groupDN = group.DistinguishedName;
+
+            processedGroups.Add(groupDN);
 
             var memberof = group.Attributes["memberof"]; // You can access ldap Attributes with Attributes property
             if (memberof != null)
             {
                 foreach (var member in memberof)
                 {
-                    var groupDN = $"{Encoding.UTF8.GetString((byte[])member)}";
-                    var nestedGroupCN = groupDN.Split(',')[0].Substring("CN=".Length);
-                    GetNestedGroups(connection, principal, distinguishedName, nestedGroupCN, logger, retrievedClaims);
+                    var nestedGroupDN = $"{Encoding.UTF8.GetString((byte[])member)}";
+                    var nestedGroupCN = nestedGroupDN.Split(',')[0].Substring("CN=".Length);
+
+                    if (processedGroups.Contains(nestedGroupDN))
+                    {
+                        // We need to keep track of already processed groups because circular references are possible with AD groups
+                        return;
+                    }
+
+                    GetNestedGroups(connection, principal, distinguishedName, nestedGroupCN, logger, retrievedClaims, processedGroups);
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR fixes a particular corner case which is possible in real-world AD deployments, namely circular group references.
That is, e.g. `GroupA -> GroupB -> GroupC -> GroupA`. This is a problematic scenario for [any software working with AD](https://serverfault.com/questions/351524/what-are-the-consequences-of-an-ad-group-that-has-as-its-member-a-group-that-is).

The fix is basically to keep track of groups that we already processed by recursively passing a `HashSet` containing already processed entries.

Fixes #37225
Fixes #38769