### PR TITLE
Fix UrlGroup UnregisteringPrefix log message

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -131,7 +131,7 @@ internal partial class UrlGroup : IDisposable
 
     internal bool UnregisterPrefix(string uriPrefix)
     {
-        Log.UnregisteringPrefix(_logger, "Stop listening on prefix: {0}");
+        Log.UnregisteringPrefix(_logger, uriPrefix);
         CheckDisposed();
 
         var statusCode = HttpApi.HttpRemoveUrlFromUrlGroup(Id, uriPrefix, 0);


### PR DESCRIPTION
Pass only the `uriPrefix` to `UnregisteringPrefix` as the message is already defined here:
https://github.com/dotnet/aspnetcore/blob/c85baf8db0c72ae8e68643029d514b2e737c9fae/src/Servers/HttpSys/src/NativeInterop/UrlGroup.Log.cs#L21-L22

Before:
```
Stop listening on prefix: Stop listening on prefix: {0}
```

After:
```
Stop listening on prefix: http://localhost:5000/
```
