### PR TITLE
Cache property intiailizers for the duration of component lifetime

### DIFF
--- a/src/Components/Components/src/ComponentFactory.cs
+++ b/src/Components/Components/src/ComponentFactory.cs
@@ -14,7 +14,7 @@ internal sealed class ComponentFactory
     private const BindingFlags _injectablePropertyBindingFlags
         = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
-    private readonly ConcurrentDictionary<Type, Action<IServiceProvider, IComponent>> _cachedInitializers = new();
+    private static readonly ConcurrentDictionary<Type, Action<IServiceProvider, IComponent>> _cachedInitializers = new();
 
     private readonly IComponentActivator _componentActivator;
 
@@ -23,7 +23,7 @@ internal sealed class ComponentFactory
         _componentActivator = componentActivator ?? throw new ArgumentNullException(nameof(componentActivator));
     }
 
-    public void ClearCache() => _cachedInitializers.Clear();
+    public static void ClearCache() => _cachedInitializers.Clear();
 
     public IComponent InstantiateComponent(IServiceProvider serviceProvider, [DynamicallyAccessedMembers(Component)] Type componentType)
     {
@@ -38,7 +38,7 @@ internal sealed class ComponentFactory
         return component;
     }
 
-    private void PerformPropertyInjection(IServiceProvider serviceProvider, IComponent instance)
+    private static void PerformPropertyInjection(IServiceProvider serviceProvider, IComponent instance)
     {
         // This is thread-safe because _cachedInitializers is a ConcurrentDictionary.
         // We might generate the initializer more than once for a given type, but would
@@ -53,7 +53,7 @@ internal sealed class ComponentFactory
         initializer(serviceProvider, instance);
     }
 
-    private Action<IServiceProvider, IComponent> CreateInitializer([DynamicallyAccessedMembers(Component)] Type type)
+    private static Action<IServiceProvider, IComponent> CreateInitializer([DynamicallyAccessedMembers(Component)] Type type)
     {
         // Do all the reflection up front
         List<(string name, Type propertyType, PropertySetter setter)>? injectables = null;

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -130,7 +130,7 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     private async void RenderRootComponentsOnHotReload()
     {
         // Before re-rendering the root component, also clear any well-known caches in the framework
-        _componentFactory.ClearCache();
+        ComponentFactory.ClearCache();
         ComponentProperties.ClearCache();
         Routing.QueryParameterValueSupplier.ClearCache();
 


### PR DESCRIPTION
ComponentFactory is instantiated on a per-renderer basis. It has a cache that stores
property initializers in a state independent way. In a Blazor server app, there is a HtmlRenderer created
during pre-rendering and a per-circuit renderer which means we're calculating (reflection) and allocating multiple
copies of property initializers. Turning it into a static avoids this.
