### PR TITLE
Use correct path for NewtonsoftJson ModelState errors

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/ModelNames.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/ModelNames.cs
@@ -35,7 +35,7 @@ public static class ModelNames
     }
 
     /// <summary>
-    /// Create an property model name with a prefix.
+    /// Create a property model name with a prefix.
     /// </summary>
     /// <param name="prefix">The prefix to use.</param>
     /// <param name="propertyName">The property name.</param>

--- a/src/Mvc/Mvc.Core/test/Formatters/JsonInputFormatterTestBase.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/JsonInputFormatterTestBase.cs
@@ -1,22 +1,14 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Logging.Testing;
-using Moq;
 using Newtonsoft.Json;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters;
 
@@ -133,6 +125,34 @@ public abstract class JsonInputFormatterTestBase : LoggedTest
     }
 
     [Fact]
+    public virtual async Task JsonFormatter_EscapedKeys()
+    {
+        var expectedKey = JsonFormatter_EscapedKeys_Expected;
+
+        // Arrange
+        var content = "[{\"It\\\"s a key\": 1234556}]";
+        var formatter = GetInputFormatter();
+
+        var contentBytes = Encoding.UTF8.GetBytes(content);
+        var httpContext = GetHttpContext(contentBytes);
+
+        var formatterContext = CreateInputFormatterContext(
+            typeof(IEnumerable<IDictionary<string, short>>), httpContext);
+
+        // Act
+        var result = await formatter.ReadAsync(formatterContext);
+
+        // Assert
+        Assert.True(result.HasError);
+        Assert.Collection(
+            formatterContext.ModelState.OrderBy(k => k.Key),
+            kvp =>
+            {
+                Assert.Equal(expectedKey, kvp.Key);
+            });
+    }
+
+    [Fact]
     public virtual async Task JsonFormatter_EscapedKeys_Bracket()
     {
         var expectedKey = JsonFormatter_EscapedKeys_Bracket_Expected;
@@ -160,12 +180,12 @@ public abstract class JsonInputFormatterTestBase : LoggedTest
     }
 
     [Fact]
-    public virtual async Task JsonFormatter_EscapedKeys()
+    public virtual async Task JsonFormatter_EscapedKeys_SingleQuote()
     {
-        var expectedKey = JsonFormatter_EscapedKeys_Expected;
+        var expectedKey = JsonFormatter_EscapedKeys_SingleQuote_Expected;
 
         // Arrange
-        var content = "[{\"It\\\"s a key\": 1234556}]";
+        var content = "[{\"It's a key\": 1234556}]";
         var formatter = GetInputFormatter();
 
         var contentBytes = Encoding.UTF8.GetBytes(content);
@@ -472,6 +492,30 @@ public abstract class JsonInputFormatterTestBase : LoggedTest
     }
 
     [Fact]
+    public virtual async Task ReadAsync_NestedParseError()
+    {
+        // Arrange
+        var formatter = GetInputFormatter();
+        var content = @"{ ""b"": { ""c"": { ""d"": efg } } }";
+        var contentBytes = Encoding.UTF8.GetBytes(content);
+        var httpContext = GetHttpContext(contentBytes);
+
+        var formatterContext = CreateInputFormatterContext(typeof(A), httpContext);
+
+        // Act
+        var result = await formatter.ReadAsync(formatterContext);
+
+        // Assert
+        Assert.True(result.HasError, "Model should have had an error!");
+        Assert.Collection(
+            formatterContext.ModelState.OrderBy(k => k.Key),
+            kvp =>
+            {
+                Assert.Equal(ReadAsync_NestedParseError_Expected, kvp.Key);
+            });
+    }
+
+    [Fact]
     public virtual async Task ReadAsync_RequiredAttribute()
     {
         // Arrange
@@ -564,6 +608,8 @@ public abstract class JsonInputFormatterTestBase : LoggedTest
 
     internal abstract string JsonFormatter_EscapedKeys_Bracket_Expected { get; }
 
+    internal abstract string JsonFormatter_EscapedKeys_SingleQuote_Expected { get; }
+
     internal abstract string JsonFormatter_EscapedKeys_Expected { get; }
 
     internal abstract string ReadAsync_ArrayOfObjects_HasCorrectKey_Expected { get; }
@@ -575,6 +621,8 @@ public abstract class JsonInputFormatterTestBase : LoggedTest
     internal abstract string ReadAsync_InvalidComplexArray_AddsOverflowErrorsToModelState_Expected { get; }
 
     internal abstract string ReadAsync_ComplexPoco_Expected { get; }
+
+    internal abstract string ReadAsync_NestedParseError_Expected { get; }
 
     protected abstract TextInputFormatter GetInputFormatter(bool allowInputFormatterExceptionMessages = true);
 
@@ -635,6 +683,21 @@ public abstract class JsonInputFormatterTestBase : LoggedTest
         public decimal Age { get; set; }
 
         public byte Small { get; set; }
+    }
+
+    class A
+    {
+        public B B { get; set; }
+    }
+
+    class B 
+    {
+        public C C { get; set; }
+    }
+
+    class C
+    {
+        public string D { get; set; }
     }
 
     private class VerifyDisposeFileBufferingReadStream : FileBufferingReadStream

--- a/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/SystemTextJsonInputFormatterTest.cs
@@ -1,16 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters;
 
@@ -57,6 +52,12 @@ public class SystemTextJsonInputFormatterTest : JsonInputFormatterTestBase
     public override Task JsonFormatter_EscapedKeys_Bracket()
     {
         return base.JsonFormatter_EscapedKeys_Bracket();
+    }
+
+    [Fact]
+    public override Task JsonFormatter_EscapedKeys_SingleQuote()
+    {
+        return base.JsonFormatter_EscapedKeys_SingleQuote();
     }
 
     [Fact]
@@ -195,6 +196,8 @@ public class SystemTextJsonInputFormatterTest : JsonInputFormatterTestBase
 
     internal override string JsonFormatter_EscapedKeys_Bracket_Expected => "$[0]['It[s a key']";
 
+    internal override string JsonFormatter_EscapedKeys_SingleQuote_Expected => "$[0]['It's a key']";
+
     internal override string ReadAsync_ArrayOfObjects_HasCorrectKey_Expected => "$[2].Age";
 
     internal override string ReadAsync_InvalidArray_AddsOverflowErrorsToModelState_Expected => "$[2]";
@@ -202,6 +205,8 @@ public class SystemTextJsonInputFormatterTest : JsonInputFormatterTestBase
     internal override string ReadAsync_InvalidComplexArray_AddsOverflowErrorsToModelState_Expected => "$[1].Small";
 
     internal override string ReadAsync_ComplexPoco_Expected => "$.Person.Numbers[2]";
+
+    internal override string ReadAsync_NestedParseError_Expected => "$.b.c.d";
 
     private class TypeWithBadConverters
     {

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -234,30 +234,81 @@ public class NewtonsoftJsonInputFormatter : TextInputFormatter, IInputFormatterE
         {
             successful = false;
 
-            // When ErrorContext.Path does not include ErrorContext.Member, add Member to form full path.
+            // The following addMember logic is intended to append the names of missing required properties to the
+            // ModelStateDictionary key. Normally, just the ModelName and ErrorContext.Path is used for this key,
+            // but ErrorContext.Path does not include the missing required property name like we want it to.
+            // For example, given the following class and input missing the required "Name" property:
+            //
+            // class Person
+            // {
+            //     [JsonProperty(Required = Required.Always)]
+            //     public string Name { get; set; }
+            // }
+            //
+            // We will see the following ErrorContext:
+            //
+            // Error   {"Required property 'Name' not found in JSON. Path 'Person'..."} System.Exception {Newtonsoft.Json.JsonSerializationException}
+            // Member  "Name"   object {string}
+            // Path    "Person" string
+            //
+            // So we update the path used for the ModelStateDictionary key to be "Person.Name" instead of just "Person".
+            // See https://github.com/aspnet/Mvc/issues/8509
             var path = eventArgs.ErrorContext.Path;
-            var member = eventArgs.ErrorContext.Member?.ToString();
-            var addMember = !string.IsNullOrEmpty(member);
+            var member = eventArgs.ErrorContext.Member as string;
+
+            // There are some deserialization exceptions that include the member in the path but not at the end.
+            // For example, given the following classes and invalid input like { "b": { "c": { "d": abc } } }:
+            //
+            // class A
+            // {
+            //     public B B { get; set; }
+            // }
+            // class B 
+            // {
+            //     public C C { get; set; }
+            // }
+            // class C 
+            // {
+            //     public string D { get; set; }
+            // }
+            //
+            // We will see the following ErrorContext:
+            //
+            // Error   {"Unexpected character encountered while parsing value: b. Path 'b.c.d'..."} System.Exception {Newtonsoft.Json.JsonReaderException}
+            // Member  "c"     object {string}
+            // Path    "b.c.d" string
+            //
+            // Notice that Member "c" is in the middle of the Path "b.c.d". The error handler gets invoked for each level of nesting.
+            // null, "b", "c" and "d" are each a Member in different ErrorContexts all reporting the same parsing error.
+            //
+            // The parsing error is reported as a JsonReaderException instead of as a JsonSerializationException like
+            // for missing required properties. We use the exception type to filter out these errors and keep the path used
+            // for the ModelStateDictionary key as "b.c.d" instead of "b.c.d.c"
+            // See https://github.com/dotnet/aspnetcore/issues/33451 
+            var addMember = !string.IsNullOrEmpty(member) && eventArgs.ErrorContext.Error is JsonSerializationException;
+
+            // There are still JsonSerilizationExceptions that set ErrorContext.Member but include it at the
+            // end of ErrorContext.Path already. The following logic attempts to filter these out.
             if (addMember)
             {
                 // Path.Member case (path.Length < member.Length) needs no further checks.
                 if (path.Length == member!.Length)
                 {
-                    // Add Member in Path.Memb case but not for Path.Path.
+                    // Add Member in Path.Member case but not for Path.Path.
                     addMember = !string.Equals(path, member, StringComparison.Ordinal);
                 }
                 else if (path.Length > member.Length)
                 {
-                    // Finally, check whether Path already ends with Member.
+                    // Finally, check whether Path already ends or starts with Member.
                     if (member[0] == '[')
                     {
                         addMember = !path.EndsWith(member, StringComparison.Ordinal);
                     }
                     else
                     {
-                        addMember = !path.EndsWith("." + member, StringComparison.Ordinal)
-                            && !path.EndsWith("['" + member + "']", StringComparison.Ordinal)
-                            && !path.EndsWith("[" + member + "]", StringComparison.Ordinal);
+                        addMember = !path.EndsWith($".{member}", StringComparison.Ordinal)
+                            && !path.EndsWith($"['{member}']", StringComparison.Ordinal)
+                            && !path.EndsWith($"[{member}]", StringComparison.Ordinal);
                     }
                 }
             }

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
@@ -1,13 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.WebUtilities;
@@ -18,7 +14,6 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Mvc.Formatters;
 
@@ -209,6 +204,12 @@ public class NewtonsoftJsonInputFormatterTest : JsonInputFormatterTestBase
     public override Task JsonFormatter_EscapedKeys_Bracket()
     {
         return base.JsonFormatter_EscapedKeys_Bracket();
+    }
+
+    [Fact(Skip = "Expected: [0]['It\\'s a key'], Actual: [0]['It\\'s a key'].It's a key")]
+    public override Task JsonFormatter_EscapedKeys_SingleQuote()
+    {
+        return base.JsonFormatter_EscapedKeys_SingleQuote();
     }
 
     [Theory]
@@ -523,13 +524,17 @@ public class NewtonsoftJsonInputFormatterTest : JsonInputFormatterTestBase
 
     internal override string JsonFormatter_EscapedKeys_Expected => "[0]['It\"s a key']";
 
-    internal override string JsonFormatter_EscapedKeys_Bracket_Expected => "[0][\'It[s a key\']";
+    internal override string JsonFormatter_EscapedKeys_Bracket_Expected => "[0]['It[s a key']";
+
+    internal override string JsonFormatter_EscapedKeys_SingleQuote_Expected => "[0]['It\\'s a key']";
 
     internal override string ReadAsync_AddsModelValidationErrorsToModelState_Expected => "Age";
 
     internal override string ReadAsync_ArrayOfObjects_HasCorrectKey_Expected => "[2].Age";
 
     internal override string ReadAsync_ComplexPoco_Expected => "Person.Numbers[2]";
+
+    internal override string ReadAsync_NestedParseError_Expected => "b.c.d";
 
     internal override string ReadAsync_InvalidComplexArray_AddsOverflowErrorsToModelState_Expected => "names[1].Small";
 

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
@@ -206,7 +206,7 @@ public class NewtonsoftJsonInputFormatterTest : JsonInputFormatterTestBase
         return base.JsonFormatter_EscapedKeys_Bracket();
     }
 
-    [Fact(Skip = "Expected: [0]['It\\'s a key'], Actual: [0]['It\\'s a key'].It's a key")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/39069")]
     public override Task JsonFormatter_EscapedKeys_SingleQuote()
     {
         return base.JsonFormatter_EscapedKeys_SingleQuote();


### PR DESCRIPTION
# Use correct path for NewtonsoftJson ModelState errors

The NewtonsoftJsonInputFormatter has logic that's intended to append the names of missing required properties to the ModelStateDictionary key. Normally, just the ModelName and ErrorContext.Path is used for this key, but ErrorContext.Path does not include the missing required property name like we want it to. For example, given the following class and input missing the required "Name" property:

```C#
class Person
{
    [JsonProperty(Required = Required.Always)]
    public string Name { get; set; }
}
```

We will see the following ErrorContext:

```
Error   {"Required property 'Name' not found in JSON. Path 'Person'..."} System.Exception {Newtonsoft.Json.JsonSerializationException}
Member  "Name"   object {string}
Path    "Person" string
```

So the path used for the ModelStateDictionary key is updated to be "Person.Name" instead of just "Person".
See https://github.com/aspnet/Mvc/issues/8509

However, this logic is caused problems with different JSON deserilization errors that include the member in the path but not at the end. For example, given the following classes and invalid input like `{ "b": { "c": { "d": abc } } }`:

```C#
class A
{
    public B B { get; set; }
}
class B 
{
    public C C { get; set; }
}
class C 
{
    public string D { get; set; }
}
```

We will see the following ErrorContext:

```
Error   {"Unexpected character encountered while parsing value: b. Path 'b.c.d'..."} System.Exception {Newtonsoft.Json.JsonReaderException}
Member  "c"     object {string}
Path    "b.c.d" string
```

Notice that Member "c" is in the middle of the Path "b.c.d". The error handler gets invoked for each level of nesting. null, "b", "c" and "d" are each a Member in different ErrorContexts all reporting the same parsing error.

The parsing error is reported as a JsonReaderException instead of as a JsonSerializationException like for missing required properties. We use the exception type to filter out these errors and keep the path used for the ModelStateDictionary key as "b.c.d" instead of "b.c.d.c" like before.

Fixes #33451
