### PR TITLE
Fix LogError argument order in WebAssemblyErrorBoundaryLogger

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyErrorBoundaryLogger.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyErrorBoundaryLogger.cs
@@ -12,14 +12,14 @@ internal sealed class WebAssemblyErrorBoundaryLogger : IErrorBoundaryLogger
 
     public WebAssemblyErrorBoundaryLogger(ILogger<ErrorBoundary> errorBoundaryLogger)
     {
-        _errorBoundaryLogger = errorBoundaryLogger ?? throw new ArgumentNullException(nameof(errorBoundaryLogger)); ;
+        _errorBoundaryLogger = errorBoundaryLogger ?? throw new ArgumentNullException(nameof(errorBoundaryLogger));
     }
 
     public ValueTask LogErrorAsync(Exception exception)
     {
         // For, client-side code, all internal state is visible to the end user. We can just
         // log directly to the console.
-        _errorBoundaryLogger.LogError(exception.ToString(), exception);
+        _errorBoundaryLogger.LogError(exception, exception.ToString());
         return ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
In https://github.com/dotnet/aspnetcore/pull/39202 the arguments which got passed into `LogError` were in the wrong order. The [`exception` comes before the `message`](https://docs.microsoft.com/de-de/dotnet/api/microsoft.extensions.logging.loggerextensions.logerror?view=dotnet-plat-ext-6.0#Microsoft_Extensions_Logging_LoggerExtensions_LogError_Microsoft_Extensions_Logging_ILogger_System_Exception_System_String_System_Object___). It worked because the [`string, Object[]`](https://docs.microsoft.com/de-de/dotnet/api/microsoft.extensions.logging.loggerextensions.logerror?view=dotnet-plat-ext-6.0#Microsoft_Extensions_Logging_LoggerExtensions_LogError_Microsoft_Extensions_Logging_ILogger_System_String_System_Object___) overload was used instead.

