### PR TITLE
StringOutputFormatter doc: explain how it works

### DIFF
--- a/src/Mvc/Mvc.Core/src/Formatters/StreamOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/StreamOutputFormatter.cs
@@ -8,7 +8,8 @@ using System.Threading.Tasks;
 namespace Microsoft.AspNetCore.Mvc.Formatters;
 
 /// <summary>
-/// Always copies the stream to the response, regardless of requested content type.
+/// Always copies the <see cref="T:System.IO.Stream" /> to the response,
+/// regardless of requested content type.
 /// </summary>
 public class StreamOutputFormatter : IOutputFormatter
 {

--- a/src/Mvc/Mvc.Core/src/Formatters/StringOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/StringOutputFormatter.cs
@@ -14,7 +14,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters;
 public class StringOutputFormatter : TextOutputFormatter
 {
     /// <summary>
-    /// Initializes a new <see cref="StringOutputFormatter"/>.
+    /// A brand new <see cref="StringOutputFormatter"/>
+    /// supports only plain text to be encoded as
+    /// <see cref="F:System.Text.Encoding.UTF8" />
+    /// or <see cref="F:System.Text.Encoding.Unicode" />.
     /// </summary>
     public StringOutputFormatter()
     {
@@ -23,7 +26,11 @@ public class StringOutputFormatter : TextOutputFormatter
         SupportedMediaTypes.Add("text/plain");
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Verifies that the object to be formatted is a <see langword="string" />
+    /// and proceeds with the standard checks of
+    /// <see cref="M:Microsoft.AspNetCore.Mvc.Formatters.OutputFormatter.CanWriteResult(OutputFormatterCanWriteContext)" />.
+    /// </summary>
     public override bool CanWriteResult(OutputFormatterCanWriteContext context)
     {
         if (context == null)

--- a/src/Mvc/Mvc.Core/src/Formatters/StringOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/StringOutputFormatter.cs
@@ -16,8 +16,8 @@ public class StringOutputFormatter : TextOutputFormatter
     /// <summary>
     /// A brand new <see cref="StringOutputFormatter"/>
     /// supports only plain text to be encoded as
-    /// <see cref="F:System.Text.Encoding.UTF8" />
-    /// or <see cref="F:System.Text.Encoding.Unicode" />.
+    /// <see cref="P:System.Text.Encoding.UTF8" />
+    /// or <see cref="P:System.Text.Encoding.Unicode" />.
     /// </summary>
     public StringOutputFormatter()
     {


### PR DESCRIPTION
# StringOutputFormatter doc: explain how it works

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Explain what a [StringOutputFormatter](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.formatters.stringoutputformatter) can format.

## Description

1. A standard [StringOutputFormatter](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.formatters.stringoutputformatter) can only format a `string` into media type `text/plain` encoded with [UTF8](https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding.utf8) or [Unicode](https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding.unicode).
2. Be specific about what a [Stream](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream) required by a [StreamOutputFormatter](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.formatters.streamoutputformatter) is.

Not worth a bug.
