### PR TITLE
Turn off parallelization on new long iis tests

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.LongTests/AssemblyInfo.cs
+++ b/src/Servers/IIS/IIS/test/IIS.LongTests/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: RequiresIIS]
+[assembly: ShortClassName]


### PR DESCRIPTION
These were running in parallel it appears:

https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-aspnetcore-refs-pull-38865-merge-fc55278bd6fa4c3992/IIS.LongTests--net7.0/1/console.9223b195.log?sv=2019-07-07&se=2021-12-27T22%3A19%3A25Z&sr=c&sp=rl&sig=P7CWJn4cwInTdHI8c67glCm5gwXkFXEgqreNXjn1TjE%3D

[xUnit.net 00:00:00.74]   Starting:    IIS.LongTests (parallel test collections = on, max threads = 2)