### PR TITLE
Don't reference test asset projects in Build.props

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -16,25 +16,25 @@
     <!-- Exclude the websockets samples for now because they use classic .csproj, which is not yet supported in our build. -->
     <ProjectToExclude Include="$(RepoRoot)src\Middleware\WebSockets\samples\**\*.csproj" />
 
-    <!-- These projects are meant to be executed by tests. -->
-    <ProjectToExclude Include="
-                      $(RepoRoot)src\Tools\dotnet-watch\test\TestProjects\**\*.csproj;
-                      $(RepoRoot)src\Tools\Tests.Common\TestProjects\**\*.csproj;
-                      $(RepoRoot)src\Razor\Razor.Design\test\testassets\**\*.*proj;
-                      $(RepoRoot)src\Razor\test\testassets\**\*.*proj;
-                      $(RepoRoot)src\Components\Web.JS\node_modules\**\*.*proj;
-                      $(RepoRoot)src\Components\WebAssembly\Sdk\testassets\**\*.csproj;
-                      " />
+    <!-- These projects are meant to be referenced only by tests. -->
+    <ProjectToExclude Include="$(RepoRoot)src\**\testassets\**\*.*proj"
+      Exclude="$(RepoRoot)src\Components\WebAssembly\testassets\WasmLinkerTest\*.*proj;
+               $(RepoRoot)src\Components\WebView\Samples\PhotinoPlatform\testassets\PhotinoTestApp\*.*proj;
+               $(RepoRoot)src\Http\Routing\test\testassets\RoutingSandbox\*.*proj;
+               $(RepoRoot)src\Security\Authentication\Negotiate\test\testassets\Negotiate.Client\*.*proj;
+               $(RepoRoot)src\Security\Authentication\Negotiate\test\testassets\Negotiate.Server\*.*proj;
+               " />
 
     <!-- These projects are not meant to be built in this repo. In the Installers case, must explicitly opt in. -->
     <!-- On the other hand, the main spa-templates project is just another project in this repo. -->
     <ProjectToExclude Include="
                       $(RepoRoot)src\submodules\googletest\**\*.*proj;
                       $(RepoRoot)src\submodules\MessagePack-CSharp\**\*.*proj;
-                      $(RepoRoot)src\Installers\**\*.*proj;
-                      $(RepoRoot)src\SignalR\clients\ts\**\node_modules\**\*.*proj;
-                      $(RepoRoot)src\ProjectTemplates\Web.ProjectTemplates\content\**\*.*proj;
                       $(RepoRoot)src\submodules\spa-templates\src\content\**\*.csproj;
+                      $(RepoRoot)src\Components\Web.JS\node_modules\**\*.*proj;
+                      $(RepoRoot)src\Installers\**\*.*proj;
+                      $(RepoRoot)src\ProjectTemplates\Web.ProjectTemplates\content\**\*.*proj;
+                      $(RepoRoot)src\SignalR\clients\ts\**\node_modules\**\*.*proj;
                       " />
 
     <!-- Exclude the benchmarks because they use <PackageReference>. -->

--- a/src/Hosting/test/FunctionalTests/Microsoft.AspNetCore.Hosting.FunctionalTests.csproj
+++ b/src/Hosting/test/FunctionalTests/Microsoft.AspNetCore.Hosting.FunctionalTests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
 
@@ -17,7 +16,15 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Hosting\Server.IntegrationTesting\src\Microsoft.AspNetCore.Server.IntegrationTesting.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Hosting\test\testassets\BasicLinkedApp\BasicLinkedApp.csproj"
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="$(RepoRoot)src\Hosting\test\testassets\IStartupInjectionAssemblyName\IStartupInjectionAssemblyName.csproj"
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="$(RepoRoot)src\Hosting\test\testassets\Microsoft.AspNetCore.Hosting.TestSites\Microsoft.AspNetCore.Hosting.TestSites.csproj"
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />
@@ -25,5 +32,4 @@
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
-
 </Project>

--- a/src/Servers/HttpSys/test/NonHelixTests/Microsoft.AspNetCore.Server.HttpSys.NonHelixTests.csproj
+++ b/src/Servers/HttpSys/test/NonHelixTests/Microsoft.AspNetCore.Server.HttpSys.NonHelixTests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <TestGroupName>HttpSys.NonHelixTests</TestGroupName>
@@ -25,6 +24,9 @@
   <ItemGroup>
     <Content Include="testroot\**\*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <ProjectReference Include="$(RepoRoot)src\Hosting\Server.IntegrationTesting\src\Microsoft.AspNetCore.Server.IntegrationTesting.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Servers\HttpSys\test\testassets\DelegationSite\DelegationSite.csproj"
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- test projects should include any necessary references
  - should further reduce build ordering problems
  - also, removes mention of a few non-existent folders
- but, special case a _few_ test asset projects
  - reference three used in test classes in relevant test projects
  - reference five that are otherwise unreferenced in Build.props
- move `src\Components\Web.JS\node_modules` mention to correct part of Build.props

nit:
- sort "not meant to be built" project list