### PR TITLE
Added InputTime as native blazor control

### DIFF
--- a/src/Components/Web/src/Forms/InputTime.cs
+++ b/src/Components/Web/src/Forms/InputTime.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.Forms;
+
+/// <summary>
+/// An input component for editing time values
+/// Supported types are <see cref="TimeOnly"/> and <see cref="string"/>.
+/// </summary>
+public class InputTime<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TValue> : InputBase<TValue>
+{
+    /// <summary>
+    /// Gets or sets the error message used when displaying an a parsing error.
+    /// </summary>
+    [Parameter] public string ParsingErrorMessage { get; set; } = "The {0} field must be time component.";
+
+    /// <summary>
+    /// Gets or sets the associated <see cref="ElementReference"/>.
+    /// <para>
+    /// May be <see langword="null"/> if accessed before the component is rendered.
+    /// </para>
+    /// </summary>
+    [DisallowNull] public ElementReference? Element { get; protected set; }
+
+    /// <summary>
+    /// Constructs an instance of <see cref="InputTime{TValue}" />
+    /// </summary>
+    public InputTime()
+    {
+        var type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
+        if (type != typeof(TimeOnly) &&
+            type != typeof(string))
+        {
+            throw new InvalidOperationException($"Unsupported {GetType()} type param '{type}'.");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "input");
+        builder.AddMultipleAttributes(1, AdditionalAttributes);
+        builder.AddAttribute(2, "type", "time");
+        builder.AddAttribute(3, "class", CssClass);
+        builder.AddAttribute(4, "value", BindConverter.FormatValue(CurrentValueAsString));
+        builder.AddAttribute(5, "onchange", EventCallback.Factory.CreateBinder<string?>(this, __value => CurrentValueAsString = __value, CurrentValueAsString));
+        builder.AddElementReferenceCapture(6, __inputReference => Element = __inputReference);
+        builder.CloseElement();
+    }
+
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        if (BindConverter.TryConvertTo(value, CultureInfo.InvariantCulture, out result))
+        {
+            Debug.Assert(result != null);
+            validationErrorMessage = null;
+            return true;
+        }
+        else
+        {
+            validationErrorMessage = string.Format(CultureInfo.InvariantCulture, ParsingErrorMessage, DisplayName ?? FieldIdentifier.FieldName);
+            return false;
+        }
+    }
+}

--- a/src/Components/Web/src/PublicAPI.Shipped.txt
+++ b/src/Components/Web/src/PublicAPI.Shipped.txt
@@ -121,6 +121,12 @@ Microsoft.AspNetCore.Components.Forms.InputTextArea
 Microsoft.AspNetCore.Components.Forms.InputTextArea.Element.get -> Microsoft.AspNetCore.Components.ElementReference?
 Microsoft.AspNetCore.Components.Forms.InputTextArea.Element.set -> void
 Microsoft.AspNetCore.Components.Forms.InputTextArea.InputTextArea() -> void
+Microsoft.AspNetCore.Components.Forms.InputTime<TValue>
+Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.Element.get -> Microsoft.AspNetCore.Components.ElementReference?
+Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.Element.set -> void
+Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.InputTime() -> void
+Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.ParsingErrorMessage.get -> string!
+Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.ParsingErrorMessage.set -> void
 Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions
 Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.get -> int
 Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.set -> void
@@ -433,6 +439,9 @@ override Microsoft.AspNetCore.Components.Forms.InputText.BuildRenderTree(Microso
 override Microsoft.AspNetCore.Components.Forms.InputText.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool
 override Microsoft.AspNetCore.Components.Forms.InputTextArea.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.Forms.InputTextArea.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool
+override Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
+override Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.FormatValueAsString(TValue? value) -> string?
+override Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.TryParseValueFromString(string? value, out TValue result, out string? validationErrorMessage) -> bool
 override Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.OnParametersSet() -> void
 override Microsoft.AspNetCore.Components.Forms.ValidationSummary.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void

--- a/src/Components/Web/src/PublicAPI.Shipped.txt
+++ b/src/Components/Web/src/PublicAPI.Shipped.txt
@@ -121,12 +121,6 @@ Microsoft.AspNetCore.Components.Forms.InputTextArea
 Microsoft.AspNetCore.Components.Forms.InputTextArea.Element.get -> Microsoft.AspNetCore.Components.ElementReference?
 Microsoft.AspNetCore.Components.Forms.InputTextArea.Element.set -> void
 Microsoft.AspNetCore.Components.Forms.InputTextArea.InputTextArea() -> void
-Microsoft.AspNetCore.Components.Forms.InputTime<TValue>
-Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.Element.get -> Microsoft.AspNetCore.Components.ElementReference?
-Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.Element.set -> void
-Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.InputTime() -> void
-Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.ParsingErrorMessage.get -> string!
-Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.ParsingErrorMessage.set -> void
 Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions
 Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.get -> int
 Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions.MaxBufferSize.set -> void
@@ -439,8 +433,6 @@ override Microsoft.AspNetCore.Components.Forms.InputText.BuildRenderTree(Microso
 override Microsoft.AspNetCore.Components.Forms.InputText.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool
 override Microsoft.AspNetCore.Components.Forms.InputTextArea.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.Forms.InputTextArea.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool
-override Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
-override Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.TryParseValueFromString(string? value, out TValue result, out string? validationErrorMessage) -> bool
 override Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.OnParametersSet() -> void
 override Microsoft.AspNetCore.Components.Forms.ValidationSummary.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void

--- a/src/Components/Web/src/PublicAPI.Shipped.txt
+++ b/src/Components/Web/src/PublicAPI.Shipped.txt
@@ -440,7 +440,6 @@ override Microsoft.AspNetCore.Components.Forms.InputText.TryParseValueFromString
 override Microsoft.AspNetCore.Components.Forms.InputTextArea.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.Forms.InputTextArea.TryParseValueFromString(string? value, out string? result, out string? validationErrorMessage) -> bool
 override Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
-override Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.FormatValueAsString(TValue? value) -> string?
 override Microsoft.AspNetCore.Components.Forms.InputTime<TValue>.TryParseValueFromString(string? value, out TValue result, out string? validationErrorMessage) -> bool
 override Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.Forms.ValidationMessage<TValue>.OnParametersSet() -> void

--- a/src/Components/Web/test/Forms/InputTimeTest.cs
+++ b/src/Components/Web/test/Forms/InputTimeTest.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Forms;
+
+public class InputTimeTest
+{
+    [Fact]
+    public async Task ValidationErrorUsesDisplayAttributeName()
+    {
+        // Arrange
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<TimeOnly, TestInputTimeComponent>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.TimeProperty,
+            AdditionalAttributes = new Dictionary<string, object>
+                {
+                    { "DisplayName", "Some time" }
+                }
+        };
+        var fieldIdentifier = FieldIdentifier.Create(() => model.TimeProperty);
+        var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        // Act
+        await inputComponent.SetCurrentValueAsStringAsync("notATime");
+
+        // Assert
+        var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+        Assert.NotEmpty(validationMessages);
+        Assert.Contains("The Some time field must be a time component.", validationMessages);
+    }
+
+    [Fact]
+    public async Task InputElementIsAssignedSuccessfully()
+    {
+        // Arrange
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<TimeOnly, TestInputTimeComponent>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.TimeProperty,
+        };
+
+        // Act
+        var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        // Assert
+        Assert.NotNull(inputSelectComponent.Element);
+    }
+
+    private class TestModel
+    {
+        public TimeOnly TimeProperty { get; set; }
+    }
+
+    private class TestInputTimeComponent : InputTime<TimeOnly>
+    {
+        public async Task SetCurrentValueAsStringAsync(string value)
+        {
+            // This is equivalent to the subclass writing to CurrentValueAsString
+            // (e.g., from @bind), except to simplify the test code there's an InvokeAsync
+            // here. In production code it wouldn't normally be required because @bind
+            // calls run on the sync context anyway.
+            await InvokeAsync(() => { base.CurrentValueAsString = value; });
+        }
+    }
+}


### PR DESCRIPTION
# Added InputTime as native blazor control

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Added new component `<InputTime>` which mimics the behavior of `<input type="time">`

## Description

`<input type="time">` can be used to retrieve a time component from a user. In my current proposal we either accept a `string` or `TimeOnly` component to bind the value to the control.