### PR TITLE
!nits! Clean up App.Ref, App.Runtime slightly

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -173,8 +173,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <Target Name="GeneratePackageOverrides"
           Condition=" '$(IsServicingBuild)' != 'true' "
           DependsOnTargets="_ResolveTargetingPackContent"
-          Inputs="$(MSBuildAllProjects)"
-          Outputs="$(ReferencePackageOverridesPath">
+          Inputs="@(RefPackContent)"
+          Outputs="$(ReferencePackageOverridesPath)">
     <ItemGroup>
       <!-- Use package version for non-Runtime references. -->
       <_AspNetCoreAppPackageOverrides Include="@(AspNetCoreReferenceAssemblyPath->'%(NuGetPackageId)|%(NuGetPackageVersion)')"
@@ -251,7 +251,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <Target Name="IncludeFrameworkListFile"
           DependsOnTargets="_ResolveTargetingPackContent"
           BeforeTargets="_GetPackageFiles"
-          Condition="'$(PackageTargetRuntime)' == '' AND '$(ManifestsPackagePath)' != ''">
+          Inputs="@(RefPackContent)"
+          Outputs="$(FrameworkListOutputPath)">
     <RepoTasks.CreateFrameworkListFile
       Files="@(RefPackContent)"
       TargetFile="$(FrameworkListOutputPath)"
@@ -262,5 +263,4 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       <_PackageFiles Include="@(RefPackContent)" />
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -557,9 +557,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
   <Target Name="IncludeFrameworkListFile"
           DependsOnTargets="_ResolveSharedFrameworkContent"
-          BeforeTargets="_GetPackageFiles"
-          Condition="'$(ManifestsPackagePath)' != ''">
-
+          BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <SharedFxContent Condition="'%(SharedFxContent.Extension)' == '.dll'">
         <PackagePath Condition="'%(SharedFxContent.IsNativeImage)' == 'true'">$(NativeAssetsPackagePath)</PackagePath>
@@ -582,7 +580,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <Target Name="IncludeVersionFile"
           DependsOnTargets="GenerateSharedFxVersionsFiles"
           BeforeTargets="_GetPackageFiles">
-
     <ItemGroup>
       <None Include="$(VersionTxtFileIntermediateOutputPath)" Pack="true" PackagePath="." />
     </ItemGroup>


### PR DESCRIPTION
- fix typos in `GeneratePackageOverrides`'s up-to-date checks
- skip `IncludeFrameworkListFile` when up-to-date
- remove useless conditions