### PR TITLE
Fix internal builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -721,7 +721,6 @@ stages:
         dependsOn:
           - Windows_build
           - Windows_arm_build
-          - Windows_arm64_build
           - ${{ if ne(variables.PostBuildSign, 'true') }}:
             - CodeSign_Xplat_MacOS_arm64
             - CodeSign_Xplat_MacOS_x64
@@ -760,7 +759,6 @@ stages:
           - Windows_arm_build
           # In addition to the dependency above that provides assets, ensure the build was successful overall.
           - Windows_build
-          - Windows_arm64_build
           - ${{ if ne(variables.PostBuildSign, 'true') }}:
             - CodeSign_Xplat_MacOS_arm64
             - CodeSign_Xplat_MacOS_x64


### PR DESCRIPTION
Internal builds are broken by https://github.com/dotnet/aspnetcore/pull/38997 because it deleted a jobname that was being used by internal build steps