### PR TITLE
[release/6.0] Stop enforcing JSON read till end if `EndInvokeJS` returns early

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ UpgradeLog.htm
 .idea
 *.svclog
 mono_crash.*.json
+mono_crash.*.blob

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -306,7 +306,10 @@ namespace Microsoft.JSInterop.Infrastructure
             var success = reader.GetBoolean();
 
             reader.Read();
-            jsRuntime.EndInvokeJS(taskId, success, ref reader);
+            if (!jsRuntime.EndInvokeJS(taskId, success, ref reader))
+            {
+                return;
+            }
 
             if (!reader.Read() || reader.TokenType != JsonTokenType.EndArray)
             {

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
@@ -263,7 +263,7 @@ namespace Microsoft.JSInterop.Infrastructure
         }
 
         [Fact]
-        public void EndInvoke_WithSuccessValue()
+        public void EndInvokeJS_WithSuccessValue()
         {
             // Arrange
             var jsRuntime = new TestJSRuntime();
@@ -282,7 +282,7 @@ namespace Microsoft.JSInterop.Infrastructure
         }
 
         [Fact]
-        public async Task EndInvoke_WithErrorString()
+        public async Task EndInvokeJS_WithErrorString()
         {
             // Arrange
             var jsRuntime = new TestJSRuntime();
@@ -299,7 +299,7 @@ namespace Microsoft.JSInterop.Infrastructure
         }
 
         [Fact]
-        public async Task EndInvoke_WithNullError()
+        public async Task EndInvokeJS_WithNullError()
         {
             // Arrange
             var jsRuntime = new TestJSRuntime();
@@ -312,6 +312,129 @@ namespace Microsoft.JSInterop.Infrastructure
             // Assert
             var ex = await Assert.ThrowsAsync<JSException>(async () => await task);
             Assert.Empty(ex.Message);
+        }
+
+        [Fact]
+        public void EndInvokeJS_DoesNotThrowJSONExceptionIfTaskCancelled()
+        {
+            // Arrange
+            var jsRuntime = new TestJSRuntime();
+            var testDTO = new TestDTO { StringVal = "Hello", IntVal = 4 };
+            var cts = new CancellationTokenSource();
+            var argsJson = JsonSerializer.Serialize(new object[] { jsRuntime.LastInvocationAsyncHandle, true, testDTO }, jsRuntime.JsonSerializerOptions);
+
+            // Act
+            var task = jsRuntime.InvokeAsync<TestDTO>("unimportant", cts.Token);
+
+            cts.Cancel();
+
+            DotNetDispatcher.EndInvokeJS(jsRuntime, argsJson);
+
+            // Assert
+            Assert.False(task.IsCompletedSuccessfully);
+            Assert.True(task.IsCanceled);
+        }
+
+        [Fact]
+        public void EndInvokeJS_ThrowsIfJsonIsEmptyString()
+        {
+            // Arrange
+            var jsRuntime = new TestJSRuntime();
+            var task = jsRuntime.InvokeAsync<TestDTO>("somemethod");
+
+            // Act & Assert
+            Assert.ThrowsAny<JsonException>(() => DotNetDispatcher.EndInvokeJS(jsRuntime, ""));
+        }
+
+        [Fact]
+        public void EndInvokeJS_ThrowsIfJsonIsNotArray()
+        {
+            // Arrange
+            var jsRuntime = new TestJSRuntime();
+            var task = jsRuntime.InvokeAsync<TestDTO>("somemethod");
+
+            // Act & Assert
+            Assert.ThrowsAny<JsonException>(() => DotNetDispatcher.EndInvokeJS(jsRuntime, $"{{\"key\": \"{jsRuntime.LastInvocationAsyncHandle}\"}}"));
+        }
+
+        [Fact]
+        public void EndInvokeJS_ThrowsIfJsonArrayIsInComplete()
+        {
+            // Arrange
+            var jsRuntime = new TestJSRuntime();
+            var task = jsRuntime.InvokeAsync<TestDTO>("somemethod");
+
+            // Act & Assert
+            Assert.ThrowsAny<JsonException>(() => DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, false"));
+        }
+
+        [Fact]
+        public void EndInvokeJS_ThrowsIfJsonArrayHasMoreThan3Arguments()
+        {
+            // Arrange
+            var jsRuntime = new TestJSRuntime();
+            var task = jsRuntime.InvokeAsync<TestDTO>("somemethod");
+
+            // Act & Assert
+            Assert.ThrowsAny<JsonException>(() => DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, false, \"Hello\", 5]"));
+        }
+
+        [Fact]
+        public void EndInvokeJS_DoesNotThrowJSONExceptionIfTaskCancelled_WithMoreThan3Arguments()
+        {
+            // Arrange
+            var jsRuntime = new TestJSRuntime();
+            var cts = new CancellationTokenSource();
+
+            // Act
+            var task = jsRuntime.InvokeAsync<TestDTO>("unimportant", cts.Token);
+
+            cts.Cancel();
+
+            DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, false, \"Hello\", 5]");
+
+            // Assert
+            Assert.False(task.IsCompletedSuccessfully);
+            Assert.True(task.IsCanceled);
+        }
+
+        [Fact]
+        public void EndInvokeJS_Works()
+        {
+            // Arrange
+            var jsRuntime = new TestJSRuntime();
+            var task = jsRuntime.InvokeAsync<TestDTO>("somemethod");
+
+            // Act
+            DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, {{\"intVal\": 7}}]");
+
+            // Assert
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(7, task.Result.IntVal);
+        }
+
+        [Fact]
+        public void EndInvokeJS_WithArrayValue()
+        {
+            var jsRuntime = new TestJSRuntime();
+            var task = jsRuntime.InvokeAsync<int[]>("somemethod");
+
+            DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, [1, 2, 3]]");
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(new[] { 1, 2, 3 }, task.Result);
+        }
+
+        [Fact]
+        public void EndInvokeJS_WithNullValue()
+        {
+            var jsRuntime = new TestJSRuntime();
+            var task = jsRuntime.InvokeAsync<TestDTO>("somemethod");
+
+            DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, null]");
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Null(task.Result);
         }
 
         [Fact]
@@ -636,80 +759,6 @@ namespace Microsoft.JSInterop.Infrastructure
                 result,
                 v => Assert.Equal(4, v),
                 v => Assert.Null(v));
-        }
-
-        [Fact]
-        public void ParseArguments_Throws_WithIncorrectDotNetObjectRefUsage()
-        {
-            // Arrange
-            var method = "SomeMethod";
-            var arguments = "[4, {\"__dotNetObject\": 7}]";
-
-            // Act
-            var ex = Assert.Throws<InvalidOperationException>(() => DotNetDispatcher.ParseArguments(new TestJSRuntime(), method, arguments, new[] { typeof(int), typeof(TestDTO), }));
-
-            // Assert
-            Assert.Equal($"In call to '{method}', parameter of type '{nameof(TestDTO)}' at index 2 must be declared as type 'DotNetObjectRef<TestDTO>' to receive the incoming value.", ex.Message);
-        }
-
-        [Fact]
-        public void EndInvokeJS_ThrowsIfJsonIsEmptyString()
-        {
-            Assert.ThrowsAny<JsonException>(() => DotNetDispatcher.EndInvokeJS(new TestJSRuntime(), ""));
-        }
-
-        [Fact]
-        public void EndInvokeJS_ThrowsIfJsonIsNotArray()
-        {
-            Assert.ThrowsAny<JsonException>(() => DotNetDispatcher.EndInvokeJS(new TestJSRuntime(), "{\"key\": \"value\"}"));
-        }
-
-        [Fact]
-        public void EndInvokeJS_ThrowsIfJsonArrayIsInComplete()
-        {
-            Assert.ThrowsAny<JsonException>(() => DotNetDispatcher.EndInvokeJS(new TestJSRuntime(), "[7, false"));
-        }
-
-        [Fact]
-        public void EndInvokeJS_ThrowsIfJsonArrayHasMoreThan3Arguments()
-        {
-            Assert.ThrowsAny<JsonException>(() => DotNetDispatcher.EndInvokeJS(new TestJSRuntime(), "[7, false, \"Hello\", 5]"));
-        }
-
-        [Fact]
-        public void EndInvokeJS_Works()
-        {
-            var jsRuntime = new TestJSRuntime();
-            var task = jsRuntime.InvokeAsync<TestDTO>("somemethod");
-
-            DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, {{\"intVal\": 7}}]");
-
-            Assert.True(task.IsCompletedSuccessfully);
-            Assert.Equal(7, task.Result.IntVal);
-        }
-
-        [Fact]
-        public void EndInvokeJS_WithArrayValue()
-        {
-            var jsRuntime = new TestJSRuntime();
-            var task = jsRuntime.InvokeAsync<int[]>("somemethod");
-
-            DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, [1, 2, 3]]");
-
-            Assert.True(task.IsCompletedSuccessfully);
-            Assert.Equal(new[] { 1, 2, 3 }, task.Result);
-        }
-
-        [Fact]
-        public void EndInvokeJS_WithNullValue()
-        {
-            var jsRuntime = new TestJSRuntime();
-            var task = jsRuntime.InvokeAsync<TestDTO>("somemethod");
-
-            DotNetDispatcher.EndInvokeJS(jsRuntime, $"[{jsRuntime.LastInvocationAsyncHandle}, true, null]");
-
-            Assert.True(task.IsCompletedSuccessfully);
-            Assert.Null(task.Result);
         }
 
         [Fact]

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
@@ -762,6 +762,20 @@ namespace Microsoft.JSInterop.Infrastructure
         }
 
         [Fact]
+        public void ParseArguments_Throws_WithIncorrectDotNetObjectRefUsage()
+        {
+            // Arrange
+            var method = "SomeMethod";
+            var arguments = "[4, {\"__dotNetObject\": 7}]";
+
+            // Act
+            var ex = Assert.Throws<InvalidOperationException>(() => DotNetDispatcher.ParseArguments(new TestJSRuntime(), method, arguments, new[] { typeof(int), typeof(TestDTO), }));
+
+            // Assert
+            Assert.Equal($"In call to '{method}', parameter of type '{nameof(TestDTO)}' at index 2 must be declared as type 'DotNetObjectRef<TestDTO>' to receive the incoming value.", ex.Message);
+        }
+
+        [Fact]
         public void ReceiveByteArray_Works()
         {
             // Arrange


### PR DESCRIPTION
# Stop enforcing JSON read till end if `EndInvokeJS` returns early

## Description

We don't want to enforce we've read till the end of the JSON if we've just abandoned the `EndInvokeJS` call entirely due to the task timing out or getting cancelled. If we abandoned the `EndInvokeJS` call, we know we haven't read till the end of the JSON payload (and that's expected), hence we shouldn't be throwing a JSON exception in that case. 

Fixes #39087, #38962, #34267
Backports https://github.com/dotnet/aspnetcore/pull/39060

## Customer Impact

If the user calls for `OpenReadStream`, but before processing the stream request, .NET cancels, then the JSON exception is thrown, fatally crashing the circuit & application. End user must reload the page to continue. This scenario can be triggered via the following sample code. 

```razor
<InputFile OnChange="@OnInputFileChange" />

@code {
    private void OnInputFileChange(InputFileChangeEventArgs e)
    {
        using var content = new MultipartFormDataContent();

        var fileContent = new StreamContent(e.File.OpenReadStream());

        // await Task.Delay(10_000); // Uncomment to stop exception (as we no longer cancel before the response is interpreted)
        Console.WriteLine("Hi I'm here without fail");
    }
    // We finish execution of the function immediately after calling `OpenReadStream`.
    // The GC thus disposes locals, thereby immediately cancelling the `OpenReadStream` request.
    // Within the framework, this translates to the `EndInvokeJS` request being cancelled for `OpenReadStream`
    // before the initial payload of the request can be processed. This is okay, and we shouldn't be enforcing
    // that the entire request was read. This is what this PR fixes. 
}
```

<details>
<summary>Exception details</summary>

![Exception](https://user-images.githubusercontent.com/19261573/146458973-7cae7c4e-6602-453d-af25-43354f129ad9.png)

</details>

## Regression?

- [x] Yes
- [ ] No

This is a regression from .NET 5. In .NET 6 we completely overhauled the underlying streaming mechanism which resulted in this edge case regression. 

## Risk

- [ ] High
- [ ] Medium
- [x] Low

We're no longer throwing an exception that the payload is unread in the event that a JSInterop call is called. When a JSInterop call is cancelled, we don't expect the payload to be read, so an exception is unnecessary. 

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A