### PR TITLE
Use TimeSpan.FromMilliseconds for clientTimeoutInterval in ClientTime…

### DIFF
--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -666,7 +666,7 @@ public partial class HubConnectionContext
 
                 if (_receivedMessageElapsedTicks >= _clientTimeoutInterval)
                 {
-                    Log.ClientTimeout(_logger, TimeSpan.FromTicks(_clientTimeoutInterval));
+                    Log.ClientTimeout(_logger, TimeSpan.FromMilliseconds(_clientTimeoutInterval));
                     AbortAllowReconnect();
                 }
             }


### PR DESCRIPTION
- Use TimeSpan.FromMilliseconds for clientTimeoutInterval in ClientTimeout log

Fixes #39171
