### PR TITLE
Avoid declaring RazorPage<T>.Model as nullable by default (#39332)

### DIFF
--- a/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Mvc.Razor.RazorPage<TModel>.Model.get -> TModel?
+Microsoft.AspNetCore.Mvc.Razor.RazorPage<TModel>.Model.get -> TModel

--- a/src/Mvc/Mvc.Razor/src/RazorPageOfT.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPageOfT.cs
@@ -15,13 +15,12 @@ namespace Microsoft.AspNetCore.Mvc.Razor
         /// <summary>
         /// Gets the Model property of the <see cref="ViewData"/> property.
         /// </summary>
-        public TModel? Model => ViewData == null ? default(TModel) : ViewData.Model;
+        public TModel Model => ViewData.Model;
 
         /// <summary>
         /// Gets or sets the dictionary for view data.
         /// </summary>
         [RazorInject]
         public ViewDataDictionary<TModel> ViewData { get; set; } = default!;
-
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.ViewFeatures/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TModel>.Model.get -> TModel?
+Microsoft.AspNetCore.Mvc.ViewFeatures.ViewDataDictionary<TModel>.Model.get -> TModel

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionaryOfT.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionaryOfT.cs
@@ -86,16 +86,10 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures
         }
 
         /// <inheritdoc />
-        public new TModel? Model
+        public new TModel Model
         {
-            get
-            {
-                return (base.Model == null) ? default(TModel) : (TModel)base.Model;
-            }
-            set
-            {
-                base.Model = value;
-            }
+            get => (base.Model is null) ? default! : (TModel)base.Model;
+            set => base.Model = value;
         }
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
@@ -6,10 +6,10 @@
 <h1 class="text-danger">Error.</h1>
 <h2 class="text-danger">An error occurred while processing your request.</h2>
 
-@if (Model?.ShowRequestId ?? false)
+@if (Model.ShowRequestId)
 {
     <p>
-        <strong>Request ID:</strong> <code>@Model?.RequestId</code>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
     </p>
 }
 


### PR DESCRIPTION
## Description

The `Model` property for `RazorPage<T>`, the base class for MVC views, is declared as nullable. Having a nullable property reflects an accurate state when the model is not initialized as part of MVC's internal infrastructure. However, having the property be nullable is frustrating for user code when they specify a non-null model. We've had reports of users getting hundreds of errors in their app when they migrate to .NET  6 (which is when this API was annotated for nullability) with nullability enabled.

Fixes https://github.com/dotnet/aspnetcore/issues/37510

## Customer Impact

Difficulty in migrating to .NET 6.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low



## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

