### PR TITLE
Don't exclude System.IO.Pipelines from TargetingPack version check

### DIFF
--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -104,22 +104,17 @@ public class TargetingPackTests
 
         Assert.All(dlls, path =>
         {
-            // Skip netstandard2.0 System.IO.Pipelines assembly. References have old versions.
-            var filename = Path.GetFileName(path);
-            if (!string.Equals("System.IO.Pipelines.dll", filename, StringComparison.OrdinalIgnoreCase))
+            using var fileStream = File.OpenRead(path);
+            using var peReader = new PEReader(fileStream, PEStreamOptions.Default);
+            var reader = peReader.GetMetadataReader(MetadataReaderOptions.Default);
+
+            Assert.All(reader.AssemblyReferences, handle =>
             {
-                using var fileStream = File.OpenRead(path);
-                using var peReader = new PEReader(fileStream, PEStreamOptions.Default);
-                var reader = peReader.GetMetadataReader(MetadataReaderOptions.Default);
+                var reference = reader.GetAssemblyReference(handle);
+                var result = (0 == reference.Version.Revision && 0 == reference.Version.Build);
 
-                Assert.All(reader.AssemblyReferences, handle =>
-                {
-                    var reference = reader.GetAssemblyReference(handle);
-                    var result = 0 == reference.Version.Revision;
-
-                    Assert.True(result, $"In {filename}, {reference.GetAssemblyName()} has unexpected version {reference.Version}.");
-                });
-            }
+                Assert.True(result, $"In {Path.GetFileName(path)}, {reference.GetAssemblyName()} has unexpected version {reference.Version}.");
+            });
         });
     }
 


### PR DESCRIPTION
First part of https://github.com/dotnet/aspnetcore/issues/31074. Also check that `Version.Build == 0` in addition to `Version.Revision`