### PR TITLE
Microsoft.AspNetCore.Http: Decorate priorFeature as nullable on StreamResponseBodyFeature ctor

### DIFF
--- a/src/Http/Http/src/PublicAPI.Shipped.txt
+++ b/src/Http/Http/src/PublicAPI.Shipped.txt
@@ -255,7 +255,6 @@ Microsoft.AspNetCore.Http.StreamResponseBodyFeature.Dispose() -> void
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.PriorFeature.get -> Microsoft.AspNetCore.Http.Features.IHttpResponseBodyFeature?
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.Stream.get -> System.IO.Stream!
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.StreamResponseBodyFeature(System.IO.Stream! stream) -> void
-Microsoft.AspNetCore.Http.StreamResponseBodyFeature.StreamResponseBodyFeature(System.IO.Stream! stream, Microsoft.AspNetCore.Http.Features.IHttpResponseBodyFeature! priorFeature) -> void
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.Writer.get -> System.IO.Pipelines.PipeWriter!
 Microsoft.Extensions.DependencyInjection.HttpServiceCollectionExtensions
 override Microsoft.AspNetCore.Http.BindingAddress.Equals(object? obj) -> bool

--- a/src/Http/Http/src/PublicAPI.Shipped.txt
+++ b/src/Http/Http/src/PublicAPI.Shipped.txt
@@ -255,6 +255,7 @@ Microsoft.AspNetCore.Http.StreamResponseBodyFeature.Dispose() -> void
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.PriorFeature.get -> Microsoft.AspNetCore.Http.Features.IHttpResponseBodyFeature?
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.Stream.get -> System.IO.Stream!
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.StreamResponseBodyFeature(System.IO.Stream! stream) -> void
+Microsoft.AspNetCore.Http.StreamResponseBodyFeature.StreamResponseBodyFeature(System.IO.Stream! stream, Microsoft.AspNetCore.Http.Features.IHttpResponseBodyFeature! priorFeature) -> void
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.Writer.get -> System.IO.Pipelines.PipeWriter!
 Microsoft.Extensions.DependencyInjection.HttpServiceCollectionExtensions
 override Microsoft.AspNetCore.Http.BindingAddress.Equals(object? obj) -> bool

--- a/src/Http/Http/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Http.StreamResponseBodyFeature.StreamResponseBodyFeature(System.IO.Stream! stream, Microsoft.AspNetCore.Http.Features.IHttpResponseBodyFeature? priorFeature) -> void

--- a/src/Http/Http/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Http.StreamResponseBodyFeature.StreamResponseBodyFeature(System.IO.Stream! stream, Microsoft.AspNetCore.Http.Features.IHttpResponseBodyFeature! priorFeature) -> void
 Microsoft.AspNetCore.Http.StreamResponseBodyFeature.StreamResponseBodyFeature(System.IO.Stream! stream, Microsoft.AspNetCore.Http.Features.IHttpResponseBodyFeature? priorFeature) -> void

--- a/src/Http/Http/src/StreamResponseBodyFeature.cs
+++ b/src/Http/Http/src/StreamResponseBodyFeature.cs
@@ -34,7 +34,7 @@ public class StreamResponseBodyFeature : IHttpResponseBodyFeature
     /// </summary>
     /// <param name="stream"></param>
     /// <param name="priorFeature"></param>
-    public StreamResponseBodyFeature(Stream stream, IHttpResponseBodyFeature priorFeature)
+    public StreamResponseBodyFeature(Stream stream, IHttpResponseBodyFeature? priorFeature)
     {
         Stream = stream ?? throw new ArgumentNullException(nameof(stream));
         PriorFeature = priorFeature;


### PR DESCRIPTION
Passing `null` for `priorFeature` seems to be a totally valid case for `StreamResponseBodyFeature` but the parameter isn't flagged as nullable.

What I want to do is this:
```csharp
var redirectedResponseBodyFeature = new StreamResponseBodyFeature(new MemoryStream(), context.Features.Get<IHttpResponseBodyFeature>());
```

But to make it happy (as far as nullable analysis warnings go) I have to do:
```csharp
var priorFeature = context.Features.Get<IHttpResponseBodyFeature>();
var redirectedResponseBodyFeature = priorFeature == null
   ? new StreamResponseBodyFeature(new MemoryStream())
   : new StreamResponseBodyFeature(new MemoryStream(), priorFeature);
```