### PR TITLE
Hard-Code BaselineTest to use 2.1.30

### DIFF
--- a/test/SharedFx.UnitTests/SharedFx.UnitTests.csproj
+++ b/test/SharedFx.UnitTests/SharedFx.UnitTests.csproj
@@ -28,7 +28,7 @@
     </AssemblyAttribute>
     <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
       <_Parameter1>PreviousAspNetCoreReleaseVersion</_Parameter1>
-      <_Parameter2>$(PreviousAspNetCoreReleaseVersion)</_Parameter2>
+      <_Parameter2>2.1.30</_Parameter2>
     </AssemblyAttribute>
     <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
       <_Parameter1>ValidateBaseline</_Parameter1>


### PR DESCRIPTION
This test is failing in SharedFx builds because it tries to download SharedFx version n-1 from blob storage, but we no longer prop the sharedFx to dotnetcli. Instead let's hard code 2.1.30 for just this test.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1533254&view=results