### PR TITLE
Kestrel HTTP 1/1: Set 'Connection: close' header when produces 413 Payload too large

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -241,6 +241,7 @@ internal sealed class Http1ContentLengthMessageBody : Http1MessageBody
         var maxRequestBodySize = _context.MaxRequestBodySize;
         if (_contentLength > maxRequestBodySize)
         {
+            _context.SetKeepAliveToClose();
             KestrelBadHttpRequestException.Throw(RequestRejectionReason.RequestBodyTooLarge, maxRequestBodySize.GetValueOrDefault().ToString(CultureInfo.InvariantCulture));
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -241,7 +241,7 @@ internal sealed class Http1ContentLengthMessageBody : Http1MessageBody
         var maxRequestBodySize = _context.MaxRequestBodySize;
         if (_contentLength > maxRequestBodySize)
         {
-            _context.SetKeepAliveToClose();
+            _context.DisableHttp1KeepAlive();
             KestrelBadHttpRequestException.Throw(RequestRejectionReason.RequestBodyTooLarge, maxRequestBodySize.GetValueOrDefault().ToString(CultureInfo.InvariantCulture));
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1321,6 +1321,11 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
                 ? target.GetAsciiStringEscaped(Constants.MaxExceptionDetailSize)
                 : string.Empty);
 
+    public void SetKeepAliveToClose()
+    {
+        _keepAlive = false;
+    }
+
     public void SetBadRequestState(BadHttpRequestException ex)
     {
         Log.ConnectionBadRequest(ConnectionId, ex);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1321,9 +1321,12 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
                 ? target.GetAsciiStringEscaped(Constants.MaxExceptionDetailSize)
                 : string.Empty);
 
-    public void SetKeepAliveToClose()
+    public void DisableHttp1KeepAlive()
     {
-        _keepAlive = false;
+        if (_httpVersion == Http.HttpVersion.Http10 || _httpVersion == Http.HttpVersion.Http11)
+        {
+            _keepAlive = false;
+        }
     }
 
     public void SetBadRequestState(BadHttpRequestException ex)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1321,6 +1321,8 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
                 ? target.GetAsciiStringEscaped(Constants.MaxExceptionDetailSize)
                 : string.Empty);
 
+    // This is called during certain bad requests so the automatic Connection: close header gets sent with custom responses.
+    // If no response is written, SetBadRequestState(BadHttpRequestException) will later also modify the status code.
     public void DisableHttp1KeepAlive()
     {
         if (_httpVersion == Http.HttpVersion.Http10 || _httpVersion == Http.HttpVersion.Http11)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
@@ -190,7 +190,7 @@ internal abstract class MessageBody
         var maxRequestBodySize = _context.MaxRequestBodySize;
         if (_observedBytes > maxRequestBodySize)
         {
-            _context.SetKeepAliveToClose();
+            _context.DisableHttp1KeepAlive();
             KestrelBadHttpRequestException.Throw(RequestRejectionReason.RequestBodyTooLarge, maxRequestBodySize.GetValueOrDefault().ToString(CultureInfo.InvariantCulture));
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
@@ -190,6 +190,7 @@ internal abstract class MessageBody
         var maxRequestBodySize = _context.MaxRequestBodySize;
         if (_observedBytes > maxRequestBodySize)
         {
+            _context.SetKeepAliveToClose();
             KestrelBadHttpRequestException.Throw(RequestRejectionReason.RequestBodyTooLarge, maxRequestBodySize.GetValueOrDefault().ToString(CultureInfo.InvariantCulture));
         }
     }


### PR DESCRIPTION
# Set 'Connection: close' header when produces 413 Payload too large

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description
Created the `SetKeepAliveToClose` method to change the field `_keepAlive` to false and called from both classes `Http1ContentLengthMessageBody` and `MessageBody` (for chunked requests) when th request body size exceeds the `MaxRequestBodySize`

## Scenario:
This fix the send of the `Connection: close` header when the max request size body has been exceeded and the application catches the `BadHttpRequestException` exception

## Design Proposal:

@Tratcher:
> When kestrel hits the hard size limit and is about to throw the BadRequestException, it should first set keepalive=false on that request. That will allow the normal response logic to generate the Connection: close header where appropriate. This isn't dependent on the final status code.

Fixes the issue: [#31169](https://github.com/dotnet/aspnetcore/issues/31169)
