### PR TITLE
Remove unnecessary unicode control characters

### DIFF
--- a/src/Http/Http/src/Features/FormOptions.cs
+++ b/src/Http/Http/src/Features/FormOptions.cs
@@ -15,25 +15,25 @@ public class FormOptions
 
     /// <summary>
     /// Default value for <see cref="MemoryBufferThreshold"/>.
-    /// Defaults to 65,536 bytes‬, which is approximately 64KB.
+    /// Defaults to 65,536 bytes, which is approximately 64KB.
     /// </summary>
     public const int DefaultMemoryBufferThreshold = 1024 * 64;
 
     /// <summary>
     /// Default value for <see cref="BufferBodyLengthLimit"/>.
-    /// Defaults to 134,217,728 bytes‬, which is 128MB.
+    /// Defaults to 134,217,728 bytes, which is 128MB.
     /// </summary>
     public const int DefaultBufferBodyLengthLimit = 1024 * 1024 * 128;
 
     /// <summary>
     /// Default value for <see cref="MultipartBoundaryLengthLimit"/>.
-    /// Defaults to 128 bytes‬.
+    /// Defaults to 128 bytes.
     /// </summary>
     public const int DefaultMultipartBoundaryLengthLimit = 128;
 
     /// <summary>
     /// Default value for <see cref="MultipartBodyLengthLimit "/>.
-    /// Defaults to 134,217,728 bytes‬, which is approximately 128MB.
+    /// Defaults to 134,217,728 bytes, which is approximately 128MB.
     /// </summary>
     public const long DefaultMultipartBodyLengthLimit = 1024 * 1024 * 128;
 
@@ -47,14 +47,14 @@ public class FormOptions
     /// If <see cref="BufferBody"/> is enabled, this many bytes of the body will be buffered in memory.
     /// If this threshold is exceeded then the buffer will be moved to a temp file on disk instead.
     /// This also applies when buffering individual multipart section bodies.
-    /// Defaults to 65,536 bytes‬, which is approximately 64KB.
+    /// Defaults to 65,536 bytes, which is approximately 64KB.
     /// </summary>
     public int MemoryBufferThreshold { get; set; } = DefaultMemoryBufferThreshold;
 
     /// <summary>
     /// If <see cref="BufferBody"/> is enabled, this is the limit for the total number of bytes that will
     /// be buffered. Forms that exceed this limit will throw an <see cref="InvalidDataException"/> when parsed.
-    /// Defaults to 134,217,728 bytes‬, which is approximately 128MB.
+    /// Defaults to 134,217,728 bytes, which is approximately 128MB.
     /// </summary>
     public long BufferBodyLengthLimit { get; set; } = DefaultBufferBodyLengthLimit;
 
@@ -68,21 +68,21 @@ public class FormOptions
     /// <summary>
     /// A limit on the length of individual keys. Forms containing keys that exceed this limit will
     /// throw an <see cref="InvalidDataException"/> when parsed.
-    /// Defaults to 2,048 bytes‬, which is approximately 2KB.
+    /// Defaults to 2,048 bytes, which is approximately 2KB.
     /// </summary>
     public int KeyLengthLimit { get; set; } = FormReader.DefaultKeyLengthLimit;
 
     /// <summary>
     /// A limit on the length of individual form values. Forms containing values that exceed this
     /// limit will throw an <see cref="InvalidDataException"/> when parsed.
-    /// Defaults to 4,194,304 bytes‬, which is approximately 4MB.
+    /// Defaults to 4,194,304 bytes, which is approximately 4MB.
     /// </summary>
     public int ValueLengthLimit { get; set; } = FormReader.DefaultValueLengthLimit;
 
     /// <summary>
     /// A limit for the length of the boundary identifier. Forms with boundaries that exceed this
     /// limit will throw an <see cref="InvalidDataException"/> when parsed.
-    /// Defaults to 128 bytes‬.
+    /// Defaults to 128 bytes.
     /// </summary>
     public int MultipartBoundaryLengthLimit { get; set; } = DefaultMultipartBoundaryLengthLimit;
 
@@ -97,14 +97,14 @@ public class FormOptions
     /// <summary>
     /// A limit for the total length of the header keys and values in each multipart section.
     /// Form sections that exceed this limit will throw an <see cref="InvalidDataException"/> when parsed.
-    /// Defaults to 16,384‬ bytes‬, which is approximately 16KB.
+    /// Defaults to 16,384 bytes, which is approximately 16KB.
     /// </summary>
     public int MultipartHeadersLengthLimit { get; set; } = MultipartReader.DefaultHeadersLengthLimit;
 
     /// <summary>
     /// A limit for the length of each multipart body. Forms sections that exceed this limit will throw an
     /// <see cref="InvalidDataException"/> when parsed.
-    /// Defaults to 134,217,728 bytes‬, which is approximately 128MB.
+    /// Defaults to 134,217,728 bytes, which is approximately 128MB.
     /// </summary>
     public long MultipartBodyLengthLimit { get; set; } = DefaultMultipartBodyLengthLimit;
 }

--- a/src/Http/WebUtilities/src/FormReader.cs
+++ b/src/Http/WebUtilities/src/FormReader.cs
@@ -26,13 +26,13 @@ public class FormReader : IDisposable
 
     /// <summary>
     /// Gets the default value for <see cref="KeyLengthLimit"/>.
-    /// Defaults to 2,048 bytes‬, which is approximately 2KB.
+    /// Defaults to 2,048 bytes, which is approximately 2KB.
     /// </summary>
     public const int DefaultKeyLengthLimit = 1024 * 2;
 
     /// <summary>
     /// Gets the default value for <see cref="ValueLengthLimit" />.
-    /// Defaults to 4,194,304 bytes‬, which is approximately 4MB.
+    /// Defaults to 4,194,304 bytes, which is approximately 4MB.
     /// </summary>
     public const int DefaultValueLengthLimit = 1024 * 1024 * 4;
 

--- a/src/Http/WebUtilities/src/MultipartReader.cs
+++ b/src/Http/WebUtilities/src/MultipartReader.cs
@@ -19,13 +19,13 @@ public class MultipartReader
 {
     /// <summary>
     /// Gets the default value for <see cref="HeadersCountLimit"/>.
-    /// Defaults to 16‬.
+    /// Defaults to 16.
     /// </summary>
     public const int DefaultHeadersCountLimit = 16;
 
     /// <summary>
     /// Gets the default value for <see cref="HeadersLengthLimit"/>.
-    /// Defaults to 16,384‬ bytes‬, which is approximately 16KB.
+    /// Defaults to 16,384 bytes, which is approximately 16KB.
     /// </summary>
     public const int DefaultHeadersLengthLimit = 1024 * 16;
     private const int DefaultBufferSize = 1024 * 4;


### PR DESCRIPTION
https://trojansource.codes/ demonstrated that unicode control characters could be used in attacks. Now most IDEs, editors and code browsers (including GitHub) warn about these.

Delete these from source to remove a source of confusion for anyone going through this code.

The characters were introduced by https://github.com/dotnet/aspnetcore/pull/32245 and you can see an
example of the warnings shown by GitHub here: https://github.com/dotnet/aspnetcore/blob/69308dafeda51d5301396c88ba9136a6da97c7b6/src/Http/Http/src/Features/FormOptions.cs