### PR TITLE
Clean up Helix.props and Helix.Common.props

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -6,16 +6,15 @@
     <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210924174119-4f64125</HelixQueueFedora34>
     <HelixQueueMariner>(Mariner)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620</HelixQueueMariner>
     <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20211001171229-97d8652</HelixQueueArmDebian11>
+
+    <!-- Do not attempt to override global property. -->
+    <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>
   </PropertyGroup>
 
-  <!-- Don't use <Choose/> for $(IsWindowsOnlyTest) checks. <When/> Condition is evaluated before project load. -->
-  <ItemGroup Condition=" '$(IsWindowsOnlyTest)' != 'true' ">
+  <ItemGroup>
     <HelixAvailablePlatform Include="Windows" />
     <HelixAvailablePlatform Include="OSX" />
     <HelixAvailablePlatform Include="Linux" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(IsWindowsOnlyTest)' == 'true' ">
-    <HelixAvailablePlatform Include="Windows" />
   </ItemGroup>
 
   <!--
@@ -59,6 +58,23 @@
         <HelixAvailableTargetQueue Include="Windows.10.Arm64v8.Open" Platform="Windows"
             Condition=" '$(IsWindowsOnlyTest)' != 'true' "/>
       </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition=" '$(HelixTargetQueue)' == '' ">
+      <PropertyGroup>
+        <IsArm64HelixQueue>false</IsArm64HelixQueue>
+        <IsWindowsHelixQueue>false</IsWindowsHelixQueue>
+        <IsMacHelixQueue>false</IsMacHelixQueue>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <IsArm64HelixQueue Condition="$(HelixTargetQueue.Contains('Arm64'))">true</IsArm64HelixQueue>
+        <IsWindowsHelixQueue Condition="$(HelixTargetQueue.Contains('Windows'))">true</IsWindowsHelixQueue>
+        <IsMacHelixQueue Condition="$(HelixTargetQueue.Contains('OSX'))">true</IsMacHelixQueue>
+      </PropertyGroup>
     </Otherwise>
   </Choose>
 </Project>

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -71,9 +71,9 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <IsArm64HelixQueue Condition="$(HelixTargetQueue.Contains('Arm64'))">true</IsArm64HelixQueue>
-        <IsWindowsHelixQueue Condition="$(HelixTargetQueue.Contains('Windows'))">true</IsWindowsHelixQueue>
-        <IsMacHelixQueue Condition="$(HelixTargetQueue.Contains('OSX'))">true</IsMacHelixQueue>
+        <IsArm64HelixQueue>$(HelixTargetQueue.Contains('Arm64'))</IsArm64HelixQueue>
+        <IsWindowsHelixQueue>$(HelixTargetQueue.Contains('Windows'))</IsWindowsHelixQueue>
+        <IsMacHelixQueue>$(HelixTargetQueue.Contains('OSX'))</IsMacHelixQueue>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -10,33 +10,20 @@
 
   <PropertyGroup>
     <HelixTimeout>00:30:00</HelixTimeout>
-    <!-- Do not attempt to override global property. -->
-    <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>
-
-    <IsArm64HelixQueue>false</IsArm64HelixQueue>
-    <IsWindowsHelixQueue>false</IsWindowsHelixQueue>
-    <IsMacHelixQueue>false</IsMacHelixQueue>
-
     <HelixTestName>$(MSBuildProjectName)--$(TargetFramework)</HelixTestName>
     <LoggingTestingDisableFileLogging Condition="'$(IsHelixJob)' == 'true'">false</LoggingTestingDisableFileLogging>
     <NodeVersion>16.11.0</NodeVersion>
+
     <!-- Have all tests depend on the latest runtimes until we get a net7.0 SDK -->
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
   </PropertyGroup>
 
-  <!-- Override a few properties in innermost (Publish) build for Helix submission. -->
-  <PropertyGroup Condition=" '$(HelixTargetQueue)' != '' ">
-    <IsArm64HelixQueue Condition="$(HelixTargetQueue.Contains('Arm64'))">true</IsArm64HelixQueue>
-    <IsWindowsHelixQueue Condition="$(HelixTargetQueue.Contains('Windows'))">true</IsWindowsHelixQueue>
-    <IsMacHelixQueue Condition="$(HelixTargetQueue.Contains('OSX'))">true</IsMacHelixQueue>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' OR '$(IsWindowsOnlyTest)' == 'true' ">
     <HelixProjectPlatform Include="Windows" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' AND '$(IsWindowsOnlyTest)' != 'true' ">
     <HelixProjectPlatform Include="@(HelixAvailablePlatform)" />
   </ItemGroup>
 

--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -19,14 +19,6 @@
     <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' OR '$(IsWindowsOnlyTest)' == 'true' ">
-    <HelixProjectPlatform Include="Windows" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' AND '$(IsWindowsOnlyTest)' != 'true' ">
-    <HelixProjectPlatform Include="@(HelixAvailablePlatform)" />
-  </ItemGroup>
-
   <ItemGroup>
     <HelixContent Include="$(RepoRoot)eng\helix\content\**\*" Exclude="$(RepoRoot)eng\helix\content\*.in" />
   </ItemGroup>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -108,6 +108,19 @@
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
   </ItemGroup>
 
+  <Choose>
+    <When Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' OR '$(IsWindowsOnlyTest)' == 'true' ">
+      <ItemGroup>
+        <HelixProjectPlatform Include="Windows" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <HelixProjectPlatform Include="@(HelixAvailablePlatform)" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
   <Target Name="_SetCreateHelixPayload">
     <PropertyGroup>
       <_SelectedPlatforms>@(HelixProjectPlatform)</_SelectedPlatforms>


### PR DESCRIPTION
- address confusion hit when fixing an internal 6.0 PR
- generally, reflect Helix.props' use of project settings better
  - checks and settings that don't use project settings are in Helix.Common.props
- move `$(Is...Queue)` settings to Helix.Common.props
  - these properties depend on the current queue and that's known in helix.proj
- move `$(IsWindowsOnlyTest)` checks to Helix.props
  - property is set in projects; never seen in helix.proj

nit: also move `$(RunQuarantinedTests)` default to Helix.Common.props
  - global property is visible in helix.proj and may at some point be useful there