### PR TITLE
Allow overriding the host header if doesn't match the absolute-form host

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -603,6 +603,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                     if (!_absoluteRequestTarget.IsDefaultPort
                         || hostText != _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture))
                     {
+                        // Superseded by RFC 7230, but notable for back-compat.
                         // https://datatracker.ietf.org/doc/html/rfc2616/#section-5.2
                         //    1. If Request-URI is an absoluteURI, the host is part of the
                         // Request-URI. Any Host header field value in the request MUST be

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -36,6 +36,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
 
         private Func<string, Encoding?> _responseHeaderEncodingSelector = DefaultHeaderEncodingSelector;
 
+        private bool? _enableInsecureAbsoluteFormHostOverride;
+        internal bool EnableInsecureAbsoluteFormHostOverride
+        {
+            get
+            {
+                if (!_enableInsecureAbsoluteFormHostOverride.HasValue)
+                {
+                    _enableInsecureAbsoluteFormHostOverride =
+                        AppContext.TryGetSwitch("Microsoft.AspNetCore.Server.Kestrel.EnableInsecureAbsoluteFormHostOverride", out var enabled) && enabled;
+                }
+                return _enableInsecureAbsoluteFormHostOverride.Value;
+            }
+            set => _enableInsecureAbsoluteFormHostOverride = value;
+        }
+
         // The following two lists configure the endpoints that Kestrel should listen to. If both lists are empty, the "urls" config setting (e.g. UseUrls) is used.
         internal List<ListenOptions> CodeBackedListenOptions { get; } = new List<ListenOptions>();
         internal List<ListenOptions> ConfigurationBackedListenOptions { get; } = new List<ListenOptions>();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
         }
 
         [Fact]
-        public async Task BadRequestIfHostHeaderDoesNotMatchRequestTarget_OptOut()
+        public async Task CanOptOutOfBadRequestIfHostHeaderDoesNotMatchRequestTarget()
         {
             var receivedHost = StringValues.Empty;
             await using var server = new TestServer(context =>


### PR DESCRIPTION
## Description

There are known clients that send the request with the full url in the request line, but then also include a malformed or mismatched Host header. IIS/Http.Sys ignores the invalid host in this scenario, where Kestrel rejects it with a 400. This change provides an opt-in switch for customers to test this new approach in Kestrel.

Fixes #39335

## Customer Impact

Some clients are not able to communicate with Kestrel, and updating the client isn't in the customer's control.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Opt-in validation change.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
