### PR TITLE
Use full suffixed version for DepProviderKey in installers

### DIFF
--- a/src/Installers/Windows/Wix.targets
+++ b/src/Installers/Windows/Wix.targets
@@ -22,7 +22,7 @@
 
   <PropertyGroup Condition="'$(OutputType)' == 'package'">
     <InstallDir>$(ProductName)</InstallDir>
-    <DepProviderKey>Microsoft.$(ProductNameShort)_$(Platform)_$(Lang),v$(PackageVersion)</DepProviderKey>
+    <DepProviderKey>Microsoft.$(ProductNameShort)_$(Platform)_$(Lang),v$(_GeneratedPackageVersion)</DepProviderKey>
     <DefineConstants>$(DefineConstants);DepProviderKey=$(DepProviderKey)</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes a bug where preview, RC, and RTM targeting pack installers all have the same Dependency Provider Key due to using only `Major.Minor.Patch` as their version string.

Test build to grab installers: https://dev.azure.com/dnceng/internal/_build/results?buildId=1512376&view=results