### PR TITLE
Use CDN for .NET Assets

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -283,7 +283,7 @@
   <!-- Restore feeds -->
   <PropertyGroup Label="Restore feeds">
     <!-- In an orchestrated build, this may be overridden to other Azure feeds. -->
-    <DotNetAssetRootUrl Condition="'$(DotNetAssetRootUrl)'==''">https://dotnetbuilds.blob.core.windows.net/public/</DotNetAssetRootUrl>
+    <DotNetAssetRootUrl Condition="'$(DotNetAssetRootUrl)'==''">https://dotnetbuilds.azureedge.net/public/</DotNetAssetRootUrl>
     <DotNetPrivateAssetRootUrl Condition="'$(DotNetPrivateAssetRootUrl)'==''">https://dotnetclimsrc.blob.core.windows.net/dotnet/</DotNetPrivateAssetRootUrl>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updating to use CDN per @MattGal's suggestion. 

https://dotnetbuilds.blob.core.windows.net/public/Runtime/7.0.0-alpha.1.21609.9/dotnet-runtime-7.0.0-alpha.1.21609.9-osx-x64.tar.gz -->
https://dotnetbuilds.azureedge.net/public/Runtime/7.0.0-alpha.1.21609.9/dotnet-runtime-7.0.0-alpha.1.21609.9-osx-x64.tar.gz

Should help bolster reliability along with https://github.com/dotnet/aspnetcore/pull/39005. 