### PR TITLE
Override default MicrosoftNETTestSdkVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -187,6 +187,11 @@
     <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildUtilitiesCoreVersion>16.9.0</MicrosoftBuildUtilitiesCoreVersion>
     <!--
+      Temporarily override the Microsoft.NET.Test.Sdk version Arcade defaults to. That's incompatible w/ test
+      framework in current .NET SDKs.
+    -->
+    <MicrosoftNETTestSdkVersion>17.1.0-preview-20211109-03</MicrosoftNETTestSdkVersion>
+    <!--
       Versions of Microsoft.CodeAnalysis packages referenced by analyzers shipped in the SDK.
       This need to be pinned since they're used in 3.1 apps and need to be loadable in VS 2019.
     -->


### PR DESCRIPTION
May still need this to allow debian11 tests to succeed in helix-matrix. Contingent on https://dev.azure.com/dnceng/public/_build/results?buildId=1505436&view=results.