### PR TITLE
Fix RedisCache update that breaks usage against older redis servers 

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -16,14 +16,27 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
     /// </summary>
     public class RedisCache : IDistributedCache, IDisposable
     {
+        // -- Explanation of why two kinds of SetScript are used --
+        // * Redis 2.0 had HSET key field value for setting individual hash fields,
+        // and HMSET key field value [field value ...] for setting multiple hash fields (against the same key)
+        // * Redis 4.0 observes this redundancy, and adds HSET key field value [field value ...],
+        // and also marks HMSET as deprecated, although it still works fine.
+        // But HSET doesn't allows multiple field/value pairs for Redis prior 4.0.
+
         // KEYS[1] = = key
         // ARGV[1] = absolute-expiration - ticks as long (-1 for none)
         // ARGV[2] = sliding-expiration - ticks as long (-1 for none)
         // ARGV[3] = relative-expiration (long, in seconds, -1 for none) - Min(absolute-expiration - Now, sliding-expiration)
         // ARGV[4] = data - byte[]
         // this order should not change LUA script depends on it
-        private const string SetScript = (@"
+        private const string SetScriptPerExtendedSetCommand = (@"
                 redis.call('HSET', KEYS[1], 'absexp', ARGV[1], 'sldexp', ARGV[2], 'data', ARGV[4])
+                if ARGV[3] ~= '-1' then
+                  redis.call('EXPIRE', KEYS[1], ARGV[3])
+                end
+                return 1");
+        private const string DeprecatedSetScript = (@"
+                redis.call('HMSET', KEYS[1], 'absexp', ARGV[1], 'sldexp', ARGV[2], 'data', ARGV[4])
                 if ARGV[3] ~= '-1' then
                   redis.call('EXPIRE', KEYS[1], ARGV[3])
                 end
@@ -32,10 +45,12 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
         private const string SlidingExpirationKey = "sldexp";
         private const string DataKey = "data";
         private const long NotPresent = -1;
+        private static readonly Version ServerVersionWithExtendedSetCommand = new Version(4, 0, 0);
 
         private volatile IConnectionMultiplexer _connection;
         private IDatabase _cache;
         private bool _disposed;
+        private string _setScript = SetScriptPerExtendedSetCommand;
 
         private readonly RedisCacheOptions _options;
         private readonly string _instance;
@@ -107,7 +122,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             var absoluteExpiration = GetAbsoluteExpiration(creationTime, options);
 
-            var result = _cache.ScriptEvaluate(SetScript, new RedisKey[] { _instance + key },
+            var result = _cache.ScriptEvaluate(_setScript, new RedisKey[] { _instance + key },
                 new RedisValue[]
                 {
                         absoluteExpiration?.Ticks ?? NotPresent,
@@ -143,7 +158,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
 
             var absoluteExpiration = GetAbsoluteExpiration(creationTime, options);
 
-            await _cache.ScriptEvaluateAsync(SetScript, new RedisKey[] { _instance + key },
+            await _cache.ScriptEvaluateAsync(_setScript, new RedisKey[] { _instance + key },
                 new RedisValue[]
                 {
                         absoluteExpiration?.Ticks ?? NotPresent,
@@ -206,7 +221,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
                         _connection = _options.ConnectionMultiplexerFactory().GetAwaiter().GetResult();
                     }
 
-                    TryRegisterProfiler();
+                    PrepareConnection();
                     _cache = _connection.GetDatabase();
                 }
             }
@@ -247,7 +262,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
                         _connection = await _options.ConnectionMultiplexerFactory();
                     }
 
-                    TryRegisterProfiler();
+                    PrepareConnection();
                     _cache = _connection.GetDatabase();
                 }
             }
@@ -257,9 +272,31 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis
             }
         }
 
+        private void PrepareConnection()
+        {
+            ValidateServerFeatures();
+            TryRegisterProfiler();
+        }
+
+        private void ValidateServerFeatures()
+        {
+            _ = _connection ?? throw new InvalidOperationException($"{nameof(_connection)} cannot be null.");
+
+            foreach (var endPoint in _connection.GetEndPoints())
+            {
+                if (_connection.GetServer(endPoint).Version < ServerVersionWithExtendedSetCommand)
+                {
+                    _setScript = DeprecatedSetScript;
+                    return;
+                }
+            }
+        }
+
         private void TryRegisterProfiler()
         {
-            if (_connection != null && _options.ProfilingSession != null)
+            _ = _connection ?? throw new InvalidOperationException($"{nameof(_connection)} cannot be null.");
+
+            if (_options.ProfilingSession != null)
             {
                 _connection.RegisterProfiler(_options.ProfilingSession);
             }


### PR DESCRIPTION
# Fix RedisCache update that breaks usage against older redis servers

Add version checks and alternate API calls to support older redis versions

## Description

6.0 changed from calling a deprecated redis API to a new one. Unfortunately the new API doesn't work on unsupported versions of redis which are still in common use.

Fixes #38715

## Customer Impact

Unblocks customers stuck using old versions of redis.

## Regression?

- [x] Yes
- [ ] No

In 6.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Restoring the prior behavior

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
