### PR TITLE
Detect HTTP/2 connection sent to HTTP/1.1 endpoint

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpOutputAborter
 {
-    internal static ReadOnlySpan<byte> Http2GoAwayProtocolErrorBytes => new byte[17] { 0, 0, 8, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13 };
+    internal static ReadOnlySpan<byte> Http2GoAwayHttp11RequiredBytes => new byte[17] { 0, 0, 8, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13 };
 
     private const byte ByteAsterisk = (byte)'*';
     private const byte ByteForwardSlash = (byte)'/';
@@ -746,7 +746,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                 {
                     Log.PossibleInvalidHttpVersionDetected(ConnectionId, Http.HttpVersion.Http11, Http.HttpVersion.Http2);
 
-                    _context.Transport.Output.Write(Http2GoAwayProtocolErrorBytes);
+                    _context.Transport.Output.Write(Http2GoAwayHttp11RequiredBytes);
 
                     // Aborting the connection here stops Http1Connection from writing HTTP/1.1 response.
                     CancelRequestAbortedToken();

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -732,7 +732,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
     private void DetectHttp2Preface(ReadOnlySequence<byte> requestData, BadHttpRequestException ex)
 #pragma warning restore CS0618 // Type or member is obsolete
     {
-        const int PrefaceLineLength = 18;
+        const int PrefaceLineLength = 16;
 
         // Only check for HTTP/2 preface on non-TLS connection.
         // When TLS is used then ALPN is used to negotiate correct version.

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -992,8 +992,10 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
         {
             return ProduceEnd();
         }
-
-        return Task.CompletedTask;
+        else
+        {
+            return Output.FlushAsync(CancellationToken.None).GetAsTask();
+        }
     }
 
     protected Task ProduceEnd()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -593,7 +593,10 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
         {
             try
             {
-                await TryProduceInvalidRequestResponse();
+                if (_requestRejectedException != null)
+                {
+                    await TryProduceInvalidRequestResponse();
+                }
             }
             catch (Exception ex)
             {
@@ -985,17 +988,15 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
         VerifyAndUpdateWrite(firstWriteByteCount);
     }
 
-    protected Task TryProduceInvalidRequestResponse()
+    protected virtual Task TryProduceInvalidRequestResponse()
     {
         // If _requestAborted is set, the connection has already been closed.
-        if (_requestRejectedException != null && !_connectionAborted)
+        if (!_connectionAborted)
         {
             return ProduceEnd();
         }
-        else
-        {
-            return Output.FlushAsync(CancellationToken.None).GetAsTask();
-        }
+
+        return Task.CompletedTask;
     }
 
     protected Task ProduceEnd()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -990,7 +990,9 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
 
     protected virtual Task TryProduceInvalidRequestResponse()
     {
-        // If _requestAborted is set, the connection has already been closed.
+        Debug.Assert(_requestRejectedException != null);
+
+        // If _connectionAborted is set, the connection has already been closed.
         if (!_connectionAborted)
         {
             return ProduceEnd();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -206,7 +206,7 @@ public class BadHttpRequestTests : LoggedTest
 
                 var data = await client.Stream.ReadAtLeastLengthAsync(17);
 
-                Assert.Equal(Http1Connection.Http2GoAwayProtocolErrorBytes.ToArray(), data);
+                Assert.Equal(Http1Connection.Http2GoAwayHttp11RequiredBytes.ToArray(), data);
             }
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -202,11 +202,12 @@ public class BadHttpRequestTests : LoggedTest
         {
             using (var client = server.CreateConnection())
             {
-                await client.Stream.WriteAsync(Core.Internal.Http2.Http2Connection.ClientPreface.ToArray());
+                await client.Stream.WriteAsync(Core.Internal.Http2.Http2Connection.ClientPreface.ToArray()).DefaultTimeout();
 
                 var data = await client.Stream.ReadAtLeastLengthAsync(17);
 
                 Assert.Equal(Http1Connection.Http2GoAwayHttp11RequiredBytes.ToArray(), data);
+                Assert.Empty(await client.Stream.ReadUntilEndAsync().DefaultTimeout());
             }
         }
     }


### PR DESCRIPTION
Related to https://github.com/dotnet/aspnetcore/pull/39358 except an HTTP/2 connection sent to HTTP/1.1 endpoint.

![image](https://user-images.githubusercontent.com/303201/148737121-6e891d62-746d-4add-bbbb-8484ccbceb4f.png)
