### PR TITLE
Don't reuse Pipe buffer when body is read

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO.Pipelines;
@@ -213,16 +214,22 @@ internal sealed class Http1ContentLengthMessageBody : Http1MessageBody
 
         _isReading = false;
 
+        // The current body is read, though there might be more bytes to read on the stream with pipelining
         if (_readCompleted)
         {
-            // If the old stored _readResult was canceled, it's already been observed. Do not store a canceled read result permanently.
-            _readResult = new ReadResult(_readResult.Buffer.Slice(consumed, _readResult.Buffer.End), isCanceled: false, isCompleted: true);
-
-            if (!_finalAdvanceCalled && _readResult.Buffer.Length == 0)
+            if (!_finalAdvanceCalled && consumed.Equals(_readResult.Buffer.End))
             {
+                // Don't reference the old buffer as it will be released by the pipe afer calling AdvancedTo
+                _readResult = new ReadResult(new ReadOnlySequence<byte>(), isCanceled: false, isCompleted: true);
+
                 _context.Input.AdvanceTo(consumed);
                 _finalAdvanceCalled = true;
                 _context.OnTrailersComplete();
+            }
+            else
+            {
+                // If the old stored _readResult was canceled, it's already been observed. Do not store a canceled read result permanently.
+                _readResult = new ReadResult(_readResult.Buffer.Slice(consumed, _readResult.Buffer.End), isCanceled: false, isCompleted: true);
             }
 
             return;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs
@@ -1083,6 +1083,43 @@ public class RequestTests : TestApplicationErrorLoggerLoggedTest
     }
 
     [Fact]
+    public async Task ContentLengthReadAsyncPipeReaderReadsCompletedBody()
+    {
+        var testContext = new TestServiceContext(LoggerFactory);
+
+        await using (var server = new TestServer(async httpContext =>
+        {
+            using var ms1 = new MemoryStream();
+            using var ms2 = new MemoryStream();
+
+            // Read the body completely, and ensure the second read doesn't fail
+            await httpContext.Request.BodyReader.CopyToAsync(ms1);
+            await httpContext.Request.BodyReader.CopyToAsync(ms2);
+
+            Assert.Equal(22, ms1.ToArray().Length);
+            Assert.Empty(ms2.ToArray());
+        }, testContext))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.Send(
+                    "POST / HTTP/1.0",
+                    "Host:",
+                    "Content-Length: 22",
+                    "",
+                    "MyVariableOne=ValueOne");
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 0",
+                    "Connection: close",
+                    $"Date: {testContext.DateHeaderValue}",
+                    "",
+                    "");
+            }
+        }
+    }
+
+    [Fact]
     public async Task ContentLengthReadAsyncSingleBytesAtATime()
     {
         var testContext = new TestServiceContext(LoggerFactory);


### PR DESCRIPTION
Fixes #38771
