### PR TITLE
Revert "Remove source-build workaround for sourcelink submodule issue"

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <GitHubRepositoryName>aspnetcore</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+    <CloneSubmodulesToInnerSourceBuildRepo>false</CloneSubmodulesToInnerSourceBuildRepo>
   </PropertyGroup>
 
   <Target Name="PrepareGlobalJsonForSourceBuild"
@@ -11,6 +12,19 @@
     <Exec
       Command="./eng/scripts/prepare-sourcebuild-globaljson.sh"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)" />
+  </Target>
+
+  <!--
+    Init submodules - temporarary workaround for https://github.com/dotnet/sourcelink/pull/653
+  -->
+  <Target Name="InitSubmodules"
+          DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
+          BeforeTargets="RunInnerSourceBuildCommand">
+
+    <Exec
+      Command="git submodule update --init --recursive"
+      WorkingDirectory="$(InnerSourceBuildRepoRoot)"
+      EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>
 
   <!--


### PR DESCRIPTION
This reverts commit 9b049bda14c442081f7f2137ec2179283c6e6a0b (https://github.com/dotnet/aspnetcore/pull/39324) as the change broke the internal builds.  See https://github.com/dotnet/aspnetcore-internal/issues/3979#issuecomment-1006801036.

