### PR TITLE
Stop enforcing JSON read till end if `EndInvokeJS` returns early

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ UpgradeLog.htm
 .idea
 *.svclog
 mono_crash.*.json
+mono_crash.*.blob

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -306,9 +306,12 @@ public static class DotNetDispatcher
         var success = reader.GetBoolean();
 
         reader.Read();
-        var completed = jsRuntime.EndInvokeJS(taskId, success, ref reader);
+        if (!jsRuntime.EndInvokeJS(taskId, success, ref reader))
+        {
+            return;
+        }
 
-        if (!reader.Read() || (completed && reader.TokenType != JsonTokenType.EndArray))
+        if (!reader.Read() || reader.TokenType != JsonTokenType.EndArray)
         {
             throw new JsonException("Invalid JSON");
         }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -306,9 +306,9 @@ public static class DotNetDispatcher
         var success = reader.GetBoolean();
 
         reader.Read();
-        jsRuntime.EndInvokeJS(taskId, success, ref reader);
+        var completed = jsRuntime.EndInvokeJS(taskId, success, ref reader);
 
-        if (!reader.Read() || reader.TokenType != JsonTokenType.EndArray)
+        if (!reader.Read() || (completed && reader.TokenType != JsonTokenType.EndArray))
         {
             throw new JsonException("Invalid JSON");
         }

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -225,13 +225,13 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
     }
 
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:RequiresUnreferencedCode", Justification = "We enforce trimmer attributes for JSON deserialized types on InvokeAsync.")]
-    internal void EndInvokeJS(long taskId, bool succeeded, ref Utf8JsonReader jsonReader)
+    internal bool EndInvokeJS(long taskId, bool succeeded, ref Utf8JsonReader jsonReader)
     {
         if (!_pendingTasks.TryRemove(taskId, out var tcs))
         {
             // We should simply return if we can't find an id for the invocation.
             // This likely means that the method that initiated the call defined a timeout and stopped waiting.
-            return;
+            return false;
         }
 
         CleanupTasksAndRegistrations(taskId);
@@ -251,11 +251,14 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
                 var exceptionText = jsonReader.GetString() ?? string.Empty;
                 TaskGenericsUtil.SetTaskCompletionSourceException(tcs, new JSException(exceptionText));
             }
+
+            return true;
         }
         catch (Exception exception)
         {
             var message = $"An exception occurred executing JS interop: {exception.Message}. See InnerException for more details.";
             TaskGenericsUtil.SetTaskCompletionSourceException(tcs, new JSException(message, exception));
+            return false;
         }
     }
 

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
@@ -263,7 +263,7 @@ public class DotNetDispatcherTest
     }
 
     [Fact]
-    public void EndInvoke_WithSuccessValue()
+    public void EndInvokeJS_WithSuccessValue()
     {
         // Arrange
         var jsRuntime = new TestJSRuntime();
@@ -282,7 +282,7 @@ public class DotNetDispatcherTest
     }
 
     [Fact]
-    public async Task EndInvoke_WithErrorString()
+    public async Task EndInvokeJS_WithErrorString()
     {
         // Arrange
         var jsRuntime = new TestJSRuntime();
@@ -299,7 +299,7 @@ public class DotNetDispatcherTest
     }
 
     [Fact]
-    public async Task EndInvoke_WithNullError()
+    public async Task EndInvokeJS_WithNullError()
     {
         // Arrange
         var jsRuntime = new TestJSRuntime();
@@ -312,6 +312,27 @@ public class DotNetDispatcherTest
         // Assert
         var ex = await Assert.ThrowsAsync<JSException>(async () => await task);
         Assert.Empty(ex.Message);
+    }
+
+    [Fact]
+    public void EndInvoke_DoesNotThrowJSONExceptionIfTaskCancelled()
+    {
+        // Arrange
+        var jsRuntime = new TestJSRuntime();
+        var testDTO = new TestDTO { StringVal = "Hello", IntVal = 4 };
+        var cts = new CancellationTokenSource();
+        var argsJson = JsonSerializer.Serialize(new object[] { jsRuntime.LastInvocationAsyncHandle, true, testDTO }, jsRuntime.JsonSerializerOptions);
+
+        // Act
+        var task = jsRuntime.InvokeAsync<TestDTO>("unimportant", cts.Token);
+
+        cts.Cancel();
+
+        DotNetDispatcher.EndInvokeJS(jsRuntime, argsJson);
+
+        // Assert
+        Assert.False(task.IsCompletedSuccessfully);
+        Assert.True(task.IsCanceled);
     }
 
     [Fact]

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
@@ -315,7 +315,7 @@ public class DotNetDispatcherTest
     }
 
     [Fact]
-    public void EndInvoke_DoesNotThrowJSONExceptionIfTaskCancelled()
+    public void EndInvokeJS_DoesNotThrowJSONExceptionIfTaskCancelled()
     {
         // Arrange
         var jsRuntime = new TestJSRuntime();

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
@@ -380,6 +380,25 @@ public class DotNetDispatcherTest
     }
 
     [Fact]
+    public void EndInvokeJS_DoesNotThrowJSONExceptionIfTaskCancelled_WithMoreThan3Arguments()
+    {
+        // Arrange
+        var jsRuntime = new TestJSRuntime();
+        var cts = new CancellationTokenSource();
+
+        // Act
+        var task = jsRuntime.InvokeAsync<TestDTO>("unimportant", cts.Token);
+
+        cts.Cancel();
+
+        DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, false, \"Hello\", 5]");
+
+        // Assert
+        Assert.False(task.IsCompletedSuccessfully);
+        Assert.True(task.IsCanceled);
+    }
+
+    [Fact]
     public void EndInvokeJS_Works()
     {
         // Arrange


### PR DESCRIPTION
We don't want to enforce we've read till the end of the JSON if we've just abandoned the `EndInvokeJS` call entirely due to the task timing out or if it stopped waiting. If we abandoned the `EndInvokeJS` call, we know we haven't read till the end of the JSON (and that's expected), hence we shouldn't be throwing an exception in that case. 

Fixes: https://github.com/dotnet/aspnetcore/issues/38962