### PR TITLE
Updated sample to use new TLS Api

### DIFF
--- a/src/Security/Authentication/Certificate/samples/Certificate.Optional.Sample/Program.cs
+++ b/src/Security/Authentication/Certificate/samples/Certificate.Optional.Sample/Program.cs
@@ -12,8 +12,8 @@ namespace Certificate.Optional.Sample;
 
 public class Program
 {
-    public const string HostWithoutCert = "example.com";
-    public const string HostWithCert = "cert.example.com";
+    public const string HostWithoutCert = "127.0.0.1";
+    public const string HostWithCert = "127.0.0.2";
 
     public static void Main(string[] args)
     {
@@ -24,9 +24,10 @@ public class Program
         Host.CreateDefaultBuilder(args)
             .ConfigureWebHostDefaults(webBuilder =>
             {
-                // the certificate is issued for example.com and cert.example.com domains
+                // load the self-signed certificate issued for 127.0.0.1 and 127.0.0.2 domains
+                // https://docs.microsoft.com/en-us/dotnet/core/additional-tools/self-signed-certificates-guide
                 var serverCertificate = CertificateLoader.LoadFromStoreCert(
-                    "example.com", "My", StoreLocation.CurrentUser,
+                    "localhost", "My", StoreLocation.CurrentUser,
                     allowInvalid: true);
 
                 webBuilder.UseStartup<Startup>();
@@ -48,7 +49,7 @@ public class Program
                                     });
                                 }
 
-                                // require a client certificate to access cert.example.com
+                                // require a client certificate to access 127.0.0.2
                                 return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions()
                                 {
                                     ClientCertificateRequired = true,

--- a/src/Security/Authentication/Certificate/samples/Certificate.Optional.Sample/README.md
+++ b/src/Security/Authentication/Certificate/samples/Certificate.Optional.Sample/README.md
@@ -7,6 +7,8 @@ Client certificates are not an HTTP feature, they're a TLS feature. As such they
 
 There's an old way to renegotiate a connection if you find you need a client cert after it's established. It's a TLS action that pauses all traffic, redoes the TLS handshake, and allows you to request a client certificate. This caused a number of problems including weakening security, TCP deadlocks for POST requests, etc.. HTTP/2 has since disallowed this mechanism.
 
-This example shows an pattern for requiring client certificates only in some parts of your site by using different host bindings. The application is set up using two host names, mydomain.com and cert.mydomain.com (I've cheated and used 127.0.0.1 and 127.0.0.2 here instead to avoid setting up DNS). cert.mydomain.com is configured in the server to require client certificates, but mydomain.com is not. When you request part of the site that requires a client certificate it can redirect to the cert.mydomain.com while preserving the request path and query and the client will prompt for a certificate.
+This example shows an pattern for requiring client certificates only in some parts of your site by using different host bindings. The application is set up using two host names, example.com and cert.example.com
 
-Redirecting back to mydomain.com does not accomplish a real sign-out because the browser still caches the client cert selected for cert.mydomain.com. The only way to clear the browser cache is to close the browser.
+cert.example.com is configured in the server to require client certificates, but example.com is not. When you request part of the site that requires a client certificate it can redirect to the cert.example.com while preserving the request path and query and the client will prompt for a certificate.
+
+Redirecting back to example.com does not accomplish a real sign-out because the browser still caches the client cert selected for cert.example.com. The only way to clear the browser cache is to close the browser.

--- a/src/Security/Authentication/Certificate/samples/Certificate.Optional.Sample/README.md
+++ b/src/Security/Authentication/Certificate/samples/Certificate.Optional.Sample/README.md
@@ -7,8 +7,6 @@ Client certificates are not an HTTP feature, they're a TLS feature. As such they
 
 There's an old way to renegotiate a connection if you find you need a client cert after it's established. It's a TLS action that pauses all traffic, redoes the TLS handshake, and allows you to request a client certificate. This caused a number of problems including weakening security, TCP deadlocks for POST requests, etc.. HTTP/2 has since disallowed this mechanism.
 
-This example shows an pattern for requiring client certificates only in some parts of your site by using different host bindings. The application is set up using two host names, example.com and cert.example.com
+This example shows an pattern for requiring client certificates only in some parts of your site by using different host bindings. The application is set up using two host names, mydomain.com and cert.mydomain.com (I've cheated and used 127.0.0.1 and 127.0.0.2 here instead to avoid setting up DNS). cert.mydomain.com is configured in the server to require client certificates, but mydomain.com is not. When you request part of the site that requires a client certificate it can redirect to the cert.mydomain.com while preserving the request path and query and the client will prompt for a certificate.
 
-cert.example.com is configured in the server to require client certificates, but example.com is not. When you request part of the site that requires a client certificate it can redirect to the cert.example.com while preserving the request path and query and the client will prompt for a certificate.
-
-Redirecting back to example.com does not accomplish a real sign-out because the browser still caches the client cert selected for cert.example.com. The only way to clear the browser cache is to close the browser.
+Redirecting back to mydomain.com does not accomplish a real sign-out because the browser still caches the client cert selected for cert.mydomain.com. The only way to clear the browser cache is to close the browser.


### PR DESCRIPTION
# Updated sample to use new TLS Api

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Updated the `Certificate.Optional.Sample` to use the new API and with host names instead of ip addresses.

## Description

I've changed the sample code to use the new method `public static ListenOptions UseHttps(this ListenOptions listenOptions, TlsHandshakeCallbackOptions callbackOptions)` to configure when the client certificate is required to make the handshake. Also changed the README to reflect the current state of the sample

## Details

+ Load the server certificate using the store, as this is required to create the instance of `SslServerAuthenticationOptions`, I got the `System.NotSupportedException: The server mode SSL must use a certificate with the associated private key` without the `ServerCertificate` property specified
+ in `README.md` and `Program.cs`: Changed ip address to host names `example.com` and `cert.example.com`, also changed the `mydomain` to `example.com`, see [IANA-managed Reserved Domain](https://www.iana.org/domains/reserved)
+ Made the implementation inside `OnConnection` callback, tried to mantain the same behavior but I saw that `ClientCertificateMode` is not avaliable anymore, so I used the `ClientCertificateRequired` together with `RemoteCertificateValidationCallback` to block the connection.

## Tests

I followed the docs to generate a [self siged certificate through powershell](https://docs.microsoft.com/en-us/dotnet/core/additional-tools/self-signed-certificates-guide) and generated a certificate for `example.com` and `cert.example.com` (This can be a inline doc in Program.cs to instruct user about the sub domain)

Changed the `hosts` file inside `C:\Windows\System32\drivers\etc` with the content:

```txt
127.0.0.1 example.com
127.0.0.1 cert.example.com
```

Used the powershell to store the certificate in `cert:\LocalMachine\Root`, restarted chrome and tried to access the https://example.com:5001 (you'll see the screenshots with the 5005 port because I tested with it, but I changed the final code to 5001 later).

![image](https://user-images.githubusercontent.com/46539053/145940613-9270cc49-ad5b-4fae-8b89-f9d2a3aa6f50.png)

now, let's try `https://cert.example.com`:

![image](https://user-images.githubusercontent.com/46539053/145940660-95deb5bf-eeef-40da-bb4d-e6f1d4f227a2.png)

✔ I choosed cancel and got the `ERR_BAD_SSL_CLIENT_AUTH_CERT` as expected:

![image](https://user-images.githubusercontent.com/46539053/145940698-601fff47-d0c4-4bc8-956d-24a34e30e7f2.png)

✔ tried again and have choosen the certificate, successfully worked:

![image](https://user-images.githubusercontent.com/46539053/145940882-faed9919-8eff-4e8c-82c7-f16f4bb7ad21.png)

## Notes

❌ the `/auth` seems not working and keeps showing the `Too many redirects` message in navigator for me, I think this isn't related to my changes since the old code had the same behavior.

![image](https://user-images.githubusercontent.com/46539053/145941207-5e00bf03-a89e-46be-a187-590fbb0243b6.png)


Fixes [#37753](https://github.com/dotnet/aspnetcore/issues/37753)
