### PR TITLE
Include the exception when logging in WebAssemblyErrorBoundaryLogger

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyErrorBoundaryLogger.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyErrorBoundaryLogger.cs
@@ -1,14 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Services;
 
-internal class WebAssemblyErrorBoundaryLogger : IErrorBoundaryLogger
+internal sealed class WebAssemblyErrorBoundaryLogger : IErrorBoundaryLogger
 {
     private readonly ILogger<ErrorBoundary> _errorBoundaryLogger;
 
@@ -21,7 +19,7 @@ internal class WebAssemblyErrorBoundaryLogger : IErrorBoundaryLogger
     {
         // For, client-side code, all internal state is visible to the end user. We can just
         // log directly to the console.
-        _errorBoundaryLogger.LogError(exception.ToString());
+        _errorBoundaryLogger.LogError(exception.ToString(), exception);
         return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/39039
