### PR TITLE
Fix typo in xml comment in GetMultipartBoundary method

### DIFF
--- a/src/Http/Http.Extensions/src/HttpRequestMultipartExtensions.cs
+++ b/src/Http/Http.Extensions/src/HttpRequestMultipartExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Http.Extensions;
 public static class HttpRequestMultipartExtensions
 {
     /// <summary>
-    /// Gets the mutipart boundary from the <c>Content-Type</c> header.
+    /// Gets the multipart boundary from the <c>Content-Type</c> header.
     /// </summary>
     /// <param name="request">The <see cref="HttpRequest"/>.</param>
     /// <returns>The multipart boundary.</returns>


### PR DESCRIPTION
# Fix typo in xml comment in GetMultipartBoundary method

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Typo fix 
