### PR TITLE
Detect HTTP/1.1 on HTTP/2 connection

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -542,7 +542,7 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
         return false;
     }
 
-    private bool IsPreface(in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
+    private static bool IsPreface(in ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
     {
         consumed = buffer.Start;
         examined = buffer.End;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -12,7 +12,6 @@ using System.Text;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -471,7 +471,10 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
                                     // TODO: Cache bytes
                                     await _context.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes(@"HTTP/1.1 400 Bad Request
 Connection: close
+Content-Type: text/plain
+Content-Length: 57
 
+An HTTP/1.x request was sent to an HTTP/2 only endpoint.
 "));
                                     await _context.Transport.Output.FlushAsync();
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -452,11 +452,10 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
 
         if (!span.SequenceEqual(ClientPreface))
         {
-            // This incoming request data isn't valid HTTP/2. Do some additional investigation of the content to see whether
-            // we can write a clear log message of what is wrong.
-            // A common pit of failure is not using TLS and having pre-negotated HTTP version.
+            // The incoming request data isn't valid HTTP/2. Investigate the content to see whether we can write a log message of what is wrong.
+            // A common pit of failure is pre-negotated requests and sending the wrong HTTP version.
             //
-            // Do this check when not using TLS. With TLS, ALPN should have already errored if the wrong version is used.
+            // With TLS, ALPN should have already errored if the wrong HTTP version is used. Do this check when not using TLS. 
             var tlsFeature = ConnectionFeatures.Get<ITlsHandshakeFeature>();
             if (tlsFeature == null)
             {
@@ -472,13 +471,12 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
 
     private void CheckWrongHttpVersion(in ReadOnlySequence<byte> buffer)
     {
-        // Check to see if the request bytes are an HTTP/1.x request.
-        // Initial request line will end with "HTTP/1.0" or "HTTP/1.1".
-        // Note that this test isn't perfect. It is possible the entire first request line isn't in the buffer./
-        // In that case nothing is written to the log.
+        // Check to see if the request bytes are an HTTP/1.x request. Initial request line will end with "HTTP/1.0" or "HTTP/1.1".
+        // Note that this test isn't perfect. It is possible the entire first request line isn't in the buffer. In that case nothing is written to the log.
         var reader = new SequenceReader<byte>(buffer);
-        if (reader.TryReadTo(out ReadOnlySpan<byte> requestLine, (byte)'\n', advancePastDelimiter: true))
+        if (reader.TryReadTo(out ReadOnlySpan<byte> requestLine, (byte)'\n'))
         {
+            // Line should be long enough for HTTP/1.X and end with \r\n
             if (requestLine.Length > 10 && requestLine[requestLine.Length - 1] == (byte)'\r')
             {
                 var detectedVersion = HttpUtilities.GetKnownVersion(requestLine.Slice(requestLine.Length - 9, 8));

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -472,13 +472,13 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
                             {
                                 Log.PossibleInvalidHttpVersionDetected(ConnectionId, HttpVersion.Http2, detectedVersion);
 
-                                var responseBytes = InvalidHttp1xErrorResponseBytes ??= Encoding.ASCII.GetBytes(@"HTTP/1.1 400 Bad Request
-Connection: close
-Content-Type: text/plain
-Content-Length: 57
-
-An HTTP/1.x request was sent to an HTTP/2 only endpoint.
-");
+                                var responseBytes = InvalidHttp1xErrorResponseBytes ??= Encoding.ASCII.GetBytes(
+                                    "HTTP/1.1 400 Bad Request\r\n" +
+                                    "Connection: close\r\n" +
+                                    "Content-Type: text/plain\r\n" +
+                                    "Content-Length: 56\r\n" +
+                                    "\r\n" +
+                                    "An HTTP/1.x request was sent to an HTTP/2 only endpoint.");
 
                                 await _context.Transport.Output.WriteAsync(responseBytes);
 
@@ -494,6 +494,7 @@ An HTTP/1.x request was sent to an HTTP/2 only endpoint.
                         }
                     }
 
+                    // Tested all states. Return HTTP/2 protocol error.
                     if (state == ReadPrefaceState.None)
                     {
                         throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorInvalidPreface, Http2ErrorCode.PROTOCOL_ERROR);
@@ -502,7 +503,7 @@ An HTTP/1.x request was sent to an HTTP/2 only endpoint.
 
                 if (result.IsCompleted)
                 {
-                    throw new Http2ConnectionErrorException(CoreStrings.Http2ErrorInvalidPreface, Http2ErrorCode.PROTOCOL_ERROR);
+                    return false;
                 }
             }
             finally

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -402,7 +402,7 @@ internal sealed partial class KestrelTrace : ILogger
     {
         if (_generalLogger.IsEnabled(LogLevel.Debug))
         {
-            PossibleInvalidHttpVersionDetected(_generalLogger, connectionId, HttpUtilities.VersionToString(expectedHttpVersion), HttpUtilities.VersionToString(detectedHttpVersion));
+            PossibleInvalidHttpVersionDetected(_badRequestsLogger, connectionId, HttpUtilities.VersionToString(expectedHttpVersion), HttpUtilities.VersionToString(detectedHttpVersion));
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.Extensions.Logging;
@@ -392,6 +393,17 @@ internal sealed partial class KestrelTrace : ILogger
     public void Http3GoAwayStreamId(string connectionId, long goAwayStreamId)
     {
         Http3GoAwayStreamId(_http3Logger, connectionId, goAwayStreamId);
+    }
+
+    [LoggerMessage(54, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Invalid content received on connection. Possible incorrect HTTP version detected. Expected {ExpectedHttpVersion} but received {DetectedHttpVersion}.", EventName = "PossibleInvalidHttpVersionDetected", SkipEnabledCheck = true)]
+    private static partial void PossibleInvalidHttpVersionDetected(ILogger logger, string connectionId, string expectedHttpVersion, string detectedHttpVersion);
+
+    public void PossibleInvalidHttpVersionDetected(string connectionId, HttpVersion expectedHttpVersion, HttpVersion detectedHttpVersion)
+    {
+        if (_generalLogger.IsEnabled(LogLevel.Debug))
+        {
+            PossibleInvalidHttpVersionDetected(_generalLogger, connectionId, HttpUtilities.VersionToString(expectedHttpVersion), HttpUtilities.VersionToString(detectedHttpVersion));
+        }
     }
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -5255,7 +5255,7 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
-    public async Task StartTlsConnection_SendHttp1xRequest_ProtocolError()
+    public async Task StartTlsConnection_SendHttp1xRequest_NoError()
     {
         CreateConnection();
 
@@ -5266,27 +5266,18 @@ public class Http2ConnectionTests : Http2TestBase
         await InitializeConnectionWithoutPrefaceAsync(_noopApplication);
 
         await SendAsync(Encoding.ASCII.GetBytes("GET / HTTP/1.1\r\n"));
-        _pair.Application.Output.Complete();
 
-        await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
-            ignoreNonGoAwayFrames: false,
-            expectedLastStreamId: 0,
-            expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
-            expectedErrorMessage: CoreStrings.Http2ErrorInvalidPreface);
+        await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
     }
 
     [Fact]
-    public async Task StartConnection_SendNothing_ProtocolError()
+    public async Task StartConnection_SendNothing_NoError()
     {
         await InitializeConnectionWithoutPrefaceAsync(_noopApplication);
 
         _pair.Application.Output.Complete();
 
-        await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
-            ignoreNonGoAwayFrames: false,
-            expectedLastStreamId: 0,
-            expectedErrorCode: Http2ErrorCode.PROTOCOL_ERROR,
-            expectedErrorMessage: CoreStrings.Http2ErrorInvalidPreface);
+        await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
     }
 
     public static TheoryData<byte[]> UpperCaseHeaderNameData

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -5275,8 +5275,6 @@ public class Http2ConnectionTests : Http2TestBase
     {
         await InitializeConnectionWithoutPrefaceAsync(_noopApplication);
 
-        _pair.Application.Output.Complete();
-
         await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
     }
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -17,7 +17,7 @@ public class Http2RequestTests : LoggedTest
     public async Task GET_NoTLS_Http11RequestToHttp2Endpoint_400Result()
     {
         // Arrange
-        var builder = CreateHostBuilder(c => Task.CompletedTask, protocol: HttpProtocols.Http2);
+        var builder = CreateHostBuilder(c => Task.CompletedTask, protocol: HttpProtocols.Http2, plaintext: true);
 
         using (var host = builder.Build())
         using (var client = HttpHelpers.CreateClient())
@@ -37,8 +37,8 @@ public class Http2RequestTests : LoggedTest
         }
     }
 
-    private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)
+    private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null, bool? plaintext = null)
     {
-        return HttpHelpers.CreateHostBuilder(AddTestLogging, requestDelegate, protocol, configureKestrel);
+        return HttpHelpers.CreateHostBuilder(AddTestLogging, requestDelegate, protocol, configureKestrel, plaintext);
     }
 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Hosting;
+
+namespace Interop.FunctionalTests.Http2;
+
+public class Http2RequestTests : LoggedTest
+{
+    [Fact]
+    public async Task GET_NoTLS_Http11RequestToHttp2Endpoint_400Result()
+    {
+        // Arrange
+        var builder = CreateHostBuilder(c => Task.CompletedTask, protocol: HttpProtocols.Http2);
+
+        using (var host = builder.Build())
+        using (var client = HttpHelpers.CreateClient())
+        {
+            await host.StartAsync().DefaultTimeout();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"http://127.0.0.1:{host.GetPort()}/");
+            request.Version = HttpVersion.Version11;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+            // Act
+            var responseMessage = await client.SendAsync(request, CancellationToken.None).DefaultTimeout();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
+            Assert.Equal("An HTTP/1.x request was sent to an HTTP/2 only endpoint.", await responseMessage.Content.ReadAsStringAsync());
+        }
+    }
+
+    private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)
+    {
+        return HttpHelpers.CreateHostBuilder(AddTestLogging, requestDelegate, protocol, configureKestrel);
+    }
+}

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -88,7 +88,7 @@ public class Http3RequestTests : LoggedTest
         }, protocol: protocol);
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync().DefaultTimeout();
 
@@ -190,7 +190,7 @@ public class Http3RequestTests : LoggedTest
         }, protocol: protocol);
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -229,7 +229,7 @@ public class Http3RequestTests : LoggedTest
         }, protocol: protocol);
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -273,7 +273,7 @@ public class Http3RequestTests : LoggedTest
         });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync().DefaultTimeout();
 
@@ -341,7 +341,7 @@ public class Http3RequestTests : LoggedTest
         }, protocol: protocol);
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync().DefaultTimeout();
 
@@ -414,7 +414,7 @@ public class Http3RequestTests : LoggedTest
         }, protocol: protocol);
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync().DefaultTimeout();
 
@@ -480,7 +480,7 @@ public class Http3RequestTests : LoggedTest
         }, protocol: protocol);
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync().DefaultTimeout();
 
@@ -526,7 +526,7 @@ public class Http3RequestTests : LoggedTest
         });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient(expect100ContinueTimeout: TimeSpan.FromMinutes(20)))
+        using (var client = HttpHelpers.CreateClient(expect100ContinueTimeout: TimeSpan.FromMinutes(20)))
         {
             await host.StartAsync().DefaultTimeout();
 
@@ -591,7 +591,7 @@ public class Http3RequestTests : LoggedTest
         });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -901,7 +901,7 @@ public class Http3RequestTests : LoggedTest
         });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -954,7 +954,7 @@ public class Http3RequestTests : LoggedTest
         });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -1020,7 +1020,7 @@ public class Http3RequestTests : LoggedTest
         });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -1073,7 +1073,7 @@ public class Http3RequestTests : LoggedTest
         });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -1134,7 +1134,7 @@ public class Http3RequestTests : LoggedTest
             });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -1199,7 +1199,7 @@ public class Http3RequestTests : LoggedTest
         {
             await host.StartAsync();
 
-            var client = Http3Helpers.CreateClient();
+            var client = HttpHelpers.CreateClient();
             try
             {
                 var port = host.GetPort();
@@ -1259,7 +1259,7 @@ public class Http3RequestTests : LoggedTest
             });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -1364,7 +1364,7 @@ public class Http3RequestTests : LoggedTest
             });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -1441,7 +1441,7 @@ public class Http3RequestTests : LoggedTest
         });
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync();
 
@@ -1499,7 +1499,7 @@ public class Http3RequestTests : LoggedTest
         }, protocol: protocol);
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync().DefaultTimeout();
 
@@ -1595,7 +1595,7 @@ public class Http3RequestTests : LoggedTest
         }, protocol: protocol);
 
         using (var host = builder.Build())
-        using (var client = Http3Helpers.CreateClient())
+        using (var client = HttpHelpers.CreateClient())
         {
             await host.StartAsync().DefaultTimeout();
 
@@ -1640,6 +1640,6 @@ public class Http3RequestTests : LoggedTest
 
     private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)
     {
-        return Http3Helpers.CreateHostBuilder(AddTestLogging, requestDelegate, protocol, configureKestrel);
+        return HttpHelpers.CreateHostBuilder(AddTestLogging, requestDelegate, protocol, configureKestrel);
     }
 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -42,7 +42,7 @@ public class Http3TlsTests : LoggedTest
         });
 
         using var host = builder.Build();
-        using var client = Http3Helpers.CreateClient();
+        using var client = HttpHelpers.CreateClient();
 
         await host.StartAsync().DefaultTimeout();
 
@@ -90,7 +90,7 @@ public class Http3TlsTests : LoggedTest
         });
 
         using var host = builder.Build();
-        using var client = Http3Helpers.CreateClient(includeClientCert: true);
+        using var client = HttpHelpers.CreateClient(includeClientCert: true);
 
         await host.StartAsync().DefaultTimeout();
 
@@ -133,7 +133,7 @@ public class Http3TlsTests : LoggedTest
         });
 
         using var host = builder.Build();
-        using var client = Http3Helpers.CreateClient(includeClientCert: true);
+        using var client = HttpHelpers.CreateClient(includeClientCert: true);
 
         await host.StartAsync().DefaultTimeout();
 
@@ -183,7 +183,7 @@ public class Http3TlsTests : LoggedTest
         });
 
         using var host = builder.Build();
-        using var client = Http3Helpers.CreateClient(includeClientCert: true);
+        using var client = HttpHelpers.CreateClient(includeClientCert: true);
 
         await host.StartAsync().DefaultTimeout();
 
@@ -236,7 +236,7 @@ public class Http3TlsTests : LoggedTest
         });
 
         using var host = builder.Build();
-        using var client = Http3Helpers.CreateClient(includeClientCert: false);
+        using var client = HttpHelpers.CreateClient(includeClientCert: false);
 
         await host.StartAsync().DefaultTimeout();
 
@@ -271,7 +271,7 @@ public class Http3TlsTests : LoggedTest
         });
 
         using var host = builder.Build();
-        using var client = Http3Helpers.CreateClient();
+        using var client = HttpHelpers.CreateClient();
 
         var exception = await Assert.ThrowsAsync<NotSupportedException>(() =>
             host.StartAsync().DefaultTimeout());
@@ -280,6 +280,6 @@ public class Http3TlsTests : LoggedTest
 
     private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)
     {
-        return Http3Helpers.CreateHostBuilder(AddTestLogging, requestDelegate, protocol, configureKestrel);
+        return HttpHelpers.CreateHostBuilder(AddTestLogging, requestDelegate, protocol, configureKestrel);
     }
 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
@@ -42,7 +42,7 @@ internal static class HttpHelpers
         return new HttpMessageInvoker(handler);
     }
 
-    public static IHostBuilder CreateHostBuilder(Action<IServiceCollection> configureServices, RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null, bool? skipHttps = null)
+    public static IHostBuilder CreateHostBuilder(Action<IServiceCollection> configureServices, RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null, bool? plaintext = null)
     {
         return new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -55,7 +55,7 @@ internal static class HttpHelpers
                             o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
                             {
                                 listenOptions.Protocols = protocol ?? HttpProtocols.Http3;
-                                if (skipHttps ?? true)
+                                if (!(plaintext ?? false))
                                 {
                                     listenOptions.UseHttps();
                                 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
@@ -55,7 +55,7 @@ internal static class HttpHelpers
                             o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
                             {
                                 listenOptions.Protocols = protocol ?? HttpProtocols.Http3;
-                                if (skipHttps ?? false)
+                                if (skipHttps ?? true)
                                 {
                                     listenOptions.UseHttps();
                                 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
@@ -15,9 +15,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Interop.FunctionalTests.Http3;
+namespace Interop.FunctionalTests;
 
-public static class Http3Helpers
+internal static class HttpHelpers
 {
     public static HttpMessageInvoker CreateClient(TimeSpan? idleTimeout = null, TimeSpan? expect100ContinueTimeout = null, bool includeClientCert = false)
     {
@@ -42,7 +42,7 @@ public static class Http3Helpers
         return new HttpMessageInvoker(handler);
     }
 
-    public static IHostBuilder CreateHostBuilder(Action<IServiceCollection> configureServices, RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)
+    public static IHostBuilder CreateHostBuilder(Action<IServiceCollection> configureServices, RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null, bool? skipHttps = null)
     {
         return new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -55,7 +55,10 @@ public static class Http3Helpers
                             o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
                             {
                                 listenOptions.Protocols = protocol ?? HttpProtocols.Http3;
-                                listenOptions.UseHttps();
+                                if (skipHttps ?? false)
+                                {
+                                    listenOptions.UseHttps();
+                                }
                             });
                         }
                         else


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/14884

![image](https://user-images.githubusercontent.com/303201/148443729-4ccfbf35-933b-45bf-a51c-28100b15e60d.png)

What do we think? It's not perfect, but it should be a lot more informative in most cases. And extra work only happens if request is already been rejected so has no perf impact. Will add unit tests if this idea has merit.

Also, we can do something similar for HTTP/1.1 (on invalid request line, check if the content is an HTTP/2 connection preface)