### PR TITLE
Ignore identical types when loading routable components

### DIFF
--- a/src/Components/Components/src/Routing/RouteTableFactory.cs
+++ b/src/Components/Components/src/Routing/RouteTableFactory.cs
@@ -44,7 +44,11 @@ internal static class RouteTableFactory
         {
             foreach (var assembly in routeKey.AdditionalAssemblies)
             {
-                GetRouteableComponents(routeableComponents, assembly);
+                // We don't need process the assembly if it's the app assembly.
+                if (assembly != routeKey.AppAssembly)
+                {
+                    GetRouteableComponents(routeableComponents, assembly);
+                }
             }
         }
 
@@ -56,10 +60,7 @@ internal static class RouteTableFactory
             {
                 if (typeof(IComponent).IsAssignableFrom(type) && type.IsDefined(typeof(RouteAttribute)))
                 {
-                    if (!routeableComponents.Contains(type))
-                    {
-                        routeableComponents.Add(type);
-                    }
+                    routeableComponents.Add(type);
                 }
             }
         }

--- a/src/Components/Components/src/Routing/RouteTableFactory.cs
+++ b/src/Components/Components/src/Routing/RouteTableFactory.cs
@@ -32,9 +32,9 @@ internal static class RouteTableFactory
 
     public static void ClearCaches() => Cache.Clear();
 
-    private static HashSet<Type> GetRouteableComponents(RouteKey routeKey)
+    private static List<Type> GetRouteableComponents(RouteKey routeKey)
     {
-        var routeableComponents = new HashSet<Type>();
+        var routeableComponents = new List<Type>();
         if (routeKey.AppAssembly is not null)
         {
             GetRouteableComponents(routeableComponents, routeKey.AppAssembly);
@@ -50,19 +50,22 @@ internal static class RouteTableFactory
 
         return routeableComponents;
 
-        static void GetRouteableComponents(HashSet<Type> routeableComponents, Assembly assembly)
+        static void GetRouteableComponents(List<Type> routeableComponents, Assembly assembly)
         {
             foreach (var type in assembly.ExportedTypes)
             {
                 if (typeof(IComponent).IsAssignableFrom(type) && type.IsDefined(typeof(RouteAttribute)))
                 {
-                    routeableComponents.Add(type);
+                    if (!routeableComponents.Contains(type))
+                    {
+                        routeableComponents.Add(type);
+                    }
                 }
             }
         }
     }
 
-    internal static RouteTable Create(HashSet<Type> componentTypes)
+    internal static RouteTable Create(List<Type> componentTypes)
     {
         var templatesByHandler = new Dictionary<Type, string[]>();
         foreach (var componentType in componentTypes)

--- a/src/Components/Components/src/Routing/RouteTableFactory.cs
+++ b/src/Components/Components/src/Routing/RouteTableFactory.cs
@@ -32,9 +32,9 @@ internal static class RouteTableFactory
 
     public static void ClearCaches() => Cache.Clear();
 
-    private static List<Type> GetRouteableComponents(RouteKey routeKey)
+    private static HashSet<Type> GetRouteableComponents(RouteKey routeKey)
     {
-        var routeableComponents = new List<Type>();
+        var routeableComponents = new HashSet<Type>();
         if (routeKey.AppAssembly is not null)
         {
             GetRouteableComponents(routeableComponents, routeKey.AppAssembly);
@@ -50,7 +50,7 @@ internal static class RouteTableFactory
 
         return routeableComponents;
 
-        static void GetRouteableComponents(List<Type> routeableComponents, Assembly assembly)
+        static void GetRouteableComponents(HashSet<Type> routeableComponents, Assembly assembly)
         {
             foreach (var type in assembly.ExportedTypes)
             {
@@ -62,7 +62,7 @@ internal static class RouteTableFactory
         }
     }
 
-    internal static RouteTable Create(List<Type> componentTypes)
+    internal static RouteTable Create(HashSet<Type> componentTypes)
     {
         var templatesByHandler = new Dictionary<Type, string[]>();
         foreach (var componentType in componentTypes)

--- a/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
+++ b/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
@@ -55,7 +55,7 @@ public class RouteTableFactoryTests
     public void CanDiscoverRoute()
     {
         // Arrange & Act
-        var routes = RouteTableFactory.Create(new List<Type> { typeof(MyComponent), });
+        var routes = RouteTableFactory.Create(new HashSet<Type> { typeof(MyComponent), });
 
         // Assert
         Assert.Equal("Test1", Assert.Single(routes.Routes).Template.TemplateText);
@@ -70,13 +70,23 @@ public class RouteTableFactoryTests
     public void CanDiscoverRoutes_WithInheritance()
     {
         // Arrange & Act
-        var routes = RouteTableFactory.Create(new List<Type> { typeof(MyComponent), typeof(MyInheritedComponent), });
+        var routes = RouteTableFactory.Create(new HashSet<Type> { typeof(MyComponent), typeof(MyInheritedComponent), });
 
         // Assert
         Assert.Collection(
             routes.Routes.OrderBy(r => r.Template.TemplateText),
             r => Assert.Equal("Test1", r.Template.TemplateText),
             r => Assert.Equal("Test2", r.Template.TemplateText));
+    }
+
+    [Fact]
+    public void IgnoresIdenticalTypes()
+    {
+        // Arrange & Act
+        var routes = RouteTableFactory.Create(new HashSet<Type> { typeof(MyComponent), typeof(MyComponent), });
+
+        // Assert
+        Assert.Equal("Test1", Assert.Single(routes.Routes).Template.TemplateText);
     }
 
     [Route("Test2")]

--- a/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
+++ b/src/Components/Components/test/Routing/RouteTableFactoryTests.cs
@@ -52,10 +52,20 @@ public class RouteTableFactoryTests
     }
 
     [Fact]
+    public void IgnoresIdenticalTypes()
+    {
+        // Arrange & Act
+        var routes = RouteTableFactory.Create(new RouteKey(GetType().Assembly, new[] { GetType().Assembly }));
+
+        // Assert
+        Assert.Equal(routes.Routes.GroupBy(x => x.Handler).Count(), routes.Routes.Length);
+    }
+
+    [Fact]
     public void CanDiscoverRoute()
     {
         // Arrange & Act
-        var routes = RouteTableFactory.Create(new HashSet<Type> { typeof(MyComponent), });
+        var routes = RouteTableFactory.Create(new List<Type> { typeof(MyComponent), });
 
         // Assert
         Assert.Equal("Test1", Assert.Single(routes.Routes).Template.TemplateText);
@@ -70,23 +80,13 @@ public class RouteTableFactoryTests
     public void CanDiscoverRoutes_WithInheritance()
     {
         // Arrange & Act
-        var routes = RouteTableFactory.Create(new HashSet<Type> { typeof(MyComponent), typeof(MyInheritedComponent), });
+        var routes = RouteTableFactory.Create(new List<Type> { typeof(MyComponent), typeof(MyInheritedComponent), });
 
         // Assert
         Assert.Collection(
             routes.Routes.OrderBy(r => r.Template.TemplateText),
             r => Assert.Equal("Test1", r.Template.TemplateText),
             r => Assert.Equal("Test2", r.Template.TemplateText));
-    }
-
-    [Fact]
-    public void IgnoresIdenticalTypes()
-    {
-        // Arrange & Act
-        var routes = RouteTableFactory.Create(new HashSet<Type> { typeof(MyComponent), typeof(MyComponent), });
-
-        // Assert
-        Assert.Equal("Test1", Assert.Single(routes.Routes).Template.TemplateText);
     }
 
     [Route("Test2")]


### PR DESCRIPTION
# Ignore identical types when loading routable components

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Instead of using a `List` of types, I replaced it with a `HashSet` so that no duplicate entries are allowed when the routable components are loaded.

This issue does happen, if you specify the same assembly for the `AppAssembly` and the `AdditionalAssemblies`. It does not happen if you specify the same assembly multiple times for `AdditionalAssemblies`, as this is already a `HashSet`.

Fixes #38882 
