### PR TITLE
Identity stores tests fixes

### DIFF
--- a/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreEncryptPersonalDataTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/UserStoreEncryptPersonalDataTest.cs
@@ -301,7 +301,7 @@ public class ProtectedUserStoreTest : SqlStoreTestBase<IdentityUser, IdentityRol
     /// </summary>
     /// <returns>Task</returns>
     [Fact]
-    public override Task CanFindUsersViaUserQuerable()
+    public override Task CanFindUsersViaUserQueryable()
         => Task.CompletedTask;
 
 }

--- a/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
+++ b/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
@@ -320,7 +320,7 @@ public abstract class IdentitySpecificationTestBase<TUser, TRole, TKey> : UserMa
     /// </summary>
     /// <returns>Task</returns>
     [Fact]
-    public async Task CanQueryableRoles()
+    public virtual async Task CanQueryableRoles()
     {
         var manager = CreateRoleManager();
         if (manager.SupportsQueryableRoles)
@@ -333,7 +333,7 @@ public abstract class IdentitySpecificationTestBase<TUser, TRole, TKey> : UserMa
             Expression<Func<TRole, bool>> func = RoleNameStartsWithPredicate("CanQueryableRolesTest");
             Assert.Equal(roles.Count, manager.Roles.Count(func));
             func = RoleNameEqualsPredicate("bogus");
-            Assert.Null(manager.Roles.FirstOrDefault(func));
+            Assert.Empty(manager.Roles.Where(func));
 
         }
     }

--- a/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
+++ b/src/Identity/Specification.Tests/src/IdentitySpecificationTestBase.cs
@@ -325,12 +325,12 @@ public abstract class IdentitySpecificationTestBase<TUser, TRole, TKey> : UserMa
         var manager = CreateRoleManager();
         if (manager.SupportsQueryableRoles)
         {
-            var roles = GenerateRoles("CanQuerableRolesTest", 4);
+            var roles = GenerateRoles("CanQueryableRolesTest", 4);
             foreach (var r in roles)
             {
                 IdentityResultAssert.IsSuccess(await manager.CreateAsync(r));
             }
-            Expression<Func<TRole, bool>> func = RoleNameStartsWithPredicate("CanQuerableRolesTest");
+            Expression<Func<TRole, bool>> func = RoleNameStartsWithPredicate("CanQueryableRolesTest");
             Assert.Equal(roles.Count, manager.Roles.Count(func));
             func = RoleNameEqualsPredicate("bogus");
             Assert.Null(manager.Roles.FirstOrDefault(func));

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -937,12 +937,12 @@ public abstract class UserManagerSpecificationTestBase<TUser, TKey>
         var mgr = CreateManager();
         if (mgr.SupportsQueryableUsers)
         {
-            var users = GenerateUsers("CanFindUsersViaUserQuerable", 4);
+            var users = GenerateUsers("CanFindUsersViaUserQueryable", 4);
             foreach (var u in users)
             {
                 IdentityResultAssert.IsSuccess(await mgr.CreateAsync(u));
             }
-            Assert.Equal(users.Count, mgr.Users.Count(UserNameStartsWithPredicate("CanFindUsersViaUserQuerable")));
+            Assert.Equal(users.Count, mgr.Users.Count(UserNameStartsWithPredicate("CanFindUsersViaUserQueryable")));
             Assert.Null(mgr.Users.FirstOrDefault(UserNameEqualsPredicate("bogus")));
         }
     }

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -943,7 +943,7 @@ public abstract class UserManagerSpecificationTestBase<TUser, TKey>
                 IdentityResultAssert.IsSuccess(await mgr.CreateAsync(u));
             }
             Assert.Equal(users.Count, mgr.Users.Count(UserNameStartsWithPredicate("CanFindUsersViaUserQueryable")));
-            Assert.Null(mgr.Users.FirstOrDefault(UserNameEqualsPredicate("bogus")));
+            Assert.Empty(mgr.Users.Where(UserNameEqualsPredicate("bogus")));
         }
     }
 

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -932,7 +932,7 @@ public abstract class UserManagerSpecificationTestBase<TUser, TKey>
     /// </summary>
     /// <returns>Task</returns>
     [Fact]
-    public virtual async Task CanFindUsersViaUserQuerable()
+    public virtual async Task CanFindUsersViaUserQueryable()
     {
         var mgr = CreateManager();
         if (mgr.SupportsQueryableUsers)


### PR DESCRIPTION
# Identity stores tests fixes
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Minor fixes to Identity store specification tests.

## Description
- Fixes typo in test comments and variables names
- Fixes Tests for Queryable functionality which break with some `IQueryable` implementations (i.e. Cosmos)
- Make `CanQueryableRoles` virtual to match its queryable user counterpart test

Fixes #39050
