### PR TITLE
Remove double publish of windows assets

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -245,7 +245,6 @@ stages:
                 /p:DotNetSignType=$(_SignType)
                 /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
                 $(_BuildArgs)
-                $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
                 /p:PublishInstallerBaseVersion=true
                 $(WindowsInstallersLogArgs)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -257,7 +257,7 @@ stages:
                 -buildInstallers
                 -noBuildNative
                 /p:DotNetSignType=$(_SignType)
-                /p:AssetManifestFileName=aspnetcore-win-assets.xml
+                /p:AssetManifestFileName=aspnetcore-win.xml
                 $(_BuildArgs)
                 $(_PublishArgs)
                 /p:PublishInstallerBaseVersion=true

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -243,10 +243,8 @@ stages:
                 -buildInstallers
                 -noBuildNative
                 /p:DotNetSignType=$(_SignType)
-                /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
-                /p:PublishInstallerBaseVersion=true
                 $(WindowsInstallersLogArgs)
         displayName: Build Installers
 
@@ -259,9 +257,10 @@ stages:
                 -buildInstallers
                 -noBuildNative
                 /p:DotNetSignType=$(_SignType)
-                /p:AssetManifestFileName=aspnetcore-win-arm64.xml
+                /p:AssetManifestFileName=aspnetcore-win-assets.xml
                 $(_BuildArgs)
                 $(_PublishArgs)
+                /p:PublishInstallerBaseVersion=true
                 $(_InternalRuntimeDownloadArgs)
                 $(WindowsArm64InstallersLogArgs)
         displayName: Build ARM64 Installers


### PR DESCRIPTION
Because we build x64/x86 and arm64 in the same job and publish in both steps, we end up double publishing the x64/x86 assets which results in failures when darc tries to publish assets.

Removing the publish from the x64/x86 step and only running publish in the last step (arm64) to avoid double publishing.