### PR TITLE
Revert "[main] Switch to Windows.Amd64.Server2022.Open (#39365)"

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -30,7 +30,7 @@
       <ItemGroup>
         <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
         <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
-        <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.11.Amd64.ClientPre.Open" Platform="Windows" />
       </ItemGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
- fix #39363
- Windows.11.Amd64.ClientPre now exists, enabling use in internal PRs
- this reverts commit ed0a74007de0c2f393fbe8d871229d0e5681ef34