### PR TITLE
Always build App.Ref and the targeting packs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -139,11 +139,6 @@
     <RuntimeInstallerBaseName>aspnetcore-runtime</RuntimeInstallerBaseName>
     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>
 
-    <!-- This is used to produce targeting pack installers/packages once per major.minor. -->
-    <IsTargetingPackBuilding
-        Condition=" '$(IsTargetingPackBuilding)' == '' AND '$(AspNetCorePatchVersion)' != '0' ">false</IsTargetingPackBuilding>
-    <IsTargetingPackBuilding Condition=" '$(IsTargetingPackBuilding)' == '' ">true</IsTargetingPackBuilding>
-
     <!--
       Archives and installers using this prefix are intended for internal use only.
       For example, this .zip is used to handoff bits to partner teams who then incorporate our shared frameworks

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -47,7 +47,6 @@
     <SharedFxProductName>$(Product) $(SharedFxVersion) Shared Framework</SharedFxProductName>
 
     <TargetingPackVersion>$(SharedFxVersion)</TargetingPackVersion>
-    <TargetingPackVersion Condition=" ! $(IsTargetingPackBuilding) ">$(TargetingPackVersionPrefix)</TargetingPackVersion>
 
     <PackageVersion Condition=" '$(NoSemVer20)' == 'true' ">$(SiteExtensionVersion)</PackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,8 +29,6 @@
       It's also used in root Directory.Build.targets to determine the version of the last-built targeting pack.
     -->
     <TargetingPackVersionPrefix>$(VersionPrefix)</TargetingPackVersionPrefix>
-    <!-- Targeting packs do not produce patch versions in servicing builds. No API changes are allowed in patches. -->
-    <TargetingPackVersionPrefix Condition="'$(IsTargetingPackBuilding)' != 'true'">$(AspNetCoreMajorMinorVersion).0</TargetingPackVersionPrefix>
     <ExperimentalVersionPrefix>0.3.$(AspNetCorePatchVersion)</ExperimentalVersionPrefix>
     <!-- ANCM versioning is intentionally 10 + AspNetCoreMajorVersion because earlier versions of ANCM shipped as 8.x. -->
     <AspNetCoreModuleVersionMajor>$([MSBuild]::Add(10, $(AspNetCoreMajorVersion)))</AspNetCoreModuleVersionMajor>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -253,8 +253,7 @@
   -->
   <ItemGroup Condition=" '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Runtime' AND
       '$(MSBuildProjectName)' != 'RepoTasks' AND
-      ($(_CompileTfmUsingReferenceAssemblies) OR
-       ('$(IsTargetingPackBuilding)' != 'false' AND '$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref')) ">
+      ($(_CompileTfmUsingReferenceAssemblies) OR '$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref') ">
     <PackageReference Include="Microsoft.Internal.Runtime.AspNetCore.Transport"
         Version="$(MicrosoftInternalRuntimeAspNetCoreTransportVersion)"
         IsImplicitlyDefined="true"
@@ -276,8 +275,7 @@
           '$(IsServicingBuild)' == 'true' AND
           '$(IsImplementationProject)' == 'true' AND
           '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Runtime' AND
-          ($(_CompileTfmUsingReferenceAssemblies) OR
-           ('$(IsTargetingPackBuilding)' != 'false' AND '$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref')) ">
+          ($(_CompileTfmUsingReferenceAssemblies) OR '$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref') ">
     <ItemGroup>
       <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)"
           Condition=" '%(NuGetPackageId)' != 'Microsoft.Internal.Runtime.AspNetCore.Transport' AND

--- a/src/Framework/App.Ref.Internal/src/Microsoft.AspNetCore.App.Ref.Internal.csproj
+++ b/src/Framework/App.Ref.Internal/src/Microsoft.AspNetCore.App.Ref.Internal.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <IsShippingPackage>false</IsShippingPackage>
     <IsPackable>true</IsPackable>
-    <IsPackable Condition="'$(IsTargetingPackBuilding)' == 'false'">false</IsPackable>
     <PackageId>$(TargetingPackName).Internal</PackageId>
     <VersionPrefix>$(TargetingPackVersionPrefix)</VersionPrefix>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <IsPackable Condition="'$(IsTargetingPackBuilding)' == 'false'">false</IsPackable>
     <PackageId>$(TargetingPackName)</PackageId>
     <VersionPrefix>$(TargetingPackVersionPrefix)</VersionPrefix>
 
@@ -89,8 +88,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- If this project won't produce a package, don't bother building anything. -->
-    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' != 'false'">
+    <BuildDependsOn>
       $(BuildDependsOn);
       _ResolveTargetingPackContent;
       GeneratePackageOverrides;
@@ -99,9 +97,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       _InstallTargetingPackIntoLocalDotNet;
       _CreateTargetingPackArchive;
     </BuildDependsOn>
-
-    <!-- No-op when in source build -->
-    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'"/>
   </PropertyGroup>
 
   <!-- Override the default MSBuild targets so that nothing is returned from the project since it represents a collection of assemblies. -->

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -56,10 +56,6 @@
       <_Parameter2>$(TargetingPackLayoutRoot)</_Parameter2>
     </AssemblyAttribute>
     <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
-      <_Parameter1>IsTargetingPackBuilding</_Parameter1>
-      <_Parameter2>$(IsTargetingPackBuilding)</_Parameter2>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
       <_Parameter1>VerifyAncmBinary</_Parameter1>
       <_Parameter2>$(VerifyAncmBinary)</_Parameter2>
     </AssemblyAttribute>
@@ -72,12 +68,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-      Condition=" $(IsTargetingPackBuilding) "
-      Private="false"
-      ReferenceOutputAssembly="false"
-      SkipGetTargetFrameworkProperties="true" />
-    <ProjectReference Include="$(RepoRoot)\src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-      Condition=" !$(IsTargetingPackBuilding) "
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -18,7 +18,6 @@ public class TargetingPackTests
     private readonly string _targetingPackTfm;
     private readonly string _targetingPackRoot;
     private readonly ITestOutputHelper _output;
-    private readonly bool _isTargetingPackBuilding;
 
     public TargetingPackTests(ITestOutputHelper output)
     {
@@ -33,17 +32,11 @@ public class TargetingPackTests
             "packs",
             "Microsoft.AspNetCore.App.Ref",
             TestData.GetTestDataValue("TargetingPackVersion"));
-        _isTargetingPackBuilding = bool.Parse(TestData.GetTestDataValue("IsTargetingPackBuilding"));
     }
 
     [Fact]
     public void TargetingPackContainsListedAssemblies()
     {
-        if (!_isTargetingPackBuilding)
-        {
-            return;
-        }
-
         var actualAssemblies = Directory.GetFiles(Path.Combine(_targetingPackRoot, "ref", _targetingPackTfm), "*.dll")
             .Select(Path.GetFileNameWithoutExtension)
             .ToHashSet();
@@ -69,11 +62,6 @@ public class TargetingPackTests
     [Fact]
     public void RefAssembliesHaveExpectedAssemblyVersions()
     {
-        if (!_isTargetingPackBuilding)
-        {
-            return;
-        }
-
         IEnumerable<string> dlls = Directory.GetFiles(Path.Combine(_targetingPackRoot, "ref", _targetingPackTfm), "*.dll", SearchOption.AllDirectories);
         Assert.NotEmpty(dlls);
 
@@ -94,11 +82,6 @@ public class TargetingPackTests
     [Fact]
     public void RefAssemblyReferencesHaveExpectedAssemblyVersions()
     {
-        if (!_isTargetingPackBuilding)
-        {
-            return;
-        }
-
         IEnumerable<string> dlls = Directory.GetFiles(Path.Combine(_targetingPackRoot, "ref", _targetingPackTfm), "*.dll", SearchOption.AllDirectories);
         Assert.NotEmpty(dlls);
 
@@ -121,11 +104,6 @@ public class TargetingPackTests
     [Fact]
     public void PackageOverridesContainsCorrectEntries()
     {
-        if (!_isTargetingPackBuilding)
-        {
-            return;
-        }
-
         var packageOverridePath = Path.Combine(_targetingPackRoot, "data", "PackageOverrides.txt");
 
         AssertEx.FileExists(packageOverridePath);
@@ -185,11 +163,6 @@ public class TargetingPackTests
     [Fact]
     public void AssembliesAreReferenceAssemblies()
     {
-        if (!_isTargetingPackBuilding)
-        {
-            return;
-        }
-
         IEnumerable<string> dlls = Directory.GetFiles(Path.Combine(_targetingPackRoot, "ref"), "*.dll", SearchOption.AllDirectories);
         Assert.NotEmpty(dlls);
 
@@ -219,11 +192,6 @@ public class TargetingPackTests
     [Fact]
     public void PlatformManifestListsAllFiles()
     {
-        if (!_isTargetingPackBuilding)
-        {
-            return;
-        }
-
         var platformManifestPath = Path.Combine(_targetingPackRoot, "data", "PlatformManifest.txt");
         var expectedAssemblies = TestData.GetSharedFxDependencies()
             .Split(';', StringSplitOptions.RemoveEmptyEntries)
@@ -289,11 +257,6 @@ public class TargetingPackTests
     [Fact]
     public void FrameworkListListsContainsCorrectEntries()
     {
-        if (!_isTargetingPackBuilding)
-        {
-            return;
-        }
-
         var frameworkListPath = Path.Combine(_targetingPackRoot, "data", "FrameworkList.xml");
         var expectedAssemblies = TestData.GetTargetingPackDependencies()
             .Split(';', StringSplitOptions.RemoveEmptyEntries)
@@ -361,7 +324,7 @@ public class TargetingPackTests
     [Fact]
     public void FrameworkListListsContainsCorrectPaths()
     {
-        if (!_isTargetingPackBuilding || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))
         {
             return;
         }
@@ -403,7 +366,7 @@ public class TargetingPackTests
     [Fact]
     public void FrameworkListListsContainsAnalyzerLanguage()
     {
-        if (!_isTargetingPackBuilding || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))
         {
             return;
         }

--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -28,7 +28,7 @@
   <Target Name="Pack" />
 
   <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)"
-      Condition="!( '$(IsTargetingPackBuilding)' == 'false' AND '$(MSBuildProjectName)' == 'Debian.TargetingPack' )">
+      Condition=" '$(MSBuildProjectName)' != 'Debian.TargetingPack' ">
     <!-- Generate debian_config.json. We can't simply use WriteLinesToFile because of https://github.com/Microsoft/msbuild/issues/1622. Use our custom GenerateFileFromTemplate task instead -->
     <PropertyGroup>
       <DebianConfigProperties>

--- a/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
+++ b/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
@@ -44,9 +44,6 @@
     <!-- Deb installers are versioned as M.N.P~PreReleaseVersionLabel-Build following the core-setup convention -->
     <DebPackageVersion Condition="'$(VersionSuffix)' != ''">$(DebPackageVersion)~$(VersionSuffix)</DebPackageVersion>
     <PackageRevision>1</PackageRevision>
-
-    <!-- Suppresses building this project completely during servicing builds. -->
-    <DebBuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'" />
   </PropertyGroup>
 
 </Project>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -37,7 +37,7 @@
   <Target Name="Pack" />
 
   <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)"
-      Condition="!( '$(IsTargetingPackBuilding)' == 'false' AND '$(MSBuildProjectName)' == 'Rpm.TargetingPack' )">
+      Condition=" '$(MSBuildProjectName)' != 'Rpm.TargetingPack' ">
     <!-- Create layout: Create changelog -->
     <PropertyGroup>
       <ChangeLogProps>DATE=$([System.DateTime]::UtcNow.ToString(ddd MMM dd yyyy))</ChangeLogProps>

--- a/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
+++ b/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
@@ -39,8 +39,5 @@
     <!-- Set package revision to '1' for RTM releases, but include the build number in pre-releases -->
     <PackageRevision Condition=" '$(VersionSuffix)' == '' ">1</PackageRevision>
     <PackageRevision Condition=" '$(VersionSuffix)' != '' ">0.1.$(VersionSuffix.Replace('-', '_'))</PackageRevision>
-
-    <!-- Suppresses building this project completely during servicing builds. -->
-    <RpmBuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'" />
   </PropertyGroup>
 </Project>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -10,7 +10,6 @@
     <OutputType>Package</OutputType>
     <Cabinet>targeting_pack_$(Platform).cab</Cabinet>
     <IsShipping>true</IsShipping>
-    <SkipCopyToArtifactsDirectory Condition="'$(IsTargetingPackBuilding)' == 'false'">true</SkipCopyToArtifactsDirectory>
     <ProjectGuid>0AC34F1B-8056-4FFB-A398-E6BB7D67B48D</ProjectGuid>
     <HarvestDirectoryAutoGenerateGuids>true</HarvestDirectoryAutoGenerateGuids>
     <HarvestDirectorySuppressSpecificWarnings>5150;5151</HarvestDirectorySuppressSpecificWarnings>
@@ -79,13 +78,9 @@
     <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Targeting Pack ($(Platform))</ProductName>
     <PackageFileName>$(OutputName)$(TargetExt)</PackageFileName>
     <DefineConstants>$(DefineConstants);ProductName=$(ProductName)</DefineConstants>
-
-    <!-- Suppresses building this project completely during servicing builds. -->
-    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'" />
   </PropertyGroup>
 
-   <Target Name="CreateTargetingPackNugetPackage" AfterTargets="CopyToArtifactsDirectory;Build"
-      Condition="'$(IsTargetingPackBuilding)' != 'false'">
+   <Target Name="CreateTargetingPackNugetPackage" AfterTargets="CopyToArtifactsDirectory;Build">
     <PropertyGroup>
       <MsiFullPath>$(InstallersOutputPath)$(PackageFileName)</MsiFullPath>
     </PropertyGroup>

--- a/src/SiteExtensions/LoggingBranch/LB.csproj
+++ b/src/SiteExtensions/LoggingBranch/LB.csproj
@@ -25,12 +25,6 @@
     <HostingStartupRuntimeStoreTargets Include="$(DefaultNetCoreTargetFramework)" Runtime="$(TargetRuntimeIdentifier)" />
 
     <ProjectReference Include="..\..\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-      Condition=" $(IsTargetingPackBuilding) "
-      Private="false"
-      ReferenceOutputAssembly="false"
-      SkipGetTargetFrameworkProperties="true" />
-    <ProjectReference Include="..\..\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-      Condition=" !$(IsTargetingPackBuilding) "
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />


### PR DESCRIPTION
- remove `$(IsTargetingPackBuilding)` entirely