### PR TITLE
Fix RedisCache update that breaks usage against older redis servers

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -29,7 +29,7 @@ public class RedisCache : IDistributedCache, IDisposable
     // ARGV[3] = relative-expiration (long, in seconds, -1 for none) - Min(absolute-expiration - Now, sliding-expiration)
     // ARGV[4] = data - byte[]
     // this order should not change LUA script depends on it
-    private const string LatestSetScript = (@"
+    private const string SetScriptPerExtendedSetCommand = (@"
                 redis.call('HSET', KEYS[1], 'absexp', ARGV[1], 'sldexp', ARGV[2], 'data', ARGV[4])
                 if ARGV[3] ~= '-1' then
                   redis.call('EXPIRE', KEYS[1], ARGV[3])
@@ -51,7 +51,7 @@ public class RedisCache : IDistributedCache, IDisposable
     private volatile IConnectionMultiplexer _connection;
     private IDatabase _cache;
     private bool _disposed;
-    private string _setScript = LatestSetScript;
+    private string _setScript = SetScriptPerExtendedSetCommand;
 
     private readonly RedisCacheOptions _options;
     private readonly string _instance;

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -274,10 +274,7 @@ public class RedisCache : IDistributedCache, IDisposable
 
     private void ValidateServerFeatures()
     {
-        if (_connection is null)
-        {
-            return;
-        }
+        _ = _connection ?? throw new InvalidOperationException($"{nameof(_connection)} cannot be null.");
 
         foreach (var endPoint in _connection.GetEndPoints())
         {
@@ -291,7 +288,9 @@ public class RedisCache : IDistributedCache, IDisposable
 
     private void TryRegisterProfiler()
     {
-        if (_connection != null && _options.ProfilingSession != null)
+        _ = _connection ?? throw new InvalidOperationException($"{nameof(_connection)} cannot be null.");
+
+        if (_options.ProfilingSession != null)
         {
             _connection.RegisterProfiler(_options.ProfilingSession);
         }

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -16,6 +16,13 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis;
 /// </summary>
 public class RedisCache : IDistributedCache, IDisposable
 {
+    // -- Explanation of why two kinds of SetScript are used --
+    // * Redis 2.0 had HSET key field value for setting individual hash fields,
+    // and HMSET key field value [field value ...] for setting multiple hash fields (against the same key)
+    // * Redis 4.0 observes this redundancy, and adds HSET key field value [field value ...],
+    // and also marks HMSET as deprecated, although it still works fine.
+    // But HSET doesn't allows multiple field/value pairs for Redis prior 4.0.
+
     // KEYS[1] = = key
     // ARGV[1] = absolute-expiration - ticks as long (-1 for none)
     // ARGV[2] = sliding-expiration - ticks as long (-1 for none)

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -22,7 +22,7 @@ public class RedisCache : IDistributedCache, IDisposable
     // ARGV[3] = relative-expiration (long, in seconds, -1 for none) - Min(absolute-expiration - Now, sliding-expiration)
     // ARGV[4] = data - byte[]
     // this order should not change LUA script depends on it
-    private const string RegularSetScript = (@"
+    private const string LatestSetScript = (@"
                 redis.call('HSET', KEYS[1], 'absexp', ARGV[1], 'sldexp', ARGV[2], 'data', ARGV[4])
                 if ARGV[3] ~= '-1' then
                   redis.call('EXPIRE', KEYS[1], ARGV[3])
@@ -39,12 +39,12 @@ public class RedisCache : IDistributedCache, IDisposable
     private const string SlidingExpirationKey = "sldexp";
     private const string DataKey = "data";
     private const long NotPresent = -1;
-    private readonly Version ServerVersionWithExtendedSetCommand = new Version(4, 0, 0);
+    private static readonly Version ServerVersionWithExtendedSetCommand = new Version(4, 0, 0);
 
     private volatile IConnectionMultiplexer _connection;
     private IDatabase _cache;
     private bool _disposed;
-    private string _setScript = RegularSetScript;
+    private string _setScript = LatestSetScript;
 
     private readonly RedisCacheOptions _options;
     private readonly string _instance;


### PR DESCRIPTION
### Summary of the changes
Checking Redis version and then calling the right API.

A couple of questions:
- Is it necessary to log the switch to the old API?
- What to do with integration tests? They are currently disabled.

Fixes #38715
