### PR TITLE
Revert .NET SDK test bump, again

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -187,11 +187,6 @@
     <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildUtilitiesCoreVersion>16.9.0</MicrosoftBuildUtilitiesCoreVersion>
     <!--
-      Temporarily override the Microsoft.NET.Test.Sdk version Arcade defaults to. That's incompatible w/ test
-      framework in current .NET SDKs.
-    -->
-    <MicrosoftNETTestSdkVersion>17.1.0-preview-20211109-03</MicrosoftNETTestSdkVersion>
-    <!--
       Versions of Microsoft.CodeAnalysis packages referenced by analyzers shipped in the SDK.
       This need to be pinned since they're used in 3.1 apps and need to be loadable in VS 2019.
     -->


### PR DESCRIPTION
Revert https://github.com/dotnet/aspnetcore/pull/38923

@dougbu I'm doing some test, the error now is different and a bit weird, looks like `testhost.dll` is not found also if present:
```
TpTrace Verbose: 0 : 324, 5, 2021/12/07, 01:10:26.772, 451381765010729, vstest.console.dll, DotnetTestHostManager: Found testhost.dll in source directory: /root/helix/work/workitem/e/testhost.dll. <-- FILE FOUND
TpTrace Verbose: 0 : 324, 5, 2021/12/07, 01:10:26.777, 451381769691535, vstest.console.dll, DotnetTestHostmanager.LaunchTestHostAsync: Compatible muxer architecture of running process 'ARM64'
TpTrace Verbose: 0 : 324, 5, 2021/12/07, 01:10:26.777, 451381769901260, vstest.console.dll, DotnetTestHostmanager.LaunchTestHostAsync: Full path of testhost.dll is /root/helix/work/workitem/e/testhost.dll <-- FILE FOUND
TpTrace Verbose: 0 : 324, 5, 2021/12/07, 01:10:26.777, 451381770038795, vstest.console.dll, DotnetTestHostmanager: Full path of host exe is /root/helix/work/correlation/dotnet-cli/dotnet
TpTrace Verbose: 0 : 324, 7, 2021/12/07, 01:10:26.780, 451381772996838, vstest.console.dll, DotnetTestHostManager: Starting process '/root/helix/work/correlation/dotnet-cli/dotnet' with command line 'exec --runtimeconfig "/root/helix/work/workitem/e/Mvc.Api.Analyzers.Test.runtimeconfig.json" --depsfile "/root/helix/work/workitem/e/Mvc.Api.Analyzers.Test.deps.json" "/root/helix/work/workitem/e/testhost.dll" --port 46083 --endpoint 127.0.0.1:046083 --role client --parentprocessid 324 --diag "/root/helix/work/workitem/uploads/vstest.host.21-12-07_01-10-26_76804_5.log" --tracelevel 4 --datacollectionport 39637 --telemetryoptedin false'
TpTrace Verbose: 0 : 324, 7, 2021/12/07, 01:10:26.794, 451381787580913, vstest.console.dll, Test Runtime launched
TpTrace Verbose: 0 : 324, 5, 2021/12/07, 01:10:26.797, 451381790004147, vstest.console.dll, TestRequestSender.WaitForRequestHandlerConnection: waiting for connection with timeout: 90000
TpTrace Warning: 0 : 324, 7, 2021/12/07, 01:10:26.881, 451381874166273, vstest.console.dll, TestHostManagerCallbacks.ErrorReceivedCallback Test host standard error line: Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly '/root/helix/work/workitem/e/testhost.dll'. The system cannot find the file specified.
TpTrace Warning: 0 : 324, 7, 2021/12/07, 01:10:26.882, 451381874692698, vstest.console.dll, TestHostManagerCallbacks.ErrorReceivedCallback Test host standard error line: 
TpTrace Warning: 0 : 324, 7, 2021/12/07, 01:10:26.882, 451381874877976, vstest.console.dll, TestHostManagerCallbacks.ErrorReceivedCallback Test host standard error line: File name: '/root/helix/work/workitem/e/testhost.dll'
TpTrace Warning: 0 : 324, 7, 2021/12/07, 01:10:28.873, 451383865897971, vstest.console.dll, TestHostManagerCallbacks.ErrorReceivedCallback Test host standard error line: 
TpTrace Verbose: 0 : 324, 7, 2021/12/07, 01:10:28.874, 451383867566174, vstest.console.dll, TestHostProvider.ExitCallBack: Host exited starting callback.

```

It's also present inside directory https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-aspnetcore-refs-heads-main-66f760ad3a714a84bc/Mvc.Api.Analyzers.Test--net7.0/1/console.e79e7e41.log?sv=2019-07-07&se=2021-12-27T01%3A00%3A55Z&sr=c&sp=rl&sig=EJnX2FoVbuVznYCTRnRjgtSlU%2F1tQ7GPF1LG17K%2BwFo%3D
