### PR TITLE
NewtonsoftJsonInputFormatter checks for ErrorContext.Handled flag (#37323)

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -232,6 +232,11 @@ public class NewtonsoftJsonInputFormatter : TextInputFormatter, IInputFormatterE
 
         void ErrorHandler(object? sender, Newtonsoft.Json.Serialization.ErrorEventArgs eventArgs)
         {
+            // Skipping error, if it's already marked as handled
+            // This allows user code to implement its own error handling
+            if (eventArgs.ErrorContext.Handled)
+                return;
+
             successful = false;
 
             // When ErrorContext.Path does not include ErrorContext.Member, add Member to form full path.

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -235,7 +235,9 @@ public class NewtonsoftJsonInputFormatter : TextInputFormatter, IInputFormatterE
             // Skipping error, if it's already marked as handled
             // This allows user code to implement its own error handling
             if (eventArgs.ErrorContext.Handled)
+            {
                 return;
+            }
 
             successful = false;
 

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
@@ -487,6 +487,45 @@ public class NewtonsoftJsonInputFormatterTest : JsonInputFormatterTestBase
         }
     }
 
+    [Fact]
+    public async Task ReadAsync_AllowUserCodeToHandleDeserializationErrors()
+    {
+        // Arrange
+        var serializerSettings = new JsonSerializerSettings
+        {
+            Error = (sender, eventArgs) =>
+            {
+                eventArgs.ErrorContext.Handled = true;
+            }
+        };
+        var formatter = new NewtonsoftJsonInputFormatter(
+            GetLogger(),
+            serializerSettings,
+            ArrayPool<char>.Shared,
+            _objectPoolProvider,
+            new MvcOptions(),
+            new MvcNewtonsoftJsonOptions());
+
+
+        var content = $"{{'id': 'should be integer', 'name': 'test location'}}";
+        var contentBytes = Encoding.UTF8.GetBytes(content);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
+        httpContext.Request.Body = new NonSeekableReadStream(contentBytes, allowSyncReads: false);
+        httpContext.Request.ContentType = "application/json";
+
+        var formatterContext = CreateInputFormatterContext(typeof(Location), httpContext);
+
+        // Act
+        var result = await formatter.ReadAsync(formatterContext);
+
+        // Assert
+        Assert.False(result.HasError);
+        var location = (Location)result.Model;
+        Assert.Equal(0, location?.Id);
+        Assert.Equal("test location", location?.Name);
+    }
+
     private class TestableJsonInputFormatter : NewtonsoftJsonInputFormatter
     {
         public TestableJsonInputFormatter(JsonSerializerSettings settings, ObjectPoolProvider objectPoolProvider)

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
@@ -506,7 +506,6 @@ public class NewtonsoftJsonInputFormatterTest : JsonInputFormatterTestBase
             new MvcOptions(),
             new MvcNewtonsoftJsonOptions());
 
-
         var content = $"{{'id': 'should be integer', 'name': 'test location'}}";
         var contentBytes = Encoding.UTF8.GetBytes(content);
         var httpContext = new DefaultHttpContext();


### PR DESCRIPTION
# NewtonsoftJsonInputFormatter checks for ErrorContext.Handled flag

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Added check for eventArgs.ErrorContext.Handled flag before reporting error.

Fixes #37323
