### PR TITLE
Split IHttpHeadersHandler into internal and pubinternal copies

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
+++ b/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
-    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpStreamHeadersHandler.cs" LinkBase="Shared\IHttpStreamHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
@@ -29,7 +29,7 @@
     <Compile Include="..\IIS.Shared.FunctionalTests\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
-    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpStreamHeadersHandler.cs" LinkBase="Shared\IHttpStreamHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" Exclude="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />

--- a/src/Servers/IIS/IIS/test/IIS.LongTests/IIS.LongTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.LongTests/IIS.LongTests.csproj
@@ -24,7 +24,7 @@
     <Compile Include="..\Common.LongTests\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
-    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpStreamHeadersHandler.cs" LinkBase="Shared\IHttpStreamHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" Exclude="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />

--- a/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewHandler.FunctionalTests/IIS.NewHandler.FunctionalTests.csproj
@@ -17,7 +17,7 @@
     <Compile Include="..\IIS.Shared.FunctionalTests\Properties\AssemblyInfo.cs" />
     <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
-    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpStreamHeadersHandler.cs" LinkBase="Shared\IHttpStreamHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" Exclude="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />

--- a/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.NewShim.FunctionalTests/IIS.NewShim.FunctionalTests.csproj
@@ -27,7 +27,7 @@
     <Compile Include="..\IIS.Shared.FunctionalTests\Properties\AssemblyInfo.cs" />
     <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
-    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpStreamHeadersHandler.cs" LinkBase="Shared\IHttpStreamHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" Exclude="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
@@ -29,7 +29,7 @@
     <Compile Include="..\Common.FunctionalTests\**\*.cs" Exclude="..\Common.FunctionalTests\Infrastructure\RequiresIISAttribute.cs" />
     <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
     <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2\" />
-    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpStreamHeadersHandler.cs" LinkBase="Shared\IHttpStreamHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" Exclude="$(SharedSourceRoot)ServerInfrastructure\DuplexPipe.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpHeadersHandler.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpHeadersHandler.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+
+public interface IHttpHeadersHandler
+{
+    void OnStaticIndexedHeader(int index);
+    void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value);
+    void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value);
+    void OnHeadersComplete(bool endStream);
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/IHttpParser.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Buffers;
-using System.Net.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -23,11 +23,10 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
-using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 
-internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpHeadersHandler, IRequestProcessor
+internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStreamHeadersHandler, IRequestProcessor
 {
     public static ReadOnlySpan<byte> ClientPreface => ClientPrefaceBytes;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
+using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -17,11 +17,10 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
-using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 
-internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpHeadersHandler, IThreadPoolWorkItem
+internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpStreamHeadersHandler, IThreadPoolWorkItem
 {
     private static ReadOnlySpan<byte> AuthorityBytes => new byte[10] { (byte)':', (byte)'a', (byte)'u', (byte)'t', (byte)'h', (byte)'o', (byte)'r', (byte)'i', (byte)'t', (byte)'y' };
     private static ReadOnlySpan<byte> MethodBytes => new byte[7] { (byte)':', (byte)'m', (byte)'e', (byte)'t', (byte)'h', (byte)'o', (byte)'d' };

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
+using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 
@@ -199,6 +200,11 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpH
     {
         var knownHeader = H3StaticTable.Get(index);
         OnHeader(knownHeader.Name, value);
+    }
+
+    public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+    {
+        OnHeader(name, value);
     }
 
     public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value) => OnHeader(name, value, checkForNewlineChars: true);

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler.OnDynamicIndexedHeader(int? index, System.ReadOnlySpan<byte> name, System.ReadOnlySpan<byte> value) -> void

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -16,7 +16,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
-using IHttpHeadersHandler = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
+using IHttpHeadersHandler = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
-using IHttpHeadersHandler = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http1ConnectionBenchmark.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
+using IHttpHeadersHandler = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/HPackDecoderBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/HPackDecoderBenchmark.cs
@@ -109,7 +109,7 @@ public class HPackDecoderBenchmark
         _decoder.Decode(_indexedHeaderDynamic_Multiple, endHeaders: true, handler: _testHeadersHandler);
     }
 
-    private class TestHeadersHandler : IHttpHeadersHandler
+    private class TestHeadersHandler : IHttpStreamHeadersHandler
     {
         public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/HPackDecoderBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/HPackDecoderBenchmark.cs
@@ -1,14 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Linq;
+using System.Net.Http;
 using System.Net.Http.HPack;
 using System.Text;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 
@@ -115,6 +111,10 @@ public class HPackDecoderBenchmark
 
     private class TestHeadersHandler : IHttpHeadersHandler
     {
+        public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        {
+        }
+
         public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
         }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http3/QPackDecoderBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http3/QPackDecoderBenchmark.cs
@@ -7,7 +7,6 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
-using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 
@@ -99,7 +98,7 @@ public class QPackDecoderBenchmark
         _decoder.Reset();
     }
 
-    private class TestHeadersHandler : IHttpHeadersHandler
+    private class TestHeadersHandler : IHttpStreamHeadersHandler
     {
         public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http3/QPackDecoderBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http3/QPackDecoderBenchmark.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http;
 using System.Net.Http.QPack;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
+using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 
@@ -99,6 +101,10 @@ public class QPackDecoderBenchmark
 
     private class TestHeadersHandler : IHttpHeadersHandler
     {
+        public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        {
+        }
+
         public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
         }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpParserBenchmark.cs
@@ -4,7 +4,6 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using IHttpHeadersHandler = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpParserBenchmark.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Buffers;
-using System.Net.Http;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
-using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
+using IHttpHeadersHandler = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 

--- a/src/Servers/Kestrel/samples/http2cat/http2cat.csproj
+++ b/src/Servers/Kestrel/samples/http2cat/http2cat.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)runtime\Http2\**\*.cs" LinkBase="Shared\Http2" />
-    <Compile Include="$(SharedSourceRoot)runtime\IHttpHeadersHandler.cs" LinkBase="Shared\IHttpHeadersHandler.cs" />
+    <Compile Include="$(SharedSourceRoot)runtime\IHttpStreamHeadersHandler.cs" LinkBase="Shared\IHttpStreamHeadersHandler.cs" />
     <Compile Include="$(SharedSourceRoot)runtime\SR.cs" LinkBase="Shared\SR.cs" />
     <Compile Include="$(SharedSourceRoot)Http2cat\**\*.cs" LinkBase="Shared\Http2cat" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" LinkBase="Shared\" />

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -25,7 +25,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using static System.IO.Pipelines.DuplexPipe;
 using Http3SettingType = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3.Http3SettingType;
-using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Testing;
 
@@ -597,7 +596,7 @@ internal class Http3RequestHeaderHandler
     public readonly Dictionary<string, string> DecodedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 }
 
-internal class Http3RequestStream : Http3StreamBase, IHttpHeadersHandler
+internal class Http3RequestStream : Http3StreamBase, IHttpStreamHeadersHandler
 {
     private readonly TestStreamContext _testStreamContext;
     private readonly Http3RequestHeaderHandler _headerHandler;

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -25,6 +25,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using static System.IO.Pipelines.DuplexPipe;
 using Http3SettingType = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3.Http3SettingType;
+using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Testing;
 
@@ -730,6 +731,11 @@ internal class Http3RequestStream : Http3StreamBase, IHttpHeadersHandler
     public void Complete()
     {
         _testStreamContext.Complete();
+    }
+
+    public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+    {
+        _headerHandler.DecodedHeaders[name.GetAsciiStringNonNullCharacters()] = value.GetAsciiOrUTF8StringNonNullCharacters();
     }
 }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Moq;
-using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 
@@ -2152,7 +2151,7 @@ public class Http2ConnectionTests : Http2TestBase
         await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
     }
 
-    private class TestHttpHeadersHandler : IHttpHeadersHandler
+    private class TestHttpHeadersHandler : IHttpStreamHeadersHandler
     {
         public readonly Dictionary<string, StringValues> Headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Moq;
+using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 
@@ -2154,6 +2155,11 @@ public class Http2ConnectionTests : Http2TestBase
     private class TestHttpHeadersHandler : IHttpHeadersHandler
     {
         public readonly Dictionary<string, StringValues> Headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        {
+            OnHeader(name, value);
+        }
 
         public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -25,6 +25,7 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit.Abstractions;
+using IHttpHeadersHandler = System.Net.Http.IHttpHeadersHandler;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 
@@ -435,6 +436,11 @@ public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, 
     }
 
     void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }
+
+    void IHttpHeadersHandler.OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+    {
+        ((IHttpHeadersHandler)this).OnHeader(name, value);
+    }
 
     protected void CreateConnection()
     {

--- a/src/Shared/Http2cat/Http2Utilities.cs
+++ b/src/Shared/Http2cat/Http2Utilities.cs
@@ -975,6 +975,11 @@ internal class Http2Utilities : IHttpHeadersHandler
         ((IHttpHeadersHandler)this).OnHeader(H2StaticTable.Get(index - 1).Name, value);
     }
 
+    public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+    {
+        ((IHttpHeadersHandler)this).OnHeader(name, value);
+    }
+
     internal class Http2FrameWithPayload : Http2Frame
     {
         public Http2FrameWithPayload() : base()

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -118,7 +118,7 @@ namespace System.Net.Http.HPack
             _headerValueOctets = new byte[DefaultStringOctetsSize];
         }
 
-        public void Decode(in ReadOnlySequence<byte> data, bool endHeaders, IHttpHeadersHandler handler)
+        public void Decode(in ReadOnlySequence<byte> data, bool endHeaders, IHttpStreamHeadersHandler handler)
         {
             foreach (ReadOnlyMemory<byte> segment in data)
             {
@@ -128,13 +128,13 @@ namespace System.Net.Http.HPack
             CheckIncompleteHeaderBlock(endHeaders);
         }
 
-        public void Decode(ReadOnlySpan<byte> data, bool endHeaders, IHttpHeadersHandler handler)
+        public void Decode(ReadOnlySpan<byte> data, bool endHeaders, IHttpStreamHeadersHandler handler)
         {
             DecodeInternal(data, handler);
             CheckIncompleteHeaderBlock(endHeaders);
         }
 
-        private void DecodeInternal(ReadOnlySpan<byte> data, IHttpHeadersHandler handler)
+        private void DecodeInternal(ReadOnlySpan<byte> data, IHttpStreamHeadersHandler handler)
         {
             int currentIndex = 0;
 
@@ -206,7 +206,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseHeaderValueLength(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderValueLength(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (currentIndex < data.Length)
             {
@@ -236,7 +236,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseHeaderNameLengthContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderNameLengthContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -249,7 +249,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseHeaderValueLengthContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderValueLengthContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -261,7 +261,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseHeaderFieldIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderFieldIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -269,7 +269,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseHeaderNameIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderNameIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -278,7 +278,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseHeaderNameLength(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderNameLength(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (currentIndex < data.Length)
             {
@@ -304,7 +304,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void Parse(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void Parse(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (currentIndex < data.Length)
             {
@@ -388,7 +388,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseLiteralHeaderField(ReadOnlySpan<byte> data, ref int currentIndex, byte b, byte mask, byte indexPrefix, bool index, IHttpHeadersHandler handler)
+        private void ParseLiteralHeaderField(ReadOnlySpan<byte> data, ref int currentIndex, byte b, byte mask, byte indexPrefix, bool index, IHttpStreamHeadersHandler handler)
         {
             _headersObserved = true;
 
@@ -415,7 +415,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseHeaderName(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderName(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             // Read remaining chars, up to the length of the current data
             int count = Math.Min(_stringLength - _stringIndex, data.Length - currentIndex);
@@ -452,7 +452,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ParseHeaderValue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderValue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             // Read remaining chars, up to the length of the current data
             int count = Math.Min(_stringLength - _stringIndex, data.Length - currentIndex);
@@ -496,7 +496,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void ProcessHeaderValue(ReadOnlySpan<byte> data, IHttpHeadersHandler handler)
+        private void ProcessHeaderValue(ReadOnlySpan<byte> data, IHttpStreamHeadersHandler handler)
         {
             ReadOnlySpan<byte> headerValueSpan = _headerValueRange == null
                 ? _headerValueOctets.AsSpan(0, _headerValueLength)
@@ -539,7 +539,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        private void OnIndexedHeaderField(int index, IHttpHeadersHandler handler)
+        private void OnIndexedHeaderField(int index, IHttpStreamHeadersHandler handler)
         {
             if (index <= H2StaticTable.Count)
             {

--- a/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
@@ -163,7 +163,7 @@ namespace System.Net.Http.QPack
             _state = State.RequiredInsertCount;
         }
 
-        public void Decode(in ReadOnlySequence<byte> data, bool endHeaders, IHttpHeadersHandler handler)
+        public void Decode(in ReadOnlySequence<byte> data, bool endHeaders, IHttpStreamHeadersHandler handler)
         {
             foreach (ReadOnlyMemory<byte> segment in data)
             {
@@ -172,13 +172,13 @@ namespace System.Net.Http.QPack
             CheckIncompleteHeaderBlock(endHeaders);
         }
 
-        public void Decode(ReadOnlySpan<byte> data, bool endHeaders, IHttpHeadersHandler handler)
+        public void Decode(ReadOnlySpan<byte> data, bool endHeaders, IHttpStreamHeadersHandler handler)
         {
             DecodeInternal(data, handler);
             CheckIncompleteHeaderBlock(endHeaders);
         }
 
-        private void DecodeInternal(ReadOnlySpan<byte> data, IHttpHeadersHandler handler)
+        private void DecodeInternal(ReadOnlySpan<byte> data, IHttpStreamHeadersHandler handler)
         {
             int currentIndex = 0;
 
@@ -253,7 +253,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseHeaderNameIndexPostBase(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderNameIndexPostBase(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -261,7 +261,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParsePostBaseIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParsePostBaseIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -269,7 +269,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseHeaderNameLength(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderNameLength(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -282,7 +282,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseHeaderName(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderName(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             // Read remaining chars, up to the length of the current data
             int count = Math.Min(_stringLength - _stringIndex, data.Length - currentIndex);
@@ -320,7 +320,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseHeaderFieldIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderFieldIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -328,7 +328,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseHeaderNameIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderNameIndex(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -337,7 +337,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseHeaderValueLength(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderValueLength(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (currentIndex < data.Length)
             {
@@ -367,7 +367,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseHeaderValue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderValue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             // Read remaining chars, up to the length of the current data
             int count = Math.Min(_stringLength - _stringIndex, data.Length - currentIndex);
@@ -404,7 +404,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseHeaderValueLengthContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseHeaderValueLengthContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -421,7 +421,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseCompressedHeaders(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseCompressedHeaders(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (currentIndex < data.Length)
             {
@@ -520,7 +520,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseRequiredInsertCountContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseRequiredInsertCountContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -529,7 +529,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseBase(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseBase(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (currentIndex < data.Length)
             {
@@ -549,7 +549,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseBaseContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseBaseContinue(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (TryDecodeInteger(data, ref currentIndex, out int intResult))
             {
@@ -558,7 +558,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ParseRequiredInsertCount(ReadOnlySpan<byte> data, ref int currentIndex, IHttpHeadersHandler handler)
+        private void ParseRequiredInsertCount(ReadOnlySpan<byte> data, ref int currentIndex, IHttpStreamHeadersHandler handler)
         {
             if (currentIndex < data.Length)
             {
@@ -588,7 +588,7 @@ namespace System.Net.Http.QPack
             }
         }
 
-        private void ProcessHeaderValue(ReadOnlySpan<byte> data, IHttpHeadersHandler handler)
+        private void ProcessHeaderValue(ReadOnlySpan<byte> data, IHttpStreamHeadersHandler handler)
         {
             ReadOnlySpan<byte> headerValueSpan = _headerValueRange == null
                 ? _headerValueOctets.AsSpan(0, _headerValueLength)
@@ -718,7 +718,7 @@ namespace System.Net.Http.QPack
             // _state = State.HeaderValueLength;
         }
 
-        private void OnPostBaseIndex(int intResult, IHttpHeadersHandler handler)
+        private void OnPostBaseIndex(int intResult, IHttpStreamHeadersHandler handler)
         {
             ThrowDynamicTableNotSupported();
             // TODO
@@ -743,7 +743,7 @@ namespace System.Net.Http.QPack
             _state = State.Base;
         }
 
-        private void OnIndexedHeaderField(int index, IHttpHeadersHandler handler)
+        private void OnIndexedHeaderField(int index, IHttpStreamHeadersHandler handler)
         {
             handler.OnStaticIndexedHeader(index);
             _state = State.CompressedHeaders;

--- a/src/Shared/runtime/IHttpHeadersHandler.cs
+++ b/src/Shared/runtime/IHttpHeadersHandler.cs
@@ -1,31 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Don't ever change this unless we are explicitly trying to remove IHttpHeadersHandler as public API.
-#if KESTREL
-using System;
-
-namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
-#else
 namespace System.Net.Http
-#endif
 {
-#if KESTREL
-    public
-#else
-    internal
-#endif
-    interface IHttpHeadersHandler
+    internal interface IHttpHeadersHandler
     {
         void OnStaticIndexedHeader(int index);
         void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value);
         void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value);
         void OnHeadersComplete(bool endStream);
-
-        // DIM to avoid breaking change on public interface (for Kestrel).
-        public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
-        {
-            OnHeader(name, value);
-        }
+        void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value);
     }
 }

--- a/src/Shared/runtime/IHttpStreamHeadersHandler.cs
+++ b/src/Shared/runtime/IHttpStreamHeadersHandler.cs
@@ -3,7 +3,7 @@
 
 namespace System.Net.Http
 {
-    internal interface IHttpHeadersHandler
+    internal interface IHttpStreamHeadersHandler
     {
         void OnStaticIndexedHeader(int index);
         void OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value);

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -719,12 +719,12 @@ namespace System.Net.Http.Unit.Tests.HPack
         }
     }
 
-    public class TestHttpHeadersHandler : IHttpHeadersHandler
+    public class TestHttpHeadersHandler : IHttpStreamHeadersHandler
     {
         public Dictionary<string, string> DecodedHeaders { get; } = new Dictionary<string, string>();
         public Dictionary<int, KeyValuePair<string, string>> DecodedStaticHeaders { get; } = new Dictionary<int, KeyValuePair<string, string>>();
 
-        void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        void IHttpStreamHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
             string headerName = Encoding.ASCII.GetString(name);
             string headerValue = Encoding.ASCII.GetString(value);
@@ -732,23 +732,23 @@ namespace System.Net.Http.Unit.Tests.HPack
             DecodedHeaders[headerName] = headerValue;
         }
 
-        void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
+        void IHttpStreamHeadersHandler.OnStaticIndexedHeader(int index)
         {
             ref readonly HeaderField entry = ref H2StaticTable.Get(index - 1);
-            ((IHttpHeadersHandler)this).OnHeader(entry.Name, entry.Value);
+            ((IHttpStreamHeadersHandler)this).OnHeader(entry.Name, entry.Value);
             DecodedStaticHeaders[index] = new KeyValuePair<string, string>(Encoding.ASCII.GetString(entry.Name), Encoding.ASCII.GetString(entry.Value));
         }
 
-        void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+        void IHttpStreamHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
         {
             byte[] name = H2StaticTable.Get(index - 1).Name;
-            ((IHttpHeadersHandler)this).OnHeader(name, value);
+            ((IHttpStreamHeadersHandler)this).OnHeader(name, value);
             DecodedStaticHeaders[index] = new KeyValuePair<string, string>(Encoding.ASCII.GetString(name), Encoding.ASCII.GetString(value));
         }
 
-        void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }
+        void IHttpStreamHeadersHandler.OnHeadersComplete(bool endStream) { }
 
-        void IHttpHeadersHandler.OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        void IHttpStreamHeadersHandler.OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
             string headerName = Encoding.ASCII.GetString(name);
             string headerValue = Encoding.ASCII.GetString(value);

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -747,5 +747,13 @@ namespace System.Net.Http.Unit.Tests.HPack
         }
 
         void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }
+
+        void IHttpHeadersHandler.OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        {
+            string headerName = Encoding.ASCII.GetString(name);
+            string headerValue = Encoding.ASCII.GetString(value);
+
+            DecodedHeaders[headerName] = headerValue;
+        }
     }
 }

--- a/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
@@ -264,12 +264,12 @@ namespace System.Net.Http.Unit.Tests.QPack
         }
     }
 
-    public class TestHttpHeadersHandler : IHttpHeadersHandler
+    public class TestHttpHeadersHandler : IHttpStreamHeadersHandler
     {
         public Dictionary<string, string> DecodedHeaders { get; } = new Dictionary<string, string>();
         public Dictionary<int, KeyValuePair<string, string>> DecodedStaticHeaders { get; } = new Dictionary<int, KeyValuePair<string, string>>();
 
-        void IHttpHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        void IHttpStreamHeadersHandler.OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
             if (name.Length == 0)
             {
@@ -282,21 +282,21 @@ namespace System.Net.Http.Unit.Tests.QPack
             DecodedHeaders[headerName] = headerValue;
         }
 
-        void IHttpHeadersHandler.OnStaticIndexedHeader(int index)
+        void IHttpStreamHeadersHandler.OnStaticIndexedHeader(int index)
         {
             ref readonly HeaderField entry = ref H3StaticTable.Get(index);
-            ((IHttpHeadersHandler)this).OnHeader(entry.Name, entry.Value);
+            ((IHttpStreamHeadersHandler)this).OnHeader(entry.Name, entry.Value);
             DecodedStaticHeaders[index] = new KeyValuePair<string, string>(Encoding.ASCII.GetString(entry.Name), Encoding.ASCII.GetString(entry.Value));
         }
 
-        void IHttpHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
+        void IHttpStreamHeadersHandler.OnStaticIndexedHeader(int index, ReadOnlySpan<byte> value)
         {
             byte[] name = H3StaticTable.Get(index).Name;
-            ((IHttpHeadersHandler)this).OnHeader(name, value);
+            ((IHttpStreamHeadersHandler)this).OnHeader(name, value);
             DecodedStaticHeaders[index] = new KeyValuePair<string, string>(Encoding.ASCII.GetString(name), Encoding.ASCII.GetString(value));
         }
 
-        void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }
+        void IHttpStreamHeadersHandler.OnHeadersComplete(bool endStream) { }
 
         public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {

--- a/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
@@ -297,5 +297,13 @@ namespace System.Net.Http.Unit.Tests.QPack
         }
 
         void IHttpHeadersHandler.OnHeadersComplete(bool endStream) { }
+
+        public void OnDynamicIndexedHeader(int? index, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+        {
+            string headerName = Encoding.ASCII.GetString(name);
+            string headerValue = Encoding.ASCII.GetString(value);
+
+            DecodedHeaders[headerName] = headerValue;
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/38981