### PR TITLE
[main] Switch to Windows.Amd64.Server2022.Open

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -30,7 +30,7 @@
       <ItemGroup>
         <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
         <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
-        <HelixAvailableTargetQueue Include="Windows.11.Amd64.ClientPre.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
       </ItemGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
- very temporary; change should be in place for less than a week
- #39363 covers going back to our preferred Windows.11.Amd64.ClientPre.Open