### PR TITLE
Support overriding AuthorizeFilter.OnAuthorizationAsync(context) in more cases

### DIFF
--- a/src/Mvc/Mvc.Core/src/ApplicationModels/AuthorizationApplicationModelProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/AuthorizationApplicationModelProvider.cs
@@ -74,16 +74,25 @@ internal class AuthorizationApplicationModelProvider : IApplicationModelProvider
 
     public static AuthorizeFilter GetFilter(IAuthorizationPolicyProvider policyProvider, IEnumerable<IAuthorizeData> authData)
     {
-        // The default policy provider will make the same policy for given input, so make it only once.
-        // This will always execute synchronously.
-        if (policyProvider.GetType() == typeof(DefaultAuthorizationPolicyProvider))
+        if (GetPolicyIfDefaultProvider(policyProvider, authData) is AuthorizationPolicy policy)
         {
-            var policy = AuthorizationPolicy.CombineAsync(policyProvider, authData).GetAwaiter().GetResult()!;
             return new AuthorizeFilter(policy);
         }
         else
         {
             return new AuthorizeFilter(policyProvider, authData);
         }
+    }
+
+    // The default policy provider will make the same policy for given input, so make it only once.
+    // This will always execute synchronously.
+    public static AuthorizationPolicy? GetPolicyIfDefaultProvider(IAuthorizationPolicyProvider policyProvider, IEnumerable<IAuthorizeData> authData)
+    {
+        if (policyProvider.GetType() != typeof(DefaultAuthorizationPolicyProvider))
+        {
+            return null;
+        }
+
+        return AuthorizationPolicy.CombineAsync(policyProvider, authData).GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
Prior to this change, you could effectively override `AuthorizeFilter.OnAuthorizationAsync(context)` in a derived class only if you constructed the `AuthorizeFilter` with an `AuthorizationPolicy` or `IAuthorizationPolicyProvider`. This is because the `IFilterFactory.CreateInstance(IServiceProvicer)` implementation on `AuthorizeFilter.OnAuthorizationAsync(context)` would return a new `AuthorizeFilter` instance withouth the overridden method if both `Policy` and `PolicyProvider` were `null`.

With this change, `AuthorizeFilter` instead initializes the `Policy` or `PolicyProvider` on the current instance rather than the new one so the behavior of an overridden `OnAuthorizationAsync` method is preserved.

Fixes #30025