### PR TITLE
Do not attempt `Publish test results` when skipping tests

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -87,7 +87,6 @@ jobs:
       displayName: Install JDK 11
     - task: NuGetCommand@2
       displayName: 'Clear NuGet caches'
-      condition: succeeded()
       inputs:
         command: custom
         arguments: 'locals all -clear'
@@ -158,24 +157,23 @@ jobs:
     - task: MicroBuildCleanup@1
       displayName: Cleanup MicroBuild tasks
       condition: always()
-    - task: PublishBuildArtifacts@1
-      displayName: Upload artifacts
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: artifacts/
-        artifactName: artifacts-Windows-SharedFx
-        artifactType: Container
-        parallel: true
-    - task: PublishBuildArtifacts@1
-      displayName: Upload dependencies.g.props
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: .deps/dependencies.g.props
-        artifactName: artifacts-dependencies-props
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload artifacts
+        continueOnError: true
+        inputs:
+          pathtoPublish: artifacts/
+          artifactName: artifacts-Windows-SharedFx
+          artifactType: Container
+          parallel: true
+      - task: PublishBuildArtifacts@1
+        displayName: Upload dependencies.g.props
+        continueOnError: true
+        inputs:
+          pathtoPublish: .deps/dependencies.g.props
+          artifactName: artifacts-dependencies-props
+          artifactType: Container
+          parallel: true
 
   - job: MacOs_SharedFx
     displayName: Build Osx-x64 SharedFx
@@ -216,15 +214,15 @@ jobs:
         PB_RESTORESOURCE: $(PB_RestoreSource)
         PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build osx-x64 SharedFX
-    - task: PublishBuildArtifacts@1
-      displayName: Upload artifacts
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: artifacts/
-        artifactName: artifacts-MacOs-SharedFx
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload artifacts
+        continueOnError: true
+        inputs:
+          pathtoPublish: artifacts/
+          artifactName: artifacts-MacOs-SharedFx
+          artifactType: Container
+          parallel: true
 
   - job: Linux_SharedFx
     displayName: Build Linux x64/arm SharedFx
@@ -280,15 +278,15 @@ jobs:
         PB_RESTORESOURCE: $(PB_RestoreSource)
         PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build linux-arm SharedFX
-    - task: PublishBuildArtifacts@1
-      displayName: Upload artifacts
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: artifacts/
-        artifactName: artifacts-Linux-SharedFx
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload artifacts
+        continueOnError: true
+        inputs:
+          pathtoPublish: artifacts/
+          artifactName: artifacts-Linux-SharedFx
+          artifactType: Container
+          parallel: true
 
   - job: Linux_Musl_SharedFx
     displayName: Build Linux-musl-x64 SharedFx
@@ -338,15 +336,15 @@ jobs:
       displayName: Build linux-musl-x64 SharedFX
     - bash: docker system prune -af
       displayName: Docker prune
-    - task: PublishBuildArtifacts@1
-      displayName: Upload artifacts
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: artifacts/
-        artifactName: artifacts-Linux-Musl-SharedFx
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload artifacts
+        continueOnError: true
+        inputs:
+          pathtoPublish: artifacts/
+          artifactName: artifacts-Linux-Musl-SharedFx
+          artifactType: Container
+          parallel: true
 
   - job: Windows_Installers
     displayName: Build Windows Installers
@@ -366,7 +364,6 @@ jobs:
       clean: true
     - task: NuGetCommand@2
       displayName: 'Clear NuGet caches'
-      condition: succeeded()
       inputs:
         command: custom
         arguments: 'locals all -clear'
@@ -416,15 +413,15 @@ jobs:
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
       condition: always()
-    - task: PublishBuildArtifacts@1
-      displayName: Upload artifacts
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: artifacts/
-        artifactName: artifacts-Windows-Installers
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload artifacts
+        continueOnError: true
+        inputs:
+          pathtoPublish: artifacts/
+          artifactName: artifacts-Windows-Installers
+          artifactType: Container
+          parallel: true
 
   - job: Package_Archive
     displayName: Build Package Archive
@@ -444,7 +441,6 @@ jobs:
       clean: true
     - task: NuGetCommand@2
       displayName: 'Clear NuGet caches'
-      condition: succeeded()
       inputs:
         command: custom
         arguments: 'locals all -clear'
@@ -474,15 +470,15 @@ jobs:
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
       condition: always()
-    - task: PublishBuildArtifacts@1
-      displayName: Upload artifacts
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: artifacts/
-        artifactName: artifacts-Package-Archive
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload artifacts
+        continueOnError: true
+        inputs:
+          pathtoPublish: artifacts/
+          artifactName: artifacts-Package-Archive
+          artifactType: Container
+          parallel: true
 
   - job: SharedFX_Installers
     displayName: Build SharedFX Installers
@@ -565,15 +561,15 @@ jobs:
       displayName: Build SharedFX Installers
     - bash: docker system prune -af
       displayName: Docker prune
-    - task: PublishBuildArtifacts@1
-      displayName: Upload artifacts
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: artifacts/
-        artifactName: artifacts-SharedFx-Installers
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload artifacts
+        continueOnError: true
+        inputs:
+          pathtoPublish: artifacts/
+          artifactName: artifacts-SharedFx-Installers
+          artifactType: Container
+          parallel: true
 
   - job: Publish
     displayName: Publish
@@ -596,7 +592,6 @@ jobs:
       clean: true
     - task: NuGetCommand@2
       displayName: 'Clear NuGet caches'
-      condition: succeeded()
       inputs:
         command: custom
         arguments: 'locals all -clear'
@@ -740,12 +735,12 @@ jobs:
     - powershell: eng\scripts\KillProcesses.ps1
       displayName: Kill processes
       condition: always()
-    - task: PublishBuildArtifacts@1
-      displayName: Upload logs
-      condition: eq(variables['system.pullrequest.isfork'], false)
-      continueOnError: true
-      inputs:
-        pathtoPublish: artifacts/logs
-        artifactName: artifacts-Publish
-        artifactType: Container
-        parallel: true
+    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Upload logs
+        continueOnError: true
+        inputs:
+          pathtoPublish: artifacts/logs
+          artifactName: artifacts-Publish
+          artifactType: Container
+          parallel: true

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -116,7 +116,6 @@ jobs:
       displayName: Install JDK 11
     - task: NuGetCommand@2
       displayName: 'Clear NuGet caches'
-      condition: succeeded()
       inputs:
         command: custom
         arguments: 'locals all -clear'
@@ -161,19 +160,19 @@ jobs:
     - script: eng/scripts/KillProcesses.sh
       displayName: Kill processes
       condition: always()
-  - task: PublishTestResults@2
-    displayName: Publish test results
-    condition: always()
-    continueOnError: true
-    inputs:
-      testRunTitle: $(AgentOsName)-$(BuildConfiguration)
-      testRunner: vstest
-      testResultsFiles: 'artifacts/logs/**/*.trx'
-      mergeTestResults: true
-  - ${{ if eq(parameters.artifacts.publish, 'true') }}:
+  - ${{ if ne(parameters.variables.PB_SKIPTESTS, 'true') }}:
+    - task: PublishTestResults@2
+      displayName: Publish test results
+      condition: always()
+      continueOnError: true
+      inputs:
+        testRunTitle: $(AgentOsName)-$(BuildConfiguration)
+        testRunner: vstest
+        testResultsFiles: 'artifacts/logs/**/*.trx'
+        mergeTestResults: true
+  - ${{ if and(eq(parameters.artifacts.publish, 'true'), eq(variables['system.pullrequest.isfork'], false)) }}:
     - task: PublishBuildArtifacts@1
       displayName: Upload artifacts
-      condition: eq(variables['system.pullrequest.isfork'], false)
       continueOnError: true
       inputs:
         ${{ if eq(parameters.buildDirectory, '') }}:


### PR DESCRIPTION
- clean up a warning about missing `*.trx` files

nit: Cleanup `condition:` use
- remove useless `condition: succeeded()`; it's the default
- evaluate `system.pullrequest.isfork` variable during template expansion
  - hide non-executing build steps