### PR TITLE
[release/6.0] Switch to Windows.Amd64.Server2022.Open

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -7,7 +7,7 @@
     <HelixQueueMariner>(Mariner)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620</HelixQueueMariner>
     <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20211001171229-97d8652</HelixQueueArmDebian11>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true'">
     <HelixAvailablePlatform Include="Windows" />
     <HelixAvailablePlatform Include="OSX" />
@@ -21,7 +21,7 @@
   <!-- x64 PR(ci.yaml) required queues for internal and public cases -->
   <ItemGroup Condition="'$(IsRequiredCheck)' == 'true' AND '$(TargetArchitecture)' == 'x64' AND '$(IsHelixDaily)' != 'true'">
     <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
-    <HelixAvailableTargetQueue Include="Windows.11.Amd64.ClientPre.Open" Platform="Windows" />
+    <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
     <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
   </ItemGroup>
 


### PR DESCRIPTION
- very temporary; change should be in place for less than a week
- #39363 covers going back to our preferred Windows.11.Amd64.ClientPre.Open