### PR TITLE
Preserve UseUrls() setting when configuration sources are cleared

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostBuilder.cs
@@ -121,7 +121,7 @@ internal sealed class GenericWebHostBuilder : IWebHostBuilder, ISupportsStartup,
 
     private void ExecuteHostingStartups()
     {
-        var webHostOptions = new WebHostOptions(_config, Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty);
+        var webHostOptions = new WebHostOptions(_config);
 
         if (webHostOptions.PreventHostingStartup)
         {
@@ -385,11 +385,12 @@ internal sealed class GenericWebHostBuilder : IWebHostBuilder, ISupportsStartup,
         return this;
     }
 
-    private static WebHostBuilderContext GetWebHostBuilderContext(HostBuilderContext context)
+    private WebHostBuilderContext GetWebHostBuilderContext(HostBuilderContext context)
     {
         if (!context.Properties.TryGetValue(typeof(WebHostBuilderContext), out var contextVal))
         {
-            var options = new WebHostOptions(context.Configuration, Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty);
+            // Use _config as a fallback for WebHostOptions in case the chained source was removed from the hosting IConfigurationBuilder.
+            var options = new WebHostOptions(context.Configuration, fallbackConfiguration: _config);
             var webHostBuilderContext = new WebHostBuilderContext
             {
                 Configuration = context.Configuration,

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -65,6 +65,12 @@ internal sealed partial class GenericWebHostService : IHostedService
         if (addresses != null && !addresses.IsReadOnly && addresses.Count == 0)
         {
             var urls = Configuration[WebHostDefaults.ServerUrlsKey];
+
+            if (string.IsNullOrEmpty(urls))
+            {
+                urls = Options.WebHostOptions.ServerUrls;
+            }
+
             if (!string.IsNullOrEmpty(urls))
             {
                 serverAddressesFeature!.PreferHostingUrls = WebHostUtilities.ParseBool(Configuration, WebHostDefaults.PreferHostingUrlsKey);

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -64,8 +64,10 @@ internal sealed partial class GenericWebHostService : IHostedService
         var addresses = serverAddressesFeature?.Addresses;
         if (addresses != null && !addresses.IsReadOnly && addresses.Count == 0)
         {
+            // We support reading "urls" from app configuration
             var urls = Configuration[WebHostDefaults.ServerUrlsKey];
 
+            // But fall back to host settings
             if (string.IsNullOrEmpty(urls))
             {
                 urls = Options.WebHostOptions.ServerUrls;
@@ -73,7 +75,18 @@ internal sealed partial class GenericWebHostService : IHostedService
 
             if (!string.IsNullOrEmpty(urls))
             {
-                serverAddressesFeature!.PreferHostingUrls = WebHostUtilities.ParseBool(Configuration, WebHostDefaults.PreferHostingUrlsKey);
+                // We support reading "preferHostingUrls" from app configuration
+                var preferHostingUrlsConfig = Configuration[WebHostDefaults.PreferHostingUrlsKey];
+
+                // But fall back to host settings
+                if (!string.IsNullOrEmpty(preferHostingUrlsConfig))
+                {
+                    serverAddressesFeature!.PreferHostingUrls = WebHostUtilities.ParseBool(preferHostingUrlsConfig);
+                }
+                else
+                {
+                    serverAddressesFeature!.PreferHostingUrls = Options.WebHostOptions.PreferHostingUrls;
+                }
 
                 foreach (var value in urls.Split(';', StringSplitOptions.RemoveEmptyEntries))
                 {

--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -275,7 +275,7 @@ internal sealed partial class WebHost : IWebHost, IAsyncDisposable
                 var urls = _config[WebHostDefaults.ServerUrlsKey] ?? _config[DeprecatedServerUrlsKey];
                 if (!string.IsNullOrEmpty(urls))
                 {
-                    serverAddressesFeature!.PreferHostingUrls = WebHostUtilities.ParseBool(_config, WebHostDefaults.PreferHostingUrlsKey);
+                    serverAddressesFeature!.PreferHostingUrls = WebHostUtilities.ParseBool(_config[WebHostDefaults.PreferHostingUrlsKey]);
 
                     foreach (var value in urls.Split(';', StringSplitOptions.RemoveEmptyEntries))
                     {

--- a/src/Hosting/Hosting/src/Internal/WebHostOptions.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHostOptions.cs
@@ -25,6 +25,7 @@ internal class WebHostOptions
         ContentRootPath = configuration[WebHostDefaults.ContentRootKey];
         PreventHostingStartup = WebHostUtilities.ParseBool(configuration, WebHostDefaults.PreventHostingStartupKey);
         SuppressStatusMessages = WebHostUtilities.ParseBool(configuration, WebHostDefaults.SuppressStatusMessagesKey);
+        ServerUrls = configuration[WebHostDefaults.ServerUrlsKey];
 
         // Search the primary assembly and configured assemblies.
         HostingStartupAssemblies = Split(ApplicationName, configuration[WebHostDefaults.HostingStartupAssembliesKey]);
@@ -38,29 +39,31 @@ internal class WebHostOptions
         }
     }
 
-    public string ApplicationName { get; set; }
+    public string ApplicationName { get; }
 
-    public bool PreventHostingStartup { get; set; }
+    public bool PreventHostingStartup { get; }
 
-    public bool SuppressStatusMessages { get; set; }
+    public bool SuppressStatusMessages { get; }
 
-    public IReadOnlyList<string> HostingStartupAssemblies { get; set; }
+    public IReadOnlyList<string> HostingStartupAssemblies { get; }
 
-    public IReadOnlyList<string> HostingStartupExcludeAssemblies { get; set; }
+    public IReadOnlyList<string> HostingStartupExcludeAssemblies { get; }
 
-    public bool DetailedErrors { get; set; }
+    public bool DetailedErrors { get; }
 
-    public bool CaptureStartupErrors { get; set; }
+    public bool CaptureStartupErrors { get; }
 
-    public string? Environment { get; set; }
+    public string? Environment { get; }
 
-    public string? StartupAssembly { get; set; }
+    public string? StartupAssembly { get; }
 
-    public string? WebRoot { get; set; }
+    public string? WebRoot { get; }
 
-    public string? ContentRootPath { get; set; }
+    public string? ContentRootPath { get; }
 
-    public TimeSpan ShutdownTimeout { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan ShutdownTimeout { get; } = TimeSpan.FromSeconds(5);
+
+    public string? ServerUrls { get; }
 
     public IEnumerable<string> GetFinalHostingStartupAssemblies()
     {

--- a/src/Hosting/Hosting/src/Internal/WebHostUtilities.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHostUtilities.cs
@@ -1,15 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Configuration;
-
 namespace Microsoft.AspNetCore.Hosting;
 
 internal class WebHostUtilities
 {
-    public static bool ParseBool(IConfiguration configuration, string key)
+    public static bool ParseBool(string? value)
     {
-        return string.Equals("true", configuration[key], StringComparison.OrdinalIgnoreCase)
-            || string.Equals("1", configuration[key], StringComparison.OrdinalIgnoreCase);
+        return string.Equals("true", value, StringComparison.OrdinalIgnoreCase)
+            || string.Equals("1", value, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Hosting/Hosting/src/WebHostBuilder.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilder.cs
@@ -220,7 +220,7 @@ public class WebHostBuilder : IWebHostBuilder
     {
         hostingStartupErrors = null;
 
-        _options = new WebHostOptions(_config, Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty);
+        _options = new WebHostOptions(_config);
 
         if (!_options.PreventHostingStartup)
         {

--- a/src/Hosting/Hosting/test/GenericWebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/GenericWebHostBuilderTests.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -34,5 +37,46 @@ public class GenericWebHostBuilderTests
         var config = host.Services.GetRequiredService<IConfiguration>();
         Assert.Null(config[randomEnvKey]);
         Environment.SetEnvironmentVariable("ASPNETCORE_" + randomEnvKey, null);
+    }
+
+    [Fact]
+    public void UseUrlsWorksAfterAppConfigurationSourcesAreCleared()
+    {
+        var server = new TestServer();
+
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseServer(server)
+                    .UseUrls("TEST_URL")
+                    .Configure(_ => { });
+            })
+            .ConfigureAppConfiguration(configBuilder =>
+            {
+                configBuilder.Sources.Clear();
+            })
+            .Build();
+
+        host.Start();
+
+        Assert.Equal("TEST_URL", server.Addresses.Single());
+    }
+
+    private class TestServer : IServer, IServerAddressesFeature
+    {
+        public TestServer()
+        {
+            Features.Set<IServerAddressesFeature>(this);
+        }
+
+        public IFeatureCollection Features { get; } = new FeatureCollection();
+
+        public ICollection<string> Addresses { get; } = new List<string>();
+        public bool PreferHostingUrls { get; set; }
+
+        public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public void Dispose() { }
     }
 }

--- a/src/Hosting/Hosting/test/GenericWebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/GenericWebHostBuilderTests.cs
@@ -63,6 +63,30 @@ public class GenericWebHostBuilderTests
         Assert.Equal("TEST_URL", server.Addresses.Single());
     }
 
+    [Fact]
+    public void UseUrlsWorksAfterHostConfigurationSourcesAreCleared()
+    {
+        var server = new TestServer();
+
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseServer(server)
+                    .UseUrls("TEST_URL")
+                    .Configure(_ => { });
+            })
+            .ConfigureHostConfiguration(configBuilder =>
+            {
+                configBuilder.Sources.Clear();
+            })
+            .Build();
+
+        host.Start();
+
+        Assert.Equal("TEST_URL", server.Addresses.Single());
+    }
+
     private class TestServer : IServer, IServerAddressesFeature
     {
         public TestServer()

--- a/src/Hosting/Hosting/test/HostingEnvironmentExtensionsTests.cs
+++ b/src/Hosting/Hosting/test/HostingEnvironmentExtensionsTests.cs
@@ -73,10 +73,9 @@ public class HostingEnvironmentExtensionsTests
         Assert.Equal("NewName", env.EnvironmentName);
     }
 
-    private WebHostOptions CreateWebHostOptions(IConfiguration configuration = null, string applicationNameFallback = null)
+    private WebHostOptions CreateWebHostOptions(IConfiguration configuration = null)
     {
         return new WebHostOptions(
-            configuration ?? Mock.Of<IConfiguration>(),
-            applicationNameFallback: applicationNameFallback);
+            configuration ?? Mock.Of<IConfiguration>());
     }
 }

--- a/src/Hosting/Hosting/test/HostingEnvironmentExtensionsTests.cs
+++ b/src/Hosting/Hosting/test/HostingEnvironmentExtensionsTests.cs
@@ -14,8 +14,12 @@ public class HostingEnvironmentExtensionsTests
     {
         IWebHostEnvironment env = new HostingEnvironment();
 
-        var webHostOptions = CreateWebHostOptions();
-        webHostOptions.WebRoot = "testroot";
+        var webHostOptions = CreateWebHostOptions(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    [WebHostDefaults.WebRootKey] = "testroot"
+                }).Build());
 
         env.Initialize(Path.GetFullPath("."), webHostOptions);
 
@@ -57,8 +61,12 @@ public class HostingEnvironmentExtensionsTests
         IWebHostEnvironment env = new HostingEnvironment();
         env.EnvironmentName = "SomeName";
 
-        var webHostOptions = CreateWebHostOptions();
-        webHostOptions.Environment = "NewName";
+        var webHostOptions = CreateWebHostOptions(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                    [WebHostDefaults.EnvironmentKey] = "NewName"
+                }).Build());
 
         env.Initialize(Path.GetFullPath("."), webHostOptions);
 

--- a/src/Hosting/Hosting/test/WebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/WebHostBuilderTests.cs
@@ -1405,11 +1405,9 @@ public class WebHostBuilderTests
         await host.StopAsync();
     }
 
-    private WebHostOptions CreateWebHostOptions(IConfiguration configuration, string applicationNameFallback = null)
+    private WebHostOptions CreateWebHostOptions(IConfiguration configuration)
     {
-        return new WebHostOptions(
-            configuration,
-            applicationNameFallback: applicationNameFallback);
+        return new WebHostOptions(configuration);
     }
 
     private class StartOrder

--- a/src/Hosting/Hosting/test/WebHostConfigurationsTests.cs
+++ b/src/Hosting/Hosting/test/WebHostConfigurationsTests.cs
@@ -22,7 +22,7 @@ public class WebHostConfigurationTests
                 { WebHostDefaults.SuppressStatusMessagesKey, "true" }
             };
 
-        var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build(), applicationNameFallback: null);
+        var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build());
 
         Assert.Equal("wwwroot", config.WebRoot);
         Assert.Equal("MyProjectReference", config.ApplicationName);
@@ -37,7 +37,7 @@ public class WebHostConfigurationTests
     public void ReadsOldEnvKey()
     {
         var parameters = new Dictionary<string, string>() { { "ENVIRONMENT", Environments.Development } };
-        var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build(), applicationNameFallback: null);
+        var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build());
 
         Assert.Equal(Environments.Development, config.Environment);
     }
@@ -48,7 +48,7 @@ public class WebHostConfigurationTests
     public void AllowsNumberForDetailedErrors(string value, bool expected)
     {
         var parameters = new Dictionary<string, string>() { { "detailedErrors", value } };
-        var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build(), applicationNameFallback: null);
+        var config = new WebHostOptions(new ConfigurationBuilder().AddInMemoryCollection(parameters).Build());
 
         Assert.Equal(expected, config.DetailedErrors);
     }


### PR DESCRIPTION
## Description

An application that clears configuration sources in `.ConfigureAppConfiguration()` would be unable to use `.UseUrls()` successfully. For example:

```C#
public static IHostBuilder CreateHostBuilder(string[] args) =>
    Host.CreateDefaultBuilder(args)
        .ConfigureAppConfiguration((context, configBuilder) =>
        {
            configBuilder.Sources.Clear(); // This hides the "urls" config from GenericWebHostedService
        })
        .ConfigureWebHostDefaults(webHostBuilder =>
        {
            webHostBuilder.UseUrls("http://localhost:12345", "https://localhost:44347"); // ignored.. same launchProfiles, env. variables etc
        })
        // ...
```


Most other `WebHostOptions` ("urls" was not an internal `WebHostOptions` before this PR) are immune to settings being lost to cleared application source because they are read from the "Host" `IConfiguration` instead of the "App" `IConfiguration`.

```C#
public static IHostBuilder CreateHostBuilder(string[] args) =>
    Host.CreateDefaultBuilder(args)

        .ConfigureWebHostDefaults(webBuilder =>
        {
            webHostBuilder.UseSetting(WebHostDefaults.CaptureStartupErrorsKey, "true");
        })
        .ConfigureHostConfiguration(configBuilder =>
        {
            configBuilder.Sources.Clear(); // This hides the "captureStartupErrors" config from GenericWebHostedService
        })
        // ...
```

To fix this, this PR uses `WebHostOptions` as a fallback source for URLs in case the chained configuration source from app config to hosting config gets removed. This PR also updates `WebHostOptions` to fall back to the builder settings config source in case the chained configuration source from hosting config to settings gets removed. App config still overrides hosting config and hosting config overrides builder settings where it did before, but this PR prevents removing config sources from removing the ability to fall back to settings set via `.UseUrls()`, `.UseSetting()` and the like.

Fixes #39432
