### PR TITLE
Remove source-build workaround for sourcelink submodule issue

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>aspnetcore</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <CloneSubmodulesToInnerSourceBuildRepo>false</CloneSubmodulesToInnerSourceBuildRepo>
   </PropertyGroup>
 
   <Target Name="PrepareGlobalJsonForSourceBuild"
@@ -12,19 +11,6 @@
     <Exec
       Command="./eng/scripts/prepare-sourcebuild-globaljson.sh"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)" />
-  </Target>
-
-  <!--
-    Init submodules - temporarary workaround for https://github.com/dotnet/sourcelink/pull/653
-  -->
-  <Target Name="InitSubmodules"
-          DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
-          BeforeTargets="RunInnerSourceBuildCommand">
-
-    <Exec
-      Command="git submodule update --init --recursive"
-      WorkingDirectory="$(InnerSourceBuildRepoRoot)"
-      EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>
 
   <!--


### PR DESCRIPTION
This change removes source-build workaround for a sourcelink submodule issue that has now been addressed.  This change is currently being carried in a source-build patch that needs to be removed.

Fixes https://github.com/dotnet/source-build/issues/2354
