### PR TITLE
Update release/6.0 to get dotnet assets from dotnetbuilds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -271,7 +271,7 @@
   <!-- Restore feeds -->
   <PropertyGroup Label="Restore feeds">
     <!-- In an orchestrated build, this may be overridden to other Azure feeds. -->
-    <DotNetAssetRootUrl Condition="'$(DotNetAssetRootUrl)'==''">https://dotnetcli.azureedge.net/dotnet/</DotNetAssetRootUrl>
-    <DotNetPrivateAssetRootUrl Condition="'$(DotNetPrivateAssetRootUrl)'==''">https://dotnetclimsrc.blob.core.windows.net/dotnet/</DotNetPrivateAssetRootUrl>
+    <DotNetAssetRootUrl Condition="'$(DotNetAssetRootUrl)'==''">https://dotnetbuilds.azureedge.net/public/</DotNetAssetRootUrl>
+    <DotNetPrivateAssetRootUrl Condition="'$(DotNetPrivateAssetRootUrl)'==''">https://dotnetbuilds.blob.core.windows.net/internal/</DotNetPrivateAssetRootUrl>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The dotnet assets for 6.0 will be removed from dotnetcli when we do https://github.com/dotnet/core-eng/issues/14101. This change is required for that change to not break the build.
