### PR TITLE
Using DictionaryKeyPolicy during ProblemDetails.Errors conversion to JSON

### DIFF
--- a/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
@@ -188,7 +188,7 @@ public class ValidationProblemDetailsJsonConverterTest
         var json = Encoding.UTF8.GetString(stream.ToArray());
 
         var expectedJSON = $"{{\"title\":\"{problemDetails.Title}\",\"status\":{problemDetails.Status}," +
-            "\"errors\":{\"property\":[\"error0\"],\"twoWords\":[\"error1\"],\"topLevelProperty.propertyName\":[\"error2\"]}}";
+            "\"errors\":{\"property\":[\"error0\"],\"twoWords\":[\"error1\"],\"topLevelProperty.PropertyName\":[\"error2\"]}}";
         Assert.NotNull(json);
         Assert.Equal(expectedJSON, json);
     }

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
@@ -146,7 +146,6 @@ public class ValidationProblemDetailsJsonConverterTest
             Status = 400
         };
 
-
         var converter = new ValidationProblemDetailsJsonConverter();
         using MemoryStream stream = new();
         using Utf8JsonWriter writer = new(stream);
@@ -157,7 +156,6 @@ public class ValidationProblemDetailsJsonConverterTest
         writer.Flush();
         var json = Encoding.UTF8.GetString(stream.ToArray());
 
-
         var expectedJSON = $"{{\"title\":\"{problemDetails.Title}\",\"status\":{problemDetails.Status}," +
             "\"errors\":{\"Property\":[\"error0\"]}}";
         Assert.NotNull(json);
@@ -167,7 +165,6 @@ public class ValidationProblemDetailsJsonConverterTest
     [Fact]
     public void WriteUsingJsonSerializerOptionsWorks()
     {
-
         var errors = new Dictionary<string, string[]>()
         {
             { "Property",  new string[]{ "error0" } },
@@ -197,6 +194,5 @@ public class ValidationProblemDetailsJsonConverterTest
             "\"errors\":{\"property\":[\"error0\"],\"twoWords\":[\"error1\"],\"topLevelProperty.propertyName\":[\"error2\"]}}";
         Assert.NotNull(json);
         Assert.Equal(expectedJSON, json);
-
     }
 }

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+
 using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -134,5 +135,68 @@ public class ValidationProblemDetailsJsonConverterTest
                 Assert.Equal("key1", kvp.Key);
                 Assert.Equal(new[] { "error1", "error2" }, kvp.Value);
             });
+    }
+
+    [Fact]
+    public void WriteWorks()
+    {
+        var problemDetails = new ValidationProblemDetails(new Dictionary<string, string[]>() { { "Property",  new string[]{ "error0" } }})
+        {
+            Title  = "One or more validation errors occurred.",
+            Status = 400
+        };
+
+
+        var converter = new ValidationProblemDetailsJsonConverter();
+        using MemoryStream stream = new();
+        using Utf8JsonWriter writer = new(stream);
+
+        // Act
+        converter.Write(writer, problemDetails, null);
+
+        writer.Flush();
+        var json = Encoding.UTF8.GetString(stream.ToArray());
+
+
+        var expectedJSON = $"{{\"title\":\"{problemDetails.Title}\",\"status\":{problemDetails.Status}," +
+            "\"errors\":{\"Property\":[\"error0\"]}}";
+        Assert.NotNull(json);
+        Assert.Equal(expectedJSON, json);
+    }
+
+    [Fact]
+    public void WriteUsingJsonSerializerOptionsWorks()
+    {
+
+        var errors = new Dictionary<string, string[]>()
+        {
+            { "Property",  new string[]{ "error0" } },
+            { "TwoWords",  new string[]{ "error1" } },
+            { "TopLevelProperty.PropertyName",  new string[]{ "error2" } },
+        };
+        var problemDetails = new ValidationProblemDetails(errors)
+        {
+            Title  = "One or more validation errors occurred.",
+            Status = 400
+        };
+
+        // Act
+        var converter = new ValidationProblemDetailsJsonConverter();
+        using MemoryStream stream = new();
+        using Utf8JsonWriter writer = new(stream);
+
+        var options = new JsonOptions().JsonSerializerOptions;
+        options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
+
+        converter.Write(writer, problemDetails, options);
+
+        writer.Flush();
+        var json = Encoding.UTF8.GetString(stream.ToArray());
+
+        var expectedJSON = $"{{\"title\":\"{problemDetails.Title}\",\"status\":{problemDetails.Status}," +
+            "\"errors\":{\"property\":[\"error0\"],\"twoWords\":[\"error1\"],\"topLevelProperty.propertyName\":[\"error2\"]}}";
+        Assert.NotNull(json);
+        Assert.Equal(expectedJSON, json);
+
     }
 }

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
@@ -1,11 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
 using System.Text;
 using System.Text.Json;
-
-using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 

--- a/src/Shared/HttpValidationProblemDetailsJsonConverter.cs
+++ b/src/Shared/HttpValidationProblemDetailsJsonConverter.cs
@@ -8,7 +8,6 @@ namespace Microsoft.AspNetCore.Http;
 
 internal sealed class HttpValidationProblemDetailsJsonConverter : JsonConverter<HttpValidationProblemDetails>
 {
-    private const char propertySeparator = '.';
     private static readonly JsonEncodedText Errors = JsonEncodedText.Encode("errors");
 
     public override HttpValidationProblemDetails Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -61,29 +60,8 @@ internal sealed class HttpValidationProblemDetailsJsonConverter : JsonConverter<
         writer.WriteStartObject();
         ProblemDetailsJsonConverter.WriteProblemDetails(writer, value, options);
 
-        static string ConvertName(string name, JsonSerializerOptions options)
-        {
-            if (string.IsNullOrEmpty(name) || options?.DictionaryKeyPolicy == null)
-            {
-                return name;
-            }
-
-            var tokens = name.Split(propertySeparator);
-            for (var i = 0; i < tokens.Length; i++)
-            {
-                tokens[i] = options!.DictionaryKeyPolicy.ConvertName(tokens[i]);
-            }
-
-            return string.Join(propertySeparator, tokens);
-        }
-
-        writer.WriteStartObject(Errors);
-        foreach (var kvp in value.Errors)
-        {
-            writer.WritePropertyName(ConvertName(kvp.Key, options));
-            JsonSerializer.Serialize(writer, kvp.Value, kvp.Value?.GetType() ?? typeof(object), options);
-        }
-        writer.WriteEndObject();
+        writer.WritePropertyName(Errors);
+        JsonSerializer.Serialize(writer, value.Errors, options);
 
         writer.WriteEndObject();
     }


### PR DESCRIPTION
# Using DictionaryKeyPolicy during ProblemDetails.Errors conversion to JSON

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Adding a call to `options!.DictionaryKeyPolicy.ConvertName` during the `WriteProblemDetails`

## Description

With this change the `HttpValidationProblemDetailsJsonConverter` will rely on the configured `JsonSerializerOptions` to convert the `ProblemDetails.Errors` property to JSON.

The `JsonSerializerOptions` could be configured with the following code:

 ```
services.AddControllers().AddJsonOptions(options => 
{ 
     options.JsonSerializerOptions.DictionaryKeyPolicy = System.Text.Json.JsonNamingPolicy.CamelCase;
 });
```

After the change the following results are expected:

### Model State errors

- **Name** - "The Name field is required."
- **PostalCode** - "The field PostalCode must be between 1 and 99999."
- **SubClass.Test1** - "The field Test1 must be between 1 and 10."

### Without option

``` json
{
    "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
    "title": "One or more validation errors occurred.",
    "status": 400,
    "traceId": "00-16743847660da7bda8bae57cb9266ab9-5318f21ebc12e9fb-00",
    "errors": {
        "Name": [
            "The Name field is required."
        ],
        "PostalCode": [
            "The field PostalCode must be between 1 and 99999."
        ],
        "SubClass.Test1": [
            "The field Test1 must be between 1 and 10."
        ]
    }
}
```

### With `camelCase` option

``` json
{
    "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
    "title": "One or more validation errors occurred.",
    "status": 400,
    "traceId": "00-66c52afd589aa7c8b7ffcbbdf847c992-c02ee1425c580f24-00",
    "errors": {
        "name": [
            "The Name field is required."
        ],
        "postalCode": [
            "The field PostalCode must be between 1 and 99999."
        ],
        "subClass.Test1": [
            "The field Test1 must be between 1 and 10."
        ]
    }
}

```
#17999
