### PR TITLE
ContentResult doc: add links to properties

### DIFF
--- a/src/Mvc/Mvc.Core/src/ContentResult.cs
+++ b/src/Mvc/Mvc.Core/src/ContentResult.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.AspNetCore.Mvc;
 
 /// <summary>
-/// A <see cref="ActionResult"/> that when executed will produce a response with content.
+/// An <see cref="ActionResult"/> that when executed will produce a response with content.
 /// </summary>
 public class ContentResult : ActionResult, IStatusCodeActionResult
 {
@@ -19,7 +19,8 @@ public class ContentResult : ActionResult, IStatusCodeActionResult
     public string? Content { get; set; }
 
     /// <summary>
-    /// Gets or sets the Content-Type header for the response.
+    /// Gets or sets the Content-Type header for the response,
+    /// to be used as <see cref="Microsoft.AspNetCore.Http.Headers.ResponseHeaders.ContentType" />.
     /// </summary>
     public string? ContentType { get; set; }
 

--- a/src/Mvc/Mvc.Core/src/ContentResult.cs
+++ b/src/Mvc/Mvc.Core/src/ContentResult.cs
@@ -24,7 +24,7 @@ public class ContentResult : ActionResult, IStatusCodeActionResult
     public string? ContentType { get; set; }
 
     /// <summary>
-    /// Gets or sets the HTTP status code.
+    /// Gets or sets the <see cref="Microsoft.AspNetCore.Http.StatusCodes" >HTTP status code</see >.
     /// </summary>
     public int? StatusCode { get; set; }
 

--- a/src/Mvc/Mvc.Core/src/ContentResult.cs
+++ b/src/Mvc/Mvc.Core/src/ContentResult.cs
@@ -25,7 +25,7 @@ public class ContentResult : ActionResult, IStatusCodeActionResult
     public string? ContentType { get; set; }
 
     /// <summary>
-    /// Gets or sets the <see cref="Microsoft.AspNetCore.Http.StatusCodes" >HTTP status code</see >.
+    /// Gets or sets the <see cref="Microsoft.AspNetCore.Http.StatusCodes">HTTP status code</see>.
     /// </summary>
     public int? StatusCode { get; set; }
 


### PR DESCRIPTION
# ContentResult doc: see cref="StatusCodes", cref="ResponseHeaders"

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Add links to properties of [ContentResult](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.contentresult#definition) that would benefit from them.

## Description

1. Add a link to [StatusCodes](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.statuscodes) to the description of [ContentResult.StatusCode](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.contentresult.statuscode#definition).
2. Add a link to [ResponseHeaders.ContentType](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.headers.responseheaders.contenttype) to the description of [ContentResult.ContentType](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.contentresult.contenttype#definition).

Not worth a bug.
