### PR TITLE
Blazor RemoteJSRuntime Use SignalR Hub Options before Global Options

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -35,14 +35,12 @@ internal partial class RemoteJSRuntime : JSRuntime
 
     public RemoteJSRuntime(
         IOptions<CircuitOptions> circuitOptions,
-        IOptions<HubOptions<ComponentHub>> hubOptions,
-        IOptions<HubOptions> globalHubOptions,
+        IOptions<HubOptions<ComponentHub>> componentHubOptions,
         ILogger<RemoteJSRuntime> logger)
     {
         _options = circuitOptions.Value;
-        _maximumIncomingBytes = hubOptions.Value.MaximumReceiveMessageSize ??
-            globalHubOptions.Value.MaximumReceiveMessageSize ??
-            long.MaxValue;
+
+        _maximumIncomingBytes = componentHubOptions.Value.MaximumReceiveMessageSize ?? long.MaxValue;
         _logger = logger;
         DefaultAsyncTimeout = _options.JSInteropDefaultCallTimeout;
         ElementReferenceContext = new WebElementReferenceContext(this);

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -39,7 +39,6 @@ internal partial class RemoteJSRuntime : JSRuntime
         ILogger<RemoteJSRuntime> logger)
     {
         _options = circuitOptions.Value;
-
         _maximumIncomingBytes = componentHubOptions.Value.MaximumReceiveMessageSize ?? long.MaxValue;
         _logger = logger;
         DefaultAsyncTimeout = _options.JSInteropDefaultCallTimeout;

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -40,8 +40,9 @@ internal partial class RemoteJSRuntime : JSRuntime
         ILogger<RemoteJSRuntime> logger)
     {
         _options = circuitOptions.Value;
-
-        _maximumIncomingBytes = hubOptions.Value.MaximumReceiveMessageSize ?? globalHubOptions.Value.MaximumReceiveMessageSize ?? long.MaxValue;
+        _maximumIncomingBytes = hubOptions.Value.MaximumReceiveMessageSize ??
+            globalHubOptions.Value.MaximumReceiveMessageSize ??
+            long.MaxValue;
         _logger = logger;
         DefaultAsyncTimeout = _options.JSInteropDefaultCallTimeout;
         ElementReferenceContext = new WebElementReferenceContext(this);

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -35,13 +35,13 @@ internal partial class RemoteJSRuntime : JSRuntime
 
     public RemoteJSRuntime(
         IOptions<CircuitOptions> circuitOptions,
-        IOptions<HubOptions> hubOptions,
+        IOptions<HubOptions<ComponentHub>> hubOptions,
+        IOptions<HubOptions> globalHubOptions,
         ILogger<RemoteJSRuntime> logger)
     {
         _options = circuitOptions.Value;
-        _maximumIncomingBytes = hubOptions.Value.MaximumReceiveMessageSize is null
-            ? long.MaxValue
-            : hubOptions.Value.MaximumReceiveMessageSize.Value;
+
+        _maximumIncomingBytes = hubOptions.Value.MaximumReceiveMessageSize ?? globalHubOptions.Value.MaximumReceiveMessageSize ?? long.MaxValue;
         _logger = logger;
         DefaultAsyncTimeout = _options.JSInteropDefaultCallTimeout;
         ElementReferenceContext = new WebElementReferenceContext(this);

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -353,7 +353,7 @@ public class CircuitHostTest
         }
 
         private static RemoteJSRuntime CreateJSRuntime(CircuitOptions options)
-            => new RemoteJSRuntime(Options.Create(options), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), null);
+            => new RemoteJSRuntime(Options.Create(options), Options.Create(new HubOptions<ComponentHub>()), null);
     }
 
     private class DispatcherComponent : ComponentBase, IDisposable

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -353,7 +353,7 @@ public class CircuitHostTest
         }
 
         private static RemoteJSRuntime CreateJSRuntime(CircuitOptions options)
-            => new RemoteJSRuntime(Options.Create(options), Options.Create(new HubOptions()), null);
+            => new RemoteJSRuntime(Options.Create(options), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), null);
     }
 
     private class DispatcherComponent : ComponentBase, IDisposable

--- a/src/Components/Server/test/Circuits/RemoteJSDataStreamTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteJSDataStreamTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
 public class RemoteJSDataStreamTest
 {
-    private static readonly TestRemoteJSRuntime _jsRuntime = new(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+    private static readonly TestRemoteJSRuntime _jsRuntime = new(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
 
     [Fact]
     public async Task CreateRemoteJSDataStreamAsync_CreatesStream()
@@ -51,7 +51,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_SuccessReadsBackStream()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
         var chunk = new byte[100];
@@ -79,7 +79,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_SuccessReadsBackPipeReader()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
         var chunk = new byte[100];
@@ -107,7 +107,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_WithError()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
 
@@ -125,7 +125,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_WithZeroLengthChunk()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
         var chunk = Array.Empty<byte>();
@@ -144,7 +144,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_WithLargerChunksThanPermitted()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
         var chunk = new byte[50_000]; // more than the 32k maximum chunk size
@@ -163,7 +163,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_ProvidedWithMoreBytesThanRemaining()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var jsStreamReference = Mock.Of<IJSStreamReference>();
         var remoteJSDataStream = await RemoteJSDataStream.CreateRemoteJSDataStreamAsync(jsRuntime, jsStreamReference, totalLength: 100, signalRMaximumIncomingBytes: 10_000, jsInteropDefaultCallTimeout: TimeSpan.FromMinutes(1), cancellationToken: CancellationToken.None);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
@@ -183,7 +183,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_ProvidedWithOutOfOrderChunk_SimulatesSignalRDisconnect()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var jsStreamReference = Mock.Of<IJSStreamReference>();
         var remoteJSDataStream = await RemoteJSDataStream.CreateRemoteJSDataStreamAsync(jsRuntime, jsStreamReference, totalLength: 100, signalRMaximumIncomingBytes: 10_000, jsInteropDefaultCallTimeout: TimeSpan.FromMinutes(1), cancellationToken: CancellationToken.None);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
@@ -208,7 +208,7 @@ public class RemoteJSDataStreamTest
     {
         // Arrange
         var unhandledExceptionRaisedTask = new TaskCompletionSource<bool>();
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         jsRuntime.UnhandledException += (_, ex) =>
         {
             Assert.Equal("Did not receive any data in the allotted time.", ex.Message);
@@ -249,7 +249,7 @@ public class RemoteJSDataStreamTest
     {
         // Arrange
         var unhandledExceptionRaisedTask = new TaskCompletionSource<bool>();
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         jsRuntime.UnhandledException += (_, ex) =>
         {
             Assert.Equal("Did not receive any data in the allotted time.", ex.Message);
@@ -305,7 +305,7 @@ public class RemoteJSDataStreamTest
 
     class TestRemoteJSRuntime : RemoteJSRuntime, IJSRuntime
     {
-        public TestRemoteJSRuntime(IOptions<CircuitOptions> circuitOptions, IOptions<HubOptions<ComponentHub>> hubOptions, IOptions<HubOptions> globalHubOptions, ILogger<RemoteJSRuntime> logger) : base(circuitOptions, hubOptions, globalHubOptions, logger)
+        public TestRemoteJSRuntime(IOptions<CircuitOptions> circuitOptions, IOptions<HubOptions<ComponentHub>> hubOptions, ILogger<RemoteJSRuntime> logger) : base(circuitOptions, hubOptions, logger)
         {
         }
 

--- a/src/Components/Server/test/Circuits/RemoteJSDataStreamTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteJSDataStreamTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
 public class RemoteJSDataStreamTest
 {
-    private static readonly TestRemoteJSRuntime _jsRuntime = new(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+    private static readonly TestRemoteJSRuntime _jsRuntime = new(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
 
     [Fact]
     public async Task CreateRemoteJSDataStreamAsync_CreatesStream()
@@ -51,7 +51,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_SuccessReadsBackStream()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
         var chunk = new byte[100];
@@ -79,7 +79,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_SuccessReadsBackPipeReader()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
         var chunk = new byte[100];
@@ -107,7 +107,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_WithError()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
 
@@ -125,7 +125,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_WithZeroLengthChunk()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
         var chunk = Array.Empty<byte>();
@@ -144,7 +144,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_WithLargerChunksThanPermitted()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var remoteJSDataStream = await CreateRemoteJSDataStreamAsync(jsRuntime);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
         var chunk = new byte[50_000]; // more than the 32k maximum chunk size
@@ -163,7 +163,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_ProvidedWithMoreBytesThanRemaining()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var jsStreamReference = Mock.Of<IJSStreamReference>();
         var remoteJSDataStream = await RemoteJSDataStream.CreateRemoteJSDataStreamAsync(jsRuntime, jsStreamReference, totalLength: 100, signalRMaximumIncomingBytes: 10_000, jsInteropDefaultCallTimeout: TimeSpan.FromMinutes(1), cancellationToken: CancellationToken.None);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
@@ -183,7 +183,7 @@ public class RemoteJSDataStreamTest
     public async Task ReceiveData_ProvidedWithOutOfOrderChunk_SimulatesSignalRDisconnect()
     {
         // Arrange
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var jsStreamReference = Mock.Of<IJSStreamReference>();
         var remoteJSDataStream = await RemoteJSDataStream.CreateRemoteJSDataStreamAsync(jsRuntime, jsStreamReference, totalLength: 100, signalRMaximumIncomingBytes: 10_000, jsInteropDefaultCallTimeout: TimeSpan.FromMinutes(1), cancellationToken: CancellationToken.None);
         var streamId = GetStreamId(remoteJSDataStream, jsRuntime);
@@ -208,7 +208,7 @@ public class RemoteJSDataStreamTest
     {
         // Arrange
         var unhandledExceptionRaisedTask = new TaskCompletionSource<bool>();
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         jsRuntime.UnhandledException += (_, ex) =>
         {
             Assert.Equal("Did not receive any data in the allotted time.", ex.Message);
@@ -249,7 +249,7 @@ public class RemoteJSDataStreamTest
     {
         // Arrange
         var unhandledExceptionRaisedTask = new TaskCompletionSource<bool>();
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         jsRuntime.UnhandledException += (_, ex) =>
         {
             Assert.Equal("Did not receive any data in the allotted time.", ex.Message);
@@ -305,7 +305,7 @@ public class RemoteJSDataStreamTest
 
     class TestRemoteJSRuntime : RemoteJSRuntime, IJSRuntime
     {
-        public TestRemoteJSRuntime(IOptions<CircuitOptions> circuitOptions, IOptions<HubOptions> hubOptions, ILogger<RemoteJSRuntime> logger) : base(circuitOptions, hubOptions, logger)
+        public TestRemoteJSRuntime(IOptions<CircuitOptions> circuitOptions, IOptions<HubOptions<ComponentHub>> hubOptions, IOptions<HubOptions> globalHubOptions, ILogger<RemoteJSRuntime> logger) : base(circuitOptions, hubOptions, globalHubOptions, logger)
         {
         }
 

--- a/src/Components/Server/test/Circuits/RemoteJSRuntimeTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteJSRuntimeTest.cs
@@ -1,23 +1,27 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using Moq;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
 public class RemoteJSRuntimeTest
 {
+    [Fact]
+    public void ReceiveByteArray_WithChunkSmallerThanDefaultMaximum()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime();
+        var data = new byte[29_000];
+
+        // Act & Assert
+        jsRuntime.TestReceiveByteArray(id: 0, data);
+    }
+
     [Fact]
     public void ReceiveByteArray_WithLargerChunksThanPermitted()
     {
@@ -31,7 +35,7 @@ public class RemoteJSRuntimeTest
     }
 
     [Fact]
-    public void ReceiveByteArray_WithLargeChunks_UsingComponentHubOptions()
+    public void ReceiveByteArray_WithLargeChunks_UsingConfiguredComponentHubOptions()
     {
         // Arrange
         var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: 52*1024);
@@ -42,34 +46,11 @@ public class RemoteJSRuntimeTest
     }
 
     [Fact]
-    public void ReceiveByteArray_WithLargerChunksThanPermitted_ComponentHubOptionsTakePrecedence()
+    public void ReceiveByteArray_WithLargeChunks_NullComponentHubOptions()
     {
         // Arrange
-        var jsRuntime = CreateTestRemoteJSRuntime(globalHubMaximumIncomingBytes: 52*1024);
-        var data = new byte[50_000]; // more than the 32k default MaximumIncomingBytes
-
-        // Act & Assert
-        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => jsRuntime.TestReceiveByteArray(id: 0, data));
-        Assert.Equal("Exceeded the maximum byte array transfer limit for a call. (Parameter 'data')", ex.Message);
-    }
-
-    [Fact]
-    public void ReceiveByteArray_WithLargeChunks_UsingGlobalHubOptions()
-    {
-        // Arrange
-        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: null, globalHubMaximumIncomingBytes: 52*1024);
-        var data = new byte[50_000];
-
-        // Act & Assert
-        jsRuntime.TestReceiveByteArray(id: 0, data);
-    }
-
-    [Fact]
-    public void ReceiveByteArray_WithLargeChunks_NullOptions()
-    {
-        // Arrange
-        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: null, globalHubMaximumIncomingBytes: null);
-        var data = new byte[50_000];
+        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: null);
+        var data = new byte[100_000];
 
         // Act & Assert
         jsRuntime.TestReceiveByteArray(id: 0, data);
@@ -82,11 +63,11 @@ public class RemoteJSRuntimeTest
         var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: 20);
 
         // Act & Assert
-        jsRuntime.TestReceiveByteArray(id: 0, new byte[0]);
+        jsRuntime.TestReceiveByteArray(id: 0, Array.Empty<byte>());
         for (var i = 1; i < 5; i++)
         {
             // Each array takes is counted as being atleast 4 bytes. 5*4 = 20 => after this loop we've received max bytes
-            jsRuntime.TestReceiveByteArray(i, new byte[0]);
+            jsRuntime.TestReceiveByteArray(i, Array.Empty<byte>());
         }
 
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() => jsRuntime.TestReceiveByteArray(5, new byte[] { 0 }));
@@ -116,19 +97,17 @@ public class RemoteJSRuntimeTest
         jsRuntime.TestReceiveByteArray(id: 0, new byte[5000]);
     }
 
-    private TestRemoteJSRuntime CreateTestRemoteJSRuntime(long? componentHubMaximumIncomingBytes = 32*1024, long? globalHubMaximumIncomingBytes = 32*1024)
+    private static TestRemoteJSRuntime CreateTestRemoteJSRuntime(long? componentHubMaximumIncomingBytes = 32*1024)
     {
         var componentHubOptions = Options.Create(new HubOptions<ComponentHub>());
         componentHubOptions.Value.MaximumReceiveMessageSize = componentHubMaximumIncomingBytes;
-        var globalHubOptions = Options.Create(new HubOptions());
-        globalHubOptions.Value.MaximumReceiveMessageSize = globalHubMaximumIncomingBytes;
-        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), componentHubOptions, globalHubOptions, Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), componentHubOptions, Mock.Of<ILogger<RemoteJSRuntime>>());
         return jsRuntime;
     }
 
     class TestRemoteJSRuntime : RemoteJSRuntime, IJSRuntime
     {
-        public TestRemoteJSRuntime(IOptions<CircuitOptions> circuitOptions, IOptions<HubOptions<ComponentHub>> hubOptions, IOptions<HubOptions> globalHubOptions, ILogger<RemoteJSRuntime> logger) : base(circuitOptions, hubOptions, globalHubOptions, logger)
+        public TestRemoteJSRuntime(IOptions<CircuitOptions> circuitOptions, IOptions<HubOptions<ComponentHub>> hubOptions, ILogger<RemoteJSRuntime> logger) : base(circuitOptions, hubOptions, logger)
         {
         }
 

--- a/src/Components/Server/test/Circuits/RemoteJSRuntimeTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteJSRuntimeTest.cs
@@ -38,7 +38,7 @@ public class RemoteJSRuntimeTest
     public void ReceiveByteArray_WithLargeChunks_UsingConfiguredComponentHubOptions()
     {
         // Arrange
-        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: 52*1024);
+        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: 52 * 1024);
         var data = new byte[50_000];
 
         // Act & Assert
@@ -97,7 +97,7 @@ public class RemoteJSRuntimeTest
         jsRuntime.TestReceiveByteArray(id: 0, new byte[5000]);
     }
 
-    private static TestRemoteJSRuntime CreateTestRemoteJSRuntime(long? componentHubMaximumIncomingBytes = 32*1024)
+    private static TestRemoteJSRuntime CreateTestRemoteJSRuntime(long? componentHubMaximumIncomingBytes = 32 * 1024)
     {
         var componentHubOptions = Options.Create(new HubOptions<ComponentHub>());
         componentHubOptions.Value.MaximumReceiveMessageSize = componentHubMaximumIncomingBytes;

--- a/src/Components/Server/test/Circuits/RemoteJSRuntimeTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteJSRuntimeTest.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits;
+
+public class RemoteJSRuntimeTest
+{
+    [Fact]
+    public void ReceiveByteArray_WithLargerChunksThanPermitted()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime();
+        var data = new byte[50_000]; // more than the 32k default MaximumIncomingBytes
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => jsRuntime.TestReceiveByteArray(id: 0, data));
+        Assert.Equal("Exceeded the maximum byte array transfer limit for a call. (Parameter 'data')", ex.Message);
+    }
+
+    [Fact]
+    public void ReceiveByteArray_WithLargeChunks_UsingComponentHubOptions()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: 52*1024);
+        var data = new byte[50_000];
+
+        // Act & Assert
+        jsRuntime.TestReceiveByteArray(id: 0, data);
+    }
+
+    [Fact]
+    public void ReceiveByteArray_WithLargerChunksThanPermitted_ComponentHubOptionsTakePrecedence()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime(globalHubMaximumIncomingBytes: 52*1024);
+        var data = new byte[50_000]; // more than the 32k default MaximumIncomingBytes
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => jsRuntime.TestReceiveByteArray(id: 0, data));
+        Assert.Equal("Exceeded the maximum byte array transfer limit for a call. (Parameter 'data')", ex.Message);
+    }
+
+    [Fact]
+    public void ReceiveByteArray_WithLargeChunks_UsingGlobalHubOptions()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: null, globalHubMaximumIncomingBytes: 52*1024);
+        var data = new byte[50_000];
+
+        // Act & Assert
+        jsRuntime.TestReceiveByteArray(id: 0, data);
+    }
+
+    [Fact]
+    public void ReceiveByteArray_WithLargeChunks_NullOptions()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: null, globalHubMaximumIncomingBytes: null);
+        var data = new byte[50_000];
+
+        // Act & Assert
+        jsRuntime.TestReceiveByteArray(id: 0, data);
+    }
+
+    [Fact]
+    public void ReceiveByteArray_RejectsLargeNumberOfSmallArrays()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime(componentHubMaximumIncomingBytes: 20);
+
+        // Act & Assert
+        jsRuntime.TestReceiveByteArray(id: 0, new byte[0]);
+        for (var i = 1; i < 5; i++)
+        {
+            // Each array takes is counted as being atleast 4 bytes. 5*4 = 20 => after this loop we've received max bytes
+            jsRuntime.TestReceiveByteArray(i, new byte[0]);
+        }
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => jsRuntime.TestReceiveByteArray(5, new byte[] { 0 }));
+        Assert.Equal("Exceeded the maximum byte array transfer limit for a call. (Parameter 'data')", ex.Message);
+    }
+
+    [Fact]
+    public void ReceiveByteArray_RejectsExcessiveData()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime();
+
+        // Act & Assert
+        jsRuntime.TestReceiveByteArray(id: 0, new byte[30000]);
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => jsRuntime.TestReceiveByteArray(1, new byte[5000]));
+        Assert.Equal("Exceeded the maximum byte array transfer limit for a call. (Parameter 'data')", ex.Message);
+    }
+
+    [Fact]
+    public void ReceiveByteArray_ResetsBytesReceivedWhenIdIsZero()
+    {
+        // Arrange
+        var jsRuntime = CreateTestRemoteJSRuntime();
+
+        // Act & Assert
+        jsRuntime.TestReceiveByteArray(id: 0, new byte[30000]);
+        jsRuntime.TestReceiveByteArray(id: 0, new byte[5000]);
+    }
+
+    private TestRemoteJSRuntime CreateTestRemoteJSRuntime(long? componentHubMaximumIncomingBytes = 32*1024, long? globalHubMaximumIncomingBytes = 32*1024)
+    {
+        var componentHubOptions = Options.Create(new HubOptions<ComponentHub>());
+        componentHubOptions.Value.MaximumReceiveMessageSize = componentHubMaximumIncomingBytes;
+        var globalHubOptions = Options.Create(new HubOptions());
+        globalHubOptions.Value.MaximumReceiveMessageSize = globalHubMaximumIncomingBytes;
+        var jsRuntime = new TestRemoteJSRuntime(Options.Create(new CircuitOptions()), componentHubOptions, globalHubOptions, Mock.Of<ILogger<RemoteJSRuntime>>());
+        return jsRuntime;
+    }
+
+    class TestRemoteJSRuntime : RemoteJSRuntime, IJSRuntime
+    {
+        public TestRemoteJSRuntime(IOptions<CircuitOptions> circuitOptions, IOptions<HubOptions<ComponentHub>> hubOptions, IOptions<HubOptions> globalHubOptions, ILogger<RemoteJSRuntime> logger) : base(circuitOptions, hubOptions, globalHubOptions, logger)
+        {
+        }
+
+        public void TestReceiveByteArray(int id, byte[] data)
+        {
+            ReceiveByteArray(id, data);
+        }
+
+        public new ValueTask<TValue> InvokeAsync<TValue>(string identifier, object[] args)
+        {
+            Assert.Equal("Blazor._internal.sendJSDataStream", identifier);
+            return ValueTask.FromResult<TValue>(default);
+        }
+    }
+}

--- a/src/Components/Server/test/Circuits/RemoteJSRuntimeTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteJSRuntimeTest.cs
@@ -136,11 +136,5 @@ public class RemoteJSRuntimeTest
         {
             ReceiveByteArray(id, data);
         }
-
-        public new ValueTask<TValue> InvokeAsync<TValue>(string identifier, object[] args)
-        {
-            Assert.Equal("Blazor._internal.sendJSDataStream", identifier);
-            return ValueTask.FromResult<TValue>(default);
-        }
     }
 }

--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -458,7 +458,7 @@ public class RemoteRendererTest
         }
 
         private static RemoteJSRuntime CreateJSRuntime(CircuitOptions options)
-            => new RemoteJSRuntime(Options.Create(options), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), null);
+            => new RemoteJSRuntime(Options.Create(options), Options.Create(new HubOptions<ComponentHub>()), null);
     }
 
     private class TestComponent : IComponent, IHandleAfterRender

--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -458,7 +458,7 @@ public class RemoteRendererTest
         }
 
         private static RemoteJSRuntime CreateJSRuntime(CircuitOptions options)
-            => new RemoteJSRuntime(Options.Create(options), Options.Create(new HubOptions()), null);
+            => new RemoteJSRuntime(Options.Create(options), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), null);
     }
 
     private class TestComponent : IComponent, IHandleAfterRender

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -30,7 +30,7 @@ internal class TestCircuitHost : CircuitHost
     {
         serviceScope = serviceScope ?? new AsyncServiceScope(Mock.Of<IServiceScope>());
         clientProxy = clientProxy ?? new CircuitClientProxy(Mock.Of<IClientProxy>(), Guid.NewGuid().ToString());
-        var jsRuntime = new RemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new RemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var serviceProvider = new Mock<IServiceProvider>();
         serviceProvider
             .Setup(services => services.GetService(typeof(IJSRuntime)))

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -30,7 +30,7 @@ internal class TestCircuitHost : CircuitHost
     {
         serviceScope = serviceScope ?? new AsyncServiceScope(Mock.Of<IServiceScope>());
         clientProxy = clientProxy ?? new CircuitClientProxy(Mock.Of<IClientProxy>(), Guid.NewGuid().ToString());
-        var jsRuntime = new RemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        var jsRuntime = new RemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Options.Create(new HubOptions()), Mock.Of<ILogger<RemoteJSRuntime>>());
         var serviceProvider = new Mock<IServiceProvider>();
         serviceProvider
             .Setup(services => services.GetService(typeof(IJSRuntime)))


### PR DESCRIPTION
Updated to use hub options over global options per Brennan's suggestion [here](https://github.com/dotnet/aspnetcore/issues/38205#issuecomment-977172370).

Fixes: https://github.com/dotnet/aspnetcore/issues/38205
Fixes: https://github.com/dotnet/aspnetcore/issues/38941