### PR TITLE
Added IServiceProvider to DataAnnotationsValidator

### DIFF
--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -12,7 +12,8 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
     private EditContext? _originalEditContext;
 
     [CascadingParameter] EditContext? CurrentEditContext { get; set; }
-    [Inject] IServiceProvider? ServiceProvider { get; set; }
+
+    [Inject] private IServiceProvider? ServiceProvider { get; set; }
 
     /// <inheritdoc />
     protected override void OnInitialized()

--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -13,7 +13,7 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
 
     [CascadingParameter] EditContext? CurrentEditContext { get; set; }
 
-    [Inject] private IServiceProvider ServiceProvider { get; set; }
+    [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
 
     /// <inheritdoc />
     protected override void OnInitialized()

--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -12,6 +12,7 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
     private EditContext? _originalEditContext;
 
     [CascadingParameter] EditContext? CurrentEditContext { get; set; }
+    [Inject] IServiceProvider? ServiceProvider { get; set; }
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -23,7 +24,7 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
                 $"inside an EditForm.");
         }
 
-        _subscriptions = CurrentEditContext.EnableDataAnnotationsValidation();
+        _subscriptions = CurrentEditContext.EnableDataAnnotationsValidation(ServiceProvider);
         _originalEditContext = CurrentEditContext;
     }
 

--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -13,7 +13,7 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
 
     [CascadingParameter] EditContext? CurrentEditContext { get; set; }
 
-    [Inject] private IServiceProvider? ServiceProvider { get; set; }
+    [Inject] private IServiceProvider ServiceProvider { get; set; }
 
     /// <inheritdoc />
     protected override void OnInitialized()

--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -33,9 +33,10 @@ public static class EditContextDataAnnotationsExtensions
     /// </summary>
     /// <param name="editContext">The <see cref="EditContext"/>.</param>
     /// <returns>A disposable object whose disposal will remove DataAnnotations validation support from the <see cref="EditContext"/>.</returns>
+    [Obsolete("This API is obsolete and may be removed in future versions.")]
     public static IDisposable EnableDataAnnotationsValidation(this EditContext editContext)
     {
-        return new DataAnnotationsEventSubscriptions(editContext, null);
+        return new DataAnnotationsEventSubscriptions(editContext, null!);
     }
     /// <summary>
     /// Enables DataAnnotations validation support for the <see cref="EditContext"/>.
@@ -43,7 +44,7 @@ public static class EditContextDataAnnotationsExtensions
     /// <param name="editContext">The <see cref="EditContext"/>.</param>
     /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to be used in the <see cref="ValidationContext"/>.</param>
     /// <returns>A disposable object whose disposal will remove DataAnnotations validation support from the <see cref="EditContext"/>.</returns>
-    public static IDisposable EnableDataAnnotationsValidation(this EditContext editContext, IServiceProvider? serviceProvider)
+    public static IDisposable EnableDataAnnotationsValidation(this EditContext editContext, IServiceProvider serviceProvider)
     {
         return new DataAnnotationsEventSubscriptions(editContext, serviceProvider);
     }
@@ -64,7 +65,7 @@ public static class EditContextDataAnnotationsExtensions
         private readonly IServiceProvider? _serviceProvider;
         private readonly ValidationMessageStore _messages;
 
-        public DataAnnotationsEventSubscriptions(EditContext editContext, IServiceProvider? serviceProvider)
+        public DataAnnotationsEventSubscriptions(EditContext editContext, IServiceProvider serviceProvider)
         {
             _editContext = editContext ?? throw new ArgumentNullException(nameof(editContext));
             _serviceProvider = serviceProvider;
@@ -85,7 +86,7 @@ public static class EditContextDataAnnotationsExtensions
             if (TryGetValidatableProperty(fieldIdentifier, out var propertyInfo))
             {
                 var propertyValue = propertyInfo.GetValue(fieldIdentifier.Model);
-                var validationContext = new ValidationContext(fieldIdentifier.Model, _serviceProvider, null)
+                var validationContext = new ValidationContext(fieldIdentifier.Model, _serviceProvider, items: null)
                 {
                     MemberName = propertyInfo.Name
                 };
@@ -106,7 +107,7 @@ public static class EditContextDataAnnotationsExtensions
 
         private void OnValidationRequested(object? sender, ValidationRequestedEventArgs e)
         {
-            var validationContext = new ValidationContext(_editContext.Model, _serviceProvider, null);
+            var validationContext = new ValidationContext(_editContext.Model, _serviceProvider, items: null);
             var validationResults = new List<ValidationResult>();
             Validator.TryValidateObject(_editContext.Model, validationContext, validationResults, true);
 

--- a/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
+++ b/src/Components/Forms/src/EditContextDataAnnotationsExtensions.cs
@@ -46,6 +46,10 @@ public static class EditContextDataAnnotationsExtensions
     /// <returns>A disposable object whose disposal will remove DataAnnotations validation support from the <see cref="EditContext"/>.</returns>
     public static IDisposable EnableDataAnnotationsValidation(this EditContext editContext, IServiceProvider serviceProvider)
     {
+        if (serviceProvider == null)
+        {
+            throw new ArgumentNullException(nameof(serviceProvider));
+        }
         return new DataAnnotationsEventSubscriptions(editContext, serviceProvider);
     }
 

--- a/src/Components/Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Forms/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-static Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.EnableDataAnnotationsValidation(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext, System.IServiceProvider? serviceProvider) -> System.IDisposable!
+static Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.EnableDataAnnotationsValidation(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext, System.IServiceProvider! serviceProvider) -> System.IDisposable!

--- a/src/Components/Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.EnableDataAnnotationsValidation(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext, System.IServiceProvider? serviceProvider) -> System.IDisposable!

--- a/src/Components/Forms/test/EditContextDataAnnotationsExtensionsTest.cs
+++ b/src/Components/Forms/test/EditContextDataAnnotationsExtensionsTest.cs
@@ -2,16 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Components.Test.Helpers;
 
 namespace Microsoft.AspNetCore.Components.Forms;
 
 public class EditContextDataAnnotationsExtensionsTest
 {
+    private static readonly IServiceProvider _serviceProvider = new TestServiceProvider();
+
     [Fact]
     public void CannotUseNullEditContext()
     {
         var editContext = (EditContext)null;
-        var ex = Assert.Throws<ArgumentNullException>(() => editContext.EnableDataAnnotationsValidation(null!));
+        var ex = Assert.Throws<ArgumentNullException>(() => editContext.EnableDataAnnotationsValidation(_serviceProvider));
         Assert.Equal("editContext", ex.ParamName);
     }
 
@@ -31,7 +34,7 @@ public class EditContextDataAnnotationsExtensionsTest
         // Arrange
         var model = new TestModel { IntFrom1To100 = 101 };
         var editContext = new EditContext(model);
-        editContext.EnableDataAnnotationsValidation(null!);
+        editContext.EnableDataAnnotationsValidation(_serviceProvider);
 
         // Act
         var isValid = editContext.Validate();
@@ -61,7 +64,7 @@ public class EditContextDataAnnotationsExtensionsTest
         // Arrange
         var model = new TestModel { IntFrom1To100 = 101 };
         var editContext = new EditContext(model);
-        editContext.EnableDataAnnotationsValidation(null!);
+        editContext.EnableDataAnnotationsValidation(_serviceProvider);
 
         // Act/Assert 1: Initially invalid
         Assert.False(editContext.Validate());
@@ -78,7 +81,7 @@ public class EditContextDataAnnotationsExtensionsTest
         // Arrange
         var model = new TestModel { IntFrom1To100 = 101 };
         var editContext = new EditContext(model);
-        editContext.EnableDataAnnotationsValidation(null!);
+        editContext.EnableDataAnnotationsValidation(_serviceProvider);
         var onValidationStateChangedCount = 0;
         editContext.OnValidationStateChanged += (sender, eventArgs) => onValidationStateChangedCount++;
 
@@ -106,7 +109,7 @@ public class EditContextDataAnnotationsExtensionsTest
         var model = new TestModel { IntFrom1To100 = 101 };
         var independentTopLevelModel = new object(); // To show we can validate things on any model, not just the top-level one
         var editContext = new EditContext(independentTopLevelModel);
-        editContext.EnableDataAnnotationsValidation(null!);
+        editContext.EnableDataAnnotationsValidation(_serviceProvider);
         var onValidationStateChangedCount = 0;
         var requiredStringIdentifier = new FieldIdentifier(model, nameof(TestModel.RequiredString));
         var intFrom1To100Identifier = new FieldIdentifier(model, nameof(TestModel.IntFrom1To100));
@@ -146,7 +149,7 @@ public class EditContextDataAnnotationsExtensionsTest
     {
         // Arrange
         var editContext = new EditContext(new TestModel());
-        editContext.EnableDataAnnotationsValidation(null!);
+        editContext.EnableDataAnnotationsValidation(_serviceProvider);
         var onValidationStateChangedCount = 0;
         editContext.OnValidationStateChanged += (sender, eventArgs) => onValidationStateChangedCount++;
 
@@ -165,7 +168,7 @@ public class EditContextDataAnnotationsExtensionsTest
         // Arrange
         var model = new TestModel { IntFrom1To100 = 101 };
         var editContext = new EditContext(model);
-        var subscription = editContext.EnableDataAnnotationsValidation(null!);
+        var subscription = editContext.EnableDataAnnotationsValidation(_serviceProvider);
 
         // Act/Assert 1: when we're attached
         Assert.False(editContext.Validate());

--- a/src/Components/Forms/test/EditContextDataAnnotationsExtensionsTest.cs
+++ b/src/Components/Forms/test/EditContextDataAnnotationsExtensionsTest.cs
@@ -11,7 +11,7 @@ public class EditContextDataAnnotationsExtensionsTest
     public void CannotUseNullEditContext()
     {
         var editContext = (EditContext)null;
-        var ex = Assert.Throws<ArgumentNullException>(() => editContext.EnableDataAnnotationsValidation());
+        var ex = Assert.Throws<ArgumentNullException>(() => editContext.EnableDataAnnotationsValidation(null!));
         Assert.Equal("editContext", ex.ParamName);
     }
 
@@ -31,7 +31,7 @@ public class EditContextDataAnnotationsExtensionsTest
         // Arrange
         var model = new TestModel { IntFrom1To100 = 101 };
         var editContext = new EditContext(model);
-        editContext.EnableDataAnnotationsValidation();
+        editContext.EnableDataAnnotationsValidation(null!);
 
         // Act
         var isValid = editContext.Validate();
@@ -61,7 +61,7 @@ public class EditContextDataAnnotationsExtensionsTest
         // Arrange
         var model = new TestModel { IntFrom1To100 = 101 };
         var editContext = new EditContext(model);
-        editContext.EnableDataAnnotationsValidation();
+        editContext.EnableDataAnnotationsValidation(null!);
 
         // Act/Assert 1: Initially invalid
         Assert.False(editContext.Validate());
@@ -78,7 +78,7 @@ public class EditContextDataAnnotationsExtensionsTest
         // Arrange
         var model = new TestModel { IntFrom1To100 = 101 };
         var editContext = new EditContext(model);
-        editContext.EnableDataAnnotationsValidation();
+        editContext.EnableDataAnnotationsValidation(null!);
         var onValidationStateChangedCount = 0;
         editContext.OnValidationStateChanged += (sender, eventArgs) => onValidationStateChangedCount++;
 
@@ -106,7 +106,7 @@ public class EditContextDataAnnotationsExtensionsTest
         var model = new TestModel { IntFrom1To100 = 101 };
         var independentTopLevelModel = new object(); // To show we can validate things on any model, not just the top-level one
         var editContext = new EditContext(independentTopLevelModel);
-        editContext.EnableDataAnnotationsValidation();
+        editContext.EnableDataAnnotationsValidation(null!);
         var onValidationStateChangedCount = 0;
         var requiredStringIdentifier = new FieldIdentifier(model, nameof(TestModel.RequiredString));
         var intFrom1To100Identifier = new FieldIdentifier(model, nameof(TestModel.IntFrom1To100));
@@ -146,7 +146,7 @@ public class EditContextDataAnnotationsExtensionsTest
     {
         // Arrange
         var editContext = new EditContext(new TestModel());
-        editContext.EnableDataAnnotationsValidation();
+        editContext.EnableDataAnnotationsValidation(null!);
         var onValidationStateChangedCount = 0;
         editContext.OnValidationStateChanged += (sender, eventArgs) => onValidationStateChangedCount++;
 
@@ -165,7 +165,7 @@ public class EditContextDataAnnotationsExtensionsTest
         // Arrange
         var model = new TestModel { IntFrom1To100 = 101 };
         var editContext = new EditContext(model);
-        var subscription = editContext.EnableDataAnnotationsValidation();
+        var subscription = editContext.EnableDataAnnotationsValidation(null!);
 
         // Act/Assert 1: when we're attached
         Assert.False(editContext.Validate());

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -75,6 +75,26 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
     }
 
     [Fact]
+    public void EditFormWorksWithDataAnnotationsValidatorAndDI()
+    {
+        var appElement = Browser.MountTestComponent<ValidationComponentDI>();
+        var form = appElement.FindElement(By.TagName("form"));
+        var userNameInput = appElement.FindElement(By.ClassName("the-quiz")).FindElement(By.TagName("input"));
+        var submitButton = appElement.FindElement(By.CssSelector("button[type=submit]"));
+        var messagesAccessor = CreateValidationMessagesAccessor(appElement);
+
+        userNameInput.SendKeys("Jaws\t");
+        submitButton.Click();
+        //We can only have this errormessage when DI is working
+        Browser.Equal(new[] { "Steven Spielberg did not star in this movie" }, messagesAccessor);
+
+        userNameInput.Clear();
+        userNameInput.SendKeys("Gremlins\t");
+        submitButton.Click();
+        Browser.Empty(messagesAccessor);
+    }
+
+    [Fact]
     public void InputTextInteractsWithEditContext()
     {
         var appElement = MountTypicalValidationComponent();

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -83,13 +83,13 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var submitButton = appElement.FindElement(By.CssSelector("button[type=submit]"));
         var messagesAccessor = CreateValidationMessagesAccessor(appElement);
 
-        userNameInput.SendKeys("Jaws\t");
+        userNameInput.SendKeys("Bacon\t");
         submitButton.Click();
         //We can only have this errormessage when DI is working
-        Browser.Equal(new[] { "Steven Spielberg did not star in this movie" }, messagesAccessor);
+        Browser.Equal(new[] { "You should not put that in a salad!" }, messagesAccessor);
 
         userNameInput.Clear();
-        userNameInput.SendKeys("Gremlins\t");
+        userNameInput.SendKeys("Watermelon\t");
         submitButton.Click();
         Browser.Empty(messagesAccessor);
     }

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/NotifyPropertyChangedValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/NotifyPropertyChangedValidationComponent.razor
@@ -42,7 +42,7 @@
     protected override void OnInitialized()
     {
         editContext = new EditContext(person);
-        editContext.EnableDataAnnotationsValidation(null!);
+        editContext.EnableDataAnnotationsValidation(new TestServiceProvider());
 
         // Wire up INotifyPropertyChanged to the EditContext
         person.PropertyChanged += (sender, eventArgs) =>
@@ -102,5 +102,11 @@
         }
 
         #endregion
+    }
+
+    public class TestServiceProvider : IServiceProvider
+    {
+        public object GetService(Type serviceType)
+            => throw new NotImplementedException();
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/NotifyPropertyChangedValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/NotifyPropertyChangedValidationComponent.razor
@@ -42,7 +42,7 @@
     protected override void OnInitialized()
     {
         editContext = new EditContext(person);
-        editContext.EnableDataAnnotationsValidation();
+        editContext.EnableDataAnnotationsValidation(null!);
 
         // Wire up INotifyPropertyChanged to the EditContext
         person.PropertyChanged += (sender, eventArgs) =>

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/ValidationComponentDI.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/ValidationComponentDI.razor
@@ -27,7 +27,7 @@
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
-            var saladChef= validationContext.GetRequiredService<SaladChef>();
+            var saladChef = validationContext.GetRequiredService<SaladChef>();
             if (saladChef.ThingsYouCanPutInASalad.Contains(value.ToString()))
             {
                 return ValidationResult.Success;    

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/ValidationComponentDI.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/ValidationComponentDI.razor
@@ -5,8 +5,8 @@
     <DataAnnotationsValidator />
 
     <p class="the-quiz">
-        Name a movie in which Steven Spielberg acted:
-        <input @bind="MovieName" class="@context.FieldCssClass(() => MovieName)" />
+        Name something you can put in a salad:
+        <input @bind="SaladIngredient" class="@context.FieldCssClass(() => SaladIngredient)" />
     </p>
 
     <button type="submit">Submit</button>
@@ -20,27 +20,27 @@
 </EditForm>
 
 @code {
-    [MovieQuizValidator]
-    public string MovieName { get; set; }
+    [SaladChefValidator]
+    public string SaladIngredient { get; set; }
 
-    public class MovieQuizValidatorAttribute : ValidationAttribute
+    public class SaladChefValidatorAttribute : ValidationAttribute
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
-            var quizHost = validationContext.GetService<MovieQuizHost>();
-            if (quizHost == null) return new ValidationResult("Can't find moviehost");
-            if (quizHost.MoviesWhereStevenSpielbergActed.Contains(value.ToString()))
+            var saladChef= validationContext.GetService<SaladChef>();
+            if (saladChef == null) return new ValidationResult("Can't find SaladChef");
+            if (saladChef.ThingsYouCanPutInASalad.Contains(value.ToString()))
             {
                 return ValidationResult.Success;    
             }
-            return new ValidationResult("Steven Spielberg did not star in this movie");
+            return new ValidationResult("You should not put that in a salad!");
         }
     }
 
    
     //Simple class to check if DI can be used in Validation attributes
-    public class MovieQuizHost
+    public class SaladChef
     {
-        public string[] MoviesWhereStevenSpielbergActed = { "The Blues Brothers", "Gremlins", "Vanilla Sky", "Double Dare", "Goldmember" };
+        public string[] ThingsYouCanPutInASalad = { "Strawberries", "Pineapple", "Honeydew", "Watermelon", "Grapes" };
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/ValidationComponentDI.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/ValidationComponentDI.razor
@@ -1,0 +1,46 @@
+﻿@using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Components.Forms
+
+<EditForm Model="@this" autocomplete="off">
+    <DataAnnotationsValidator />
+
+    <p class="the-quiz">
+        Name a movie in which Steven Spielberg acted:
+        <input @bind="MovieName" class="@context.FieldCssClass(() => MovieName)" />
+    </p>
+
+    <button type="submit">Submit</button>
+    <ul class="validation-errors">
+        @foreach (var message in context.GetValidationMessages())
+        {
+            <li class="validation-message">@message</li>
+        }
+    </ul>
+
+</EditForm>
+
+@code {
+    [MovieQuizValidator]
+    public string MovieName { get; set; }
+
+    public class MovieQuizValidatorAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var quizHost = validationContext.GetService<MovieQuizHost>();
+            if (quizHost == null) return new ValidationResult("Can't find moviehost");
+            if (quizHost.MoviesWhereStevenSpielbergActed.Contains(value.ToString()))
+            {
+                return ValidationResult.Success;    
+            }
+            return new ValidationResult("Steven Spielberg did not star in this movie");
+        }
+    }
+
+   
+    //Simple class to check if DI can be used in Validation attributes
+    public class MovieQuizHost
+    {
+        public string[] MoviesWhereStevenSpielbergActed = { "The Blues Brothers", "Gremlins", "Vanilla Sky", "Double Dare", "Goldmember" };
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/ValidationComponentDI.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/ValidationComponentDI.razor
@@ -27,8 +27,7 @@
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
-            var saladChef= validationContext.GetService<SaladChef>();
-            if (saladChef == null) return new ValidationResult("Can't find SaladChef");
+            var saladChef= validationContext.GetRequiredService<SaladChef>();
             if (saladChef.ThingsYouCanPutInASalad.Contains(value.ToString()))
             {
                 return ValidationResult.Success;    
@@ -36,9 +35,8 @@
             return new ValidationResult("You should not put that in a salad!");
         }
     }
-
    
-    //Simple class to check if DI can be used in Validation attributes
+    // Simple class to check if DI can be used in Validation attributes
     public class SaladChef
     {
         public string[] ThingsYouCanPutInASalad = { "Strawberries", "Pineapple", "Honeydew", "Watermelon", "Grapes" };

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -40,6 +40,7 @@
         <option value="BasicTestApp.FormsTest.SimpleValidationComponentUsingExperimentalValidator">Simple validation using experimental validator</option>
         <option value="BasicTestApp.FormsTest.TypicalValidationComponent">Typical validation</option>
         <option value="BasicTestApp.FormsTest.TypicalValidationComponentUsingExperimentalValidator">Typical validation using experimental validator</option>
+        <option value="BasicTestApp.FormsTest.ValidationComponentDI">Validation with Dependency Injection</option>
         <option value="BasicTestApp.FormsTest.InputFileComponent">Input file</option>
         <option value="BasicTestApp.FormsTest.InputRangeComponent">Input range</option>
         <option value="BasicTestApp.FormsTest.InputsWithoutEditForm">Inputs without EditForm</option>

--- a/src/Components/test/testassets/BasicTestApp/Program.cs
+++ b/src/Components/test/testassets/BasicTestApp/Program.cs
@@ -38,7 +38,7 @@ public class Program
         });
 
         builder.Services.AddScoped<PreserveStateService>();
-        builder.Services.AddTransient<FormsTest.ValidationComponentDI.MovieQuizHost>();
+        builder.Services.AddTransient<FormsTest.ValidationComponentDI.SaladChef>();
 
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 

--- a/src/Components/test/testassets/BasicTestApp/Program.cs
+++ b/src/Components/test/testassets/BasicTestApp/Program.cs
@@ -38,6 +38,7 @@ public class Program
         });
 
         builder.Services.AddScoped<PreserveStateService>();
+        builder.Services.AddTransient<FormsTest.ValidationComponentDI.MovieQuizHost>();
 
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 

--- a/src/Components/test/testassets/TestServer/ServerStartup.cs
+++ b/src/Components/test/testassets/TestServer/ServerStartup.cs
@@ -29,6 +29,7 @@ public class ServerStartup
                 javaScriptInitializer: "myJsRootComponentInitializers.testInitializer");
         });
         services.AddSingleton<ResourceRequestLog>();
+        services.AddTransient<BasicTestApp.FormsTest.ValidationComponentDI.SaladChef>();
 
         // Since tests run in parallel, we use an ephemeral key provider to avoid filesystem
         // contention issues.


### PR DESCRIPTION
### Added DI to ValidationContext

This PR adds the ability to use Dependency Injection in a ``ValidationAttribute`` when using the default ``<DataAnnotationsValidator>``

Implemented by adding an overload to the extension methods to remain binary and source compatible.
This method can also be used by other custom validators
closes: #39382
