### PR TITLE
Avoid sending a PR if there's already one open

### DIFF
--- a/.github/workflows/ReportDiff.ps1
+++ b/.github/workflows/ReportDiff.ps1
@@ -28,7 +28,7 @@ $issue = $issue + '/comments'
 $result = Invoke-RestMethod -Method POST -Headers $Headers -Uri $issue -Body $json
 
 # Check if there's an open PR in AspNetCore or Runtime to resolve this difference.
-$sendPr = $true
+$sendpr = $true
 $Headers = @{ Accept = 'application/vnd.github.v3+json' };
 
 $prsLink = "https://api.github.com/repos/dotnet/aspnetcore/pulls?state=open"
@@ -36,8 +36,8 @@ $result = Invoke-RestMethod -Method GET -Headers $Headers -Uri $prsLink
 
 foreach ($pr in $result) {
   if ($pr.body -And $pr.body.Contains("Fixes #18943")) {
-    $sendPr = $false
-    return $sendPr
+    $sendpr = $false
+    return $sendpr
   }
 }
 
@@ -46,9 +46,9 @@ $result = Invoke-RestMethod -Method GET -Headers $Headers -Uri $prsLink
 
 foreach ($pr in $result) {
   if ($pr.body -And $pr.body.Contains("Fixes https://github.com/dotnet/aspnetcore/issues/18943")) {
-    $sendPr = $false
-    return $sendPr
+    $sendpr = $false
+    return $sendpr
   }
 }
 
-return $sendPr
+return $sendpr

--- a/.github/workflows/ReportDiff.ps1
+++ b/.github/workflows/ReportDiff.ps1
@@ -26,4 +26,29 @@ $diff
 $json = ConvertTo-Json -InputObject @{ 'body' = $body }
 $issue = $issue + '/comments'
 $result = Invoke-RestMethod -Method POST -Headers $Headers -Uri $issue -Body $json
-return $changed
+
+# Check if there's an open PR in AspNetCore or Runtime to resolve this difference.
+$sendPr = $true
+$Headers = @{ Accept = 'application/vnd.github.v3+json' };
+
+$prsLink = "https://api.github.com/repos/dotnet/aspnetcore/pulls?state=open"
+$result = Invoke-RestMethod -Method GET -Headers $Headers -Uri $prsLink
+
+foreach ($pr in $result) {
+  if ($pr.body -And $pr.body.Contains("Fixes #18943")) {
+    $sendPr = $false
+    return $sendPr
+  }
+}
+
+$prsLink = "https://api.github.com/repos/dotnet/runtime/pulls?state=open"
+$result = Invoke-RestMethod -Method GET -Headers $Headers -Uri $prsLink
+
+foreach ($pr in $result) {
+  if ($pr.body -And $pr.body.Contains("Fixes https://github.com/dotnet/aspnetcore/issues/18943")) {
+    $sendPr = $false
+    return $sendPr
+  }
+}
+
+return $sendPr

--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -59,10 +59,10 @@ jobs:
       run: |
         # Test this script using an issue in the local forked repo
         $issue = 'https://api.github.com/repos/dotnet/aspnetcore/issues/18943'
-        $changed = .\aspnetcore\.github\workflows\ReportDiff.ps1
-        echo "::set-output name=changed::$changed"
+        $sendpr = .\aspnetcore\.github\workflows\ReportDiff.ps1
+        echo "::set-output name=sendpr::$sendpr"
     - name: Send PR
-      if: steps.check.outputs.changed == 'true'
+      if: steps.check.outputs.sendpr == 'true'
       # https://github.com/marketplace/actions/create-pull-request
       uses: dotnet/actions-create-pull-request@v3
       with:


### PR DESCRIPTION
This addresses feedback with the github action sync script that it should not create duplicate PRs if there's already one open in AspNetCore or Runtime. To do that we scan for open PRs that claim to fix #18943.