### PR TITLE
Stop trying to launch browser from codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,8 @@
   "remoteEnv": {
     "PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
     "DOTNET_MULTILEVEL_LOOKUP": "0",
-    "TARGET": "net7.0"
+    "TARGET": "net7.0",
+    "DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER": "true"
   },
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode"


### PR DESCRIPTION
This isn't a supported operation and yields `dotnet watch 🌐 Unable to launch the browser. Navigate to https://localhost:<PORT>` every time.
