### PR TITLE
Added support for binding the raw request body

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -605,9 +605,7 @@ public static partial class RequestDelegateFactory
         Debug.Assert(factoryContext.RequestBodyParameter is not null, "factoryContext.JsonRequestBodyParameter is null for a JSON body.");
 
         var bodyType = factoryContext.RequestBodyParameter.ParameterType;
-        var isRawBodyType = bodyType == typeof(byte[]) ||
-                            bodyType == typeof(ReadOnlyMemory<byte>) ||
-                            bodyType == typeof(ReadOnlySequence<byte>);
+        var isRawBodyType = bodyType == typeof(ReadOnlySequence<byte>);
         var parameterTypeName = TypeNameHelper.GetTypeDisplayName(factoryContext.RequestBodyParameter.ParameterType, fullName: false);
         var parameterName = factoryContext.RequestBodyParameter.Name;
 
@@ -708,25 +706,7 @@ public static partial class RequestDelegateFactory
 
                         if (result.IsCompleted)
                         {
-                            if (bodyType == typeof(ReadOnlySequence<byte>))
-                            {
-                                // REVIEW: Does this need to be a copy? We can tell users to consume the buffer
-                                // immediately in the action (they can copy if they need to).
-                                return (buffer, true);
-                            }
-
-                            // This is very LOH unfriendly
-                            var copiedBuffer = buffer.ToArray();
-
-                            // Consume the whole thing
-                            bodyReader.AdvanceTo(buffer.End);
-
-                            if (bodyType == typeof(ReadOnlyMemory<byte>))
-                            {
-                                return (new ReadOnlyMemory<byte>(copiedBuffer), true);
-                            }
-
-                            return (copiedBuffer, true);
+                            return (buffer, true);
                         }
 
                         // Buffer the body

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -629,9 +629,18 @@ public static partial class RequestDelegateFactory
                     boundValues[i] = await binders[i](httpContext);
                 }
 
-                var bodyValue = await ReadBodyAsync(httpContext);
+                var stream = httpContext.Request.Body;
 
-                await continuation(target, httpContext, bodyValue, boundValues);
+                try
+                {
+                    var bodyValue = await ReadBodyAsync(httpContext);
+
+                    await continuation(target, httpContext, bodyValue, boundValues);
+                }
+                finally
+                {
+                    httpContext.Request.Body = stream;
+                }
             };
         }
         else
@@ -642,9 +651,18 @@ public static partial class RequestDelegateFactory
 
             return async (target, httpContext) =>
             {
-                var bodyValue = await ReadBodyAsync(httpContext);
+                var stream = httpContext.Request.Body;
 
-                await continuation(target, httpContext, bodyValue);
+                try
+                {
+                    var bodyValue = await ReadBodyAsync(httpContext);
+
+                    await continuation(target, httpContext, bodyValue);
+                }
+                finally
+                {
+                    httpContext.Request.Body = stream;
+                }
             };
         }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -663,6 +663,10 @@ public static partial class RequestDelegateFactory
 
                     if (result.IsCompleted)
                     {
+                        // We're not buffering the body so we want to block consuming code from reading again
+                        // and getting weird errors. Treat further reads as a fully consumed body.
+                        httpContext.Request.Body = Stream.Null;
+
                         return buffer;
                     }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1223,7 +1223,7 @@ public static partial class RequestDelegateFactory
                 // }
                 var checkRequiredBodyBlock = Expression.Block(
                     Expression.IfThen(
-                        Expression.Equal(BodyValueExpr, Expression.Constant(null)),
+                    Expression.Equal(BodyValueExpr, Expression.Constant(null)),
                         Expression.Block(
                             Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
                             Expression.Call(LogRequiredParameterNotProvidedMethod,

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -629,12 +629,7 @@ public static partial class RequestDelegateFactory
                     boundValues[i] = await binders[i](httpContext);
                 }
 
-                var (bodyValue, successful) = await TryReadBodyAsync(httpContext);
-
-                if (!successful)
-                {
-                    return;
-                }
+                var bodyValue = await ReadBodyAsync(httpContext);
 
                 await continuation(target, httpContext, bodyValue, boundValues);
             };
@@ -647,18 +642,13 @@ public static partial class RequestDelegateFactory
 
             return async (target, httpContext) =>
             {
-                var (bodyValue, successful) = await TryReadBodyAsync(httpContext);
-
-                if (!successful)
-                {
-                    return;
-                }
+                var bodyValue = await ReadBodyAsync(httpContext);
 
                 await continuation(target, httpContext, bodyValue);
             };
         }
 
-        static async Task<(ReadOnlySequence<byte>, bool)> TryReadBodyAsync(HttpContext httpContext)
+        static async ValueTask<ReadOnlySequence<byte>> ReadBodyAsync(HttpContext httpContext)
         {
             var feature = httpContext.Features.Get<IHttpRequestBodyDetectionFeature>();
 
@@ -673,7 +663,7 @@ public static partial class RequestDelegateFactory
 
                     if (result.IsCompleted)
                     {
-                        return (buffer, true);
+                        return buffer;
                     }
 
                     // Buffer the body
@@ -681,7 +671,7 @@ public static partial class RequestDelegateFactory
                 }
             }
 
-            return (default, true);
+            return default;
         }
     }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -599,7 +599,7 @@ public static partial class RequestDelegateFactory
 
     private static Func<object?, HttpContext, Task> HandleRequestBodyAndCompileRequestDelegateForJson(Expression responseWritingMethodCall, FactoryContext factoryContext)
     {
-        Debug.Assert(factoryContext.JsonRequestBodyParameter is not null, "factoryContext.RequestBodyParameter is null for a body parameter.");
+        Debug.Assert(factoryContext.JsonRequestBodyParameter is not null, "factoryContext.JsonRequestBodyParameter is null for a JSON body.");
 
         var bodyType = factoryContext.JsonRequestBodyParameter.ParameterType;
         var parameterTypeName = TypeNameHelper.GetTypeDisplayName(factoryContext.JsonRequestBodyParameter.ParameterType, fullName: false);
@@ -1184,7 +1184,6 @@ public static partial class RequestDelegateFactory
 
         factoryContext.JsonRequestBodyParameter = parameter;
         factoryContext.AllowEmptyRequestBody = allowEmpty || isOptional;
-
         factoryContext.Metadata.Add(new AcceptsMetadata(parameter.ParameterType, factoryContext.AllowEmptyRequestBody, DefaultAcceptsContentType));
 
         if (!factoryContext.AllowEmptyRequestBody)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -206,7 +206,7 @@ public static partial class RequestDelegateFactory
         if (factoryContext.RequestBodyParameter is not null &&
             factoryContext.FirstFormRequestBodyParameter is not null)
         {
-            var errorMessage = BuildErrorMessageForFormAndJsonBodyParameters(factoryContext);
+            var errorMessage = BuildErrorMessageForFormAndBodyParameters(factoryContext);
             throw new InvalidOperationException(errorMessage);
         }
         if (factoryContext.HasMultipleBodyParameters)
@@ -1717,10 +1717,10 @@ public static partial class RequestDelegateFactory
         return errorMessage.ToString();
     }
 
-    private static string BuildErrorMessageForFormAndJsonBodyParameters(FactoryContext factoryContext)
+    private static string BuildErrorMessageForFormAndBodyParameters(FactoryContext factoryContext)
     {
         var errorMessage = new StringBuilder();
-        errorMessage.AppendLine("An action cannot use both form and JSON body parameters.");
+        errorMessage.AppendLine("An action cannot use both form and body parameters.");
         errorMessage.AppendLine("Below is the list of parameters that we found: ");
         errorMessage.AppendLine();
         errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}| {"Source",-30}"));

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -593,8 +593,10 @@ public static partial class RequestDelegateFactory
         {
             return HandleRequestBodyAndCompileRequestDelegateForForm(responseWritingMethodCall, factoryContext);
         }
-
-        return HandleRequestBodyAndCompileRequestDelegateForJson(responseWritingMethodCall, factoryContext);
+        else
+        {
+            return HandleRequestBodyAndCompileRequestDelegateForJson(responseWritingMethodCall, factoryContext);
+        }
     }
 
     private static Func<object?, HttpContext, Task> HandleRequestBodyAndCompileRequestDelegateForJson(Expression responseWritingMethodCall, FactoryContext factoryContext)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -205,7 +205,7 @@ public static partial class RequestDelegateFactory
         if (factoryContext.JsonRequestBodyParameter is not null &&
             factoryContext.FirstFormRequestBodyParameter is not null)
         {
-            var errorMessage = BuildErrorMessageForFormAndBodyParameters(factoryContext);
+            var errorMessage = BuildErrorMessageForFormAndJsonBodyParameters(factoryContext);
             throw new InvalidOperationException(errorMessage);
         }
         if (factoryContext.HasMultipleBodyParameters)
@@ -594,10 +594,10 @@ public static partial class RequestDelegateFactory
             return HandleRequestBodyAndCompileRequestDelegateForForm(responseWritingMethodCall, factoryContext);
         }
 
-        return HandleRequestBodyAndCompileRequestDelegateForJsonBody(responseWritingMethodCall, factoryContext);
+        return HandleRequestBodyAndCompileRequestDelegateForJson(responseWritingMethodCall, factoryContext);
     }
 
-    private static Func<object?, HttpContext, Task> HandleRequestBodyAndCompileRequestDelegateForJsonBody(Expression responseWritingMethodCall, FactoryContext factoryContext)
+    private static Func<object?, HttpContext, Task> HandleRequestBodyAndCompileRequestDelegateForJson(Expression responseWritingMethodCall, FactoryContext factoryContext)
     {
         Debug.Assert(factoryContext.JsonRequestBodyParameter is not null, "factoryContext.RequestBodyParameter is null for a body parameter.");
 
@@ -1692,7 +1692,7 @@ public static partial class RequestDelegateFactory
         return errorMessage.ToString();
     }
 
-    private static string BuildErrorMessageForFormAndBodyParameters(FactoryContext factoryContext)
+    private static string BuildErrorMessageForFormAndJsonBodyParameters(FactoryContext factoryContext)
     {
         var errorMessage = new StringBuilder();
         errorMessage.AppendLine("An action cannot use both form and JSON body parameters.");

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -607,9 +607,6 @@ public static partial class RequestDelegateFactory
     private static Func<object?, HttpContext, Task> HandleRequestBodyAndCompileRequestDelegateForRawBody(Expression responseWritingMethodCall, FactoryContext factoryContext)
     {
         Debug.Assert(factoryContext.RequestBodyParameter is not null, "factoryContext.RequestBodyParameter is null for a body parameter.");
-
-        var bodyType = factoryContext.RequestBodyParameter.ParameterType;
-
         Debug.Assert(factoryContext.RequestBodyParameter.Name is not null, "CreateArgument() should throw if parameter.Name is null.");
 
         if (factoryContext.ParameterBinders.Count > 0)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -596,13 +596,13 @@ public static partial class RequestDelegateFactory
         }
         else
         {
-            return HandleRequestBodyAndCompileRequestDelegateForJson(responseWritingMethodCall, factoryContext);
+            return HandleRequestBodyAndCompileRequestDelegateForOtherBody(responseWritingMethodCall, factoryContext);
         }
     }
 
-    private static Func<object?, HttpContext, Task> HandleRequestBodyAndCompileRequestDelegateForJson(Expression responseWritingMethodCall, FactoryContext factoryContext)
+    private static Func<object?, HttpContext, Task> HandleRequestBodyAndCompileRequestDelegateForOtherBody(Expression responseWritingMethodCall, FactoryContext factoryContext)
     {
-        Debug.Assert(factoryContext.RequestBodyParameter is not null, "factoryContext.JsonRequestBodyParameter is null for a JSON body.");
+        Debug.Assert(factoryContext.RequestBodyParameter is not null, "factoryContext.RequestBodyParameter is null for a body parameter.");
 
         var bodyType = factoryContext.RequestBodyParameter.ParameterType;
         var isRawBodyType = bodyType == typeof(ReadOnlySequence<byte>);

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1458,6 +1458,8 @@ public class RequestDelegateFactoryTests : LoggedTest
 
         await requestDelegate(httpContext);
 
+        Assert.Same(httpContext.Request.Body, stream);
+
         var rawRequestBody = httpContext.Items["body"];
         Assert.NotNull(rawRequestBody);
         Assert.Equal(requestBodyBytes, (byte[])rawRequestBody!);

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1447,10 +1447,6 @@ public class RequestDelegateFactoryTests : LoggedTest
         var rawRequestBody = httpContext.Items["body"];
         Assert.NotNull(rawRequestBody);
         Assert.Equal(requestBodyBytes, (byte[])rawRequestBody!);
-        if (httpContext.Items.TryGetValue("bodyIsEmpty", out var bodyIsEmpty))
-        {
-            Assert.True((bool)bodyIsEmpty!);
-        }
     }
 
     [Theory]
@@ -1496,10 +1492,6 @@ public class RequestDelegateFactoryTests : LoggedTest
         var rawRequestBody = httpContext.Items["body"];
         Assert.NotNull(rawRequestBody);
         Assert.Equal(requestBodyBytes, (byte[])rawRequestBody!);
-        if (httpContext.Items.TryGetValue("bodyIsEmpty", out var bodyIsEmpty))
-        {
-            Assert.True((bool)bodyIsEmpty!);
-        }
     }
 
     class PipeRequestBodyFeature : IRequestBodyPipeFeature

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1409,7 +1409,6 @@ public class RequestDelegateFactoryTests : LoggedTest
         }
     }
 
-
     [Theory]
     [MemberData(nameof(RawFromBodyActions))]
     public async Task RequestDelegatePopulatesFromRawBodyParameter(Delegate action)

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1469,8 +1469,6 @@ public class RequestDelegateFactoryTests : LoggedTest
 
         var responseFeature = (TestHttpResponseFeature)httpContext.Features.Get<IHttpResponseFeature>()!;
 
-        var mockReader = new Mock<PipeReader>();
-
         var stream = new MemoryStream(requestBodyBytes);
         httpContext.Request.Body = stream;
 

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1402,10 +1402,10 @@ public class RequestDelegateFactoryTests : LoggedTest
 
             return new[]
             {
-                    new object[] { (Action<HttpContext, ReadOnlySequence<byte>>)TestReadOnlySequence },
-                    new object[] { (Action<HttpContext, Stream>)TestStream },
-                    new object[] { (Func<HttpContext, PipeReader, Task>)TestPipeReader },
-                };
+                new object[] { (Action<HttpContext, ReadOnlySequence<byte>>)TestReadOnlySequence },
+                new object[] { (Action<HttpContext, Stream>)TestStream },
+                new object[] { (Func<HttpContext, PipeReader, Task>)TestPipeReader },
+            };
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1483,6 +1483,64 @@ public class RequestDelegateFactoryTests : LoggedTest
     }
 
     [Theory]
+    [MemberData(nameof(RawFromBodyActions))]
+    public async Task RequestDelegatePopulatesFromRawBodyParameterPipeReader(Delegate action)
+    {
+        var httpContext = CreateHttpContext();
+
+        var requestBodyBytes = JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            Name = "Write more tests!"
+        });
+
+        var pipeReader = PipeReader.Create(new MemoryStream(requestBodyBytes));
+        var stream = pipeReader.AsStream();
+        httpContext.Features.Set<IRequestBodyPipeFeature>(new PipeRequestBodyFeature(pipeReader));
+        httpContext.Request.Body = stream;
+
+        httpContext.Request.Headers["Content-Length"] = requestBodyBytes.Length.ToString(CultureInfo.InvariantCulture);
+        httpContext.Features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(true));
+
+        var mock = new Mock<IServiceProvider>();
+        httpContext.RequestServices = mock.Object;
+
+        var factoryResult = RequestDelegateFactory.Create(action);
+
+        var requestDelegate = factoryResult.RequestDelegate;
+
+        await requestDelegate(httpContext);
+
+        Assert.Same(httpContext.Request.Body, stream);
+        Assert.Same(httpContext.Request.BodyReader, pipeReader);
+
+        // Assert that we can read the body from both the pipe reader and Stream after executing and verify that they are empty (the pipe reader isn't seekable here)
+        int read = await httpContext.Request.Body.ReadAsync(new byte[requestBodyBytes.Length].AsMemory());
+        Assert.Equal(0, read);
+
+        var result = await httpContext.Request.BodyReader.ReadAsync();
+        Assert.Equal(0, result.Buffer.Length);
+        Assert.True(result.IsCompleted);
+        httpContext.Request.BodyReader.AdvanceTo(result.Buffer.End);
+
+        var rawRequestBody = httpContext.Items["body"];
+        Assert.NotNull(rawRequestBody);
+        Assert.Equal(requestBodyBytes, (byte[])rawRequestBody!);
+        if (httpContext.Items.TryGetValue("bodyIsEmpty", out var bodyIsEmpty))
+        {
+            Assert.True((bool)bodyIsEmpty!);
+        }
+    }
+
+    class PipeRequestBodyFeature : IRequestBodyPipeFeature
+    {
+        public PipeRequestBodyFeature(PipeReader pipeReader)
+        {
+            Reader = pipeReader;
+        }
+        public PipeReader Reader { get; set; }
+    }
+
+    [Theory]
     [MemberData(nameof(ExplicitFromBodyActions))]
     public async Task RequestDelegateRejectsEmptyBodyGivenExplicitFromBodyParameter(Delegate action)
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1400,11 +1400,18 @@ public class RequestDelegateFactoryTests : LoggedTest
                 httpContext.Items.Add("body", ms.ToArray());
             }
 
+            void TestPipeReaderAndROS(HttpContext httpContext, ReadOnlySequence<byte> body, PipeReader reader)
+            {
+                httpContext.Items.Add("body", body.ToArray());
+                reader.AdvanceTo(body.End);
+            }
+
             return new[]
             {
                 new object[] { (Action<HttpContext, ReadOnlySequence<byte>>)TestReadOnlySequence },
                 new object[] { (Action<HttpContext, Stream>)TestStream },
                 new object[] { (Func<HttpContext, PipeReader, Task>)TestPipeReader },
+                new object[] { (Action<HttpContext, ReadOnlySequence<byte>, PipeReader>)TestPipeReaderAndROS },
             };
         }
     }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1460,6 +1460,19 @@ public class RequestDelegateFactoryTests : LoggedTest
 
         Assert.Same(httpContext.Request.Body, stream);
 
+        // Assert that we can read the body from both the pipe reader and Stream after executing
+        httpContext.Request.Body.Position = 0;
+        byte[] data = new byte[requestBodyBytes.Length];
+        int read = await httpContext.Request.Body.ReadAsync(data.AsMemory());
+        Assert.Equal(read, data.Length);
+        Assert.Equal(requestBodyBytes, data);
+
+        httpContext.Request.Body.Position = 0;
+        var result = await httpContext.Request.BodyReader.ReadAsync();
+        Assert.Equal(requestBodyBytes.Length, result.Buffer.Length);
+        Assert.Equal(requestBodyBytes, result.Buffer.ToArray());
+        httpContext.Request.BodyReader.AdvanceTo(result.Buffer.End);
+
         var rawRequestBody = httpContext.Items["body"];
         Assert.NotNull(rawRequestBody);
         Assert.Equal(requestBodyBytes, (byte[])rawRequestBody!);


### PR DESCRIPTION
- Added support for PipeReader, Stream, ~ReadOnlySequence<byte>, ReadOnlyMemory<byte> and byte[]~
- Added test

~This will potentially break custom JSON converters for byte[] (maybe base64 JSON encoded content?)~

Fixes https://github.com/dotnet/aspnetcore/issues/38153

~TBD: Fix the error messages that talk about JSON binding when these types are being used.~