### PR TITLE
Removing from API Description parameters when inferred (FromPath) and not in the route

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -246,8 +246,8 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             var parameter = context.Results[i];
 
             if (parameter.Source == BindingSource.Path ||
-                   parameter.Source == BindingSource.ModelBinding ||
-                   parameter.Source == BindingSource.Custom)
+               parameter.Source == BindingSource.ModelBinding ||
+               parameter.Source == BindingSource.Custom)
             {
                 if (routeParameters.TryGetValue(parameter.Name, out var routeInfo))
                 {

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -271,7 +271,8 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                         // If we didn't see the parameter in the route and no FromRoute metadata is set, it probably means
                         // the parameter binding source was inferred (InferParameterBindingInfoConvention)  
                         // probably because another route to this action contains it as route parameter and
-                        // will be emoved from the API description
+                        // will be removed from the API description
+                        // https://github.com/dotnet/aspnetcore/issues/26234
                         context.Results.RemoveAt(i);
                     }
                 }

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -2,12 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Extensions.Options;
@@ -257,6 +260,20 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                         // a route parameter that matches, let's switch it to path.
                         parameter.Source = BindingSource.Path;
                     }
+                }
+                else
+                {
+                    if (parameter.Source == BindingSource.Path &&
+                        parameter.ModelMetadata is DefaultModelMetadata defaultModelMetadata &&
+                        !defaultModelMetadata.Attributes.Attributes.OfType<IFromRouteMetadata>().Any())
+                    {
+                        // If we didn't see the parameter in the route and no FromRoute metadata is set, it probably means
+                        // the parameter binding source was inferred (InferParameterBindingInfoConvention)  
+                        // probably because another route to this action contains it as route parameter.
+                        // let's switch it to ModelBinding
+                        parameter.Source = BindingSource.ModelBinding;
+                    }
+
                 }
             }
         }

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -241,6 +241,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             routeParameters.Add(routeParameter.Name!, CreateRouteInfo(routeParameter));
         }
 
+        var inferredPathParametersToRemove = new List<ApiParameterDescription>();
         foreach (var parameter in context.Results)
         {
             if (parameter.Source == BindingSource.Path ||
@@ -269,12 +270,19 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                         // If we didn't see the parameter in the route and no FromRoute metadata is set, it probably means
                         // the parameter binding source was inferred (InferParameterBindingInfoConvention)  
                         // probably because another route to this action contains it as route parameter.
-                        // let's switch it to ModelBinding
-                        parameter.Source = BindingSource.ModelBinding;
+                        // let's add it to be removed from the API description
+                        inferredPathParametersToRemove.Add(parameter);
                     }
 
                 }
             }
+        }
+
+        // Remove all parameters detected as Inferred FromPath
+        // but that are not in the route
+        foreach (var inferredParameter in inferredPathParametersToRemove)
+        {
+            context.Results.Remove(inferredParameter);
         }
 
         // Lastly, create a parameter representation for each route parameter that did not find

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -274,7 +274,6 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                         // will be emoved from the API description
                         context.Results.RemoveAt(i);
                     }
-
                 }
             }
         }

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -241,12 +241,13 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             routeParameters.Add(routeParameter.Name!, CreateRouteInfo(routeParameter));
         }
 
-        var inferredPathParametersToRemove = new List<ApiParameterDescription>();
-        foreach (var parameter in context.Results)
+        for (var i = context.Results.Count - 1; i >= 0; i--)
         {
+            var parameter = context.Results[i];
+
             if (parameter.Source == BindingSource.Path ||
-                parameter.Source == BindingSource.ModelBinding ||
-                parameter.Source == BindingSource.Custom)
+                   parameter.Source == BindingSource.ModelBinding ||
+                   parameter.Source == BindingSource.Custom)
             {
                 if (routeParameters.TryGetValue(parameter.Name, out var routeInfo))
                 {
@@ -269,20 +270,13 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                     {
                         // If we didn't see the parameter in the route and no FromRoute metadata is set, it probably means
                         // the parameter binding source was inferred (InferParameterBindingInfoConvention)  
-                        // probably because another route to this action contains it as route parameter.
-                        // let's add it to be removed from the API description
-                        inferredPathParametersToRemove.Add(parameter);
+                        // probably because another route to this action contains it as route parameter and
+                        // will be emoved from the API description
+                        context.Results.RemoveAt(i);
                     }
 
                 }
             }
-        }
-
-        // Remove all parameters detected as Inferred FromPath
-        // but that are not in the route
-        foreach (var inferredParameter in inferredPathParametersToRemove)
-        {
-            context.Results.Remove(inferredParameter);
         }
 
         // Lastly, create a parameter representation for each route parameter that did not find

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
-
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -244,13 +244,14 @@ public class DefaultApiDescriptionProviderTest
     }
 
     [Theory]
-    [InlineData("api/products/{id}", nameof(BindingSource.Path), nameof(BindingSource.Path))]
-    [InlineData("api/products", nameof(BindingSource.Path), nameof(BindingSource.ModelBinding))]
-    [InlineData("api/products", nameof(BindingSource.Body), nameof(BindingSource.Body))]
+    [InlineData("api/products/{id}", nameof(BindingSource.Path), true)]
+    [InlineData("api/products", nameof(BindingSource.Path), false)]
+    [InlineData("api/products", nameof(BindingSource.Body), true)]
+    [InlineData("api/products", nameof(BindingSource.Query), true)]
     public void GetApiDescription_WithInferredBindingSource(
         string template,
         string inferredBindingSourceName,
-        string expectedBindingSourceName)
+        bool inferredParameterShouldBeIncluded)
     {
         // Arrange
         var action = CreateActionDescriptor(nameof(FromModelBinding));
@@ -264,7 +265,7 @@ public class DefaultApiDescriptionProviderTest
             };
         }
 
-        var expectedBindingSource = new BindingSource(expectedBindingSourceName, displayName: null, isGreedy: false, isFromRequest: true);
+        var expectedBindingSource = new BindingSource(inferredBindingSourceName, displayName: null, isGreedy: false, isFromRequest: true);
 
         // Act
         var descriptions = GetApiDescriptions(action);
@@ -272,9 +273,14 @@ public class DefaultApiDescriptionProviderTest
         // Assert
         var description = Assert.Single(descriptions);
 
-        var parameter = Assert.Single(description.ParameterDescriptions);
-        Assert.Equal(expectedBindingSource, parameter.Source);
-        Assert.Equal("id", parameter.Name);
+        Assert.Equal(inferredParameterShouldBeIncluded, description.ParameterDescriptions.Count == 1);
+
+        if (inferredParameterShouldBeIncluded)
+        {
+            var parameter = Assert.Single(description.ParameterDescriptions);
+            Assert.Equal(expectedBindingSource, parameter.Source);
+            Assert.Equal("id", parameter.Name);
+        }
     }
 
     [Fact]

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -254,7 +254,7 @@ public class DefaultApiDescriptionProviderTest
 
         action.Parameters[0].BindingInfo = new BindingInfo()
         {
-            BindingSource = new BindingSource("Path", displayName: null, isGreedy: false, isFromRequest: true)
+            BindingSource = BindingSource.Path
         };
 
         // Act
@@ -282,10 +282,9 @@ public class DefaultApiDescriptionProviderTest
         var action = CreateActionDescriptor(nameof(FromModelBinding));
         action.AttributeRouteInfo = new AttributeRouteInfo { Template = template };
 
-        var bindingSource = new BindingSource("Path", displayName: null, isGreedy: false, isFromRequest: true);
         action.Parameters[0].BindingInfo = new BindingInfo()
         {
-            BindingSource = bindingSource
+            BindingSource = BindingSource.Path
         };
 
         // Act
@@ -294,7 +293,7 @@ public class DefaultApiDescriptionProviderTest
         // Assert
         var description = Assert.Single(descriptions);
         var parameter = Assert.Single(description.ParameterDescriptions);
-        Assert.Equal(bindingSource, parameter.Source);
+        Assert.Equal(BindingSource.Path, parameter.Source);
         Assert.Equal("id", parameter.Name);
     }
 

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -5,7 +5,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Text;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
@@ -22,7 +21,6 @@ using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
-
 using Moq;
 
 namespace Microsoft.AspNetCore.Mvc.Description;
@@ -264,7 +262,6 @@ public class DefaultApiDescriptionProviderTest
         var description = Assert.Single(descriptions);
         Assert.Empty(description.ParameterDescriptions);
     }
-
 
     [Theory]
     [InlineData("api/products/{id}")]


### PR DESCRIPTION
# Changing from Path to ModelBinding when inferred API parameters

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

The  `InferParameterBindingInfoConvention` will follow the rule described here [ApiBehaviorOptions.SuppressInferBindingSourcesForParameters Property](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.suppressinferbindingsourcesforparameters?view=aspnetcore-6.0)

![image](https://user-images.githubusercontent.com/12376385/149391417-770152ca-8055-4a62-bee7-526185e8e07f.png)

https://github.com/dotnet/aspnetcore/blob/2325e1297aa85b089cce53bc93da3bc9cda7165a/src/Mvc/Mvc.Core/src/ApplicationModels/InferParameterBindingInfoConvention.cs#L94

However, it causes the issue #26234, since both will contain the parameter listed from route. With that in this PR I am adding a small check to verify if the parameter with `BindingSource == Path` and that does not contain a `FromRoute` attribute is part of the current route and if not, it will be changed back to `ModelBinding`.

This change will affect only the `APIExplorer` provider.

Fixes #26234