### PR TITLE
Bump up download file timeout

### DIFF
--- a/eng/tools/RepoTasks/DownloadFile.cs
+++ b/eng/tools/RepoTasks/DownloadFile.cs
@@ -100,7 +100,7 @@ public class DownloadFile : Microsoft.Build.Utilities.Task
 
         Log.LogMessage(MessageImportance.High, $"Attempting download '{source}' to '{target}'");
 
-        using (var httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(5) })
+        using (var httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(7.5) })
         {
             for (int retryNumber = 0; retryNumber < MaxRetries; retryNumber++)
             {


### PR DESCRIPTION
MacOS jobs have had a significant increase in failure rates due to timing out when attempting to retrieve from blob storage. This PR increases the timeout value. 

```
##[error]src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj(458,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Problems downloading file from 'https://dotnetbuilds.blob.core.windows.net/public/Runtime/7.0.0-alpha.1.21609.9/dotnet-runtime-7.0.0-alpha.1.21609.9-osx-x64.tar.gz'. The request was canceled due to the configured HttpClient.Timeout of 300 seconds elapsing. at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts) 
 at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken) 
 at RepoTasks.DownloadFile.DownloadWithRetriesAsync(String source, String target, List`1 errorMessages) in /_/eng/tools/RepoTasks/DownloadFile.cs:line 109 
/Users/runner/work/1/s/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj(458,5): error : Problems downloading file from 'https://dotnetbuilds.blob.core.windows.net/public/Runtime/7.0.0-alpha.1.21609.9/dotnet-runtime-7.0.0-alpha.1.21609.9-osx-x64.tar.gz'. The request was canceled due to the configured HttpClient.Timeout of 300 seconds elapsing. at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts) 
/Users/runner/work/1/s/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj(458,5): error : at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken) 
/Users/runner/work/1/s/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj(458,5): error : at RepoTasks.DownloadFile.DownloadWithRetriesAsync(String source, String target, List`1 errorMessages) in /_/eng/tools/RepoTasks/DownloadFile.cs:line 109 
```

Example Pipeline: https://dev.azure.com/dnceng/public/_build/results?buildId=1507432&view=logs&jobId=9895f7d8-b062-540b-461c-07f8695bfcc6&j=9895f7d8-b062-540b-461c-07f8695bfcc6&t=a6c33838-4cf4-594d-88cb-801ae7f8db2f

I contacted first responders, there doesn't seem to be a known network/blob storage issue which would cause this. 