### PR TITLE
Add status code alias with enum as parameter

### DIFF
--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq.Expressions;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
@@ -229,6 +230,15 @@ public abstract class ControllerBase
     [NonAction]
     public virtual StatusCodeResult StatusCode([ActionResultStatusCode] int statusCode)
         => new StatusCodeResult(statusCode);
+
+    /// <summary>
+    /// Creates a <see cref="StatusCodeResult"/> object by specifying a <paramref name="statusCode"/>.
+    /// </summary>
+    /// <param name="statusCode">The enum HttpStatusCode to set on the response.</param>
+    /// <returns>The created <see cref="StatusCodeResult"/> object for the response.</returns>
+    [NonAction]
+    public virtual StatusCodeResult StatusCode(HttpStatusCode statusCode)
+        => new StatusCodeResult((int) statusCode);
 
     /// <summary>
     /// Creates a <see cref="ObjectResult"/> object by specifying a <paramref name="statusCode"/> and <paramref name="value"/>


### PR DESCRIPTION
# Enhance StatusCode method with enum parameter

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Added a convenience method to be able to use HttpStatusCode enum instead of raw integers.