### PR TITLE
Enable codestyle analyzers in VS

### DIFF
--- a/eng/targets/CSharp.Common.targets
+++ b/eng/targets/CSharp.Common.targets
@@ -35,9 +35,6 @@
     <NoWarn Condition="'$(TargetFrameworks)' != ''">$(NoWarn);IDE0005</NoWarn>
 
     <!-- Enable .NET code style analysis during build for src projects. -->
-    <!-- Workaround bug where turning this on produces warnings in VS -->
-    <!-- See https://github.com/dotnet/roslyn/issues/54867 for more info. -->
-    <EnforceCodeStyleInBuild Condition="'$(BuildingInsideVisualStudio)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '17.0'))">false</EnforceCodeStyleInBuild>
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == ''">true</EnforceCodeStyleInBuild>
 
     <!-- Enable trimming annotation validation in DI. See https://github.com/dotnet/runtime/blob/main/docs/workflow/trimming/feature-switches.md -->


### PR DESCRIPTION
While the linked issue remains unresolved, the GA build of VS 2022 [no longer produces errors](https://github.com/dotnet/aspnetcore/pull/34664) when using analyzers from the 6.0 (or newer) SDK.

