### PR TITLE
!nits! Build cleanup

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -46,6 +46,8 @@ variables:
   value: .NETCORE
 - name: PostBuildSign
   value: true
+- name: _UseHelixOpenQueues
+  value: ${{ ne(variables['System.TeamProject'], 'internal') }}
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)
@@ -103,8 +105,6 @@ variables:
   - name: WindowsArm64InstallersLogArgs
     value: /bl:artifacts/log/Release/Build.Installers.Arm64.binlog
 - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-  - name: _UseHelixOpenQueues
-    value: 'true'
   - name: _SignType
     value: ''
   - name: _InternalRuntimeDownloadArgs
@@ -124,8 +124,6 @@ variables:
            /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
            /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
   - group: DotNet-HelixApi-Access
-  - name: _UseHelixOpenQueues
-    value: 'false'
   - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
     - name: _SignType
       value: real

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -16,13 +16,10 @@ schedules:
   always: false
 
 variables:
-- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-  - name: _UseHelixOpenQueues
-    value: 'true'
+- name: _UseHelixOpenQueues
+  value: ${{ ne(variables['System.TeamProject'], 'internal') }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
-  - name: _UseHelixOpenQueues
-    value: 'false'
 
 jobs:
 - template: jobs/default-build.yml

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -40,13 +40,10 @@ schedules:
   always: true
 
 variables:
-- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-  - name: _UseHelixOpenQueues
-    value: 'true'
+- name: _UseHelixOpenQueues
+  value: ${{ ne(variables['System.TeamProject'], 'internal') }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
-  - name: _UseHelixOpenQueues
-    value: 'false'
 
 jobs:
 - template: jobs/default-build.yml

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -11,13 +11,10 @@ schedules:
   always: true
 
 variables:
-- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-  - name: _UseHelixOpenQueues
-    value: 'true'
+- name: _UseHelixOpenQueues
+  value: ${{ ne(variables['System.TeamProject'], 'internal') }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
-  - name: _UseHelixOpenQueues
-    value: 'false'
 
 jobs:
 - template: jobs/default-build.yml

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,18 +24,19 @@
         $(RepoRelativeProjectDir.Contains('benchmarkapps')) ">true</IsBenchmarkProject>
     <IsMicrobenchmarksProject Condition=" $(MSBuildProjectName.EndsWith('.Microbenchmarks')) ">true</IsMicrobenchmarksProject>
     <IsSpecificationTestProject Condition="$(MSBuildProjectName.EndsWith('.Specification.Tests'))">true</IsSpecificationTestProject>
-    <IsUnitTestProject Condition=" '$(IsUnitTestProject)' == '' ">false</IsUnitTestProject>
-    <IsUnitTestProject Condition=" '$(IsSpecificationTestProject)' != 'true' AND
+    <IsUnitTestProject Condition=" '$(IsUnitTestProject)' == '' AND
+        '$(IsSpecificationTestProject)' != 'true' AND
         ( $(MSBuildProjectName.EndsWith('Tests')) OR
           $(MSBuildProjectName.EndsWith('.Test')) OR
           $(MSBuildProjectName.EndsWith('.FunctionalTest')) ) ">true</IsUnitTestProject>
+    <IsUnitTestProject Condition=" '$(IsUnitTestProject)' == '' ">false</IsUnitTestProject>
     <IsTestAssetProject Condition=" $(RepoRelativeProjectDir.Contains('testassets')) OR $(MSBuildProjectName.Contains('TestCommon'))">true</IsTestAssetProject>
     <IsSampleProject Condition=" $(RepoRelativeProjectDir.ToUpperInvariant().Contains('SAMPLE')) ">true</IsSampleProject>
     <IsAnalyzersProject Condition="$(MSBuildProjectName.EndsWith('.Analyzers'))">true</IsAnalyzersProject>
     <IsShipping Condition=" '$(IsSampleProject)' == 'true' OR
         '$(IsTestAssetProject)' == 'true' OR
         '$(IsBenchmarkProject)' == 'true' OR
-        '$(IsUnitTestProject)' == 'true'">false</IsShipping>
+        $(IsUnitTestProject) ">false</IsShipping>
 
     <!--
       Following logic mimics core-setup approach as well as
@@ -247,6 +248,5 @@
   <Import Project="eng\targets\Wix.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.wixproj'" />
   <Import Project="eng\targets\Npm.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
   <Import Project="eng\targets\Java.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.javaproj'" />
-  <Import Project="eng\targets\Helix.props" Condition="'$(IsTestProject)' == 'true'" />
-
+  <Import Project="eng\targets\Helix.props" Condition=" $(IsTestProject) " />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,4 @@
 ﻿<Project>
-
   <PropertyGroup>
     <!-- Only build Microsoft.AspNetCore.App, Microsoft.AspNetCore.App.Ref, and ref/ assemblies in source build. -->
     <!-- Analyzer package are needed in source build for WebSDK -->
@@ -10,8 +9,7 @@
      suppress all targets for TestProjects using ExcludeFromBuild. -->
     <ExcludeFromBuild Condition="'$(IsPackable)' != 'true' and
         '$(SkipTestBuild)' == 'true' and
-        ('$(IsTestProject)' == 'true' or
-         '$(IsUnitTestProject)' == 'true' or
+        ($(IsTestProject) or
          '$(IsTestAssetProject)' == 'true' or
          '$(IsBenchmarkProject)' == 'true' or
          '$(IsSampleProject)' == 'true' or
@@ -62,7 +60,7 @@
   <PropertyGroup Condition=" '$(MSBuildProjectExtension)' == '.csproj' ">
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
     <IsPackable
-        Condition="'$(IsPackable)' == '' AND ( '$(IsTestProject)' == 'true' OR '$(IsTestAssetProject)' == 'true' OR
+        Condition="'$(IsPackable)' == '' AND ( $(IsTestProject) OR '$(IsTestAssetProject)' == 'true' OR
          '$(IsBenchmarkProject)' == 'true' OR '$(IsSampleProject)' == 'true' OR '$(IsMicrobenchmarksProject)' == 'true') ">false</IsPackable>
   </PropertyGroup>
 
@@ -112,7 +110,7 @@
         '$(IsSampleProject)' != 'true' AND
         '$(IsSpecificationTestProject)' != 'true' AND
         '$(IsTestAssetProject)' != 'true' AND
-        '$(IsTestProject)' != 'true' AND
+        !$(IsTestProject) AND
         '$(IsMicrobenchmarksProject)' != 'true' ">true</IsImplementationProject>
 
     <!-- This determines whether a project is available as a <Reference> to other projects in this repo. -->
@@ -131,7 +129,7 @@
     <IsPackable Condition="'$(IsPackable)' == '' AND ('$(IsImplementationProject)' == 'true' OR '$(IsAnalyzersProject)' == 'true') ">true</IsPackable>
     <IsPackable Condition="'$(IsPackable)' == '' ">false</IsPackable>
 
-    <BuildHelixPayload Condition="'$(BuildHelixPayload)' == '' AND '$(IsTestProject)' == 'true'">true</BuildHelixPayload>
+    <BuildHelixPayload Condition="'$(BuildHelixPayload)' == '' AND $(IsTestProject) ">true</BuildHelixPayload>
     <SkipTests Condition="'$(SkipHelixReadyTests)' == 'true' AND '$(BuildHelixPayload)' == 'true'">true</SkipTests>
   </PropertyGroup>
 
@@ -194,8 +192,7 @@
   <Import Project="eng\targets\Wix.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.wixproj'" />
   <Import Project="eng\targets\Npm.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
   <Import Project="eng\targets\Java.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.javaproj'" />
-  <Import Project="eng\targets\Helix.targets" Condition="'$(IsTestProject)' == 'true'" />
+  <Import Project="eng\targets\Helix.targets" Condition=" $(IsTestProject) " />
   <Import Project="eng\targets\FunctionalTestAsset.targets" Condition="'$(IsTestAssetProject)' == 'true'" />
   <Import Project="eng\targets\FunctionalTestWithAssets.targets" Condition="'$(ContainsFunctionalTestAssets)' == 'true'" />
-
 </Project>

--- a/eng/targets/CSharp.Common.props
+++ b/eng/targets/CSharp.Common.props
@@ -1,5 +1,4 @@
 <Project>
-
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
 
@@ -12,16 +11,16 @@
     <PackageReference Include="MicroBuild.Core" Version="0.3.0" PrivateAssets="All" AllowExplicitReference="true" ExcludeAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+  <ItemGroup Condition=" $(IsTestProject) ">
     <Reference Include="Microsoft.AspNetCore.Testing" />
     <Reference Include="Moq" />
     <Reference Include="NETStandard.Library" />
     <Compile Include="$(SharedSourceRoot)test\SuccessfulTests.cs" LinkBase="SharedTests" Visible="false" />
   </ItemGroup>
 
-  <Import Project="$(RepoRoot)src\Testing\src\build\Microsoft.AspNetCore.Testing.props" Condition=" '$(IsTestProject)' == 'true' " />
+  <Import Project="$(RepoRoot)src\Testing\src\build\Microsoft.AspNetCore.Testing.props" Condition=" $(IsTestProject) " />
 
-  <ItemDefinitionGroup Condition=" '$(IsTestProject)' == 'true' ">
+  <ItemDefinitionGroup Condition=" $(IsTestProject) ">
     <Content>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
@@ -33,5 +32,4 @@
     <IgnoreYarnWarnings>false</IgnoreYarnWarnings>
     <IgnoreYarnWarnings Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</IgnoreYarnWarnings>
   </PropertyGroup>
-
 </Project>

--- a/eng/targets/CSharp.Common.targets
+++ b/eng/targets/CSharp.Common.targets
@@ -1,5 +1,4 @@
 <Project>
-
   <!-- For 'legacy' .csproj files, set map TargetFrameworkVersion back to TargetFramework -->
   <PropertyGroup Condition=" '$(TargetFramework)' == '' AND '$(TargetFrameworks)' == '' ">
     <TargetFramework>net$(TargetFrameworkVersion.TrimStart('vV').Replace('.',''))</TargetFramework>
@@ -26,7 +25,7 @@
      <Features Condition="'$(_IsSrcProject)' == 'true'">$(Features);nullablePublicOnly</Features>
 
     <!-- Turn off platform compatibility analyzer warnings in test, test assets, and samples. -->
-    <NoWarn Condition=" '$(IsTestProject)' == 'true' OR
+    <NoWarn Condition=" $(IsTestProject) OR
         '$(IsTestAssetProject)' == 'true' OR
         '$(ISBenchmarkProject)' == 'true' OR
         '$(IsSampleProject)' == 'true' OR
@@ -39,7 +38,7 @@
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>
 
     <!-- Enable trimming annotation validation in DI. See https://github.com/dotnet/runtime/blob/main/docs/workflow/trimming/feature-switches.md -->
-    <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition="'$(IsTestProject)' == 'true'">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
+    <VerifyDependencyInjectionOpenGenericServiceTrimmability Condition=" $(IsTestProject) ">true</VerifyDependencyInjectionOpenGenericServiceTrimmability>
   </PropertyGroup>
 
   <!-- Enable implicit usings for projects that target the default TFM -->
@@ -52,7 +51,7 @@
     <Using Remove="System.Linq" Condition="'$(_IsSrcProject)' == 'true'" />
     <!-- System.Net.Http types will frequently conflict with ASP.NET Core types-->
     <Using Remove="System.Net.Http" />
-    <Using Include="Xunit" Condition="'$(IsTestProject)' == 'true' OR '$(IsUnitTestProject)' == 'true'" />
+    <Using Include="Xunit" Condition=" $(IsTestProject) " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DotNetBuildFromSource)' != 'true' AND $(AddPublicApiAnalyzers) ">
@@ -143,5 +142,4 @@
 
   <Import Project="Packaging.targets" />
   <Import Project="ResolveReferences.targets" />
-
 </Project>

--- a/eng/targets/Cpp.Common.targets
+++ b/eng/targets/Cpp.Common.targets
@@ -1,6 +1,5 @@
 <!-- Targets for making .vcxproj better. -->
 <Project>
-
   <Import Project="$(MicroBuildPluginDirectory)\MicroBuild.Plugins.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(DisableMicroBuild)' != 'true' AND '$(MicroBuildPluginDirectory)' != ''" />
 
   <Target Name="GetVcxprojFilesToSign" BeforeTargets="SignFiles">
@@ -12,7 +11,7 @@
   <Target Name="Pack" />
   <Target Name="Restore" />
   <Target Name="ResolveNuGetPackageAssets" />
-  <Target Name="Test" Condition="'$(IsTestProject)' == 'true'" >
+  <Target Name="Test" Condition=" $(IsTestProject) " >
     <Warning Condition="'$(TestProjectSkipReason)' != ''" Text="Skipped $(MSBuildProjectFileName): $(TestProjectSkipReason)" />
     <Exec Condition="'$(TestProjectSkipReason)' == ''" Command="&quot;$(TargetPath)&quot;" />
   </Target>

--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -10,7 +10,8 @@
 
   <PropertyGroup>
     <HelixTimeout>00:30:00</HelixTimeout>
-    <RunQuarantinedTests>false</RunQuarantinedTests>
+    <!-- Do not attempt to override global property. -->
+    <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>
 
     <IsArm64HelixQueue>false</IsArm64HelixQueue>
     <IsWindowsHelixQueue>false</IsWindowsHelixQueue>

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -1,5 +1,4 @@
 <Project DefaultTargets="Build" InitialTargets="_CheckForInvalidConfiguration">
-
   <!-- Version of this SDK is set in global.json -->
   <Sdk Name="Yarn.MSBuild" />
 
@@ -132,10 +131,9 @@
     <Move SourceFiles="$(_BackupPackageJson)" DestinationFiles="$(PackageJson)" />
   </Target>
 
-  <Target Name="Test" Condition="'$(IsTestProject)' == 'true' AND '$(SkipTests)' != 'true'">
+  <Target Name="Test" Condition=" $(IsTestProject) AND '$(SkipTests)' != 'true'">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Test" />
     <Message Importance="High" Text="Running npm tests for $(MSBuildProjectName)" />
     <Yarn Command="$(NpmTestArgs)" StandardOutputImportance="High" StandardErrorImportance="High" IgnoreStandardErrorWarningFormat="$(IgnoreYarnWarnings)" />
   </Target>
-
 </Project>

--- a/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/Microsoft.AspNetCore.Analyzer.Testing.csproj
+++ b/src/Analyzers/Microsoft.AspNetCore.Analyzer.Testing/src/Microsoft.AspNetCore.Analyzer.Testing.csproj
@@ -6,7 +6,6 @@
     <PackageTags>$(PackageTags);testing</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- This is actually a library for test projects, not a test project. Treat project as a test asset. -->
-    <IsUnitTestProject>false</IsUnitTestProject>
     <IsTestAssetProject>true</IsTestAssetProject>
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->
     <UseLatestPackageReferences>true</UseLatestPackageReferences>

--- a/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj
+++ b/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj
@@ -1,12 +1,15 @@
 ﻿<Project DefaultTargets="Build">
   <PropertyGroup>
-    <IsTestProject>true</IsTestProject>
+    <IsUnitTestProject>true</IsUnitTestProject>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
+    <!-- Npm tests don't run on Helix currently, so we need to set this to false to still run the tests on non-Helix -->
+    <BuildHelixPayload>false</BuildHelixPayload>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebView/Directory.Build.props
+++ b/src/Components/WebView/Directory.Build.props
@@ -1,8 +1,7 @@
 ﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
-  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
+  <PropertyGroup Condition=" !$(IsTestProject) ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
 </Project>

--- a/src/JSInterop/Microsoft.JSInterop.JS/src/Microsoft.JSInterop.JS.npmproj
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/Microsoft.JSInterop.JS.npmproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <PackageId>@microsoft/dotnet-js-interop</PackageId>
     <IsPackable>true</IsPackable>
-    <IsTestProject>false</IsTestProject>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
 

--- a/src/Mvc/test/Mvc.IntegrationTests/Microsoft.AspNetCore.Mvc.IntegrationTests.csproj
+++ b/src/Mvc/test/Mvc.IntegrationTests/Microsoft.AspNetCore.Mvc.IntegrationTests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <UseSharedCompilation>false</UseSharedCompilation>
@@ -14,5 +13,4 @@
 
     <Reference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
-
 </Project>

--- a/src/ProjectTemplates/Directory.Build.props
+++ b/src/ProjectTemplates/Directory.Build.props
@@ -6,9 +6,9 @@
     <IsProjectReferenceProvider>false</IsProjectReferenceProvider>
   </PropertyGroup>
 
-  <Import Project="TemplateProjects.props" Condition="'$(IsTestProject)' != 'true' AND '$(IsTestAssetProject)' != 'true'" />
+  <Import Project="TemplateProjects.props" Condition=" !$(IsTestProject) AND '$(IsTestAssetProject)' != 'true'" />
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+  <ItemGroup Condition=" $(IsTestProject) ">
     <Content Include="$(MSBuildThisFileDirectory)xunit.runner.json" Link="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Servers/Kestrel/Directory.Build.props
+++ b/src/Servers/Kestrel/Directory.Build.props
@@ -10,7 +10,7 @@
     <KestrelSharedSourceRoot>$(MSBuildThisFileDirectory)shared\</KestrelSharedSourceRoot>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(IsTestProject)' == 'true' ">
+  <PropertyGroup Condition=" $(IsTestProject) ">
     <!--
       Workaround for "Use executable flags in Microsoft.NET.Test.Sdk" (https://github.com/Microsoft/vstest/issues/792).
       Remove when fixed.
@@ -18,7 +18,7 @@
     <HasRuntimeOutput>true</HasRuntimeOutput>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+  <ItemGroup Condition=" $(IsTestProject) ">
     <None Include="$(MSBuildThisFileDirectory)xunit.runner.json" Link="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/SignalR/Directory.Build.props
+++ b/src/SignalR/Directory.Build.props
@@ -11,15 +11,14 @@
     <MoqPublicKey>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</MoqPublicKey>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
+  <PropertyGroup Condition=" !$(IsTestProject) ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;signalr</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+  <ItemGroup Condition=" $(IsTestProject) ">
     <Content Include="$(MSBuildThisFileDirectory)xunit.runner.json" Link="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
 </Project>

--- a/src/SignalR/Directory.Build.targets
+++ b/src/SignalR/Directory.Build.targets
@@ -1,11 +1,10 @@
 ﻿<Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+  <PropertyGroup Condition=" $(IsTestProject) ">
     <!-- Don't run SignalR tests in parallel with others. This causes OutOfMemoryException on hosted Azure Pipelines agents. -->
     <TestGroupName>SignalR</TestGroupName>
 
     <RuntimeIdentifier Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">win-x86</RuntimeIdentifier>
   </PropertyGroup>
-
 </Project>

--- a/src/SignalR/clients/java/signalr/core/signalr.client.java.core.javaproj
+++ b/src/SignalR/clients/java/signalr/core/signalr.client.java.core.javaproj
@@ -6,7 +6,6 @@
     <PackageId>java:signalr</PackageId>
     <!-- In servicing builds, this will be set to value if the Java client is not configured to be released in the currently building patch. -->
     <IsPackable>true</IsPackable>
-    <IsTestProject>false</IsTestProject>
     <PublishDir>$(OutputPath)</PublishDir>
   </PropertyGroup>
 

--- a/src/SignalR/clients/java/signalr/messagepack/signalr.client.java.messagepack.javaproj
+++ b/src/SignalR/clients/java/signalr/messagepack/signalr.client.java.messagepack.javaproj
@@ -6,7 +6,6 @@
     <PackageId>java:signalr-messagepack</PackageId>
     <!-- In servicing builds, this will be set to value if the Java client is not configured to be released in the currently building patch. -->
     <IsPackable>true</IsPackable>
-    <IsTestProject>false</IsTestProject>
     <PublishDir>$(OutputPath)</PublishDir>
   </PropertyGroup>
 

--- a/src/SignalR/clients/java/signalr/test/signalr.client.java.Tests.javaproj
+++ b/src/SignalR/clients/java/signalr/test/signalr.client.java.Tests.javaproj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
     <!-- Installing Java on ARM will take some work -->
     <SkipHelixArm>true</SkipHelixArm>
     <SkipHelixAlpine>true</SkipHelixAlpine>

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Npm.FunctionalTests.npmproj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
     <BrowserTestHostName Condition="'$(ContinuousIntegrationBuild)' == 'true'">sauce.local</BrowserTestHostName>
     <_TestSauceArgs>--verbose --no-color --configuration $(Configuration) --sauce-user "$(SauceUser)" --sauce-key "$(SauceKey)"</_TestSauceArgs>
     <_TestSauceArgs Condition="'$(BrowserTestHostName)' != ''">$(_TestSauceArgs) --use-hostname "$(BrowserTestHostName)"</_TestSauceArgs>
@@ -19,7 +18,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 
-  <Target Name="Test" Condition="'$(IsTestProject)' == 'true' AND '$(SkipTests)' != 'true'">
+  <Target Name="Test" Condition=" $(IsTestProject) AND '$(SkipTests)' != 'true'">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Test" />
     <Message Importance="High" Text="Running tests for $(MSBuildProjectName)" />
     <Yarn Condition="'$(DailyTests)' != 'true'" Command="$(NpmTestArgs)" />
@@ -59,5 +58,4 @@
     <Copy SourceFiles="@(SignalRJSBrowserClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot/lib/signalr" />
     <Copy SourceFiles="@(SignalRJSWebWorkerClientFiles)" DestinationFolder="$(MSBuildThisFileDirectory)wwwroot/lib/signalr-webworker" />
   </Target>
-
 </Project>

--- a/src/SignalR/clients/ts/client-ts.npmproj
+++ b/src/SignalR/clients/ts/client-ts.npmproj
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <IsUnitTestProject>true</IsUnitTestProject>
     <TestDependsOnAspNetRuntime>false</TestDependsOnAspNetRuntime>
     <TestDependsOnAspNetPackages>false</TestDependsOnAspNetPackages>
   </PropertyGroup>
@@ -7,8 +8,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <!-- Keep this property after importing Directory.Build.props, it works around arcade assuming test projects have "Test" in the name -->
-    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <IsBuildable>false</IsBuildable>
     <!-- Npm tests don't run on Helix currently, so we need to set this to false to still run the tests on non-Helix -->

--- a/src/SignalR/clients/ts/common/common.npmproj
+++ b/src/SignalR/clients/ts/common/common.npmproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsBuildable>false</IsBuildable>
-    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/signalr-protocol-msgpack.npmproj
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/signalr-protocol-msgpack.npmproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <PackageId>@microsoft/signalr-protocol-msgpack</PackageId>
     <IsPackable>true</IsPackable>
-    <IsTestProject>false</IsTestProject>
     <PackOnBuild>true</PackOnBuild>
   </PropertyGroup>
 

--- a/src/SignalR/clients/ts/signalr/signalr.npmproj
+++ b/src/SignalR/clients/ts/signalr/signalr.npmproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <PackageId>@microsoft/signalr</PackageId>
     <IsPackable>true</IsPackable>
-    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -8,8 +8,6 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
-    <!-- This is actually a library for test projects, not a test project. -->
-    <IsUnitTestProject>false</IsUnitTestProject>
     <IsPackable>true</IsPackable>
     <GenerateFrameworkReferenceAssembly>true</GenerateFrameworkReferenceAssembly>
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->


### PR DESCRIPTION
- condense `$(_UseHelixOpenQueues)` YAML
- restore ability to override `$(IsUnitTestProject)`
- treat `$(IsUnitTestProject)` and `$(IsTestProject)` as `bool` after Arcade SDK.props imported
- avoid attempts to override `$(RunQuarantinedTests)`; it's set globally
- remove unnecessary `$(IsUnitTestProject)` and `$(IsTestProject)` settings
  - override `$(IsUnitTestProject)` (not `$(IsTestProject)`) _before_ root Directory.Build.props