### PR TITLE
ModelMetadata doc: How to set Placeholder

### DIFF
--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -363,8 +363,8 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
     public abstract int Order { get; }
 
     /// <summary>
-    /// Gets the text to display as a placeholder value for an editor,
-    /// corresponding to <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Prompt" />.
+    /// Gets the text to display as a placeholder value for an editor.
+    /// By default, this is configured using <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Prompt" />.
     /// </summary>
     public abstract string? Placeholder { get; }
 

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -363,7 +363,8 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
     public abstract int Order { get; }
 
     /// <summary>
-    /// Gets the text to display as a placeholder value for an editor.
+    /// Gets the text to display as a placeholder value for an editor,
+    /// corresponding to <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute.Prompt" />.
     /// </summary>
     public abstract string? Placeholder { get; }
 


### PR DESCRIPTION
# ModelMetadata doc: How to set Placeholder

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Explain how to set [Placeholder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.modelbinding.modelmetadata.placeholder) using [Prompt](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.displayattribute.prompt).

## Description

The [default model metadata provider](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.modelbinding.metadata.defaultmodelmetadataprovider) takes the [Placeholder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.modelbinding.modelmetadata.placeholder) from [Prompt](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.displayattribute.prompt).

Not worth a bug.
